### PR TITLE
8265899: Use pattern matching for instanceof at module jdk.compiler(part 1)

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/ClientCodeWrapper.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/ClientCodeWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -119,9 +119,9 @@ public class ClientCodeWrapper {
     public JavaFileManager wrap(JavaFileManager fm) {
         if (isTrusted(fm))
             return fm;
-        if (fm instanceof StandardJavaFileManager)
-            return new WrappedStandardJavaFileManager((StandardJavaFileManager) fm);
-        return new WrappedJavaFileManager(fm);
+        return (fm instanceof StandardJavaFileManager standardJavaFileManager) ?
+                new WrappedStandardJavaFileManager(standardJavaFileManager) :
+                new WrappedJavaFileManager(fm);
     }
 
     public FileObject wrap(FileObject fo) {
@@ -131,10 +131,8 @@ public class ClientCodeWrapper {
     }
 
     FileObject unwrap(FileObject fo) {
-        if (fo instanceof WrappedFileObject)
-            return ((WrappedFileObject) fo).clientFileObject;
-        else
-            return fo;
+        return (fo instanceof WrappedFileObject wrappedFileObject) ?
+                wrappedFileObject.clientFileObject : fo;
     }
 
     public JavaFileObject wrap(JavaFileObject fo) {
@@ -151,10 +149,8 @@ public class ClientCodeWrapper {
     }
 
     JavaFileObject unwrap(JavaFileObject fo) {
-        if (fo instanceof WrappedJavaFileObject)
-            return ((JavaFileObject) ((WrappedJavaFileObject) fo).clientFileObject);
-        else
-            return fo;
+        return (fo instanceof WrappedJavaFileObject wrappedJavaFileObject) ?
+                ((JavaFileObject) wrappedJavaFileObject.clientFileObject) : fo;
     }
 
     public <T /*super JavaFileObject*/> DiagnosticListener<T> wrap(DiagnosticListener<T> dl) {
@@ -170,10 +166,8 @@ public class ClientCodeWrapper {
     }
 
     TaskListener unwrap(TaskListener l) {
-        if (l instanceof WrappedTaskListener)
-            return ((WrappedTaskListener) l).clientTaskListener;
-        else
-            return l;
+        return (l instanceof WrappedTaskListener wrappedTaskListener) ?
+                wrappedTaskListener.clientTaskListener : l;
     }
 
     Collection<TaskListener> unwrap(Collection<? extends TaskListener> listeners) {
@@ -185,12 +179,8 @@ public class ClientCodeWrapper {
 
     @SuppressWarnings("unchecked")
     private <T> Diagnostic<T> unwrap(final Diagnostic<T> diagnostic) {
-        if (diagnostic instanceof JCDiagnostic) {
-            JCDiagnostic d = (JCDiagnostic) diagnostic;
-            return (Diagnostic<T>) new DiagnosticSourceUnwrapper(d);
-        } else {
-            return diagnostic;
-        }
+        return (diagnostic instanceof JCDiagnostic jcDiagnostic) ?
+                (Diagnostic<T>) new DiagnosticSourceUnwrapper(jcDiagnostic) : diagnostic;
     }
 
     protected boolean isTrusted(Object o) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacScope.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacScope.java
@@ -127,10 +127,9 @@ public class JavacScope implements com.sun.source.tree.Scope {
     }
 
     public boolean equals(Object other) {
-        if (other instanceof JavacScope) {
-            JavacScope s = (JavacScope) other;
-            return (env.equals(s.env)
-                && isStarImportScope() == s.isStarImportScope());
+        if (other instanceof JavacScope javacScope) {
+            return (env.equals(javacScope.env)
+                && isStarImportScope() == javacScope.isStarImportScope());
         } else
             return false;
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacScope.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacScope.java
@@ -127,11 +127,9 @@ public class JavacScope implements com.sun.source.tree.Scope {
     }
 
     public boolean equals(Object other) {
-        if (other instanceof JavacScope javacScope) {
-            return (env.equals(javacScope.env)
-                && isStarImportScope() == javacScope.isStarImportScope());
-        } else
-            return false;
+        return other instanceof JavacScope javacScope
+                && env.equals(javacScope.env)
+                && isStarImportScope() == javacScope.isStarImportScope();
     }
 
     public int hashCode() {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTaskImpl.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTaskImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -232,7 +232,7 @@ public class JavacTaskImpl extends BasicJavacTask {
     void cleanup() {
         if (compiler != null)
             compiler.close();
-        if (fileManager instanceof BaseFileManager && ((BaseFileManager) fileManager).autoClose) {
+        if (fileManager instanceof BaseFileManager baseFileManager && baseFileManager.autoClose) {
             try {
                 fileManager.close();
             } catch (IOException ignore) {
@@ -321,10 +321,10 @@ public class JavacTaskImpl extends BasicJavacTask {
         }
         else {
             for (CompilationUnitTree cu : trees) {
-                if (cu instanceof JCCompilationUnit) {
+                if (cu instanceof JCCompilationUnit compilationUnit) {
                     if (roots == null)
                         roots = new ListBuffer<>();
-                    roots.append((JCCompilationUnit)cu);
+                    roots.append(compilationUnit);
                     notYetEntered.remove(cu.getSourceFile());
                 }
                 else

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTaskPool.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTaskPool.java
@@ -295,10 +295,9 @@ public class JavacTaskPool {
         TreeScanner<Void, Symtab> pollutionScanner = new TreeScanner<Void, Symtab>() {
             @Override @DefinedBy(Api.COMPILER_TREE)
             public Void scan(Tree tree, Symtab syms) {
-                if (tree instanceof LetExpr) {
-                    LetExpr le = (LetExpr) tree;
-                    scan(le.defs, syms);
-                    scan(le.expr, syms);
+                if (tree instanceof LetExpr letExpr) {
+                    scan(letExpr.defs, syms);
+                    scan(letExpr.expr, syms);
                     return null;
                 } else {
                     return super.scan(tree, syms);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTool.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -173,8 +173,8 @@ public final class JavacTool implements JavaCompiler {
 
             if (fileManager == null) {
                 fileManager = getStandardFileManager(diagnosticListener, null, null);
-                if (fileManager instanceof BaseFileManager) {
-                    ((BaseFileManager) fileManager).autoClose = true;
+                if (fileManager instanceof BaseFileManager baseFileManager) {
+                    baseFileManager.autoClose = true;
                 }
             }
             fileManager = ccw.wrap(fileManager);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JRTIndex.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JRTIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -229,8 +229,8 @@ public class JRTIndex {
     }
 
     public boolean isInJRT(FileObject fo) {
-        if (fo instanceof PathFileObject) {
-            Path path = ((PathFileObject) fo).getPath();
+        if (fo instanceof PathFileObject pathFileObject) {
+            Path path = pathFileObject.getPath();
             return (path.getFileSystem() == jrtfs);
         } else {
             return false;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
@@ -790,8 +790,8 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
             return null;
         }
 
-        if (file instanceof PathFileObject) {
-            return ((PathFileObject) file).inferBinaryName(path);
+        if (file instanceof PathFileObject pathFileObject) {
+            return pathFileObject.inferBinaryName(path);
         } else
             throw new IllegalArgumentException(file.getClass().getName());
     }
@@ -800,8 +800,8 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
     public boolean isSameFile(FileObject a, FileObject b) {
         nullCheck(a);
         nullCheck(b);
-        if (a instanceof PathFileObject && b instanceof PathFileObject)
-            return ((PathFileObject) a).isSameFile((PathFileObject) b);
+        if (a instanceof PathFileObject pathFileObjectA && b instanceof PathFileObject pathFileObjectB)
+            return pathFileObjectA.isSameFile(pathFileObjectB);
         return a.equals(b);
     }
 
@@ -908,8 +908,8 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
                 dir = getClassOutDir();
             } else {
                 String baseName = fileName.basename();
-                if (sibling != null && sibling instanceof PathFileObject) {
-                    return ((PathFileObject) sibling).getSibling(baseName);
+                if (sibling != null && sibling instanceof PathFileObject pathFileObject) {
+                    return pathFileObject.getSibling(baseName);
                 } else {
                     Path p = getPath(baseName);
                     Path real = fsInfo.getCanonicalFile(p);
@@ -943,8 +943,8 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
         Iterable<? extends File> files)
     {
         ArrayList<PathFileObject> result;
-        if (files instanceof Collection<?>)
-            result = new ArrayList<>(((Collection<?>)files).size());
+        if (files instanceof Collection<?> collection)
+            result = new ArrayList<>(collection.size());
         else
             result = new ArrayList<>();
         for (File f: files) {
@@ -957,17 +957,16 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
     }
 
     @Override @DefinedBy(Api.COMPILER)
-    public Iterable<? extends JavaFileObject> getJavaFileObjectsFromPaths(
-        Collection<? extends Path> paths)
-    {
+    public Iterable<? extends JavaFileObject> getJavaFileObjectsFromPaths(Collection<? extends Path> paths) {
         ArrayList<PathFileObject> result;
-        if (paths instanceof Collection<?>)
-            result = new ArrayList<>(((Collection<?>)paths).size());
-        else
+        if (paths != null) {
+            result = new ArrayList<>(paths.size());
+            for (Path p: paths)
+                result.add(PathFileObject.forSimplePath(this,
+                        fsInfo.getCanonicalFile(p), p));
+        } else {
             result = new ArrayList<>();
-        for (Path p: paths)
-            result.add(PathFileObject.forSimplePath(this,
-                    fsInfo.getCanonicalFile(p), p));
+        }
         return result;
     }
 
@@ -1100,13 +1099,10 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
 
         @Override
         public boolean equals(Object o) {
-          if (o == null || !(o instanceof PathAndContainer)) {
-            return false;
-          }
-          PathAndContainer that = (PathAndContainer) o;
-          return path.equals(that.path)
-              && container.equals(that.container)
-              && index == that.index;
+            return (o instanceof PathAndContainer pathAndContainer)
+                    && path.equals(pathAndContainer.path)
+                    && container.equals(pathAndContainer.container)
+                    && index == pathAndContainer.index;
         }
 
         @Override
@@ -1160,9 +1156,9 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
     @Override @DefinedBy(Api.COMPILER)
     public Location getLocationForModule(Location location, JavaFileObject fo) throws IOException {
         checkModuleOrientedOrOutputLocation(location);
-        if (!(fo instanceof PathFileObject))
+        if (!(fo instanceof PathFileObject pathFileObject))
             return null;
-        Path p = Locations.normalize(((PathFileObject) fo).path);
+        Path p = Locations.normalize(pathFileObject.path);
             // need to find p in location
         return locations.getLocationForModule(location, p);
     }
@@ -1190,8 +1186,8 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
 
     @Override @DefinedBy(Api.COMPILER)
     public Path asPath(FileObject file) {
-        if (file instanceof PathFileObject) {
-            return ((PathFileObject) file).path;
+        if (file instanceof PathFileObject pathFileObject) {
+            return pathFileObject.path;
         } else
             throw new IllegalArgumentException(file.getName());
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/Locations.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/Locations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1232,10 +1232,9 @@ public class Locations {
 
             for (Set<Location> set : listLocationsForModules()) {
                 for (Location locn : set) {
-                    if (locn instanceof ModuleLocationHandler) {
-                        ModuleLocationHandler l = (ModuleLocationHandler) locn;
-                        if (!moduleTable.nameMap.containsKey(l.moduleName)) {
-                            moduleTable.add(l);
+                    if (locn instanceof ModuleLocationHandler moduleLocationHandler) {
+                        if (!moduleTable.nameMap.containsKey(moduleLocationHandler.moduleName)) {
+                            moduleTable.add(moduleLocationHandler);
                         }
                     }
                 }
@@ -2200,8 +2199,8 @@ public class Locations {
 
     protected LocationHandler getHandler(Location location) {
         Objects.requireNonNull(location);
-        return (location instanceof LocationHandler)
-                ? (LocationHandler) location
+        return (location instanceof LocationHandler locationHandler)
+                ? locationHandler
                 : handlersForLocation.get(location);
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/PathFileObject.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/PathFileObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -532,7 +532,7 @@ public abstract class PathFileObject implements JavaFileObject {
 
     @Override
     public boolean equals(Object other) {
-        return (other instanceof PathFileObject && path.equals(((PathFileObject) other).path));
+        return (other instanceof PathFileObject pathFileObject && path.equals(pathFileObject.path));
     }
 
     @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/RelativePath.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/RelativePath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,9 +73,7 @@ public abstract class RelativePath implements Comparable<RelativePath> {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof RelativePath))
-            return false;
-         return path.equals(((RelativePath) other).path);
+        return (other instanceof RelativePath relativePath) && path.equals(relativePath.path);
     }
 
     @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Arguments.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Arguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -478,11 +478,10 @@ public class Arguments {
 
         // The following checks are to help avoid accidental confusion between
         // directories of modules and exploded module directories.
-        if (fm instanceof StandardJavaFileManager) {
-            StandardJavaFileManager sfm = (StandardJavaFileManager) fileManager;
-            if (sfm.hasLocation(StandardLocation.CLASS_OUTPUT)) {
-                Path outDir = sfm.getLocationAsPaths(StandardLocation.CLASS_OUTPUT).iterator().next();
-                if (sfm.hasLocation(StandardLocation.MODULE_SOURCE_PATH)) {
+        if (fm instanceof StandardJavaFileManager standardJavaFileManager) {
+            if (standardJavaFileManager.hasLocation(StandardLocation.CLASS_OUTPUT)) {
+                Path outDir = standardJavaFileManager.getLocationAsPaths(StandardLocation.CLASS_OUTPUT).iterator().next();
+                if (standardJavaFileManager.hasLocation(StandardLocation.MODULE_SOURCE_PATH)) {
                     // multi-module mode
                     if (Files.exists(outDir.resolve("module-info.class"))) {
                         log.error(Errors.MultiModuleOutdirCannotBeExplodedModule(outDir));
@@ -565,12 +564,12 @@ public class Arguments {
 
         boolean lintOptions = options.isUnset(Option.XLINT_CUSTOM, "-" + LintCategory.OPTIONS.option);
         if (lintOptions && source.compareTo(Source.DEFAULT) < 0 && !options.isSet(Option.RELEASE)) {
-            if (fm instanceof BaseFileManager) {
+            if (fm instanceof BaseFileManager baseFileManager) {
                 if (source.compareTo(Source.JDK8) <= 0) {
-                    if (((BaseFileManager) fm).isDefaultBootClassPath())
+                    if (baseFileManager.isDefaultBootClassPath())
                         log.warning(LintCategory.OPTIONS, Warnings.SourceNoBootclasspath(source.name));
                 } else {
-                    if (((BaseFileManager) fm).isDefaultSystemModulesPath())
+                    if (baseFileManager.isDefaultSystemModulesPath())
                         log.warning(LintCategory.OPTIONS, Warnings.SourceNoSystemModulesPath(source.name));
                 }
             }
@@ -914,10 +913,10 @@ public class Arguments {
 
     private void report(DiagnosticInfo diag) {
         // Would be good to have support for -XDrawDiagnostics here
-        if (diag instanceof JCDiagnostic.Error) {
-            log.error((JCDiagnostic.Error)diag);
-        } else if (diag instanceof JCDiagnostic.Warning){
-            log.warning((JCDiagnostic.Warning)diag);
+        if (diag instanceof JCDiagnostic.Error errorDiag) {
+            log.error(errorDiag);
+        } else if (diag instanceof JCDiagnostic.Warning warningDiag){
+            log.warning(warningDiag);
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/DelegatingJavaFileManager.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/DelegatingJavaFileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,9 +51,8 @@ public class DelegatingJavaFileManager implements JavaFileManager {
                                                  JavaFileManager releaseFM,
                                                  JavaFileManager originalFM) {
         context.put(JavaFileManager.class, (JavaFileManager) null);
-        JavaFileManager nue = originalFM instanceof StandardJavaFileManager
-                ? new DelegatingSJFM(releaseFM,
-                                                        (StandardJavaFileManager) originalFM)
+        JavaFileManager nue = originalFM instanceof StandardJavaFileManager standardJavaFileManager
+                ? new DelegatingSJFM(releaseFM, standardJavaFileManager)
                 : new DelegatingJavaFileManager(releaseFM, originalFM);
         context.put(JavaFileManager.class, nue);
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1086,8 +1086,8 @@ public class JavaCompiler {
                 for (List<JCTree> defs = unit.defs;
                      defs.nonEmpty();
                      defs = defs.tail) {
-                    if (defs.head instanceof JCClassDecl)
-                        cdefs.append((JCClassDecl)defs.head);
+                    if (defs.head instanceof JCClassDecl classDecl)
+                        cdefs.append(classDecl);
                 }
             }
             rootClasses = cdefs.toList();
@@ -1577,8 +1577,8 @@ public class JavaCompiler {
                 //emit standard Java source file, only for compilation
                 //units enumerated explicitly on the command line
                 JCClassDecl cdef = (JCClassDecl)env.tree;
-                if (untranslated instanceof JCClassDecl &&
-                    rootClasses.contains((JCClassDecl)untranslated)) {
+                if (untranslated instanceof JCClassDecl classDecl &&
+                    rootClasses.contains(classDecl)) {
                     results.add(new Pair<>(env, cdef));
                 }
                 return;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Main.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -258,11 +258,11 @@ public class Main {
 
         // init file manager
         fileManager = context.get(JavaFileManager.class);
-        JavaFileManager undel = fileManager instanceof DelegatingJavaFileManager ?
-                ((DelegatingJavaFileManager) fileManager).getBaseFileManager() : fileManager;
-        if (undel instanceof BaseFileManager) {
-            ((BaseFileManager) undel).setContext(context); // reinit with options
-            ok &= ((BaseFileManager) undel).handleOptions(args.getDeferredFileManagerOptions());
+        JavaFileManager undel = fileManager instanceof DelegatingJavaFileManager delegatingJavaFileManager ?
+                delegatingJavaFileManager.getBaseFileManager() : fileManager;
+        if (undel instanceof BaseFileManager baseFileManager) {
+            baseFileManager.setContext(context); // reinit with options
+            ok &= baseFileManager.handleOptions(args.getDeferredFileManagerOptions());
         }
 
         // handle this here so it works even if no other options given

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/model/AnnotationProxyMaker.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/model/AnnotationProxyMaker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -246,8 +246,8 @@ public class AnnotationProxyMaker {
         }
 
         public void visitError(Attribute.Error e) {
-            if (e instanceof Attribute.UnresolvedClass)
-                value = new MirroredTypeExceptionProxy(((Attribute.UnresolvedClass)e).classType);
+            if (e instanceof Attribute.UnresolvedClass unresolvedClass)
+                value = new MirroredTypeExceptionProxy(unresolvedClass.classType);
             else
                 value = null;       // indicates a type mismatch
         }
@@ -302,8 +302,8 @@ public class AnnotationProxyMaker {
 
         public boolean equals(Object obj) {
             return type != null &&
-                   obj instanceof MirroredTypeExceptionProxy &&
-                   type.equals(((MirroredTypeExceptionProxy) obj).type);
+                   obj instanceof MirroredTypeExceptionProxy proxy &&
+                   type.equals(proxy.type);
         }
 
         protected RuntimeException generateException() {
@@ -347,9 +347,8 @@ public class AnnotationProxyMaker {
 
         public boolean equals(Object obj) {
             return types != null &&
-                   obj instanceof MirroredTypesExceptionProxy &&
-                   types.equals(
-                      ((MirroredTypesExceptionProxy) obj).types);
+                   obj instanceof MirroredTypesExceptionProxy proxy &&
+                   types.equals(proxy.types);
         }
 
         protected RuntimeException generateException() {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/model/JavacElements.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/model/JavacElements.java
@@ -115,7 +115,7 @@ public class JavacElements implements Elements {
         enter = Enter.instance(context);
         resolve = Resolve.instance(context);
         JavacTask t = context.get(JavacTask.class);
-        javacTaskImpl = t instanceof JavacTaskImpl ? (JavacTaskImpl) t : null;
+        javacTaskImpl = t instanceof JavacTaskImpl taskImpl ? taskImpl : null;
         log = Log.instance(context);
         Source source = Source.instance(context);
         allowModules = Feature.MODULES.allowedInSource(source);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/model/JavacTypes.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/model/JavacTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -329,18 +329,17 @@ public class JavacTypes implements javax.lang.model.util.Types {
                 || elem.getModifiers().contains(Modifier.PRIVATE))
             return Collections.emptySet();
 
-        if (!(elem instanceof MethodSymbol))
+        if (!(elem instanceof MethodSymbol methodSymbol))
             throw new IllegalArgumentException();
 
-        MethodSymbol m = (MethodSymbol) elem;
-        ClassSymbol origin = (ClassSymbol) m.owner;
+        ClassSymbol origin = (ClassSymbol) methodSymbol.owner;
 
         Set<MethodSymbol> results = new LinkedHashSet<>();
         for (Type t : types.closure(origin.type)) {
             if (t != origin.type) {
                 ClassSymbol c = (ClassSymbol) t.tsym;
-                for (Symbol sym : c.members().getSymbolsByName(m.name)) {
-                    if (sym.kind == MTH && m.overrides(sym, origin, types, true)) {
+                for (Symbol sym : c.members().getSymbolsByName(methodSymbol.name)) {
+                    if (sym.kind == MTH && methodSymbol.overrides(sym, origin, types, true)) {
                         results.add((MethodSymbol) sym);
                     }
                 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/platform/JDKPlatformProvider.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/platform/JDKPlatformProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -239,8 +239,8 @@ public class JDKPlatformProvider implements PlatformProvider {
 
                 @Override
                 public String inferBinaryName(Location location, JavaFileObject file) {
-                    if (file instanceof SigJavaFileObject) {
-                        file = ((SigJavaFileObject) file).getDelegate();
+                    if (file instanceof SigJavaFileObject sigJavaFileObject) {
+                        file = sigJavaFileObject.getDelegate();
                     }
                     return super.inferBinaryName(location, file);
                 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocPretty.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocPretty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -500,8 +500,8 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
                 print(" ");
                 print(attrs, " ");
                 DocTree last = node.getAttributes().get(attrs.size() - 1);
-                if (node.isSelfClosing() && last instanceof AttributeTree
-                        && ((AttributeTree) last).getValueKind() == ValueKind.UNQUOTED)
+                if (node.isSelfClosing() && last instanceof AttributeTree attributeTree
+                        && attributeTree.getValueKind() == ValueKind.UNQUOTED)
                     print(" ");
             }
             if (node.isSelfClosing())

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2178,7 +2178,7 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
 
         @Override @DefinedBy(Api.COMPILER_TREE)
         public JCPattern getPattern() {
-            return pattern instanceof JCPattern ? (JCPattern) pattern : null;
+            return pattern instanceof JCPattern jcPattern ? jcPattern : null;
         }
 
         @DefinedBy(Api.COMPILER_TREE)

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -701,9 +701,9 @@ public class Pretty extends JCTree.Visitor {
                 if ((tree.mods.flags & VARARGS) != 0) {
                     JCTree vartype = tree.vartype;
                     List<JCAnnotation> tas = null;
-                    if (vartype instanceof JCAnnotatedType) {
-                        tas = ((JCAnnotatedType)vartype).annotations;
-                        vartype = ((JCAnnotatedType)vartype).underlyingType;
+                    if (vartype instanceof JCAnnotatedType annotatedType) {
+                        tas = annotatedType.annotations;
+                        vartype = annotatedType.underlyingType;
                     }
                     printExpr(((JCArrayTypeTree) vartype).elemtype);
                     if (tas != null) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -131,8 +131,8 @@ public class TreeMaker implements JCTree.Factory {
                 || node instanceof JCModuleDecl
                 || node instanceof JCSkip
                 || node instanceof JCErroneous
-                || (node instanceof JCExpressionStatement
-                    && ((JCExpressionStatement)node).expr instanceof JCErroneous),
+                || (node instanceof JCExpressionStatement expressionStatement
+                    && expressionStatement.expr instanceof JCErroneous),
                     () -> node.getClass().getSimpleName());
         JCCompilationUnit tree = new JCCompilationUnit(defs);
         tree.pos = pos;
@@ -886,8 +886,8 @@ public class TreeMaker implements JCTree.Factory {
         } else if (value instanceof Byte) {
             result = Literal(BYTE, value).
                 setType(syms.byteType.constType(value));
-        } else if (value instanceof Character) {
-            int v = (int) (((Character) value).toString().charAt(0));
+        } else if (value instanceof Character charVal) {
+            int v = charVal.toString().charAt(0);
             result = Literal(CHAR, v).
                 setType(syms.charType.constType(v));
         } else if (value instanceof Double) {
@@ -899,8 +899,8 @@ public class TreeMaker implements JCTree.Factory {
         } else if (value instanceof Short) {
             result = Literal(SHORT, value).
                 setType(syms.shortType.constType(value));
-        } else if (value instanceof Boolean) {
-            int v = ((Boolean) value) ? 1 : 0;
+        } else if (value instanceof Boolean boolVal) {
+            int v = boolVal ? 1 : 0;
             result = Literal(BOOLEAN, v).
                 setType(syms.booleanType.constType(v));
         } else {
@@ -921,15 +921,15 @@ public class TreeMaker implements JCTree.Factory {
             result = QualIdent(e.value);
         }
         public void visitError(Attribute.Error e) {
-            if (e instanceof UnresolvedClass) {
-                result = ClassLiteral(((UnresolvedClass) e).classType).setType(syms.classType);
+            if (e instanceof UnresolvedClass unresolvedClass) {
+                result = ClassLiteral(unresolvedClass.classType).setType(syms.classType);
             } else {
                 result = Erroneous();
             }
         }
         public void visitCompound(Attribute.Compound compound) {
-            if (compound instanceof Attribute.TypeCompound) {
-                result = visitTypeCompoundInternal((Attribute.TypeCompound) compound);
+            if (compound instanceof Attribute.TypeCompound typeCompound) {
+                result = visitTypeCompoundInternal(typeCompound);
             } else {
                 result = visitCompoundInternal(compound);
             }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/AbstractDiagnosticFormatter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/AbstractDiagnosticFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -148,8 +148,8 @@ public abstract class AbstractDiagnosticFormatter implements DiagnosticFormatter
             throw new IllegalArgumentException(); // d should have source set
         if (fullname)
             return fo.getName();
-        else if (fo instanceof PathFileObject)
-            return ((PathFileObject) fo).getShortName();
+        else if (fo instanceof PathFileObject pathFileObject)
+            return pathFileObject.getShortName();
         else
             return PathFileObject.getSimpleName(fo);
     }
@@ -178,50 +178,50 @@ public abstract class AbstractDiagnosticFormatter implements DiagnosticFormatter
      * @return string representation of the diagnostic argument
      */
     protected String formatArgument(JCDiagnostic d, Object arg, Locale l) {
-        if (arg instanceof JCDiagnostic) {
+        if (arg instanceof JCDiagnostic diagnostic) {
             String s = null;
             depth++;
             try {
-                s = formatMessage((JCDiagnostic)arg, l);
+                s = formatMessage(diagnostic, l);
             }
             finally {
                 depth--;
             }
             return s;
         }
-        else if (arg instanceof JCExpression) {
-            return expr2String((JCExpression)arg);
+        else if (arg instanceof JCExpression expression) {
+            return expr2String(expression);
         }
-        else if (arg instanceof Iterable<?> && !(arg instanceof Path)) {
-            return formatIterable(d, (Iterable<?>)arg, l);
+        else if (arg instanceof Iterable<?> iterable && !(arg instanceof Path)) {
+            return formatIterable(d, iterable, l);
         }
-        else if (arg instanceof Type) {
-            return printer.visit((Type)arg, l);
+        else if (arg instanceof Type type) {
+            return printer.visit(type, l);
         }
-        else if (arg instanceof Symbol) {
-            return printer.visit((Symbol)arg, l);
+        else if (arg instanceof Symbol symbol) {
+            return printer.visit(symbol, l);
         }
-        else if (arg instanceof JavaFileObject) {
-            return ((JavaFileObject)arg).getName();
+        else if (arg instanceof JavaFileObject javaFileObject) {
+            return javaFileObject.getName();
         }
-        else if (arg instanceof Profile) {
-            return ((Profile)arg).name;
+        else if (arg instanceof Profile profile) {
+            return profile.name;
         }
-        else if (arg instanceof Option) {
-            return ((Option)arg).primaryName;
+        else if (arg instanceof Option option) {
+            return option.primaryName;
         }
-        else if (arg instanceof Formattable) {
-            return ((Formattable)arg).toString(l, messages);
+        else if (arg instanceof Formattable formattable) {
+            return formattable.toString(l, messages);
         }
-        else if (arg instanceof Target) {
-            return ((Target)arg).name;
+        else if (arg instanceof Target target) {
+            return target.name;
         }
-        else if (arg instanceof Source) {
-            return ((Source)arg).name;
+        else if (arg instanceof Source source) {
+            return source.name;
         }
-        else if (arg instanceof Tag) {
+        else if (arg instanceof Tag tag) {
             return messages.getLocalizedString(l, "compiler.misc.tree.tag." +
-                                                  StringUtils.toLowerCase(((Tag) arg).name()));
+                                                  StringUtils.toLowerCase(tag.name()));
         }
         else {
             return String.valueOf(arg);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Constants.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,8 +44,8 @@ public class Constants {
      * null) are returned unchanged.
      */
     public static Object decode(Object value, Type type) {
-        if (value instanceof Integer) {
-            int i = (Integer) value;
+        if (value instanceof Integer intVal) {
+            int i = intVal;
             switch (type.getTag()) {
             case BOOLEAN:  return i != 0;
             case CHAR:     return (char) i;
@@ -69,8 +69,8 @@ public class Constants {
         case DOUBLE:    return formatDouble((Double) value);
         case CHAR:      return formatChar((Character) value);
         }
-        if (value instanceof String)
-            return formatString((String) value);
+        if (value instanceof String str)
+            return formatString(str);
         return value + "";
     }
 
@@ -80,13 +80,13 @@ public class Constants {
      * Java source.
      */
     public static String format(Object value) {
-        if (value instanceof Byte)      return formatByte((Byte) value);
-        if (value instanceof Short)     return formatShort((Short) value);
-        if (value instanceof Long)      return formatLong((Long) value);
-        if (value instanceof Float)     return formatFloat((Float) value);
-        if (value instanceof Double)    return formatDouble((Double) value);
-        if (value instanceof Character) return formatChar((Character) value);
-        if (value instanceof String)    return formatString((String) value);
+        if (value instanceof Byte byteVal)      return formatByte(byteVal);
+        if (value instanceof Short shortVal)     return formatShort(shortVal);
+        if (value instanceof Long longVal)      return formatLong(longVal);
+        if (value instanceof Float floatVal)     return formatFloat(floatVal);
+        if (value instanceof Double doubleVal)    return formatDouble(doubleVal);
+        if (value instanceof Character charVal) return formatChar(charVal);
+        if (value instanceof String strVal)    return formatString(strVal);
         if (value instanceof Integer ||
             value instanceof Boolean)   return value.toString();
         else

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Context.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Context.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -145,8 +145,7 @@ public class Context {
     public <T> T get(Key<T> key) {
         checkState(ht);
         Object o = ht.get(key);
-        if (o instanceof Factory<?>) {
-            Factory<?> fac = (Factory<?>)o;
+        if (o instanceof Factory<?> fac) {
             o = fac.make(this);
             if (o instanceof Factory<?>)
                 throw new AssertionError("T extends Context.Factory");

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Dependencies.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Dependencies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -202,7 +202,7 @@ public abstract class Dependencies {
 
             @Override
             public boolean equals(Object obj) {
-                return obj instanceof Node && data.equals(((Node) obj).data);
+                return obj instanceof Node node && data.equals(node.data);
             }
 
             @Override
@@ -401,8 +401,8 @@ public abstract class Dependencies {
 
             @Override
             public void visitNode(Node node, Void arg) {
-                if (node instanceof CompletionNode) {
-                    if (((CompletionNode) node).ck != ck) {
+                if (node instanceof CompletionNode completionNode) {
+                    if (completionNode.ck != ck) {
                         dependencyNodeMap.remove(node.data);
                     }
                 }
@@ -410,8 +410,8 @@ public abstract class Dependencies {
 
             @Override
             public void visitDependency(GraphUtils.DependencyKind dk, Node from, Node to, Void arg) {
-                if (to instanceof CompletionNode) {
-                    if (((CompletionNode) to).ck != ck) {
+                if (to instanceof CompletionNode completionNode) {
+                    if (completionNode.ck != ck) {
                         from.depsByKind.get(dk).remove(to);
                     }
                 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/DiagnosticSource.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/DiagnosticSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -183,10 +183,9 @@ public class DiagnosticSource {
     protected char[] initBuf(JavaFileObject fileObject) throws IOException {
         char[] buf;
         CharSequence cs = fileObject.getCharContent(true);
-        if (cs instanceof CharBuffer) {
-            CharBuffer cb = (CharBuffer) cs;
-            buf = JavacFileManager.toArray(cb);
-            bufLen = cb.limit();
+        if (cs instanceof CharBuffer charBuffer) {
+            buf = JavacFileManager.toArray(charBuffer);
+            bufLen = charBuffer.limit();
         } else {
             buf = cs.toString().toCharArray();
             bufLen = buf.length;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/JCDiagnostic.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/JCDiagnostic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -287,8 +287,8 @@ public class JCDiagnostic implements Diagnostic<JavaFileObject> {
                 //replace all nested FragmentKey with full-blown JCDiagnostic objects
                 return DiagnosticInfo.of(diagnosticInfo.type, diagnosticInfo.prefix, diagnosticInfo.code,
                         Stream.of(diagnosticInfo.args).map(o -> {
-                            return (o instanceof Fragment) ?
-                                    fragment((Fragment)o) : o;
+                            return (o instanceof Fragment frag) ?
+                                    fragment(frag) : o;
                         }).toArray());
             }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/List.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/List.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -358,11 +358,11 @@ public class List<A> extends AbstractCollection<A> implements java.util.List<A> 
      */
     @Override
     public boolean equals(Object other) {
-        if (other instanceof List<?>)
-            return equals(this, (List<?>)other);
-        if (other instanceof java.util.List<?>) {
+        if (other instanceof List<?> javacList)
+            return equals(this, javacList);
+        if (other instanceof java.util.List<?> javaUtilList) {
             List<A> t = this;
-            Iterator<?> oIter = ((java.util.List<?>) other).iterator();
+            Iterator<?> oIter = javaUtilList.iterator();
             while (t.tail != null && oIter.hasNext()) {
                 Object o = oIter.next();
                 if ( !(t.head == null ? o == null : t.head.equals(o)))

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
@@ -548,8 +548,8 @@ public class Log extends AbstractLog {
         private void getCodeRecursive(ListBuffer<String> buf, JCDiagnostic d) {
             buf.add(d.getCode());
             for (Object o : d.getArgs()) {
-                if (o instanceof JCDiagnostic) {
-                    getCodeRecursive(buf, (JCDiagnostic)o);
+                if (o instanceof JCDiagnostic diagnostic) {
+                    getCodeRecursive(buf, diagnostic);
                 }
             }
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Pair.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Pair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,10 +49,9 @@ public class Pair<A, B> {
     }
 
     public boolean equals(Object other) {
-        return
-            other instanceof Pair<?,?> &&
-            Objects.equals(fst, ((Pair<?,?>)other).fst) &&
-            Objects.equals(snd, ((Pair<?,?>)other).snd);
+        return other instanceof Pair<?,?> pair &&
+            Objects.equals(fst, pair.fst) &&
+            Objects.equals(snd, pair.snd);
     }
 
     public int hashCode() {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/RawDiagnosticFormatter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/RawDiagnosticFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -155,13 +155,13 @@ public final class RawDiagnosticFormatter extends AbstractDiagnosticFormatter {
         String s;
         if (arg instanceof Formattable) {
             s = arg.toString();
-        } else if (arg instanceof JCExpression) {
+        } else if (arg instanceof JCExpression expression) {
             Assert.checkNonNull(rawDiagnosticPosHelper);
-            s = "@" + rawDiagnosticPosHelper.getPosition((JCExpression)arg);
-        } else if (arg instanceof PathFileObject) {
-            s = ((PathFileObject) arg).getShortName();
-        } else if (arg instanceof Tag) {
-            s = "compiler.misc.tree.tag." + StringUtils.toLowerCase(((Tag) arg).name());
+            s = "@" + rawDiagnosticPosHelper.getPosition(expression);
+        } else if (arg instanceof PathFileObject pathFileObject) {
+            s = pathFileObject.getShortName();
+        } else if (arg instanceof Tag tag) {
+            s = "compiler.misc.tree.tag." + StringUtils.toLowerCase(tag.name());
         } else if (arg instanceof Source && arg == Source.DEFAULT &&
                 CODES_NEEDING_SOURCE_NORMALIZATION.contains(diag.getCode())) {
             s = "DEFAULT";

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/RichDiagnosticFormatter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/RichDiagnosticFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -180,17 +180,17 @@ public class RichDiagnosticFormatter extends
      * @param arg the argument to be translated
      */
     protected void preprocessArgument(Object arg) {
-        if (arg instanceof Type) {
-            preprocessType((Type)arg);
+        if (arg instanceof Type type) {
+            preprocessType(type);
         }
-        else if (arg instanceof Symbol) {
-            preprocessSymbol((Symbol)arg);
+        else if (arg instanceof Symbol symbol) {
+            preprocessSymbol(symbol);
         }
-        else if (arg instanceof JCDiagnostic) {
-            preprocessDiagnostic((JCDiagnostic)arg);
+        else if (arg instanceof JCDiagnostic diagnostic) {
+            preprocessDiagnostic(diagnostic);
         }
-        else if (arg instanceof Iterable<?> && !(arg instanceof Path)) {
-            for (Object o : (Iterable<?>)arg) {
+        else if (arg instanceof Iterable<?> iterable && !(arg instanceof Path)) {
+            for (Object o : iterable) {
                 preprocessArgument(o);
             }
         }
@@ -556,8 +556,8 @@ public class RichDiagnosticFormatter extends
             if (indexOf(t, WhereClauseKind.TYPEVAR) == -1) {
                 //access the bound type and skip error types
                 Type bound = t.getUpperBound();
-                while ((bound instanceof ErrorType))
-                    bound = ((ErrorType)bound).getOriginalType();
+                while ((bound instanceof ErrorType errorType))
+                    bound = errorType.getOriginalType();
                 //retrieve the bound list - if the type variable
                 //has not been attributed the bound is not set
                 List<Type> bounds = (bound != null) &&

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/SharedNameTable.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/SharedNameTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -203,10 +203,9 @@ public class SharedNameTable extends Name.Table {
          */
         @DefinedBy(Api.LANGUAGE_MODEL)
         public boolean equals(Object other) {
-            if (other instanceof Name)
-                return
-                    table == ((Name)other).table && index == ((Name) other).getIndex();
-            else return false;
+            return (other instanceof Name name)
+                    && table == name.table
+                    && index == name.getIndex();
         }
 
     }


### PR DESCRIPTION
Hi all,

This series of patches update the code of the module jdk.compiler by using the pattern matching for instanceof.

This patch would revise the following packages:
```
com.sun.tools.javac.api
com.sun.tools.javac.file
com.sun.tools.javac.main
com.sun.tools.javac.model
com.sun.tools.javac.platform
com.sun.tools.javac.tree
com.sun.tools.javac.util
```

Thank you for taking the time to review.

--
Best Regards,
Guoxiong.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265899](https://bugs.openjdk.java.net/browse/JDK-8265899): Use pattern matching for instanceof at module jdk.compiler(part 1)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3673/head:pull/3673` \
`$ git checkout pull/3673`

Update a local copy of the PR: \
`$ git checkout pull/3673` \
`$ git pull https://git.openjdk.java.net/jdk pull/3673/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3673`

View PR using the GUI difftool: \
`$ git pr show -t 3673`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3673.diff">https://git.openjdk.java.net/jdk/pull/3673.diff</a>

</details>
