### PR TITLE
Compare timed UUIDs based on timestamp if possible

### DIFF
--- a/src/java.base/share/classes/java/util/UUID.java
+++ b/src/java.base/share/classes/java/util/UUID.java
@@ -511,6 +511,12 @@ public final class UUID implements java.io.Serializable, Comparable<UUID> {
      */
     @Override
     public int compareTo(UUID val) {
+        // Compare the timstamps if both UUIDs are timed UUID
+        // Do not do this if the timestamps are the same
+        if (version() == 1 && val.version() == 1 && timestamp() != val.timestamp()) {
+            return Long.compare(timestamp(), val.timestamp());
+        }
+
         // The ordering is intentionally set up so that the UUIDs
         // can simply be numerically compared as two numbers
         return (this.mostSigBits < val.mostSigBits ? -1 :

--- a/test/jdk/java/util/UUID/UUIDTest.java
+++ b/test/jdk/java/util/UUID/UUIDTest.java
@@ -279,6 +279,14 @@ public class UUIDTest {
         if (id.compareTo(id) != 0)
             throw new RuntimeException("compareTo failure");
 
+        // Timed UUID comparisons
+        UUID id6 = UUID.fromString("d93ddd70-a355-11eb-8080-808080808080");
+        UUID id7 = UUID.fromString("d93e047f-a355-11eb-7f7f-7f7f7f7f7f7f");
+        UUID id8 = UUID.fromString("77797570-a34d-11eb-8080-808080808080");
+        if ((id6.compareTo(id7) >= 0) ||
+            (id6.compareTo(id8) >= 0) ||
+           ( id7.compareTo(id8) >= 0))
+        throw new RuntimeException("compareTo failure");
     }
 
 }


### PR DESCRIPTION
I've noticed that the UUID.compareTo function does not take the timestamps in timed UUIDs into account in its comparison, which caused some bugs in one of my systems. This PR adds this functionality. Alternatively the javadocs could be improved to explain that timestamps are not used in the comparison if the change in this PR is not wanted.

I've added some checks to the compareTo test which would fail if my change wasn't implemented or implemented correctly. I use 2 UUIDs with the same timestamp and one with a different one.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3620/head:pull/3620` \
`$ git checkout pull/3620`

Update a local copy of the PR: \
`$ git checkout pull/3620` \
`$ git pull https://git.openjdk.java.net/jdk pull/3620/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3620`

View PR using the GUI difftool: \
`$ git pr show -t 3620`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3620.diff">https://git.openjdk.java.net/jdk/pull/3620.diff</a>

</details>
