### PR TITLE
8265518: C1: Intrinsic support for Preconditions.checkIndex

### DIFF
--- a/src/hotspot/share/c1/c1_Compiler.cpp
+++ b/src/hotspot/share/c1/c1_Compiler.cpp
@@ -207,7 +207,8 @@ bool Compiler::is_intrinsic_supported(const methodHandle& method) {
   case vmIntrinsics::_putCharUnaligned:
   case vmIntrinsics::_putIntUnaligned:
   case vmIntrinsics::_putLongUnaligned:
-  case vmIntrinsics::_checkIndex:
+  case vmIntrinsics::_Preconditions_checkIndex:
+  case vmIntrinsics::_Preconditions_checkLongIndex:
   case vmIntrinsics::_updateCRC32:
   case vmIntrinsics::_updateBytesCRC32:
   case vmIntrinsics::_updateByteBufferCRC32:

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1878,6 +1878,8 @@ void LIRGenerator::do_PreconditionsCheckIndex(Intrinsic* x, BasicType type) {
       len = LIR_OprFact::longConst(length.result()->as_jlong());
     }
   }
+  // C1 can not handle the case that comparing index with constant value while condition
+  // is neither lir_cond_equal nor lir_cond_notEqual, see LIR_Assembler::comp_op.
   LIR_Opr zero_reg = new_register(type);
   __ move(zero, zero_reg);
 #if defined(X86) && !defined(_LP64)

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -485,22 +485,6 @@ void LIRGenerator::array_range_check(LIR_Opr array, LIR_Opr index,
   }
 }
 
-
-void LIRGenerator::nio_range_check(LIR_Opr buffer, LIR_Opr index, LIR_Opr result, CodeEmitInfo* info) {
-  CodeStub* stub = new RangeCheckStub(info, index);
-  if (index->is_constant()) {
-    cmp_mem_int(lir_cond_belowEqual, buffer, java_nio_Buffer::limit_offset(), index->as_jint(), info);
-    __ branch(lir_cond_belowEqual, stub); // forward branch
-  } else {
-    cmp_reg_mem(lir_cond_aboveEqual, index, buffer,
-                java_nio_Buffer::limit_offset(), T_INT, info);
-    __ branch(lir_cond_aboveEqual, stub); // forward branch
-  }
-  __ move(index, result);
-}
-
-
-
 void LIRGenerator::arithmetic_op(Bytecodes::Code code, LIR_Opr result, LIR_Opr left, LIR_Opr right, LIR_Opr tmp_op, CodeEmitInfo* info) {
   LIR_Opr result_op = result;
   LIR_Opr left_op   = left;
@@ -1859,39 +1843,43 @@ void LIRGenerator::do_LoadField(LoadField* x) {
                  info ? new CodeEmitInfo(info) : NULL, info);
 }
 
