### PR TITLE
8265690: Use the latest Ubuntu base image version in Docker testing

### DIFF
--- a/test/lib/jdk/test/lib/containers/docker/DockerfileConfig.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerfileConfig.java
@@ -52,7 +52,7 @@ public class DockerfileConfig {
             case "s390x":
                 return "s390x/ubuntu";
             default:
-                return "oraclelinux";
+                return "ubuntu";
         }
     }
 
@@ -63,13 +63,6 @@ public class DockerfileConfig {
             return version;
         }
 
-        switch (Platform.getOsArch()) {
-            case "aarch64":
-            case "ppc64le":
-            case "s390x":
-                return "latest";
-            default:
-                return "7.6";
-        }
+        return "latest";
     }
 }


### PR DESCRIPTION
Use latest Ubuntu base image to get latest glibc, so that host-built JDK has a higher chance to pass. Current "oraclelinux:7.6" image apparently has glibc 2.27. Please see the bug for more discussion.

Additional testing:
 - [x] `hotspot_containers` tests on Ubuntu 20.04 (glibc 2.31) -- used to fail, now passes
 - [x] `hotspot_containers` tests on Debian 9 (glibc 2.24) -- continues to pass
 - [x] `hotspot_containers` tests on Centos 7 (glibc 2.17) -- continues to pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265690](https://bugs.openjdk.java.net/browse/JDK-8265690): Use the latest Ubuntu base image version in Docker testing


### Reviewers
 * @mgkwill (no known github.com user name / role) ⚠️ Review applies to d36717b5e04959c80d59f922c38242457ba3e357
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3605/head:pull/3605` \
`$ git checkout pull/3605`

Update a local copy of the PR: \
`$ git checkout pull/3605` \
`$ git pull https://git.openjdk.java.net/jdk pull/3605/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3605`

View PR using the GUI difftool: \
`$ git pr show -t 3605`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3605.diff">https://git.openjdk.java.net/jdk/pull/3605.diff</a>

</details>
