### PR TITLE
8266038: Move newAddress() to JVMDebugger

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/JVMDebugger.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/JVMDebugger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,4 +45,5 @@ public interface JVMDebugger extends Debugger {
   public void putHeapConst(long heapOopSize, long klassPtrSize,
                            long narrowKlassBase, int narrowKlassShift,
                            long narrowOopBase, int narrowOopShift);
+  public Address newAddress(long value);
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdDebugger.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdDebugger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,6 @@ public interface BsdDebugger extends JVMDebugger {
   public BsdOopHandle readCompOopHandle(long address) throws DebuggerException;
   public long[]       getThreadIntegerRegisterSet(long unique_thread_id) throws DebuggerException;
   public long         getAddressValue(Address addr) throws DebuggerException;
-  public Address      newAddress(long value) throws DebuggerException;
 
   // For BsdCDebugger
   public List<ThreadProxy> getThreadList();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/LinuxDebugger.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/LinuxDebugger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,6 @@ public interface LinuxDebugger extends JVMDebugger {
   public LinuxOopHandle readCompOopHandle(long address) throws DebuggerException;
   public long[]       getThreadIntegerRegisterSet(int lwp_id) throws DebuggerException;
   public long         getAddressValue(Address addr) throws DebuggerException;
-  public Address      newAddress(long value) throws DebuggerException;
   public Address      findLibPtrByAddress(Address pc);
 
   // For LinuxCDebugger

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/proc/ProcDebugger.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/proc/ProcDebugger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,6 @@ public interface ProcDebugger extends JVMDebugger {
   public ProcOopHandle readCompOopHandle(long address) throws DebuggerException;
   public long[]       getThreadIntegerRegisterSet(int tid) throws DebuggerException;
   public long         getAddressValue(Address addr) throws DebuggerException;
-  public Address      newAddress(long value) throws DebuggerException;
 
   // for ProcCDebugger, ProcCFrame and SharedObject
   public List<ThreadProxy> getThreadList() throws DebuggerException;

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/WindbgDebugger.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/WindbgDebugger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,6 @@ public interface WindbgDebugger extends JVMDebugger {
   // the indices match those in debugger/x86/X86ThreadContext.java or
   // debugger/amd64/AMD64ThreadContext.java.
   public long[]       getThreadIntegerRegisterSet(long threadId) throws DebuggerException;
-  public Address      newAddress(long value) throws DebuggerException;
 
   public long         getThreadIdFromSysId(long sysId) throws DebuggerException;
   // Support for the CDebugger interface. Retrieves the thread list of


### PR DESCRIPTION
SA has `newAddress()` to create `Address` instance, however it is declared in each debugger classes (e.g. `LinuxDebugger`). So we can't access it directly from `VM` class.

Before SA improvement for ZGC in [JDK-8220624](https://bugs.openjdk.java.net/browse/JDK-8220624), we need to move `newAddress()` to super class (`JVMDebugger`).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266038](https://bugs.openjdk.java.net/browse/JDK-8266038): Move newAddress() to JVMDebugger


### Reviewers
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3714/head:pull/3714` \
`$ git checkout pull/3714`

Update a local copy of the PR: \
`$ git checkout pull/3714` \
`$ git pull https://git.openjdk.java.net/jdk pull/3714/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3714`

View PR using the GUI difftool: \
`$ git pr show -t 3714`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3714.diff">https://git.openjdk.java.net/jdk/pull/3714.diff</a>

</details>
