### PR TITLE
8265793: Remove duplicate jtreg TEST.groups references for some client tests

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -74,10 +74,6 @@ tier3 = \
     :build \
     :jdk_vector \
     :jdk_rmi \
-    :jdk_beans \
-    :jdk_imageio \
-    :jdk_sound \
-    :jdk_client_sanity \
     :jdk_jfr_tier3
 
 ###############################################################################


### PR DESCRIPTION
Delete some duplicates

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265793](https://bugs.openjdk.java.net/browse/JDK-8265793): Remove duplicate jtreg TEST.groups references for some client tests


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3642/head:pull/3642` \
`$ git checkout pull/3642`

Update a local copy of the PR: \
`$ git checkout pull/3642` \
`$ git pull https://git.openjdk.java.net/jdk pull/3642/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3642`

View PR using the GUI difftool: \
`$ git pr show -t 3642`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3642.diff">https://git.openjdk.java.net/jdk/pull/3642.diff</a>

</details>
