### PR TITLE
8184134: HeapRegion::LogOfHRGrainWords is unused

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -48,7 +48,6 @@
 #include "utilities/powerOfTwo.hpp"
 
 int    HeapRegion::LogOfHRGrainBytes = 0;
-int    HeapRegion::LogOfHRGrainWords = 0;
 int    HeapRegion::LogCardsPerRegion = 0;
 size_t HeapRegion::GrainBytes        = 0;
 size_t HeapRegion::GrainWords        = 0;
@@ -84,9 +83,6 @@ void HeapRegion::setup_heap_region_size(size_t max_heap_size) {
   guarantee(LogOfHRGrainBytes == 0, "we should only set it once");
   LogOfHRGrainBytes = region_size_log;
 
-  guarantee(LogOfHRGrainWords == 0, "we should only set it once");
-  LogOfHRGrainWords = LogOfHRGrainBytes - LogHeapWordSize;
-
   guarantee(GrainBytes == 0, "we should only set it once");
   // The cast to int is safe, given that we've bounded region_size by
   // MIN_REGION_SIZE and MAX_REGION_SIZE.
@@ -94,7 +90,6 @@ void HeapRegion::setup_heap_region_size(size_t max_heap_size) {
 
   guarantee(GrainWords == 0, "we should only set it once");
   GrainWords = GrainBytes >> LogHeapWordSize;
-  guarantee((size_t) 1 << LogOfHRGrainWords == GrainWords, "sanity");
 
   guarantee(CardsPerRegion == 0, "we should only set it once");
   CardsPerRegion = GrainBytes >> G1CardTable::card_shift;

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -293,7 +293,6 @@ public:
   void initialize(bool clear_space = false, bool mangle_space = SpaceDecorator::Mangle);
 
   static int    LogOfHRGrainBytes;
-  static int    LogOfHRGrainWords;
   static int    LogCardsPerRegion;
 
   static size_t GrainBytes;
@@ -318,8 +317,8 @@ public:
 
   // It sets up the heap region size (GrainBytes / GrainWords), as
   // well as other related fields that are based on the heap region
-  // size (LogOfHRGrainBytes / LogOfHRGrainWords /
-  // CardsPerRegion). All those fields are considered constant
+  // size (LogOfHRGrainBytes / CardsPerRegion).
+  // All those fields are considered constant
   // throughout the JVM's execution, therefore they should only be set
   // up once during initialization time.
   static void setup_heap_region_size(size_t max_heap_size);

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -315,11 +315,10 @@ public:
   static size_t max_region_size();
   static size_t min_region_size_in_words();
 
-  // It sets up the heap region size (GrainBytes / GrainWords), as
-  // well as other related fields that are based on the heap region
-  // size (LogOfHRGrainBytes / CardsPerRegion).
-  // All those fields are considered constant
-  // throughout the JVM's execution, therefore they should only be set
+  // It sets up the heap region size (GrainBytes / GrainWords), as well as
+  // other related fields that are based on the heap region size
+  // (LogOfHRGrainBytes / CardsPerRegion). All those fields are considered
+  // constant throughout the JVM's execution, therefore they should only be set
   // up once during initialization time.
   static void setup_heap_region_size(size_t max_heap_size);
 


### PR DESCRIPTION
Trivial change of removing unused code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8184134](https://bugs.openjdk.java.net/browse/JDK-8184134): HeapRegion::LogOfHRGrainWords is unused


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to 192a7a473ff694327caef469355ede9c0028ec71
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to 192a7a473ff694327caef469355ede9c0028ec71


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3671/head:pull/3671` \
`$ git checkout pull/3671`

Update a local copy of the PR: \
`$ git checkout pull/3671` \
`$ git pull https://git.openjdk.java.net/jdk pull/3671/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3671`

View PR using the GUI difftool: \
`$ git pr show -t 3671`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3671.diff">https://git.openjdk.java.net/jdk/pull/3671.diff</a>

</details>
