### PR TITLE
8265933: Move Java monitor related fields from class Thread to JavaThread

### DIFF
--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -263,9 +263,6 @@ Thread::Thread() {
   NOT_PRODUCT(_skip_gcalot = false;)
   _jvmti_env_iteration_count = 0;
   set_allocated_bytes(0);
-  _current_pending_monitor = NULL;
-  _current_pending_monitor_is_from_java = true;
-  _current_waiting_monitor = NULL;
   _current_pending_raw_monitor = NULL;
 
   _suspend_flags = 0;
@@ -275,10 +272,6 @@ Thread::Thread() {
   _hashStateY = 842502087;
   _hashStateZ = 0x8767;    // (int)(3579807591LL & 0xffff) ;
   _hashStateW = 273326509;
-
-  _OnTrap   = 0;
-  _Stalled  = 0;
-  _TypeTag  = 0x2BAD;
 
   // Many of the following fields are effectively final - immutable
   // Note that nascent threads can't use the Native Monitor-Mutex
@@ -1052,6 +1045,11 @@ JavaThread::JavaThread() :
   _callee_target(nullptr),
   _vm_result(nullptr),
   _vm_result_2(nullptr),
+
+  _current_pending_monitor(NULL),
+  _current_pending_monitor_is_from_java(true),
+  _current_waiting_monitor(NULL),
+  _Stalled(0),
 
   _monitor_chunks(nullptr),
   _special_runtime_exit_condition(_no_async_condition),

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -308,16 +308,8 @@ class Thread: public ThreadShadow {
 
   JFR_ONLY(DEFINE_THREAD_LOCAL_FIELD_JFR;)      // Thread-local data for jfr
 
-  ObjectMonitor* _current_pending_monitor;      // ObjectMonitor this thread
-                                                // is waiting to lock
-  bool _current_pending_monitor_is_from_java;   // locking is from Java code
   JvmtiRawMonitor* _current_pending_raw_monitor; // JvmtiRawMonitor this thread
                                                  // is waiting to lock
-
-
-  // ObjectMonitor on which this thread called Object.wait()
-  ObjectMonitor* _current_waiting_monitor;
-
  public:
   enum {
     is_definitely_current_thread = true
@@ -493,28 +485,6 @@ class Thread: public ThreadShadow {
   bool is_trace_suspend()               { return (_suspend_flags & _trace_flag) != 0; }
 
   bool is_obj_deopt_suspend()           { return (_suspend_flags & _obj_deopt) != 0; }
-
-  // For tracking the heavyweight monitor the thread is pending on.
-  ObjectMonitor* current_pending_monitor() {
-    return _current_pending_monitor;
-  }
-  void set_current_pending_monitor(ObjectMonitor* monitor) {
-    _current_pending_monitor = monitor;
-  }
-  void set_current_pending_monitor_is_from_java(bool from_java) {
-    _current_pending_monitor_is_from_java = from_java;
-  }
-  bool current_pending_monitor_is_from_java() {
-    return _current_pending_monitor_is_from_java;
-  }
-
-  // For tracking the ObjectMonitor on which this thread called Object.wait()
-  ObjectMonitor* current_waiting_monitor() {
-    return _current_waiting_monitor;
-  }
-  void set_current_waiting_monitor(ObjectMonitor* monitor) {
-    _current_waiting_monitor = monitor;
-  }
 
   // For tracking the Jvmti raw monitor the thread is pending on.
   JvmtiRawMonitor* current_pending_raw_monitor() {
@@ -693,8 +663,6 @@ protected:
   JFR_ONLY(DEFINE_THREAD_LOCAL_OFFSET_JFR;)
 
  public:
-  volatile intptr_t _Stalled;
-  volatile int _TypeTag;
   ParkEvent * volatile _ParkEvent;            // for Object monitors, JVMTI raw monitors,
                                               // and ObjectSynchronizer::read_stable_mark
 
@@ -703,7 +671,6 @@ protected:
   // (which can't itself be read from the signal handler if a signal hits during the Thread destructor).
   bool has_terminated()                       { return Atomic::load(&_ParkEvent) == NULL; };
 
-  volatile int _OnTrap;                       // Resume-at IP delta
   jint _hashStateW;                           // Marsaglia Shift-XOR thread-local RNG
   jint _hashStateX;                           // thread-specific hashCode generator state
   jint _hashStateY;
@@ -821,9 +788,36 @@ class JavaThread: public Thread {
   // elided card-marks for performance along the fast-path.
   MemRegion     _deferred_card_mark;
 
-  MonitorChunk* _monitor_chunks;                 // Contains the off stack monitors
-                                                 // allocated during deoptimization
-                                                 // and by JNI_MonitorEnter/Exit
+  ObjectMonitor* _current_pending_monitor;              // ObjectMonitor this thread is waiting to lock
+  bool           _current_pending_monitor_is_from_java; // locking is from Java code
+  ObjectMonitor* _current_waiting_monitor;              // ObjectMonitor on which this thread called Object.wait()
+ public:
+  volatile intptr_t _Stalled;
+
+  // For tracking the heavyweight monitor the thread is pending on.
+  ObjectMonitor* current_pending_monitor() {
+    return _current_pending_monitor;
+  }
+  void set_current_pending_monitor(ObjectMonitor* monitor) {
+    _current_pending_monitor = monitor;
+  }
+  void set_current_pending_monitor_is_from_java(bool from_java) {
+    _current_pending_monitor_is_from_java = from_java;
+  }
+  bool current_pending_monitor_is_from_java() {
+    return _current_pending_monitor_is_from_java;
+  }
+  ObjectMonitor* current_waiting_monitor() {
+    return _current_waiting_monitor;
+  }
+  void set_current_waiting_monitor(ObjectMonitor* monitor) {
+    _current_waiting_monitor = monitor;
+  }
+
+ private:
+  MonitorChunk* _monitor_chunks;              // Contains the off stack monitors
+                                              // allocated during deoptimization
+                                              // and by JNI_MonitorEnter/Exit
 
   // Async. requests support
   enum AsyncRequests {

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -734,15 +734,15 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
   nonstatic_field(Thread,                      _active_handles,                               JNIHandleBlock*)                       \
   nonstatic_field(Thread,                      _tlab,                                         ThreadLocalAllocBuffer)                \
   nonstatic_field(Thread,                      _allocated_bytes,                              jlong)                                 \
-  nonstatic_field(Thread,                      _current_pending_monitor,                      ObjectMonitor*)                        \
-  nonstatic_field(Thread,                      _current_pending_monitor_is_from_java,         bool)                                  \
-  nonstatic_field(Thread,                      _current_waiting_monitor,                      ObjectMonitor*)                        \
   nonstatic_field(NamedThread,                 _name,                                         char*)                                 \
   nonstatic_field(NamedThread,                 _processed_thread,                             Thread*)                               \
   nonstatic_field(JavaThread,                  _threadObj,                                    OopHandle)                             \
   nonstatic_field(JavaThread,                  _anchor,                                       JavaFrameAnchor)                       \
   nonstatic_field(JavaThread,                  _vm_result,                                    oop)                                   \
   nonstatic_field(JavaThread,                  _vm_result_2,                                  Metadata*)                             \
+  nonstatic_field(JavaThread,                  _current_pending_monitor,                      ObjectMonitor*)                        \
+  nonstatic_field(JavaThread,                  _current_pending_monitor_is_from_java,         bool)                                  \
+  nonstatic_field(JavaThread,                  _current_waiting_monitor,                      ObjectMonitor*)                        \
   nonstatic_field(JavaThread,                  _pending_async_exception,                      oop)                                   \
   volatile_nonstatic_field(JavaThread,         _exception_oop,                                oop)                                   \
   volatile_nonstatic_field(JavaThread,         _exception_pc,                                 address)                               \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Thread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Thread.java
@@ -52,16 +52,17 @@ public class Thread extends VMObject {
   }
 
   private static synchronized void initialize(TypeDataBase db) {
-    Type type = db.lookupType("Thread");
+    Type typeThread = db.lookupType("Thread");
+    Type typeJavaThread = db.lookupType("JavaThread");
 
-    suspendFlagsField = type.getCIntegerField("_suspend_flags");
+    suspendFlagsField = typeThread.getCIntegerField("_suspend_flags");
     HAS_ASYNC_EXCEPTION = db.lookupIntConstant("Thread::_has_async_exception").intValue();
 
-    tlabFieldOffset    = type.getField("_tlab").getOffset();
-    activeHandlesField = type.getAddressField("_active_handles");
-    currentPendingMonitorField = type.getAddressField("_current_pending_monitor");
-    currentWaitingMonitorField = type.getAddressField("_current_waiting_monitor");
-    allocatedBytesField = type.getJLongField("_allocated_bytes");
+    tlabFieldOffset    = typeThread.getField("_tlab").getOffset();
+    activeHandlesField = typeThread.getAddressField("_active_handles");
+    currentPendingMonitorField = typeJavaThread.getAddressField("_current_pending_monitor");
+    currentWaitingMonitorField = typeJavaThread.getAddressField("_current_waiting_monitor");
+    allocatedBytesField = typeThread.getJLongField("_allocated_bytes");
   }
 
   public Thread(Address addr) {


### PR DESCRIPTION
Hi,

Please review the following change. Fields in class Thread related to Java object monitors like _current_pending_monitor, _current_pending_monitor_is_from_java, _current_waiting_monitor and _Stalled should be moved to the JavaThread class. Members _OnTrap and _TypeTag were grouped together with _Stalled but are not used so I removed them. It seems they were part of the ObjectMonitor implementation at some point but I couldn't find how they were used.
Tested in mach5 tier1-2.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265933](https://bugs.openjdk.java.net/browse/JDK-8265933): Move Java monitor related fields from class Thread to JavaThread


### Reviewers
 * [Robbin Ehn](https://openjdk.java.net/census#rehn) (@robehn - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3722/head:pull/3722` \
`$ git checkout pull/3722`

Update a local copy of the PR: \
`$ git checkout pull/3722` \
`$ git pull https://git.openjdk.java.net/jdk pull/3722/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3722`

View PR using the GUI difftool: \
`$ git pr show -t 3722`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3722.diff">https://git.openjdk.java.net/jdk/pull/3722.diff</a>

</details>
