### PR TITLE
8265972: Remove declarations with no implementations in javaClasses.hpp

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -383,8 +383,6 @@ class java_lang_Thread : AllStatic {
  public:
   static void serialize_offsets(SerializeClosure* f) NOT_CDS_RETURN;
 
-  // Instance creation
-  static oop create();
   // Returns the JavaThread associated with the thread obj
   static JavaThread* thread(oop java_thread);
   // Set JavaThread for instance
@@ -521,7 +519,6 @@ class java_lang_Throwable: AllStatic {
   static void set_message(oop throwable, oop value);
   static Symbol* detail_message(oop throwable);
   static void print_stack_element(outputStream *st, Method* method, int bci);
-  static void print_stack_usage(Handle stream);
 
   static void compute_offsets();
   static void serialize_offsets(SerializeClosure* f) NOT_CDS_RETURN;
@@ -706,8 +703,6 @@ class java_lang_reflect_Field : public java_lang_reflect_AccessibleObject {
 
   static void set_signature(oop constructor, oop value);
   static void set_annotations(oop constructor, oop value);
-  static void set_parameter_annotations(oop method, oop value);
-  static void set_annotation_default(oop method, oop value);
 
   // Debugging
   friend class JavaClasses;
@@ -888,8 +883,6 @@ class java_lang_ref_Reference: AllStatic {
   static inline void set_discovered(oop ref, oop value);
   static inline void set_discovered_raw(oop ref, oop value);
   static inline HeapWord* discovered_addr_raw(oop ref);
-  static inline oop queue(oop ref);
-  static inline void set_queue(oop ref, oop value);
   static bool is_referent_field(oop obj, ptrdiff_t offset);
   static inline bool is_final(oop ref);
   static inline bool is_phantom(oop ref);
@@ -923,8 +916,6 @@ class java_lang_ref_SoftReference: public java_lang_ref_Reference {
 };
 
 // Interface to java.lang.invoke.MethodHandle objects
-
-class MethodHandleEntry;
 
 class java_lang_invoke_MethodHandle: AllStatic {
   friend class JavaClasses;
@@ -998,7 +989,6 @@ class java_lang_invoke_LambdaForm: AllStatic {
 
   // Accessors
   static oop            vmentry(oop lform);
-  static void       set_vmentry(oop lform, oop invoker);
 
   // Testers
   static bool is_subclass(Klass* klass) {


### PR DESCRIPTION
Trivial change of removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265972](https://bugs.openjdk.java.net/browse/JDK-8265972): Remove declarations with no implementations in javaClasses.hpp


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3692/head:pull/3692` \
`$ git checkout pull/3692`

Update a local copy of the PR: \
`$ git checkout pull/3692` \
`$ git pull https://git.openjdk.java.net/jdk pull/3692/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3692`

View PR using the GUI difftool: \
`$ git pr show -t 3692`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3692.diff">https://git.openjdk.java.net/jdk/pull/3692.diff</a>

</details>
