### PR TITLE
8265782: Bump bootjdk to jdk-17+19 on macosx-aarch64 at Oracle

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -396,8 +396,13 @@ var getJibProfilesCommon = function (input, data) {
         };
     };
 
-    common.boot_jdk_version = "16";
-    common.boot_jdk_build_number = "36";
+    if (input.build_os == 'macosx' && input.build_cpu == 'aarch64') {
+        common.boot_jdk_version = "17";
+        common.boot_jdk_build_number = "19";
+    } else {
+        common.boot_jdk_version = "16";
+        common.boot_jdk_build_number = "36";
+    }
     common.boot_jdk_home = input.get("boot_jdk", "install_path") + "/jdk-"
         + common.boot_jdk_version
         + (input.build_os == "macosx" ? ".jdk/Contents/Home" : "");
@@ -1080,27 +1085,15 @@ var getJibProfilesDependencies = function (input, common) {
         boot_jdk_platform = "windows-" + input.build_cpu;
         boot_jdk_ext = ".zip";
     }
-    var boot_jdk;
-    if (boot_jdk_platform == 'osx-aarch64') {
-        boot_jdk = {
-            organization: common.organization,
-            ext: "tar.gz",
-            module: "jdk-macosx_aarch64",
-            revision: "16+1.0-beta1",
-            configure_args: "--with-boot-jdk=" + common.boot_jdk_home,
-            environment_path: common.boot_jdk_home + "/bin"
-        }
-    } else {
-        boot_jdk = {
-            server: "jpg",
-            product: "jdk",
-            version: common.boot_jdk_version,
-            build_number: common.boot_jdk_build_number,
-            file: "bundles/" + boot_jdk_platform + "/jdk-" + common.boot_jdk_version + "_"
-                + boot_jdk_platform + "_bin" + boot_jdk_ext,
-            configure_args: "--with-boot-jdk=" + common.boot_jdk_home,
-            environment_path: common.boot_jdk_home + "/bin"
-        }
+    var boot_jdk = {
+        server: "jpg",
+        product: "jdk",
+        version: common.boot_jdk_version,
+        build_number: common.boot_jdk_build_number,
+        file: "bundles/" + boot_jdk_platform + "/jdk-" + common.boot_jdk_version + "_"
+            + boot_jdk_platform + "_bin" + boot_jdk_ext,
+        configure_args: "--with-boot-jdk=" + common.boot_jdk_home,
+        environment_path: common.boot_jdk_home + "/bin"
     }
 
     var makeBinDir = (input.build_os == "windows"


### PR DESCRIPTION
The bootjdk used for macosx-aarch64 at Oracle is a custom build of JDK 16 from early December, so does not include all the JDK 16 GA functionality. This leads to build issues after JDK-8263621 which uses a method not included in the custom version. Let's bump the bootjdk used for macosx-aarch64 to jdk-17+19 instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265782](https://bugs.openjdk.java.net/browse/JDK-8265782): Bump bootjdk to jdk-17+19 on macosx-aarch64 at Oracle


### Reviewers
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)
 * [Tim Bell](https://openjdk.java.net/census#tbell) (@tbell29552 - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3636/head:pull/3636` \
`$ git checkout pull/3636`

Update a local copy of the PR: \
`$ git checkout pull/3636` \
`$ git pull https://git.openjdk.java.net/jdk pull/3636/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3636`

View PR using the GUI difftool: \
`$ git pr show -t 3636`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3636.diff">https://git.openjdk.java.net/jdk/pull/3636.diff</a>

</details>
