### PR TITLE
8265682: G1: Mutex::_name dangling in HeapRegionRemSet references after JDK-8264146

### DIFF
--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -258,6 +258,7 @@ bool Monitor::wait(int64_t timeout) {
 
 Mutex::~Mutex() {
   assert_owner(NULL);
+  os::free(const_cast<char*>(_name));
 }
 
 // Only Threads_lock and Heap_lock may be safepoint_check_sometimes.
@@ -266,9 +267,10 @@ bool is_sometimes_ok(const char* name) {
 }
 
 Mutex::Mutex(int Rank, const char * name, bool allow_vm_block,
-             SafepointCheckRequired safepoint_check_required) : _owner(NULL), _name(name) {
+             SafepointCheckRequired safepoint_check_required) : _owner(NULL) {
   assert(os::mutex_init_done(), "Too early!");
   assert(name != NULL, "Mutex requires a name");
+  _name = os::strdup(name, mtInternal);
 #ifdef ASSERT
   _allow_vm_block  = allow_vm_block;
   _rank            = Rank;

--- a/test/hotspot/gtest/runtime/test_mutex.cpp
+++ b/test/hotspot/gtest/runtime/test_mutex.cpp
@@ -47,7 +47,7 @@ TEST_VM(MutexName, mutex_name) {
   }
   for (int i = 0; i < iterations; i++) {
     FormatBuffer<128> f("MyLock lock #%u", i);
-    ASSERT_TRUE(strcmp(m[i]->name(), f.buffer()) == 0) << "Wrong name!";
+    ASSERT_STREQ(m[i]->name(), f.buffer()) << "Wrong name!";
   }
 }
 

--- a/test/hotspot/gtest/runtime/test_mutex.cpp
+++ b/test/hotspot/gtest/runtime/test_mutex.cpp
@@ -25,7 +25,31 @@
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/mutex.hpp"
 #include "runtime/mutexLocker.hpp"
+#include "runtime/thread.hpp"
+#include "utilities/formatBuffer.hpp"
+#include "threadHelper.inline.hpp"
 #include "unittest.hpp"
+
+const int iterations = 10;
+static Mutex* m[iterations];
+static int i = 0;
+
+static void create_mutex(Thread* thr) {
+  m[i] = new Mutex(Mutex::leaf, FormatBuffer<128>("MyLock lock #%u", i), true, Mutex::_safepoint_check_never);
+  i++;
+}
+
+TEST_VM(MutexName, mutex_name) {
+  // Create mutexes in threads, where the names are created on the thread
+  // stacks and then check that their names are correct.
+  for (int i = 0; i < iterations; i++) {
+    nomt_test_doer(create_mutex);
+  }
+  for (int i = 0; i < iterations; i++) {
+    FormatBuffer<128> f("MyLock lock #%u", i);
+    ASSERT_TRUE(strcmp(m[i]->name(), f.buffer()) == 0) << "Wrong name!";
+  }
+}
 
 #ifdef ASSERT
 


### PR DESCRIPTION
This change makes the Mutex constructor stdup the name passed in for the few cases that the name is constructed on the stack.  Most names are shorter than 64 characters so it's still a savings.
Tested with tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265682](https://bugs.openjdk.java.net/browse/JDK-8265682): G1: Mutex::_name dangling in HeapRegionRemSet references after JDK-8264146


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to fec5c8af3bc3761e8137869ce5bcca2866e3f7ea
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3639/head:pull/3639` \
`$ git checkout pull/3639`

Update a local copy of the PR: \
`$ git checkout pull/3639` \
`$ git pull https://git.openjdk.java.net/jdk pull/3639/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3639`

View PR using the GUI difftool: \
`$ git pr show -t 3639`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3639.diff">https://git.openjdk.java.net/jdk/pull/3639.diff</a>

</details>
