### PR TITLE
8265759: Shenandoah: Avoid race for referent in assert

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
@@ -388,8 +388,8 @@ oop ShenandoahReferenceProcessor::drop(oop reference, ReferenceType type) {
 
 #ifdef ASSERT
   oop referent = reference_referent<T>(reference);
-  assert(referent == NULL ||
-         ShenandoahHeap::heap()->marking_context()->is_marked(referent), "only drop references with alive referents");
+  assert(referent == NULL || ShenandoahHeap::heap()->marking_context()->is_marked(referent),
+         "only drop references with alive referents");
 #endif
 
   // Unlink and return next in list

--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
@@ -386,8 +386,11 @@ template <typename T>
 oop ShenandoahReferenceProcessor::drop(oop reference, ReferenceType type) {
   log_trace(gc, ref)("Dropped Reference: " PTR_FORMAT " (%s)", p2i(reference), reference_type_name(type));
 
-  assert(reference_referent<T>(reference) == NULL ||
-         ShenandoahHeap::heap()->marking_context()->is_marked(reference_referent<T>(reference)), "only drop references with alive referents");
+#ifdef ASSERT
+  oop referent = reference_referent<T>(reference);
+  assert(referent == NULL ||
+         ShenandoahHeap::heap()->marking_context()->is_marked(referent), "only drop references with alive referents");
+#endif
 
   // Unlink and return next in list
   oop next = reference_discovered<T>(reference);


### PR DESCRIPTION
There is an assert is ShenandoahReferenceProcessor::drop() which is racy: when referent is concurrently cleaned it may enter mark-bit-map with NULL even though we just checked that the referent is not NULL.

Testing:
 - [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265759](https://bugs.openjdk.java.net/browse/JDK-8265759): Shenandoah: Avoid race for referent in assert


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to 73a36ca434879ff8b23cabc783974a801f9c4451
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**) ⚠️ Review applies to 73a36ca434879ff8b23cabc783974a801f9c4451


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3632/head:pull/3632` \
`$ git checkout pull/3632`

Update a local copy of the PR: \
`$ git checkout pull/3632` \
`$ git pull https://git.openjdk.java.net/jdk pull/3632/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3632`

View PR using the GUI difftool: \
`$ git pr show -t 3632`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3632.diff">https://git.openjdk.java.net/jdk/pull/3632.diff</a>

</details>
