### PR TITLE
8263621: Convert jdk.compiler to use Stream.toList()

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/BasicJavacTask.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/BasicJavacTask.java
@@ -204,7 +204,7 @@ public class BasicJavacTask extends JavacTask {
                 java.util.List<String> options =
                         pluginDesc.getOptions().entrySet().stream()
                                 .map(e -> e.getKey() + "=" + e.getValue())
-                                .collect(Collectors.toList());
+                                .toList();
                 try {
                     initPlugin(pluginDesc.getPlugin(), options.toArray(new String[options.size()]));
                 } catch (RuntimeException ex) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
@@ -491,7 +491,7 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
 
             java.util.List<Path> files;
             try (Stream<Path> s = Files.list(d)) {
-                files = (sortFiles == null ? s : s.sorted(sortFiles)).collect(Collectors.toList());
+                files = (sortFiles == null ? s : s.sorted(sortFiles)).toList();
             } catch (IOException ignore) {
                 return;
             }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/Locations.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/Locations.java
@@ -953,7 +953,7 @@ public class Locations {
             Path modules = javaHome.resolve("modules");
             if (Files.isDirectory(modules.resolve("java.base"))) {
                 try (Stream<Path> listedModules = Files.list(modules)) {
-                    return listedModules.collect(Collectors.toList());
+                    return listedModules.toList();
                 }
             }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/model/JavacTypes.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/model/JavacTypes.java
@@ -123,7 +123,7 @@ public class JavacTypes implements javax.lang.model.util.Types {
         Type ty = (Type)t;
         return types.directSupertypes(ty).stream()
                 .map(Type::stripMetadataIfNeeded)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @DefinedBy(Api.LANGUAGE_MODEL)

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacProcessingEnvironment.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacProcessingEnvironment.java
@@ -343,7 +343,7 @@ public class JavacProcessingEnvironment implements ProcessingEnvironment, Closea
             platformProcessors = platformProvider.getAnnotationProcessors()
                                                  .stream()
                                                  .map(PluginInfo::getPlugin)
-                                                 .collect(Collectors.toList());
+                                                 .toList();
         }
         List<Iterator<? extends Processor>> iterators = List.of(processorIterator,
                                                                 platformProcessors.iterator());

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/PrintingProcessor.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/PrintingProcessor.java
@@ -280,7 +280,7 @@ public class PrintingProcessor extends AbstractProcessor {
                          e.getEnclosedElements()
                          .stream()
                          .filter(elt -> elementUtils.getOrigin(elt) == Elements.Origin.EXPLICIT )
-                         .collect(Collectors.toList()) ) )
+                         .toList() ) )
                     this.visit(element);
             }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/sjavac/comp/PubapiVisitor.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/sjavac/comp/PubapiVisitor.java
@@ -152,20 +152,20 @@ public class PubapiVisitor extends ElementScanner14<Void, Void> {
     private List<PubApiTypeParam> getTypeParameters(List<? extends TypeParameterElement> elements) {
         return elements.stream()
                        .map(e -> new PubApiTypeParam(e.getSimpleName().toString(), getTypeDescs(e.getBounds())))
-                       .collect(Collectors.toList());
+                       .toList();
     }
 
     private List<TypeMirror> getParamTypes(ExecutableElement e) {
         return e.getParameters()
                 .stream()
                 .map(VariableElement::asType)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private List<TypeDesc> getTypeDescs(List<? extends TypeMirror> list) {
         return list.stream()
                    .map(TypeDesc::fromType)
-                   .collect(Collectors.toList());
+                   .toList();
     }
 
     public PubApi getCollectedPubApi() {

--- a/src/jdk.compiler/share/classes/com/sun/tools/sjavac/pubapi/PubApi.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/sjavac/pubapi/PubApi.java
@@ -272,11 +272,11 @@ public class PubApi implements Serializable {
     private static List<TypeDesc> parseTypeDescs(List<String> strs) {
         return strs.stream()
                    .map(TypeDesc::decodeString)
-                   .collect(Collectors.toList());
+                   .toList();
     }
 
     private static List<PubApiTypeParam> parseTypeParams(List<String> strs) {
-        return strs.stream().map(PubApi::parseTypeParam).collect(Collectors.toList());
+        return strs.stream().map(PubApi::parseTypeParam).toList();
     }
 
     // Parse a type parameter string. Example input:

--- a/src/jdk.compiler/share/classes/jdk/internal/shellsupport/doc/JavadocHelper.java
+++ b/src/jdk.compiler/share/classes/jdk/internal/shellsupport/doc/JavadocHelper.java
@@ -284,12 +284,12 @@ public abstract class JavadocHelper implements AutoCloseable {
                                     executableElement.getParameters()
                                                      .stream()
                                                      .map(param -> param.getSimpleName().toString())
-                                                     .collect(Collectors.toList());
+                                                     .toList();
                             List<String> throwsList =
                                     executableElement.getThrownTypes()
                                                      .stream()
                                                      .map(TypeMirror::toString)
-                                                     .collect(Collectors.toList());
+                                                     .toList();
                             Set<String> missingParams = new HashSet<>(parameters);
                             Set<String> missingThrows = new HashSet<>(throwsList);
                             boolean hasReturn = false;


### PR DESCRIPTION
Converting use of `Collectors.toList()` to `Stream.toList()` where appropriate. Per [JDK-8260559](https://bugs.openjdk.java.net/browse/JDK-8260559).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263621](https://bugs.openjdk.java.net/browse/JDK-8263621): Convert jdk.compiler to use Stream.toList()


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3629/head:pull/3629` \
`$ git checkout pull/3629`

Update a local copy of the PR: \
`$ git checkout pull/3629` \
`$ git pull https://git.openjdk.java.net/jdk pull/3629/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3629`

View PR using the GUI difftool: \
`$ git pr show -t 3629`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3629.diff">https://git.openjdk.java.net/jdk/pull/3629.diff</a>

</details>
