### PR TITLE
8265890: ProblemList sun/security/ssl/SSLSocketImpl/SSLSocketImplThrowsWrongExceptions.java on macOS-X64 and Linux-aarch64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -706,7 +706,7 @@ javax/security/auth/kerberos/KerberosTixDateTest.java           8039280 generic-
 sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java 8039280 generic-all
 sun/security/provider/PolicyParser/ExtDirsChange.java           8039280 generic-all
 sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all
-sun/security/ssl/SSLSocketImpl/SSLSocketImplThrowsWrongExceptions.java 8262409 linux-generic,macosx-x64
+sun/security/ssl/SSLSocketImpl/SSLSocketImplThrowsWrongExceptions.java 8262409 linux-all,macosx-x64
 
 ############################################################################
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -706,7 +706,7 @@ javax/security/auth/kerberos/KerberosTixDateTest.java           8039280 generic-
 sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java 8039280 generic-all
 sun/security/provider/PolicyParser/ExtDirsChange.java           8039280 generic-all
 sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all
-sun/security/ssl/SSLSocketImpl/SSLSocketImplThrowsWrongExceptions.java 8262409 linux-x64
+sun/security/ssl/SSLSocketImpl/SSLSocketImplThrowsWrongExceptions.java 8262409 linux-generic,macosx-x64
 
 ############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList sun/security/ssl/SSLSocketImpl/SSLSocketImplThrowsWrongExceptions.java
on macOS-X64 and Linux-aarch64. It is already ProblemListed on linux-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265890](https://bugs.openjdk.java.net/browse/JDK-8265890): ProblemList sun/security/ssl/SSLSocketImpl/SSLSocketImplThrowsWrongExceptions.java on macOS-X64 and Linux-aarch64


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3668/head:pull/3668` \
`$ git checkout pull/3668`

Update a local copy of the PR: \
`$ git checkout pull/3668` \
`$ git pull https://git.openjdk.java.net/jdk pull/3668/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3668`

View PR using the GUI difftool: \
`$ git pr show -t 3668`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3668.diff">https://git.openjdk.java.net/jdk/pull/3668.diff</a>

</details>
