### PR TITLE
JDK-6676643: Improve current C_GetAttributeValue native implementation

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
@@ -39,6 +39,7 @@ import sun.nio.ch.DirectBuffer;
 import sun.security.jca.JCAUtil;
 import sun.security.pkcs11.wrapper.*;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
+import static sun.security.pkcs11.wrapper.PKCS11Exception.*;
 
 /**
  * P11 AEAD Cipher implementation class. This class currently supports

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
@@ -38,6 +38,7 @@ import sun.nio.ch.DirectBuffer;
 import sun.security.jca.JCAUtil;
 import sun.security.pkcs11.wrapper.*;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
+import static sun.security.pkcs11.wrapper.PKCS11Exception.*;
 
 /**
  * Cipher implementation class. This class currently supports

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyStore.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,6 +73,7 @@ import static sun.security.pkcs11.P11Util.*;
 
 import sun.security.pkcs11.wrapper.*;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
+import static sun.security.pkcs11.wrapper.PKCS11Exception.*;
 
 import sun.security.rsa.RSAKeyFactory;
 

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
@@ -36,6 +36,7 @@ import sun.nio.ch.DirectBuffer;
 
 import sun.security.pkcs11.wrapper.*;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
+import static sun.security.pkcs11.wrapper.PKCS11Exception.*;
 
 /**
  * MAC implementation class. This class currently supports HMAC using

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PSSSignature.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PSSSignature.java
@@ -40,7 +40,7 @@ import java.security.interfaces.*;
 import sun.security.pkcs11.wrapper.*;
 import sun.security.util.KnownOIDs;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
-
+import static sun.security.pkcs11.wrapper.PKCS11Exception.*;
 
 /**
  * RSASSA-PSS Signature implementation class. This class currently supports the

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
@@ -42,6 +42,7 @@ import sun.security.rsa.RSAPadding;
 
 import sun.security.pkcs11.wrapper.*;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
+import static sun.security.pkcs11.wrapper.PKCS11Exception.*;
 import sun.security.util.KeyUtil;
 
 /**

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,6 +51,7 @@ import sun.security.pkcs11.Secmod.*;
 
 import sun.security.pkcs11.wrapper.*;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
+import static sun.security.pkcs11.wrapper.PKCS11Exception.*;
 
 /**
  * PKCS#11 provider main class.

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Token.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Token.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ import sun.security.jca.JCAUtil;
 import sun.security.pkcs11.wrapper.*;
 import static sun.security.pkcs11.TemplateManager.*;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
+import static sun.security.pkcs11.wrapper.PKCS11Exception.*;
 
 /**
  * PKCS#11 token.
@@ -385,7 +386,7 @@ class Token implements Serializable {
                                                 mechanism);
                 mechInfoMap.put(mechanism, result);
             } catch (PKCS11Exception e) {
-                if (e.getErrorCode() != PKCS11Constants.CKR_MECHANISM_INVALID) {
+                if (e.getErrorCode() != CKR_MECHANISM_INVALID) {
                     throw e;
                 } else {
                     mechInfoMap.put(mechanism, INVALID_MECH);

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -57,6 +57,7 @@ import java.security.PrivilegedAction;
 import sun.security.util.Debug;
 
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
+import static sun.security.pkcs11.wrapper.PKCS11Exception.*;
 
 /**
  * This is the default implementation of the PKCS11 interface. IT connects to

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Constants.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -1043,130 +1043,7 @@ public interface PKCS11Constants {
     public static final long  CKF_EXTENSION          = 0x80000000L;
 
     /* Identifies the return value of a Cryptoki function */
