### PR TITLE
8171381: [TEST_BUG] [macos] javax/swing/JPopupMenu/7156657/bug7156657.java fails on OS X

### DIFF
--- a/test/jdk/javax/swing/JPopupMenu/7156657/bug7156657.java
+++ b/test/jdk/javax/swing/JPopupMenu/7156657/bug7156657.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.Robot;
-import java.awt.Toolkit;
 import java.awt.Window;
 import java.awt.image.BufferedImage;
 import java.util.concurrent.Callable;
@@ -37,8 +36,6 @@ import javax.swing.JMenuItem;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.SwingUtilities;
-
-import sun.awt.SunToolkit;
 
 /*
    @test
@@ -58,7 +55,6 @@ public class bug7156657 {
 
     public static void main(String[] args) throws Exception {
         final Robot robot = new Robot();
-        final SunToolkit toolkit = ((SunToolkit) Toolkit.getDefaultToolkit());
 
         Boolean skipTest = Util.invokeOnEDT(new Callable<Boolean>() {
             @Override
@@ -94,7 +90,7 @@ public class bug7156657 {
             return;
         }
 
-        toolkit.realSync();
+        robot.waitForIdle();
 
         SwingUtilities.invokeAndWait(new Runnable() {
             @Override
@@ -103,7 +99,7 @@ public class bug7156657 {
             }
         });
 
-        toolkit.realSync();
+        robot.waitForIdle();
 
         Rectangle popupRectangle = Util.invokeOnEDT(new Callable<Rectangle>() {
             @Override
@@ -121,7 +117,7 @@ public class bug7156657 {
             }
         });
 
-        toolkit.realSync();
+        robot.waitForIdle();
 
         BufferedImage greenBackgroundCapture = robot.createScreenCapture(popupRectangle);
 

--- a/test/jdk/javax/swing/JPopupMenu/7156657/bug7156657.java
+++ b/test/jdk/javax/swing/JPopupMenu/7156657/bug7156657.java
@@ -44,7 +44,6 @@ import javax.swing.SwingUtilities;
    @summary Version 7 doesn't support translucent popup menus against a
             translucent window
    @library ../../regtesthelpers
-   @modules java.desktop/sun.awt
 */
 public class bug7156657 {
     private static JFrame lowerFrame;


### PR DESCRIPTION
Replaces usage of SunToolkit.realSync() with Robot.waitForIdle()

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8171381](https://bugs.openjdk.java.net/browse/JDK-8171381): [TEST_BUG] [macos] javax/swing/JPopupMenu/7156657/bug7156657.java fails on OS X


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3606/head:pull/3606` \
`$ git checkout pull/3606`

Update a local copy of the PR: \
`$ git checkout pull/3606` \
`$ git pull https://git.openjdk.java.net/jdk pull/3606/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3606`

View PR using the GUI difftool: \
`$ git pr show -t 3606`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3606.diff">https://git.openjdk.java.net/jdk/pull/3606.diff</a>

</details>
