### PR TITLE
8265816: Handle new VectorMaskCast node for x86

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -7516,6 +7516,18 @@ instruct vstoreMask8B_evex(vec dst, vec src, immI_8 size) %{
   ins_pipe( pipe_slow );
 %}
 
+instruct vmaskcast(vec dst) %{
+  predicate((vector_length(n) == vector_length(n->in(1))) &&
+            (vector_length_in_bytes(n) == vector_length_in_bytes(n->in(1))));
+  match(Set dst (VectorMaskCast dst));
+  ins_cost(0);
+  format %{ "vector_mask_cast $dst" %}
+  ins_encode %{
+    // empty
+  %}
+  ins_pipe(empty);
+%}
+
 //-------------------------------- Load Iota Indices ----------------------------------
 
 instruct loadIotaIndices(vec dst, immI_0 src, rRegP scratch) %{


### PR DESCRIPTION
To eliminate unnecessary vector mask conversion during unboxing a
VectorMaskCast node was added as part of JDK-8264104 for aarch64. This patch handles the x86 side of it.

Please review.

Best Regards,
Sandhya

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265816](https://bugs.openjdk.java.net/browse/JDK-8265816): Handle new VectorMaskCast node for x86


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3645/head:pull/3645` \
`$ git checkout pull/3645`

Update a local copy of the PR: \
`$ git checkout pull/3645` \
`$ git pull https://git.openjdk.java.net/jdk pull/3645/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3645`

View PR using the GUI difftool: \
`$ git pr show -t 3645`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3645.diff">https://git.openjdk.java.net/jdk/pull/3645.diff</a>

</details>
