### PR TITLE
8265980: Fix systemDictionary and loaderConstraints printing

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -487,12 +487,6 @@ void VM_PopulateDumpSharedSpace::doit() {
   FileMapInfo::check_nonempty_dir_in_shared_path_table();
 
   NOT_PRODUCT(SystemDictionary::verify();)
-  // The following guarantee is meant to ensure that no loader constraints
-  // exist yet, since the constraints table is not shared.  This becomes
-  // more important now that we don't re-initialize vtables/itables for
-  // shared classes at runtime, where constraints were previously created.
-  guarantee(SystemDictionary::constraints()->number_of_entries() == 0,
-            "loader constraints are not saved");
 
   // At this point, many classes have been loaded.
   // Gather systemDictionary classes in a global array and do everything to

--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -207,6 +207,7 @@ void DictionaryEntry::add_protection_domain(ClassLoaderData* loader_data, Handle
     protection_domain->print_value_on(&ls);
     ls.print(" ");
     print_count(&ls);
+    ls.cr();
   }
 }
 
@@ -580,7 +581,7 @@ void DictionaryEntry::print_count(outputStream *st) {
                               current = current->next_acquire()) {
     count++;
   }
-  st->print_cr("pd set count = #%d", count);
+  st->print("pd set count = #%d", count);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/hotspot/share/classfile/loaderConstraints.cpp
+++ b/src/hotspot/share/classfile/loaderConstraints.cpp
@@ -191,6 +191,7 @@ void log_ldr_constraint_msg(Symbol* class_name, const char* reason,
 bool LoaderConstraintTable::add_entry(Symbol* class_name,
                                       InstanceKlass* klass1, Handle class_loader1,
                                       InstanceKlass* klass2, Handle class_loader2) {
+
   LogTarget(Info, class, loader, constraints) lt;
   if (klass1 != NULL && klass2 != NULL) {
     if (klass1 == klass2) {
@@ -244,9 +245,8 @@ bool LoaderConstraintTable::add_entry(Symbol* class_name,
     p->set_loaders(NEW_C_HEAP_ARRAY(ClassLoaderData*, 2, mtClass));
     p->set_loader(0, class_loader1());
     p->set_loader(1, class_loader2());
-    p->set_klass(klass);
-    p->set_next(bucket(index));
-    set_entry(index, p);
+    Hashtable<InstanceKlass*, mtClass>::add_entry(index, p);
+
     if (lt.is_enabled()) {
       ResourceMark rm;
       lt.print("adding new constraint for name: %s, loader[0]: %s,"
@@ -476,13 +476,15 @@ void LoaderConstraintTable::print_on(outputStream* st) const {
                                 probe != NULL;
                                 probe = probe->next()) {
       st->print("%4d: ", cindex);
-      probe->name()->print_on(st);
-      st->print(" , loaders:");
+      st->print("Symbol: %s loaders:", probe->name()->as_C_string());
       for (int n = 0; n < probe->num_loaders(); n++) {
+        st->cr();
+        st->print("    ");
         probe->loader_data(n)->print_value_on(st);
-        st->print(", ");
       }
       st->cr();
     }
   }
 }
+
+void LoaderConstraintTable::print() const { print_on(tty); }

--- a/src/hotspot/share/classfile/loaderConstraints.hpp
+++ b/src/hotspot/share/classfile/loaderConstraints.hpp
@@ -80,6 +80,7 @@ public:
   void purge_loader_constraints();
 
   void verify(PlaceholderTable* placeholders);
+  void print() const;
   void print_on(outputStream* st) const;
 };
 

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -88,7 +88,6 @@
 #include "jfr/jfr.hpp"
 #endif
 
-LoaderConstraintTable* SystemDictionary::_loader_constraints  = NULL;
 ResolutionErrorTable*  SystemDictionary::_resolution_errors   = NULL;
 SymbolPropertyTable*   SystemDictionary::_invoke_method_table = NULL;
 ProtectionDomainCacheTable*   SystemDictionary::_pd_cache_table = NULL;
@@ -99,14 +98,18 @@ OopHandle   SystemDictionary::_java_platform_loader;
 // Default ProtectionDomainCacheSize value
 const int defaultProtectionDomainCacheSize = 1009;
 
-const int _loader_constraint_size = 107;                     // number of entries in constraint table
 const int _resolution_error_size  = 107;                     // number of entries in resolution error table
 const int _invoke_method_size     = 139;                     // number of entries in invoke method table
 
 // Hashtable holding placeholders for classes being loaded.
 const int _placeholder_table_size = 1009;
-PlaceholderTable* _placeholders   = NULL;
+static PlaceholderTable* _placeholders   = NULL;
 static PlaceholderTable*   placeholders() { return _placeholders; }
+
+// Constraints on class loaders
+const int _loader_constraint_size = 107;                     // number of entries in constraint table
+static LoaderConstraintTable*  _loader_constraints;
+static LoaderConstraintTable* constraints() { return _loader_constraints; }
 
 // ----------------------------------------------------------------------------
 // Java-level SystemLoader and PlatformLoader

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -70,7 +70,6 @@ class BootstrapInfo;
 class ClassFileStream;
 class ClassLoadInfo;
 class Dictionary;
-class LoaderConstraintTable;
 template <MEMFLAGS F> class HashtableBucket;
 class ResolutionErrorTable;
 class SymbolPropertyTable;
@@ -296,9 +295,6 @@ public:
  private:
   // Static tables owned by the SystemDictionary
 
-  // Constraints on class loaders
-  static LoaderConstraintTable*  _loader_constraints;
-
   // Resolution errors
   static ResolutionErrorTable*   _resolution_errors;
 
@@ -318,8 +314,7 @@ private:
   static OopHandle  _java_system_loader;
   static OopHandle  _java_platform_loader;
 
-  friend class VM_PopulateDumpSharedSpace;
-  static LoaderConstraintTable* constraints() { return _loader_constraints; }
+  // friend class VM_PopulateDumpSharedSpace;
   static ResolutionErrorTable* resolution_errors() { return _resolution_errors; }
   static SymbolPropertyTable* invoke_method_table() { return _invoke_method_table; }
 

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -314,7 +314,6 @@ private:
   static OopHandle  _java_system_loader;
   static OopHandle  _java_platform_loader;
 
-  // friend class VM_PopulateDumpSharedSpace;
   static ResolutionErrorTable* resolution_errors() { return _resolution_errors; }
   static SymbolPropertyTable* invoke_method_table() { return _invoke_method_table; }
 


### PR DESCRIPTION
This is a trivial change to fix printing in PrintSystemDictionaryAtExit, see CR for more details.
Tested with tier1 on 5 Oracle-supported platforms and manually.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265980](https://bugs.openjdk.java.net/browse/JDK-8265980): Fix systemDictionary and loaderConstraints printing


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3696/head:pull/3696` \
`$ git checkout pull/3696`

Update a local copy of the PR: \
`$ git checkout pull/3696` \
`$ git pull https://git.openjdk.java.net/jdk pull/3696/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3696`

View PR using the GUI difftool: \
`$ git pr show -t 3696`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3696.diff">https://git.openjdk.java.net/jdk/pull/3696.diff</a>

</details>
