### PR TITLE
JDK-8263396: Atomic::CmpxchgByteUsingInt::set_byte_in_int needs an explicit cast

### DIFF
--- a/src/hotspot/share/runtime/atomic.hpp
+++ b/src/hotspot/share/runtime/atomic.hpp
@@ -818,7 +818,8 @@ inline uint32_t Atomic::CmpxchgByteUsingInt::set_byte_in_int(uint32_t n,
                                                              uint8_t b,
                                                              uint32_t idx) {
   int bitsIdx = BitsPerByte * idx;
-  return (n & ~(0xff << bitsIdx)) | (b << bitsIdx);
+  return (n & ~(static_cast<uint32_t>(0xff) << bitsIdx))
+          | (static_cast<uint32_t>(b) << bitsIdx);
 }
 
 inline uint8_t Atomic::CmpxchgByteUsingInt::get_byte_in_int(uint32_t n,


### PR DESCRIPTION
Hi,

please review this PR to fix a problem found by SonarCloud. I think it's best to fix it to avoid confusion.

As required by the standard, operands of arithmetical operators are implicitly promoted to at least int. Code being fixed assumes int to be at least 32 bits and all implicit promotions are performed to at least 32 bits.  It's not a problem with any of the platforms supported by OpenJDK but it won't work correctly on platforms and compilers with 16 bit ints: shift operators will use 16 bit integer and anything shifted to bits 16:31 will be lost.

Testing: original case with gcc bug on Arm 32 is not reproduced, pre-submit tests were run.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263396](https://bugs.openjdk.java.net/browse/JDK-8263396): Atomic::CmpxchgByteUsingInt::set_byte_in_int needs an explicit cast


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3723/head:pull/3723` \
`$ git checkout pull/3723`

Update a local copy of the PR: \
`$ git checkout pull/3723` \
`$ git pull https://git.openjdk.java.net/jdk pull/3723/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3723`

View PR using the GUI difftool: \
`$ git pr show -t 3723`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3723.diff">https://git.openjdk.java.net/jdk/pull/3723.diff</a>

</details>
