### PR TITLE
8266055: ZGC: ZHeap::print_extended_on() doesn't disable deferred delete

### DIFF
--- a/src/hotspot/share/gc/z/zHeap.cpp
+++ b/src/hotspot/share/gc/z/zHeap.cpp
@@ -494,7 +494,7 @@ void ZHeap::print_extended_on(outputStream* st) const {
   }
 
   // Allow pages to be deleted
-  _page_allocator.enable_deferred_delete();
+  _page_allocator.disable_deferred_delete();
 }
 
 bool ZHeap::print_location(outputStream* st, uintptr_t addr) const {


### PR DESCRIPTION
In `ZHeap::print_extended_on()`, the last call to `_page_allocator.enable_deferred_delete()` should be `_page_allocator.disable_deferred_delete()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266055](https://bugs.openjdk.java.net/browse/JDK-8266055): ZGC: ZHeap::print_extended_on() doesn't disable deferred delete


### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3717/head:pull/3717` \
`$ git checkout pull/3717`

Update a local copy of the PR: \
`$ git checkout pull/3717` \
`$ git pull https://git.openjdk.java.net/jdk pull/3717/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3717`

View PR using the GUI difftool: \
`$ git pr show -t 3717`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3717.diff">https://git.openjdk.java.net/jdk/pull/3717.diff</a>

</details>
