### PR TITLE
8263972: C2: LoadVector/StoreVector type mismatch in MemNode::can_see_stored_value()  

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -46,6 +46,7 @@
 #include "opto/phaseX.hpp"
 #include "opto/regmask.hpp"
 #include "opto/rootnode.hpp"
+#include "opto/vectornode.hpp"
 #include "utilities/align.hpp"
 #include "utilities/copy.hpp"
 #include "utilities/macros.hpp"
@@ -1128,8 +1129,17 @@ Node* MemNode::can_see_stored_value(Node* st, PhaseTransform* phase) const {
         // Thus, we are able to replace L by V.
       }
       // Now prove that we have a LoadQ matched to a StoreQ, for some Q.
-      if (store_Opcode() != st->Opcode())
+      if (store_Opcode() != st->Opcode()) {
         return NULL;
+      }
+      // LoadVector/StoreVector needs additional check to ensure the types match.
+      if (store_Opcode() == Op_StoreVector) {
+        const TypeVect*  in_vt = st->as_StoreVector()->vect_type();
+        const TypeVect* out_vt = as_LoadVector()->vect_type();
+        if (in_vt != out_vt) {
+          return NULL;
+        }
+      }
       return st->in(MemNode::ValueIn);
     }
 

--- a/test/hotspot/jtreg/compiler/vectorization/TestMemoryVectorMismatched.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestMemoryVectorMismatched.java
@@ -24,7 +24,7 @@ package compiler.vectorization;
 
 /**
  * @test
- * @bug 8263972 
+ * @bug 8263972
  * @requires vm.compiler2.enabled & vm.compMode != "Xint"
  *
  * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,*TestMemoryVectorMismatched::test compiler.vectorization.TestMemoryVectorMismatched
@@ -32,7 +32,7 @@ package compiler.vectorization;
 public class TestMemoryVectorMismatched {
     public static void main(String[] g) {
         int a = 400;
-        long expected = -35984L; 
+        long expected = -35984L;
         for (int i = 0; i < 10; i++) {
             long v = test(a);
             if (v != expected) {

--- a/test/hotspot/jtreg/compiler/vectorization/TestMemoryVectorMismatched.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestMemoryVectorMismatched.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.vectorization;
+
+/**
+ * @test
+ * @bug 8263972 
+ * @requires vm.compiler2.enabled & vm.compMode != "Xint"
+ *
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,*TestMemoryVectorMismatched::test compiler.vectorization.TestMemoryVectorMismatched
+ */
+public class TestMemoryVectorMismatched {
+    public static void main(String[] g) {
+        int a = 400;
+        long expected = -35984L; 
+        for (int i = 0; i < 10; i++) {
+            long v = test(a);
+            if (v != expected) {
+                throw new AssertionError("Wrong result: " + v + " != " + expected);
+            }
+        }
+    }
+
+    static long test(int a) {
+        int i16, d = 5, e = -56973;
+        long f[] = new long[a];
+        init(f, 5);
+        for (i16 = 2; i16 < 92; i16++) {
+            f[i16 - 1] *= d;
+            f[i16 + 1] *= d;
+        }
+        while (++e < 0) {
+        }
+        return checkSum(f);
+    }
+
+    public static void init(long[] a, long seed) {
+        for (int j = 0; j < a.length; j++) {
+            a[j] = (j % 2 == 0) ? seed + j : seed - j;
+        }
+    }
+
+
+    public static long checkSum(long[] a) {
+        long sum = 0;
+        for (int j = 0; j < a.length; j++) {
+            sum += (a[j] / (j + 1) + a[j] % (j + 1));
+        }
+        return sum;
+    }
+}


### PR DESCRIPTION
`MemNode::can_see_stored_value()` doesn't take type info for `LoadVector`/`StoreVector` into account.

Eliminating `LoadVector`/`StoreVector` pair in presence of a type mismatch leads to a broken graph (omitting vector cast nodes) and sometimes manifest as a broken generated code. 

The fix adds necessary checks for vector case. 

Testing:
- [x] regression test
- [x] hs-tier1 - hs-tier4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263972](https://bugs.openjdk.java.net/browse/JDK-8263972): C2: LoadVector/StoreVector type mismatch in MemNode::can_see_stored_value()


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3698/head:pull/3698` \
`$ git checkout pull/3698`

Update a local copy of the PR: \
`$ git checkout pull/3698` \
`$ git pull https://git.openjdk.java.net/jdk pull/3698/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3698`

View PR using the GUI difftool: \
`$ git pr show -t 3698`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3698.diff">https://git.openjdk.java.net/jdk/pull/3698.diff</a>

</details>
