### PR TITLE
8265917: Different values computed by C2 and interpreter/C1 for Math.pow(x, 2.0) on x86_32

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86_pow.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_pow.cpp
@@ -2538,10 +2538,12 @@ void MacroAssembler::fast_pow(XMMRegister xmm0, XMMRegister xmm1, XMMRegister xm
   Label L_2TAG_PACKET_48_0_2, L_2TAG_PACKET_49_0_2, L_2TAG_PACKET_50_0_2, L_2TAG_PACKET_51_0_2;
   Label L_2TAG_PACKET_52_0_2, L_2TAG_PACKET_53_0_2, L_2TAG_PACKET_54_0_2, L_2TAG_PACKET_55_0_2;
   Label L_2TAG_PACKET_56_0_2, L_2TAG_PACKET_57_0_2, L_2TAG_PACKET_58_0_2, start;
+  Label L_NOT_DOUBLE2;
 
   assert_different_registers(tmp, eax, ecx, edx);
 
   address static_const_table_pow = (address)_static_const_table_pow;
+  static double DOUBLE2 = 2.0;
 
   bind(start);
   subl(rsp, 120);
@@ -2549,6 +2551,15 @@ void MacroAssembler::fast_pow(XMMRegister xmm0, XMMRegister xmm1, XMMRegister xm
   lea(tmp, ExternalAddress(static_const_table_pow));
   movsd(xmm0, Address(rsp, 128));
   movsd(xmm1, Address(rsp, 136));
+
+  // Special case: pow(x, 2.0) => x * x
+  ucomisd(xmm1, ExternalAddress((address) &DOUBLE2));
+  jccb(Assembler::notEqual, L_NOT_DOUBLE2);
+  jccb(Assembler::parity, L_NOT_DOUBLE2);
+  mulsd(xmm0, xmm0);
+  jmp(L_2TAG_PACKET_21_0_2);
+
+  bind(L_NOT_DOUBLE2);
   xorpd(xmm2, xmm2);
   movl(eax, 16368);
   pinsrw(xmm2, eax, 3);

--- a/src/hotspot/cpu/x86/macroAssembler_x86_pow.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_pow.cpp
@@ -2515,6 +2515,8 @@ ATTRIBUTE_ALIGNED(16) juint _static_const_table_pow[] =
 
 };
 
+ATTRIBUTE_ALIGNED(8) double _DOUBLE2 = 2.0;
+
 //registers,
 // input: xmm0, xmm1
 // scratch: xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7
@@ -2543,7 +2545,7 @@ void MacroAssembler::fast_pow(XMMRegister xmm0, XMMRegister xmm1, XMMRegister xm
   assert_different_registers(tmp, eax, ecx, edx);
 
   address static_const_table_pow = (address)_static_const_table_pow;
-  static double DOUBLE2 = 2.0;
+  address DOUBLE2 = (address) &_DOUBLE2;
 
   bind(start);
   subl(rsp, 120);
@@ -2553,7 +2555,7 @@ void MacroAssembler::fast_pow(XMMRegister xmm0, XMMRegister xmm1, XMMRegister xm
   movsd(xmm1, Address(rsp, 136));
 
   // Special case: pow(x, 2.0) => x * x
-  ucomisd(xmm1, ExternalAddress((address) &DOUBLE2));
+  ucomisd(xmm1, ExternalAddress(DOUBLE2));
   jccb(Assembler::notEqual, L_NOT_DOUBLE2);
   jccb(Assembler::parity, L_NOT_DOUBLE2);
   mulsd(xmm0, xmm0);

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -1639,10 +1639,12 @@ bool LibraryCallKit::inline_math_pow() {
   const TypeD* d = _gvn.type(exp)->isa_double_constant();
   if (d != NULL) {
     if (d->getd() == 2.0) {
+#if !(defined(X86) && !defined(_LP64)) // excludes x86_32
       // Special case: pow(x, 2.0) => x * x
       Node* base = round_double_node(argument(0));
       set_result(_gvn.transform(new MulDNode(base, base)));
       return true;
+#endif
     }
 #if defined(X86) && defined(_LP64)
     else if (d->getd() == 0.5 && Matcher::match_rule_supported(Op_SqrtD)) {

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -1639,12 +1639,10 @@ bool LibraryCallKit::inline_math_pow() {
   const TypeD* d = _gvn.type(exp)->isa_double_constant();
   if (d != NULL) {
     if (d->getd() == 2.0) {
-#if !(defined(X86) && !defined(_LP64)) // excludes x86_32
       // Special case: pow(x, 2.0) => x * x
       Node* base = round_double_node(argument(0));
       set_result(_gvn.transform(new MulDNode(base, base)));
       return true;
-#endif
     }
 #if defined(X86) && defined(_LP64)
     else if (d->getd() == 0.5 && Matcher::match_rule_supported(Op_SqrtD)) {

--- a/test/hotspot/jtreg/compiler/intrinsics/math/TestPow2Opt.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/math/TestPow2Opt.java
@@ -25,34 +25,29 @@
  * @test
  * @bug 8265917
  * @summary test the optimization of pow(x, 2.0)
+ * @run main/othervm TestPow2Opt
+ * @run main/othervm -Xint TestPow2Opt
  * @run main/othervm -Xbatch -XX:TieredStopAtLevel=1 TestPow2Opt
  * @run main/othervm -Xbatch -XX:-TieredCompilation  TestPow2Opt
  */
 
 public class TestPow2Opt {
 
-  static double test(double a) {
-    return Math.pow(a, 2.0);
+  static void test(double a) {
+    double r1 = a * a;
+    double r2 = Math.pow(a, 2.0);
+    if (r1 != r2) {
+      throw new RuntimeException("pow(" + a + ", 2.0), expected: " + r1 + ", actual: " + r2);
+    }
   }
 
   public static void main(String[] args) throws Exception {
-    // v1: value returned by the interpreter
-    double v1 = test(1.0 / 2047);
-
-    // Warmup
-    double sum = 0.0;
-    for (int i = 1; i < 100000; i++) {
-      sum += test(i + 0.0);
+    for (int i = 0; i < 10; i++) {
+      for (int j = 1; j < 100000; j++) {
+        test(j * 1.0);
+        test(1.0 / j);
+      }
     }
-
-    // v2: value returned by the compiler
-    double v2 = test(1.0 / 2047);
-
-    if (v1 != v2) {
-      throw new RuntimeException("v1 should be equal to v2, actual: " + "v1 = " + v1 + " v2 = " + v2);
-    }
-
-    System.out.println(sum);
   }
 
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/math/TestPow2Opt.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/math/TestPow2Opt.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8265917
+ * @summary test the optimization of pow(x, 2.0)
+ * @run main/othervm -Xbatch -XX:TieredStopAtLevel=1 TestPow2Opt
+ * @run main/othervm -Xbatch -XX:-TieredCompilation  TestPow2Opt
+ */
+
+public class TestPow2Opt {
+
+  static double test(double a) {
+    return Math.pow(a, 2.0);
+  }
+
+  public static void main(String[] args) throws Exception {
+    // v1: value returned by the interpreter
+    double v1 = test(1.0 / 2047);
+
+    // Warmup
+    double sum = 0.0;
+    for (int i = 1; i < 100000; i++) {
+      sum += test(i + 0.0);
+    }
+
+    // v2: value returned by the compiler
+    double v2 = test(1.0 / 2047);
+
+    if (v1 != v2) {
+      throw new RuntimeException("v1 should be equal to v2, actual: " + "v1 = " + v1 + " v2 = " + v2);
+    }
+
+    System.out.println(sum);
+  }
+
+}


### PR DESCRIPTION
Hi all,

C2 may produce different results for Math.pow(x, 2.0) compared with interpreter/C1 on x86_32.

E.g., for Math.pow(1.0 / 2047, 2.0):
```
interpreter: 2.38651580386563E-7 
         C2: 2.3865158038656307E-7
```

The reason is that C2 will replace Math.pow(x, 2.0) with x*x.
However, there is no such optimization for interpreter/C1 on x86_32.

The fix just disables C2's opt for Math.pow(x, 2.0) on x86_32 since nobody (or very few people) would run x86_32.
And we don't have a plan to implement such opt on x86_32.

Another reason to fix this bug is that we need this patch to extend C2's opt for Math.pow(x, 0.5) on other platforms.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265917](https://bugs.openjdk.java.net/browse/JDK-8265917): Different values computed by C2 and interpreter/C1 for Math.pow(x, 2.0) on x86_32


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3677/head:pull/3677` \
`$ git checkout pull/3677`

Update a local copy of the PR: \
`$ git checkout pull/3677` \
`$ git pull https://git.openjdk.java.net/jdk pull/3677/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3677`

View PR using the GUI difftool: \
`$ git pr show -t 3677`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3677.diff">https://git.openjdk.java.net/jdk/pull/3677.diff</a>

</details>
