### PR TITLE
8265683: vmTestbase/nsk/jdb tests failed with "JDWP exit error AGENT_ERROR_INTERNAL(181)"

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -253,8 +253,15 @@ findThread(ThreadList *list, jthread thread)
         if ( list == NULL || list == &otherThreads ) {
             node = nonTlsSearch(getEnv(), &otherThreads, thread);
         }
-        /* A thread with no TLS should never be in the runningThreads list. */
-        JDI_ASSERT(!nonTlsSearch(getEnv(), &runningThreads, thread));
+        /*
+         * Search runningThreads list. The TLS lookup may have failed because the
+         * thread has terminated, but the ThreadNode may still be present.
+         */
+        if ( node == NULL ) {
+            if (list == NULL || list == &runningThreads ) {
+                node = nonTlsSearch(getEnv(), &runningThreads, thread);
+            }
+        }
     }
 
     /* If a list is supplied, only return ones in this list */

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -258,7 +258,7 @@ findThread(ThreadList *list, jthread thread)
          * thread has terminated, but the ThreadNode may still be present.
          */
         if ( node == NULL ) {
-            if (list == NULL || list == &runningThreads ) {
+            if ( list == NULL || list == &runningThreads ) {
                 node = nonTlsSearch(getEnv(), &runningThreads, thread);
             }
         }


### PR DESCRIPTION
This bug was introduced by my recent changes for [JDK-8265028](https://bugs.openjdk.java.net/browse/JDK-8265028), which attempted to speed up ThreadNode lookups by not looking in the runningThreads list if the TLS lookup failed. At the time it was thought that the thread could not possibly be on the list, but it turns out sometimes it can.

For now I'm just doing a quick fix to replace the assert being triggered with a lookup instead, which is pretty much how it worked before JDK-8265028. However, I eventually want to get back to not having to do the lookup, but first I need to better understand why this is happening in the first place, and the tests are failing too often to wait for that, thus the quick fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265683](https://bugs.openjdk.java.net/browse/JDK-8265683): vmTestbase/nsk/jdb tests failed with "JDWP exit error AGENT_ERROR_INTERNAL(181)"


### Reviewers
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**) ⚠️ Review applies to 784962daf044ee488275bce9f602e29251efb01f
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to 784962daf044ee488275bce9f602e29251efb01f


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3634/head:pull/3634` \
`$ git checkout pull/3634`

Update a local copy of the PR: \
`$ git checkout pull/3634` \
`$ git pull https://git.openjdk.java.net/jdk pull/3634/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3634`

View PR using the GUI difftool: \
`$ git pr show -t 3634`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3634.diff">https://git.openjdk.java.net/jdk/pull/3634.diff</a>

</details>
