### PR TITLE
8241248: NullPointerException in sun.security.ssl.HKDF.extract(HKDF.java:93)

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/ServerHello.java
+++ b/src/java.base/share/classes/sun/security/ssl/ServerHello.java
@@ -560,9 +560,6 @@ final class ServerHello {
 
                 setUpPskKD(shc,
                         shc.resumingSession.consumePreSharedKey());
-
-                // The session can't be resumed again---remove it from cache
-                sessionCache.remove(shc.resumingSession.getSessionId());
             }
 
             // update the responders


### PR DESCRIPTION
Hello All,

Could you please review the fix for the JDK-8241248?
The issue happens during the TLSv1.3 handshake without server stateless session resumption in case of server receives several parallel requests with the same pre_shared_key.
The main idea of the fix is to remove resuming session from the session cache in the early stage.

JBS: https://bugs.openjdk.java.net/browse/JDK-8241248
Webrev: http://cr.openjdk.java.net/~abakhtin/8241248/webrev.v0/

The test from the bug report using OpenSSL is passed ( -Djdk.tls.server.enableSessionTicketExtension=false )
javax/net/ssl and sun/security/ssl jtreg tests passed

Regards
Alexey