### PR TITLE
8265961: Fix comments in logging.properties

### DIFF
--- a/src/java.logging/share/conf/logging.properties
+++ b/src/java.logging/share/conf/logging.properties
@@ -2,7 +2,7 @@
 #  	Default Logging Configuration File
 #
 # You can use a different file by specifying a filename
-# in the java.util.logging.config.file system property.
+# with the java.util.logging.config.file system property.
 # For example, java -Djava.util.logging.config.file=myfile
 ############################################################
 
@@ -47,7 +47,7 @@ java.util.logging.FileHandler.formatter = java.util.logging.XMLFormatter
 java.util.logging.ConsoleHandler.level = INFO
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 
-# Example to customize the SimpleFormatter output format 
+# Example to customize the SimpleFormatter output format
 # to print one-line log message like this:
 #     <level>: <log message> [<date/time>]
 #

--- a/src/java.logging/share/conf/logging.properties
+++ b/src/java.logging/share/conf/logging.properties
@@ -2,15 +2,15 @@
 #  	Default Logging Configuration File
 #
 # You can use a different file by specifying a filename
-# with the java.util.logging.config.file system property.  
-# For example java -Djava.util.logging.config.file=myfile
+# in the java.util.logging.config.file system property.
+# For example, java -Djava.util.logging.config.file=myfile
 ############################################################
 
 ############################################################
 #  	Global properties
 ############################################################
 
-# "handlers" specifies a comma separated list of log Handler 
+# "handlers" specifies a comma-separated list of log Handler
 # classes.  These handlers will be installed during VM startup.
 # Note that these classes must be on the system classpath.
 # By default we only configure a ConsoleHandler, which will only
@@ -23,7 +23,7 @@ handlers= java.util.logging.ConsoleHandler
 # Default global logging level.
 # This specifies which kinds of events are logged across
 # all loggers.  For any given facility this global level
-# can be overriden by a facility specific level
+# can be overridden by a facility-specific level
 # Note that the ConsoleHandler also has a separate level
 # setting to limit messages printed to the console.
 .level= INFO
@@ -43,7 +43,7 @@ java.util.logging.FileHandler.count = 1
 java.util.logging.FileHandler.maxLocks = 100
 java.util.logging.FileHandler.formatter = java.util.logging.XMLFormatter
 
-# Limit the message that are printed on the console to INFO and above.
+# Limit the messages that are printed on the console to INFO and above.
 java.util.logging.ConsoleHandler.level = INFO
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 
@@ -54,7 +54,7 @@ java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 # java.util.logging.SimpleFormatter.format=%4$s: %5$s [%1$tc]%n
 
 ############################################################
-# Facility specific properties.
+# Facility-specific properties.
 # Provides extra control for each logger.
 ############################################################
 


### PR DESCRIPTION
I had been looking for an example of a "properties" file when spotted a typo in `logging.properties`. I decided to proofread the file. That resulted in finding a few other issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265961](https://bugs.openjdk.java.net/browse/JDK-8265961): Fix comments in logging.properties


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to 69388538d2fa41e811a0feaa58c69b1c4840504f
 * [Mark Reinhold](https://openjdk.java.net/census#mr) (@mbreinhold - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3688/head:pull/3688` \
`$ git checkout pull/3688`

Update a local copy of the PR: \
`$ git checkout pull/3688` \
`$ git pull https://git.openjdk.java.net/jdk pull/3688/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3688`

View PR using the GUI difftool: \
`$ git pr show -t 3688`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3688.diff">https://git.openjdk.java.net/jdk/pull/3688.diff</a>

</details>
