### PR TITLE
Switch macos/aarch64 GitHub Action to build on macOS-11.0

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1366,7 +1366,7 @@ jobs:
 
   macos_aarch64_build:
     name: macOS aarch64
-    runs-on: "macos-10.15"
+    runs-on: "macos-11.0"
     needs: prerequisites
     if: needs.prerequisites.outputs.should_run != 'false' && needs.prerequisites.outputs.platform_macos_aarch64 != 'false'
 


### PR DESCRIPTION
Apple M1 chips are only supported on macos 11 and beyond. We should match that build level (even if we are cross-compiling right now)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3690/head:pull/3690` \
`$ git checkout pull/3690`

Update a local copy of the PR: \
`$ git checkout pull/3690` \
`$ git pull https://git.openjdk.java.net/jdk pull/3690/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3690`

View PR using the GUI difftool: \
`$ git pr show -t 3690`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3690.diff">https://git.openjdk.java.net/jdk/pull/3690.diff</a>

</details>
