### PR TITLE
8198621: java/awt/Focus/KeyEventForBadFocusOwnerTest/KeyEventForBadFocusOwnerTest.java fails on mac

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -133,7 +133,6 @@ java/awt/Focus/ChoiceFocus/ChoiceFocus.java 8169103 windows-all,macosx-all
 java/awt/Focus/ClearLwQueueBreakTest/ClearLwQueueBreakTest.java 8198618 macosx-all
 java/awt/Focus/ConsumeNextKeyTypedOnModalShowTest/ConsumeNextKeyTypedOnModalShowTest.java 6986252 macosx-all
 java/awt/Focus/FocusTraversalPolicy/ButtonGroupLayoutTraversal/ButtonGroupLayoutTraversalTest.java 8198619 macosx-all
-java/awt/Focus/KeyEventForBadFocusOwnerTest/KeyEventForBadFocusOwnerTest.java 8198621 macosx-all
 java/awt/Focus/MouseClickRequestFocusRaceTest/MouseClickRequestFocusRaceTest.java 8194753 linux-all,macosx-all
 java/awt/Focus/NoAutotransferToDisabledCompTest/NoAutotransferToDisabledCompTest.java 7152980 macosx-all
 java/awt/Focus/SimpleWindowActivationTest/SimpleWindowActivationTest.java 8159599 macosx-all

