### PR TITLE
8265915: adjust state_unloading_cycle compuation order in nmethod::is_unloading

### DIFF
--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1758,10 +1758,10 @@ public:
 bool nmethod::is_unloading() {
   uint8_t state = RawAccess<MO_RELAXED>::load(&_is_unloading_state);
   bool state_is_unloading = IsUnloadingState::is_unloading(state);
-  uint8_t state_unloading_cycle = IsUnloadingState::unloading_cycle(state);
   if (state_is_unloading) {
     return true;
   }
+  uint8_t state_unloading_cycle = IsUnloadingState::unloading_cycle(state);
   uint8_t current_cycle = CodeCache::unloading_cycle();
   if (state_unloading_cycle == current_cycle) {
     return false;


### PR DESCRIPTION
Trivial change of moving state_unloading_cycle computation after state_is_unloading checking. Avoiding useless state_unloading_cycle computation when state_is_unloading is true.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265915](https://bugs.openjdk.java.net/browse/JDK-8265915): adjust state_unloading_cycle compuation order in nmethod::is_unloading


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3676/head:pull/3676` \
`$ git checkout pull/3676`

Update a local copy of the PR: \
`$ git checkout pull/3676` \
`$ git pull https://git.openjdk.java.net/jdk pull/3676/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3676`

View PR using the GUI difftool: \
`$ git pr show -t 3676`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3676.diff">https://git.openjdk.java.net/jdk/pull/3676.diff</a>

</details>
