### PR TITLE
8265880: ProblemList serviceability/dcmd/gc/RunFinalizationTest.java on Linux-X64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -102,6 +102,7 @@ resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java 8262386 generic-al
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatIntervalTest.java 8214032 generic-all
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatArrayCorrectnessTest.java 8224150 generic-all
 serviceability/jvmti/ModuleAwareAgents/ThreadStart/MAAThreadStart.java 8225354 windows-all
+serviceability/dcmd/gc/RunFinalizationTest.java 8227120 linux-x64
 
 #############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList serviceability/dcmd/gc/RunFinalizationTest.java on Linux-X64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265880](https://bugs.openjdk.java.net/browse/JDK-8265880): ProblemList serviceability/dcmd/gc/RunFinalizationTest.java on Linux-X64


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3666/head:pull/3666` \
`$ git checkout pull/3666`

Update a local copy of the PR: \
`$ git checkout pull/3666` \
`$ git pull https://git.openjdk.java.net/jdk pull/3666/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3666`

View PR using the GUI difftool: \
`$ git pr show -t 3666`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3666.diff">https://git.openjdk.java.net/jdk/pull/3666.diff</a>

</details>
