### PR TITLE
8136517: [macosx]Test  java/awt/Focus/8073453/AWTFocusTransitionTest.java fails on MacOSX

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -199,8 +199,6 @@ java/awt/Focus/8013611/JDK8013611.java 8175366 windows-all,macosx-all
 java/awt/Focus/6378278/InputVerifierTest.java 8198616 macosx-all
 java/awt/Focus/6382144/EndlessLoopTest.java 8198617 macosx-all
 java/awt/Focus/6981400/Test1.java 8029675 windows-all,macosx-all
-java/awt/Focus/8073453/AWTFocusTransitionTest.java 8136517 macosx-all
-java/awt/Focus/8073453/SwingFocusTransitionTest.java 8136517 macosx-all
 java/awt/Focus/6981400/Test3.java 8173264 generic-all
 java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java 8169476 windows-all,macosx-all
 java/awt/event/KeyEvent/KeyChar/KeyCharTest.java 8169474,8224055 macosx-all,windows-all

--- a/test/jdk/java/awt/Focus/8073453/AWTFocusTransitionTest.java
+++ b/test/jdk/java/awt/Focus/8073453/AWTFocusTransitionTest.java
@@ -36,7 +36,6 @@ import java.awt.DefaultFocusTraversalPolicy;
 import java.awt.Frame;
 import java.awt.GridLayout;
 import java.awt.Panel;
-import java.awt.Point;
 import java.awt.Robot;
 import java.awt.TextField;
 import java.awt.event.KeyEvent;
