### PR TITLE
8265884: ProblemList compiler/codecache/jmx/PoolsIndependenceTest.java on macOS-X64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -68,6 +68,8 @@ compiler/whitebox/ClearMethodStateTest.java 8265360 macosx-aarch64
 compiler/whitebox/EnqueueMethodForCompilationTest.java 8265360 macosx-aarch64
 compiler/whitebox/MakeMethodNotCompilableTest.java 8265360 macosx-aarch64
 
+compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macos-x64
+
 #############################################################################
 
 # :hotspot_gc

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -68,7 +68,7 @@ compiler/whitebox/ClearMethodStateTest.java 8265360 macosx-aarch64
 compiler/whitebox/EnqueueMethodForCompilationTest.java 8265360 macosx-aarch64
 compiler/whitebox/MakeMethodNotCompilableTest.java 8265360 macosx-aarch64
 
-compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macos-x64
+compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-x64
 
 #############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList compiler/codecache/jmx/PoolsIndependenceTest.java on macOS-X64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265884](https://bugs.openjdk.java.net/browse/JDK-8265884): ProblemList compiler/codecache/jmx/PoolsIndependenceTest.java on macOS-X64


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3667/head:pull/3667` \
`$ git checkout pull/3667`

Update a local copy of the PR: \
`$ git checkout pull/3667` \
`$ git pull https://git.openjdk.java.net/jdk pull/3667/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3667`

View PR using the GUI difftool: \
`$ git pr show -t 3667`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3667.diff">https://git.openjdk.java.net/jdk/pull/3667.diff</a>

</details>
