### PR TITLE
G1: Introduce API to run multiple separate tasks in a single gangtask

### DIFF
--- a/src/hotspot/share/gc/g1/g1BatchedGangTask.cpp
+++ b/src/hotspot/share/gc/g1/g1BatchedGangTask.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+
+#include "gc/g1/g1BatchedGangTask.hpp"
+#include "gc/g1/g1CollectedHeap.inline.hpp"
+#include "gc/g1/g1GCParPhaseTimesTracker.hpp"
+#include "runtime/atomic.hpp"
+#include "utilities/growableArray.hpp"
+
+void G1AbstractSubTask::record_work_item(uint worker_id, uint index, size_t count) {
+  G1CollectedHeap* g1h = G1CollectedHeap::heap();
+  g1h->phase_times()->record_thread_work_item(_tag, worker_id, count, index);
+}
+
+const char* G1AbstractSubTask::name() const {
+  G1CollectedHeap* g1h = G1CollectedHeap::heap();
+  return g1h->phase_times()->phase_name(_tag);
+}
+
+bool G1BatchedGangTask::try_claim_serial_task(int& task) {
+  task = Atomic::load(&_num_serial_tasks_done);
+  if (task < _serial_tasks.length()) {
+    task = Atomic::add(&_num_serial_tasks_done, 1) - 1;
+  }
+  return task < _serial_tasks.length();
+}
+
+G1BatchedGangTask::G1BatchedGangTask(const char* name, G1GCPhaseTimes* phase_times) :
+  AbstractGangTask(name),
+  _num_serial_tasks_done(0),
+  _phase_times(phase_times),
+  _serial_tasks(),
+  _parallel_tasks() {
+}
+
+uint G1BatchedGangTask::num_busy_workers() const {
+  double sum = 0.0;
+  for (G1AbstractSubTask* task : _serial_tasks) {
+    sum += task->num_busy_workers();
+  }
+  for (G1AbstractSubTask* task : _parallel_tasks) {
+    sum += task->num_busy_workers();
+  }
+  return ceil(sum);
+}
+
+void G1BatchedGangTask::set_max_workers(uint max_workers) {
+  for (G1AbstractSubTask* task : _serial_tasks) {
+    task->set_max_workers(max_workers);
+  }
+  for (G1AbstractSubTask* task : _parallel_tasks) {
+    task->set_max_workers(max_workers);
+  }
+}
+
+void G1BatchedGangTask::work(uint worker_id) {
+  int t = 0;
+  while (try_claim_serial_task(t)) {
+    G1AbstractSubTask* task = _serial_tasks.at(t);
+    G1GCParPhaseTimesTracker x(_phase_times, task->tag(), worker_id);
+    task->do_work(worker_id);
+  }
+  for (G1AbstractSubTask* task : _parallel_tasks) {
+    G1GCParPhaseTimesTracker x(_phase_times, task->tag(), worker_id);
+    task->do_work(worker_id);
+  }
+}
+
+G1BatchedGangTask::~G1BatchedGangTask() {
+  assert(Atomic::load(&_num_serial_tasks_done) >= _serial_tasks.length(),
+         "Only %d tasks of %d claimed", Atomic::load(&_num_serial_tasks_done), _serial_tasks.length());
+
+  for (G1AbstractSubTask* task : _parallel_tasks) {
+    delete task;
+  }
+  for (G1AbstractSubTask* task : _serial_tasks) {
+    delete task;
+  }
+}  

--- a/src/hotspot/share/gc/g1/g1BatchedGangTask.cpp
+++ b/src/hotspot/share/gc/g1/g1BatchedGangTask.cpp
@@ -99,4 +99,4 @@ G1BatchedGangTask::~G1BatchedGangTask() {
   for (G1AbstractSubTask* task : _serial_tasks) {
     delete task;
   }
-}  
+}

--- a/src/hotspot/share/gc/g1/g1BatchedGangTask.hpp
+++ b/src/hotspot/share/gc/g1/g1BatchedGangTask.hpp
@@ -115,7 +115,7 @@ protected:
 public:
   void work(uint worker_id) override;
 
-  // How many workers can this gang task keep busy and could be started. 
+  // How many workers can this gang task keep busy and could be started.
   uint num_busy_workers() const;
   // Informs the G1AbstractSubTasks about that we will start execution with the
   // given number of workers.

