### PR TITLE
8197800: Test java/awt/Focus/NonFocusableWindowTest/NoEventsTest.java fails on Windows

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -273,7 +273,6 @@ java/awt/Choice/ChoiceMouseWheelTest/ChoiceMouseWheelTest.java 7100044 macosx-al
 java/awt/Component/GetScreenLocTest/GetScreenLocTest.java 4753654 generic-all
 java/awt/Component/SetEnabledPerformance/SetEnabledPerformance.java 8165863 macosx-all
 java/awt/Clipboard/HTMLTransferTest/HTMLTransferTest.java 8017454 macosx-all
-java/awt/Focus/NonFocusableWindowTest/NoEventsTest.java 8000171 windows-all
 java/awt/Frame/MiscUndecorated/RepaintTest.java 8079267 windows-all,linux-all
 java/awt/Robot/ModifierRobotKey/ModifierRobotKeyTest.java 8157173 generic-all
 java/awt/Modal/FileDialog/FileDialogAppModal1Test.java 7186009 macosx-all


### PR DESCRIPTION
This test rootcause which is 

sun.awt.SunToolkit$InfiniteLoop
at sun.awt.SunToolkit.realSync(SunToolkit.java:1498)
at sun.awt.SunToolkit.realSync(SunToolkit.java:1426)
at java.awt.Robot.waitForIdle(Robot.java:574)
at NoEventsTest.pause(NoEventsTest.java:50)
at NoEventsTest.performFocusClick(NoEventsTest.java:161)
at NoEventsTest.main(NoEventsTest.java:109)

is found out to be same as with this bug JDK-8000171 via this comment 
https://bugs.openjdk.java.net/browse/JDK-8000171?focusedCommentId=13825066&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13825066
which is dup of 8196100: javax/swing/text/JTextComponent/5074573/bug5074573.java fails and  and fixed there.

So, we can remove the test from problemlist

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8197800](https://bugs.openjdk.java.net/browse/JDK-8197800): Test java/awt/Focus/NonFocusableWindowTest/NoEventsTest.java fails on Windows


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3623/head:pull/3623` \
`$ git checkout pull/3623`

Update a local copy of the PR: \
`$ git checkout pull/3623` \
`$ git pull https://git.openjdk.java.net/jdk pull/3623/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3623`

View PR using the GUI difftool: \
`$ git pr show -t 3623`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3623.diff">https://git.openjdk.java.net/jdk/pull/3623.diff</a>

</details>
