### PR TITLE
8198617: java/awt/Focus/6382144/EndlessLoopTest.java fails on mac

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -196,7 +196,6 @@ java/awt/EventDispatchThread/LoopRobustness/LoopRobustness.java 8073636 macosx-a
 java/awt/FullScreen/FullScreenInsets/FullScreenInsets.java 7019055 windows-all,linux-all
 java/awt/Focus/8013611/JDK8013611.java 8175366 windows-all,macosx-all
 java/awt/Focus/6378278/InputVerifierTest.java 8198616 macosx-all
-java/awt/Focus/6382144/EndlessLoopTest.java 8198617 macosx-all
 java/awt/Focus/6981400/Test1.java 8029675 windows-all,macosx-all
 java/awt/Focus/8073453/AWTFocusTransitionTest.java 8136517 macosx-all
 java/awt/Focus/8073453/SwingFocusTransitionTest.java 8136517 macosx-all

--- a/test/jdk/java/awt/Focus/6382144/EndlessLoopTest.java
+++ b/test/jdk/java/awt/Focus/6382144/EndlessLoopTest.java
@@ -97,7 +97,6 @@ public class EndlessLoopTest
                 });
                 JTextField t2 = new JTextField();
 
-
                 frame.getContentPane().add(t1, BorderLayout.NORTH);
                 frame.getContentPane().add(t2, BorderLayout.SOUTH);
                 frame.setLocationRelativeTo(null);
@@ -139,7 +138,7 @@ public class EndlessLoopTest
             }
 
             EndlessLoopTest.pass();
