### PR TITLE
8265914: Duplicated NotANode and not_a_node

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -287,13 +287,6 @@ void Compile::gvn_replace_by(Node* n, Node* nn) {
 }
 
 
-static inline bool not_a_node(const Node* n) {
-  if (n == NULL)                   return true;
-  if (((intptr_t)n & 1) != 0)      return true;  // uninitialized, etc.
-  if (*(address*)n == badAddress)  return true;  // kill by Node::destruct
-  return false;
-}
-
 // Identify all nodes that are reachable from below, useful.
 // Use breadth-first pass that records state in a Unique_Node_List,
 // recursive traversal is slower.

--- a/src/hotspot/share/opto/multnode.cpp
+++ b/src/hotspot/share/opto/multnode.cpp
@@ -140,7 +140,7 @@ void ProjNode::dump_spec(outputStream *st) const { st->print("#%d",_con); if(_is
 void ProjNode::dump_compact_spec(outputStream *st) const {
   for (DUIterator i = this->outs(); this->has_out(i); i++) {
     Node* o = this->out(i);
-    if (NotANode(o)) {
+    if (not_a_node(o)) {
       st->print("[?]");
     } else if (o == NULL) {
       st->print("[_]");

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -1653,7 +1653,7 @@ Node* Node::find(const int idx, bool only_ctrl) {
 }
 
 bool Node::add_to_worklist(Node* n, Node_List* worklist, Arena* old_arena, VectorSet* old_space, VectorSet* new_space) {
-  if (NotANode(n)) {
+  if (not_a_node(n)) {
     return false; // Gracefully handle NULL, -1, 0xabababab, etc.
   }
 
@@ -1681,14 +1681,14 @@ static bool is_disconnected(const Node* n) {
 void Node::dump_orig(outputStream *st, bool print_key) const {
   Compile* C = Compile::current();
   Node* orig = _debug_orig;
-  if (NotANode(orig)) orig = NULL;
+  if (not_a_node(orig)) orig = NULL;
   if (orig != NULL && !C->node_arena()->contains(orig)) orig = NULL;
   if (orig == NULL) return;
   if (print_key) {
     st->print(" !orig=");
   }
   Node* fast = orig->debug_orig(); // tortoise & hare algorithm to detect loops
-  if (NotANode(fast)) fast = NULL;
+  if (not_a_node(fast)) fast = NULL;
   while (orig != NULL) {
     bool discon = is_disconnected(orig);  // if discon, print [123] else 123
     if (discon) st->print("[");
@@ -1697,16 +1697,16 @@ void Node::dump_orig(outputStream *st, bool print_key) const {
     st->print("%d", orig->_idx);
     if (discon) st->print("]");
     orig = orig->debug_orig();
-    if (NotANode(orig)) orig = NULL;
+    if (not_a_node(orig)) orig = NULL;
     if (orig != NULL && !C->node_arena()->contains(orig)) orig = NULL;
     if (orig != NULL) st->print(",");
     if (fast != NULL) {
       // Step fast twice for each single step of orig:
       fast = fast->debug_orig();
-      if (NotANode(fast)) fast = NULL;
+      if (not_a_node(fast)) fast = NULL;
       if (fast != NULL && fast != orig) {
         fast = fast->debug_orig();
-        if (NotANode(fast)) fast = NULL;
+        if (not_a_node(fast)) fast = NULL;
       }
       if (fast == orig) {
         st->print("...");
@@ -1719,7 +1719,7 @@ void Node::dump_orig(outputStream *st, bool print_key) const {
 void Node::set_debug_orig(Node* orig) {
   _debug_orig = orig;
   if (BreakAtNode == 0)  return;
-  if (NotANode(orig))  orig = NULL;
+  if (not_a_node(orig))  orig = NULL;
   int trip = 10;
   while (orig != NULL) {
     if (orig->debug_idx() == BreakAtNode || (int)orig->_idx == BreakAtNode) {
@@ -1728,7 +1728,7 @@ void Node::set_debug_orig(Node* orig) {
       BREAKPOINT;
     }
     orig = orig->debug_orig();
-    if (NotANode(orig))  orig = NULL;
+    if (not_a_node(orig))  orig = NULL;
     if (trip-- <= 0)  break;
   }
 }
@@ -1824,8 +1824,8 @@ void Node::dump_req(outputStream *st) const {
     Node* d = in(i);
     if (d == NULL) {
       st->print("_ ");
-    } else if (NotANode(d)) {
-      st->print("NotANode ");  // uninitialized, sentinel, garbage, etc.
+    } else if (not_a_node(d)) {
+      st->print("not_a_node ");  // uninitialized, sentinel, garbage, etc.
     } else {
       st->print("%c%d ", Compile::current()->node_arena()->contains(d) ? ' ' : 'o', d->_idx);
     }
@@ -1841,7 +1841,7 @@ void Node::dump_prec(outputStream *st) const {
     Node* p = in(i);
     if (p != NULL) {
       if (!any_prec++) st->print(" |");
-      if (NotANode(p)) { st->print("NotANode "); continue; }
+      if (not_a_node(p)) { st->print("not_a_node "); continue; }
       st->print("%c%d ", Compile::current()->node_arena()->contains(in(i)) ? ' ' : 'o', in(i)->_idx);
     }
   }
@@ -1856,8 +1856,8 @@ void Node::dump_out(outputStream *st) const {
     Node* u = _out[i];
     if (u == NULL) {
       st->print("_ ");
-    } else if (NotANode(u)) {
-      st->print("NotANode ");
+    } else if (not_a_node(u)) {
+      st->print("not_a_node ");
     } else {
       st->print("%c%d ", Compile::current()->node_arena()->contains(u) ? ' ' : 'o', u->_idx);
     }
@@ -1894,7 +1894,7 @@ static void collect_nodes_i(GrowableArray<Node*>* queue, const Node* start, int 
       for(uint k = 0; k < limit; k++) {
         Node* n = direction > 0 ? tp->in(k) : tp->raw_out(k);
 
-        if (NotANode(n))  continue;
+        if (not_a_node(n))  continue;
         // do not recurse through top or the root (would reach unrelated stuff)
         if (n->is_Root() || n->is_top()) continue;
         if (only_ctrl && !n->is_CFG()) continue;
@@ -1915,7 +1915,7 @@ static void collect_nodes_i(GrowableArray<Node*>* queue, const Node* start, int 
 
 //------------------------------dump_nodes-------------------------------------
 static void dump_nodes(const Node* start, int d, bool only_ctrl) {
-  if (NotANode(start)) return;
+  if (not_a_node(start)) return;
 
   GrowableArray <Node *> queue(Compile::current()->live_nodes());
   collect_nodes_i(&queue, start, d, (uint) ABS(d), true, only_ctrl, false);
@@ -2083,7 +2083,7 @@ static void collect_nodes_in(Node* start, GrowableArray<Node*> *ns, bool primary
       Node* current = nodes.at(n_idx++);
       for (uint i = 0; i < current->len(); i++) {
         Node* n = current->in(i);
-        if (NotANode(n)) {
+        if (not_a_node(n)) {
           continue;
         }
         if ((primary_is_data && n->is_CFG()) || (!primary_is_data && !n->is_CFG())) {
@@ -2145,7 +2145,7 @@ void Node::collect_nodes_out_all_ctrl_boundary(GrowableArray<Node*> *ns) const {
   nodes.push((Node*) this);
   while (nodes.length() > 0) {
     Node* current = nodes.pop();
-    if (NotANode(current)) {
+    if (not_a_node(current)) {
       continue;
     }
     ns->append_if_missing(current);

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1247,19 +1247,12 @@ public:
   }
 };
 
-
-#ifndef PRODUCT
-
-// Used in debugging code to avoid walking across dead or uninitialized edges.
-inline bool NotANode(const Node* n) {
+inline bool not_a_node(const Node* n) {
   if (n == NULL)                   return true;
   if (((intptr_t)n & 1) != 0)      return true;  // uninitialized, etc.
   if (*(address*)n == badAddress)  return true;  // kill by Node::destruct
   return false;
 }
-
-#endif
-
 
 //-----------------------------------------------------------------------------
 // Iterators over DU info, and associated Node functions.

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/opto/Node.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/opto/Node.java
@@ -152,7 +152,7 @@ public class Node extends VMObject {
         for(int k = 0; k < limit; k++) {
           Node n = d > 0 ? tp.in(k) : tp.rawOut(k);
 
-          // if (NotANode(n))  continue;
+          // if (not_a_node(n))  continue;
           if (n == null) continue;
           // do not recurse through top or the root (would reach unrelated stuff)
           // if (n.isRoot() || n.isTop())  continue;
@@ -254,8 +254,8 @@ public class Node extends VMObject {
       Node u = rawOut(i);
       if (u == null) {
         out.print("_ ");
-      // } else if (NotANode(u)) {
-      //   out.print("NotANode ");
+      // } else if (not_a_node(u)) {
+      //   out.print("not_a_node ");
       } else {
         // out.print("%c%d ", Compile::current()->nodeArena()->contains(u) ? ' ' : 'o', u->_idx);
         out.print(' ');


### PR DESCRIPTION
NotANode(node.hpp) and not_a_node(compile.cpp) are completely repeated guys.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265914](https://bugs.openjdk.java.net/browse/JDK-8265914): Duplicated NotANode and not_a_node


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3715/head:pull/3715` \
`$ git checkout pull/3715`

Update a local copy of the PR: \
`$ git checkout pull/3715` \
`$ git pull https://git.openjdk.java.net/jdk pull/3715/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3715`

View PR using the GUI difftool: \
`$ git pr show -t 3715`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3715.diff">https://git.openjdk.java.net/jdk/pull/3715.diff</a>

</details>
