### PR TITLE
8266078: Reader.read(CharBuffer) advances Reader position for read-only Charbuffers

### DIFF
--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -185,6 +185,9 @@ public abstract class Reader implements Readable, Closeable {
      * @since 1.5
      */
     public int read(CharBuffer target) throws IOException {
+        if (target.isReadOnly())
+            throw new ReadOnlyBufferException();
+
         int nread;
         if (target.hasArray()) {
             char[] cbuf = target.array();
@@ -197,10 +200,10 @@ public abstract class Reader implements Readable, Closeable {
             if (nread > 0)
                 target.position(pos + nread);
         } else {
-            if (target.isReadOnly())
-                throw new ReadOnlyBufferException();
             int len = target.remaining();
             char[] cbuf = new char[len];
+            // If a read-only check had not been done above, then
+            // the stream would be incorrectly advanced here.
             nread = read(cbuf, 0, len);
             if (nread > 0)
                 target.put(cbuf, 0, nread);

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -27,6 +27,7 @@ package java.io;
 
 
 import java.nio.CharBuffer;
+import java.nio.ReadOnlyBufferException;
 import java.util.Objects;
 
 /**
@@ -196,6 +197,8 @@ public abstract class Reader implements Readable, Closeable {
             if (nread > 0)
                 target.position(pos + nread);
         } else {
+            if (target.isReadOnly())
+                throw new ReadOnlyBufferException();
             int len = target.remaining();
             char[] cbuf = new char[len];
             nread = read(cbuf, 0, len);

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -202,8 +202,6 @@ public abstract class Reader implements Readable, Closeable {
         } else {
             int len = target.remaining();
             char[] cbuf = new char[len];
-            // If a read-only check had not been done above, then
-            // the stream would be incorrectly advanced here.
             nread = read(cbuf, 0, len);
             if (nread > 0)
                 target.put(cbuf, 0, nread);

--- a/test/jdk/java/io/Reader/ReadIntoReadOnlyBuffer.java
+++ b/test/jdk/java/io/Reader/ReadIntoReadOnlyBuffer.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.ReadOnlyBufferException;
+
+/*
+ * @test
+ * @bug 8266078
+ * @summary Tests that attempting to read into a read-only CharBuffer
+ *          does not advance the Reader position
+ * @run main ReadIntoReadOnlyBuffer
+ */
+public class ReadIntoReadOnlyBuffer {
+    private static final String THE_STRING = "123";
+    public static void main(String[] args) throws Exception {
+        CharBuffer buf = CharBuffer.allocate(8).asReadOnlyBuffer();
+        StringReader r = new StringReader(THE_STRING);
+        read(r, buf);
+        buf = ByteBuffer.allocateDirect(16).asCharBuffer().asReadOnlyBuffer();
+        r = new StringReader(THE_STRING);
+        read(r, buf);
+    }
+
+    private static void read(Reader r, CharBuffer b) throws IOException {
+        try {
+            r.read(b);
+            throw new RuntimeException();
+        } catch (ReadOnlyBufferException expected) {
+        }
+
+        char[] c = new char[3];
+        int n = r.read(c);
+        if (n != c.length) {
+            throw new RuntimeException("Expected " + c.length + ", got " + n);
+        }
+
+        String s = new String(c);
+        if (!s.equals(THE_STRING)) {
+            throw new RuntimeException("Expected " + THE_STRING + ", got " + s);
+        }
+    }
+}

--- a/test/jdk/java/io/Reader/ReadIntoReadOnlyBuffer.java
+++ b/test/jdk/java/io/Reader/ReadIntoReadOnlyBuffer.java
@@ -49,7 +49,7 @@ public class ReadIntoReadOnlyBuffer {
     private static void read(Reader r, CharBuffer b) throws IOException {
         try {
             r.read(b);
-            throw new RuntimeException();
+            throw new RuntimeException("ReadOnlyBufferException expected");
         } catch (ReadOnlyBufferException expected) {
         }
 


### PR DESCRIPTION
Please consider this request to modify `Reader.read(CharBuffer)` to check whether the buffer is read-only before reading any characters from the character stream. This can happen now if the buffer is read-only. Character are first read thereby advancing the stream before an attempt is made to put them in the `CharBuffer` thus incorrectly advancing the stream position.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266078](https://bugs.openjdk.java.net/browse/JDK-8266078): Reader.read(CharBuffer) advances Reader position for read-only Charbuffers


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to 4a899b268135f2fa113125057df23f80d10a6f61
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to 4a899b268135f2fa113125057df23f80d10a6f61
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3725/head:pull/3725` \
`$ git checkout pull/3725`

Update a local copy of the PR: \
`$ git checkout pull/3725` \
`$ git pull https://git.openjdk.java.net/jdk pull/3725/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3725`

View PR using the GUI difftool: \
`$ git pr show -t 3725`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3725.diff">https://git.openjdk.java.net/jdk/pull/3725.diff</a>

</details>
