### PR TITLE
8265746: Update java.time to use instanceof pattern variable (part II)

### DIFF
--- a/src/java.base/share/classes/java/time/Clock.java
+++ b/src/java.base/share/classes/java/time/Clock.java
@@ -618,11 +618,9 @@ public abstract class Clock {
         }
         @Override
         public boolean equals(Object obj) {
-            if (obj instanceof FixedClock) {
-                FixedClock other = (FixedClock) obj;
-                return instant.equals(other.instant) && zone.equals(other.zone);
-            }
-            return false;
+            return (obj instanceof FixedClock other
+                    && instant.equals(other.instant)
+                    && zone.equals(other.zone));
         }
         @Override
         public int hashCode() {
@@ -670,11 +668,9 @@ public abstract class Clock {
         }
         @Override
         public boolean equals(Object obj) {
-            if (obj instanceof OffsetClock) {
-                OffsetClock other = (OffsetClock) obj;
-                return baseClock.equals(other.baseClock) && offset.equals(other.offset);
-            }
-            return false;
+            return (obj instanceof OffsetClock other
+                    && baseClock.equals(other.baseClock)
+                    && offset.equals(other.offset));
         }
         @Override
         public int hashCode() {

--- a/src/java.base/share/classes/java/time/Clock.java
+++ b/src/java.base/share/classes/java/time/Clock.java
@@ -618,9 +618,9 @@ public abstract class Clock {
         }
         @Override
         public boolean equals(Object obj) {
-            return (obj instanceof FixedClock other
+            return obj instanceof FixedClock other
                     && instant.equals(other.instant)
-                    && zone.equals(other.zone));
+                    && zone.equals(other.zone);
         }
         @Override
         public int hashCode() {
@@ -668,9 +668,9 @@ public abstract class Clock {
         }
         @Override
         public boolean equals(Object obj) {
-            return (obj instanceof OffsetClock other
+            return obj instanceof OffsetClock other
                     && baseClock.equals(other.baseClock)
-                    && offset.equals(other.offset));
+                    && offset.equals(other.offset);
         }
         @Override
         public int hashCode() {

--- a/src/java.base/share/classes/java/time/Instant.java
+++ b/src/java.base/share/classes/java/time/Instant.java
@@ -703,10 +703,9 @@ public final class Instant
      */
     @Override
     public Instant with(TemporalField field, long newValue) {
-        if (field instanceof ChronoField) {
-            ChronoField f = (ChronoField) field;
-            f.checkValidValue(newValue);
-            switch (f) {
+        if (field instanceof ChronoField chronoField) {
+            chronoField.checkValidValue(newValue);
+            switch (chronoField) {
                 case MILLI_OF_SECOND: {
                     int nval = (int) newValue * 1000_000;
                     return (nval != nanos ? create(seconds, nval) : this);
@@ -1143,9 +1142,8 @@ public final class Instant
     @Override
     public long until(Temporal endExclusive, TemporalUnit unit) {
         Instant end = Instant.from(endExclusive);
-        if (unit instanceof ChronoUnit) {
-            ChronoUnit f = (ChronoUnit) unit;
-            switch (f) {
+        if (unit instanceof ChronoUnit chronoUnit) {
+            switch (chronoUnit) {
                 case NANOS: return nanosUntil(end);
                 case MICROS: return nanosUntil(end) / 1000;
                 case MILLIS: return Math.subtractExact(end.toEpochMilli(), toEpochMilli());

--- a/src/java.base/share/classes/java/time/LocalDate.java
+++ b/src/java.base/share/classes/java/time/LocalDate.java
@@ -602,10 +602,9 @@ public final class LocalDate
      */
     @Override
     public ValueRange range(TemporalField field) {
-        if (field instanceof ChronoField) {
-            ChronoField f = (ChronoField) field;
-            if (f.isDateBased()) {
-                switch (f) {
+        if (field instanceof ChronoField chronoField) {
+            if (chronoField.isDateBased()) {
+                switch (chronoField) {
                     case DAY_OF_MONTH: return ValueRange.of(1, lengthOfMonth());
                     case DAY_OF_YEAR: return ValueRange.of(1, lengthOfYear());
                     case ALIGNED_WEEK_OF_MONTH: return ValueRange.of(1, getMonth() == Month.FEBRUARY && isLeapYear() == false ? 4 : 5);
@@ -1045,10 +1044,9 @@ public final class LocalDate
      */
     @Override
     public LocalDate with(TemporalField field, long newValue) {
-        if (field instanceof ChronoField) {
-            ChronoField f = (ChronoField) field;
-            f.checkValidValue(newValue);
-            switch (f) {
+        if (field instanceof ChronoField chronoField) {
+            chronoField.checkValidValue(newValue);
+            switch (chronoField) {
                 case DAY_OF_WEEK: return plusDays(newValue - getDayOfWeek().getValue());
                 case ALIGNED_DAY_OF_WEEK_IN_MONTH: return plusDays(newValue - getLong(ALIGNED_DAY_OF_WEEK_IN_MONTH));
                 case ALIGNED_DAY_OF_WEEK_IN_YEAR: return plusDays(newValue - getLong(ALIGNED_DAY_OF_WEEK_IN_YEAR));
@@ -1168,8 +1166,7 @@ public final class LocalDate
      */
     @Override
     public LocalDate plus(TemporalAmount amountToAdd) {
-        if (amountToAdd instanceof Period) {
-            Period periodToAdd = (Period) amountToAdd;
+        if (amountToAdd instanceof Period periodToAdd) {
             return plusMonths(periodToAdd.toTotalMonths()).plusDays(periodToAdd.getDays());
         }
         Objects.requireNonNull(amountToAdd, "amountToAdd");
@@ -1259,9 +1256,8 @@ public final class LocalDate
      */
     @Override
     public LocalDate plus(long amountToAdd, TemporalUnit unit) {
-        if (unit instanceof ChronoUnit) {
-            ChronoUnit f = (ChronoUnit) unit;
-            switch (f) {
+        if (unit instanceof ChronoUnit chronoUnit) {
+            switch (chronoUnit) {
                 case DAYS: return plusDays(amountToAdd);
                 case WEEKS: return plusWeeks(amountToAdd);
                 case MONTHS: return plusMonths(amountToAdd);
@@ -1418,8 +1414,7 @@ public final class LocalDate
      */
     @Override
     public LocalDate minus(TemporalAmount amountToSubtract) {
-        if (amountToSubtract instanceof Period) {
-            Period periodToSubtract = (Period) amountToSubtract;
+        if (amountToSubtract instanceof Period periodToSubtract) {
             return minusMonths(periodToSubtract.toTotalMonths()).minusDays(periodToSubtract.getDays());
         }
         Objects.requireNonNull(amountToSubtract, "amountToSubtract");

--- a/src/java.base/share/classes/java/time/LocalDateTime.java
+++ b/src/java.base/share/classes/java/time/LocalDateTime.java
@@ -574,9 +574,8 @@ public final class LocalDateTime
      */
     @Override
     public boolean isSupported(TemporalField field) {
-        if (field instanceof ChronoField) {
-            ChronoField f = (ChronoField) field;
-            return f.isDateBased() || f.isTimeBased();
+        if (field instanceof ChronoField chronoField) {
+            return chronoField.isDateBased() || chronoField.isTimeBased();
         }
         return field != null && field.isSupportedBy(this);
     }
@@ -648,9 +647,8 @@ public final class LocalDateTime
      */
     @Override
     public ValueRange range(TemporalField field) {
-        if (field instanceof ChronoField) {
-            ChronoField f = (ChronoField) field;
-            return (f.isTimeBased() ? time.range(field) : date.range(field));
+        if (field instanceof ChronoField chronoField) {
+            return (chronoField.isTimeBased() ? time.range(field) : date.range(field));
         }
         return field.rangeRefinedBy(this);
     }
@@ -685,9 +683,8 @@ public final class LocalDateTime
      */
     @Override
     public int get(TemporalField field) {
-        if (field instanceof ChronoField) {
-            ChronoField f = (ChronoField) field;
-            return (f.isTimeBased() ? time.get(field) : date.get(field));
+        if (field instanceof ChronoField chronoField) {
+            return (chronoField.isTimeBased() ? time.get(field) : date.get(field));
         }
         return ChronoLocalDateTime.super.get(field);
     }
@@ -717,9 +714,8 @@ public final class LocalDateTime
      */
     @Override
     public long getLong(TemporalField field) {
-        if (field instanceof ChronoField) {
-            ChronoField f = (ChronoField) field;
-            return (f.isTimeBased() ? time.getLong(field) : date.getLong(field));
+        if (field instanceof ChronoField chronoField) {
+            return (chronoField.isTimeBased() ? time.getLong(field) : date.getLong(field));
         }
         return field.getFrom(this);
     }
@@ -964,9 +960,8 @@ public final class LocalDateTime
      */
     @Override
     public LocalDateTime with(TemporalField field, long newValue) {
-        if (field instanceof ChronoField) {
-            ChronoField f = (ChronoField) field;
-            if (f.isTimeBased()) {
+        if (field instanceof ChronoField chronoField) {
+            if (chronoField.isTimeBased()) {
                 return with(date, time.with(field, newValue));
             } else {
                 return with(date.with(field, newValue), time);
@@ -1146,8 +1141,7 @@ public final class LocalDateTime
      */
     @Override
     public LocalDateTime plus(TemporalAmount amountToAdd) {
-        if (amountToAdd instanceof Period) {
-            Period periodToAdd = (Period) amountToAdd;
+        if (amountToAdd instanceof Period periodToAdd) {
             return with(date.plus(periodToAdd), time);
         }
         Objects.requireNonNull(amountToAdd, "amountToAdd");
@@ -1182,9 +1176,8 @@ public final class LocalDateTime
      */
     @Override
     public LocalDateTime plus(long amountToAdd, TemporalUnit unit) {
-        if (unit instanceof ChronoUnit) {
-            ChronoUnit f = (ChronoUnit) unit;
-            switch (f) {
+        if (unit instanceof ChronoUnit chronoUnit) {
+            switch (chronoUnit) {
                 case NANOS: return plusNanos(amountToAdd);
                 case MICROS: return plusDays(amountToAdd / MICROS_PER_DAY).plusNanos((amountToAdd % MICROS_PER_DAY) * 1000);
                 case MILLIS: return plusDays(amountToAdd / MILLIS_PER_DAY).plusNanos((amountToAdd % MILLIS_PER_DAY) * 1000_000);
@@ -1365,8 +1358,7 @@ public final class LocalDateTime
      */
     @Override
     public LocalDateTime minus(TemporalAmount amountToSubtract) {
-        if (amountToSubtract instanceof Period) {
-            Period periodToSubtract = (Period) amountToSubtract;
+        if (amountToSubtract instanceof Period periodToSubtract) {
             return with(date.minus(periodToSubtract), time);
         }
         Objects.requireNonNull(amountToSubtract, "amountToSubtract");

--- a/src/java.base/share/classes/java/time/LocalTime.java
+++ b/src/java.base/share/classes/java/time/LocalTime.java
@@ -855,10 +855,9 @@ public final class LocalTime
      */
     @Override
     public LocalTime with(TemporalField field, long newValue) {
-        if (field instanceof ChronoField) {
-            ChronoField f = (ChronoField) field;
-            f.checkValidValue(newValue);
-            switch (f) {
+        if (field instanceof ChronoField chronoField) {
+            chronoField.checkValidValue(newValue);
+            switch (chronoField) {
                 case NANO_OF_SECOND: return withNano((int) newValue);
                 case NANO_OF_DAY: return LocalTime.ofNanoOfDay(newValue);
                 case MICRO_OF_SECOND: return withNano((int) newValue * 1000);

--- a/src/java.base/share/classes/java/time/OffsetDateTime.java
+++ b/src/java.base/share/classes/java/time/OffsetDateTime.java
@@ -967,12 +967,11 @@ public final class OffsetDateTime
      */
     @Override
     public OffsetDateTime with(TemporalField field, long newValue) {
-        if (field instanceof ChronoField) {
-            ChronoField f = (ChronoField) field;
-            switch (f) {
+        if (field instanceof ChronoField chronoField) {
+            switch (chronoField) {
                 case INSTANT_SECONDS: return ofInstant(Instant.ofEpochSecond(newValue, getNano()), offset);
                 case OFFSET_SECONDS: {
-                    return with(dateTime, ZoneOffset.ofTotalSeconds(f.checkValidIntValue(newValue)));
+                    return with(dateTime, ZoneOffset.ofTotalSeconds(chronoField.checkValidIntValue(newValue)));
                 }
             }
             return with(dateTime.with(field, newValue), offset);

--- a/src/java.base/share/classes/java/time/Year.java
+++ b/src/java.base/share/classes/java/time/Year.java
@@ -619,10 +619,9 @@ public final class Year
      */
     @Override
     public Year with(TemporalField field, long newValue) {
-        if (field instanceof ChronoField) {
-            ChronoField f = (ChronoField) field;
-            f.checkValidValue(newValue);
-            switch (f) {
+        if (field instanceof ChronoField chronoField) {
+            chronoField.checkValidValue(newValue);
+            switch (chronoField) {
                 case YEAR_OF_ERA: return Year.of((int) (year < 1 ? 1 - newValue : newValue));
                 case YEAR: return Year.of((int) newValue);
                 case ERA: return (getLong(ERA) == newValue ? this : Year.of(1 - year));

--- a/src/java.base/share/classes/java/time/YearMonth.java
+++ b/src/java.base/share/classes/java/time/YearMonth.java
@@ -682,10 +682,9 @@ public final class YearMonth
      */
     @Override
     public YearMonth with(TemporalField field, long newValue) {
-        if (field instanceof ChronoField) {
-            ChronoField f = (ChronoField) field;
-            f.checkValidValue(newValue);
-            switch (f) {
+        if (field instanceof ChronoField chronoField) {
+            chronoField.checkValidValue(newValue);
+            switch (chronoField) {
                 case MONTH_OF_YEAR: return withMonth((int) newValue);
                 case PROLEPTIC_MONTH: return plusMonths(newValue - getProlepticMonth());
                 case YEAR_OF_ERA: return withYear((int) (year < 1 ? 1 - newValue : newValue));

--- a/src/java.base/share/classes/java/time/ZonedDateTime.java
+++ b/src/java.base/share/classes/java/time/ZonedDateTime.java
@@ -1236,11 +1236,9 @@ public final class ZonedDateTime
             return resolveLocal(LocalDateTime.of(dateTime.toLocalDate(), (LocalTime) adjuster));
         } else if (adjuster instanceof LocalDateTime) {
             return resolveLocal((LocalDateTime) adjuster);
-        } else if (adjuster instanceof OffsetDateTime) {
-            OffsetDateTime odt = (OffsetDateTime) adjuster;
+        } else if (adjuster instanceof OffsetDateTime odt) {
             return ofLocal(odt.toLocalDateTime(), zone, odt.getOffset());
-        } else if (adjuster instanceof Instant) {
-            Instant instant = (Instant) adjuster;
+        } else if (adjuster instanceof Instant instant) {
             return create(instant.getEpochSecond(), instant.getNano(), zone);
         } else if (adjuster instanceof ZoneOffset) {
             return resolveOffset((ZoneOffset) adjuster);
@@ -1302,13 +1300,12 @@ public final class ZonedDateTime
      */
     @Override
     public ZonedDateTime with(TemporalField field, long newValue) {
-        if (field instanceof ChronoField) {
-            ChronoField f = (ChronoField) field;
-            switch (f) {
+        if (field instanceof ChronoField chronoField) {
+            switch (chronoField) {
                 case INSTANT_SECONDS:
                     return create(newValue, getNano(), zone);
                 case OFFSET_SECONDS:
-                    ZoneOffset offset = ZoneOffset.ofTotalSeconds(f.checkValidIntValue(newValue));
+                    ZoneOffset offset = ZoneOffset.ofTotalSeconds(chronoField.checkValidIntValue(newValue));
                     return resolveOffset(offset);
             }
             return resolveLocal(dateTime.with(field, newValue));
@@ -1553,8 +1550,7 @@ public final class ZonedDateTime
      */
     @Override
     public ZonedDateTime plus(TemporalAmount amountToAdd) {
-        if (amountToAdd instanceof Period) {
-            Period periodToAdd = (Period) amountToAdd;
+        if (amountToAdd instanceof Period periodToAdd) {
             return resolveLocal(dateTime.plus(periodToAdd));
         }
         Objects.requireNonNull(amountToAdd, "amountToAdd");
@@ -1810,8 +1806,7 @@ public final class ZonedDateTime
      */
     @Override
     public ZonedDateTime minus(TemporalAmount amountToSubtract) {
-        if (amountToSubtract instanceof Period) {
-            Period periodToSubtract = (Period) amountToSubtract;
+        if (amountToSubtract instanceof Period periodToSubtract) {
             return resolveLocal(dateTime.minus(periodToSubtract));
         }
         Objects.requireNonNull(amountToSubtract, "amountToSubtract");
@@ -2190,13 +2185,10 @@ public final class ZonedDateTime
         if (this == obj) {
             return true;
         }
-        if (obj instanceof ZonedDateTime) {
-            ZonedDateTime other = (ZonedDateTime) obj;
-            return dateTime.equals(other.dateTime) &&
-                offset.equals(other.offset) &&
-                zone.equals(other.zone);
-        }
-        return false;
+        return (obj instanceof ZonedDateTime other
+            && dateTime.equals(other.dateTime)
+            && offset.equals(other.offset)
+            && zone.equals(other.zone));
     }
 
     /**

--- a/src/java.base/share/classes/java/time/ZonedDateTime.java
+++ b/src/java.base/share/classes/java/time/ZonedDateTime.java
@@ -2185,10 +2185,10 @@ public final class ZonedDateTime
         if (this == obj) {
             return true;
         }
-        return (obj instanceof ZonedDateTime other
-            && dateTime.equals(other.dateTime)
-            && offset.equals(other.offset)
-            && zone.equals(other.zone));
+        return obj instanceof ZonedDateTime other
+                && dateTime.equals(other.dateTime)
+                && offset.equals(other.offset)
+                && zone.equals(other.zone);
     }
 
     /**

--- a/src/java.base/share/classes/java/time/chrono/ChronoLocalDateImpl.java
+++ b/src/java.base/share/classes/java/time/chrono/ChronoLocalDateImpl.java
@@ -197,9 +197,8 @@ abstract class ChronoLocalDateImpl<D extends ChronoLocalDate>
     @Override
     @SuppressWarnings("unchecked")
     public D plus(long amountToAdd, TemporalUnit unit) {
-        if (unit instanceof ChronoUnit) {
-            ChronoUnit f = (ChronoUnit) unit;
-            switch (f) {
+        if (unit instanceof ChronoUnit chronoUnit) {
+            switch (chronoUnit) {
                 case DAYS: return plusDays(amountToAdd);
                 case WEEKS: return plusDays(Math.multiplyExact(amountToAdd, 7));
                 case MONTHS: return plusMonths(amountToAdd);

--- a/src/java.base/share/classes/java/time/chrono/ChronoLocalDateTimeImpl.java
+++ b/src/java.base/share/classes/java/time/chrono/ChronoLocalDateTimeImpl.java
@@ -238,36 +238,32 @@ final class ChronoLocalDateTimeImpl<D extends ChronoLocalDate>
     //-----------------------------------------------------------------------
     @Override
     public boolean isSupported(TemporalField field) {
-        if (field instanceof ChronoField) {
-            ChronoField f = (ChronoField) field;
-            return f.isDateBased() || f.isTimeBased();
+        if (field instanceof ChronoField chronoField) {
+            return chronoField.isDateBased() || chronoField.isTimeBased();
         }
         return field != null && field.isSupportedBy(this);
     }
 
     @Override
     public ValueRange range(TemporalField field) {
-        if (field instanceof ChronoField) {
-            ChronoField f = (ChronoField) field;
-            return (f.isTimeBased() ? time.range(field) : date.range(field));
+        if (field instanceof ChronoField chronoField) {
+            return (chronoField.isTimeBased() ? time.range(field) : date.range(field));
         }
         return field.rangeRefinedBy(this);
     }
 
     @Override
     public int get(TemporalField field) {
-        if (field instanceof ChronoField) {
-            ChronoField f = (ChronoField) field;
-            return (f.isTimeBased() ? time.get(field) : date.get(field));
+        if (field instanceof ChronoField chronoField) {
+            return (chronoField.isTimeBased() ? time.get(field) : date.get(field));
         }
         return range(field).checkValidIntValue(getLong(field), field);
     }
 
     @Override
     public long getLong(TemporalField field) {
-        if (field instanceof ChronoField) {
-            ChronoField f = (ChronoField) field;
-            return (f.isTimeBased() ? time.getLong(field) : date.getLong(field));
+        if (field instanceof ChronoField chronoField) {
+            return (chronoField.isTimeBased() ? time.getLong(field) : date.getLong(field));
         }
         return field.getFrom(this);
     }
@@ -289,9 +285,8 @@ final class ChronoLocalDateTimeImpl<D extends ChronoLocalDate>
 
     @Override
     public ChronoLocalDateTimeImpl<D> with(TemporalField field, long newValue) {
-        if (field instanceof ChronoField) {
-            ChronoField f = (ChronoField) field;
-            if (f.isTimeBased()) {
+        if (field instanceof ChronoField chronoField) {
+            if (chronoField.isTimeBased()) {
                 return with(date, time.with(field, newValue));
             } else {
                 return with(date.with(field, newValue), time);
@@ -303,9 +298,8 @@ final class ChronoLocalDateTimeImpl<D extends ChronoLocalDate>
     //-----------------------------------------------------------------------
     @Override
     public ChronoLocalDateTimeImpl<D> plus(long amountToAdd, TemporalUnit unit) {
-        if (unit instanceof ChronoUnit) {
-            ChronoUnit f = (ChronoUnit) unit;
-            switch (f) {
+        if (unit instanceof ChronoUnit chronoUnit) {
+            switch (chronoUnit) {
                 case NANOS: return plusNanos(amountToAdd);
                 case MICROS: return plusDays(amountToAdd / MICROS_PER_DAY).plusNanos((amountToAdd % MICROS_PER_DAY) * 1000);
                 case MILLIS: return plusDays(amountToAdd / MILLIS_PER_DAY).plusNanos((amountToAdd % MILLIS_PER_DAY) * 1000000);

--- a/src/java.base/share/classes/java/time/chrono/ChronoPeriodImpl.java
+++ b/src/java.base/share/classes/java/time/chrono/ChronoPeriodImpl.java
@@ -199,10 +199,9 @@ final class ChronoPeriodImpl
      */
     private ChronoPeriodImpl validateAmount(TemporalAmount amount) {
         Objects.requireNonNull(amount, "amount");
-        if (!(amount instanceof ChronoPeriodImpl)) {
+        if (!(amount instanceof ChronoPeriodImpl period)) {
             throw new DateTimeException("Unable to obtain ChronoPeriod from TemporalAmount: " + amount.getClass());
         }
-        ChronoPeriodImpl period = (ChronoPeriodImpl) amount;
         if (!(chrono.equals(period.getChronology()))) {
             throw new ClassCastException("Chronology mismatch, expected: " + chrono.getId() + ", actual: " + period.getChronology().getId());
         }

--- a/src/java.base/share/classes/java/time/chrono/ChronoZonedDateTimeImpl.java
+++ b/src/java.base/share/classes/java/time/chrono/ChronoZonedDateTimeImpl.java
@@ -283,12 +283,11 @@ final class ChronoZonedDateTimeImpl<D extends ChronoLocalDate>
     //-----------------------------------------------------------------------
     @Override
     public ChronoZonedDateTime<D> with(TemporalField field, long newValue) {
-        if (field instanceof ChronoField) {
-            ChronoField f = (ChronoField) field;
-            switch (f) {
+        if (field instanceof ChronoField chronoField) {
+            switch (chronoField) {
                 case INSTANT_SECONDS: return plus(newValue - toEpochSecond(), SECONDS);
                 case OFFSET_SECONDS: {
-                    ZoneOffset offset = ZoneOffset.ofTotalSeconds(f.checkValidIntValue(newValue));
+                    ZoneOffset offset = ZoneOffset.ofTotalSeconds(chronoField.checkValidIntValue(newValue));
                     return create(dateTime.toInstant(offset), zone);
                 }
             }

--- a/src/java.base/share/classes/java/time/chrono/HijrahDate.java
+++ b/src/java.base/share/classes/java/time/chrono/HijrahDate.java
@@ -394,12 +394,11 @@ public final class HijrahDate
 
     @Override
     public HijrahDate with(TemporalField field, long newValue) {
-        if (field instanceof ChronoField) {
-            ChronoField f = (ChronoField) field;
+        if (field instanceof ChronoField chronoField) {
             // not using checkValidIntValue so EPOCH_DAY and PROLEPTIC_MONTH work
-            chrono.range(f).checkValidValue(newValue, f);    // TODO: validate value
+            chrono.range(chronoField).checkValidValue(newValue, chronoField);    // TODO: validate value
             int nvalue = (int) newValue;
-            switch (f) {
+            switch (chronoField) {
                 case DAY_OF_WEEK: return plusDays(newValue - getDayOfWeek());
                 case ALIGNED_DAY_OF_WEEK_IN_MONTH: return plusDays(newValue - getLong(ALIGNED_DAY_OF_WEEK_IN_MONTH));
                 case ALIGNED_DAY_OF_WEEK_IN_YEAR: return plusDays(newValue - getLong(ALIGNED_DAY_OF_WEEK_IN_YEAR));

--- a/src/java.base/share/classes/java/time/chrono/JapaneseDate.java
+++ b/src/java.base/share/classes/java/time/chrono/JapaneseDate.java
@@ -514,17 +514,16 @@ public final class JapaneseDate
     //-----------------------------------------------------------------------
     @Override
     public JapaneseDate with(TemporalField field, long newValue) {
-        if (field instanceof ChronoField) {
-            ChronoField f = (ChronoField) field;
-            if (getLong(f) == newValue) {  // getLong() validates for supported fields
+        if (field instanceof ChronoField chronoField) {
+            if (getLong(chronoField) == newValue) {  // getLong() validates for supported fields
                 return this;
             }
-            switch (f) {
+            switch (chronoField) {
                 case YEAR_OF_ERA:
                 case YEAR:
                 case ERA: {
-                    int nvalue = getChronology().range(f).checkValidIntValue(newValue, f);
-                    switch (f) {
+                    int nvalue = getChronology().range(chronoField).checkValidIntValue(newValue, chronoField);
+                    switch (chronoField) {
                         case YEAR_OF_ERA:
                             return this.withYear(nvalue);
                         case YEAR:

--- a/src/java.base/share/classes/java/time/chrono/MinguoDate.java
+++ b/src/java.base/share/classes/java/time/chrono/MinguoDate.java
@@ -311,20 +311,19 @@ public final class MinguoDate
     //-----------------------------------------------------------------------
     @Override
     public MinguoDate with(TemporalField field, long newValue) {
-        if (field instanceof ChronoField) {
-            ChronoField f = (ChronoField) field;
-            if (getLong(f) == newValue) {
+        if (field instanceof ChronoField chronoField) {
+            if (getLong(chronoField) == newValue) {
                 return this;
             }
-            switch (f) {
+            switch (chronoField) {
                 case PROLEPTIC_MONTH:
-                    getChronology().range(f).checkValidValue(newValue, f);
+                    getChronology().range(chronoField).checkValidValue(newValue, chronoField);
                     return plusMonths(newValue - getProlepticMonth());
                 case YEAR_OF_ERA:
                 case YEAR:
                 case ERA: {
-                    int nvalue = getChronology().range(f).checkValidIntValue(newValue, f);
-                    switch (f) {
+                    int nvalue = getChronology().range(chronoField).checkValidIntValue(newValue, chronoField);
+                    switch (chronoField) {
                         case YEAR_OF_ERA:
                             return with(isoDate.withYear(getProlepticYear() >= 1 ? nvalue + YEARS_DIFFERENCE : (1 - nvalue)  + YEARS_DIFFERENCE));
                         case YEAR:

--- a/src/java.base/share/classes/java/time/chrono/ThaiBuddhistDate.java
+++ b/src/java.base/share/classes/java/time/chrono/ThaiBuddhistDate.java
@@ -311,20 +311,19 @@ public final class ThaiBuddhistDate
     //-----------------------------------------------------------------------
     @Override
     public ThaiBuddhistDate with(TemporalField field, long newValue) {
-        if (field instanceof ChronoField) {
-            ChronoField f = (ChronoField) field;
-            if (getLong(f) == newValue) {
+        if (field instanceof ChronoField chronoField) {
+            if (getLong(chronoField) == newValue) {
                 return this;
             }
-            switch (f) {
+            switch (chronoField) {
                 case PROLEPTIC_MONTH:
-                    getChronology().range(f).checkValidValue(newValue, f);
+                    getChronology().range(chronoField).checkValidValue(newValue, chronoField);
                     return plusMonths(newValue - getProlepticMonth());
                 case YEAR_OF_ERA:
                 case YEAR:
                 case ERA: {
-                    int nvalue = getChronology().range(f).checkValidIntValue(newValue, f);
-                    switch (f) {
+                    int nvalue = getChronology().range(chronoField).checkValidIntValue(newValue, chronoField);
+                    switch (chronoField) {
                         case YEAR_OF_ERA:
                             return with(isoDate.withYear((getProlepticYear() >= 1 ? nvalue : 1 - nvalue)  - YEARS_DIFFERENCE));
                         case YEAR:

--- a/src/java.base/share/classes/java/time/format/DecimalStyle.java
+++ b/src/java.base/share/classes/java/time/format/DecimalStyle.java
@@ -353,12 +353,11 @@ public final class DecimalStyle {
         if (this == obj) {
             return true;
         }
-        if (obj instanceof DecimalStyle) {
-            DecimalStyle other = (DecimalStyle) obj;
-            return (zeroDigit == other.zeroDigit && positiveSign == other.positiveSign &&
-                    negativeSign == other.negativeSign && decimalSeparator == other.decimalSeparator);
-        }
-        return false;
+        return (obj instanceof DecimalStyle other
+                &&  zeroDigit == other.zeroDigit
+                && positiveSign == other.positiveSign
+                && negativeSign == other.negativeSign
+                && decimalSeparator == other.decimalSeparator);
     }
 
     /**

--- a/src/java.base/share/classes/java/time/format/Parsed.java
+++ b/src/java.base/share/classes/java/time/format/Parsed.java
@@ -282,8 +282,7 @@ final class Parsed implements TemporalAccessor {
                     TemporalField targetField = entry.getKey();
                     TemporalAccessor resolvedObject = targetField.resolve(fieldValues, this, resolverStyle);
                     if (resolvedObject != null) {
-                        if (resolvedObject instanceof ChronoZonedDateTime) {
-                            ChronoZonedDateTime<?> czdt = (ChronoZonedDateTime<?>) resolvedObject;
+                        if (resolvedObject instanceof ChronoZonedDateTime<?> czdt) {
                             if (zone == null) {
                                 zone = czdt.getZone();
                             } else if (zone.equals(czdt.getZone()) == false) {
@@ -291,8 +290,7 @@ final class Parsed implements TemporalAccessor {
                             }
                             resolvedObject = czdt.toLocalDateTime();
                         }
-                        if (resolvedObject instanceof ChronoLocalDateTime) {
-                            ChronoLocalDateTime<?> cldt = (ChronoLocalDateTime<?>) resolvedObject;
+                        if (resolvedObject instanceof ChronoLocalDateTime<?> cldt) {
                             updateCheckConflict(cldt.toLocalTime(), Period.ZERO);
                             updateCheckConflict(cldt.toLocalDate());
                             changedCount++;

--- a/src/java.base/share/classes/java/time/zone/TzdbZoneRulesProvider.java
+++ b/src/java.base/share/classes/java/time/zone/TzdbZoneRulesProvider.java
@@ -130,8 +130,7 @@ final class TzdbZoneRulesProvider extends ZoneRulesProvider {
             throw new ZoneRulesException("Unknown time-zone ID: " + zoneId);
         }
         try {
-            if (obj instanceof byte[]) {
-                byte[] bytes = (byte[]) obj;
+            if (obj instanceof byte[] bytes) {
                 DataInputStream dis = new DataInputStream(new ByteArrayInputStream(bytes));
                 obj = Ser.read(dis);
                 regionToRules.put(zoneId, obj);


### PR DESCRIPTION
Hi,

Could someone please review the second half of my update for the `java.time` package to make use of the `instanceof` pattern variable?

This PR was split into two parts due to the large number of files affected.

Kind regards,
 Patrick

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265746](https://bugs.openjdk.java.net/browse/JDK-8265746): Update java.time to use instanceof pattern variable (part II)


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to 974ccbf07e223c857dee65da67abe22c0c367ffc
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3650/head:pull/3650` \
`$ git checkout pull/3650`

Update a local copy of the PR: \
`$ git checkout pull/3650` \
`$ git pull https://git.openjdk.java.net/jdk pull/3650/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3650`

View PR using the GUI difftool: \
`$ git pr show -t 3650`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3650.diff">https://git.openjdk.java.net/jdk/pull/3650.diff</a>

</details>
