### PR TITLE
8265967: Unused NullCheckNode forward declaration in node.hpp

### DIFF
--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -133,7 +133,6 @@ class Node;
 class Node_Array;
 class Node_List;
 class Node_Stack;
-class NullCheckNode;
 class OopMap;
 class ParmNode;
 class PCTableNode;


### PR DESCRIPTION
Please review this trivial change that removes the forward declaration of a nonexistent `NullCheckNode`.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265967](https://bugs.openjdk.java.net/browse/JDK-8265967): Unused NullCheckNode forward declaration in node.hpp


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3691/head:pull/3691` \
`$ git checkout pull/3691`

Update a local copy of the PR: \
`$ git checkout pull/3691` \
`$ git pull https://git.openjdk.java.net/jdk pull/3691/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3691`

View PR using the GUI difftool: \
`$ git pr show -t 3691`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3691.diff">https://git.openjdk.java.net/jdk/pull/3691.diff</a>

</details>
