### PR TITLE
8265901: Use pattern matching for instanceof at module jdk.compiler(part 3)

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/sjavac/Module.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/sjavac/Module.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ public class Module implements Comparable<Module> {
 
     @Override
     public boolean equals(Object o) {
-        return (o instanceof Module) && name.equals(((Module)o).name);
+        return (o instanceof Module module) && name.equals(module.name);
     }
 
     @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/sjavac/Package.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/sjavac/Package.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -117,7 +117,7 @@ public class Package implements Comparable<Package> {
 
     @Override
     public boolean equals(Object o) {
-        return (o instanceof Package) && name.equals(((Package)o).name);
+        return (o instanceof Package pac) && name.equals(pac.name);
     }
 
     @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/sjavac/Source.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/sjavac/Source.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,7 @@ public class Source implements Comparable<Source> {
 
     @Override
     public boolean equals(Object o) {
-        return (o instanceof Source) && name.equals(((Source)o).name);
+        return (o instanceof Source source) && name.equals(source.name);
     }
 
     @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/sjavac/comp/JavaFileObjectWithLocation.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/sjavac/comp/JavaFileObjectWithLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,9 +60,8 @@ public class JavaFileObjectWithLocation<F extends JavaFileObject> extends Forwar
 
     @Override
     public boolean equals(Object obj) {
-        if (!(obj instanceof JavaFileObjectWithLocation))
-            return false;
-        JavaFileObjectWithLocation<?> other = (JavaFileObjectWithLocation<?>) obj;
-        return loc.equals(other.loc) && fileObject.equals(other.fileObject);
+        return (obj instanceof JavaFileObjectWithLocation<?> javaFileObjectWithLocation)
+                && loc.equals(javaFileObjectWithLocation.loc)
+                && fileObject.equals(javaFileObjectWithLocation.fileObject);
     }
 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/sjavac/comp/PathAndPackageVerifier.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/sjavac/comp/PathAndPackageVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -138,8 +138,8 @@ public class PathAndPackageVerifier implements TaskListener {
         @Override
         public String next() {
             Name name;
-            if (next instanceof JCIdent) {
-                name = ((JCIdent) next).name;
+            if (next instanceof JCIdent identNext) {
+                name = identNext.name;
                 next = null;
             } else {
                 JCFieldAccess fa = (JCFieldAccess) next;

--- a/src/jdk.compiler/share/classes/com/sun/tools/sjavac/comp/SjavacImpl.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/sjavac/comp/SjavacImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,9 +122,9 @@ public class SjavacImpl implements Sjavac {
 
             // Clean up
             JavaFileManager fileManager = context.get(JavaFileManager.class);
-            if (fileManager instanceof JavacFileManager) {
+            if (fileManager instanceof JavacFileManager javacFileManager) {
                 try {
-                    ((JavacFileManager) fileManager).close();
+                    javacFileManager.close();
                 } catch (IOException es) {
                     throw new UncheckedIOException(es);
                 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/sjavac/comp/SmartFileManager.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/sjavac/comp/SmartFileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,9 +82,9 @@ public class SmartFileManager extends ForwardingJavaFileManager<JavaFileManager>
      * Set whether or not to use ct.sym as an alternate to rt.jar.
      */
     public void setSymbolFileEnabled(boolean b) {
-        if (!(fileManager instanceof JavacFileManager))
+        if (!(fileManager instanceof JavacFileManager javacFileManager))
             throw new IllegalStateException();
-        ((JavacFileManager) fileManager).setSymbolFileEnabled(b);
+        javacFileManager.setSymbolFileEnabled(b);
     }
 
     @DefinedBy(Api.COMPILER)
@@ -175,12 +175,9 @@ public class SmartFileManager extends ForwardingJavaFileManager<JavaFileManager>
     }
 
     private boolean isModuleInfo(FileObject fo) {
-        if (fo instanceof JavaFileObject) {
-            JavaFileObject jfo = (JavaFileObject) fo;
-            return jfo.isNameCompatible("module-info", Kind.SOURCE)
-                || jfo.isNameCompatible("module-info", Kind.CLASS);
-        }
-        return false;
+        return (fo instanceof JavaFileObject javaFileObject)
+                && (javaFileObject.isNameCompatible("module-info", Kind.SOURCE)
+                    || javaFileObject.isNameCompatible("module-info", Kind.CLASS));
     }
 
     @Override @DefinedBy(Api.COMPILER)
@@ -243,8 +240,8 @@ public class SmartFileManager extends ForwardingJavaFileManager<JavaFileManager>
     }
 
     private static FileObject locWrap(FileObject fo, Location loc) {
-        if (fo instanceof JavaFileObject)
-            return locWrap((JavaFileObject) fo, loc);
+        if (fo instanceof JavaFileObject javaFileObject)
+            return locWrap(javaFileObject, loc);
         return fo == null ? null : new FileObjectWithLocation<>(fo, loc);
     }
 
@@ -263,16 +260,16 @@ public class SmartFileManager extends ForwardingJavaFileManager<JavaFileManager>
     }
 
     private static FileObject locUnwrap(FileObject fo) {
-        if (fo instanceof FileObjectWithLocation<?>)
-            return ((FileObjectWithLocation<?>) fo).getDelegate();
-        if (fo instanceof JavaFileObjectWithLocation<?>)
-            return ((JavaFileObjectWithLocation<?>) fo).getDelegate();
+        if (fo instanceof FileObjectWithLocation<?> fileObjectWithLocation)
+            return fileObjectWithLocation.getDelegate();
+        if (fo instanceof JavaFileObjectWithLocation<?> javaFileObjectWithLocation)
+            return javaFileObjectWithLocation.getDelegate();
         return fo;
     }
 
     private static JavaFileObject locUnwrap(JavaFileObject fo) {
-        if (fo instanceof JavaFileObjectWithLocation<?>)
-            return ((JavaFileObjectWithLocation<?>) fo).getDelegate();
+        if (fo instanceof JavaFileObjectWithLocation<?> javaFileObjectWithLocation)
+            return javaFileObjectWithLocation.getDelegate();
         return fo;
     }
 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/sjavac/comp/dependencies/NewDependencyCollector.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/sjavac/comp/dependencies/NewDependencyCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,8 +111,8 @@ public class NewDependencyCollector implements TaskListener {
 
     private Location getLocationOf(ClassSymbol cs) {
         JavaFileObject jfo = cs.outermostClass().classfile;
-        if (jfo instanceof JavaFileObjectWithLocation) {
-            return ((JavaFileObjectWithLocation<?>) jfo).getLocation();
+        if (jfo instanceof JavaFileObjectWithLocation<?> javaFileObjectWithLocation) {
+            return javaFileObjectWithLocation.getLocation();
         }
 
         // jfo is most likely on PLATFORM_CLASS_PATH.
@@ -177,14 +177,13 @@ public class NewDependencyCollector implements TaskListener {
     }
 
     private Set<ClassSymbol> allSupertypes(TypeSymbol t) {
-        if (t == null || !(t instanceof ClassSymbol)) {
+        if (t == null || !(t instanceof ClassSymbol classSymbol)) {
             return Collections.emptySet();
         }
         Set<ClassSymbol> result = new HashSet<>();
-        ClassSymbol cs = (ClassSymbol) t;
-        result.add(cs);
-        result.addAll(allSupertypes(cs.getSuperclass().tsym));
-        for (Type it : cs.getInterfaces()) {
+        result.add(classSymbol);
+        result.addAll(allSupertypes(classSymbol.getSuperclass().tsym));
+        for (Type it : classSymbol.getInterfaces()) {
             result.addAll(allSupertypes(it.tsym));
         }
         return result;

--- a/src/jdk.compiler/share/classes/com/sun/tools/sjavac/comp/dependencies/PublicApiCollector.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/sjavac/comp/dependencies/PublicApiCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,8 +90,8 @@ public class PublicApiCollector implements TaskListener {
 
     private void collectClassSymbols(JCCompilationUnit cu) {
         for (Tree t : cu.getTypeDecls()) {
-            if (t instanceof JCClassDecl)  // Can also be a JCSkip
-                classSymbols.add(((JCClassDecl) t).sym);
+            if (t instanceof JCClassDecl classDecl)  // Can also be a JCSkip
+                classSymbols.add(classDecl.sym);
         }
     }
 


### PR DESCRIPTION
Hi all,

This series of patches update the code of the module jdk.compiler by using the pattern matching for instanceof.

This patch only revises the package `com.sun.tools.sjavac`.

Thank you for taking the time to review.

--
Best Regards,
Guoxiong.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265901](https://bugs.openjdk.java.net/browse/JDK-8265901): Use pattern matching for instanceof at module jdk.compiler(part 3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Joel Borggrén-Franck](https://openjdk.java.net/census#jfranck) (@jbf - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3675/head:pull/3675` \
`$ git checkout pull/3675`

Update a local copy of the PR: \
`$ git checkout pull/3675` \
`$ git pull https://git.openjdk.java.net/jdk pull/3675/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3675`

View PR using the GUI difftool: \
`$ git pr show -t 3675`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3675.diff">https://git.openjdk.java.net/jdk/pull/3675.diff</a>

</details>
