### PR TITLE
8265490: Unterminated string passed to FindClass() in hotspot test

### DIFF
--- a/test/hotspot/jtreg/runtime/jni/FindClassUtf8/libFindClassUtf8.c
+++ b/test/hotspot/jtreg/runtime/jni/FindClassUtf8/libFindClassUtf8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 
 JNIEXPORT void JNICALL Java_FindClassUtf8_nTest(JNIEnv* env, jclass jclazz)
 {
-    const uint64_t chars = 0x5b3132315d20f818UL;  // f8 is invalid utf8
+    jbyte chars[] = {0x18, 0xf8, 0x20, 0x5d, 0x31, 0x32, 0x31, 0x5b, 0}; // f8 is invalid utf8
 
     jclass badClass = (*env)->FindClass(env, (const char*)&chars);
 }


### PR DESCRIPTION
Please review this small fix for JDK-8265490 to null terminate the char* that test FindClassUtf8 passes to JNI_FindClass().  The modified test was run on Linux, Mac OS, and Windows platforms using Mach5 hs-tiers 1 and 2.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265490](https://bugs.openjdk.java.net/browse/JDK-8265490): Unterminated string passed to FindClass() in hotspot test


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3604/head:pull/3604` \
`$ git checkout pull/3604`

Update a local copy of the PR: \
`$ git checkout pull/3604` \
`$ git pull https://git.openjdk.java.net/jdk pull/3604/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3604`

View PR using the GUI difftool: \
`$ git pr show -t 3604`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3604.diff">https://git.openjdk.java.net/jdk/pull/3604.diff</a>

</details>
