### PR TITLE
8266027: The diamond finder does not find diamond candidates in field initializers

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Analyzer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Analyzer.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 
 import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.NewClassTree;
+import com.sun.source.tree.VariableTree;
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Kinds.Kind;
 import com.sun.tools.javac.code.Source;
@@ -556,14 +557,17 @@ public class Analyzer {
             log.useSource(rewriting.env.toplevel.getSourceFile());
 
             JCStatement treeToAnalyze = (JCStatement)rewriting.originalTree;
+            JCTree wrappedTree = null;
+
             if (rewriting.env.info.scope.owner.kind == Kind.TYP) {
                 //add a block to hoist potential dangling variable declarations
                 treeToAnalyze = make.at(Position.NOPOS)
                                     .Block(Flags.SYNTHETIC, List.of((JCStatement)rewriting.originalTree));
+                wrappedTree = rewriting.originalTree;
             }
 
             //TODO: to further refine the analysis, try all rewriting combinations
-            deferredAttr.attribSpeculative(treeToAnalyze, rewriting.env, attr.statInfo, new TreeRewriter(rewriting),
+            deferredAttr.attribSpeculative(treeToAnalyze, rewriting.env, attr.statInfo, new TreeRewriter(rewriting, wrappedTree),
                     () -> rewriting.diagHandler(), AttributionMode.ANALYZER, argumentAttr.withLocalCacheContext());
             rewriting.analyzer.process(rewriting.oldTree, rewriting.replacement, rewriting.erroneous);
         } catch (Throwable ex) {
@@ -768,9 +772,11 @@ public class Analyzer {
    class TreeRewriter extends AnalyzerCopier {
 
         RewritingContext rewriting;
+        JCTree wrappedTree;
 
-        TreeRewriter(RewritingContext rewriting) {
+        TreeRewriter(RewritingContext rewriting, JCTree wrappedTree) {
             this.rewriting = rewriting;
+            this.wrappedTree = wrappedTree;
         }
 
         @Override
@@ -783,5 +789,19 @@ public class Analyzer {
             }
             return newTree;
         }
+
+        @Override
+        public JCTree visitVariable(VariableTree node, Void p) {
+            JCTree result = super.visitVariable(node, p);
+            if (node == wrappedTree) {
+                //The current tree is a field and has been wrapped by a block, so it effectivelly
+                //became local variable. If it has some modifiers (except for final), an error
+                //would be reported, causing the whole rewrite to fail. Removing the non-final
+                //modifiers from the variable here:
+                ((JCVariableDecl) result).mods.flags &= Flags.FINAL;
+            }
+            return result;
+        }
+
     }
 }

--- a/test/langtools/tools/javac/analyzer/DiamondFields.java
+++ b/test/langtools/tools/javac/analyzer/DiamondFields.java
@@ -1,0 +1,29 @@
+/**
+ * @test /nodynamiccopyright/
+ * @bug 8266027
+ * @summary Verify the diamond finder works on fields with modifiers.
+ * @compile/ref=DiamondFields.out -XDfind=diamond -XDrawDiagnostics DiamondFields.java
+ */
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class DiamondFields {
+                List<String> f1 = new LinkedList<String>();
+    private     List<String> f2 = new LinkedList<String>();
+    static      List<String> f3 = new LinkedList<String>();
+    @Deprecated List<String> f4 = new LinkedList<String>();
+    final       List<String> f5 = new LinkedList<String>();
+
+    DiamondFields() {
+        List<String> l1 = new LinkedList<String>();
+        final List<String> l2 = new LinkedList<String>();
+        @Deprecated List<String> l3 = new LinkedList<String>();
+    }
+
+    void t() {
+        List<String> l1 = new LinkedList<String>();
+        final List<String> l2 = new LinkedList<String>();
+        @Deprecated List<String> l3 = new LinkedList<String>();
+    }
+}

--- a/test/langtools/tools/javac/analyzer/DiamondFields.out
+++ b/test/langtools/tools/javac/analyzer/DiamondFields.out
@@ -1,0 +1,12 @@
+DiamondFields.java:12:49: compiler.warn.diamond.redundant.args
+DiamondFields.java:13:49: compiler.warn.diamond.redundant.args
+DiamondFields.java:14:49: compiler.warn.diamond.redundant.args
+DiamondFields.java:15:49: compiler.warn.diamond.redundant.args
+DiamondFields.java:16:49: compiler.warn.diamond.redundant.args
+DiamondFields.java:19:41: compiler.warn.diamond.redundant.args
+DiamondFields.java:20:47: compiler.warn.diamond.redundant.args
+DiamondFields.java:21:53: compiler.warn.diamond.redundant.args
+DiamondFields.java:25:41: compiler.warn.diamond.redundant.args
+DiamondFields.java:26:47: compiler.warn.diamond.redundant.args
+DiamondFields.java:27:53: compiler.warn.diamond.redundant.args
+11 warnings


### PR DESCRIPTION
Consider code like:
```
public class Test {
     private List<String> f2 = new LinkedList<String>();
}
```

Running with javac with `-XDfind=diamond` will not produce any warning about a possible diamond use. The reason is that the field:
```
private List<String> f2 = new LinkedList<String>();
```

will get wrapped by a block, and attributed as a block, but since it has the `private` modifier, an error will be produced, and the transformation will be deemed impossible.

The proposed solution is to clear the modifiers when/if wrapping fields with blocks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266027](https://bugs.openjdk.java.net/browse/JDK-8266027): The diamond finder does not find diamond candidates in field initializers


### Reviewers
 * [Joel Borggrén-Franck](https://openjdk.java.net/census#jfranck) (@jbf - **Reviewer**)
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3713/head:pull/3713` \
`$ git checkout pull/3713`

Update a local copy of the PR: \
`$ git checkout pull/3713` \
`$ git pull https://git.openjdk.java.net/jdk pull/3713/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3713`

View PR using the GUI difftool: \
`$ git pr show -t 3713`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3713.diff">https://git.openjdk.java.net/jdk/pull/3713.diff</a>

</details>
