### PR TITLE
JDK-8265613: False positives for "Related Packages"

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/PackageSummaryBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/PackageSummaryBuilder.java
@@ -322,6 +322,7 @@ public class PackageSummaryBuilder extends AbstractBuilder {
         String pkgPrefix = lastdot > 0 ? pkgName.substring(0, lastdot) : null;
         List<PackageElement> packages = new ArrayList<>(
                 filterPackages(p -> p.getQualifiedName().toString().equals(pkgPrefix)));
+        boolean hasSuperPackage = !packages.isEmpty();
 
         // add subpackages unless there are very many of them
         Pattern subPattern = Pattern.compile(pkgName.replace(".", "\\.") + "\\.\\w+");
@@ -331,8 +332,9 @@ public class PackageSummaryBuilder extends AbstractBuilder {
             packages.addAll(subpackages);
         }
 
-        // only add sibling packages if we are beneath threshold, and number of siblings is beneath threshold as well
-        if (pkgPrefix != null && packages.size() <= MAX_SIBLING_PACKAGES) {
+        // only add sibling packages if there is a non-empty super package, we are beneath threshold,
+        // and number of siblings is beneath threshold as well
+        if (hasSuperPackage && pkgPrefix != null && packages.size() <= MAX_SIBLING_PACKAGES) {
             Pattern siblingPattern = Pattern.compile(pkgPrefix.replace(".", "\\.") + "\\.\\w+");
 
             List<PackageElement> siblings = filterPackages(

--- a/test/langtools/jdk/javadoc/doclet/testRelatedPackages/TestRelatedPackages.java
+++ b/test/langtools/jdk/javadoc/doclet/testRelatedPackages/TestRelatedPackages.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8260388
+ * @bug 8260388 8265613
  * @summary Listing (sub)packages at package level of API documentation
  * @library /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -52,95 +52,97 @@ public class TestRelatedPackages extends JavadocTester {
     @Test
     public void testRelatedPackages(Path base) throws Exception {
         Path src = base.resolve("src-packages");
-        tb.writeFile(src.resolve("p1/package-info.java"), "package p1;\n");
-        tb.writeFile(src.resolve("p1/s1/A.java"), "package p1.s1; public class A {}\n");
-        tb.writeFile(src.resolve("p1/s2/package-info.java"), "package p1.s1;\n");
-        tb.writeFile(src.resolve("p1/s3/B.java"), "package p1.s3; public class B {}\n");
-        tb.writeFile(src.resolve("p1/s3/t1/package-info.java"), "package p1.s3.t1;\n");
-        tb.writeFile(src.resolve("p1/s3/t2/C.java"), "package p1.s3.t2; public class C {}\n");
+        tb.writeFile(src.resolve("t/p1/package-info.java"), "package t.p1;\n");
+        tb.writeFile(src.resolve("t/p1/s1/A.java"), "package t.p1.s1; public class A {}\n");
+        tb.writeFile(src.resolve("t/p1/s2/package-info.java"), "package t.p1.s1;\n");
+        tb.writeFile(src.resolve("t/p1/s3/B.java"), "package t.p1.s3; public class B {}\n");
+        tb.writeFile(src.resolve("t/p1/s3/t1/package-info.java"), "package t.p1.s3.t1;\n");
+        tb.writeFile(src.resolve("t/p1/s3/t2/C.java"), "package t.p1.s3.t2; public class C {}\n");
+        tb.writeFile(src.resolve("t/p2/X.java"), "package t.p2; public class X {}\n");
 
         javadoc("-d", "out-packages",
                 "-sourcepath", src.toString(),
-                "-subpackages", "p1");
+                "-subpackages", "t.p1:t.p2");
         checkExit(Exit.OK);
-        checkOutput("p1/package-summary.html", true,
+        checkOutput("t/p1/package-summary.html", true,
                 """
                     <div class="caption"><span>Related Packages</span></div>
                     <div class="summary-table two-column-summary">
                     <div class="table-header col-first">Package</div>
                     <div class="table-header col-last">Description</div>
-                    <div class="col-first even-row-color"><a href="s1/package-summary.html">p1.s1</a></div>
+                    <div class="col-first even-row-color"><a href="s1/package-summary.html">t.p1.s1</a></div>
                     <div class="col-last even-row-color">&nbsp;</div>
-                    <div class="col-first odd-row-color"><a href="s2/package-summary.html">p1.s2</a></div>
+                    <div class="col-first odd-row-color"><a href="s2/package-summary.html">t.p1.s2</a></div>
                     <div class="col-last odd-row-color">&nbsp;</div>
-                    <div class="col-first even-row-color"><a href="s3/package-summary.html">p1.s3</a></div>
+                    <div class="col-first even-row-color"><a href="s3/package-summary.html">t.p1.s3</a></div>
                     <div class="col-last even-row-color">&nbsp;</div>
                     </div>""");
-        checkOutput("p1/s1/package-summary.html", true,
+        checkOutput("t/p1/s1/package-summary.html", true,
                 """
                     <div class="caption"><span>Related Packages</span></div>
                     <div class="summary-table two-column-summary">
                     <div class="table-header col-first">Package</div>
                     <div class="table-header col-last">Description</div>
-                    <div class="col-first even-row-color"><a href="../package-summary.html">p1</a></div>
+                    <div class="col-first even-row-color"><a href="../package-summary.html">t.p1</a></div>
                     <div class="col-last even-row-color">&nbsp;</div>
-                    <div class="col-first odd-row-color"><a href="../s2/package-summary.html">p1.s2</a></div>
+                    <div class="col-first odd-row-color"><a href="../s2/package-summary.html">t.p1.s2</a></div>
                     <div class="col-last odd-row-color">&nbsp;</div>
-                    <div class="col-first even-row-color"><a href="../s3/package-summary.html">p1.s3</a></div>
+                    <div class="col-first even-row-color"><a href="../s3/package-summary.html">t.p1.s3</a></div>
                     <div class="col-last even-row-color">&nbsp;</div>
                     </div>""");
-        checkOutput("p1/s2/package-summary.html", true,
+        checkOutput("t/p1/s2/package-summary.html", true,
                 """
                     <div class="caption"><span>Related Packages</span></div>
                     <div class="summary-table two-column-summary">
                     <div class="table-header col-first">Package</div>
                     <div class="table-header col-last">Description</div>
-                    <div class="col-first even-row-color"><a href="../package-summary.html">p1</a></div>
+                    <div class="col-first even-row-color"><a href="../package-summary.html">t.p1</a></div>
                     <div class="col-last even-row-color">&nbsp;</div>
-                    <div class="col-first odd-row-color"><a href="../s1/package-summary.html">p1.s1</a></div>
+                    <div class="col-first odd-row-color"><a href="../s1/package-summary.html">t.p1.s1</a></div>
                     <div class="col-last odd-row-color">&nbsp;</div>
-                    <div class="col-first even-row-color"><a href="../s3/package-summary.html">p1.s3</a></div>
+                    <div class="col-first even-row-color"><a href="../s3/package-summary.html">t.p1.s3</a></div>
                     <div class="col-last even-row-color">&nbsp;</div>
                     </div>""");
-        checkOutput("p1/s3/package-summary.html", true,
+        checkOutput("t/p1/s3/package-summary.html", true,
                 """
                     <div class="caption"><span>Related Packages</span></div>
                     <div class="summary-table two-column-summary">
                     <div class="table-header col-first">Package</div>
                     <div class="table-header col-last">Description</div>
-                    <div class="col-first even-row-color"><a href="../package-summary.html">p1</a></div>
+                    <div class="col-first even-row-color"><a href="../package-summary.html">t.p1</a></div>
                     <div class="col-last even-row-color">&nbsp;</div>
-                    <div class="col-first odd-row-color"><a href="t1/package-summary.html">p1.s3.t1</a></div>
+                    <div class="col-first odd-row-color"><a href="t1/package-summary.html">t.p1.s3.t1</a></div>
                     <div class="col-last odd-row-color">&nbsp;</div>
-                    <div class="col-first even-row-color"><a href="t2/package-summary.html">p1.s3.t2</a></div>
+                    <div class="col-first even-row-color"><a href="t2/package-summary.html">t.p1.s3.t2</a></div>
                     <div class="col-last even-row-color">&nbsp;</div>
-                    <div class="col-first odd-row-color"><a href="../s1/package-summary.html">p1.s1</a></div>
+                    <div class="col-first odd-row-color"><a href="../s1/package-summary.html">t.p1.s1</a></div>
                     <div class="col-last odd-row-color">&nbsp;</div>
-                    <div class="col-first even-row-color"><a href="../s2/package-summary.html">p1.s2</a></div>
+                    <div class="col-first even-row-color"><a href="../s2/package-summary.html">t.p1.s2</a></div>
                     <div class="col-last even-row-color">&nbsp;</div>
                     </div>""");
-        checkOutput("p1/s3/t1/package-summary.html", true,
+        checkOutput("t/p1/s3/t1/package-summary.html", true,
                 """
                     <div class="caption"><span>Related Packages</span></div>
                     <div class="summary-table two-column-summary">
                     <div class="table-header col-first">Package</div>
                     <div class="table-header col-last">Description</div>
-                    <div class="col-first even-row-color"><a href="../package-summary.html">p1.s3</a></div>
+                    <div class="col-first even-row-color"><a href="../package-summary.html">t.p1.s3</a></div>
                     <div class="col-last even-row-color">&nbsp;</div>
-                    <div class="col-first odd-row-color"><a href="../t2/package-summary.html">p1.s3.t2</a></div>
+                    <div class="col-first odd-row-color"><a href="../t2/package-summary.html">t.p1.s3.t2</a></div>
                     <div class="col-last odd-row-color">&nbsp;</div>
                     </div>""");
-        checkOutput("p1/s3/t2/package-summary.html", true,
+        checkOutput("t/p1/s3/t2/package-summary.html", true,
                 """
                     <div class="caption"><span>Related Packages</span></div>
                     <div class="summary-table two-column-summary">
                     <div class="table-header col-first">Package</div>
                     <div class="table-header col-last">Description</div>
-                    <div class="col-first even-row-color"><a href="../package-summary.html">p1.s3</a></div>
+                    <div class="col-first even-row-color"><a href="../package-summary.html">t.p1.s3</a></div>
                     <div class="col-last even-row-color">&nbsp;</div>
-                    <div class="col-first odd-row-color"><a href="../t1/package-summary.html">p1.s3.t1</a></div>
+                    <div class="col-first odd-row-color"><a href="../t1/package-summary.html">t.p1.s3.t1</a></div>
                     <div class="col-last odd-row-color">&nbsp;</div>
                     </div>""");
+        checkOutput("t/p2/package-summary.html", false, "Related Packages");
     }
 
     @Test


### PR DESCRIPTION
The suggested simple fix to only include sibling packages if there is a common non-empty super package seems to work quite well. I have compiled a list to show the change in related packages listings generated for the JDK documentation (old output on the left, new output on the right).

https://gist.github.com/hns/d0f946255a69027405836201b047965d/revisions?diff=split

I updated the test to include an unlisted sibling package.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265613](https://bugs.openjdk.java.net/browse/JDK-8265613): False positives for "Related Packages"


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3655/head:pull/3655` \
`$ git checkout pull/3655`

Update a local copy of the PR: \
`$ git checkout pull/3655` \
`$ git pull https://git.openjdk.java.net/jdk pull/3655/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3655`

View PR using the GUI difftool: \
`$ git pr show -t 3655`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3655.diff">https://git.openjdk.java.net/jdk/pull/3655.diff</a>

</details>
