### PR TITLE
8265911: assert(comp != __null) failed: Compiler instance missing

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -653,7 +653,9 @@ void CompileBroker::compilation_init_phase1(Thread* THREAD) {
       }
       if (FLAG_IS_DEFAULT(JVMCIHostThreads)) {
       } else {
+#ifdef COMPILER1
         _c1_count = JVMCIHostThreads;
+#endif // COMPILER1
       }
     }
   }


### PR DESCRIPTION
As I debugged into the code, the `_c1_count` was set to `1` [1] with flags `-XX:+EnableJVMCI -XX:+UseJVMCICompiler -XX:JVMCIHostThreads=1`. However, [2] would never be executed, and thus `_compilers[0]` was `NULL`. 

When C1 is disabled, `_c1_count` should always be `0`, so I added this `#ifdef` guard to avoid changing value of `_c1_count` under this circumstance.

[1] https://github.com/openjdk/jdk/blob/f1f2afda5a0ab8f213e8a1b5324a251928c8d81a/src/hotspot/share/compiler/compileBroker.cpp#L656
[2] https://github.com/openjdk/jdk/blob/f1f2afda5a0ab8f213e8a1b5324a251928c8d81a/src/hotspot/share/compiler/compileBroker.cpp#L664

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265911](https://bugs.openjdk.java.net/browse/JDK-8265911): assert(comp != __null) failed: Compiler instance missing


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3672/head:pull/3672` \
`$ git checkout pull/3672`

Update a local copy of the PR: \
`$ git checkout pull/3672` \
`$ git pull https://git.openjdk.java.net/jdk pull/3672/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3672`

View PR using the GUI difftool: \
`$ git pr show -t 3672`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3672.diff">https://git.openjdk.java.net/jdk/pull/3672.diff</a>

</details>
