### PR TITLE
8264317: Lanai: IncorrectUnmanagedImageRotatedClip.java fails on apple M1

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLClip.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLClip.m
@@ -310,6 +310,7 @@ static void initTemplatePipelineDescriptors() {
             clearPassDescriptor.stencilAttachment.texture = _stencilTextureRef;
             clearPassDescriptor.stencilAttachment.clearStencil = 0;
             clearPassDescriptor.stencilAttachment.loadAction = MTLLoadActionClear;
+            clearPassDescriptor.stencilAttachment.storeAction = MTLStoreActionStore;
 
             id<MTLCommandBuffer> commandBuf = [_mtlc createCommandBuffer];
             id <MTLRenderCommandEncoder> clearEncoder = [commandBuf renderCommandEncoderWithDescriptor:clearPassDescriptor];

--- a/test/jdk/java/awt/image/DrawImage/IncorrectUnmanagedImageRotatedClip.java
+++ b/test/jdk/java/awt/image/DrawImage/IncorrectUnmanagedImageRotatedClip.java
@@ -45,7 +45,7 @@ import static java.awt.image.BufferedImage.TYPE_INT_ARGB;
 /**
  * @test
  * @key headful
- * @bug 8059942
+ * @bug 8059942 8264317
  * @summary Tests rotated clip when unmanaged image is drawn to VI.
  *          Results of the blit to compatibleImage are used for comparison.
  * @run main/othervm -Dsun.java2d.uiScale=1 IncorrectUnmanagedImageRotatedClip


### PR DESCRIPTION
Explicitly set storeAction in clear pass for stencil texture

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264317](https://bugs.openjdk.java.net/browse/JDK-8264317): Lanai: IncorrectUnmanagedImageRotatedClip.java fails on apple M1


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3651/head:pull/3651` \
`$ git checkout pull/3651`

Update a local copy of the PR: \
`$ git checkout pull/3651` \
`$ git pull https://git.openjdk.java.net/jdk pull/3651/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3651`

View PR using the GUI difftool: \
`$ git pr show -t 3651`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3651.diff">https://git.openjdk.java.net/jdk/pull/3651.diff</a>

</details>
