### PR TITLE
8266014: Regression brought by optimization done with JDK-4926314

### DIFF
--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -188,9 +188,7 @@ public abstract class Reader implements Readable, Closeable {
         if (target.hasArray()) {
             char[] cbuf = target.array();
             int pos = target.position();
-            int rem = target.limit() - pos;
-            if (rem <= 0)
-                return -1;
+            int rem = Math.max(target.limit() - pos, 0);
             int off = target.arrayOffset() + pos;
             nread = this.read(cbuf, off, rem);
             if (nread > 0)

--- a/test/jdk/java/io/Reader/ReadCharBuffer.java
+++ b/test/jdk/java/io/Reader/ReadCharBuffer.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4926314
+ * @bug 4926314 8266014
  * @summary Test for Reader#read(CharBuffer).
  * @run testng ReadCharBuffer
  */
@@ -33,7 +33,10 @@ import org.testng.annotations.Test;
 
 
 import java.io.IOException;
+import java.io.BufferedReader;
+import java.io.CharArrayReader;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.util.Arrays;
@@ -96,6 +99,19 @@ public class ReadCharBuffer {
         }
         expected.append("Gx");
         assertEquals(buffer.toString(), expected.toString());
+    }
+
+    @Test
+    public void readZeroLength() {
+        BufferedReader r =
+            new BufferedReader(new CharArrayReader(new char[]{1, 2, 3}));
+        int n = -1;
+        try {
+            n = r.read(CharBuffer.allocate(0));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        assertEquals(n, 0);
     }
 
     private void fillBuffer(CharBuffer buffer) {


### PR DESCRIPTION
Please consider this request to correct a minor problem with the optimization added for JDK-4926314. The change is to attempt to read the number of elements remaining in the target buffer unless that number is non-positive in which case read zero. The test addition fails with and passes with the implementation change.