### PR TITLE
8264786: [macos] All Swing/AWT apps cause Allow Notifications prompt to appear when app is launched

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CTrayIcon.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CTrayIcon.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ extern "C" {
 /*
  * AWTTrayIcon
  */
-@interface AWTTrayIcon : NSObject {
+@interface AWTTrayIcon : NSObject <NSUserNotificationCenterDelegate>{
     jobject peer;
     AWTTrayIconView *view;
     NSStatusItem *theItem;

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CTrayIcon.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CTrayIcon.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,11 +68,14 @@ static NSSize ScaledImageSizeForStatusBar(NSSize imageSize, BOOL autosize) {
 
     view = [[AWTTrayIconView alloc] initWithTrayIcon:self];
     [theItem setView:view];
+    [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate:self];
 
     return self;
 }
 
 -(void) dealloc {
+    [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate:nil];
+
     JNIEnv *env = [ThreadUtilities getJNIEnvUncached];
     (*env)->DeleteGlobalRef(env, peer);
 
@@ -165,6 +168,12 @@ static NSSize ScaledImageSizeForStatusBar(NSSize imageSize, BOOL autosize) {
     (*env)->CallVoidMethod(env, peer, jm_handleMouseEvent, jEvent);
     CHECK_EXCEPTION();
     (*env)->DeleteLocalRef(env, jEvent);
+}
+
+- (BOOL)userNotificationCenter:(NSUserNotificationCenter *)center
+     shouldPresentNotification:(NSUserNotification *)notification
+{
+    return YES; // We always show notifications to the user
 }
 
 @end //AWTTrayIcon

--- a/src/java.desktop/macosx/native/libosxapp/NSApplicationAWT.h
+++ b/src/java.desktop/macosx/native/libosxapp/NSApplicationAWT.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 #import "JNIUtilities.h"
 #import <Cocoa/Cocoa.h>
 
-JNIEXPORT @interface NSApplicationAWT : NSApplication <NSUserNotificationCenterDelegate> {
+JNIEXPORT @interface NSApplicationAWT : NSApplication {
     NSString *fApplicationName;
     NSWindow *eventTransparentWindow;
     NSTimeInterval dummyEventTimestamp;

--- a/src/java.desktop/macosx/native/libosxapp/NSApplicationAWT.m
+++ b/src/java.desktop/macosx/native/libosxapp/NSApplicationAWT.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,8 +77,6 @@ AWT_ASSERT_APPKIT_THREAD;
 
 - (void)dealloc
 {
-    [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate:nil];
-
     [fApplicationName release];
     fApplicationName = nil;
 
@@ -158,15 +156,8 @@ AWT_ASSERT_APPKIT_THREAD;
     }
 
     [super finishLaunching];
-
-    [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate:self];
 }
 
-- (BOOL)userNotificationCenter:(NSUserNotificationCenter *)center
-     shouldPresentNotification:(NSUserNotification *)notification
-{
-    return YES; // We always show notifications to the user
-}
 
 - (void) registerWithProcessManager
 {


### PR DESCRIPTION
The fix for the JDK-8187639 reimplemented the tray icon messages using the standard notification center, it worked fine on macOS 10.9. But on the new macOS, the usage of that API requests permission from the user. Since the code was added to the NSApplicationAWT this request is always shown even if the app does not use tray icons. This fix moves the code to the tray icon itself. I have tested this on macOS 11.2. It will be good if someone can check macOS 10.14 or macOS 10.15.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264786](https://bugs.openjdk.java.net/browse/JDK-8264786): [macos] All Swing/AWT apps cause Allow Notifications prompt to appear when app is launched


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3707/head:pull/3707` \
`$ git checkout pull/3707`

Update a local copy of the PR: \
`$ git checkout pull/3707` \
`$ git pull https://git.openjdk.java.net/jdk pull/3707/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3707`

View PR using the GUI difftool: \
`$ git pr show -t 3707`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3707.diff">https://git.openjdk.java.net/jdk/pull/3707.diff</a>

</details>