--- a/src/hotspot/share/gc/g1/g1BatchedGangTask.hpp
+++ b/src/hotspot/share/gc/g1/g1BatchedGangTask.hpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_GC_G1_G1BATCHEDGANGTASK_HPP
+#define SHARE_GC_G1_G1BATCHEDGANGTASK_HPP
+
+#include "gc/g1/g1GCPhaseTimes.hpp"
+#include "gc/shared/workgroup.hpp"
+#include "memory/allocation.hpp"
+
+template <typename E, MEMFLAGS F>
+class GrowableArrayCHeap;
+
+// G1AbstractSubTask represents a task to be performed either within an
+// G1BatchedGangTask running on a single thread ("serially") or multiple threads
+// ("in parallel"). A G1AbstractSubTask is always associated with a phase tag
+// that is used to automatically store timing information.
+//
+// See G1BatchedGangTask for information on execution.
+class G1AbstractSubTask : public CHeapObj<mtGC> {
+  G1GCPhaseTimes::GCParPhases _tag;
+
+  NONCOPYABLE(G1AbstractSubTask);
+
+protected:
+  // Record work item for this tag in G1GCPhaseTimes.
+  void record_work_item(uint worker_id, uint index, size_t count);
+
+public:
+  G1AbstractSubTask(G1GCPhaseTimes::GCParPhases tag) : _tag(tag) { }
+  virtual ~G1AbstractSubTask() { }
+
+  // How many worker (threads) would this task be able to keep busy for at least
+  // as long as to amortize worker startup costs.
+  // Called by G1BatchedGangTask to determine total number of workers.
+  virtual double num_busy_workers() const { return 1.0; }
+
+  // Called by G1BatchedGangTask to provide information about the the maximum
+  // number of workers for all subtasks after it has been determined.
+  virtual void set_max_workers(uint max_workers) { }
+
+  // Perform the actual work.
+  virtual void do_work(uint worker_id) = 0;
+
+  // Tag for this G1AbstractSubTask.
+  G1GCPhaseTimes::GCParPhases tag() const { return _tag; }
+  // Human readable name.
+  const char* name() const;
+};
+
+// G1BatchedGangTask runs a set of G1AbstractSubTask using a work gang.
+//
+// Subclasses of this class add their G1AbstractSubTasks into either the list
+// of "serial" or the list of "parallel" tasks.
+// During execution in the work gang, this class will make sure that the "serial"
+// tasks are executed by a single thread only exactly once, while "parallel"
+// tasks may be executed by different workers, at most once per given worker id.
+//
+// The G1AbstractSubTask's do_work() method gets a unique worker_id each time the
+// method is called.
+// There is no guarantee that G1AbstractSubTasks::do_work() of different tasks
+// are actually run in parallel.
+//
+// The current framework assumes that constructors and destructors of the
+// G1AbstractSubTasks are executed in the constructor/destructor of an instance
+// of this class.
+//
+// The constructor, destructor and the do_work() methods from different
+// G1AbstractSubTasks may run in any order so they must not have any
+// dependencies at all.
+//
+// For a given G1AbstractSubTask T call order of its methods are as follows:
+//
+// 1) T()
+// 2) T::thread_usage()
+// 3) T::set_max_workers()
+// 4) T::do_work()  // potentially in parallel with any other registered G1AbstractSubTask
+// 5) ~T()
+//
+class G1BatchedGangTask : public AbstractGangTask {
+  volatile int _num_serial_tasks_done;
+  G1GCPhaseTimes* _phase_times;
+
+  bool try_claim_serial_task(int& task);
+
+  NONCOPYABLE(G1BatchedGangTask);
+
+protected:
+  GrowableArrayCHeap<G1AbstractSubTask*, mtGC> _serial_tasks;
+  GrowableArrayCHeap<G1AbstractSubTask*, mtGC> _parallel_tasks;
+
+  G1BatchedGangTask(const char* name, G1GCPhaseTimes* phase_times);
+
+public:
+  void work(uint worker_id) override;
+
+  // How many workers can this gang task keep busy and could be started. 
+  uint num_busy_workers() const;
+  // Informs the G1AbstractSubTasks about that we will start execution with the
+  // given number of workers.
+  void set_max_workers(uint max_workers);
+
+  ~G1BatchedGangTask();
+};
+
+#endif // SHARE_GC_G1_G1BATCHEDGANGTASK_HPP

