### PR TITLE
8264320: ShouldNotReachHere in Compile::print_inlining_move_to()

### DIFF
--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -563,6 +563,10 @@ Node *Node::clone() const {
     if (cg != NULL) {
       CallGenerator* cloned_cg = cg->with_call_node(n->as_Call());
       n->as_Call()->set_generator(cloned_cg);
+
+      C->print_inlining_assert_ready();
+      C->print_inlining_move_to(cg);
+      C->print_inlining_update(cloned_cg);
     }
   }
   if (n->is_SafePoint()) {


### PR DESCRIPTION
Cloned `CallNode` gets a fresh `CallGenerator` which has to be put on `_print_inlining_list` when -XX:+PrintInlining is used.

Otherwise, if the  `CallGenerator` ends up on `_late_inlines` list (which is processed by `Compile::process_late_inline_calls_no_inline()`, `Compile::print_inlining_move_to()` can't locate it in `_print_inlining_list` and triggers the crash. 

The fix is to put cloned `CallGenerator` next to original one in `_print_inlining_list`.

Testing:
- [x] failing test
- [x] hs-tier1 - hs-tier4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264320](https://bugs.openjdk.java.net/browse/JDK-8264320): ShouldNotReachHere in Compile::print_inlining_move_to()


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3635/head:pull/3635` \
`$ git checkout pull/3635`

Update a local copy of the PR: \
`$ git checkout pull/3635` \
`$ git pull https://git.openjdk.java.net/jdk pull/3635/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3635`

View PR using the GUI difftool: \
`$ git pr show -t 3635`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3635.diff">https://git.openjdk.java.net/jdk/pull/3635.diff</a>

</details>