+// int/long jdk.internal.util.Preconditions.checkIndex
+void LIRGenerator::do_PreconditionsCheckIndex(Intrinsic* x, BasicType type) {
+  assert(x->number_of_arguments() == 3, "wrong type");
+  LIRItem index(x->argument_at(0), this);
+  LIRItem length(x->argument_at(1), this);
+  LIRItem oobef(x->argument_at(2), this);
 
-//------------------------java.nio.Buffer.checkIndex------------------------
-
-// int java.nio.Buffer.checkIndex(int)
-void LIRGenerator::do_NIOCheckIndex(Intrinsic* x) {
-  // NOTE: by the time we are in checkIndex() we are guaranteed that
-  // the buffer is non-null (because checkIndex is package-private and
-  // only called from within other methods in the buffer).
-  assert(x->number_of_arguments() == 2, "wrong type");
-  LIRItem buf  (x->argument_at(0), this);
-  LIRItem index(x->argument_at(1), this);
-  buf.load_item();
   index.load_item();
+  length.load_item();
+  oobef.load_item();
 
   LIR_Opr result = rlock_result(x);
-  if (GenerateRangeChecks) {
-    CodeEmitInfo* info = state_for(x);
-    CodeStub* stub = new RangeCheckStub(info, index.result());
-    if (index.result()->is_constant()) {
-      cmp_mem_int(lir_cond_belowEqual, buf.result(), java_nio_Buffer::limit_offset(), index.result()->as_jint(), info);
-      __ branch(lir_cond_belowEqual, stub);
-    } else {
-      cmp_reg_mem(lir_cond_aboveEqual, index.result(), buf.result(),
-                  java_nio_Buffer::limit_offset(), T_INT, info);
-      __ branch(lir_cond_aboveEqual, stub);
-    }
-    __ move(index.result(), result);
-  } else {
-    // Just load the index into the result register
-    __ move(index.result(), result);
+  // x->state() is created from copy_state_for_exception, it does not contains arguments
+  // we should prepare them before entering into interpreter mode due to deoptimization.
+  ValueStack* state = x->state();
+  for (int i = 0; i < x->number_of_arguments(); i++) {
+    Value arg = x->argument_at(i);
+    state->push(arg->type(), arg);
   }
-}
+  CodeEmitInfo* info = state_for(x, state);
+  CodeStub* deopt = new DeoptimizeStub(info, Deoptimization::Reason_range_check,
+                                       Deoptimization::Action_make_not_entrant);
 
+  if (length.result()->is_constant()) {
+    if (type == T_INT) {
+      __ cmp(lir_cond_aboveEqual, index.result(), LIR_OprFact::intConst(length.result()->as_jint()));
+    } else {
+      assert(type == T_LONG, "sanity check");
+      __ cmp(lir_cond_aboveEqual, index.result(), LIR_OprFact::longConst(length.result()->as_jlong()));
+    }
+    __ branch(lir_cond_aboveEqual, deopt);
+  } else {
+    __ cmp(lir_cond_belowEqual, length.result(), index.result());
+    __ branch(lir_cond_belowEqual, deopt);
+  }
+  __ move(index.result(), result);
+}
 
 //------------------------array access--------------------------------------
 
@@ -3115,8 +3103,12 @@ void LIRGenerator::do_Intrinsic(Intrinsic* x) {
   case vmIntrinsics::_fmaD:           do_FmaIntrinsic(x); break;
   case vmIntrinsics::_fmaF:           do_FmaIntrinsic(x); break;
 
-  // java.nio.Buffer.checkIndex
-  case vmIntrinsics::_checkIndex:     do_NIOCheckIndex(x); break;
+  case vmIntrinsics::_Preconditions_checkIndex:
+    do_PreconditionsCheckIndex(x, T_INT);
+    break;
+  case vmIntrinsics::_Preconditions_checkLongIndex:
+    do_PreconditionsCheckIndex(x, T_LONG);
+    break;
 
   case vmIntrinsics::_compareAndSetReference:
     do_CompareAndSwap(x, objectType);

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1869,13 +1869,13 @@ void LIRGenerator::do_PreconditionsCheckIndex(Intrinsic* x, BasicType type) {
   if (length.result()->is_constant()) {
 #if defined(X86) && !defined(_LP64)
     // BEWARE! On 32-bit x86 cmp clobbers its left argument so we need a temp copy.
-    LIR_Opr index_copy = new_register(index->type());
-    __ move(index, index_copy);
+    LIR_Opr index_copy = new_register(index.type());
+    __ move(index.result(), index_copy);
     if (type == T_INT) {
-      __ cmp(lir_cond_aboveEqual, index_copy.result(), LIR_OprFact::intConst(length.result()->as_jint()));
+      __ cmp(lir_cond_aboveEqual, index_copy, LIR_OprFact::intConst(length.result()->as_jint()));
     } else {
       assert(type == T_LONG, "sanity check");
-      __ cmp(lir_cond_aboveEqual, index_copy.result(), LIR_OprFact::longConst(length.result()->as_jlong()));
+      __ cmp(lir_cond_aboveEqual, index_copy, LIR_OprFact::longConst(length.result()->as_jlong()));
     }
 #else
     if (type == T_INT) {

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1887,8 +1887,15 @@ void LIRGenerator::do_PreconditionsCheckIndex(Intrinsic* x, BasicType type) {
 #endif
     __ branch(lir_cond_aboveEqual, deopt);
   } else {
-    __ cmp(lir_cond_belowEqual, length.result(), index.result());
-    __ branch(lir_cond_belowEqual, deopt);
+#if defined(X86) && !defined(_LP64)
+    // BEWARE! On 32-bit x86 cmp clobbers its left argument so we need a temp copy.
+    LIR_Opr index_copy = new_register(index.type());
+    __ move(index.result(), index_copy);
+    __ cmp(lir_cond_aboveEqual, index_copy, length.result());
+#else
+    __ cmp(lir_cond_aboveEqual, index.result(), length.result());
+#endif
+    __ branch(lir_cond_aboveEqual, deopt);
   }
   __ move(index.result(), result);
 }

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1878,22 +1878,24 @@ void LIRGenerator::do_PreconditionsCheckIndex(Intrinsic* x, BasicType type) {
       len = LIR_OprFact::longConst(length.result()->as_jlong());
     }
   }
+  LIR_Opr zero_reg = new_register(type);
+  __ move(zero, zero_reg);
 #if defined(X86) && !defined(_LP64)
   // BEWARE! On 32-bit x86 cmp clobbers its left argument so we need a temp copy.
   LIR_Opr index_copy = new_register(index.type());
   // index >= 0
   __ move(index.result(), index_copy);
-  __ cmp(lir_cond_less, index_copy, zero);
+  __ cmp(lir_cond_less, index_copy, zero_reg);
   __ branch(lir_cond_less, new DeoptimizeStub(info, Deoptimization::Reason_range_check,
                                                     Deoptimization::Action_make_not_entrant));
   // index < length
   __ move(index.result(), index_copy);
   __ cmp(lir_cond_greaterEqual, index_copy, len);
   __ branch(lir_cond_greaterEqual, new DeoptimizeStub(info, Deoptimization::Reason_range_check,
-                                                          Deoptimization::Action_make_not_entrant));
+                                                            Deoptimization::Action_make_not_entrant));
 #else
   // index >= 0
-  __ cmp(lir_cond_less, index.result(), zero);
+  __ cmp(lir_cond_less, index.result(), zero_reg);
   __ branch(lir_cond_less, new DeoptimizeStub(info, Deoptimization::Reason_range_check,
                                                     Deoptimization::Action_make_not_entrant));
   // index < length

--- a/src/hotspot/share/c1/c1_LIRGenerator.hpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.hpp
@@ -260,7 +260,7 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
   void do_LibmIntrinsic(Intrinsic* x);
   void do_ArrayCopy(Intrinsic* x);
   void do_CompareAndSwap(Intrinsic* x, ValueType* type);
-  void do_NIOCheckIndex(Intrinsic* x);
+  void do_PreconditionsCheckIndex(Intrinsic* x, BasicType type);
   void do_FPIntrinsics(Intrinsic* x);
   void do_Reference_get(Intrinsic* x);
   void do_update_CRC32(Intrinsic* x);
@@ -348,8 +348,6 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
 
   // this loads the length and compares against the index
   void array_range_check          (LIR_Opr array, LIR_Opr index, CodeEmitInfo* null_check_info, CodeEmitInfo* range_check_info);
-  // For java.nio.Buffer.checkIndex
-  void nio_range_check            (LIR_Opr buffer, LIR_Opr index, LIR_Opr result, CodeEmitInfo* info);
 
   void arithmetic_op_int  (Bytecodes::Code code, LIR_Opr result, LIR_Opr left, LIR_Opr right, LIR_Opr tmp);
   void arithmetic_op_long (Bytecodes::Code code, LIR_Opr result, LIR_Opr left, LIR_Opr right, CodeEmitInfo* info = NULL);

--- a/src/hotspot/share/c1/c1_globals.hpp
+++ b/src/hotspot/share/c1/c1_globals.hpp
@@ -153,9 +153,6 @@
   product(bool, InlineSynchronizedMethods, true,                            \
           "Inline synchronized methods")                                    \
                                                                             \
-  product(bool, InlineNIOCheckIndex, true, DIAGNOSTIC,                      \
-          "Intrinsify java.nio.Buffer.checkIndex")                          \
-                                                                            \
   develop(bool, CanonicalizeNodes, true,                                    \
           "Canonicalize graph nodes")                                       \
                                                                             \

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -4653,9 +4653,6 @@ void java_lang_AssertionStatusDirectives::set_deflt(oop o, bool val) {
   o->bool_field_put(_deflt_offset, val);
 }
 
-
-// Support for intrinsification of java.nio.Buffer.checkIndex
-
 int java_nio_Buffer::_limit_offset;
 
 #define BUFFER_FIELDS_DO(macro) \

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -4653,23 +4653,6 @@ void java_lang_AssertionStatusDirectives::set_deflt(oop o, bool val) {
   o->bool_field_put(_deflt_offset, val);
 }
 
-int java_nio_Buffer::_limit_offset;
-
-#define BUFFER_FIELDS_DO(macro) \
-  macro(_limit_offset, k, "limit", int_signature, false)
-
-void java_nio_Buffer::compute_offsets() {
-  InstanceKlass* k = vmClasses::nio_Buffer_klass();
-  assert(k != NULL, "must be loaded in 1.4+");
-  BUFFER_FIELDS_DO(FIELD_COMPUTE_OFFSET);
-}
-
-#if INCLUDE_CDS
-void java_nio_Buffer::serialize_offsets(SerializeClosure* f) {
-  BUFFER_FIELDS_DO(FIELD_SERIALIZE_OFFSET);
-}
-#endif
-
 int java_util_concurrent_locks_AbstractOwnableSynchronizer::_owner_offset;
 
 #define AOS_FIELDS_DO(macro) \

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -66,7 +66,6 @@ class RecordComponent;
   f(java_lang_reflect_Constructor) \
   f(java_lang_reflect_Field) \
   f(java_lang_reflect_RecordComponent) \
-  f(java_nio_Buffer) \
   f(reflect_ConstantPool) \
   f(reflect_UnsafeStaticFieldAccessorImpl) \
   f(java_lang_reflect_Parameter) \
@@ -1586,15 +1585,6 @@ class java_lang_AssertionStatusDirectives: AllStatic {
   friend class JavaClasses;
 };
 
-
-class java_nio_Buffer: AllStatic {
- private:
-  static int _limit_offset;
-
- public:
-  static void compute_offsets();
-  static void serialize_offsets(SerializeClosure* f) NOT_CDS_RETURN;
-};
 
 class java_util_concurrent_locks_AbstractOwnableSynchronizer : AllStatic {
  private:

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -1592,7 +1592,6 @@ class java_nio_Buffer: AllStatic {
   static int _limit_offset;
 
  public:
-  static int  limit_offset() { CHECK_INIT(_limit_offset); }
   static void compute_offsets();
   static void serialize_offsets(SerializeClosure* f) NOT_CDS_RETURN;
 };

--- a/src/hotspot/share/classfile/vmIntrinsics.cpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.cpp
@@ -88,7 +88,8 @@ bool vmIntrinsics::preserves_state(vmIntrinsics::ID id) {
   case vmIntrinsics::_dlog10:
   case vmIntrinsics::_dexp:
   case vmIntrinsics::_dpow:
-  case vmIntrinsics::_checkIndex:
+  case vmIntrinsics::_Preconditions_checkIndex:
+  case vmIntrinsics::_Preconditions_checkLongIndex:
   case vmIntrinsics::_Reference_get:
   case vmIntrinsics::_updateCRC32:
   case vmIntrinsics::_updateBytesCRC32:
@@ -467,11 +468,6 @@ bool vmIntrinsics::disabled_by_jvm_flags(vmIntrinsics::ID id) {
   case vmIntrinsics::_copyMemory:
     if (!InlineArrayCopy || !InlineUnsafeOps) return true;
     break;
-#ifdef COMPILER1
-  case vmIntrinsics::_checkIndex:
-    if (!InlineNIOCheckIndex) return true;
-    break;
-#endif // COMPILER1
 #ifdef COMPILER2
   case vmIntrinsics::_clone:
   case vmIntrinsics::_copyOf:

--- a/src/hotspot/share/classfile/vmIntrinsics.hpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.hpp
@@ -341,10 +341,6 @@ class methodHandle;
   do_intrinsic(_Preconditions_checkLongIndex, jdk_internal_util_Preconditions, checkIndex_name, Preconditions_checkLongIndex_signature, F_S)   \
    do_signature(Preconditions_checkLongIndex_signature,          "(JJLjava/util/function/BiFunction;)J")                \
                                                                                                                         \
-  do_class(java_nio_Buffer,               "java/nio/Buffer")                                                            \
-  do_intrinsic(_checkIndex,               java_nio_Buffer,        checkIndex_name, int_int_signature,            F_R)   \
-   do_name(     checkIndex_name,                                 "checkIndex")                                          \
-                                                                                                                        \
   do_class(java_lang_StringCoding,        "java/lang/StringCoding")                                                     \
   do_intrinsic(_hasNegatives,             java_lang_StringCoding, hasNegatives_name, hasNegatives_signature,     F_S)   \
    do_name(     hasNegatives_name,                               "hasNegatives")                                        \

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -124,6 +124,7 @@
   template(java_io_FileInputStream,                   "java/io/FileInputStream")                  \
   template(java_io_ByteArrayInputStream,              "java/io/ByteArrayInputStream")             \
   template(java_io_Serializable,                      "java/io/Serializable")                     \
+  template(java_nio_Buffer,                           "java/nio/Buffer")                          \
   template(java_util_Arrays,                          "java/util/Arrays")                         \
   template(java_util_Objects,                         "java/util/Objects")                        \
   template(java_util_Properties,                      "java/util/Properties")                     \
@@ -482,6 +483,7 @@
   template(use_unaligned_access_name,                 "UNALIGNED_ACCESS")                         \
   template(data_cache_line_flush_size_name,           "DATA_CACHE_LINE_FLUSH_SIZE")               \
   template(during_unsafe_access_name,                 "during_unsafe_access")                     \
+  template(checkIndex_name,                           "checkIndex")                               \
                                                                                                   \
   /* name symbols needed by intrinsics */                                                         \
   VM_INTRINSICS_DO(VM_INTRINSIC_IGNORE, VM_SYMBOL_IGNORE, template, VM_SYMBOL_IGNORE, VM_ALIAS_IGNORE) \

--- a/src/java.base/share/classes/java/nio/Buffer.java
+++ b/src/java.base/share/classes/java/nio/Buffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,9 +33,9 @@ import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.misc.VM.BufferPool;
 import jdk.internal.vm.annotation.ForceInline;
-import jdk.internal.vm.annotation.IntrinsicCandidate;
 
 import java.io.FileDescriptor;
+import java.util.Objects;
 import java.util.Spliterator;
 
 /**
@@ -736,11 +736,8 @@ public abstract class Buffer {
      * IndexOutOfBoundsException} if it is not smaller than the limit
      * or is smaller than zero.
      */
-    @IntrinsicCandidate
     final int checkIndex(int i) {                       // package-private
-        if ((i < 0) || (i >= limit))
-            throw new IndexOutOfBoundsException();
-        return i;
+        return Objects.checkIndex(i, limit);
     }
 
     final int checkIndex(int i, int nb) {               // package-private

--- a/test/hotspot/jtreg/compiler/c1/TestCheckIndexC1Intrinsic.java
+++ b/test/hotspot/jtreg/compiler/c1/TestCheckIndexC1Intrinsic.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2021, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @author Yi Yang
+ * @bug 8265518
+ * @summary C1 intrinsic support for jdk.internal.util.Preconditions.checkIndex
+ * @requires vm.compiler1.enabled
+ * @library /test/lib
+ * @modules java.base/jdk.internal.util
+ * @run main/othervm -XX:TieredStopAtLevel=1 -Xbatch
+ *                   -XX:CompileCommand=dontinline,*TestCheckIndexC1Intrinsic.check*
+ *                   -XX:CompileCommand=compileonly,*TestCheckIndexC1Intrinsic.check*
+ *                   compiler.c1.TestCheckIndexC1Intrinsic
+ */
+
+package compiler.c1;
+
+import jdk.test.lib.Asserts;
+import jdk.internal.util.Preconditions;
+
+public class TestCheckIndexC1Intrinsic {
+    static int limit = 100;
+
+    private static class MyException extends RuntimeException {
+        public MyException(String msg) {
+            super(msg);
+        }
+    }
+
+    static void check0() {
+        long res = Preconditions.checkIndex(0, 1, null);
+        Asserts.assertEquals((int)res, 0);
+        try {
+            Preconditions.checkIndex(1, 1, null);
+        } catch (IndexOutOfBoundsException e) {
+            // got it!
+        }
+        try {
+            Preconditions.checkIndex(Integer.MIN_VALUE, -1, null);
+        } catch (IndexOutOfBoundsException e) {
+            // got it!
+        }
+        try {
+            Preconditions.checkIndex(Integer.MIN_VALUE, Integer.MIN_VALUE, null);
+        } catch (IndexOutOfBoundsException e) {
+            // got it!
+        }
+        try {
+            Preconditions.checkIndex(Long.MAX_VALUE, Long.MAX_VALUE, null);
+        } catch (IndexOutOfBoundsException e) {
+            // got it!
+        }
+        res = Preconditions.checkIndex(Long.MAX_VALUE - 1, Long.MAX_VALUE, null);
+        Asserts.assertEquals(res, Long.MAX_VALUE - 1);
+
+        try {
+            // read fields
+            Preconditions.checkIndex(limit + 1, limit, (s, integers) -> new MyException("Reason:" + s +"::" + integers));
+        } catch(MyException e){
+            // got it!
+        }
+    }
+
+    static void check1(int i) {
+        try {
+            Preconditions.checkIndex(i, 9999, (s, integers) -> new RuntimeException("ex"));
+        } catch (RuntimeException e) {
+            Asserts.assertTrue("ex".equals(e.getMessage()));
+        }
+    }
+
+    static void check2(long i) {
+        try {
+            Preconditions.checkIndex(i, 9999L, (s, integers) -> new RuntimeException("ex"));
+        } catch (RuntimeException e) {
+            Asserts.assertTrue("ex".equals(e.getMessage()));
+        }
+    }
+
+    static void check3(int i) {
+        try {
+            Preconditions.checkIndex(i, 9999, null);
+        } catch (IndexOutOfBoundsException e) {
+            // got it!
+        }
+    }
+
+    static void check4(long i) {
+        try {
+            Preconditions.checkIndex(i, 9999L, null);
+        } catch (IndexOutOfBoundsException e) {
+            // got it!
+        }
+    }
+
+    static void check5(int i) {
+        Preconditions.checkIndex(i, 99999, (s, integers) -> new RuntimeException("ex"));
+    }
+
+    static void check6(long i) {
+        Preconditions.checkIndex(i, 99999L, (s, integers) -> new RuntimeException("ex"));
+    }
+
+    static void check7(int i) {
+        Preconditions.checkIndex(i, 99999, null);
+    }
+
+    static void check8(long i) {
+        Preconditions.checkIndex(i, 99999L, null);
+    }
+
+    public static void main(String... args) {
+        for (int i = 0; i < 1_0000; i++) {
+            check0();
+
+            check1(i);
+            check2((long) i);
+            check3(i);
+            check4((long) i);
+
+            check5(i);
+            check6((long) i);
+            check7(i);
+            check8((long) i);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/c1/TestCheckIndexC1Intrinsic.java
+++ b/test/hotspot/jtreg/compiler/c1/TestCheckIndexC1Intrinsic.java
@@ -132,8 +132,16 @@ public class TestCheckIndexC1Intrinsic {
         Preconditions.checkIndex(i, 99999L, null);
     }
 
+    static void check9(int i) {
+        Preconditions.checkIndex(i, i + 1, null);
+    }
+
+    static void check10(long i) {
+        Preconditions.checkIndex(i, i + 1L, null);
+    }
+
     public static void main(String... args) {
-        for (int i = 0; i < 1_0000; i++) {
+        for (int i = 0; i < 10_000; i++) {
             check0();
 
             check1(i);
@@ -145,6 +153,9 @@ public class TestCheckIndexC1Intrinsic {
             check6((long) i);
             check7(i);
             check8((long) i);
+
+            check9(i);
+            check10((long)i);
         }
     }
 }

--- a/test/hotspot/jtreg/compiler/c1/TestCheckIndexC1Intrinsic.java
+++ b/test/hotspot/jtreg/compiler/c1/TestCheckIndexC1Intrinsic.java
@@ -55,21 +55,25 @@ public class TestCheckIndexC1Intrinsic {
         Asserts.assertEquals((int)res, 0);
         try {
             Preconditions.checkIndex(1, 1, null);
+            throw new AssertionError("Expected IndexOutOfBoundsException not thrown");
         } catch (IndexOutOfBoundsException e) {
             // got it!
         }
         try {
             Preconditions.checkIndex(Integer.MIN_VALUE, -1, null);
+            throw new AssertionError("Expected IndexOutOfBoundsException not thrown");
         } catch (IndexOutOfBoundsException e) {
             // got it!
         }
         try {
             Preconditions.checkIndex(Integer.MIN_VALUE, Integer.MIN_VALUE, null);
+            throw new AssertionError("Expected IndexOutOfBoundsException not thrown");
         } catch (IndexOutOfBoundsException e) {
             // got it!
         }
         try {
             Preconditions.checkIndex(Long.MAX_VALUE, Long.MAX_VALUE, null);
+            throw new AssertionError("Expected IndexOutOfBoundsException not thrown");
         } catch (IndexOutOfBoundsException e) {
             // got it!
         }
@@ -78,7 +82,8 @@ public class TestCheckIndexC1Intrinsic {
 
         try {
             // read fields
-            Preconditions.checkIndex(limit + 1, limit, (s, integers) -> new MyException("Reason:" + s +"::" + integers));
+            Preconditions.checkIndex(limit + 1, limit, (s, integers) -> new MyException("Reason:" + s + "::" + integers));
+            throw new AssertionError("Expected IndexOutOfBoundsException not thrown");
         } catch(MyException e){
             // got it!
         }
@@ -104,7 +109,7 @@ public class TestCheckIndexC1Intrinsic {
         try {
             Preconditions.checkIndex(i, 9999, null);
         } catch (IndexOutOfBoundsException e) {
-            // got it!
+            Asserts.assertTrue(i == 9999);
         }
     }
 
@@ -112,7 +117,7 @@ public class TestCheckIndexC1Intrinsic {
         try {
             Preconditions.checkIndex(i, 9999L, null);
         } catch (IndexOutOfBoundsException e) {
-            // got it!
+            Asserts.assertTrue(i == 9999L);
         }
     }
 

--- a/test/hotspot/jtreg/compiler/c1/TestCheckIndexC1Intrinsic.java
+++ b/test/hotspot/jtreg/compiler/c1/TestCheckIndexC1Intrinsic.java
@@ -90,34 +90,65 @@ public class TestCheckIndexC1Intrinsic {
     }
 
     static void check1(int i) {
+        boolean trigger = false;
         try {
             Preconditions.checkIndex(i, 9999, (s, integers) -> new RuntimeException("ex"));
         } catch (RuntimeException e) {
             Asserts.assertTrue("ex".equals(e.getMessage()));
+            trigger = true;
+        } finally {
+            if (trigger) {
+                Asserts.assertTrue(i == 9999L);
+            } else {
+                Asserts.assertTrue(i != 9999L);
+            }
         }
     }
 
     static void check2(long i) {
+        boolean trigger = false;
         try {
             Preconditions.checkIndex(i, 9999L, (s, integers) -> new RuntimeException("ex"));
         } catch (RuntimeException e) {
             Asserts.assertTrue("ex".equals(e.getMessage()));
+            trigger = true;
+        } finally {
+            if (trigger) {
+                Asserts.assertTrue(i == 9999L);
+            } else {
+                Asserts.assertTrue(i != 9999L);
+            }
         }
     }
 
     static void check3(int i) {
+        boolean trigger = false;
         try {
             Preconditions.checkIndex(i, 9999, null);
         } catch (IndexOutOfBoundsException e) {
             Asserts.assertTrue(i == 9999);
+            trigger = true;
+        } finally {
+            if (trigger) {
+                Asserts.assertTrue(i == 9999L);
+            } else {
+                Asserts.assertTrue(i != 9999L);
+            }
         }
     }
 
     static void check4(long i) {
+        boolean trigger = false;
         try {
             Preconditions.checkIndex(i, 9999L, null);
         } catch (IndexOutOfBoundsException e) {
-            Asserts.assertTrue(i == 9999L);
+            trigger = true;
+        } finally {
+            if (trigger) {
+                Asserts.assertTrue(i == 9999L);
+            } else {
+                Asserts.assertTrue(i != 9999L);
+            }
         }
     }
 


### PR DESCRIPTION
The JDK codebase re-created many variants of checkIndex(`grep -I -r 'cehckIndex' jdk/`). A notable variant is java.nio.Buffer.checkIndex, which annotated with @IntrinsicCandidate and it only has a corresponding C1 intrinsic version.

In fact, there is an utility method `jdk.internal.util.Preconditions.checkIndex`(wrapped by java.lang.Objects.checkIndex) that behaves the same as these variants of checkIndex, we can replace these re-created variants of checkIndex by Objects.checkIndex, it would significantly reduce duplicated code and enjoys performance improvement because Preconditions.checkIndex is @IntrinsicCandidate and it has a corresponding intrinsic method in HotSpot.

But, the problem is currently HotSpot only implements the C2 version of Preconditions.checkIndex. To reuse it global-widely in JDK code, I think we can firstly implement its C1 counterpart. There are also a few kinds of stuff we can do later:

1. Replace all variants of checkIndex by Objects.checkIndex in the whole JDK codebase.
2. Remove Buffer.checkIndex and obsolete/deprecate InlineNIOCheckIndex flag

Testing: cds, compiler and jdk

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265518](https://bugs.openjdk.java.net/browse/JDK-8265518): C1: Intrinsic support for Preconditions.checkIndex


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to 954abc6e1bd086f4d0f8b2a9c717936b2b7604d3
 * [Igor Veresov](https://openjdk.java.net/census#iveresov) (@veresov - **Reviewer**) ⚠️ Review applies to 307d7a104eb1e02fba2c56b7243c6bb45f279f0b


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3615/head:pull/3615` \
`$ git checkout pull/3615`

Update a local copy of the PR: \
`$ git checkout pull/3615` \
`$ git pull https://git.openjdk.java.net/jdk pull/3615/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3615`

View PR using the GUI difftool: \
`$ git pr show -t 3615`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3615.diff">https://git.openjdk.java.net/jdk/pull/3615.diff</a>

</details>
