### PR TITLE
8265938: C2's conditional move optimization does not handle top Phi

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -718,7 +718,9 @@ Node *PhaseIdealLoop::conditional_move( Node *region ) {
         break;
       }
     }
-    if (phi == NULL)  break;
+    if (phi == NULL || _igvn.type(phi) == Type::TOP) {
+      break;
+    }
     if (PrintOpto && VerifyLoopOptimizations) { tty->print_cr("CMOV"); }
     // Move speculative ops
     wq.push(phi);

--- a/test/hotspot/jtreg/compiler/loopopts/TestCMoveWithDeadPhi.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestCMoveWithDeadPhi.java
@@ -25,11 +25,14 @@
  * @test
  * @bug 8265938
  * @summary Test conditional move optimization with a TOP PhiNode.
+ * @library /test/lib
  * @run main/othervm -XX:CompileCommand=compileonly,compiler.loopopts.TestCMoveWithDeadPhi::test
  *                   compiler.loopopts.TestCMoveWithDeadPhi
  */
 
 package compiler.loopopts;
+
+import jdk.test.lib.Utils;
 
 public class TestCMoveWithDeadPhi {
 
@@ -62,7 +65,8 @@ public class TestCMoveWithDeadPhi {
             }
         };
         // Give thread some time to trigger compilation
+        thread.setDaemon(true);
         thread.start();
-        Thread.sleep(4000);
+        Thread.sleep(Utils.adjustTimeout(4000));
     }
 }

--- a/test/hotspot/jtreg/compiler/loopopts/TestCMoveWithDeadPhi.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestCMoveWithDeadPhi.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8265938
+ * @summary Test conditional move optimization with a TOP PhiNode.
+ * @run main/othervm -XX:CompileCommand=compileonly,compiler.loopopts.TestCMoveWithDeadPhi::test
+ *                   compiler.loopopts.TestCMoveWithDeadPhi
+ */
+
+package compiler.loopopts;
+
+public class TestCMoveWithDeadPhi {
+
+    static void test(boolean b) {
+        if (b) {
+            long l = 42;
+            for (int i = 0; i < 100; i++) {
+                if (i < 10) {
+                    l++;
+                    if (i == 5) {
+                        break;
+                    }
+                }
+            }
+
+            // Infinite loop
+            for (int j = 0; j < 100; j++) {
+                j--;
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        // Execute test in own thread because it contains an infinite loop
+        Thread thread = new Thread() {
+            public void run() {
+                for (int i = 0; i < 50_000; ++i) {
+                    test((i % 2) == 0);
+                }
+            }
+        };
+        // Give thread some time to trigger compilation
+        thread.start();
+        Thread.sleep(4000);
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopopts/TestStrangeControl.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestStrangeControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -19,19 +19,21 @@
  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  * or visit www.oracle.com if you need additional information or have any
  * questions.
- *
  */
 
 /*
  * @test
  * @bug 8228888
  * @summary Test PhaseIdealLoop::has_local_phi_input() with phi input with non-dominating control.
+ * @library /test/lib
  * @compile StrangeControl.jasm
  * @run main/othervm -Xbatch -XX:CompileCommand=inline,compiler.loopopts.StrangeControl::test
  *                   compiler.loopopts.TestStrangeControl
  */
 
 package compiler.loopopts;
+
+import jdk.test.lib.Utils;
 
 public class TestStrangeControl {
 
@@ -42,8 +44,9 @@ public class TestStrangeControl {
                 StrangeControl.test(42);
             }
         };
+        thread.setDaemon(true);
         thread.start();
         // Give thread executing strange control loop enough time to trigger OSR compilation
-        Thread.sleep(4000);
+        Thread.sleep(Utils.adjustTimeout(4000));
     }
 }


### PR DESCRIPTION
C2's CCP optimization sets the type of a PhiNode to TOP because it became dead after loop unrolling. Now since that node is not reachable from the bottom due to an infinite loop at the end of the method, CCP does not enqueue the PhiNode for IGVN. As a result, the dead subgraph is not removed. During loop opts, the conditional move optimization fails on the PhiNode because its type is top. The expected behavior is to simply bail out with "COMPILE SKIPPED: infinite loop (retry at different tier)".

I suggest to fix this by simply handling a TOP Phi in the conditional move optimization code.

This issue was reported by John Jiang (johnsjiang@tencent.com).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265938](https://bugs.openjdk.java.net/browse/JDK-8265938): C2's conditional move optimization does not handle top Phi


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to d0e0e81941a0d41460c0927980d36d8b6db4ff0f
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3684/head:pull/3684` \
`$ git checkout pull/3684`

Update a local copy of the PR: \
`$ git checkout pull/3684` \
`$ git pull https://git.openjdk.java.net/jdk pull/3684/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3684`

View PR using the GUI difftool: \
`$ git pr show -t 3684`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3684.diff">https://git.openjdk.java.net/jdk/pull/3684.diff</a>

</details>
