### PR TITLE
8196300: java/awt/TextArea/TextAreaScrolling/TextAreaScrolling.java times out

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -265,7 +265,6 @@ sun/java2d/SunGraphics2D/SourceClippingBlitTest/SourceClippingBlitTest.java 8196
 sun/java2d/X11SurfaceData/SharedMemoryPixmapsTest/SharedMemoryPixmapsTest.sh 8221451 linux-all
 java/awt/FullScreen/DisplayChangeVITest/DisplayChangeVITest.java 8169469 windows-all
 java/awt/Graphics2D/DrawString/DrawRotatedStringUsingRotatedFont.java 8197796 generic-all
-java/awt/TextArea/TextAreaScrolling/TextAreaScrolling.java 8196300 windows-all
 java/awt/print/PrinterJob/PSQuestionMark.java 7003378 generic-all
 java/awt/print/PrinterJob/GlyphPositions.java 7003378 generic-all
 java/awt/Choice/ChoiceMouseWheelTest/ChoiceMouseWheelTest.java 7100044 macosx-all,linux-all

--- a/test/jdk/java/awt/TextArea/TextAreaScrolling/TextAreaScrolling.java
+++ b/test/jdk/java/awt/TextArea/TextAreaScrolling/TextAreaScrolling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,27 +69,32 @@ public class TextAreaScrolling {
 
     public void performTest() {
         robot.waitForIdle();
-        robot.delay(200);
+        robot.delay(1000);
         Point loc = textArea.getLocationOnScreen();
         Rectangle textAreaBounds = new Rectangle();
         textArea.getBounds(textAreaBounds);
 
         // Move mouse at center in first row of TextArea.
         robot.mouseMove(loc.x + textAreaBounds.width / 2, loc.y + 5);
+        robot.waitForIdle();
+        robot.delay(500);
 
         // Perform selection by scrolling to left from end of char sequence.
-        robot.mousePress(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.mouseMove(loc.x - 5, loc.y + 5);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.waitForIdle();
+        robot.delay(500);
 
         // Perform double click on beginning word of TextArea
         robot.mouseMove(loc.x + 5, loc.y + 5);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
-        robot.delay(100);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
-        robot.delay(100);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.waitForIdle();
+        robot.delay(500);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.delay(500);
         robot.waitForIdle();
 
         if (textArea.getSelectedText().contentEquals("5678")) {


### PR DESCRIPTION
This test was timing out on windows during nightly testing possibly due to samevm mode issue when it was problemlisted.
Modified test to increase the timing delay after frame is made visible, added waitForIdle() at suitable places and delays to make sure the execution steps are visible during execution.
Modified test pass in several iterations in all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8196300](https://bugs.openjdk.java.net/browse/JDK-8196300): java/awt/TextArea/TextAreaScrolling/TextAreaScrolling.java times out


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3686/head:pull/3686` \
`$ git checkout pull/3686`

Update a local copy of the PR: \
`$ git checkout pull/3686` \
`$ git pull https://git.openjdk.java.net/jdk pull/3686/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3686`

View PR using the GUI difftool: \
`$ git pr show -t 3686`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3686.diff">https://git.openjdk.java.net/jdk/pull/3686.diff</a>

</details>
