### PR TITLE
8265831: 8257831 broke Windows x86 build

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -58,6 +58,7 @@
 #include "runtime/perfMemory.hpp"
 #include "runtime/safefetch.inline.hpp"
 #include "runtime/safepointMechanism.hpp"
+#include "runtime/semaphore.inline.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/statSampler.hpp"
 #include "runtime/thread.inline.hpp"


### PR DESCRIPTION
Hi,

may I please have reviews for this trivial build fix? Thanks!

The error is just a missing include. I have no idea why this only breaks x86 though. It has nothing to do with different calling conventions between caller and callee (typical for x86 windows). I just assume the Windows x64 build pulls semaphore.inline.hpp via some other includes.

Cheers, Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265831](https://bugs.openjdk.java.net/browse/JDK-8265831): 8257831 broke Windows x86 build


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3647/head:pull/3647` \
`$ git checkout pull/3647`

Update a local copy of the PR: \
`$ git checkout pull/3647` \
`$ git pull https://git.openjdk.java.net/jdk pull/3647/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3647`

View PR using the GUI difftool: \
`$ git pr show -t 3647`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3647.diff">https://git.openjdk.java.net/jdk/pull/3647.diff</a>

</details>
