### PR TITLE
8265453: SafepointMechanism::should_process() should receive JavaThread*

### DIFF
--- a/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
+++ b/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2007, 2008, 2009, 2010, 2011 Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -551,8 +551,9 @@ int ZeroInterpreter::native_entry(Method* method, intptr_t UNUSED, TRAPS) {
 }
 
 int ZeroInterpreter::getter_entry(Method* method, intptr_t UNUSED, TRAPS) {
+  JavaThread* thread = THREAD->as_Java_thread();
   // Drop into the slow path if we need a safepoint check
-  if (SafepointMechanism::should_process(THREAD)) {
+  if (SafepointMechanism::should_process(thread)) {
     return normal_entry(method, 0, THREAD);
   }
 
@@ -577,7 +578,6 @@ int ZeroInterpreter::getter_entry(Method* method, intptr_t UNUSED, TRAPS) {
     return normal_entry(method, 0, THREAD);
   }
 
-  JavaThread* thread = THREAD->as_Java_thread();
   ZeroStack* stack = thread->zero_stack();
   intptr_t* topOfStack = stack->sp();
 
@@ -639,8 +639,9 @@ int ZeroInterpreter::getter_entry(Method* method, intptr_t UNUSED, TRAPS) {
 }
 
 int ZeroInterpreter::setter_entry(Method* method, intptr_t UNUSED, TRAPS) {
+  JavaThread* thread = THREAD->as_Java_thread();
   // Drop into the slow path if we need a safepoint check
-  if (SafepointMechanism::should_process(THREAD)) {
+  if (SafepointMechanism::should_process(thread)) {
     return normal_entry(method, 0, THREAD);
   }
 
@@ -666,7 +667,6 @@ int ZeroInterpreter::setter_entry(Method* method, intptr_t UNUSED, TRAPS) {
     return normal_entry(method, 0, THREAD);
   }
 
-  JavaThread* thread = THREAD->as_Java_thread();
   ZeroStack* stack = thread->zero_stack();
   intptr_t* topOfStack = stack->sp();
 
@@ -734,7 +734,7 @@ int ZeroInterpreter::empty_entry(Method* method, intptr_t UNUSED, TRAPS) {
   ZeroStack *stack = thread->zero_stack();
 
   // Drop into the slow path if we need a safepoint check
-  if (SafepointMechanism::should_process(THREAD)) {
+  if (SafepointMechanism::should_process(thread)) {
     return normal_entry(method, 0, THREAD);
   }
 

--- a/src/hotspot/share/runtime/safepointMechanism.hpp
+++ b/src/hotspot/share/runtime/safepointMechanism.hpp
@@ -48,7 +48,6 @@ class SafepointMechanism : public AllStatic {
 
   static inline void disarm_local_poll(JavaThread* thread);
 
-  static inline bool local_poll(Thread* thread);
   static inline bool global_poll();
 
   static void process(JavaThread *thread);
@@ -80,7 +79,7 @@ public:
   };
 
   // Call this method to see if this thread should block for a safepoint or process handshake.
-  static inline bool should_process(Thread* thread);
+  static inline bool should_process(JavaThread* thread);
 
   // Processes a pending requested operation.
   static inline void process_if_requested(JavaThread* thread);

--- a/src/hotspot/share/runtime/safepointMechanism.inline.hpp
+++ b/src/hotspot/share/runtime/safepointMechanism.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,24 +60,14 @@ bool SafepointMechanism::global_poll() {
   return (SafepointSynchronize::_state != SafepointSynchronize::_not_synchronized);
 }
 
-bool SafepointMechanism::local_poll(Thread* thread) {
-  if (thread->is_Java_thread()) {
-    return local_poll_armed(thread->as_Java_thread());
-  } else {
-    // If the poll is on a non-java thread we can only check the global state.
-    return global_poll();
-  }
+bool SafepointMechanism::should_process(JavaThread* thread) {
+  return local_poll_armed(thread);
 }
 
-bool SafepointMechanism::should_process(Thread* thread) {
-  return local_poll(thread);
-}
-
-void SafepointMechanism::process_if_requested(JavaThread *thread) {
-  if (!local_poll_armed(thread)) {
-    return;
+void SafepointMechanism::process_if_requested(JavaThread* thread) {
+  if (local_poll_armed(thread)) {
+    process_if_requested_slow(thread);
   }
-  process_if_requested_slow(thread);
 }
 
 void SafepointMechanism::process_if_requested_with_exit_check(JavaThread* thread, bool check_asyncs) {


### PR DESCRIPTION
Hi,

Please review this cleanup in class SafepointMechanism. Since method should_process() is only called by JavaThreads the check in local_poll() is redundant. It also makes the generated code for should_process() unnecessary long since we only need to check the poll bit. I only had to fix a couple of calls from the zero interpreter that where passing a Thread* instead of a JavaThread*.
Tested tier1 in mach5 and that it builds zero. 

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265453](https://bugs.openjdk.java.net/browse/JDK-8265453): SafepointMechanism::should_process() should receive JavaThread*


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3603/head:pull/3603` \
`$ git checkout pull/3603`

Update a local copy of the PR: \
`$ git checkout pull/3603` \
`$ git pull https://git.openjdk.java.net/jdk pull/3603/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3603`

View PR using the GUI difftool: \
`$ git pr show -t 3603`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3603.diff">https://git.openjdk.java.net/jdk/pull/3603.diff</a>

</details>
