### PR TITLE
8265462: Handle multiple slots in the NSS Internal Module from SunPKCS11's Secmod

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Secmod.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Secmod.java
@@ -73,6 +73,12 @@ public final class Secmod {
 
     private static final String TRUST_LIB_NAME = "nssckbi";
 
+    private final static int NETSCAPE_SLOT_ID = 0x1;
+
+    private final static int PRIVATE_KEY_SLOT_ID = 0x2;
+
+    private final static int FIPS_SLOT_ID = 0x3;
+
     // handle to be passed to the native code, 0 means not initialized
     private long nssHandle;
 
@@ -392,20 +398,21 @@ public final class Secmod {
         private Map<Bytes,TrustAttributes> trust;
 
         Module(String libraryDir, String libraryName, String commonName,
-                boolean fips, int slot) {
+                int slotIndex, int slotId) {
             ModuleType type;
 
             if ((libraryName == null) || (libraryName.length() == 0)) {
                 // must be softtoken
                 libraryName = System.mapLibraryName(SOFTTOKEN_LIB_NAME);
-                if (fips == false) {
-                    type = (slot == 0) ? ModuleType.CRYPTO : ModuleType.KEYSTORE;
-                } else {
+                if (slotId == NETSCAPE_SLOT_ID) {
+                    type = ModuleType.CRYPTO;
+                } else if (slotId == PRIVATE_KEY_SLOT_ID) {
+                    type = ModuleType.KEYSTORE;
+                } else if (slotId == FIPS_SLOT_ID) {
                     type = ModuleType.FIPS;
-                    if (slot != 0) {
-                        throw new RuntimeException
-                            ("Slot index should be 0 for FIPS slot");
-                    }
+                } else {
+                    throw new RuntimeException("Unexpected slot ID in the" +
+                            " NSS Internal Module");
                 }
             } else {
                 if (libraryName.endsWith(System.mapLibraryName(TRUST_LIB_NAME))
@@ -426,7 +433,7 @@ public final class Secmod {
             }
             this.libraryName = libraryFile.getPath();
             this.commonName = commonName;
-            this.slot = slot;
+            this.slot = slotIndex;
             this.type = type;
             initConfiguration();
         }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Secmod.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Secmod.java
@@ -73,6 +73,9 @@ public final class Secmod {
 
     private static final String TRUST_LIB_NAME = "nssckbi";
 
+    // Slot IDs - defined in j2secmod.h on the native side
+    // Values obtained from NSS's pkcs11i.h header
+
     private final static int NETSCAPE_SLOT_ID = 0x1;
 
     private final static int PRIVATE_KEY_SLOT_ID = 0x2;
@@ -411,8 +414,8 @@ public final class Secmod {
                 } else if (slotId == FIPS_SLOT_ID) {
                     type = ModuleType.FIPS;
                 } else {
-                    throw new RuntimeException("Unexpected slot ID in the" +
-                            " NSS Internal Module");
+                    throw new RuntimeException("Unexpected slot ID " + slotId +
+                            " in the NSS Internal Module");
                 }
             } else {
                 if (libraryName.endsWith(System.mapLibraryName(TRUST_LIB_NAME))

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/j2secmod.h
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/j2secmod.h
@@ -51,29 +51,137 @@ void *findFunction(JNIEnv *env, jlong jHandle, const char *functionName);
 // NSS types
 
 typedef int PRBool;
+typedef unsigned short PRUint16;
+typedef short PRInt16;
+typedef unsigned int PRUint32;
+typedef int PRInt32;
+typedef long long PRInt64;
+
+typedef PRUint32 PRIntervalTime;
+typedef PRInt64 PRTime;
+
+typedef struct PK11SlotInfoStr PK11SlotInfo;
 
 typedef struct SECMODModuleStr SECMODModule;
 typedef struct SECMODModuleListStr SECMODModuleList;
 
-struct SECMODModuleStr {
-    void        *v1;
-    PRBool      internal;       /* true of internally linked modules, false
-                                 * for the loaded modules */
-    PRBool      loaded;         /* Set to true if module has been loaded */
-    PRBool      isFIPS;         /* Set to true if module is finst internal */
-    char        *dllName;       /* name of the shared library which implements
-                                 * this module */
-    char        *commonName;    /* name of the module to display to the user */
-    void        *library;       /* pointer to the library. opaque. used only by
-                                 * pk11load.c */
+/* PKCS #11 disable reasons */
+typedef enum {
+    PK11_DIS_NONE = 0,
+    PK11_DIS_USER_SELECTED = 1,
+    PK11_DIS_COULD_NOT_INIT_TOKEN = 2,
+    PK11_DIS_TOKEN_VERIFY_FAILED = 3,
+    PK11_DIS_TOKEN_NOT_PRESENT = 4
+} PK11DisableReasons;
 
-    void        *functionList; /* The PKCS #11 function table */
-    void        *refLock;       /* only used pk11db.c */
-    int         refCount;       /* Module reference count */
-    void        **slots;        /* array of slot points attached to this mod*/
-    int         slotCount;      /* count of slot in above array */
-    void        *slotInfo;      /* special info about slots default settings */
-    int         slotInfoCount;  /* count */
+/* represent a pkcs#11 slot reference counted. */
+struct PK11SlotInfoStr {
+    /* the PKCS11 function list for this slot */
+    void *functionList;
+    SECMODModule *module; /* our parent module */
+    /* Boolean to indicate the current state of this slot */
+    PRBool needTest;           /* Has this slot been tested for Export complience */
+    PRBool isPerm;             /* is this slot a permanment device */
+    PRBool isHW;               /* is this slot a hardware device */
+    PRBool isInternal;         /* is this slot one of our internal PKCS #11 devices */
+    PRBool disabled;           /* is this slot disabled... */
+    PK11DisableReasons reason; /* Why this slot is disabled */
+    PRBool readOnly;           /* is the token in this slot read-only */
+    PRBool needLogin;          /* does the token of the type that needs
+                                * authentication (still true even if token is logged
+                                * in) */
+    PRBool hasRandom;          /* can this token generated random numbers */
+    PRBool defRWSession;       /* is the default session RW (we open our default
+                                * session rw if the token can only handle one session
+                                * at a time. */
+    PRBool isThreadSafe;       /* copied from the module */
+    /* The actual flags (many of which are distilled into the above PRBools) */
+    CK_FLAGS flags; /* flags from PKCS #11 token Info */
+    /* a default session handle to do quick and dirty functions */
+    CK_SESSION_HANDLE session;
+    void *sessionLock; /* lock for this session */
+    /* our ID */
+    CK_SLOT_ID slotID;
+    /* persistant flags saved from startup to startup */
+    unsigned long defaultFlags;
+    /* keep track of who is using us so we don't accidently get freed while
+     * still in use */
+    PRInt32 refCount; /* to be in/decremented by atomic calls ONLY! */
+    void *freeListLock;
+    void *freeSymKeysWithSessionHead;
+    void *freeSymKeysHead;
+    int keyCount;
+    int maxKeyCount;
+    /* Password control functions for this slot. many of these are only
+     * active if the appropriate flag is on in defaultFlags */
+    int askpw;           /* what our password options are */
+    int timeout;         /* If we're ask_timeout, what is our timeout time is
+                          * seconds */
+    int authTransact;    /* allow multiple authentications off one password if
+                          * they are all part of the same transaction */
+    PRTime authTime;     /* when were we last authenticated */
+    int minPassword;     /* smallest legal password */
+    int maxPassword;     /* largest legal password */
+    PRUint16 series;     /* break up the slot info into various groups of
+                          * inserted tokens so that keys and certs can be
+                          * invalidated */
+    PRUint16 flagSeries; /* record the last series for the last event
+                          * returned for this slot */
+    PRBool flagState;    /* record the state of the last event returned for this
+                          * slot. */
+    PRUint16 wrapKey;    /* current wrapping key for SSL master secrets */
+    CK_MECHANISM_TYPE wrapMechanism;
+    /* current wrapping mechanism for current wrapKey */
+    CK_OBJECT_HANDLE refKeys[1];      /* array of existing wrapping keys for */
+    CK_MECHANISM_TYPE *mechanismList; /* list of mechanism supported by this
+                                       * token */
+    int mechanismCount;
+    /* cache the certificates stored on the token of this slot */
+    void **cert_array;
+    int array_size;
+    int cert_count;
+    char serial[16];
+    /* since these are odd sizes, keep them last. They are odd sizes to
+     * allow them to become null terminated strings */
+    char slot_name[65];
+    char token_name[33];
+    PRBool hasRootCerts;
+    PRBool hasRootTrust;
+    PRBool hasRSAInfo;
+    CK_FLAGS RSAInfoFlags;
+    PRBool protectedAuthPath;
+    PRBool isActiveCard;
+    PRIntervalTime lastLoginCheck;
+    unsigned int lastState;
+    /* for Stan */
+    void *nssToken;
+    /* the tokeninfo struct */
+    CK_TOKEN_INFO tokenInfo;
+    /* fast mechanism lookup */
+    char mechanismBits[256];
+    CK_PROFILE_ID *profileList;
+    int profileCount;
+};
+
+struct SECMODModuleStr {
+    void         *v1;
+    PRBool       internal;       /* true of internally linked modules, false
+                                  * for the loaded modules */
+    PRBool       loaded;         /* Set to true if module has been loaded */
+    PRBool       isFIPS;         /* Set to true if module is finst internal */
+    char         *dllName;       /* name of the shared library which implements
+                                  * this module */
+    char         *commonName;    /* name of the module to display to the user */
+    void         *library;       /* pointer to the library. opaque. used only by
+                                  * pk11load.c */
+
+    void         *functionList; /* The PKCS #11 function table */
+    void         *refLock;       /* only used pk11db.c */
+    int          refCount;       /* Module reference count */
+    PK11SlotInfo **slots;        /* array of slot points attached to this mod*/
+    int          slotCount;      /* count of slot in above array */
+    void         *slotInfo;      /* special info about slots default settings */
+    int          slotInfoCount;  /* count */
     // incomplete, sizeof() is wrong
 };
 

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/j2secmod.h
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/j2secmod.h
@@ -65,6 +65,7 @@ typedef struct PK11SlotInfoStr PK11SlotInfo;
 typedef struct SECMODModuleStr SECMODModule;
 typedef struct SECMODModuleListStr SECMODModuleList;
 
+// Defined in NSS's secmodt.h header
 /* PKCS #11 disable reasons */
 typedef enum {
     PK11_DIS_NONE = 0,
@@ -74,6 +75,13 @@ typedef enum {
     PK11_DIS_TOKEN_NOT_PRESENT = 4
 } PK11DisableReasons;
 
+// Slot IDs - defined in Secmod.java on the Java side
+// Values obtained from NSS's pkcs11i.h header
+#define NETSCAPE_SLOT_ID 1
+#define PRIVATE_KEY_SLOT_ID 2
+#define FIPS_SLOT_ID 3
+
+// Defined in NSS's secmodti.h header
 /* represent a pkcs#11 slot reference counted. */
 struct PK11SlotInfoStr {
     /* the PKCS11 function list for this slot */
@@ -163,6 +171,7 @@ struct PK11SlotInfoStr {
     int profileCount;
 };
 
+// Defined in NSS's secmodt.h header
 struct SECMODModuleStr {
     void         *v1;
     PRBool       internal;       /* true of internally linked modules, false
@@ -185,6 +194,7 @@ struct SECMODModuleStr {
     // incomplete, sizeof() is wrong
 };
 
+// Defined in NSS's secmodt.h header
 struct SECMODModuleListStr {
     SECMODModuleList    *next;
     SECMODModule        *module;

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11t.h
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11t.h
@@ -102,9 +102,14 @@ typedef CK_ULONG CK_NOTIFICATION;
 #define CKN_SURRENDER           0UL
 #define CKN_OTP_CHANGED         1UL
 
+typedef CK_ULONG CK_PROFILE_ID;
+
 typedef CK_ULONG          CK_SLOT_ID;
 
 typedef CK_SLOT_ID CK_PTR CK_SLOT_ID_PTR;
+#define NETSCAPE_SLOT_ID 1
+#define PRIVATE_KEY_SLOT_ID 2
+#define FIPS_SLOT_ID 3
 
 
 /* CK_SLOT_INFO provides information about a slot */

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11t.h
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11t.h
@@ -102,14 +102,9 @@ typedef CK_ULONG CK_NOTIFICATION;
 #define CKN_SURRENDER           0UL
 #define CKN_OTP_CHANGED         1UL
 
-typedef CK_ULONG CK_PROFILE_ID;
-
 typedef CK_ULONG          CK_SLOT_ID;
 
 typedef CK_SLOT_ID CK_PTR CK_SLOT_ID_PTR;
-#define NETSCAPE_SLOT_ID 1
-#define PRIVATE_KEY_SLOT_ID 2
-#define FIPS_SLOT_ID 3
 
 
 /* CK_SLOT_INFO provides information about a slot */


### PR DESCRIPTION
Hi,

Please find in this PR a proposal to fix JDK-8265462 [1].

With this fix, OpenJDK will only use the known slot IDs for the NSS Internal Module. If the NSS Internal Module has more slots (for example, as a result of an initialization sequence such as the one triggered from the libnsssysinit.so library), they will be ignored. The goal is to handle multiple-slots scenarios while keeping OpenJDK's previous behavior.

No regressions observed in the jdk/sun/security/pkcs11 tests category.

A new regression test was not added as part of this changeset because of its complexity. It would depend on a specific NSS configuration, or the NSS library would need to be mocked. I've done manual testing in my environment and JDK-8265462 [1] has further information about it.

Thanks,
Martin.-

--
[1] - https://bugs.openjdk.java.net/browse/JDK-8265462

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265462](https://bugs.openjdk.java.net/browse/JDK-8265462): Handle multiple slots in the NSS Internal Module from SunPKCS11's Secmod


### Reviewers
 * [Valerie Peng](https://openjdk.java.net/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3661/head:pull/3661` \
`$ git checkout pull/3661`

Update a local copy of the PR: \
`$ git checkout pull/3661` \
`$ git pull https://git.openjdk.java.net/jdk pull/3661/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3661`

View PR using the GUI difftool: \
`$ git pr show -t 3661`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3661.diff">https://git.openjdk.java.net/jdk/pull/3661.diff</a>

</details>