@@ -48,30 +47,15 @@ public class AWTFocusTransitionTest {
     private static TextField textField;
     private static Button button;
 
-    private static void blockTillDisplayed(Component comp) {
-        Point p = null;
-        while (p == null) {
-            try {
-                p = comp.getLocationOnScreen();
-            } catch (IllegalStateException e) {
-                try {
-                    Thread.sleep(500);
-                } catch (InterruptedException ie) {
-                }
-            }
-        }
-    }
-
     public static void main(String[] args) throws Exception {
         robot = new Robot();
-        robot.setAutoDelay(50);
+        robot.setAutoDelay(100);
 
         try {
             createAndShowGUI();
 
             robot.waitForIdle();
 
-            blockTillDisplayed(textField);
             checkFocusOwner(textField);
 
             robot.keyPress(KeyEvent.VK_TAB);
@@ -123,7 +107,6 @@ public class AWTFocusTransitionTest {
         p.add(panel);
 
         frame.add(p);
-        frame.setAlwaysOnTop(true);
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }

--- a/test/jdk/java/awt/Focus/8073453/AWTFocusTransitionTest.java
+++ b/test/jdk/java/awt/Focus/8073453/AWTFocusTransitionTest.java
@@ -26,12 +26,19 @@
  * @key headful
  * @bug 8073453
  * @summary Focus doesn't move when pressing Shift + Tab keys
- * @author Dmitry Markov
  * @compile AWTFocusTransitionTest.java
  * @run main/othervm AWTFocusTransitionTest
  */
 
-import java.awt.*;
+import java.awt.Button;
+import java.awt.Component;
+import java.awt.DefaultFocusTraversalPolicy;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.TextField;
 import java.awt.event.KeyEvent;
 
 public class AWTFocusTransitionTest {
@@ -40,6 +47,20 @@ public class AWTFocusTransitionTest {
     private static Frame frame;
     private static TextField textField;
     private static Button button;
+
+    private static void blockTillDisplayed(Component comp) {
+        Point p = null;
+        while (p == null) {
+            try {
+                p = comp.getLocationOnScreen();
+            } catch (IllegalStateException e) {
+                try {
+                    Thread.sleep(500);
+                } catch (InterruptedException ie) {
+                }
+            }
+        }
+    }
 
     public static void main(String[] args) throws Exception {
         robot = new Robot();
@@ -50,6 +71,7 @@ public class AWTFocusTransitionTest {
 
             robot.waitForIdle();
 
+            blockTillDisplayed(textField);
             checkFocusOwner(textField);
 
             robot.keyPress(KeyEvent.VK_TAB);
@@ -101,14 +123,16 @@ public class AWTFocusTransitionTest {
         p.add(panel);
 
         frame.add(p);
+        frame.setAlwaysOnTop(true);
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
 
     private static void checkFocusOwner(Component component) {
         if (component != frame.getFocusOwner()) {
-            throw new RuntimeException("Test Failed! Incorrect focus owner: " + frame.getFocusOwner() +
+            throw new RuntimeException("Test Failed! Incorrect focus " +
+                    "owner: " + frame.getFocusOwner() +
                     ", but expected: " + component);
         }
     }
 }
-

--- a/test/jdk/java/awt/Focus/8073453/SwingFocusTransitionTest.java
+++ b/test/jdk/java/awt/Focus/8073453/SwingFocusTransitionTest.java
@@ -39,7 +39,6 @@ import javax.swing.SwingUtilities;
 import java.awt.Component;
 import java.awt.DefaultFocusTraversalPolicy;
 import java.awt.GridLayout;
-import java.awt.Point;
 import java.awt.Robot;
 import java.awt.event.KeyEvent;
 
@@ -50,23 +49,9 @@ public class SwingFocusTransitionTest {
     private static JTextField textField;
     private static JButton button;
 
-    private static void blockTillDisplayed(Component comp) {
-        Point p = null;
-        while (p == null) {
-            try {
-                p = comp.getLocationOnScreen();
-            } catch (IllegalStateException e) {
-                try {
-                    Thread.sleep(500);
-                } catch (InterruptedException ie) {
-                }
-            }
-        }
-    }
-
     public static void main(String[] args) throws Exception {
         robot = new Robot();
-        robot.setAutoDelay(50);
+        robot.setAutoDelay(100);
 
         try {
             SwingUtilities.invokeAndWait(new Runnable() {
@@ -78,7 +63,6 @@ public class SwingFocusTransitionTest {
 
             robot.waitForIdle();
 
-            blockTillDisplayed(textField);
             checkFocusOwner(textField);
 
             robot.keyPress(KeyEvent.VK_TAB);
@@ -135,7 +119,6 @@ public class SwingFocusTransitionTest {
         p.add(panel);
 
         frame.add(p);
-        frame.setAlwaysOnTop(true);
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }

--- a/test/jdk/java/awt/Focus/8073453/SwingFocusTransitionTest.java
+++ b/test/jdk/java/awt/Focus/8073453/SwingFocusTransitionTest.java
@@ -26,13 +26,21 @@
  * @key headful
  * @bug 8073453
  * @summary Focus doesn't move when pressing Shift + Tab keys
- * @author Dmitry Markov
  * @compile SwingFocusTransitionTest.java
  * @run main/othervm SwingFocusTransitionTest
  */
 
-import javax.swing.*;
-import java.awt.*;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.LayoutFocusTraversalPolicy;
+import javax.swing.SwingUtilities;
+import java.awt.Component;
+import java.awt.DefaultFocusTraversalPolicy;
+import java.awt.GridLayout;
+import java.awt.Point;
+import java.awt.Robot;
 import java.awt.event.KeyEvent;
 
 public class SwingFocusTransitionTest {
@@ -41,6 +49,20 @@ public class SwingFocusTransitionTest {
     private static JFrame frame;
     private static JTextField textField;
     private static JButton button;
+
+    private static void blockTillDisplayed(Component comp) {
+        Point p = null;
+        while (p == null) {
+            try {
+                p = comp.getLocationOnScreen();
+            } catch (IllegalStateException e) {
+                try {
+                    Thread.sleep(500);
+                } catch (InterruptedException ie) {
+                }
+            }
+        }
+    }
 
     public static void main(String[] args) throws Exception {
         robot = new Robot();
@@ -56,6 +78,7 @@ public class SwingFocusTransitionTest {
 
             robot.waitForIdle();
 
+            blockTillDisplayed(textField);
             checkFocusOwner(textField);
 
             robot.keyPress(KeyEvent.VK_TAB);
@@ -112,19 +135,22 @@ public class SwingFocusTransitionTest {
         p.add(panel);
 
         frame.add(p);
+        frame.setAlwaysOnTop(true);
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
 
-    private static void checkFocusOwner(final Component component) throws Exception {
+    private static void checkFocusOwner(final Component component)
+            throws Exception {
         SwingUtilities.invokeAndWait(new Runnable() {
             @Override
             public void run() {
                 if (component != frame.getFocusOwner()) {
-                    throw new RuntimeException("Test Failed! Incorrect focus owner: " + frame.getFocusOwner() +
+                    throw new RuntimeException("Test Failed! Incorrect focus" +
+                            " owner: " + frame.getFocusOwner() +
                             ", but expected: " + component);
                 }
             }
         });
     }
 }
-


### PR DESCRIPTION
The tests java/awt/Focus/8073453/AWTFocusTransitionTest.java and java/awt/Focus/8073453/SwingFocusTransitionTest.java fail on MacOS intermittently and are problem listed. The test needs lot of Robot actions. It does not test if the components are visible on the screen.

The changes fix this issue. Also, the frame is moved to centre of screen and set to be at top always. Some more cleanup is done. The test is passing for multiple iterations on all platforms on CI. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8136517](https://bugs.openjdk.java.net/browse/JDK-8136517): [macosx]Test  java/awt/Focus/8073453/AWTFocusTransitionTest.java fails on MacOSX


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3624/head:pull/3624` \
`$ git checkout pull/3624`

Update a local copy of the PR: \
`$ git checkout pull/3624` \
`$ git pull https://git.openjdk.java.net/jdk pull/3624/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3624`

View PR using the GUI difftool: \
`$ git pr show -t 3624`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3624.diff">https://git.openjdk.java.net/jdk/pull/3624.diff</a>

</details>