--- a/test/jdk/java/awt/Focus/KeyEventForBadFocusOwnerTest/KeyEventForBadFocusOwnerTest.java
+++ b/test/jdk/java/awt/Focus/KeyEventForBadFocusOwnerTest/KeyEventForBadFocusOwnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,88 +54,99 @@ public class KeyEventForBadFocusOwnerTest {
     volatile static boolean unexpectedItemSelected = false;
 
     static Robot robot;
+    static JFrame frame;
 
     public static void main(String[] args) throws Exception {
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                JFrame frame = new JFrame("TEST");
-                JMenuBar mb = new JMenuBar();
-                JMenu one = new JMenu(ITEM_ONE_TEXT);
-                JMenu two = new JMenu(ITEM_TWO_TEXT);
+        try {
+            SwingUtilities.invokeAndWait(new Runnable() {
+                public void run() {
+                    frame = new JFrame("TEST");
+                    JMenuBar mb = new JMenuBar();
+                    JMenu one = new JMenu(ITEM_ONE_TEXT);
+                    JMenu two = new JMenu(ITEM_TWO_TEXT);
 
-                mb.add(one);
-                mb.add(two);
+                    mb.add(one);
+                    mb.add(two);
 
-                ActionListener al = new ActionListener() {
-                    public void actionPerformed(ActionEvent ae) {
-                        String itemText = ((JMenuItem)ae.getSource()).getText();
-                        System.out.println("--> " + itemText);
-                        unexpectedItemSelected = true;
-                    }
-                };
-                one.setMnemonic(KeyEvent.VK_O);
-                JMenuItem item = new JMenuItem("one 1");
-                item.setMnemonic(KeyEvent.VK_O);
-                item.addActionListener(al);
-                one.add(item);
-                one.add("two");
-                one.add("three");
-
-                two.setMnemonic(KeyEvent.VK_T);
-                item = new JMenuItem("two 2");
-                item.setMnemonic(KeyEvent.VK_T);
-                item.addActionListener(al);
-                two.add(item);
-                two.add("three");
-                two.add("four");
-
-                PopupMenuListener popupMenuListener = new PopupMenuListener() {
-                    public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
-                        System.out.print(e);
-                        System.out.print(e.getSource());
-                        String itemText = ((JPopupMenu)e.getSource()).getName();
-                        System.out.println("Menu " + itemText + "is opened.");
-                        switch(itemText) {
-                            case ITEM_ONE_TEXT:
-                                itemOneSelected = true;
-                                break;
-                            case ITEM_TWO_TEXT:
-                                itemTwoSelected = true;
-                                break;
+                    ActionListener al = new ActionListener() {
+                        public void actionPerformed(ActionEvent ae) {
+                            String itemText = ((JMenuItem)ae.getSource()).getText();
+                            System.out.println("--> " + itemText);
+                            unexpectedItemSelected = true;
                         }
-                    }
+                    };
+                    one.setMnemonic(KeyEvent.VK_O);
+                    JMenuItem item = new JMenuItem("one 1");
+                    item.setMnemonic(KeyEvent.VK_O);
+                    item.addActionListener(al);
+                    one.add(item);
+                    one.add("two");
+                    one.add("three");
 
-                    public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {}
-                    public void popupMenuCanceled(PopupMenuEvent e) {}
-                };
-                one.getPopupMenu().setName(ITEM_ONE_TEXT);
-                two.getPopupMenu().setName(ITEM_TWO_TEXT);
-                one.getPopupMenu().addPopupMenuListener(popupMenuListener);
-                two.getPopupMenu().addPopupMenuListener(popupMenuListener);
-                frame.setJMenuBar(mb);
-                frame.setSize(100,100);
-                frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-                frame.pack();
-                frame.setVisible(true);
+                    two.setMnemonic(KeyEvent.VK_T);
+                    item = new JMenuItem("two 2");
+                    item.setMnemonic(KeyEvent.VK_T);
+                    item.addActionListener(al);
+                    two.add(item);
+                    two.add("three");
+                    two.add("four");
+
+                    PopupMenuListener popupMenuListener = new PopupMenuListener() {
+                        public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
+                            System.out.print(e);
+                            System.out.print(e.getSource());
+                            String itemText = ((JPopupMenu)e.getSource()).getName();
+                            System.out.println("Menu " + itemText + "is opened.");
+                            switch(itemText) {
+                                case ITEM_ONE_TEXT:
+                                    itemOneSelected = true;
+                                    break;
+                                case ITEM_TWO_TEXT:
+                                    itemTwoSelected = true;
+                                    break;
+                            }
+                        }
+
+                        public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {}
+                        public void popupMenuCanceled(PopupMenuEvent e) {}
+                    };
+                    one.getPopupMenu().setName(ITEM_ONE_TEXT);
+                    two.getPopupMenu().setName(ITEM_TWO_TEXT);
+                    one.getPopupMenu().addPopupMenuListener(popupMenuListener);
+                    two.getPopupMenu().addPopupMenuListener(popupMenuListener);
+                    frame.setJMenuBar(mb);
+                    frame.setSize(100,100);
+                    frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+                    frame.setLocationRelativeTo(null);
+                    frame.pack();
+                    frame.setVisible(true);
+                }
+            });
+
+
+            robot = new Robot();
+            robot.setAutoDelay(100);
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            Util.hitMnemonics(robot, KeyEvent.VK_O);
+            Util.hitMnemonics(robot, KeyEvent.VK_T);
+
+            robot.waitForIdle();
+            Thread.sleep(1000); // workaround for MacOS
+
+            if (unexpectedItemSelected) {
+                throw new Exception("Test failed. KeyEvent dispatched to old focus owner. ");
             }
-        });
-
-
-        robot = new Robot();
-        robot.setAutoDelay(100);
-        robot.waitForIdle();
-
-        Util.hitMnemonics(robot, KeyEvent.VK_O);
-        Util.hitMnemonics(robot, KeyEvent.VK_T);
-
-        robot.waitForIdle();
-        Thread.sleep(1000); // workaround for MacOS
-
-        if (unexpectedItemSelected) {
-            throw new Exception("Test failed. KeyEvent dispatched to old focus owner. ");
-        }
-        if (!itemOneSelected || !itemTwoSelected) {
-            throw new Exception("Not all expected events were received");
+            if (!itemOneSelected || !itemTwoSelected) {
+                throw new Exception("Not all expected events were received");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
This test was failing in earlier test sprint in CI system citing java.lang.Exception: Not all expected events were received 
One of the reason could be the frame was placed at topleft corner of screen.
Modified test to move frame to center of screen. Also, frame is disposed at end.

Several iteration of test passed in all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8198621](https://bugs.openjdk.java.net/browse/JDK-8198621): java/awt/Focus/KeyEventForBadFocusOwnerTest/KeyEventForBadFocusOwnerTest.java fails on mac


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3649/head:pull/3649` \
`$ git checkout pull/3649`

Update a local copy of the PR: \
`$ git checkout pull/3649` \
`$ git pull https://git.openjdk.java.net/jdk pull/3649/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3649`

View PR using the GUI difftool: \
`$ git pr show -t 3649`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3649.diff">https://git.openjdk.java.net/jdk/pull/3649.diff</a>

</details>
