### PR TITLE
8265699: (bf) Scopes passed to ScopedMemoryAccess.copy[Swap]Memory in incorrect order

### DIFF
--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -548,7 +548,8 @@ class Direct$Type$Buffer$RW$$BO$
         assert (pos <= lim);
         int rem = (pos <= lim ? lim - pos : 0);
         try {
-            SCOPED_MEMORY_ACCESS.copyMemory(scope(), scope(), null,
+            // null is passed as destination Scope to avoid checking scope() twice
+            SCOPED_MEMORY_ACCESS.copyMemory(scope(), null, null,
                     ix(pos), null, ix(0), (long)rem << $LG_BYTES_PER_VALUE$);
         } finally {
             Reference.reachabilityFence(this);

--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -481,7 +481,7 @@ class Direct$Type$Buffer$RW$$BO$
             try {
 #if[!byte]
                 if (order() != ByteOrder.nativeOrder())
-                    SCOPED_MEMORY_ACCESS.copySwapMemory(scope(), null, src,
+                    SCOPED_MEMORY_ACCESS.copySwapMemory(null, scope(), src,
                                           srcOffset,
                                           null,
                                           ix(pos),
@@ -489,7 +489,7 @@ class Direct$Type$Buffer$RW$$BO$
                                           (long)1 << $LG_BYTES_PER_VALUE$);
                 else
 #end[!byte]
-                    SCOPED_MEMORY_ACCESS.copyMemory(scope(), null, src,
+                    SCOPED_MEMORY_ACCESS.copyMemory(null, scope(), src,
                                       srcOffset,
                                       null,
                                       ix(pos),
@@ -518,7 +518,7 @@ class Direct$Type$Buffer$RW$$BO$
             try {
 #if[!byte]
                 if (order() != ByteOrder.nativeOrder())
-                    SCOPED_MEMORY_ACCESS.copySwapMemory(scope(), null, src,
+                    SCOPED_MEMORY_ACCESS.copySwapMemory(null, scope(), src,
                                           srcOffset,
                                           null,
                                           ix(index),
@@ -527,7 +527,7 @@ class Direct$Type$Buffer$RW$$BO$
                 else
 #end[!byte]
                     SCOPED_MEMORY_ACCESS.copyMemory(
-                            scope(), null, src,
+                            null, scope(), src,
                             srcOffset, null, ix(index), (long)length << $LG_BYTES_PER_VALUE$);
             } finally {
                 Reference.reachabilityFence(this);
@@ -548,7 +548,7 @@ class Direct$Type$Buffer$RW$$BO$
         assert (pos <= lim);
         int rem = (pos <= lim ? lim - pos : 0);
         try {
-            SCOPED_MEMORY_ACCESS.copyMemory(scope(), null, null,
+            SCOPED_MEMORY_ACCESS.copyMemory(scope(), scope(), null,
                     ix(pos), null, ix(0), (long)rem << $LG_BYTES_PER_VALUE$);
         } finally {
             Reference.reachabilityFence(this);

--- a/src/java.base/share/classes/java/nio/X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/X-Buffer.java.template
@@ -1058,7 +1058,7 @@ public abstract class $Type$Buffer
 #end[!byte]
                 try {
                     SCOPED_MEMORY_ACCESS.copyMemory(
-                            scope(), src.scope(), srcBase,
+                            src.scope(), scope(), srcBase,
                             srcAddr, base, addr, len);
                 } finally {
                     Reference.reachabilityFence(src);
@@ -1068,7 +1068,7 @@ public abstract class $Type$Buffer
             } else {
                 try {
                     SCOPED_MEMORY_ACCESS.copySwapMemory(
-                            scope(), src.scope(), srcBase,
+                            src.scope(), scope(), srcBase,
                             srcAddr, base, addr, len, (long)1 << $LG_BYTES_PER_VALUE$);
                 } finally {
                     Reference.reachabilityFence(src);


### PR DESCRIPTION
Please consider this request to correct what appear to be `jdk.internal.misc.ScopedMemoryAccess$Scope`s passed in incorrect order to the `copyMemory()` and `copySwapMemory()` methods of `jdk.internal.misc.ScopedMemoryAccess` in some of the `java.nio.Buffer` bulk transfer methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265699](https://bugs.openjdk.java.net/browse/JDK-8265699): (bf) Scopes passed to ScopedMemoryAccess.copy[Swap]Memory in incorrect order


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3607/head:pull/3607` \
`$ git checkout pull/3607`

Update a local copy of the PR: \
`$ git checkout pull/3607` \
`$ git pull https://git.openjdk.java.net/jdk pull/3607/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3607`

View PR using the GUI difftool: \
`$ git pr show -t 3607`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3607.diff">https://git.openjdk.java.net/jdk/pull/3607.diff</a>

</details>
