### PR TITLE
8265798: Minimal build broken by JDK-8261090

### DIFF
--- a/src/hotspot/share/interpreter/rewriter.cpp
+++ b/src/hotspot/share/interpreter/rewriter.cpp
@@ -568,10 +568,12 @@ void Rewriter::rewrite_bytecodes(TRAPS) {
 }
 
 void Rewriter::rewrite(InstanceKlass* klass, TRAPS) {
+#if INCLUDE_CDS
   if (klass->is_shared()) {
     assert(!klass->is_rewritten(), "rewritten shared classes cannot be rewritten again");
     assert(MetaspaceShared::is_old_class(klass), "only shared old classes aren't rewritten");
   }
+#endif // INCLUDE_CDS
   ResourceMark rm(THREAD);
   constantPoolHandle cpool(THREAD, klass->constants());
   Rewriter     rw(klass, cpool, klass->methods(), CHECK);

--- a/src/hotspot/share/memory/metaspaceShared.hpp
+++ b/src/hotspot/share/memory/metaspaceShared.hpp
@@ -137,7 +137,7 @@ public:
   static void link_and_cleanup_shared_classes(TRAPS) NOT_CDS_RETURN;
   static bool link_class_for_cds(InstanceKlass* ik, TRAPS) NOT_CDS_RETURN_(false);
   static bool linking_required(InstanceKlass* ik) NOT_CDS_RETURN_(false);
-  static bool is_old_class(InstanceKlass* ik);
+  static bool is_old_class(InstanceKlass* ik) NOT_CDS_RETURN_(false);
 
 #if INCLUDE_CDS
   // Alignment for the 3 core CDS regions (MC/RW/RO) only.


### PR DESCRIPTION
Please review this small patch for fixing broken minimal build.

Tests:
- [x] linux-x64 minimal vm build locally
- [x] builds-tier5 (including linux-x64-zero and linux-x64-zero-debug)
- [x] tiers1 and 2 (in progress)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265798](https://bugs.openjdk.java.net/browse/JDK-8265798): Minimal build broken by JDK-8261090


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3646/head:pull/3646` \
`$ git checkout pull/3646`

Update a local copy of the PR: \
`$ git checkout pull/3646` \
`$ git pull https://git.openjdk.java.net/jdk pull/3646/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3646`

View PR using the GUI difftool: \
`$ git pr show -t 3646`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3646.diff">https://git.openjdk.java.net/jdk/pull/3646.diff</a>

</details>
