### PR TITLE
8255915:  jdk/incubator/vector/AddTest.java timed out

### DIFF
--- a/test/jdk/jdk/incubator/vector/AddTest.java
+++ b/test/jdk/jdk/incubator/vector/AddTest.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @modules jdk.incubator.vector
+ * @requires vm.compiler2.enabled
  */
 
 import jdk.incubator.vector.FloatVector;


### PR DESCRIPTION
Update the test to require C2, since under execution with -Xcomp and C1 only this test can time out.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255915](https://bugs.openjdk.java.net/browse/JDK-8255915): jdk/incubator/vector/AddTest.java timed out


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3718/head:pull/3718` \
`$ git checkout pull/3718`

Update a local copy of the PR: \
`$ git checkout pull/3718` \
`$ git pull https://git.openjdk.java.net/jdk pull/3718/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3718`

View PR using the GUI difftool: \
`$ git pr show -t 3718`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3718.diff">https://git.openjdk.java.net/jdk/pull/3718.diff</a>

</details>
