### PR TITLE
8228442: DHKeyExchange/LegacyDHEKeyExchange.java failed due to "SSLException: An established connection was aborted by the software in your host machine"

### DIFF
--- a/test/jdk/sun/security/ssl/DHKeyExchange/LegacyDHEKeyExchange.java
+++ b/test/jdk/sun/security/ssl/DHKeyExchange/LegacyDHEKeyExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,298 +28,59 @@
  * @test
  * @bug 8148108
  * @summary Disable Diffie-Hellman keys less than 1024 bits
+ * @library /javax/net/ssl/templates
  * @run main/othervm -Djdk.tls.ephemeralDHKeySize=legacy LegacyDHEKeyExchange
  */
 
-import java.io.*;
-import javax.net.ssl.*;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLSocket;
+import java.util.concurrent.CountDownLatch;
 
-public class LegacyDHEKeyExchange {
+public class LegacyDHEKeyExchange extends SSLSocketTemplate{
 
-    /*
-     * =============================================================
-     * Set the various variables needed for the tests, then
-     * specify what tests to run on each side.
-     */
+    private final CountDownLatch serverDoneLatch = new CountDownLatch(1);
+    private final CountDownLatch clientDoneLatch = new CountDownLatch(1);
 
-    /*
-     * Should we run the client or server in a separate thread?
-     * Both sides can throw exceptions, but do you have a preference
-     * as to which side should be the main thread.
-     */
-    static boolean separateServerThread = false;
-
-    /*
-     * Where do we find the keystores?
-     */
-    static String pathToStores = "../../../../javax/net/ssl/etc";
-    static String keyStoreFile = "keystore";
-    static String trustStoreFile = "truststore";
-    static String passwd = "passphrase";
-
-    /*
-     * Is the server ready to serve?
-     */
-    volatile static boolean serverReady = false;
-
-    /*
-     * Turn on SSL debugging?
-     */
-    static boolean debug = false;
-
-    /*
-     * If the client or server is doing some kind of object creation
-     * that the other side depends on, and that thread prematurely
-     * exits, you may experience a hang.  The test harness will
-     * terminate all hung threads after its timeout has expired,
-     * currently 3 minutes by default, but you might try to be
-     * smart about it....
-     */
-
-    /*
-     * Define the server side of the test.
-     *
-     * If the server prematurely exits, serverReady will be set to true
-     * to avoid infinite hangs.
-     */
-    void doServerSide() throws Exception {
-        SSLServerSocketFactory sslssf =
-            (SSLServerSocketFactory) SSLServerSocketFactory.getDefault();
-        SSLServerSocket sslServerSocket =
-            (SSLServerSocket) sslssf.createServerSocket(serverPort);
-
-        serverPort = sslServerSocket.getLocalPort();
-
-        /*
-         * Signal Client, we're ready for his connect.
-         */
-        serverReady = true;
-
-        try (SSLSocket sslSocket = (SSLSocket)sslServerSocket.accept()) {
-            InputStream sslIS = sslSocket.getInputStream();
-            OutputStream sslOS = sslSocket.getOutputStream();
-
-            sslIS.read();
-            sslOS.write(85);
-            sslOS.flush();
-
-            throw new Exception(
-                "Leagcy DH keys (< 1024) should be restricted");
-        } catch (SSLHandshakeException she) {
-            // ignore, client should terminate the connection
-        } finally {
-            sslServerSocket.close();
-        }
-    }
-
-    /*
-     * Define the client side of the test.
-     *
-     * If the server prematurely exits, serverReady will be set to true
-     * to avoid infinite hangs.
-     */
-    void doClientSide() throws Exception {
-
-        /*
-         * Wait for server to get started.
-         */
-        while (!serverReady) {
-            Thread.sleep(50);
-        }
-
-        SSLSocketFactory sslsf =
-            (SSLSocketFactory) SSLSocketFactory.getDefault();
-        SSLSocket sslSocket = (SSLSocket)
-            sslsf.createSocket("localhost", serverPort);
-
+    @Override
+    protected void configureClientSocket(SSLSocket socket) {
         String[] suites = new String [] {"TLS_DHE_RSA_WITH_AES_128_CBC_SHA"};
-        sslSocket.setEnabledCipherSuites(suites);
+        socket.setEnabledCipherSuites(suites);
+    }
 
+    @Override
+    protected void runServerApplication(SSLSocket socket) throws Exception {
         try {
-            InputStream sslIS = sslSocket.getInputStream();
-            OutputStream sslOS = sslSocket.getOutputStream();
-
-            sslOS.write(280);
-            sslOS.flush();
-            sslIS.read();
-
-            throw new Exception("Leagcy DH keys (< 1024) should be restricted");
+            super.runServerApplication(socket);
+            throw new Exception("Legacy DH keys (< 1024) should be restricted");
         } catch (SSLHandshakeException she) {
-            // ignore, should be caused by algorithm constraints
+            String expectedExMsg = "Received fatal alert: insufficient_security";
+            if (!expectedExMsg.equals(she.getMessage())) {
+                throw she;
+            }
         } finally {
-            sslSocket.close();
+            serverDoneLatch.countDown();
+            clientDoneLatch.await();
         }
     }
 
-    /*
-     * =============================================================
-     * The remainder is just support stuff
-     */
-
-    // use any free port by default
-    volatile int serverPort = 0;
-
-    volatile Exception serverException = null;
-    volatile Exception clientException = null;
+    @Override
+    protected void runClientApplication(SSLSocket socket) throws Exception {
+        try (socket) {
+            super.runClientApplication(socket);
+            throw new Exception("Legacy DH keys (< 1024) should be restricted");
+        } catch (SSLHandshakeException she) {
+            String expectedExMsg = "DH ServerKeyExchange does not comply to" +
+                    " algorithm constraints";
+            if (!expectedExMsg.equals(she.getMessage())) {
+                throw she;
+            }
+        } finally {
+            serverDoneLatch.await();
+            clientDoneLatch.countDown();
+        }
+    }
 
     public static void main(String[] args) throws Exception {
-        String keyFilename =
-            System.getProperty("test.src", ".") + "/" + pathToStores +
-                "/" + keyStoreFile;
-        String trustFilename =
-            System.getProperty("test.src", ".") + "/" + pathToStores +
-                "/" + trustStoreFile;
-
-        System.setProperty("javax.net.ssl.keyStore", keyFilename);
-        System.setProperty("javax.net.ssl.keyStorePassword", passwd);
-        System.setProperty("javax.net.ssl.trustStore", trustFilename);
-        System.setProperty("javax.net.ssl.trustStorePassword", passwd);
-
-        if (debug) {
-            System.setProperty("javax.net.debug", "all");
-        }
-
-        /*
-         * Start the tests.
-         */
-        new LegacyDHEKeyExchange();
-    }
-
-    Thread clientThread = null;
-    Thread serverThread = null;
-
-    /*
-     * Primary constructor, used to drive remainder of the test.
-     *
-     * Fork off the other side, then do your work.
-     */
-    LegacyDHEKeyExchange() throws Exception {
-        Exception startException = null;
-        try {
-            if (separateServerThread) {
-                startServer(true);
-                startClient(false);
-            } else {
-                startClient(true);
-                startServer(false);
-            }
-        } catch (Exception e) {
-            startException = e;
-        }
-
-        /*
-         * Wait for other side to close down.
-         */
-        if (separateServerThread) {
-            if (serverThread != null) {
-                serverThread.join();
-            }
-        } else {
-            if (clientThread != null) {
-                clientThread.join();
-            }
-        }
-
-        /*
-         * When we get here, the test is pretty much over.
-         * Which side threw the error?
-         */
-        Exception local;
-        Exception remote;
-
-        if (separateServerThread) {
-            remote = serverException;
-            local = clientException;
-        } else {
-            remote = clientException;
-            local = serverException;
-        }
-
-        Exception exception = null;
-
-        /*
-         * Check various exception conditions.
-         */
-        if ((local != null) && (remote != null)) {
-            // If both failed, return the curthread's exception.
-            local.initCause(remote);
-            exception = local;
-        } else if (local != null) {
-            exception = local;
-        } else if (remote != null) {
-            exception = remote;
-        } else if (startException != null) {
-            exception = startException;
-        }
-
-        /*
-         * If there was an exception *AND* a startException,
-         * output it.
-         */
-        if (exception != null) {
-            if (exception != startException && startException != null) {
-                exception.addSuppressed(startException);
-            }
-            throw exception;
-        }
-
-        // Fall-through: no exception to throw!
-    }
-
-    void startServer(boolean newThread) throws Exception {
-        if (newThread) {
-            serverThread = new Thread() {
-                @Override
-                public void run() {
-                    try {
-                        doServerSide();
-                    } catch (Exception e) {
-                        /*
-                         * Our server thread just died.
-                         *
-                         * Release the client, if not active already...
-                         */
-                        System.err.println("Server died...");
-                        serverReady = true;
-                        serverException = e;
-                    }
-                }
-            };
-            serverThread.start();
-        } else {
-            try {
-                doServerSide();
-            } catch (Exception e) {
-                serverException = e;
-            } finally {
-                serverReady = true;
-            }
-        }
-    }
-
-    void startClient(boolean newThread) throws Exception {
-        if (newThread) {
-            clientThread = new Thread() {
-                @Override
-                public void run() {
-                    try {
-                        doClientSide();
-                    } catch (Exception e) {
-                        /*
-                         * Our client thread just died.
-                         */
-                        System.err.println("Client died...");
-                        clientException = e;
-                    }
-                }
-            };
-            clientThread.start();
-        } else {
-            try {
-                doClientSide();
-            } catch (Exception e) {
-                clientException = e;
-            }
-        }
+        new LegacyDHEKeyExchange().run();
     }
 }


### PR DESCRIPTION
Test DHKeyExchange/LegacyDHEKeyExchange.java has been seen to fail intermittently. There is a thread synchronisation issue that is fixed by:

- Using SSLSocketTemplate that handles client/server socket configuration and synchronisation before connection
- Making use of a CountDownLatch and socket linger to facilitate the socket to close gracefully after both ends have finished the transmission

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8228442](https://bugs.openjdk.java.net/browse/JDK-8228442): DHKeyExchange/LegacyDHEKeyExchange.java failed due to "SSLException: An established connection was aborted by the software in your host machine"


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3622/head:pull/3622` \
`$ git checkout pull/3622`

Update a local copy of the PR: \
`$ git checkout pull/3622` \
`$ git pull https://git.openjdk.java.net/jdk pull/3622/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3622`

View PR using the GUI difftool: \
`$ git pr show -t 3622`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3622.diff">https://git.openjdk.java.net/jdk/pull/3622.diff</a>

</details>
