### PR TITLE
8266013: Unexpected replacement character handling on stateful CharsetEncoder

### DIFF
--- a/src/java.base/share/classes/java/nio/charset/Charset-X-Coder.java.template
+++ b/src/java.base/share/classes/java/nio/charset/Charset-X-Coder.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -141,6 +141,9 @@ public abstract class Charset$Coder$ {
     private final float max$ItypesPerOtype$;
 
     private $replType$ replacement;
+#if[encoder]
+    private char[] replacementChars = new char[] { '\uFFFD' };
+#end[encoder]
     private CodingErrorAction malformedInputAction
         = CodingErrorAction.REPORT;
     private CodingErrorAction unmappableCharacterAction
@@ -300,6 +303,12 @@ public abstract class Charset$Coder$ {
         this.replacement = Arrays.copyOf(newReplacement, newReplacement.$replLength$);
 #end[encoder]
         implReplaceWith(this.replacement);
+#if[encoder]
+        ByteBuffer bb = ByteBuffer.wrap(this.replacement);
+        CharBuffer cb = CharBuffer.wrap(replacementChars);
+        CoderResult cr = checkReplacement(bb, cb);
+        if (!cr.isUnderflow()) replacementChars[0] = '\uFFFD';
+#end[encoder]
         return this;
     }
 
@@ -319,6 +328,24 @@ public abstract class Charset$Coder$ {
 
     private WeakReference<CharsetDecoder> cachedDecoder = null;
 
+    private CoderResult checkReplacement(ByteBuffer bb, CharBuffer cb) {
+        WeakReference<CharsetDecoder> wr = cachedDecoder;
+        CharsetDecoder dec = null;
+        if ((wr == null) || ((dec = wr.get()) == null)) {
+            dec = charset().newDecoder();
+            dec.onMalformedInput(CodingErrorAction.REPORT);
+            dec.onUnmappableCharacter(CodingErrorAction.REPORT);
+            cachedDecoder = new WeakReference<CharsetDecoder>(dec);
+        } else {
+            dec.reset();
+        }
+        if (cb == null) {
+            cb = CharBuffer.allocate((int)(bb.remaining()
+                                     * dec.maxCharsPerByte()));
+        }
+        return dec.decode(bb, cb, true);
+    }
+
     /**
      * Tells whether or not the given byte array is a legal replacement value
      * for this encoder.
@@ -336,20 +363,8 @@ public abstract class Charset$Coder$ {
      *          is a legal replacement value for this encoder
      */
     public boolean isLegalReplacement(byte[] repl) {
-        WeakReference<CharsetDecoder> wr = cachedDecoder;
-        CharsetDecoder dec = null;
-        if ((wr == null) || ((dec = wr.get()) == null)) {
-            dec = charset().newDecoder();
-            dec.onMalformedInput(CodingErrorAction.REPORT);
-            dec.onUnmappableCharacter(CodingErrorAction.REPORT);
-            cachedDecoder = new WeakReference<CharsetDecoder>(dec);
-        } else {
-            dec.reset();
-        }
         ByteBuffer bb = ByteBuffer.wrap(repl);
-        CharBuffer cb = CharBuffer.allocate((int)(bb.remaining()
-                                                  * dec.maxCharsPerByte()));
-        CoderResult cr = dec.decode(bb, cb, true);
+        CoderResult cr = checkReplacement(bb, null);
         return !cr.isError();
     }
 
@@ -611,9 +626,29 @@ public abstract class Charset$Coder$ {
                 return cr;
 
             if (action == CodingErrorAction.REPLACE) {
+#if[encoder]
+                CoderResult crTemp;
+                if (replacementChars[0] == '\uFFFD'
+                    && !unmappableCharacterAction.equals(CodingErrorAction.REPLACE)) {
+                    CodingErrorAction currentAction = unmappableCharacterAction;
+                    onUnmappableCharacter(CodingErrorAction.REPLACE);
+                    crTemp = encodeLoop(CharBuffer.wrap(replacementChars), out);
+                    onUnmappableCharacter(currentAction);
+                } else {
+                    crTemp = encodeLoop(CharBuffer.wrap(replacementChars), out);
+                }
+                if (crTemp.isOverflow()) return crTemp;
+                if (crTemp.isError()) {
+                    if (out.remaining() < replacement.length)
+                        return CoderResult.OVERFLOW;
+                    out.put(replacement);
+                }
+#end[encoder]
+#if[decoder]
                 if (out.remaining() < replacement.$replLength$)
                     return CoderResult.OVERFLOW;
                 out.put(replacement);
+#end[decoder]
             }
 
             if ((action == CodingErrorAction.IGNORE)

--- a/src/java.base/share/classes/java/nio/charset/Charset-X-Coder.java.template
+++ b/src/java.base/share/classes/java/nio/charset/Charset-X-Coder.java.template
@@ -304,10 +304,12 @@ public abstract class Charset$Coder$ {
 #end[encoder]
         implReplaceWith(this.replacement);
 #if[encoder]
-        ByteBuffer bb = ByteBuffer.wrap(this.replacement);
-        CharBuffer cb = CharBuffer.wrap(replacementChars);
-        CoderResult cr = checkReplacement(bb, cb);
-        if (!cr.isUnderflow()) replacementChars[0] = '\uFFFD';
+        if (maxBytesPerChar > 3.0) {
+            ByteBuffer bb = ByteBuffer.wrap(this.replacement);
+            CharBuffer cb = CharBuffer.wrap(replacementChars);
+            CoderResult cr = checkReplacement(bb, cb);
+            if (!cr.isUnderflow()) replacementChars[0] = '\uFFFD';
+        }
 #end[encoder]
         return this;
     }
@@ -627,18 +629,24 @@ public abstract class Charset$Coder$ {
 
             if (action == CodingErrorAction.REPLACE) {
 #if[encoder]
-                CoderResult crTemp;
-                if (replacementChars[0] == '\uFFFD'
-                    && !unmappableCharacterAction.equals(CodingErrorAction.REPLACE)) {
-                    CodingErrorAction currentAction = unmappableCharacterAction;
-                    onUnmappableCharacter(CodingErrorAction.REPLACE);
-                    crTemp = encodeLoop(CharBuffer.wrap(replacementChars), out);
-                    onUnmappableCharacter(currentAction);
+                if (maxBytesPerChar > 3.0) {
+                    CoderResult crTemp;
+                    if (replacementChars[0] == '\uFFFD'
+                        && !unmappableCharacterAction.equals(CodingErrorAction.REPLACE)) {
+                        CodingErrorAction currentAction = unmappableCharacterAction;
+                        onUnmappableCharacter(CodingErrorAction.REPLACE);
+                        crTemp = encodeLoop(CharBuffer.wrap(replacementChars), out);
+                        onUnmappableCharacter(currentAction);
+                    } else {
+                        crTemp = encodeLoop(CharBuffer.wrap(replacementChars), out);
+                    }
+                    if (crTemp.isOverflow()) return crTemp;
+                    if (crTemp.isError()) {
+                        if (out.remaining() < replacement.length)
+                            return CoderResult.OVERFLOW;
+                        out.put(replacement);
+                    }
                 } else {
-                    crTemp = encodeLoop(CharBuffer.wrap(replacementChars), out);
-                }
-                if (crTemp.isOverflow()) return crTemp;
-                if (crTemp.isError()) {
                     if (out.remaining() < replacement.length)
                         return CoderResult.OVERFLOW;
                     out.put(replacement);

--- a/src/java.base/share/classes/sun/nio/cs/DoubleByte.java
+++ b/src/java.base/share/classes/sun/nio/cs/DoubleByte.java
@@ -1004,9 +1004,27 @@ public class DoubleByte {
                         Character.isLowSurrogate(src[sp])) {
                         sp++;
                     }
-                    dst[dp++] = repl[0];
-                    if (repl.length > 1)
+                    if (repl.length == 1) {
+                        if (currentState == DBCS) {
+                            currentState = SBCS;
+                            dst[dp++] = SI;
+                        }
+                        dst[dp++] = repl[0];
+                    } else if (repl.length == 4) {
+                        if (currentState == SBCS) {
+                            currentState = DBCS;
+                            dst[dp++] = SO;
+                        }
                         dst[dp++] = repl[1];
+                        dst[dp++] = repl[2];
+                    } else {
+                        if (currentState == SBCS) {
+                            currentState = DBCS;
+                            dst[dp++] = SO;
+                        }
+                        dst[dp++] = repl[0];
+                        dst[dp++] = repl[1];
+                    }
                     continue;
                 } //else
                 if (bb > MAX_SINGLEBYTE) {           // DoubleByte
@@ -1041,9 +1059,27 @@ public class DoubleByte {
                 int bb = encodeChar(c);
                 if (bb == UNMAPPABLE_ENCODING) {
                     // no surrogate pair in latin1 string
-                    dst[dp++] = repl[0];
-                    if (repl.length > 1)
+                    if (repl.length == 1) {
+                        if (currentState == DBCS) {
+                            currentState = SBCS;
+                            dst[dp++] = SI;
+                        }
+                        dst[dp++] = repl[0];
+                    } else if (repl.length == 4) {
+                        if (currentState == SBCS) {
+                            currentState = DBCS;
+                            dst[dp++] = SO;
+                        }
                         dst[dp++] = repl[1];
+                        dst[dp++] = repl[2];
+                    } else {
+                        if (currentState == SBCS) {
+                            currentState = DBCS;
+                            dst[dp++] = SO;
+                        }
+                        dst[dp++] = repl[0];
+                        dst[dp++] = repl[1];
+                    }
                     continue;
                 } //else
                 if (bb > MAX_SINGLEBYTE) {           // DoubleByte
@@ -1080,9 +1116,27 @@ public class DoubleByte {
                         Character.isLowSurrogate(StringUTF16.getChar(src, sp))) {
                         sp++;
                     }
-                    dst[dp++] = repl[0];
-                    if (repl.length > 1)
+                    if (repl.length == 1) {
+                        if (currentState == DBCS) {
+                            currentState = SBCS;
+                            dst[dp++] = SI;
+                        }
+                        dst[dp++] = repl[0];
+                    } else if (repl.length == 4) {
+                        if (currentState == SBCS) {
+                            currentState = DBCS;
+                            dst[dp++] = SO;
+                        }
                         dst[dp++] = repl[1];
+                        dst[dp++] = repl[2];
+                    } else {
+                        if (currentState == SBCS) {
+                            currentState = DBCS;
+                            dst[dp++] = SO;
+                        }
+                        dst[dp++] = repl[0];
+                        dst[dp++] = repl[1];
+                    }
                     continue;
                 } //else
                 if (bb > MAX_SINGLEBYTE) {           // DoubleByte

--- a/test/jdk/sun/nio/cs/StatefulEncoder.java
+++ b/test/jdk/sun/nio/cs/StatefulEncoder.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 8266013
+   @summary Checks stateful encoder's replacement logic
+*/
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.CoderResult;
+import java.util.Arrays;
+import java.io.UnsupportedEncodingException;
+
+public class StatefulEncoder {
+    static int errCnt = 0;
+    final static String bugID = "8266013";
+
+    private static void checkGetBytes(Charset cs, char[] chsA, char[] chsB) {
+        byte[] a = (new String(chsA)).getBytes(cs);
+        byte[] b = (new String(chsB)).getBytes(cs);
+        if (!Arrays.equals(a, b)) {
+            errCnt++;
+            System.err.print("getBytes: "+cs.name()+": ");
+            for (byte b1 : a) System.err.printf("\\x%02X", (int)b1&0xFF);
+            System.err.print("<->");
+            for (byte b1 : b) System.err.printf("\\x%02X", (int)b1&0xFF);
+            System.err.println();
+        }
+    }
+
+    private static void checkGetBytes1(Charset cs, char[] chsA, char[] chsB) {
+        String csName = cs.name();
+        try {
+            byte[] a = (new String(chsA)).getBytes(csName);
+            byte[] b = (new String(chsB)).getBytes(csName);
+            if (!Arrays.equals(a, b)) {
+                errCnt++;
+                System.err.print("getBytes1:"+csName+": ");
+                for (byte b1 : a) System.err.printf("\\x%02X", (int)b1&0xFF);
+                System.err.print("<->");
+                for (byte b1 : b) System.err.printf("\\x%02X", (int)b1&0xFF);
+                System.err.println();
+            }
+        } catch (UnsupportedEncodingException uee) {
+            new Error(uee);
+        }
+    }
+
+    private static void checkEncode(Charset cs, char[] chsA, char[] chsB) {
+        CharsetEncoder ce = cs.newEncoder()
+                              .onMalformedInput(CodingErrorAction.REPLACE)
+                              .onUnmappableCharacter(CodingErrorAction.REPLACE);
+        try {
+            ce.reset();
+            ByteBuffer bbA = ce.encode(CharBuffer.wrap(chsA));
+            byte[] a = Arrays.copyOf(bbA.array(), bbA.limit());
+            ce.reset();
+            ByteBuffer bbB = ce.encode(CharBuffer.wrap(chsB));
+            byte[] b = Arrays.copyOf(bbB.array(), bbB.limit());
+            if (!Arrays.equals(a, b)) {
+                errCnt++;
+                System.err.print("encode:   "+cs.name()+": ");
+                for (byte b1 : a) System.err.printf("\\x%02X", (int)b1&0xFF);
+                System.err.print("<->");
+                for (byte b1 : b) System.err.printf("\\x%02X", (int)b1&0xFF);
+                System.err.println();
+            }
+        } catch (CharacterCodingException cce) {
+            errCnt++;
+            System.err.println(cce);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        for (Charset cs : Charset.availableCharsets().values()) {
+            if (cs.canEncode()) {
+                CharsetEncoder ce = cs.newEncoder();
+                if (ce.canEncode(' ') && ce.canEncode('\u3000')) {
+                    byte[] repl = ce.replacement();
+                    String replStr = new String(repl, cs);
+                    char[] replChsA = new char[2];
+                    char[] replChsB = new char[2];
+                    replChsA[1] = '\uD800';
+                    replChsB[1] = replStr.length() > 1 ? '\uFFFD' : replStr.charAt(0);
+                    replChsA[0] = ' ';
+                    replChsB[0] = ' ';
+                    checkGetBytes(cs, replChsA, replChsB);
+                    checkGetBytes1(cs, replChsA, replChsB);
+                    checkEncode(cs, replChsA, replChsB);
+                    replChsA[0] = '\u3000';
+                    replChsB[0] = '\u3000';
+                    checkGetBytes(cs, replChsA, replChsB);
+                    checkGetBytes1(cs, replChsA, replChsB);
+                    checkEncode(cs, replChsA, replChsB);
+                }
+            }
+        }
+        if (errCnt > 0)
+            throw new Exception("failure of test for bug " + bugID);
+
+    }
+}


### PR DESCRIPTION
When an invalid character is converted by getBytes() method, the character is converted to replacement byte data.
Shift code (SO/SI) may not be added into right place by EBCDIC Mix charset.
EBCDIC Mix charset encoder is stateful encoder.
Shift code should be added by switching character set.
On x-IBM1364, "\u3000\uD800" should be converted to "\x0E\x40\x40\x0F\x6F", but "\x0E\x40\x40\x6F\x0F"
SI is not in right place.

Also ISO2022 related charsets use escape sequence to switch character set.
But same kind of issue is there.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8266013](https://bugs.openjdk.java.net/browse/JDK-8266013): Unexpected replacement character handling on stateful CharsetEncoder


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3719/head:pull/3719` \
`$ git checkout pull/3719`

Update a local copy of the PR: \
`$ git checkout pull/3719` \
`$ git pull https://git.openjdk.java.net/jdk pull/3719/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3719`

View PR using the GUI difftool: \
`$ git pr show -t 3719`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3719.diff">https://git.openjdk.java.net/jdk/pull/3719.diff</a>

</details>
