### PR TITLE
8266028: C2 computes -0.0 for Math.pow(-0.0, 0.5)

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -1654,7 +1654,7 @@ bool LibraryCallKit::inline_math_pow() {
       Node* phi = new PhiNode(region, Type::DOUBLE);
 
       Node* cmp  = _gvn.transform(new CmpDNode(base, zero));
-      Node* test = _gvn.transform(new BoolNode(cmp, BoolTest::lt));
+      Node* test = _gvn.transform(new BoolNode(cmp, BoolTest::le));
 
       Node* if_pow = generate_slow_guard(test, NULL);
       Node* value_sqrt = _gvn.transform(new SqrtDNode(C, control(), base));

--- a/test/hotspot/jtreg/compiler/intrinsics/math/TestPow0Dot5Opt.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/math/TestPow0Dot5Opt.java
@@ -43,17 +43,6 @@ public class TestPow0Dot5Opt {
     if (r1 != r2) {
       throw new RuntimeException("pow(" + a + ", 0.5), expected: " + r1 + ", actual: " + r2);
     }
-  }
-
-  public static void main(String[] args) throws Exception {
-    for (int i = 0; i < 10; i++) {
-      for (int j = 1; j < 100000; j++) {
-        test(j * 1.0);
-        test(1.0 / j);
-      }
-    }
-
-    test(0.0);
 
     // Special case: pow(+0.0, 0.5) = 0.0
     double r = Math.pow(+0.0, 0.5);
@@ -83,6 +72,15 @@ public class TestPow0Dot5Opt {
     r = Math.pow(Double.NaN, 0.5);
     if (!Double.isNaN(r)) {
       throw new RuntimeException("pow(NaN, 0.5), expected: NaN, actual: " + r);
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    for (int i = 0; i < 10; i++) {
+      for (int j = 1; j < 100000; j++) {
+        test(j * 1.0);
+        test(1.0 / j);
+      }
     }
   }
 


### PR DESCRIPTION
Hi all,

C2 computes -0.0 for Math.pow(-0.0, 0.5) which should be 0.0 according to the API specs.
This bug was found while I was implementing the same optimization for x86_32 (JDK-8265940).

The reason is that CmpDNode [1] doesn't distinguish -0.0 from 0.0.
Math.pow(-0.0, 0.5) was replaced with Math.sqrt(-0.0) incorrectly since CmpDNode says -0.0 < 0.0 if false.

The fix excludes C2's optimization for x=0.0/-0.0. 
And the jtreg test has been improved to make sure the corner cases are covered by the compilers.

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/library_call.cpp#L1656

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266028](https://bugs.openjdk.java.net/browse/JDK-8266028): C2 computes -0.0 for Math.pow(-0.0, 0.5)


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3712/head:pull/3712` \
`$ git checkout pull/3712`

Update a local copy of the PR: \
`$ git checkout pull/3712` \
`$ git pull https://git.openjdk.java.net/jdk pull/3712/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3712`

View PR using the GUI difftool: \
`$ git pr show -t 3712`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3712.diff">https://git.openjdk.java.net/jdk/pull/3712.diff</a>

</details>
