### PR TITLE
8265786: ProblemList serviceability/sa/sadebugd/DisableRegistryTest.java on ZGC

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -61,4 +61,5 @@ serviceability/sa/TestJmapCore.java                           8220624   generic-
 serviceability/sa/TestJmapCoreMetaspace.java                  8220624   generic-all
 serviceability/sa/TestSysProps.java                           8220624   generic-all
 serviceability/sa/sadebugd/DebugdConnectTest.java             8220624   generic-all
+serviceability/sa/sadebugd/DisableRegistryTest.java           8220624   generic-all
 vmTestbase/jit/escape/AdaptiveBlocking/AdaptiveBlocking001/AdaptiveBlocking001.java 8260303 windows-x64


### PR DESCRIPTION
A trivial fix to ProblemList serviceability/sa/sadebugd/DisableRegistryTest.java on ZGC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265786](https://bugs.openjdk.java.net/browse/JDK-8265786): ProblemList serviceability/sa/sadebugd/DisableRegistryTest.java on ZGC


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3641/head:pull/3641` \
`$ git checkout pull/3641`

Update a local copy of the PR: \
`$ git checkout pull/3641` \
`$ git pull https://git.openjdk.java.net/jdk pull/3641/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3641`

View PR using the GUI difftool: \
`$ git pr show -t 3641`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3641.diff">https://git.openjdk.java.net/jdk/pull/3641.diff</a>

</details>