-	} finally {
+        } finally {
             SwingUtilities.invokeAndWait(() -> {
                 if (frame != null) {
                     frame.dispose();

--- a/test/jdk/java/awt/Focus/6382144/EndlessLoopTest.java
+++ b/test/jdk/java/awt/Focus/6382144/EndlessLoopTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
   @key headful
   @bug 6382144
   @summary REGRESSION: InputVerifier and JOptionPane
-  @author oleg.sukhodolsky: area=awt.focus
   @run main EndlessLoopTest
 */
 
@@ -57,81 +56,96 @@ import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
 
 public class EndlessLoopTest
 {
 
     //*** test-writer defined static variables go here ***
     static volatile int n_iv_calls;
+    static JFrame frame;
+    static JTextField t1;
+    static JButton button;
 
-
-    private static void init()
+    private static void init() throws Exception
     {
         //*** Create instructions for the user here ***
 
-        JFrame frame = new JFrame();
-        final JDialog dialog = new JDialog(frame, true);
-        JButton button = new JButton("press me");
-        button.addActionListener(new ActionListener() {
-                public void actionPerformed(ActionEvent ae) {
-                    dialog.dispose();
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame();
+                final JDialog dialog = new JDialog(frame, true);
+                button = new JButton("press me");
+                button.addActionListener(new ActionListener() {
+                    public void actionPerformed(ActionEvent ae) {
+                        dialog.dispose();
+                    }
+                });
+                dialog.getContentPane().add(button);
+                dialog.setLocationRelativeTo(null);
+                dialog.pack();
+
+                t1 = new JTextField();
+                t1.setInputVerifier(new InputVerifier() {
+                    public boolean verify(JComponent input) {
+                        n_iv_calls++;
+                        if (n_iv_calls == 1) {
+                            dialog.setVisible(true);
+                        }
+                        return true;
+                    }
+                });
+                JTextField t2 = new JTextField();
+
+
+                frame.getContentPane().add(t1, BorderLayout.NORTH);
+                frame.getContentPane().add(t2, BorderLayout.SOUTH);
+                frame.setLocationRelativeTo(null);
+                frame.setSize(200, 200);
+                frame.setVisible(true);
+            });
+
+            Robot r = null;
+            try {
+                r = new Robot();
+            } catch (AWTException e) {
+                EndlessLoopTest.fail(e);
+            }
+
+            try {
+                r.setAutoDelay(100);
+                r.waitForIdle();
+                r.delay(1000);
+
+                mouseClickOnComp(r, t1);
+                r.waitForIdle();
+
+                if (!t1.isFocusOwner()) {
+                    throw new RuntimeException("t1 is not a focus owner");
+                }
+                n_iv_calls = 0;
+                r.keyPress(KeyEvent.VK_TAB);
+                r.keyRelease(KeyEvent.VK_TAB);
+                r.waitForIdle();
+
+                mouseClickOnComp(r, button);
+                r.waitForIdle();
+            } catch (Exception e) {
+                EndlessLoopTest.fail(e);
+            }
+
+            if (n_iv_calls != 1) {
+                EndlessLoopTest.fail(new RuntimeException("InputVerifier was called " + n_iv_calls + " times"));
+            }
+
+            EndlessLoopTest.pass();
+	} finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
                 }
             });
-        dialog.getContentPane().add(button);
-        dialog.pack();
-
-        JTextField t1 = new JTextField();
-        t1.setInputVerifier(new InputVerifier() {
-            public boolean verify(JComponent input) {
-                n_iv_calls++;
-                if (n_iv_calls == 1) {
-                    dialog.setVisible(true);
-                }
-                return true;
-            }
-        });
-        JTextField t2 = new JTextField();
-
-
-        frame.getContentPane().add(t1, BorderLayout.NORTH);
-        frame.getContentPane().add(t2, BorderLayout.SOUTH);
-        frame.setSize(200, 200);
-        frame.setVisible(true);
-
-        Robot r = null;
-        try {
-            r = new Robot();
-        } catch (AWTException e) {
-            EndlessLoopTest.fail(e);
         }
-
-        try {
-            r.waitForIdle();
-
-            mouseClickOnComp(r, t1);
-            r.waitForIdle();
-
-            if (!t1.isFocusOwner()) {
-                throw new RuntimeException("t1 is not a focus owner");
-            }
-            n_iv_calls = 0;
-            r.keyPress(KeyEvent.VK_TAB);
-            r.delay(10);
-            r.keyRelease(KeyEvent.VK_TAB);
-            r.waitForIdle();
-
-            mouseClickOnComp(r, button);
-            r.waitForIdle();
-        } catch (Exception e) {
-            EndlessLoopTest.fail(e);
-        }
-
-        if (n_iv_calls != 1) {
-            EndlessLoopTest.fail(new RuntimeException("InputVerifier was called " + n_iv_calls + " times"));
-        }
-
-        EndlessLoopTest.pass();
-
     }//End  init()
 
 
@@ -140,10 +154,9 @@ public class EndlessLoopTest
         loc.x += comp.getWidth() / 2;
         loc.y += comp.getHeight() / 2;
         r.mouseMove(loc.x, loc.y);
-        r.delay(10);
-        r.mousePress(InputEvent.BUTTON1_MASK);
-        r.delay(10);
-        r.mouseRelease(InputEvent.BUTTON1_MASK);
+        r.waitForIdle();
+        r.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        r.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
     }
 
     /*****************************************************
@@ -170,7 +183,7 @@ public class EndlessLoopTest
     //  instantiated in the same VM.  Being static (and using
     //  static vars), it aint gonna work.  Not worrying about
     //  it for now.
-    public static void main( String args[] ) throws InterruptedException
+    public static void main( String args[] ) throws Exception
     {
         mainThread = Thread.currentThread();
         try


### PR DESCRIPTION
This test was failing earlier in our nightly testing citing "java.lang.RuntimeException: java.awt.IllegalComponentStateException: component must be showing on the screen to determine its location "
Updated test to 
use swing components in EDT, 
setAutoDelay for mouse events, 
add a delay after frame is made visible,
move the frame to center of screen 
and dispose of the frame finally.

Several iterations of the test pass in all platforms. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8198617](https://bugs.openjdk.java.net/browse/JDK-8198617): java/awt/Focus/6382144/EndlessLoopTest.java fails on mac


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3614/head:pull/3614` \
`$ git checkout pull/3614`

Update a local copy of the PR: \
`$ git checkout pull/3614` \
`$ git pull https://git.openjdk.java.net/jdk pull/3614/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3614`

View PR using the GUI difftool: \
`$ git pr show -t 3614`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3614.diff">https://git.openjdk.java.net/jdk/pull/3614.diff</a>

</details>
