### PR TITLE
8265757: stack-use-after-scope in perfMemory_posix.cpp get_user_name_slow()

### DIFF
--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -527,6 +527,7 @@ static char* get_user_name_slow(int vmid, int nspid, TRAPS) {
   // directory search
   char* oldest_user = NULL;
   time_t oldest_ctime = 0;
+  char buffer[MAXPATHLEN + 1];
   int searchpid;
   char* tmpdirname = (char *)os::get_temp_directory();
 #if defined(LINUX)
@@ -537,7 +538,6 @@ static char* get_user_name_slow(int vmid, int nspid, TRAPS) {
   if (nspid == -1) {
     searchpid = vmid;
   } else {
-    char buffer[MAXPATHLEN + 1];
     jio_snprintf(buffer, MAXPATHLEN, "/proc/%d/root%s", vmid, tmpdirname);
     tmpdirname = buffer;
     searchpid = nspid;


### PR DESCRIPTION
Please review this small change to fix JDK-8265757.  The fix was tested with Mach5 tiers 1 and 2 on Linux, MacOS aarch64, and Windows.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265757](https://bugs.openjdk.java.net/browse/JDK-8265757): stack-use-after-scope in perfMemory_posix.cpp get_user_name_slow()


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3630/head:pull/3630` \
`$ git checkout pull/3630`

Update a local copy of the PR: \
`$ git checkout pull/3630` \
`$ git pull https://git.openjdk.java.net/jdk pull/3630/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3630`

View PR using the GUI difftool: \
`$ git pr show -t 3630`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3630.diff">https://git.openjdk.java.net/jdk/pull/3630.diff</a>

</details>