-    public static final long  CKR_OK                 = 0x00000000L;
-    public static final long  CKR_CANCEL             = 0x00000001L;
-    public static final long  CKR_HOST_MEMORY        = 0x00000002L;
-    public static final long  CKR_SLOT_ID_INVALID    = 0x00000003L;
-
-    public static final long  CKR_GENERAL_ERROR      = 0x00000005L;
-    public static final long  CKR_FUNCTION_FAILED    = 0x00000006L;
-
-    public static final long  CKR_ARGUMENTS_BAD      = 0x00000007L;
-    public static final long  CKR_NO_EVENT           = 0x00000008L;
-    public static final long  CKR_NEED_TO_CREATE_THREADS
-                                                     = 0x00000009L;
-    public static final long  CKR_CANT_LOCK          = 0x0000000AL;
-
-    public static final long  CKR_ATTRIBUTE_READ_ONLY       = 0x00000010L;
-    public static final long  CKR_ATTRIBUTE_SENSITIVE       = 0x00000011L;
-    public static final long  CKR_ATTRIBUTE_TYPE_INVALID    = 0x00000012L;
-    public static final long  CKR_ATTRIBUTE_VALUE_INVALID   = 0x00000013L;
-    public static final long  CKR_ACTION_PROHIBITED         = 0x0000001BL;
-
-    public static final long  CKR_DATA_INVALID              = 0x00000020L;
-    public static final long  CKR_DATA_LEN_RANGE            = 0x00000021L;
-    public static final long  CKR_DEVICE_ERROR              = 0x00000030L;
-    public static final long  CKR_DEVICE_MEMORY             = 0x00000031L;
-    public static final long  CKR_DEVICE_REMOVED            = 0x00000032L;
-    public static final long  CKR_ENCRYPTED_DATA_INVALID    = 0x00000040L;
-    public static final long  CKR_ENCRYPTED_DATA_LEN_RANGE  = 0x00000041L;
-    public static final long  CKR_AEAD_DECRYPT_FAILED       = 0x00000042L;
-    public static final long  CKR_FUNCTION_CANCELED         = 0x00000050L;
-    public static final long  CKR_FUNCTION_NOT_PARALLEL     = 0x00000051L;
-
-    public static final long  CKR_FUNCTION_NOT_SUPPORTED    = 0x00000054L;
-
-    public static final long  CKR_KEY_HANDLE_INVALID        = 0x00000060L;
-
-    public static final long  CKR_KEY_SIZE_RANGE            = 0x00000062L;
-    public static final long  CKR_KEY_TYPE_INCONSISTENT     = 0x00000063L;
-
-    public static final long  CKR_KEY_NOT_NEEDED                 = 0x00000064L;
-    public static final long  CKR_KEY_CHANGED                    = 0x00000065L;
-    public static final long  CKR_KEY_NEEDED                     = 0x00000066L;
-    public static final long  CKR_KEY_INDIGESTIBLE               = 0x00000067L;
-    public static final long  CKR_KEY_FUNCTION_NOT_PERMITTED     = 0x00000068L;
-    public static final long  CKR_KEY_NOT_WRAPPABLE              = 0x00000069L;
-    public static final long  CKR_KEY_UNEXTRACTABLE              = 0x0000006AL;
-
-    public static final long  CKR_MECHANISM_INVALID              = 0x00000070L;
-    public static final long  CKR_MECHANISM_PARAM_INVALID        = 0x00000071L;
-
-    public static final long  CKR_OBJECT_HANDLE_INVALID          = 0x00000082L;
-    public static final long  CKR_OPERATION_ACTIVE               = 0x00000090L;
-    public static final long  CKR_OPERATION_NOT_INITIALIZED      = 0x00000091L;
-    public static final long  CKR_PIN_INCORRECT                  = 0x000000A0L;
-    public static final long  CKR_PIN_INVALID                    = 0x000000A1L;
-    public static final long  CKR_PIN_LEN_RANGE                  = 0x000000A2L;
-
-    public static final long  CKR_PIN_EXPIRED                    = 0x000000A3L;
-    public static final long  CKR_PIN_LOCKED                     = 0x000000A4L;
-
-    public static final long  CKR_SESSION_CLOSED                 = 0x000000B0L;
-    public static final long  CKR_SESSION_COUNT                  = 0x000000B1L;
-    public static final long  CKR_SESSION_HANDLE_INVALID         = 0x000000B3L;
-    public static final long  CKR_SESSION_PARALLEL_NOT_SUPPORTED = 0x000000B4L;
-    public static final long  CKR_SESSION_READ_ONLY              = 0x000000B5L;
-    public static final long  CKR_SESSION_EXISTS                 = 0x000000B6L;
-
-    public static final long  CKR_SESSION_READ_ONLY_EXISTS       = 0x000000B7L;
-    public static final long  CKR_SESSION_READ_WRITE_SO_EXISTS   = 0x000000B8L;
-
-    public static final long  CKR_SIGNATURE_INVALID              = 0x000000C0L;
-    public static final long  CKR_SIGNATURE_LEN_RANGE            = 0x000000C1L;
-    public static final long  CKR_TEMPLATE_INCOMPLETE            = 0x000000D0L;
-    public static final long  CKR_TEMPLATE_INCONSISTENT          = 0x000000D1L;
-    public static final long  CKR_TOKEN_NOT_PRESENT              = 0x000000E0L;
-    public static final long  CKR_TOKEN_NOT_RECOGNIZED           = 0x000000E1L;
-    public static final long  CKR_TOKEN_WRITE_PROTECTED          = 0x000000E2L;
-    public static final long  CKR_UNWRAPPING_KEY_HANDLE_INVALID  = 0x000000F0L;
-    public static final long  CKR_UNWRAPPING_KEY_SIZE_RANGE      = 0x000000F1L;
-    public static final long  CKR_UNWRAPPING_KEY_TYPE_INCONSISTENT
-                                                                 = 0x000000F2L;
-    public static final long  CKR_USER_ALREADY_LOGGED_IN         = 0x00000100L;
-    public static final long  CKR_USER_NOT_LOGGED_IN             = 0x00000101L;
-    public static final long  CKR_USER_PIN_NOT_INITIALIZED       = 0x00000102L;
-    public static final long  CKR_USER_TYPE_INVALID              = 0x00000103L;
-
-    public static final long  CKR_USER_ANOTHER_ALREADY_LOGGED_IN = 0x00000104L;
-    public static final long  CKR_USER_TOO_MANY_TYPES            = 0x00000105L;
-
-    public static final long  CKR_WRAPPED_KEY_INVALID            = 0x00000110L;
-    public static final long  CKR_WRAPPED_KEY_LEN_RANGE          = 0x00000112L;
-    public static final long  CKR_WRAPPING_KEY_HANDLE_INVALID    = 0x00000113L;
-    public static final long  CKR_WRAPPING_KEY_SIZE_RANGE        = 0x00000114L;
-    public static final long  CKR_WRAPPING_KEY_TYPE_INCONSISTENT = 0x00000115L;
-    public static final long  CKR_RANDOM_SEED_NOT_SUPPORTED      = 0x00000120L;
-
-    public static final long  CKR_RANDOM_NO_RNG                  = 0x00000121L;
-
-    public static final long  CKR_DOMAIN_PARAMS_INVALID          = 0x00000130L;
-
-    public static final long  CKR_CURVE_NOT_SUPPORTED            = 0x00000140L;
-
-    public static final long  CKR_BUFFER_TOO_SMALL               = 0x00000150L;
-    public static final long  CKR_SAVED_STATE_INVALID            = 0x00000160L;
-    public static final long  CKR_INFORMATION_SENSITIVE          = 0x00000170L;
-    public static final long  CKR_STATE_UNSAVEABLE               = 0x00000180L;
-
-    public static final long  CKR_CRYPTOKI_NOT_INITIALIZED       = 0x00000190L;
-    public static final long  CKR_CRYPTOKI_ALREADY_INITIALIZED   = 0x00000191L;
-    public static final long  CKR_MUTEX_BAD                      = 0x000001A0L;
-    public static final long  CKR_MUTEX_NOT_LOCKED               = 0x000001A1L;
-
-    public static final long  CKR_NEW_PIN_MODE                   = 0x000001B0L;
-    public static final long  CKR_NEXT_OTP                       = 0x000001B1L;
-
-    public static final long  CKR_EXCEEDED_MAX_ITERATIONS        = 0x000001B5L;
-    public static final long  CKR_FIPS_SELF_TEST_FAILED          = 0x000001B6L;
-    public static final long  CKR_LIBRARY_LOAD_FAILED            = 0x000001B7L;
-    public static final long  CKR_PIN_TOO_WEAK                   = 0x000001B8L;
-    public static final long  CKR_PUBLIC_KEY_INVALID             = 0x000001B9L;
-    public static final long  CKR_FUNCTION_REJECTED              = 0x00000200L;
-    public static final long  CKR_TOKEN_RESOURCE_EXCEEDED        = 0x00000201L;
-    public static final long  CKR_OPERATION_CANCEL_FAILED        = 0x00000202L;
-
-    public static final long  CKR_VENDOR_DEFINED                 = 0x80000000L;
+    // These CKR_xxx constants are stored/defined in PKCS11Exception class
 
     /* Uncomment when actually used
     public static final long  CKF_END_OF_MESSAGE      = 0x00000001L;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Exception.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Exception.java
@@ -72,139 +72,154 @@ public class PKCS11Exception extends Exception {
 
     protected String errorMsg;
 
-    private static final Map<Long,String> errorMap = new HashMap<>();
+    public static final long CKR_GENERAL_ERROR = RV.CKR_GENERAL_ERROR.value();
+    public static final long CKR_ATTRIBUTE_TYPE_INVALID =
+            RV.CKR_ATTRIBUTE_TYPE_INVALID.value();
+    public static final long CKR_DATA_LEN_RANGE = RV.CKR_DATA_LEN_RANGE.value();
+    public static final long CKR_ENCRYPTED_DATA_INVALID =
+            RV.CKR_ENCRYPTED_DATA_INVALID.value();
+    public static final long CKR_ENCRYPTED_DATA_LEN_RANGE =
+            RV.CKR_ENCRYPTED_DATA_LEN_RANGE.value();
+    public static final long CKR_MECHANISM_INVALID =
+            RV.CKR_MECHANISM_INVALID.value();
+    public static final long CKR_MECHANISM_PARAM_INVALID =
+            RV.CKR_MECHANISM_PARAM_INVALID.value();
+    public static final long CKR_OPERATION_NOT_INITIALIZED =
+            RV.CKR_OPERATION_NOT_INITIALIZED.value();
+    public static final long CKR_PIN_INCORRECT =
+            RV.CKR_PIN_INCORRECT.value();
+    public static final long CKR_SIGNATURE_INVALID =
+            RV.CKR_SIGNATURE_INVALID.value();
+    public static final long CKR_SIGNATURE_LEN_RANGE =
+            RV.CKR_SIGNATURE_LEN_RANGE.value();
+    public static final long CKR_USER_ALREADY_LOGGED_IN =
+            RV.CKR_USER_ALREADY_LOGGED_IN.value();
+    public static final long CKR_USER_NOT_LOGGED_IN =
+            RV.CKR_USER_NOT_LOGGED_IN.value();
+    public static final long CKR_BUFFER_TOO_SMALL =
+            RV.CKR_BUFFER_TOO_SMALL.value();
+    public static final long CKR_CRYPTOKI_ALREADY_INITIALIZED =
+            RV.CKR_CRYPTOKI_ALREADY_INITIALIZED.value();
 
-    public static final long CKR_GENERAL_ERROR = 0x00000005L;
-    public static final long CKR_ATTRIBUTE_TYPE_INVALID = 0x00000012L;
-    public static final long CKR_DATA_LEN_RANGE = 0x00000021L;
-    public static final long CKR_ENCRYPTED_DATA_INVALID = 0x00000040L;
-    public static final long CKR_ENCRYPTED_DATA_LEN_RANGE = 0x00000041L;
-    public static final long CKR_MECHANISM_INVALID = 0x00000070L;
-    public static final long CKR_MECHANISM_PARAM_INVALID = 0x00000071L;
-    public static final long CKR_OPERATION_NOT_INITIALIZED = 0x00000091L;
-    public static final long CKR_PIN_INCORRECT = 0x000000A0L;
-    public static final long CKR_SIGNATURE_INVALID = 0x000000C0L;
-    public static final long CKR_SIGNATURE_LEN_RANGE = 0x000000C1L;
-    public static final long CKR_USER_ALREADY_LOGGED_IN = 0x00000100L;
-    public static final long CKR_USER_NOT_LOGGED_IN = 0x00000101L;
-    public static final long CKR_BUFFER_TOO_SMALL = 0x00000150L;
-    public static final long CKR_CRYPTOKI_ALREADY_INITIALIZED = 0x00000191L;
+    // enum for all PKCS#11 return value
+    static enum RV {
+        CKR_OK(0x00000000L),
+        CKR_CANCEL(0x00000001L),
+        CKR_HOST_MEMORY(0x00000002L),
+        CKR_SLOT_ID_INVALID(0x00000003L),
+        CKR_GENERAL_ERROR(0x00000005L),
+        CKR_FUNCTION_FAILED(0x00000006L),
+        CKR_ARGUMENTS_BAD(0x00000007L),
+        CKR_NO_EVENT(0x00000008L),
+        CKR_NEED_TO_CREATE_THREADS(0x00000009L),
+        CKR_CANT_LOCK(0x0000000AL),
+        CKR_ATTRIBUTE_READ_ONLY(0x00000010L),
+        CKR_ATTRIBUTE_SENSITIVE(0x00000011L),
+        CKR_ATTRIBUTE_TYPE_INVALID(0x00000012L),
+        CKR_ATTRIBUTE_VALUE_INVALID(0x00000013L),
+        CKR_ACTION_PROHIBITED(0x0000001BL),
+        CKR_DATA_INVALID(0x00000020L),
+        CKR_DATA_LEN_RANGE(0x00000021L),
+        CKR_DEVICE_ERROR(0x00000030L),
+        CKR_DEVICE_MEMORY(0x00000031L),
+        CKR_DEVICE_REMOVED(0x00000032L),
+        CKR_ENCRYPTED_DATA_INVALID(0x00000040L),
+        CKR_ENCRYPTED_DATA_LEN_RANGE(0x00000041L),
+        CKR_AEAD_DECRYPT_FAILED(0x00000042L),
+        CKR_FUNCTION_CANCELED(0x00000050L),
+        CKR_FUNCTION_NOT_PARALLEL(0x00000051L),
+        CKR_FUNCTION_NOT_SUPPORTED(0x00000054L),
+        CKR_KEY_HANDLE_INVALID(0x00000060L),
+        CKR_KEY_SIZE_RANGE(0x00000062L),
+        CKR_KEY_TYPE_INCONSISTENT(0x00000063L),
+        CKR_KEY_NOT_NEEDED(0x00000064L),
+        CKR_KEY_CHANGED(0x00000065L),
+        CKR_KEY_NEEDED(0x00000066L),
+        CKR_KEY_INDIGESTIBLE(0x00000067L),
+        CKR_KEY_FUNCTION_NOT_PERMITTED(0x00000068L),
+        CKR_KEY_NOT_WRAPPABLE(0x00000069L),
+        CKR_KEY_UNEXTRACTABLE(0x0000006AL),
+        CKR_MECHANISM_INVALID(0x00000070L),
+        CKR_MECHANISM_PARAM_INVALID(0x00000071L),
+        CKR_OBJECT_HANDLE_INVALID(0x00000082L),
+        CKR_OPERATION_ACTIVE(0x00000090L),
+        CKR_OPERATION_NOT_INITIALIZED(0x00000091L),
+        CKR_PIN_INCORRECT(0x000000A0L),
+        CKR_PIN_INVALID(0x000000A1L),
+        CKR_PIN_LEN_RANGE(0x000000A2L),
+        CKR_PIN_EXPIRED(0x000000A3L),
+        CKR_PIN_LOCKED(0x000000A4L),
+        CKR_SESSION_CLOSED(0x000000B0L),
+        CKR_SESSION_COUNT(0x000000B1L),
+        CKR_SESSION_HANDLE_INVALID(0x000000B3L),
+        CKR_SESSION_PARALLEL_NOT_SUPPORTED(0x000000B4L),
+        CKR_SESSION_READ_ONLY(0x000000B5L),
+        CKR_SESSION_EXISTS(0x000000B6L),
+        CKR_SESSION_READ_ONLY_EXISTS(0x000000B7L),
+        CKR_SESSION_READ_WRITE_SO_EXISTS(0x000000B8L),
+        CKR_SIGNATURE_INVALID(0x000000C0L),
+        CKR_SIGNATURE_LEN_RANGE(0x000000C1L),
+        CKR_TEMPLATE_INCOMPLETE(0x000000D0L),
+        CKR_TEMPLATE_INCONSISTENT(0x000000D1L),
+        CKR_TOKEN_NOT_PRESENT(0x000000E0L),
+        CKR_TOKEN_NOT_RECOGNIZED(0x000000E1L),
+        CKR_TOKEN_WRITE_PROTECTED(0x000000E2L),
+        CKR_UNWRAPPING_KEY_HANDLE_INVALID(0x000000F0L),
+        CKR_UNWRAPPING_KEY_SIZE_RANGE(0x000000F1L),
+        CKR_UNWRAPPING_KEY_TYPE_INCONSISTENT(0x000000F2L),
+        CKR_USER_ALREADY_LOGGED_IN(0x00000100L),
+        CKR_USER_NOT_LOGGED_IN(0x00000101L),
+        CKR_USER_PIN_NOT_INITIALIZED(0x00000102L),
+        CKR_USER_TYPE_INVALID(0x00000103L),
+        CKR_USER_ANOTHER_ALREADY_LOGGED_IN(0x00000104L),
+        CKR_USER_TOO_MANY_TYPES(0x00000105L),
+        CKR_WRAPPED_KEY_INVALID(0x00000110L),
+        CKR_WRAPPED_KEY_LEN_RANGE(0x00000112L),
+        CKR_WRAPPING_KEY_HANDLE_INVALID(0x00000113L),
+        CKR_WRAPPING_KEY_SIZE_RANGE(0x00000114L),
+        CKR_WRAPPING_KEY_TYPE_INCONSISTENT(0x00000115L),
+        CKR_RANDOM_SEED_NOT_SUPPORTED(0x00000120L),
+        CKR_RANDOM_NO_RNG(0x00000121L),
+        CKR_DOMAIN_PARAMS_INVALID(0x00000130L),
+        CKR_CURVE_NOT_SUPPORTED(0x00000140L),
+        CKR_BUFFER_TOO_SMALL(0x00000150L),
+        CKR_SAVED_STATE_INVALID(0x00000160L),
+        CKR_INFORMATION_SENSITIVE(0x00000170L),
+        CKR_STATE_UNSAVEABLE(0x00000180L),
+        CKR_CRYPTOKI_NOT_INITIALIZED(0x00000190L),
+        CKR_CRYPTOKI_ALREADY_INITIALIZED(0x00000191L),
+        CKR_MUTEX_BAD(0x000001A0L),
+        CKR_MUTEX_NOT_LOCKED(0x000001A1L),
+        CKR_NEW_PIN_MODE(0x000001B0L),
+        CKR_NEXT_OTP(0x000001B1L),
+        CKR_EXCEEDED_MAX_ITERATIONS(0x000001B5L),
+        CKR_FIPS_SELF_TEST_FAILED(0x000001B6L),
+        CKR_LIBRARY_LOAD_FAILED(0x000001B7L),
+        CKR_PIN_TOO_WEAK(0x000001B8L),
+        CKR_PUBLIC_KEY_INVALID(0x000001B9L),
+        CKR_FUNCTION_REJECTED(0x00000200L),
+        CKR_TOKEN_RESOURCE_EXCEEDED(0x00000201L),
+        CKR_OPERATION_CANCEL_FAILED(0x00000202L),
+        CKR_VENDOR_DEFINED(0x80000000L);
 
-    static {
-        register("CKR_OK", 0x00000000L);
-        register("CKR_CANCEL", 0x00000001L);
-        register("CKR_HOST_MEMORY", 0x00000002L);
-        register("CKR_SLOT_ID_INVALID", 0x00000003L);
-        register("CKR_GENERAL_ERROR", CKR_GENERAL_ERROR);
-        register("CKR_FUNCTION_FAILED", 0x00000006L);
-        register("CKR_ARGUMENTS_BAD", 0x00000007L);
-        register("CKR_NO_EVENT", 0x00000008L);
-        register("CKR_NEED_TO_CREATE_THREADS", 0x00000009L);
-        register("CKR_CANT_LOCK", 0x0000000AL);
-        register("CKR_ATTRIBUTE_READ_ONLY", 0x00000010L);
-        register("CKR_ATTRIBUTE_SENSITIVE", 0x00000011L);
-        register("CKR_ATTRIBUTE_TYPE_INVALID", CKR_ATTRIBUTE_TYPE_INVALID);
-        register("CKR_ATTRIBUTE_VALUE_INVALID", 0x00000013L);
-        register("CKR_ACTION_PROHIBITED", 0x0000001BL);
-        register("CKR_DATA_INVALID", 0x00000020L);
-        register("CKR_DATA_LEN_RANGE", CKR_DATA_LEN_RANGE);
-        register("CKR_DEVICE_ERROR", 0x00000030L);
-        register("CKR_DEVICE_MEMORY", 0x00000031L);
-        register("CKR_DEVICE_REMOVED", 0x00000032L);
-        register("CKR_ENCRYPTED_DATA_INVALID", CKR_ENCRYPTED_DATA_INVALID);
-        register("CKR_ENCRYPTED_DATA_LEN_RANGE", CKR_ENCRYPTED_DATA_LEN_RANGE);
-        register("CKR_AEAD_DECRYPT_FAILED", 0x00000042L);
-        register("CKR_FUNCTION_CANCELED", 0x00000050L);
-        register("CKR_FUNCTION_NOT_PARALLEL", 0x00000051L);
-        register("CKR_FUNCTION_NOT_SUPPORTED", 0x00000054L);
-        register("CKR_KEY_HANDLE_INVALID", 0x00000060L);
-        register("CKR_KEY_SIZE_RANGE", 0x00000062L);
-        register("CKR_KEY_TYPE_INCONSISTENT", 0x00000063L);
-        register("CKR_KEY_NOT_NEEDED", 0x00000064L);
-        register("CKR_KEY_CHANGED", 0x00000065L);
-        register("CKR_KEY_NEEDED", 0x00000066L);
-        register("CKR_KEY_INDIGESTIBLE", 0x00000067L);
-        register("CKR_KEY_FUNCTION_NOT_PERMITTED", 0x00000068L);
-        register("CKR_KEY_NOT_WRAPPABLE", 0x00000069L);
-        register("CKR_KEY_UNEXTRACTABLE", 0x0000006AL);
-        register("CKR_MECHANISM_INVALID", CKR_MECHANISM_INVALID);
-        register("CKR_MECHANISM_PARAM_INVALID", CKR_MECHANISM_PARAM_INVALID);
-        register("CKR_OBJECT_HANDLE_INVALID", 0x00000082L);
-        register("CKR_OPERATION_ACTIVE", 0x00000090L);
-        register("CKR_OPERATION_NOT_INITIALIZED",
-                CKR_OPERATION_NOT_INITIALIZED);
-        register("CKR_PIN_INCORRECT", CKR_PIN_INCORRECT);
-        register("CKR_PIN_INVALID", 0x000000A1L);
-        register("CKR_PIN_LEN_RANGE", 0x000000A2L);
-        register("CKR_PIN_EXPIRED", 0x000000A3L);
-        register("CKR_PIN_LOCKED", 0x000000A4L);
-        register("CKR_SESSION_CLOSED", 0x000000B0L);
-        register("CKR_SESSION_COUNT", 0x000000B1L);
-        register("CKR_SESSION_HANDLE_INVALID", 0x000000B3L);
-        register("CKR_SESSION_PARALLEL_NOT_SUPPORTED", 0x000000B4L);
-        register("CKR_SESSION_READ_ONLY", 0x000000B5L);
-        register("CKR_SESSION_EXISTS", 0x000000B6L);
-        register("CKR_SESSION_READ_ONLY_EXISTS", 0x000000B7L);
-        register("CKR_SESSION_READ_WRITE_SO_EXISTS", 0x000000B8L);
-        register("CKR_SIGNATURE_INVALID", CKR_SIGNATURE_INVALID);
-        register("CKR_SIGNATURE_LEN_RANGE", CKR_SIGNATURE_LEN_RANGE);
-        register("CKR_TEMPLATE_INCOMPLETE", 0x000000D0L);
-        register("CKR_TEMPLATE_INCONSISTENT", 0x000000D1L);
-        register("CKR_TOKEN_NOT_PRESENT", 0x000000E0L);
-        register("CKR_TOKEN_NOT_RECOGNIZED", 0x000000E1L);
-        register("CKR_TOKEN_WRITE_PROTECTED", 0x000000E2L);
-        register("CKR_UNWRAPPING_KEY_HANDLE_INVALID", 0x000000F0L);
-        register("CKR_UNWRAPPING_KEY_SIZE_RANGE", 0x000000F1L);
-        register("CKR_UNWRAPPING_KEY_TYPE_INCONSISTENT", 0x000000F2L);
-        register("CKR_USER_ALREADY_LOGGED_IN", CKR_USER_ALREADY_LOGGED_IN);
-        register("CKR_USER_NOT_LOGGED_IN", CKR_USER_NOT_LOGGED_IN);
-        register("CKR_USER_PIN_NOT_INITIALIZED", 0x00000102L);
-        register("CKR_USER_TYPE_INVALID", 0x00000103L);
-        register("CKR_USER_ANOTHER_ALREADY_LOGGED_IN", 0x00000104L);
-        register("CKR_USER_TOO_MANY_TYPES", 0x00000105L);
-        register("CKR_WRAPPED_KEY_INVALID", 0x00000110L);
-        register("CKR_WRAPPED_KEY_LEN_RANGE", 0x00000112L);
-        register("CKR_WRAPPING_KEY_HANDLE_INVALID", 0x00000113L);
-        register("CKR_WRAPPING_KEY_SIZE_RANGE", 0x00000114L);
-        register("CKR_WRAPPING_KEY_TYPE_INCONSISTENT", 0x00000115L);
-        register("CKR_RANDOM_SEED_NOT_SUPPORTED", 0x00000120L);
-        register("CKR_RANDOM_NO_RNG", 0x00000121L);
-        register("CKR_DOMAIN_PARAMS_INVALID", 0x00000130L);
-        register("CKR_CURVE_NOT_SUPPORTED", 0x00000140L);
-        register("CKR_BUFFER_TOO_SMALL", CKR_BUFFER_TOO_SMALL);
-        register("CKR_SAVED_STATE_INVALID", 0x00000160L);
-        register("CKR_INFORMATION_SENSITIVE", 0x00000170L);
-        register("CKR_STATE_UNSAVEABLE", 0x00000180L);
-        register("CKR_CRYPTOKI_NOT_INITIALIZED", 0x00000190L);
-        register("CKR_CRYPTOKI_ALREADY_INITIALIZED",
-                CKR_CRYPTOKI_ALREADY_INITIALIZED);
-        register("CKR_MUTEX_BAD", 0x000001A0L);
-        register("CKR_MUTEX_NOT_LOCKED", 0x000001A1L);
-        register("CKR_NEW_PIN_MODE", 0x000001B0L);
-        register("CKR_NEXT_OTP", 0x000001B1L);
-        register("CKR_EXCEEDED_MAX_ITERATIONS", 0x000001B5L);
-        register("CKR_FIPS_SELF_TEST_FAILED", 0x000001B6L);
-        register("CKR_LIBRARY_LOAD_FAILED", 0x000001B7L);
-        register("CKR_PIN_TOO_WEAK", 0x000001B8L);
-        register("CKR_PUBLIC_KEY_INVALID", 0x000001B9L);
-        register("CKR_FUNCTION_REJECTED", 0x00000200L);
-        register("CKR_TOKEN_RESOURCE_EXCEEDED", 0x00000201L);
-        register("CKR_OPERATION_CANCEL_FAILED", 0x00000202L);
-        register("CKR_VENDOR_DEFINED", 0x80000000L);
+        private final long value;
+
+        RV(long value) {
+            this.value = value;
+        }
+        long value() {
+            return value;
+        }
     };
 
-    private static void register(String name, long errorCode) {
-        errorMap.put(errorCode, name);
-    }
-
     private static String lookup(long errorCode) {
-        String res = errorMap.get(errorCode);
-        // for unknown PKCS11 return values, just use hex as its string
-        if (res == null) {
-            res = "0x" + Functions.toFullHexString((int)errorCode);
-            errorMap.put(errorCode, res);
+        for (RV r : RV.values()) {
+            if (r.value() == errorCode) {
+                return r.name();
+            }
         }
-        return res;
+        // for unknown PKCS11 return values, just use hex as its string
+        return "0x" + Functions.toFullHexString((int)errorCode);
     }
 
     /**

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Exception.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Exception.java
@@ -72,34 +72,34 @@ public class PKCS11Exception extends Exception {
 
     protected String errorMsg;
 
-    public static final long CKR_GENERAL_ERROR = RV.CKR_GENERAL_ERROR.value();
+    public static final long CKR_GENERAL_ERROR = RV.CKR_GENERAL_ERROR.value;
     public static final long CKR_ATTRIBUTE_TYPE_INVALID =
-            RV.CKR_ATTRIBUTE_TYPE_INVALID.value();
-    public static final long CKR_DATA_LEN_RANGE = RV.CKR_DATA_LEN_RANGE.value();
+            RV.CKR_ATTRIBUTE_TYPE_INVALID.value;
+    public static final long CKR_DATA_LEN_RANGE = RV.CKR_DATA_LEN_RANGE.value;
     public static final long CKR_ENCRYPTED_DATA_INVALID =
-            RV.CKR_ENCRYPTED_DATA_INVALID.value();
+            RV.CKR_ENCRYPTED_DATA_INVALID.value;
     public static final long CKR_ENCRYPTED_DATA_LEN_RANGE =
-            RV.CKR_ENCRYPTED_DATA_LEN_RANGE.value();
+            RV.CKR_ENCRYPTED_DATA_LEN_RANGE.value;
     public static final long CKR_MECHANISM_INVALID =
-            RV.CKR_MECHANISM_INVALID.value();
+            RV.CKR_MECHANISM_INVALID.value;
     public static final long CKR_MECHANISM_PARAM_INVALID =
-            RV.CKR_MECHANISM_PARAM_INVALID.value();
+            RV.CKR_MECHANISM_PARAM_INVALID.value;
     public static final long CKR_OPERATION_NOT_INITIALIZED =
-            RV.CKR_OPERATION_NOT_INITIALIZED.value();
+            RV.CKR_OPERATION_NOT_INITIALIZED.value;
     public static final long CKR_PIN_INCORRECT =
-            RV.CKR_PIN_INCORRECT.value();
+            RV.CKR_PIN_INCORRECT.value;
     public static final long CKR_SIGNATURE_INVALID =
-            RV.CKR_SIGNATURE_INVALID.value();
+            RV.CKR_SIGNATURE_INVALID.value;
     public static final long CKR_SIGNATURE_LEN_RANGE =
-            RV.CKR_SIGNATURE_LEN_RANGE.value();
+            RV.CKR_SIGNATURE_LEN_RANGE.value;
     public static final long CKR_USER_ALREADY_LOGGED_IN =
-            RV.CKR_USER_ALREADY_LOGGED_IN.value();
+            RV.CKR_USER_ALREADY_LOGGED_IN.value;
     public static final long CKR_USER_NOT_LOGGED_IN =
-            RV.CKR_USER_NOT_LOGGED_IN.value();
+            RV.CKR_USER_NOT_LOGGED_IN.value;
     public static final long CKR_BUFFER_TOO_SMALL =
-            RV.CKR_BUFFER_TOO_SMALL.value();
+            RV.CKR_BUFFER_TOO_SMALL.value;
     public static final long CKR_CRYPTOKI_ALREADY_INITIALIZED =
-            RV.CKR_CRYPTOKI_ALREADY_INITIALIZED.value();
+            RV.CKR_CRYPTOKI_ALREADY_INITIALIZED.value;
 
     // enum for all PKCS#11 return value
     static enum RV {
@@ -207,14 +207,11 @@ public class PKCS11Exception extends Exception {
         RV(long value) {
             this.value = value;
         }
-        long value() {
-            return value;
-        }
     };
 
     private static String lookup(long errorCode) {
         for (RV r : RV.values()) {
-            if (r.value() == errorCode) {
+            if (r.value == errorCode) {
                 return r.name();
             }
         }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Exception.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Exception.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -63,229 +63,160 @@ import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
  * @invariants
  */
 public class PKCS11Exception extends Exception {
-    private static final long serialVersionUID = 4877072363729195L;
+    private static final long serialVersionUID = 4077027363729192L;
 
     /**
      * The code of the error which was the reason for this exception.
      */
-    protected long errorCode_;
+    protected long errorCode;
 
-    private static final Map<Long,String> errorMap;
+    protected String errorMsg;
+
+    private static final Map<Long,String> errorMap = new HashMap<>();
+
+    public static final long CKR_GENERAL_ERROR = 0x00000005L;
+    public static final long CKR_ATTRIBUTE_TYPE_INVALID = 0x00000012L;
+    public static final long CKR_DATA_LEN_RANGE = 0x00000021L;
+    public static final long CKR_ENCRYPTED_DATA_INVALID = 0x00000040L;
+    public static final long CKR_ENCRYPTED_DATA_LEN_RANGE = 0x00000041L;
+    public static final long CKR_MECHANISM_INVALID = 0x00000070L;
+    public static final long CKR_MECHANISM_PARAM_INVALID = 0x00000071L;
+    public static final long CKR_OPERATION_NOT_INITIALIZED = 0x00000091L;
+    public static final long CKR_PIN_INCORRECT = 0x000000A0L;
+    public static final long CKR_SIGNATURE_INVALID = 0x000000C0L;
+    public static final long CKR_SIGNATURE_LEN_RANGE = 0x000000C1L;
+    public static final long CKR_USER_ALREADY_LOGGED_IN = 0x00000100L;
+    public static final long CKR_USER_NOT_LOGGED_IN = 0x00000101L;
+    public static final long CKR_BUFFER_TOO_SMALL = 0x00000150L;
+    public static final long CKR_CRYPTOKI_ALREADY_INITIALIZED = 0x00000191L;
 
     static {
-        long[] errorCodes = new long[] {
-            CKR_OK,
-            CKR_CANCEL,
-            CKR_HOST_MEMORY,
-            CKR_SLOT_ID_INVALID,
-            CKR_GENERAL_ERROR,
-            CKR_FUNCTION_FAILED,
-            CKR_ARGUMENTS_BAD,
-            CKR_NO_EVENT,
-            CKR_NEED_TO_CREATE_THREADS,
-            CKR_CANT_LOCK,
-            CKR_ATTRIBUTE_READ_ONLY,
-            CKR_ATTRIBUTE_SENSITIVE,
-            CKR_ATTRIBUTE_TYPE_INVALID,
-            CKR_ATTRIBUTE_VALUE_INVALID,
-            CKR_ACTION_PROHIBITED,
-            CKR_DATA_INVALID,
-            CKR_DATA_LEN_RANGE,
-            CKR_DEVICE_ERROR,
-            CKR_DEVICE_MEMORY,
-            CKR_DEVICE_REMOVED,
-            CKR_ENCRYPTED_DATA_INVALID,
-            CKR_ENCRYPTED_DATA_LEN_RANGE,
-            CKR_AEAD_DECRYPT_FAILED,
-            CKR_FUNCTION_CANCELED,
-            CKR_FUNCTION_NOT_PARALLEL,
-            CKR_FUNCTION_NOT_SUPPORTED,
-            CKR_KEY_HANDLE_INVALID,
-            CKR_KEY_SIZE_RANGE,
-            CKR_KEY_TYPE_INCONSISTENT,
-            CKR_KEY_NOT_NEEDED,
-            CKR_KEY_CHANGED,
-            CKR_KEY_NEEDED,
-            CKR_KEY_INDIGESTIBLE,
-            CKR_KEY_FUNCTION_NOT_PERMITTED,
-            CKR_KEY_NOT_WRAPPABLE,
-            CKR_KEY_UNEXTRACTABLE,
-            CKR_MECHANISM_INVALID,
-            CKR_MECHANISM_PARAM_INVALID,
-            CKR_OBJECT_HANDLE_INVALID,
-            CKR_OPERATION_ACTIVE,
-            CKR_OPERATION_NOT_INITIALIZED,
-            CKR_PIN_INCORRECT,
-            CKR_PIN_INVALID,
-            CKR_PIN_LEN_RANGE,
-            CKR_PIN_EXPIRED,
-            CKR_PIN_LOCKED,
-            CKR_SESSION_CLOSED,
-            CKR_SESSION_COUNT,
-            CKR_SESSION_HANDLE_INVALID,
-            CKR_SESSION_PARALLEL_NOT_SUPPORTED,
-            CKR_SESSION_READ_ONLY,
-            CKR_SESSION_EXISTS,
-            CKR_SESSION_READ_ONLY_EXISTS,
-            CKR_SESSION_READ_WRITE_SO_EXISTS,
-            CKR_SIGNATURE_INVALID,
-            CKR_SIGNATURE_LEN_RANGE,
-            CKR_TEMPLATE_INCOMPLETE,
-            CKR_TEMPLATE_INCONSISTENT,
-            CKR_TOKEN_NOT_PRESENT,
-            CKR_TOKEN_NOT_RECOGNIZED,
-            CKR_TOKEN_WRITE_PROTECTED,
-            CKR_UNWRAPPING_KEY_HANDLE_INVALID,
-            CKR_UNWRAPPING_KEY_SIZE_RANGE,
-            CKR_UNWRAPPING_KEY_TYPE_INCONSISTENT,
-            CKR_USER_ALREADY_LOGGED_IN,
-            CKR_USER_NOT_LOGGED_IN,
-            CKR_USER_PIN_NOT_INITIALIZED,
-            CKR_USER_TYPE_INVALID,
-            CKR_USER_ANOTHER_ALREADY_LOGGED_IN,
-            CKR_USER_TOO_MANY_TYPES,
-            CKR_WRAPPED_KEY_INVALID,
-            CKR_WRAPPED_KEY_LEN_RANGE,
-            CKR_WRAPPING_KEY_HANDLE_INVALID,
-            CKR_WRAPPING_KEY_SIZE_RANGE,
-            CKR_WRAPPING_KEY_TYPE_INCONSISTENT,
-            CKR_RANDOM_SEED_NOT_SUPPORTED,
-            CKR_RANDOM_NO_RNG,
-            CKR_DOMAIN_PARAMS_INVALID,
-            CKR_CURVE_NOT_SUPPORTED,
-            CKR_BUFFER_TOO_SMALL,
-            CKR_SAVED_STATE_INVALID,
-            CKR_INFORMATION_SENSITIVE,
-            CKR_STATE_UNSAVEABLE,
-            CKR_CRYPTOKI_NOT_INITIALIZED,
-            CKR_CRYPTOKI_ALREADY_INITIALIZED,
-            CKR_MUTEX_BAD,
-            CKR_MUTEX_NOT_LOCKED,
-            CKR_NEW_PIN_MODE,
-            CKR_NEXT_OTP,
-            CKR_EXCEEDED_MAX_ITERATIONS,
-            CKR_FIPS_SELF_TEST_FAILED,
-            CKR_LIBRARY_LOAD_FAILED,
-            CKR_PIN_TOO_WEAK,
-            CKR_PUBLIC_KEY_INVALID,
-            CKR_FUNCTION_REJECTED,
-            CKR_TOKEN_RESOURCE_EXCEEDED,
-            CKR_OPERATION_CANCEL_FAILED,
-            CKR_VENDOR_DEFINED,
-        };
-        String[] errorMessages = new String[] {
-            "CKR_OK",
-            "CKR_CANCEL",
-            "CKR_HOST_MEMORY",
-            "CKR_SLOT_ID_INVALID",
-            "CKR_GENERAL_ERROR",
-            "CKR_FUNCTION_FAILED",
-            "CKR_ARGUMENTS_BAD",
-            "CKR_NO_EVENT",
-            "CKR_NEED_TO_CREATE_THREADS",
-            "CKR_CANT_LOCK",
-            "CKR_ATTRIBUTE_READ_ONLY",
-            "CKR_ATTRIBUTE_SENSITIVE",
-            "CKR_ATTRIBUTE_TYPE_INVALID",
-            "CKR_ATTRIBUTE_VALUE_INVALID",
-            "CKR_ACTION_PROHIBITED",
-            "CKR_DATA_INVALID",
-            "CKR_DATA_LEN_RANGE",
-            "CKR_DEVICE_ERROR",
-            "CKR_DEVICE_MEMORY",
-            "CKR_DEVICE_REMOVED",
-            "CKR_ENCRYPTED_DATA_INVALID",
-            "CKR_ENCRYPTED_DATA_LEN_RANGE",
-            "CKR_AEAD_DECRYPT_FAILED",
-            "CKR_FUNCTION_CANCELED",
-            "CKR_FUNCTION_NOT_PARALLEL",
-            "CKR_FUNCTION_NOT_SUPPORTED",
-            "CKR_KEY_HANDLE_INVALID",
-            "CKR_KEY_SIZE_RANGE",
-            "CKR_KEY_TYPE_INCONSISTENT",
-            "CKR_KEY_NOT_NEEDED",
-            "CKR_KEY_CHANGED",
-            "CKR_KEY_NEEDED",
-            "CKR_KEY_INDIGESTIBLE",
-            "CKR_KEY_FUNCTION_NOT_PERMITTED",
-            "CKR_KEY_NOT_WRAPPABLE",
-            "CKR_KEY_UNEXTRACTABLE",
-            "CKR_MECHANISM_INVALID",
-            "CKR_MECHANISM_PARAM_INVALID",
-            "CKR_OBJECT_HANDLE_INVALID",
-            "CKR_OPERATION_ACTIVE",
-            "CKR_OPERATION_NOT_INITIALIZED",
-            "CKR_PIN_INCORRECT",
-            "CKR_PIN_INVALID",
-            "CKR_PIN_LEN_RANGE",
-            "CKR_PIN_EXPIRED",
-            "CKR_PIN_LOCKED",
-            "CKR_SESSION_CLOSED",
-            "CKR_SESSION_COUNT",
-            "CKR_SESSION_HANDLE_INVALID",
-            "CKR_SESSION_PARALLEL_NOT_SUPPORTED",
-            "CKR_SESSION_READ_ONLY",
-            "CKR_SESSION_EXISTS",
-            "CKR_SESSION_READ_ONLY_EXISTS",
-            "CKR_SESSION_READ_WRITE_SO_EXISTS",
-            "CKR_SIGNATURE_INVALID",
-            "CKR_SIGNATURE_LEN_RANGE",
-            "CKR_TEMPLATE_INCOMPLETE",
-            "CKR_TEMPLATE_INCONSISTENT",
-            "CKR_TOKEN_NOT_PRESENT",
-            "CKR_TOKEN_NOT_RECOGNIZED",
-            "CKR_TOKEN_WRITE_PROTECTED",
-            "CKR_UNWRAPPING_KEY_HANDLE_INVALID",
-            "CKR_UNWRAPPING_KEY_SIZE_RANGE",
-            "CKR_UNWRAPPING_KEY_TYPE_INCONSISTENT",
-            "CKR_USER_ALREADY_LOGGED_IN",
-            "CKR_USER_NOT_LOGGED_IN",
-            "CKR_USER_PIN_NOT_INITIALIZED",
-            "CKR_USER_TYPE_INVALID",
-            "CKR_USER_ANOTHER_ALREADY_LOGGED_IN",
-            "CKR_USER_TOO_MANY_TYPES",
-            "CKR_WRAPPED_KEY_INVALID",
-            "CKR_WRAPPED_KEY_LEN_RANGE",
-            "CKR_WRAPPING_KEY_HANDLE_INVALID",
-            "CKR_WRAPPING_KEY_SIZE_RANGE",
-            "CKR_WRAPPING_KEY_TYPE_INCONSISTENT",
-            "CKR_RANDOM_SEED_NOT_SUPPORTED",
-            "CKR_RANDOM_NO_RNG",
-            "CKR_DOMAIN_PARAMS_INVALID",
-            "CKR_CURVE_NOT_SUPPORTED",
-            "CKR_BUFFER_TOO_SMALL",
-            "CKR_SAVED_STATE_INVALID",
-            "CKR_INFORMATION_SENSITIVE",
-            "CKR_STATE_UNSAVEABLE",
-            "CKR_CRYPTOKI_NOT_INITIALIZED",
-            "CKR_CRYPTOKI_ALREADY_INITIALIZED",
-            "CKR_MUTEX_BAD",
-            "CKR_MUTEX_NOT_LOCKED",
-            "CKR_NEW_PIN_MODE",
-            "CKR_NEXT_OTP",
-            "CKR_EXCEEDED_MAX_ITERATIONS",
-            "CKR_FIPS_SELF_TEST_FAILED",
-            "CKR_LIBRARY_LOAD_FAILED",
-            "CKR_PIN_TOO_WEAK",
-            "CKR_PUBLIC_KEY_INVALID",
-            "CKR_FUNCTION_REJECTED",
-            "CKR_TOKEN_RESOURCE_EXCEEDED",
-            "CKR_OPERATION_CANCEL_FAILED",
-            "CKR_VENDOR_DEFINED",
-        };
-        errorMap = new HashMap<Long,String>();
-        for (int i = 0; i < errorCodes.length; i++) {
-            errorMap.put(Long.valueOf(errorCodes[i]), errorMessages[i]);
-        }
+        register("CKR_OK", 0x00000000L);
+        register("CKR_CANCEL", 0x00000001L);
+        register("CKR_HOST_MEMORY", 0x00000002L);
+        register("CKR_SLOT_ID_INVALID", 0x00000003L);
+        register("CKR_GENERAL_ERROR", CKR_GENERAL_ERROR);
+        register("CKR_FUNCTION_FAILED", 0x00000006L);
+        register("CKR_ARGUMENTS_BAD", 0x00000007L);
+        register("CKR_NO_EVENT", 0x00000008L);
+        register("CKR_NEED_TO_CREATE_THREADS", 0x00000009L);
+        register("CKR_CANT_LOCK", 0x0000000AL);
+        register("CKR_ATTRIBUTE_READ_ONLY", 0x00000010L);
+        register("CKR_ATTRIBUTE_SENSITIVE", 0x00000011L);
+        register("CKR_ATTRIBUTE_TYPE_INVALID", CKR_ATTRIBUTE_TYPE_INVALID);
+        register("CKR_ATTRIBUTE_VALUE_INVALID", 0x00000013L);
+        register("CKR_ACTION_PROHIBITED", 0x0000001BL);
+        register("CKR_DATA_INVALID", 0x00000020L);
+        register("CKR_DATA_LEN_RANGE", CKR_DATA_LEN_RANGE);
+        register("CKR_DEVICE_ERROR", 0x00000030L);
+        register("CKR_DEVICE_MEMORY", 0x00000031L);
+        register("CKR_DEVICE_REMOVED", 0x00000032L);
+        register("CKR_ENCRYPTED_DATA_INVALID", CKR_ENCRYPTED_DATA_INVALID);
+        register("CKR_ENCRYPTED_DATA_LEN_RANGE", CKR_ENCRYPTED_DATA_LEN_RANGE);
+        register("CKR_AEAD_DECRYPT_FAILED", 0x00000042L);
+        register("CKR_FUNCTION_CANCELED", 0x00000050L);
+        register("CKR_FUNCTION_NOT_PARALLEL", 0x00000051L);
+        register("CKR_FUNCTION_NOT_SUPPORTED", 0x00000054L);
+        register("CKR_KEY_HANDLE_INVALID", 0x00000060L);
+        register("CKR_KEY_SIZE_RANGE", 0x00000062L);
+        register("CKR_KEY_TYPE_INCONSISTENT", 0x00000063L);
+        register("CKR_KEY_NOT_NEEDED", 0x00000064L);
+        register("CKR_KEY_CHANGED", 0x00000065L);
+        register("CKR_KEY_NEEDED", 0x00000066L);
+        register("CKR_KEY_INDIGESTIBLE", 0x00000067L);
+        register("CKR_KEY_FUNCTION_NOT_PERMITTED", 0x00000068L);
+        register("CKR_KEY_NOT_WRAPPABLE", 0x00000069L);
+        register("CKR_KEY_UNEXTRACTABLE", 0x0000006AL);
+        register("CKR_MECHANISM_INVALID", CKR_MECHANISM_INVALID);
+        register("CKR_MECHANISM_PARAM_INVALID", CKR_MECHANISM_PARAM_INVALID);
+        register("CKR_OBJECT_HANDLE_INVALID", 0x00000082L);
+        register("CKR_OPERATION_ACTIVE", 0x00000090L);
+        register("CKR_OPERATION_NOT_INITIALIZED",
+                CKR_OPERATION_NOT_INITIALIZED);
+        register("CKR_PIN_INCORRECT", CKR_PIN_INCORRECT);
+        register("CKR_PIN_INVALID", 0x000000A1L);
+        register("CKR_PIN_LEN_RANGE", 0x000000A2L);
+        register("CKR_PIN_EXPIRED", 0x000000A3L);
+        register("CKR_PIN_LOCKED", 0x000000A4L);
+        register("CKR_SESSION_CLOSED", 0x000000B0L);
+        register("CKR_SESSION_COUNT", 0x000000B1L);
+        register("CKR_SESSION_HANDLE_INVALID", 0x000000B3L);
+        register("CKR_SESSION_PARALLEL_NOT_SUPPORTED", 0x000000B4L);
+        register("CKR_SESSION_READ_ONLY", 0x000000B5L);
+        register("CKR_SESSION_EXISTS", 0x000000B6L);
+        register("CKR_SESSION_READ_ONLY_EXISTS", 0x000000B7L);
+        register("CKR_SESSION_READ_WRITE_SO_EXISTS", 0x000000B8L);
+        register("CKR_SIGNATURE_INVALID", CKR_SIGNATURE_INVALID);
+        register("CKR_SIGNATURE_LEN_RANGE", CKR_SIGNATURE_LEN_RANGE);
+        register("CKR_TEMPLATE_INCOMPLETE", 0x000000D0L);
+        register("CKR_TEMPLATE_INCONSISTENT", 0x000000D1L);
+        register("CKR_TOKEN_NOT_PRESENT", 0x000000E0L);
+        register("CKR_TOKEN_NOT_RECOGNIZED", 0x000000E1L);
+        register("CKR_TOKEN_WRITE_PROTECTED", 0x000000E2L);
+        register("CKR_UNWRAPPING_KEY_HANDLE_INVALID", 0x000000F0L);
+        register("CKR_UNWRAPPING_KEY_SIZE_RANGE", 0x000000F1L);
+        register("CKR_UNWRAPPING_KEY_TYPE_INCONSISTENT", 0x000000F2L);
+        register("CKR_USER_ALREADY_LOGGED_IN", CKR_USER_ALREADY_LOGGED_IN);
+        register("CKR_USER_NOT_LOGGED_IN", CKR_USER_NOT_LOGGED_IN);
+        register("CKR_USER_PIN_NOT_INITIALIZED", 0x00000102L);
+        register("CKR_USER_TYPE_INVALID", 0x00000103L);
+        register("CKR_USER_ANOTHER_ALREADY_LOGGED_IN", 0x00000104L);
+        register("CKR_USER_TOO_MANY_TYPES", 0x00000105L);
+        register("CKR_WRAPPED_KEY_INVALID", 0x00000110L);
+        register("CKR_WRAPPED_KEY_LEN_RANGE", 0x00000112L);
+        register("CKR_WRAPPING_KEY_HANDLE_INVALID", 0x00000113L);
+        register("CKR_WRAPPING_KEY_SIZE_RANGE", 0x00000114L);
+        register("CKR_WRAPPING_KEY_TYPE_INCONSISTENT", 0x00000115L);
+        register("CKR_RANDOM_SEED_NOT_SUPPORTED", 0x00000120L);
+        register("CKR_RANDOM_NO_RNG", 0x00000121L);
+        register("CKR_DOMAIN_PARAMS_INVALID", 0x00000130L);
+        register("CKR_CURVE_NOT_SUPPORTED", 0x00000140L);
+        register("CKR_BUFFER_TOO_SMALL", CKR_BUFFER_TOO_SMALL);
+        register("CKR_SAVED_STATE_INVALID", 0x00000160L);
+        register("CKR_INFORMATION_SENSITIVE", 0x00000170L);
+        register("CKR_STATE_UNSAVEABLE", 0x00000180L);
+        register("CKR_CRYPTOKI_NOT_INITIALIZED", 0x00000190L);
+        register("CKR_CRYPTOKI_ALREADY_INITIALIZED",
+                CKR_CRYPTOKI_ALREADY_INITIALIZED);
+        register("CKR_MUTEX_BAD", 0x000001A0L);
+        register("CKR_MUTEX_NOT_LOCKED", 0x000001A1L);
+        register("CKR_NEW_PIN_MODE", 0x000001B0L);
+        register("CKR_NEXT_OTP", 0x000001B1L);
+        register("CKR_EXCEEDED_MAX_ITERATIONS", 0x000001B5L);
+        register("CKR_FIPS_SELF_TEST_FAILED", 0x000001B6L);
+        register("CKR_LIBRARY_LOAD_FAILED", 0x000001B7L);
+        register("CKR_PIN_TOO_WEAK", 0x000001B8L);
+        register("CKR_PUBLIC_KEY_INVALID", 0x000001B9L);
+        register("CKR_FUNCTION_REJECTED", 0x00000200L);
+        register("CKR_TOKEN_RESOURCE_EXCEEDED", 0x00000201L);
+        register("CKR_OPERATION_CANCEL_FAILED", 0x00000202L);
+        register("CKR_VENDOR_DEFINED", 0x80000000L);
+    };
+
+    private static void register(String name, long errorCode) {
+        errorMap.put(errorCode, name);
     }
 
+    private static String lookup(long errorCode) {
+        String res = errorMap.get(errorCode);
+        // for unknown PKCS11 return values, just use hex as its string
+        if (res == null) {
+            res = "0x" + Functions.toFullHexString((int)errorCode);
+            errorMap.put(errorCode, res);
+        }
+        return res;
+    }
 
     /**
-     * Constructor taking the error code as defined for the CKR_* constants
-     * in PKCS#11.
+     * Constructor taking the error code (the CKR_* constants in PKCS#11) and
+     * extra info for error message.
      */
-    public PKCS11Exception(long errorCode) {
-        errorCode_ = errorCode;
+    public PKCS11Exception(long errorCode, String extraInfo) {
+        this.errorCode = errorCode;
+        this.errorMsg = lookup(errorCode);
+        if (extraInfo != null) {
+            this.errorMsg += extraInfo;
+        }
     }
 
     /**
@@ -299,11 +230,7 @@ public class PKCS11Exception extends Exception {
      * @postconditions (result <> null)
      */
     public String getMessage() {
-        String message = errorMap.get(Long.valueOf(errorCode_));
-        if (message == null) {
-            message = "0x" + Functions.toFullHexString((int)errorCode_);
-        }
-        return message;
+        return errorMsg;
     }
 
     /**
@@ -314,7 +241,6 @@ public class PKCS11Exception extends Exception {
      * @postconditions
      */
     public long getErrorCode() {
-        return errorCode_ ;
+        return errorCode;
     }
-
 }

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
@@ -95,7 +95,7 @@ void destroyLockObject(JNIEnv *env, jobject jLockObject) {
 /*
  * Add the given pkcs11Implementation object to the list of present modules.
  * Attach the given data to the entry. If the given pkcs11Implementation is
- * already in the lsit, just override its old module data with the new one.
+ * already in the list, just override its old module data with the new one.
  * None of the arguments can be NULL. If one of the arguments is NULL, this
  * function does nothing.
  */
@@ -183,10 +183,10 @@ void removeAllModuleEntries(JNIEnv *env) {
  * function to convert a PKCS#11 return value into a PKCS#11Exception
  *
  * This function generates a PKCS#11Exception with the returnValue as the
- * errorcode. If the returnValue is not CKR_OK. The functin returns 0, if the
+ * errorcode. If the returnValue is not CKR_OK. The function returns 0, if the
  * returnValue is CKR_OK. Otherwise, it returns the returnValue as a jLong.
  *
- * @param env - used to call JNI funktions and to get the Exception class
+ * @param env - used to call JNI functions and to get the Exception class
  * @param returnValue - of the PKCS#11 function
  */
 jlong ckAssertReturnValueOK(JNIEnv *env, CK_RV returnValue) {
@@ -198,10 +198,10 @@ jlong ckAssertReturnValueOK(JNIEnv *env, CK_RV returnValue) {
  * PKCS#11Exception
  *
  * This function generates a PKCS#11Exception with the returnValue as the
- * errorcode. If the returnValue is not CKR_OK. The functin returns 0, if the
+ * errorcode. If the returnValue is not CKR_OK. The function returns 0, if the
  * returnValue is CKR_OK. Otherwise, it returns the returnValue as a jLong.
  *
- * @param env - used to call JNI funktions and to get the Exception class
+ * @param env - used to call JNI functions and to get the Exception class
  * @param returnValue - of the PKCS#11 function
  * @param msg - additional message for the generated PKCS11Exception
  */
@@ -274,7 +274,7 @@ void throwIOException(JNIEnv *env, const char *msg)
  * This function simply throws a PKCS#11RuntimeException with the given
  * string as its message.
  *
- * @param env Used to call JNI funktions and to get the Exception class.
+ * @param env Used to call JNI functions and to get the Exception class.
  * @param jmessage The message string of the Exception object.
  */
 void throwPKCS11RuntimeException(JNIEnv *env, const char *message)
@@ -286,7 +286,7 @@ void throwPKCS11RuntimeException(JNIEnv *env, const char *message)
  * This function simply throws a PKCS#11RuntimeException. The message says that
  * the object is not connected to the module.
  *
- * @param env Used to call JNI funktions and to get the Exception class.
+ * @param env Used to call JNI functions and to get the Exception class.
  */
 void throwDisconnectedRuntimeException(JNIEnv *env)
 {
@@ -502,7 +502,7 @@ CK_MECHANISM_PTR updateGCMParams(JNIEnv *env, CK_MECHANISM_PTR mechPtr) {
 /*
  * converts a jbooleanArray to a CK_BBOOL array. The allocated memory has to be freed after use!
  *
- * @param env - used to call JNI funktions to get the array informtaion
+ * @param env - used to call JNI functions to get the array informtaion
  * @param jArray - the Java array to convert
  * @param ckpArray - the reference, where the pointer to the new CK_BBOOL array will be stored
  * @param ckpLength - the reference, where the array length will be stored
@@ -544,7 +544,7 @@ void jBooleanArrayToCKBBoolArray(JNIEnv *env, const jbooleanArray jArray, CK_BBO
 /*
  * converts a jbyteArray to a CK_BYTE array. The allocated memory has to be freed after use!
  *
- * @param env - used to call JNI funktions to get the array informtaion
+ * @param env - used to call JNI functions to get the array informtaion
  * @param jArray - the Java array to convert
  * @param ckpArray - the reference, where the pointer to the new CK_BYTE array will be stored
  * @param ckpLength - the reference, where the array length will be stored
@@ -591,7 +591,7 @@ void jByteArrayToCKByteArray(JNIEnv *env, const jbyteArray jArray, CK_BYTE_PTR *
 /*
  * converts a jlongArray to a CK_ULONG array. The allocated memory has to be freed after use!
  *
- * @param env - used to call JNI funktions to get the array informtaion
+ * @param env - used to call JNI functions to get the array informtaion
  * @param jArray - the Java array to convert
  * @param ckpArray - the reference, where the pointer to the new CK_ULONG array will be stored
  * @param ckpLength - the reference, where the array length will be stored
@@ -633,7 +633,7 @@ void jLongArrayToCKULongArray(JNIEnv *env, const jlongArray jArray, CK_ULONG_PTR
 /*
  * converts a jcharArray to a CK_CHAR array. The allocated memory has to be freed after use!
  *
- * @param env - used to call JNI funktions to get the array informtaion
+ * @param env - used to call JNI functions to get the array informtaion
  * @param jArray - the Java array to convert
  * @param ckpArray - the reference, where the pointer to the new CK_CHAR array will be stored
  * @param ckpLength - the reference, where the array length will be stored
@@ -675,7 +675,7 @@ void jCharArrayToCKCharArray(JNIEnv *env, const jcharArray jArray, CK_CHAR_PTR *
 /*
  * converts a jcharArray to a CK_UTF8CHAR array. The allocated memory has to be freed after use!
  *
- * @param env - used to call JNI funktions to get the array informtaion
+ * @param env - used to call JNI functions to get the array informtaion
  * @param jArray - the Java array to convert
  * @param ckpArray - the reference, where the pointer to the new CK_UTF8CHAR array will be stored
  * @param ckpLength - the reference, where the array length will be stored
@@ -717,7 +717,7 @@ void jCharArrayToCKUTF8CharArray(JNIEnv *env, const jcharArray jArray, CK_UTF8CH
 /*
  * converts a jstring to a CK_CHAR array. The allocated memory has to be freed after use!
  *
- * @param env - used to call JNI funktions to get the array informtaion
+ * @param env - used to call JNI functions to get the array informtaion
  * @param jArray - the Java array to convert
  * @param ckpArray - the reference, where the pointer to the new CK_CHAR array will be stored
  * @param ckpLength - the reference, where the array length will be stored
@@ -751,7 +751,7 @@ void jStringToCKUTF8CharArray(JNIEnv *env, const jstring jArray, CK_UTF8CHAR_PTR
  * converts a jobjectArray with Java Attributes to a CK_ATTRIBUTE array. The allocated memory
  * has to be freed after use!
  *
- * @param env - used to call JNI funktions to get the array informtaion
+ * @param env - used to call JNI functions to get the array informtaion
  * @param jArray - the Java Attribute array (template) to convert
  * @param ckpArray - the reference, where the pointer to the new CK_ATTRIBUTE array will be
  *                   stored
@@ -797,7 +797,7 @@ void jAttributeArrayToCKAttributeArray(JNIEnv *env, jobjectArray jArray, CK_ATTR
 /*
  * converts a CK_BYTE array and its length to a jbyteArray.
  *
- * @param env - used to call JNI funktions to create the new Java array
+ * @param env - used to call JNI functions to create the new Java array
  * @param ckpArray - the pointer to the CK_BYTE array to convert
  * @param ckpLength - the length of the array to convert
  * @return - the new Java byte array or NULL if error occurred
@@ -835,7 +835,7 @@ jbyteArray ckByteArrayToJByteArray(JNIEnv *env, const CK_BYTE_PTR ckpArray, CK_U
 /*
  * converts a CK_ULONG array and its length to a jlongArray.
  *
- * @param env - used to call JNI funktions to create the new Java array
+ * @param env - used to call JNI functions to create the new Java array
  * @param ckpArray - the pointer to the CK_ULONG array to convert
  * @param ckpLength - the length of the array to convert
  * @return - the new Java long array
@@ -866,7 +866,7 @@ jlongArray ckULongArrayToJLongArray(JNIEnv *env, const CK_ULONG_PTR ckpArray, CK
 /*
  * converts a CK_CHAR array and its length to a jcharArray.
  *
- * @param env - used to call JNI funktions to create the new Java array
+ * @param env - used to call JNI functions to create the new Java array
  * @param ckpArray - the pointer to the CK_CHAR array to convert
  * @param ckpLength - the length of the array to convert
  * @return - the new Java char array
@@ -897,7 +897,7 @@ jcharArray ckCharArrayToJCharArray(JNIEnv *env, const CK_CHAR_PTR ckpArray, CK_U
 /*
  * converts a CK_UTF8CHAR array and its length to a jcharArray.
  *
- * @param env - used to call JNI funktions to create the new Java array
+ * @param env - used to call JNI functions to create the new Java array
  * @param ckpArray - the pointer to the CK_UTF8CHAR array to convert
  * @param ckpLength - the length of the array to convert
  * @return - the new Java char array
@@ -946,7 +946,7 @@ jcharArray ckUTF8CharArrayToJCharArray(JNIEnv *env, const CK_UTF8CHAR_PTR ckpArr
 /*
  * converts a CK_BBOOL pointer to a Java boolean Object.
  *
- * @param env - used to call JNI funktions to create the new Java object
+ * @param env - used to call JNI functions to create the new Java object
  * @param ckpValue - the pointer to the CK_BBOOL value
  * @return - the new Java boolean object with the boolean value
  */
@@ -970,7 +970,7 @@ jobject ckBBoolPtrToJBooleanObject(JNIEnv *env, const CK_BBOOL *ckpValue)
 /*
  * converts a CK_ULONG pointer to a Java long Object.
  *
- * @param env - used to call JNI funktions to create the new Java object
+ * @param env - used to call JNI functions to create the new Java object
  * @param ckpValue - the pointer to the CK_ULONG value
  * @return - the new Java long object with the long value
  */
@@ -995,7 +995,7 @@ jobject ckULongPtrToJLongObject(JNIEnv *env, const CK_ULONG_PTR ckpValue)
  * converts a Java boolean object into a pointer to a CK_BBOOL value. The memory has to be
  * freed after use!
  *
- * @param env - used to call JNI funktions to get the value out of the Java object
+ * @param env - used to call JNI functions to get the value out of the Java object
  * @param jObject - the "java/lang/Boolean" object to convert
  * @return - the pointer to the new CK_BBOOL value
  */
@@ -1025,7 +1025,7 @@ CK_BBOOL* jBooleanObjectToCKBBoolPtr(JNIEnv *env, jobject jObject)
  * converts a Java byte object into a pointer to a CK_BYTE value. The memory has to be
  * freed after use!
  *
- * @param env - used to call JNI funktions to get the value out of the Java object
+ * @param env - used to call JNI functions to get the value out of the Java object
  * @param jObject - the "java/lang/Byte" object to convert
  * @return - the pointer to the new CK_BYTE value
  */
@@ -1054,7 +1054,7 @@ CK_BYTE_PTR jByteObjectToCKBytePtr(JNIEnv *env, jobject jObject)
  * converts a Java integer object into a pointer to a CK_ULONG value. The memory has to be
  * freed after use!
  *
- * @param env - used to call JNI funktions to get the value out of the Java object
+ * @param env - used to call JNI functions to get the value out of the Java object
  * @param jObject - the "java/lang/Integer" object to convert
  * @return - the pointer to the new CK_ULONG value
  */
@@ -1083,7 +1083,7 @@ CK_ULONG* jIntegerObjectToCKULongPtr(JNIEnv *env, jobject jObject)
  * converts a Java long object into a pointer to a CK_ULONG value. The memory has to be
  * freed after use!
  *
- * @param env - used to call JNI funktions to get the value out of the Java object
+ * @param env - used to call JNI functions to get the value out of the Java object
  * @param jObject - the "java/lang/Long" object to convert
  * @return - the pointer to the new CK_ULONG value
  */
@@ -1113,7 +1113,7 @@ CK_ULONG* jLongObjectToCKULongPtr(JNIEnv *env, jobject jObject)
  * converts a Java char object into a pointer to a CK_CHAR value. The memory has to be
  * freed after use!
  *
- * @param env - used to call JNI funktions to get the value out of the Java object
+ * @param env - used to call JNI functions to get the value out of the Java object
  * @param jObject - the "java/lang/Char" object to convert
  * @return - the pointer to the new CK_CHAR value
  */
@@ -1143,7 +1143,7 @@ CK_CHAR_PTR jCharObjectToCKCharPtr(JNIEnv *env, jobject jObject)
  * converts a Java object into a pointer to CK-type or a CK-structure with the length in Bytes.
  * The memory of the returned pointer MUST BE FREED BY CALLER!
  *
- * @param env - used to call JNI funktions to get the Java classes and objects
+ * @param env - used to call JNI functions to get the Java classes and objects
  * @param jObject - the Java object to convert
  * @param ckpLength - pointer to the length (bytes) of the newly-allocated CK-value or CK-structure
  * @return ckpObject - pointer to the newly-allocated CK-value or CK-structure

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11wrapper.h
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11wrapper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -305,6 +305,7 @@ CK_MECHANISM_PTR updateGCMParams(JNIEnv *env, CK_MECHANISM_PTR mechPtr);
  */
 
 jlong ckAssertReturnValueOK(JNIEnv *env, CK_RV returnValue);
+jlong ckAssertReturnValueOK2(JNIEnv *env, CK_RV returnValue, const char *msg);
 void throwOutOfMemoryError(JNIEnv *env, const char *message);
 void throwNullPointerException(JNIEnv *env, const char *message);
 void throwIOException(JNIEnv *env, const char *message);


### PR DESCRIPTION
Anyone can help review this somewhat trivial fix? The main change is inside src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_objmgmt.c. This is to help better troubleshooting by reporting the type of unavailable attributes in PKCS11 exception message when C_GetAttributeValue(...) call failed. The java file changes are just cleanup for consolidating the CKR_* constants definition into PKCS11Exception class.

Thanks,
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-6676643](https://bugs.openjdk.java.net/browse/JDK-6676643): Improve current C_GetAttributeValue native implementation


### Reviewers
 * @SalusaSecondus (no known github.com user name / role) ⚠️ Review applies to a08ce8bd738140e6c8ea85b7c709025ef0f2cad0
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**) ⚠️ Review applies to 285196b49788f7ed23c53080eff03e017db731fc


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3709/head:pull/3709` \
`$ git checkout pull/3709`

Update a local copy of the PR: \
`$ git checkout pull/3709` \
`$ git pull https://git.openjdk.java.net/jdk pull/3709/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3709`

View PR using the GUI difftool: \
`$ git pr show -t 3709`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3709.diff">https://git.openjdk.java.net/jdk/pull/3709.diff</a>

</details>
