### PR TITLE
8265702: ZGC on macOS/aarch64

### DIFF
--- a/make/autoconf/jvm-features.m4
+++ b/make/autoconf/jvm-features.m4
@@ -400,7 +400,8 @@ AC_DEFUN_ONCE([JVM_FEATURES_CHECK_ZGC],
       fi
     elif test "x$OPENJDK_TARGET_CPU" = "xaarch64"; then
       if test "x$OPENJDK_TARGET_OS" = "xlinux" || \
-          test "x$OPENJDK_TARGET_OS" = "xwindows"; then
+          test "x$OPENJDK_TARGET_OS" = "xwindows" || \
+          test "x$OPENJDK_TARGET_OS" = "xmacosx"; then
         AC_MSG_RESULT([yes])
       else
         AC_MSG_RESULT([no, $OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU])

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2146,7 +2146,7 @@ uint os::processor_id() {
   assert(processor_id >= 0 && processor_id < os::processor_count(), "invalid processor id");
 
   return (uint)processor_id;
-#else
+#else // defined(__APPLE__) && defined(__x86_64__)
   // Return 0 until we find a good way to get the current processor id on
   // the platform. Returning 0 is safe, since there is always at least one
   // processor, but might not be optimal for performance in some cases.

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -128,7 +128,7 @@ static jlong initial_time_count=0;
 
 static int clock_tics_per_sec = 100;
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && defined(__x86_64__)
 static const int processor_id_unassigned = -1;
 static const int processor_id_assigning = -2;
 static const int processor_id_map_size = 256;
@@ -238,7 +238,7 @@ void os::Bsd::initialize_system_info() {
     set_processor_count(1);   // fallback
   }
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && defined(__x86_64__)
   // initialize processor id map
   for (int i = 0; i < processor_id_map_size; i++) {
     processor_id_map[i] = processor_id_unassigned;
@@ -2114,8 +2114,8 @@ int os::active_processor_count() {
   return _processor_count;
 }
 
-#if defined(__APPLE__) && defined(__x86_64__)
 uint os::processor_id() {
+#if defined(__APPLE__) && defined(__x86_64__)
   // Get the initial APIC id and return the associated processor id. The initial APIC
   // id is limited to 8-bits, which means we can have at most 256 unique APIC ids. If
   // the system has more processors (or the initial APIC ids are discontiguous) the
@@ -2146,8 +2146,13 @@ uint os::processor_id() {
   assert(processor_id >= 0 && processor_id < os::processor_count(), "invalid processor id");
 
   return (uint)processor_id;
-}
+#else
+  // Return 0 until we find a good way to get the current processor id on
+  // the platform. Returning 0 is safe, since there is always at least one
+  // processor, but might not be optimal for performance in some cases.
+  return 0;
 #endif
+}
 
 void os::set_native_thread_name(const char *name) {
 #if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > MAC_OS_X_VERSION_10_5

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -1377,7 +1377,7 @@ address OptoRuntime::handle_exception_C(JavaThread* current) {
   // deoptimized frame
 
   if (nm != NULL) {
-    RegisterMap map(current, false);
+    RegisterMap map(current, false /* update_map */, false /* process_frames */);
     frame caller = current->last_frame().sender(&map);
 #ifdef ASSERT
     assert(caller.is_compiled_frame(), "must be");


### PR DESCRIPTION
This patch enables ZGC on macOS/aarch64. It does three things:
1) Enables building of ZGC on this platform.
2) Adds `os::processor_id()`, which for now always returns 0.
3) Fixes a WX issue in `OptoRuntime::handle_exception_C()`, where the stackwater mark might unnecessarily process a frame when the thread is in WXExec mode. In this case, the we're not touching any oops, so we don't need to process any frames.

Testing: Passes the same tests as macOS/x86_64 (with the exception of pre-existing issues unrelated to ZGC).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265702](https://bugs.openjdk.java.net/browse/JDK-8265702): ZGC on macOS/aarch64


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to c8913936aff026987c427f9a268def715b2eac0f
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to c8913936aff026987c427f9a268def715b2eac0f
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to c8913936aff026987c427f9a268def715b2eac0f
 * [Gerard Ziemski](https://openjdk.java.net/census#gziemski) (@gerard-ziemski - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3609/head:pull/3609` \
`$ git checkout pull/3609`

Update a local copy of the PR: \
`$ git checkout pull/3609` \
`$ git pull https://git.openjdk.java.net/jdk pull/3609/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3609`

View PR using the GUI difftool: \
`$ git pr show -t 3609`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3609.diff">https://git.openjdk.java.net/jdk/pull/3609.diff</a>

</details>
