### PR TITLE
8254846 Warn before building if Xcode has no disk space left

### DIFF
--- a/make/autoconf/basic.m4
+++ b/make/autoconf/basic.m4
@@ -89,6 +89,15 @@ AC_DEFUN_ONCE([BASIC_SETUP_PATHS],
   fi
   AC_SUBST(WORKSPACE_ROOT)
 
+  # OpenJDK needs at least 6GB free to compile.
+  AC_MSG_CHECKING([for available disk space])
+  DISK_SPACE=`$DF -k "${WORKSPACE_ROOT}" | $TAIL -1 | $AWK '{print $ 4}'`
+  if test "$DISK_SPACE" -gt "6000000"; then
+    AC_MSG_RESULT([$DISK_SPACE])
+  else
+    AC_MSG_ERROR([openjdk requires at least 6 GB of free disk space to compile])
+  fi
+
   UTIL_FIXUP_PATH(CONFIGURE_START_DIR)
   AC_SUBST(CONFIGURE_START_DIR)
 


### PR DESCRIPTION
This PR creates a simple sanity check for all systems to verify that there is at least 6 GB available disk space before compiling.

I got the 6 GB requirement from https://github.com/openjdk/jdk/blob/master/doc/building.md#building-on-x86

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8254846](https://bugs.openjdk.java.net/browse/JDK-8254846): Warn before building if Xcode has no disk space left


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3693/head:pull/3693` \
`$ git checkout pull/3693`

Update a local copy of the PR: \
`$ git checkout pull/3693` \
`$ git pull https://git.openjdk.java.net/jdk pull/3693/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3693`

View PR using the GUI difftool: \
`$ git pr show -t 3693`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3693.diff">https://git.openjdk.java.net/jdk/pull/3693.diff</a>

</details>
