### PR TITLE
8266088: compiler/arguments/TestPrintOptoAssemblyLineNumbers test should user driver mode

### DIFF
--- a/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
@@ -28,9 +28,9 @@
  *
  * @requires vm.compiler2.enabled & vm.debug == true
  *
- * @library /compiler/patches /test/lib
- * @run main/othervm compiler.arguments.TestPrintOptoAssemblyLineNumbers
-*/
+ * @library /test/lib
+ * @run driver compiler.arguments.TestPrintOptoAssemblyLineNumbers
+ */
 
 package compiler.arguments;
 
@@ -41,31 +41,31 @@ import jdk.test.lib.process.ProcessTools;
 public class TestPrintOptoAssemblyLineNumbers {
     public static void main(String[] args) throws Throwable {
         // create subprocess to run some code with -XX:+PrintOptoAssembly enabled
-        String[] procArgs = new String[]{
+        String[] procArgs = new String[] {
             "-XX:+UnlockDiagnosticVMOptions",
             "-XX:-TieredCompilation",
             "-XX:+PrintOptoAssembly",
-            "compiler.arguments.TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly"
-            };
+            CheckC2OptoAssembly.class.getName()
+        };
 
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(procArgs);
         String output = new OutputAnalyzer(pb.start()).getOutput();
 
-        if(output.contains("TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly::main @ bci:11")){
+        if (output.contains("TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly::main @ bci:11")){
             // if C2 optimizer invoked ensure output includes line numbers:
             Asserts.assertTrue(output.contains("TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly::main @ bci:11 (line 68)"));
         }
     }
 
-    public static class CheckC2OptoAssembly{ // contents of this class serves to just invoke C2
-        public static boolean foo(String arg){
+    public static class CheckC2OptoAssembly { // contents of this class serves to just invoke C2
+        public static boolean foo(String arg) {
             return arg.contains("45");
         }
 
-        public static void main(String[] args){
+        public static void main(String[] args) {
             int count = 0;
-            for(int x = 0; x < 200_000; x++){
-                if(foo("something" + x)){ // <- test expects this line of code to be on line 68
+            for (int x = 0; x < 200_000; x++){
+                if (foo("something" + x)) { // <- test expects this line of code to be on line 68
                     count += 1;
                 }
             }

--- a/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
@@ -66,7 +66,7 @@ public class TestPrintOptoAssemblyLineNumbers {
 
         public static void main(String[] args) {
             int count = 0;
-            for (int x = 0; x < 200_000; x++){
+            for (int x = 0; x < 200_000; x++) {
                 if (foo("something" + x)) { // <- test expects this line of code to be on line 68
                     count += 1;
                 }

--- a/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
@@ -51,7 +51,7 @@ public class TestPrintOptoAssemblyLineNumbers {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(procArgs);
         String output = new OutputAnalyzer(pb.start()).getOutput();
 
-        if (output.contains("TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly::main @ bci:11")){
+        if (output.contains("TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly::main @ bci:11")) {
             // if C2 optimizer invoked ensure output includes line numbers:
             Asserts.assertTrue(output.contains("TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly::main @ bci:11 (line 68)"));
         }

--- a/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
@@ -34,7 +34,6 @@
 
 package compiler.arguments;
 
-import jdk.test.lib.Asserts;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
@@ -49,11 +48,12 @@ public class TestPrintOptoAssemblyLineNumbers {
         };
 
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(procArgs);
-        String output = new OutputAnalyzer(pb.start()).getOutput();
+        OutputAnalyzer oa = new OutputAnalyzer(pb.start());
+        oa.shouldHaveExitValue(0);
 
-        if (output.contains("TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly::main @ bci:11")) {
+        if (oa.getOutput().contains("TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly::main @ bci:11")) {
             // if C2 optimizer invoked ensure output includes line numbers:
-            Asserts.assertTrue(output.contains("TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly::main @ bci:11 (line 68)"));
+            oa.stdoutShouldContain("TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly::main @ bci:11 (line 68)");
         }
     }
 

--- a/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
@@ -37,6 +37,8 @@ package compiler.arguments;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
+//    THIS TEST IS LINE NUMBER SENSITIVE
+
 public class TestPrintOptoAssemblyLineNumbers {
     public static void main(String[] args) throws Throwable {
         // create subprocess to run some code with -XX:+PrintOptoAssembly enabled
@@ -53,7 +55,7 @@ public class TestPrintOptoAssemblyLineNumbers {
 
         if (oa.getOutput().contains("TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly::main @ bci:11")) {
             // if C2 optimizer invoked ensure output includes line numbers:
-            oa.stdoutShouldContain("TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly::main @ bci:11 (line 68)");
+            oa.stdoutShouldContain("TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly::main @ bci:11 (line 70)");
         }
     }
 

--- a/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
@@ -56,7 +56,7 @@ public class TestPrintOptoAssemblyLineNumbers {
 
         if (oa.getOutput().contains("TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly::main @ bci:11")) {
             // if C2 optimizer invoked ensure output includes line numbers:
-            oa.stdoutShouldContain("TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly::main @ bci:11 (line 70)");
+            oa.stdoutShouldContain("TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly::main @ bci:11 (line 71)");
         }
     }
 
@@ -68,7 +68,7 @@ public class TestPrintOptoAssemblyLineNumbers {
         public static void main(String[] args) {
             int count = 0;
             for (int x = 0; x < 200_000; x++) {
-                if (foo("something" + x)) { // <- test expects this line of code to be on line 68
+                if (foo("something" + x)) { // <- test expects this line of code to be on line 71
                     count += 1;
                 }
             }


### PR DESCRIPTION
Hi all,

could you please review this tiny patch for `TestPrintOptoAssemblyLineNumbers` test? 
from JBS:
> compiler/arguments/TestPrintOptoAssemblyLineNumbers class is a driver class that spawns a new JVM and validates its output, there is no need for the JVM which executes TestPrintOptoAssemblyLineNumbers to be run w/ all vm flags.

besides addressing this, the patch also removes `/compiler/patches` from `@library` as it's not needed and fixes code style here and there.

testing:
- [x] `compiler/arguments/TestPrintOptoAssemblyLineNumbers` on `{linux,windows,macosx}-x64-debug`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266088](https://bugs.openjdk.java.net/browse/JDK-8266088): compiler/arguments/TestPrintOptoAssemblyLineNumbers test should user driver mode


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3726/head:pull/3726` \
`$ git checkout pull/3726`

Update a local copy of the PR: \
`$ git checkout pull/3726` \
`$ git pull https://git.openjdk.java.net/jdk pull/3726/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3726`

View PR using the GUI difftool: \
`$ git pr show -t 3726`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3726.diff">https://git.openjdk.java.net/jdk/pull/3726.diff</a>

</details>
