### PR TITLE
8265909 : build.tools.dtdbuilder.DTDBuilder.java failed detecting missing path of dtd_home

### DIFF
--- a/make/jdk/src/classes/build/tools/dtdbuilder/DTDBuilder.java
+++ b/make/jdk/src/classes/build/tools/dtdbuilder/DTDBuilder.java
@@ -283,8 +283,8 @@ class DTDBuilder extends DTD {
 
     public static void main(String argv[]) {
 
-        String dtd_home = System.getProperty("dtd_home") + File.separator;
-        if (dtd_home.equals("null" + File.separator)) {
+        String dtd_home = System.getProperty("dtd_home");
+        if (dtd_home == null) {
             System.err.println("Must set property 'dtd_home'");
             return;
         }
@@ -292,12 +292,12 @@ class DTDBuilder extends DTD {
         DTDBuilder dtd = null;
         try {
             dtd = new DTDBuilder(argv[0]);
-            mapping = new PublicMapping(dtd_home, "public.map");
+            mapping = new PublicMapping(dtd_home + File.separator, "public.map");
             String path = mapping.get(argv[0]);
             new DTDParser().parse(new FileInputStream(path), dtd);
 
         } catch (IOException e) {
-            System.err.println("Could not open DTD file "+argv[0]);
+            System.err.println("Could not open DTD file " + argv[0]);
             e.printStackTrace(System.err);
             System.exit(1);
         }

--- a/make/jdk/src/classes/build/tools/dtdbuilder/DTDBuilder.java
+++ b/make/jdk/src/classes/build/tools/dtdbuilder/DTDBuilder.java
@@ -56,6 +56,7 @@ import java.net.URL;
  * @see DTDParser
  * @see Parser
  * @author Arthur van Hoff
+ * @author Guy Abossolo Foh
  */
 public
 class DTDBuilder extends DTD {
@@ -283,7 +284,7 @@ class DTDBuilder extends DTD {
     public static void main(String argv[]) {
 
         String dtd_home = System.getProperty("dtd_home") + File.separator;
-        if (dtd_home == null) {
+        if (dtd_home.equals("null" + File.separator)) {
             System.err.println("Must set property 'dtd_home'");
             return;
         }


### PR DESCRIPTION
This concerns [dtdbuilder tools](https://github.com/openjdk/jdk/tree/master/make/jdk/src/classes/build/tools/dtdbuilder).

In jshell, try `System.getProperty("html32") + ""` you'll get a `String`.

So, in `DTDBuilder.java` when none `dtd_home` property is set, the `dtd_home` string value is not `null`, causing an exception with the present test.

The expected value is `"Must set property 'dtd_home'"`

And in this case, should'nt we have a `System.exit(1)` too rather than a simple `return` ?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265909](https://bugs.openjdk.java.net/browse/JDK-8265909): build.tools.dtdbuilder.DTDBuilder.java failed detecting missing path of dtd_home


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3626/head:pull/3626` \
`$ git checkout pull/3626`

Update a local copy of the PR: \
`$ git checkout pull/3626` \
`$ git pull https://git.openjdk.java.net/jdk pull/3626/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3626`

View PR using the GUI difftool: \
`$ git pr show -t 3626`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3626.diff">https://git.openjdk.java.net/jdk/pull/3626.diff</a>

</details>
