### PR TITLE
8221503: vmTestbase/nsk/jdb/eval/eval001/eval001.java fails with: com.sun.jdi.InvalidTypeException: Can't assign double[][][] to double[][][]

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/ArrayTypeImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/ArrayTypeImpl.java
@@ -91,28 +91,7 @@ public class ArrayTypeImpl extends ReferenceTypeImpl
      * this method is sometimes needed for proper type checking.
      */
     Type findComponentType(String signature) throws ClassNotLoadedException {
-
-        JNITypeParser sig = new JNITypeParser(signature);
-        if (sig.isReference()) {
-            // It's a reference type
-            JNITypeParser parser = new JNITypeParser(componentSignature());
-            List<ReferenceType> list = vm.classesByName(parser.typeName());
-            Iterator<ReferenceType> iter = list.iterator();
-            while (iter.hasNext()) {
-                ReferenceType type = iter.next();
-                ClassLoaderReference cl = type.classLoader();
-                if ((cl == null)?
-                         (classLoader() == null) :
-                         (cl.equals(classLoader()))) {
-                    return type;
-                }
-            }
-            // Component class has not yet been loaded
-            throw new ClassNotLoadedException(componentTypeName());
-        } else {
-            // It's a primitive type
-            return vm.primitiveTypeMirror(sig.jdwpTag());
-        }
+        return findType(signature);
     }
 
     public Type componentType() throws ClassNotLoadedException {


### PR DESCRIPTION
findComponentType() logic is wrong. In findComponentType() method, We always get vm.classesByName() retruns empty list
list = vm.classesByName(parser.typeName());
We have "parser.typeName()" retruns " double[][]"
vm.classesByName("") is expecting the fully qualified name example "java.lang.Double"
This always returns empty list, resulting into ClassNotLoadedException as it assumes the Component class has not yet been loaded, hence the test case fails.

There was a suggested fix from Egor Ushakov from JetBrains, I am proposing the same to get this fix. I have verified the patch with required testing it works fine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ 8221503 is used in problem lists: [test/hotspot/jtreg/ProblemList.txt]

### Issue
 * [JDK-8221503](https://bugs.openjdk.java.net/browse/JDK-8221503): vmTestbase/nsk/jdb/eval/eval001/eval001.java fails with: com.sun.jdi.InvalidTypeException: Can't assign double[][][] to double[][][]


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3657/head:pull/3657` \
`$ git checkout pull/3657`

Update a local copy of the PR: \
`$ git checkout pull/3657` \
`$ git pull https://git.openjdk.java.net/jdk pull/3657/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3657`

View PR using the GUI difftool: \
`$ git pr show -t 3657`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3657.diff">https://git.openjdk.java.net/jdk/pull/3657.diff</a>

</details>