--- a/test/hotspot/gtest/gc/g1/test_g1BatchedGangTask.cpp
+++ b/test/hotspot/gtest/gc/g1/test_g1BatchedGangTask.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+
+#include "gc/g1/g1BatchedGangTask.hpp"
+#include "gc/shared/workgroup.hpp"
+#include "runtime/atomic.hpp"
+#include "unittest.hpp"
+
+class G1BatchedGangTaskWorkers : AllStatic {
+  static WorkGang* _work_gang;
+  static WorkGang* work_gang() {
+    if (_work_gang == NULL) {
+      _work_gang = new WorkGang("G1 Small Workers", MaxWorkers, false, false);
+      _work_gang->initialize_workers();
+      _work_gang->update_active_workers(MaxWorkers);
+    }
+    return _work_gang;
+  }
+
+public:
+  static const uint MaxWorkers = 4;
+  static void run_task(AbstractGangTask* task) {
+    work_gang()->run_task(task);
+  }
+};
+
+WorkGang* G1BatchedGangTaskWorkers::_work_gang = NULL;
+
+class G1TestSubTask : public G1AbstractSubTask {
+  mutable uint _phase;
+  volatile uint _num_do_work; // Amount of do_work() has been called.
+
+  void check_and_inc_phase(uint expected) const {
+    ASSERT_EQ(_phase, expected);
+    _phase++;
+  }
+
+  bool volatile* _do_work_called_by;
+
+protected:
+  uint _max_workers;
+
+  void do_work_called(uint worker_id) {
+    Atomic::inc(&_num_do_work);
+    bool orig_value = Atomic::cmpxchg(&_do_work_called_by[worker_id], false, true);
+    ASSERT_EQ(orig_value, false);
+  }
+
+  void verify_do_work_called_by(uint num_workers) {
+    ASSERT_EQ(Atomic::load(&_num_do_work), num_workers);
+    // Do not need to check the _do_work_called_by array. The count is already verified
+    // by above statement, and we already check that a given flag is only set once.
+  }
+
+public:
+  // Actual use of GCParPhasesSentinel will cause an assertion failure when trying
+  // to add timing information - this should be disabled here.
+  G1TestSubTask() : G1AbstractSubTask(G1GCPhaseTimes::GCParPhasesSentinel),
+    _phase(0),
+    _num_do_work(0),
+    _do_work_called_by(NULL),
+    _max_workers(0) {
+    check_and_inc_phase(0);
+  }
+
+  ~G1TestSubTask() {
+    check_and_inc_phase(3);
+    FREE_C_HEAP_ARRAY(bool, _do_work_called_by);
+  }
+
+  double num_busy_workers() const override {
+    check_and_inc_phase(1);
+    return 1.0;
+  }
+
+  // Called by G1BatchedGangTask to provide information about the the maximum
+  // number of workers for all subtasks after it has been determined.
+  void set_max_workers(uint max_workers) override {
+    assert(max_workers >= 1, "must be");
+    check_and_inc_phase(2);
+
+    _do_work_called_by = NEW_C_HEAP_ARRAY(bool, max_workers, mtInternal);
+    for (uint i = 0; i < max_workers; i++) {
+      _do_work_called_by[i] = false;
+    }
+    _max_workers = max_workers;
+  }
+
+  void do_work(uint worker_id) override {
+    do_work_called(worker_id);
+  }
+};
+
+class G1SerialTestSubTask : public G1TestSubTask {
+public:
+  G1SerialTestSubTask() : G1TestSubTask() { }
+  ~G1SerialTestSubTask() {
+    verify_do_work_called_by(1);
+  }
+
+  double num_busy_workers() const override {
+    G1TestSubTask::num_busy_workers();
+    return 1.0;
+  }
+};
+
+class G1ParallelTestSubTask : public G1TestSubTask {
+public:
+  G1ParallelTestSubTask() : G1TestSubTask() { }
+  ~G1ParallelTestSubTask() {
+    verify_do_work_called_by(_max_workers);
+  }
+
+  double num_busy_workers() const override {
+    G1TestSubTask::num_busy_workers();
+    return 2.0;
+  }
+};
+
+class G1TestBatchedGangTask : public G1BatchedGangTask {
+public:
+  G1TestBatchedGangTask() : G1BatchedGangTask("Batched Gang Test Task", NULL) {
+    _serial_tasks.push(new G1SerialTestSubTask());
+    _parallel_tasks.push(new G1ParallelTestSubTask());
+  }
+};
+
+TEST_VM(G1BatchedGangTask, check) {
+  G1TestBatchedGangTask task;
+  uint tasks = task.num_busy_workers();
+  ASSERT_EQ(tasks, 3u);
+  task.set_max_workers(G1BatchedGangTaskWorkers::MaxWorkers);
+  G1BatchedGangTaskWorkers::run_task(&task);
+}


### PR DESCRIPTION
JDK-8214237 is going to join different somewhat independent (sub-)tasks of the post evacuation phase into basically two gangtasks to improve performance (reduce startup and shutdown of work gangs).

To facilitate doing that, introduce an API that manages subtasks of a given gangtask and provide some helpers to do common work.

This CR is only about adding the API and testing to somewhat simplify the actual move of the post evacuate tasks into parallel tasks. There is no new functionality, this change only splits up the code into smaller pieces for JDK-8214237.

[Here](https://github.com/openjdk/jdk/compare/master...tschatzl:parallel-phases-join-everything) is the full change that uses this API to implement JDK-8214237 (which I'll try to split up a bit before) to see how it will be used (in [G1YoungGCPostEvacuateTasks.hpp](https://github.com/openjdk/jdk/compare/master...tschatzl:parallel-phases-join-everything#diff-64bc43a24e11978920bb9523cb1507a7275ace22d9eead4c34177339a3258e42).
With this change pushed, the JDK-8214237 is 99.9% moving code to the new files and wiring it up.

Suggestions for better naming are welcome.

Testing: new gtest, tier1-5 with mentioned patch for JDK-8214237.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3652/head:pull/3652` \
`$ git checkout pull/3652`

Update a local copy of the PR: \
`$ git checkout pull/3652` \
`$ git pull https://git.openjdk.java.net/jdk pull/3652/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3652`

View PR using the GUI difftool: \
`$ git pr show -t 3652`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3652.diff">https://git.openjdk.java.net/jdk/pull/3652.diff</a>

</details>
