### PR TITLE
8265836: OperatingSystemImpl.getCpuLoad() returns incorrect CPU load inside a container

### DIFF
--- a/src/jdk.management/aix/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/aix/native/libmanagement_ext/UnixOperatingSystem.c
@@ -51,6 +51,13 @@ Java_com_sun_management_internal_OperatingSystemImpl_getSingleCpuLoad0
     return -1.0;
 }
 
+JNIEXPORT jlong JNICALL
+Java_com_sun_management_internal_OperatingSystemImpl_getHostTotalCpuTicks0
+(JNIEnv *env, jobject dummy, jint cpu_number)
+{
+    return -1.0;
+}
+
 JNIEXPORT jint JNICALL
 Java_com_sun_management_internal_OperatingSystemImpl_getHostConfiguredCpuCount0
 (JNIEnv *env, jobject mbean)

--- a/src/jdk.management/aix/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/aix/native/libmanagement_ext/UnixOperatingSystem.c
@@ -53,7 +53,7 @@ Java_com_sun_management_internal_OperatingSystemImpl_getSingleCpuLoad0
 
 JNIEXPORT jlong JNICALL
 Java_com_sun_management_internal_OperatingSystemImpl_getHostTotalCpuTicks0
-(JNIEnv *env, jobject dummy, jint cpu_number)
+(JNIEnv *env, jobject mbean)
 {
     return -1.0;
 }

--- a/src/jdk.management/macosx/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/macosx/native/libmanagement_ext/UnixOperatingSystem.c
@@ -167,6 +167,13 @@ Java_com_sun_management_internal_OperatingSystemImpl_getSingleCpuLoad0
     return -1.0;
 }
 
+JNIEXPORT jlong JNICALL
+Java_com_sun_management_internal_OperatingSystemImpl_getHostTotalCpuTicks0
+(JNIEnv *env, jobject dummy, jint cpu_number)
+{
+    return -1.0;
+}
+
 JNIEXPORT jint JNICALL
 Java_com_sun_management_internal_OperatingSystemImpl_getHostConfiguredCpuCount0
 (JNIEnv *env, jobject mbean)

--- a/src/jdk.management/macosx/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/macosx/native/libmanagement_ext/UnixOperatingSystem.c
@@ -169,7 +169,7 @@ Java_com_sun_management_internal_OperatingSystemImpl_getSingleCpuLoad0
 
 JNIEXPORT jlong JNICALL
 Java_com_sun_management_internal_OperatingSystemImpl_getHostTotalCpuTicks0
-(JNIEnv *env, jobject dummy, jint cpu_number)
+(JNIEnv *env, jobject mbean)
 {
     return -1.0;
 }

--- a/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
+++ b/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
@@ -42,8 +42,8 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
 
     private static final int MAX_ATTEMPTS_NUMBER = 10;
     private final Metrics containerMetrics;
-    private long shareCpuUsage = -1;  // used for cpu-shares-based cpuload calc.
-    private long hostTotalTicks = -1; // used for cpu-shares-based cpuload calc.
+    private long usageTicks = -1; // used for cpu load calculation
+    private long totalTicks = -1; // used for cpu load calculation
 
     OperatingSystemImpl(VMManagement vm) {
         super(vm);
@@ -164,16 +164,16 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
                     // retrieved via an earlier call of this method. Total ticks are
                     // scaled to the container effective number of cpus.
                     long distance = 0;
-                    if (this.shareCpuUsage > -1) {
-                        distance = usageNanos - this.shareCpuUsage;
+                    if (this.usageTicks > -1) {
+                        distance = usageNanos - this.usageTicks;
                     }
-                    this.shareCpuUsage = usageNanos;
+                    this.usageTicks = usageNanos;
                     long totalDistance = 0;
                     long hostTicks = getHostTotalCpuTicks0();
-                    if (this.hostTotalTicks > -1 && hostTicks > -1) {
-                         totalDistance = hostTicks - this.hostTotalTicks;
+                    if (this.totalTicks > -1 && hostTicks > -1) {
+                         totalDistance = hostTicks - this.totalTicks;
                     }
-                    this.hostTotalTicks = hostTicks;
+                    this.totalTicks = hostTicks;
                     int totalCPUs = getHostOnlineCpuCount0();
                     int containerCPUs = getAvailableProcessors();
                     // scale the total host load to the actual container cpus

--- a/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
+++ b/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
@@ -136,12 +136,11 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
         if (containerMetrics != null) {
             long quota = containerMetrics.getCpuQuota();
             if (quota > 0) {
-                long periodLength = containerMetrics.getCpuPeriod();
                 long numPeriods = containerMetrics.getCpuNumPeriods();
                 long usageNanos = containerMetrics.getCpuUsage();
-                if (periodLength > 0 && numPeriods > 0 && usageNanos > 0) {
-                    long elapsedNanos = TimeUnit.MICROSECONDS.toNanos(periodLength * numPeriods);
-                    double systemLoad = (double) usageNanos / elapsedNanos;
+                if (numPeriods > 0 && usageNanos > 0) {
+                    long quotaNanos = TimeUnit.MICROSECONDS.toNanos(quota * numPeriods);
+                    double systemLoad = (double) usageNanos / quotaNanos;
                     // Ensure the return value is in the range 0.0 -> 1.0
                     systemLoad = Math.max(0.0, systemLoad);
                     systemLoad = Math.min(1.0, systemLoad);

--- a/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
+++ b/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
@@ -41,7 +41,6 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
     implements com.sun.management.UnixOperatingSystemMXBean {
 
     private static final int MAX_ATTEMPTS_NUMBER = 10;
-    private static final int PER_CPU_SHARES = 1024;
     private final Metrics containerMetrics;
     private long shareCpuUsage = -1;  // used for cpu-shares-based cpuload calc.
     private long hostTotalTicks = -1; // used for cpu-shares-based cpuload calc.


### PR DESCRIPTION
OperatingSystemImpl.getCpuLoad() may return 1.0 in a container, even though the CPU load is obviously below 100%.

We created a 5-core container and run 4 "while (true)" loops in the container. OperatingSystemImpl.getCpuLoad() returned 1.0, which is incorrect (0.8 is correct).
"systemLoad" in getCpuLoad() is exactly 4.0 before "systemLoad = Math.min(1.0, systemLoad);". The problem is caused by using the elapsed time (specified by "cpu.cfs_period_us") instead of the total CPU time (specified by "cpu.cfs_quota_us"). Therefore, it is more reasonable to divide cpu usage time by "quotaNanos" instead of "elapsedNanos".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265836](https://bugs.openjdk.java.net/browse/JDK-8265836): OperatingSystemImpl.getCpuLoad() returns incorrect CPU load inside a container


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Yasumasa Suenaga](https://openjdk.java.net/census#ysuenaga) (@YaSuenag - **Reviewer**)


### Contributors
 * Shaojun Wang `<jeffery.wsj@alibaba-inc.com>`
 * Severin Gehwolf `<sgehwolf@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3656/head:pull/3656` \
`$ git checkout pull/3656`

Update a local copy of the PR: \
`$ git checkout pull/3656` \
`$ git pull https://git.openjdk.java.net/jdk pull/3656/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3656`

View PR using the GUI difftool: \
`$ git pr show -t 3656`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3656.diff">https://git.openjdk.java.net/jdk/pull/3656.diff</a>

</details>
