### PR TITLE
JDK-8258602: JavaDoc field summary does not indicate final modifier

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
@@ -243,6 +243,9 @@ public abstract class AbstractMemberWriter implements MemberSummaryWriter, Membe
         if (utils.isStatic(member)) {
             code.add("static ");
         }
+        if (!utils.isEnum(member) && utils.isFinal(member)) {
+            code.add("final ");
+        }
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/FieldWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/FieldWriter.java
@@ -75,7 +75,7 @@ public interface FieldWriter extends MemberWriter {
      * Adds the preview output for the given member.
      *
      * @param member the member being documented
-     * @param annotationDocTree content tree to which the preview information will be added
+     * @param contentTree content tree to which the preview information will be added
      */
     void addPreview(VariableElement member, Content contentTree);
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -402,6 +402,10 @@ public class Utils {
         return e.getModifiers().contains(Modifier.DEFAULT);
     }
 
+    public boolean isFinal(Element e) {
+        return e.getModifiers().contains(Modifier.FINAL);
+    }
+
     public boolean isPackagePrivate(Element e) {
         return !(isPublic(e) || isPrivate(e) || isProtected(e));
     }

--- a/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFX.java
+++ b/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFX.java
@@ -78,7 +78,7 @@ public class TestJavaFX extends JavadocTester {
                     <dl class="notes">
                     <dt>Property description:</dt>""",
                 """
-                    <div class="col-first odd-row-color"><code><a href="C.DoubleProperty.html" title\
+                    <div class="col-first odd-row-color"><code>final <a href="C.DoubleProperty.html" title\
                     ="class in pkg1">C.DoubleProperty</a></code></div>
                     <div class="col-second odd-row-color"><code><a href="#rateProperty" class="membe\
                     r-name-link">rate</a></code></div>
@@ -181,10 +181,10 @@ public class TestJavaFX extends JavadocTester {
                     <div class="caption"><span>Properties</span></div>
                     <div class="summary-table three-column-summary">""",
                 """
-                    <div class="col-first even-row-color"><code><a href="C.BooleanProperty.html" title="class in pkg1">C.BooleanProperty</a></code></div>
+                    <div class="col-first even-row-color"><code>final <a href="C.BooleanProperty.html" title="class in pkg1">C.BooleanProperty</a></code></div>
                     """,
                 """
-                    <div class="col-first odd-row-color"><code><a href="C.DoubleProperty.html" title="class in pkg1">C.DoubleProperty</a></code></div>
+                    <div class="col-first odd-row-color"><code>final <a href="C.DoubleProperty.html" title="class in pkg1">C.DoubleProperty</a></code></div>
                     """);
 
         checkOutput("pkg1/C.html", false,
@@ -335,16 +335,16 @@ public class TestJavaFX extends JavadocTester {
                     <div class="col-last odd-row-color method-summary-table method-summary-table-tab\
                     2 method-summary-table-tab4">&nbsp;</div>
                     <div class="col-first even-row-color method-summary-table method-summary-table-t\
-                    ab2 method-summary-table-tab4"><code>java.util.List&lt;java.util.Set&lt;? super \
-                    java.lang.Object&gt;&gt;</code></div>
+                    ab2 method-summary-table-tab4"><code>final java.util.List&lt;java.util.Set&lt;? \
+                    super java.lang.Object&gt;&gt;</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
                     tab2 method-summary-table-tab4"><code><a href="#deltaProperty()" class="member-n\
                     ame-link">deltaProperty</a>()</code></div>
                     <div class="col-last even-row-color method-summary-table method-summary-table-ta\
                     b2 method-summary-table-tab4">&nbsp;</div>
                     <div class="col-first odd-row-color method-summary-table method-summary-table-ta\
-                    b2 method-summary-table-tab4"><code>java.util.List&lt;java.lang.String&gt;</code\
-                    ></div>
+                    b2 method-summary-table-tab4"><code>final java.util.List&lt;java.lang.String&gt;\
+                    </code></div>
                     <div class="col-second odd-row-color method-summary-table method-summary-table-t\
                     ab2 method-summary-table-tab4"><code><a href="#gammaProperty()" class="member-na\
                     me-link">gammaProperty</a>()</code></div>

--- a/test/langtools/jdk/javadoc/doclet/testMemberSummary/TestMemberSummary.java
+++ b/test/langtools/jdk/javadoc/doclet/testMemberSummary/TestMemberSummary.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug      4951228 6290760 8025633 8026567 8081854 8162363 8175200 8177417 8186332 8182765
+ *           8258602
  * @summary  Test the case where the overridden method returns a different
  *           type than the method in the child class.  Make sure the
  *           documentation is inherited but the return type isn't.
@@ -79,5 +80,102 @@ public class TestMemberSummary extends JavadocTester {
                     <section class="detail" id="f(T[])">
                     <h3 id="f(java.lang.Object[])">f</h3>
                     """);
+    }
+
+    @Test
+    public void testSummaries() {
+        javadoc("-d", "out-summaries",
+                "-private",
+                "-sourcepath", testSrc,
+                "pkg3");
+        checkExit(Exit.OK);
+        checkOutput("pkg3/Members.html", true,
+                """
+                    <div class="caption"><span>Nested Classes</span></div>
+                    <div class="summary-table three-column-summary">
+                    <div class="table-header col-first">Modifier and Type</div>
+                    <div class="table-header col-second">Class</div>
+                    <div class="table-header col-last">Description</div>
+                    <div class="col-first even-row-color"><code>private static interface&nbsp;</code></div>
+                    <div class="col-second even-row-color"><code><a href="Members.A.html" class="type-name-link" title="annotation interface in pkg3">Members.A</a></code></div>
+                    <div class="col-last even-row-color">&nbsp;</div>
+                    <div class="col-first odd-row-color"><code>private static final class&nbsp;</code></div>
+                    <div class="col-second odd-row-color"><code><a href="Members.C.html" class="type-name-link" title="class in pkg3">Members.C</a></code></div>
+                    <div class="col-last odd-row-color">&nbsp;</div>
+                    <div class="col-first even-row-color"><code>private static class&nbsp;</code></div>
+                    <div class="col-second even-row-color"><code><a href="Members.E.html" class="type-name-link" title="enum class in pkg3">Members.E</a></code></div>
+                    <div class="col-last even-row-color">&nbsp;</div>
+                    <div class="col-first odd-row-color"><code>private static interface&nbsp;</code></div>
+                    <div class="col-second odd-row-color"><code><a href="Members.I.html" class="type-name-link" title="interface in pkg3">Members.I</a></code></div>
+                    <div class="col-last odd-row-color">&nbsp;</div>
+                    <div class="col-first even-row-color"><code>private static final class&nbsp;</code></div>
+                    <div class="col-second even-row-color"><code><a href="Members.R.html" class="type-name-link" title="class in pkg3">Members.R</a></code></div>
+                    <div class="col-last even-row-color">&nbsp;</div>
+                    </div>""",
+                """
+                    <div class="caption"><span>Fields</span></div>
+                    <div class="summary-table three-column-summary">
+                    <div class="table-header col-first">Modifier and Type</div>
+                    <div class="table-header col-second">Field</div>
+                    <div class="table-header col-last">Description</div>
+                    <div class="col-first even-row-color"><code>private static final int</code></div>
+                    <div class="col-second even-row-color"><code><a href="#F" class="member-name-link">F</a></code></div>
+                    <div class="col-last even-row-color">&nbsp;</div>
+                    </div>""",
+                """
+                    <div class="caption"><span>Constructors</span></div>
+                    <div class="summary-table three-column-summary">
+                    <div class="table-header col-first">Modifier</div>
+                    <div class="table-header col-second">Constructor</div>
+                    <div class="table-header col-last">Description</div>
+                    <div class="col-first even-row-color"><code>private </code></div>
+                    <div class="col-constructor-name even-row-color"><code><a href="#%3Cinit%3E()" class="member-name-link">Members</a>()</code></div>
+                    <div class="col-last even-row-color">&nbsp;</div>
+                    </div>
+                    """);
+        checkOutput("pkg3/Members.A.html", true,
+                """
+                    <div class="caption"><span>Required Elements</span></div>
+                    <div class="summary-table three-column-summary">
+                    <div class="table-header col-first">Modifier and Type</div>
+                    <div class="table-header col-second">Required Element</div>
+                    <div class="table-header col-last">Description</div>
+                    <div class="col-first even-row-color"><code>int</code></div>
+                    <div class="col-second even-row-color"><code><a href="#v()" class="member-name-link">v</a></code></div>
+                    <div class="col-last even-row-color">&nbsp;</div>
+                    </div>""",
+                """
+                    <div class="caption"><span>Optional Elements</span></div>
+                    <div class="summary-table three-column-summary">
+                    <div class="table-header col-first">Modifier and Type</div>
+                    <div class="table-header col-second">Optional Element</div>
+                    <div class="table-header col-last">Description</div>
+                    <div class="col-first even-row-color"><code><a href="https://download.java.net/java/early_access/jdk17/docs/api/java.base/java/lang/String.html" title="class or interface in java.lang" class="external-link">String</a></code></div>
+                    <div class="col-second even-row-color"><code><a href="#s()" class="member-name-link">s</a></code></div>
+                    <div class="col-last even-row-color">&nbsp;</div>
+                    </div>
+                    """);
+        checkOutput("pkg3/Members.E.html", true,
+                """
+                    <h2>Enum Constant Summary</h2>
+                    <div class="caption"><span>Enum Constants</span></div>
+                    <div class="summary-table two-column-summary">
+                    <div class="table-header col-first">Enum Constant</div>
+                    <div class="table-header col-last">Description</div>
+                    <div class="col-first even-row-color"><code><a href="#C" class="member-name-link">C</a></code></div>
+                    <div class="col-last even-row-color">&nbsp;</div>
+                    </div>""");
+        checkOutput("pkg3/Members.R.html", true,
+                """
+                    <div class="caption"><span>Fields</span></div>
+                    <div class="summary-table three-column-summary">
+                    <div class="table-header col-first">Modifier and Type</div>
+                    <div class="table-header col-second">Field</div>
+                    <div class="table-header col-last">Description</div>
+                    <div class="col-first even-row-color"><code>private final int</code></div>
+                    <div class="col-second even-row-color"><code><a href="#i" class="member-name-link">i</a></code></div>
+                    <div class="col-last even-row-color">
+                    <div class="block">The field for the <code>i</code> record component.</div>
+                    </div>""");
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testMemberSummary/pkg3/Members.java
+++ b/test/langtools/jdk/javadoc/doclet/testMemberSummary/pkg3/Members.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package pkg3;
+
+/**
+ * Test class for member and nested class summaries
+ */
+public class Members {
+
+    private Members() {}
+
+    private static final int F = 3;
+
+    private static final class C {}
+
+    private static final void M() {}
+
+    private enum E {
+        C;
+    }
+
+    private interface I {
+        default void i() {}
+    }
+
+    private @interface A {
+        int v();
+        String s() default "";
+    }
+
+    private record R(int i) {}
+
+}

--- a/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverrideMethods.java
+++ b/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverrideMethods.java
@@ -347,7 +347,7 @@ public class TestOverrideMethods  extends JavadocTester {
                     <div class="block">This is Base::m5.</div>
                     </div>
                     <div class="col-first odd-row-color method-summary-table method-summary-table-ta\
-                    b2 method-summary-table-tab4"><code>java.lang.Object</code></div>
+                    b2 method-summary-table-tab4"><code>final java.lang.Object</code></div>
                     <div class="col-second odd-row-color method-summary-table method-summary-table-t\
                     ab2 method-summary-table-tab4"><code><a href="#m6()" class="member-name-link">m6\
                     </a>()</code></div>

--- a/test/langtools/jdk/javadoc/doclet/testProperty/TestProperty.java
+++ b/test/langtools/jdk/javadoc/doclet/testProperty/TestProperty.java
@@ -77,9 +77,9 @@ public class TestProperty extends JavadocTester {
 
                 // no tab classes should be used in the property table
                 """
-                    <div class="col-first even-row-color"><code><a href="ObjectProperty.html" title="clas\
-                    s in pkg">ObjectProperty</a>&lt;<a href="MyObj.html" title="class in pkg">MyObj<\
-                    /a>[]&gt;</code></div>
+                    <div class="col-first even-row-color"><code>final <a href="ObjectProperty.html" \
+                    title="class in pkg">ObjectProperty</a>&lt;<a href="MyObj.html" title="class in \
+                    pkg">MyObj</a>[]&gt;</code></div>
                     <div class="col-second even-row-color"><code><a href="#badProperty" class="membe\
                     r-name-link">bad</a></code></div>
                     <div class="col-last even-row-color">""",
@@ -87,9 +87,9 @@ public class TestProperty extends JavadocTester {
                 // tab classes should be used in the method table
                 """
                     <div class="col-first even-row-color method-summary-table method-summary-table-t\
-                    ab2 method-summary-table-tab4"><code><a href="ObjectProperty.html" title="class in pk\
-                    g">ObjectProperty</a>&lt;<a href="MyObj.html" title="class in pkg">MyObj</a>[]&g\
-                    t;</code></div>
+                    ab2 method-summary-table-tab4"><code>final <a href="ObjectProperty.html" title="\
+                    class in pkg">ObjectProperty</a>&lt;<a href="MyObj.html" title="class in pkg">My\
+                    Obj</a>[]&gt;</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
                     tab2 method-summary-table-tab4"><code><a href="#badProperty()" class="member-nam\
                     e-link">badProperty</a>()</code></div>"""


### PR DESCRIPTION
I found that adding the `final` modifier does not add too much visual noise to the documentation. I didn't find any occurrence where there were more than two modifiers on a member summary (usually either `static final` or `protected final`). 

On the other hand, I do think the `final` modifier adds important information about the member. Although this is more true for fields than for other members, for reasons of consistency I decided to show it for all kinds of members except for those where it is not allowed (such as for enums).

To my surprise I also noticed that there weren't any test cases for field summaries, so I added a new test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258602](https://bugs.openjdk.java.net/browse/JDK-8258602): JavaDoc field summary does not indicate final modifier


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3716/head:pull/3716` \
`$ git checkout pull/3716`

Update a local copy of the PR: \
`$ git checkout pull/3716` \
`$ git pull https://git.openjdk.java.net/jdk pull/3716/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3716`

View PR using the GUI difftool: \
`$ git pr show -t 3716`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3716.diff">https://git.openjdk.java.net/jdk/pull/3716.diff</a>

</details>
