### PR TITLE
8265784: [C2] Hoisting of DecodeN leaves MachTemp inputs behind

### DIFF
--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -1247,7 +1247,6 @@ void PhaseCFG::verify() const {
         if (def && def != n) {
           Block* def_block = get_block_for_node(def);
           assert(def_block || def->is_Con(), "must have block; constants for debug info ok");
-          assert(!def->is_MachTemp() || def_block == block, "MachTemp should reside in same block");
           // Verify that all definitions dominate their uses (except for virtual
           // instructions merging multiple definitions).
           assert(n->is_Root() || n->is_Region() || n->is_Phi() || n->is_MachMerge() ||

--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -1247,6 +1247,7 @@ void PhaseCFG::verify() const {
         if (def && def != n) {
           Block* def_block = get_block_for_node(def);
           assert(def_block || def->is_Con(), "must have block; constants for debug info ok");
+          assert(!def->is_MachTemp() || def_block == block, "MachTemp should reside in same block");
           // Verify that all definitions dominate their uses (except for virtual
           // instructions merging multiple definitions).
           assert(n->is_Root() || n->is_Region() || n->is_Phi() || n->is_MachMerge() ||

--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -378,6 +378,15 @@ void PhaseCFG::implicit_null_check(Block* block, Node *proj, Node *val, int allo
       valb->find_remove(val);
       block->add_inst(val);
       map_node_to_block(val, block);
+      // Also hoist MachTemp inputs if they exist.
+      for (uint i = 2; i < val->req(); i++) {
+        // DecodeN has 2 regular inputs + optional MachTemp inputs.
+        MachTempNode *temp = val->in(i)->as_MachTemp();
+        assert(get_block_for_node(temp) == valb, "MachTemp is expected to be in same block as the DecodeN");
+        valb->find_remove(temp);
+        block->add_inst(temp);
+        map_node_to_block(temp, block);
+      }
       // DecodeN on x86 may kill flags. Check for flag-killing projections
       // that also need to be hoisted.
       for (DUIterator_Fast jmax, j = val->fast_outs(jmax); j < jmax; j++) {

--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -378,12 +378,12 @@ void PhaseCFG::implicit_null_check(Block* block, Node *proj, Node *val, int allo
       for (uint i = 2; i < val->req(); i++) {
         // DecodeN has 2 regular inputs + optional MachTemp or load Base inputs.
         Node *temp = val->in(i);
-        if (get_block_for_node(temp) == valb) {
-          // Input node resides in the same block. Needs to get hoisted, too.
+        Block *tempb = get_block_for_node(temp);
+        if (!tempb->dominates(block)) {
           // We only expect nodes without further inputs, like MachTemp or load Base.
           assert(temp->req() == 0 || (temp->req() == 1 && temp->in(0) == (Node*)C->root()),
                  "need for recursive hoisting not expected");
-          valb->find_remove(temp);
+          tempb->find_remove(temp);
           block->add_inst(temp);
           map_node_to_block(temp, block);
         }

--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -382,7 +382,7 @@ void PhaseCFG::implicit_null_check(Block* block, Node *proj, Node *val, int allo
           // Input node resides in the same block. Needs to get hoisted, too.
           // We only expect nodes without further inputs, like MachTemp or load Base.
           assert(temp->req() == 0 || (temp->req() == 1 && temp->in(0) == (Node*)C->root()),
-        		 "need for recursive hoisting not expected");
+                 "need for recursive hoisting not expected");
           valb->find_remove(temp);
           block->add_inst(temp);
           map_node_to_block(temp, block);

--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -380,6 +380,7 @@ void PhaseCFG::implicit_null_check(Block* block, Node *proj, Node *val, int allo
         Node *temp = val->in(i);
         Block *tempb = get_block_for_node(temp);
         if (!tempb->dominates(block)) {
+          assert(block->dominates(tempb), "sanity check: temp node placement");
           // We only expect nodes without further inputs, like MachTemp or load Base.
           assert(temp->req() == 0 || (temp->req() == 1 && temp->in(0) == (Node*)C->root()),
                  "need for recursive hoisting not expected");


### PR DESCRIPTION
PPC64 and s390 have DecodeN implementations which use a MachTemp input. When LCM hoists the DecodeN, the MachTemp nodes reside in the old block, but should get hoisted together with the DecodeN node.
Same is true for load Base input which exists on s390 for example. Unfortunately, that's just a platform specific MachNode which is not nicely recognizable in LCM.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265784](https://bugs.openjdk.java.net/browse/JDK-8265784): [C2] Hoisting of DecodeN leaves MachTemp inputs behind


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 86a4a6a89680b2e531c516ee89619c26a3bc45af
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3637/head:pull/3637` \
`$ git checkout pull/3637`

Update a local copy of the PR: \
`$ git checkout pull/3637` \
`$ git pull https://git.openjdk.java.net/jdk pull/3637/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3637`

View PR using the GUI difftool: \
`$ git pr show -t 3637`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3637.diff">https://git.openjdk.java.net/jdk/pull/3637.diff</a>

</details>
