### PR TITLE
8221503: vmTestbase/nsk/jdb/eval/eval001/eval001.java fails with: com.sun.jdi.InvalidTypeException: Can't assign double[][][] to double[][][]

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/ArrayReferenceImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/ArrayReferenceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -249,7 +249,7 @@ public class ArrayReferenceImpl extends ObjectReferenceImpl
                 String srcComponentSignature =
                     srcParser.componentSignature(destDims);
                 Type srcComponentType =
-                    arrayType().findComponentType(srcComponentSignature);
+                    arrayType().findType(srcComponentSignature);
                 valid = ArrayTypeImpl.isComponentAssignable(destComponentType,
                                                           srcComponentType);
             }
@@ -281,7 +281,7 @@ public class ArrayReferenceImpl extends ObjectReferenceImpl
             return arrayType().componentSignature();
         }
         public Type findType(String signature) throws ClassNotLoadedException {
-            return arrayType().findComponentType(signature);
+            return arrayType().findType(signature);
         }
     }
 }

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/ArrayTypeImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/ArrayTypeImpl.java
@@ -81,21 +81,8 @@ public class ArrayTypeImpl extends ReferenceTypeImpl
         return new ArrayList<>(0);   // arrays don't have methods
     }
 
-    /*
-     * Find the type object, if any, of a component type of this array.
-     * The component type does not have to be immediate; e.g. this method
-     * can be used to find the component Foo of Foo[][]. This method takes
-     * advantage of the property that an array and its component must have
-     * the same class loader. Since array set operations don't have an
-     * implicit enclosing type like field and variable set operations,
-     * this method is sometimes needed for proper type checking.
-     */
-    Type findComponentType(String signature) throws ClassNotLoadedException {
-        return findType(signature);
-    }
-
     public Type componentType() throws ClassNotLoadedException {
-        return findComponentType(componentSignature());
+        return findType(componentSignature());
     }
 
     static boolean isComponentAssignable(Type destination, Type source) {

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/ArrayTypeImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/ArrayTypeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,28 +91,7 @@ public class ArrayTypeImpl extends ReferenceTypeImpl
      * this method is sometimes needed for proper type checking.
      */
     Type findComponentType(String signature) throws ClassNotLoadedException {
-
-        JNITypeParser sig = new JNITypeParser(signature);
-        if (sig.isReference()) {
-            // It's a reference type
-            JNITypeParser parser = new JNITypeParser(componentSignature());
-            List<ReferenceType> list = vm.classesByName(parser.typeName());
-            Iterator<ReferenceType> iter = list.iterator();
-            while (iter.hasNext()) {
-                ReferenceType type = iter.next();
-                ClassLoaderReference cl = type.classLoader();
-                if ((cl == null)?
-                         (classLoader() == null) :
-                         (cl.equals(classLoader()))) {
-                    return type;
-                }
-            }
-            // Component class has not yet been loaded
-            throw new ClassNotLoadedException(componentTypeName());
-        } else {
-            // It's a primitive type
-            return vm.primitiveTypeMirror(sig.jdwpTag());
-        }
+        return findType(signature);
     }
 
     public Type componentType() throws ClassNotLoadedException {

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -126,8 +126,6 @@ vmTestbase/nsk/monitoring/ThreadMXBean/ThreadInfo/Deadlock/JavaDeadlock001/TestD
 
 vmTestbase/nsk/jdi/ThreadReference/stop/stop001/TestDescription.java 7034630 generic-all
 
-vmTestbase/nsk/jdb/eval/eval001/eval001.java 8221503 generic-all
-
 vmTestbase/metaspace/gc/firstGC_10m/TestDescription.java 8208250 generic-all
 vmTestbase/metaspace/gc/firstGC_50m/TestDescription.java 8208250 generic-all
 vmTestbase/metaspace/gc/firstGC_99m/TestDescription.java 8208250 generic-all


### PR DESCRIPTION
findComponentType() logic is wrong. In findComponentType() method, We always get vm.classesByName() retruns empty list
list = vm.classesByName(parser.typeName());
We have "parser.typeName()" retruns " double[][]"
vm.classesByName("") is expecting the fully qualified name example "java.lang.Double"
This always returns empty list, resulting into ClassNotLoadedException as it assumes the Component class has not yet been loaded, hence the test case fails.

There was a suggested fix from Egor Ushakov from JetBrains, I am proposing the same to get this fix. I have verified the patch with required testing it works fine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8221503](https://bugs.openjdk.java.net/browse/JDK-8221503): vmTestbase/nsk/jdb/eval/eval001/eval001.java fails with: com.sun.jdi.InvalidTypeException: Can't assign double[][][] to double[][][]


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3658/head:pull/3658` \
`$ git checkout pull/3658`

Update a local copy of the PR: \
`$ git checkout pull/3658` \
`$ git pull https://git.openjdk.java.net/jdk pull/3658/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3658`

View PR using the GUI difftool: \
`$ git pr show -t 3658`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3658.diff">https://git.openjdk.java.net/jdk/pull/3658.diff</a>

</details>
