### PR TITLE
8163367: Test javax/swing/JComboBox/8033069/bug8033069NoScrollBar.java javax/swing/JComboBox/8033069/bug8033069ScrollBar.java fails intermittently 

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -734,7 +734,6 @@ javax/swing/JWindow/ShapedAndTranslucentWindows/PerPixelTranslucentSwing.java 81
 javax/swing/JWindow/ShapedAndTranslucentWindows/SetShapeAndClickSwing.java 8013450 macosx-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/TranslucentJComboBox.java 8024627 macosx-all
 # The next test below is an intermittent failure
-javax/swing/JComboBox/8033069/bug8033069ScrollBar.java 8163367 generic-all
 javax/swing/JTree/DnD/LastNodeLowerHalfDrop.java 8159131 linux-all
 javax/swing/JTree/4633594/JTreeFocusTest.java 8173125 macosx-all
 javax/swing/AbstractButton/6711682/bug6711682.java 8060765 windows-all,macosx-all

--- a/test/jdk/javax/swing/JComboBox/8033069/bug8033069NoScrollBar.java
+++ b/test/jdk/javax/swing/JComboBox/8033069/bug8033069NoScrollBar.java
@@ -100,6 +100,7 @@ public class bug8033069NoScrollBar {
         frame.add(panel);
 
         frame.pack();
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
 

--- a/test/jdk/javax/swing/JComboBox/8033069/bug8033069NoScrollBar.java
+++ b/test/jdk/javax/swing/JComboBox/8033069/bug8033069NoScrollBar.java
@@ -60,8 +60,8 @@ public class bug8033069NoScrollBar {
     private JComboBox cb1;
     private JComboBox cb2;
 
-    volatile private Point p;
-    volatile private Dimension d;
+    private volatile Point p;
+    private volatile Dimension d;
 
     public static void main(String[] args) throws Exception {
         iterateLookAndFeels(new bug8033069NoScrollBar(NO_SCROLL_ITEMS));

--- a/test/jdk/javax/swing/JComboBox/8033069/bug8033069NoScrollBar.java
+++ b/test/jdk/javax/swing/JComboBox/8033069/bug8033069NoScrollBar.java
@@ -45,9 +45,8 @@ import javax.swing.UnsupportedLookAndFeelException;
  * @library ../../regtesthelpers
  * @build Util
  * @run main bug8033069NoScrollBar
- * @author Alexey Ivanov
  */
-public class bug8033069NoScrollBar implements Runnable {
+public class bug8033069NoScrollBar {
 
     private static final String[] NO_SCROLL_ITEMS = new String[] {
         "A", "B", "C", "D", "E", "F"
@@ -60,6 +59,9 @@ public class bug8033069NoScrollBar implements Runnable {
     private JFrame frame;
     private JComboBox cb1;
     private JComboBox cb2;
+
+    private Point p;
+    private Dimension d;
 
     public static void main(String[] args) throws Exception {
         iterateLookAndFeels(new bug8033069NoScrollBar(NO_SCROLL_ITEMS));
@@ -103,19 +105,25 @@ public class bug8033069NoScrollBar implements Runnable {
 
     public void runTest() throws Exception {
         try {
-            SwingUtilities.invokeAndWait(this);
+            SwingUtilities.invokeAndWait(this::setupUI);
 
             robot.waitForIdle();
             assertFalse("cb1 popup is visible",
                         Util.invokeOnEDT(cb1::isPopupVisible));
 
             // Move mouse pointer to the center of the fist combo box
-            Point p = cb1.getLocationOnScreen();
-            Dimension d = cb1.getSize();
+            SwingUtilities.invokeAndWait(() -> {
+                p = cb1.getLocationOnScreen();
+                d = cb1.getSize();
+            });
+            robot.waitForIdle();
+
             robot.mouseMove(p.x + d.width / 2, p.y + d.height / 2);
+            robot.waitForIdle();
+
             // Click it to open popup
-            robot.mousePress(InputEvent.BUTTON1_MASK);
-            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
 
             robot.waitForIdle();
             assertTrue("cb1 popup is not visible",
@@ -133,6 +141,7 @@ public class bug8033069NoScrollBar implements Runnable {
 
             // Move mouse down on the popup
             robot.mouseMove(p.x + d.width / 2, p.y + d.height * 3);
+            robot.waitForIdle();
 
             robot.mouseWheel(1);
             robot.waitForIdle();
@@ -146,9 +155,14 @@ public class bug8033069NoScrollBar implements Runnable {
 
 
             // Move mouse pointer to the center of the second combo box
-            p = cb2.getLocationOnScreen();
-            d = cb2.getSize();
+            SwingUtilities.invokeAndWait(() -> {
+                p = cb2.getLocationOnScreen();
+                d = cb2.getSize();
+            });
+            robot.waitForIdle();
+
             robot.mouseMove(p.x + d.width / 2, p.y + d.height / 2);
+            robot.waitForIdle();
 
             robot.mouseWheel(1);
             robot.waitForIdle();
@@ -156,16 +170,11 @@ public class bug8033069NoScrollBar implements Runnable {
                         Util.invokeOnEDT(cb1::isPopupVisible));
         } finally {
             if (frame != null) {
-                frame.dispose();
+                SwingUtilities.invokeAndWait(frame::dispose);
             }
         }
 
         System.out.println("Test passed");
-    }
-
-    @Override
-    public void run() {
-        setupUI();
     }
 
     private static void assertTrue(String message, boolean value) {

--- a/test/jdk/javax/swing/JComboBox/8033069/bug8033069NoScrollBar.java
+++ b/test/jdk/javax/swing/JComboBox/8033069/bug8033069NoScrollBar.java
@@ -60,8 +60,8 @@ public class bug8033069NoScrollBar {
     private JComboBox cb1;
     private JComboBox cb2;
 
-    private Point p;
-    private Dimension d;
+    volatile private Point p;
+    volatile private Dimension d;
 
     public static void main(String[] args) throws Exception {
         iterateLookAndFeels(new bug8033069NoScrollBar(NO_SCROLL_ITEMS));
@@ -104,6 +104,12 @@ public class bug8033069NoScrollBar {
         frame.setVisible(true);
     }
 
+    private void disposeUI() {
+        if (frame != null) {
+            frame.dispose();
+        }
+    }
+
     public void runTest() throws Exception {
         try {
             SwingUtilities.invokeAndWait(this::setupUI);
@@ -117,11 +123,8 @@ public class bug8033069NoScrollBar {
                 p = cb1.getLocationOnScreen();
                 d = cb1.getSize();
             });
-            robot.waitForIdle();
 
             robot.mouseMove(p.x + d.width / 2, p.y + d.height / 2);
-            robot.waitForIdle();
-
             // Click it to open popup
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
@@ -142,7 +145,6 @@ public class bug8033069NoScrollBar {
 
             // Move mouse down on the popup
             robot.mouseMove(p.x + d.width / 2, p.y + d.height * 3);
-            robot.waitForIdle();
 
             robot.mouseWheel(1);
             robot.waitForIdle();
@@ -160,19 +162,15 @@ public class bug8033069NoScrollBar {
                 p = cb2.getLocationOnScreen();
                 d = cb2.getSize();
             });
-            robot.waitForIdle();
 
             robot.mouseMove(p.x + d.width / 2, p.y + d.height / 2);
-            robot.waitForIdle();
 
             robot.mouseWheel(1);
             robot.waitForIdle();
             assertFalse("cb1 popup is visible after mouse wheel up on cb2",
                         Util.invokeOnEDT(cb1::isPopupVisible));
         } finally {
-            if (frame != null) {
-                SwingUtilities.invokeAndWait(frame::dispose);
-            }
+            SwingUtilities.invokeAndWait(this::disposeUI);
         }
 
         System.out.println("Test passed");


### PR DESCRIPTION
The tests a javax/swing/JComboBox/8033069/bug8033069ScrollBar.java and javax/swing/JComboBox/8033069/bug8033069NoScrollBar.java fails intermittently. The tests have a few problems which could cause this behaviour and the are being fixed here.

1. Test access the Swing components without EDT thread at couple of places.
2. Test is not calling waitForIdle or delay after Robot.mouseMove operations.

There is some additional cleanup done in the fix and moved the frame in centre. The tests pass with multiple iterations on CI. Link in the JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8163367](https://bugs.openjdk.java.net/browse/JDK-8163367): Test javax/swing/JComboBox/8033069/bug8033069NoScrollBar.java javax/swing/JComboBox/8033069/bug8033069ScrollBar.java fails intermittently


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3678/head:pull/3678` \
`$ git checkout pull/3678`

Update a local copy of the PR: \
`$ git checkout pull/3678` \
`$ git pull https://git.openjdk.java.net/jdk pull/3678/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3678`

View PR using the GUI difftool: \
`$ git pr show -t 3678`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3678.diff">https://git.openjdk.java.net/jdk/pull/3678.diff</a>

</details>
