### PR TITLE
8266074: Vtable-based CHA implementation

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -2026,7 +2026,7 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
       // by dynamic class loading.  Be sure to test the "static" receiver
       // dest_method here, as opposed to the actual receiver, which may
       // falsely lead us to believe that the receiver is final or private.
-      dependency_recorder()->assert_unique_concrete_method(actual_recv, cha_monomorphic_target);
+      dependency_recorder()->assert_unique_concrete_method(actual_recv, cha_monomorphic_target, callee_holder, target);
     }
     code = Bytecodes::_invokespecial;
   }

--- a/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
@@ -346,6 +346,9 @@ void BCEscapeAnalyzer::invoke(StateInfo &state, Bytecodes::Code code, ciMethod* 
           (code == Bytecodes::_invokevirtual && !target->is_final_method())) {
         _dependencies.append(actual_recv);
         _dependencies.append(inline_target);
+        _dependencies.append(callee_holder);
+        _dependencies.append(target);
+        assert(callee_holder->is_interface() == (code == Bytecodes::_invokeinterface), "sanity");
       }
       _dependencies.appendAll(analyzer.dependencies());
     }
@@ -1495,9 +1498,11 @@ void BCEscapeAnalyzer::copy_dependencies(Dependencies *deps) {
     // callee will trigger recompilation.
     deps->assert_evol_method(method());
   }
-  for (int i = 0; i < _dependencies.length(); i+=2) {
-    ciKlass *k = _dependencies.at(i)->as_klass();
-    ciMethod *m = _dependencies.at(i+1)->as_method();
-    deps->assert_unique_concrete_method(k, m);
+  for (int i = 0; i < _dependencies.length(); i+=4) {
+    ciKlass*  recv_klass      = _dependencies.at(i+0)->as_klass();
+    ciMethod* target          = _dependencies.at(i+1)->as_method();
+    ciKlass*  resolved_klass  = _dependencies.at(i+2)->as_klass();
+    ciMethod* resolved_method = _dependencies.at(i+3)->as_method();
+    deps->assert_unique_concrete_method(recv_klass, target, resolved_klass, resolved_method);
   }
 }

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -712,10 +712,14 @@ ciMethod* ciMethod::find_monomorphic_target(ciInstanceKlass* caller,
   {
     MutexLocker locker(Compile_lock);
     InstanceKlass* context = actual_recv->get_instanceKlass();
-    target = methodHandle(THREAD, Dependencies::find_unique_concrete_method(context,
-                                                                            root_m->get_Method(),
-                                                                            callee_holder->get_Klass(),
-                                                                            this->get_Method()));
+    if (UseVtableBasedCHA) {
+      target = methodHandle(THREAD, Dependencies::find_unique_concrete_method(context,
+                                                                              root_m->get_Method(),
+                                                                              callee_holder->get_Klass(),
+                                                                              this->get_Method()));
+    } else {
+      target = methodHandle(THREAD, Dependencies::find_unique_concrete_method(context, root_m->get_Method()));
+    }
     assert(target() == NULL || !target()->is_abstract(), "not allowed");
     // %%% Should upgrade this ciMethod API to look for 1 or 2 concrete methods.
   }

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -712,7 +712,11 @@ ciMethod* ciMethod::find_monomorphic_target(ciInstanceKlass* caller,
   {
     MutexLocker locker(Compile_lock);
     InstanceKlass* context = actual_recv->get_instanceKlass();
-    target = methodHandle(THREAD, Dependencies::find_unique_concrete_method(context, root_m->get_Method()));
+    target = methodHandle(THREAD, Dependencies::find_unique_concrete_method(context,
+                                                                            root_m->get_Method(),
+                                                                            callee_holder->get_Klass(),
+                                                                            this->get_Method()));
+    assert(target() == NULL || !target()->is_abstract(), "not allowed");
     // %%% Should upgrade this ciMethod API to look for 1 or 2 concrete methods.
   }
 

--- a/src/hotspot/share/code/dependencies.cpp
+++ b/src/hotspot/share/code/dependencies.cpp
@@ -1860,7 +1860,10 @@ Method* Dependencies::find_unique_concrete_method(InstanceKlass* ctxk, Method* m
   Klass*   p = wf.participant(0);
   Method* fm = wf.found_method(0);
   assert(fm == NULL || p != NULL, "no participant");
-  if (fm == Universe::throw_illegal_access_error() || fm == Universe::throw_no_such_method_error()) {
+  // Normalize all error-throwing cases to NULL.
+  if (fm == Universe::throw_illegal_access_error() ||
+      fm == Universe::throw_no_such_method_error() ||
+      !Dependencies::is_concrete_method(fm, p)) {
     fm = NULL; // error-throwing method
   }
   if (Dependencies::is_concrete_method(m, ctxk)) {

--- a/src/hotspot/share/code/dependencies.hpp
+++ b/src/hotspot/share/code/dependencies.hpp
@@ -135,6 +135,12 @@ class Dependencies: public ResourceObj {
     // in a subtype* of CX.  It asserts that MM(CX, M1) is no greater
     // than {M1}.
     unique_concrete_method_2, // one unique concrete method under CX
+
+    // In addition to the method M1 and the context class CX, the parameters
+    // to this dependency are the resolved class RC1 and the
+    // resolved method RM1. It asserts that MM(CX, M1, RC1, RM1)
+    // is no greater than {M1}. RC1 and RM1 are used to improve the precision
+    // of the analysis.
     unique_concrete_method_4, // one unique concrete method under CX
 
     // This dependency asserts that no instances of class or it's

--- a/src/hotspot/share/code/dependencies.hpp
+++ b/src/hotspot/share/code/dependencies.hpp
@@ -333,6 +333,7 @@ class Dependencies: public ResourceObj {
   void assert_leaf_type(ciKlass* ctxk);
   void assert_abstract_with_unique_concrete_subtype(ciKlass* ctxk, ciKlass* conck);
   void assert_unique_concrete_method(ciKlass* ctxk, ciMethod* uniqm);
+  void assert_unique_concrete_method(ciKlass* ctxk, ciMethod* uniqm, ciKlass* resolved_klass, ciMethod* resolved_method);
   void assert_has_no_finalizable_subclasses(ciKlass* ctxk);
   void assert_call_site_target_value(ciCallSite* call_site, ciMethodHandle* method_handle);
 
@@ -419,7 +420,9 @@ class Dependencies: public ResourceObj {
 
   // Detecting possible new assertions:
   static Klass*  find_unique_concrete_subtype(InstanceKlass* ctxk);
-  static Method* find_unique_concrete_method(InstanceKlass* ctxk, Method* m);
+  static Method* find_unique_concrete_method(InstanceKlass* ctxk, Method* m,
+                                             Klass** participant = NULL); // out parameter
+  static Method* find_unique_concrete_method(InstanceKlass* ctxk, Method* m, Klass* resolved_klass, Method* resolved_method);
 
 #ifdef ASSERT
   static bool verify_method_context(InstanceKlass* ctxk, Method* m);

--- a/src/hotspot/share/code/dependencies.hpp
+++ b/src/hotspot/share/code/dependencies.hpp
@@ -156,7 +156,7 @@ class Dependencies: public ResourceObj {
     implicit_ctxk_types = 0,
     explicit_ctxk_types = all_types & ~(non_ctxk_types | implicit_ctxk_types),
 
-    max_arg_count = 3,   // current maximum number of arguments (incl. ctxk)
+    max_arg_count = 4,   // current maximum number of arguments (incl. ctxk)
 
     // A "context type" is a class or interface that
     // provides context for evaluating a dependency.
@@ -325,6 +325,7 @@ class Dependencies: public ResourceObj {
 
   void assert_common_1(DepType dept, ciBaseObject* x);
   void assert_common_2(DepType dept, ciBaseObject* x0, ciBaseObject* x1);
+  void assert_common_4(DepType dept, ciKlass* ctxk, ciBaseObject* x1, ciBaseObject* x2, ciBaseObject* x3);
 
  public:
   // Adding assertions to a new dependency set at compile time:
@@ -456,7 +457,8 @@ class Dependencies: public ResourceObj {
   void log_dependency(DepType dept,
                       ciBaseObject* x0,
                       ciBaseObject* x1 = NULL,
-                      ciBaseObject* x2 = NULL) {
+                      ciBaseObject* x2 = NULL,
+                      ciBaseObject* x3 = NULL) {
     if (log() == NULL) {
       return;
     }
@@ -471,6 +473,9 @@ class Dependencies: public ResourceObj {
     }
     if (x2 != NULL) {
       ciargs->push(x2);
+    }
+    if (x3 != NULL) {
+      ciargs->push(x3);
     }
     assert(ciargs->length() == dep_args(dept), "");
     log_dependency(dept, ciargs);

--- a/src/hotspot/share/code/dependencies.hpp
+++ b/src/hotspot/share/code/dependencies.hpp
@@ -132,7 +132,8 @@ class Dependencies: public ResourceObj {
     // context class CX.  M1 must be either inherited in CX or defined
     // in a subtype* of CX.  It asserts that MM(CX, M1) is no greater
     // than {M1}.
-    unique_concrete_method,       // one unique concrete method under CX
+    unique_concrete_method_2, // one unique concrete method under CX
+    unique_concrete_method_4, // one unique concrete method under CX
 
     // This dependency asserts that no instances of class or it's
     // subclasses require finalization registration.
@@ -402,6 +403,7 @@ class Dependencies: public ResourceObj {
   static Klass* check_leaf_type(InstanceKlass* ctxk);
   static Klass* check_abstract_with_unique_concrete_subtype(InstanceKlass* ctxk, Klass* conck, KlassDepChange* changes = NULL);
   static Klass* check_unique_concrete_method(InstanceKlass* ctxk, Method* uniqm, KlassDepChange* changes = NULL);
+  static Klass* check_unique_concrete_method(InstanceKlass* ctxk, Method* uniqm, Klass* resolved_klass, Method* resolved_method, KlassDepChange* changes = NULL);
   static Klass* check_has_no_finalizable_subclasses(InstanceKlass* ctxk, KlassDepChange* changes = NULL);
   static Klass* check_call_site_target_value(oop call_site, oop method_handle, CallSiteDepChange* changes = NULL);
   // A returned Klass* is NULL if the dependency assertion is still

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -40,6 +40,7 @@
 #include "classfile/verifier.hpp"
 #include "classfile/vmClasses.hpp"
 #include "classfile/vmSymbols.hpp"
+#include "code/codeCache.hpp"
 #include "code/dependencyContext.hpp"
 #include "compiler/compilationPolicy.hpp"
 #include "compiler/compileBroker.hpp"
@@ -994,7 +995,17 @@ bool InstanceKlass::link_class_impl(TRAPS) {
       // In case itable verification is ever added.
       // itable().verify(tty, true);
 #endif
-      set_init_state(linked);
+      if (UseVtableBasedCHA) {
+        MutexLocker ml(THREAD, Compile_lock);
+        set_init_state(linked);
+
+        // Now flush all code that assume the class is not linked.
+        if (Universe::is_fully_initialized()) {
+          CodeCache::flush_dependents_on(this);
+        }
+      } else {
+        set_init_state(linked);
+      }
       if (JvmtiExport::should_post_class_prepare()) {
         JvmtiExport::post_class_prepare(THREAD->as_Java_thread(), this);
       }

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -883,7 +883,7 @@ class Compile : public Phase {
                                   const TypeOopPtr* receiver_type, bool is_virtual,
                                   bool &call_does_dispatch, int &vtable_index,
                                   bool check_access = true);
-  ciMethod* optimize_inlining(ciMethod* caller, ciInstanceKlass* klass,
+  ciMethod* optimize_inlining(ciMethod* caller, ciInstanceKlass* klass, ciKlass* holder,
                               ciMethod* callee, const TypeOopPtr* receiver_type,
                               bool check_access = true);
 

--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -337,7 +337,7 @@ CallGenerator* Compile::call_generator(ciMethod* callee, int vtable_index, bool 
 
           CallGenerator* cg = CallGenerator::for_guarded_call(holder, miss_cg, hit_cg);
           if (hit_cg != NULL && cg != NULL) {
-            dependencies()->assert_unique_concrete_method(declared_interface, cha_monomorphic_target);
+            dependencies()->assert_unique_concrete_method(declared_interface, cha_monomorphic_target, declared_interface, callee);
             return cg;
           }
         }
@@ -1084,7 +1084,7 @@ ciMethod* Compile::optimize_virtual_call(ciMethod* caller, ciInstanceKlass* klas
   vtable_index       = Method::invalid_vtable_index;
 
   // Choose call strategy.
-  ciMethod* optimized_virtual_method = optimize_inlining(caller, klass, callee,
+  ciMethod* optimized_virtual_method = optimize_inlining(caller, klass, holder, callee,
                                                          receiver_type, check_access);
 
   // Have the call been sufficiently improved such that it is no longer a virtual?
@@ -1099,7 +1099,7 @@ ciMethod* Compile::optimize_virtual_call(ciMethod* caller, ciInstanceKlass* klas
 }
 
 // Identify possible target method and inlining style
-ciMethod* Compile::optimize_inlining(ciMethod* caller, ciInstanceKlass* klass,
+ciMethod* Compile::optimize_inlining(ciMethod* caller, ciInstanceKlass* klass, ciKlass* holder,
                                      ciMethod* callee, const TypeOopPtr* receiver_type,
                                      bool check_access) {
   // only use for virtual or interface calls
@@ -1178,7 +1178,7 @@ ciMethod* Compile::optimize_inlining(ciMethod* caller, ciInstanceKlass* klass,
       // by dynamic class loading.  Be sure to test the "static" receiver
       // dest_method here, as opposed to the actual receiver, which may
       // falsely lead us to believe that the receiver is final or private.
-      dependencies()->assert_unique_concrete_method(actual_receiver, cha_monomorphic_target);
+      dependencies()->assert_unique_concrete_method(actual_receiver, cha_monomorphic_target, holder, callee);
     }
     return cha_monomorphic_target;
   }

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -994,6 +994,9 @@ const intx ObjectAlignmentInBytes = 8;
   develop(bool, UseCHA, true,                                               \
           "Enable CHA")                                                     \
                                                                             \
+  product(bool, UseVtableBasedCHA, true,  DIAGNOSTIC,                       \
+          "Use vtable information during CHA")                              \
+                                                                            \
   product(bool, UseTypeProfile, true,                                       \
           "Check interpreter profile for historically monomorphic calls")   \
                                                                             \

--- a/test/hotspot/jtreg/compiler/cha/StrengthReduceInterfaceCall.java
+++ b/test/hotspot/jtreg/compiler/cha/StrengthReduceInterfaceCall.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @requires !vm.graal.enabled
+ * @requires !vm.graal.enabled & vm.opt.final.UseVtableBasedCHA == true
  * @modules java.base/jdk.internal.org.objectweb.asm
  *          java.base/jdk.internal.misc
  *          java.base/jdk.internal.vm.annotation
@@ -32,7 +32,6 @@
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  *
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
- *                   -XX:+UseVtableBasedCHA
  *                   -XX:+PrintCompilation -XX:+PrintInlining -XX:+TraceDependencies -verbose:class -XX:CompileCommand=quiet
  *                   -XX:CompileCommand=compileonly,*::test -XX:CompileCommand=compileonly,*::m -XX:CompileCommand=dontinline,*::test
  *                   -Xbatch -XX:+WhiteBoxAPI -Xmixed
@@ -40,7 +39,6 @@
  *                      compiler.cha.StrengthReduceInterfaceCall
  *
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
- *                   -XX:+UseVtableBasedCHA
  *                   -XX:+PrintCompilation -XX:+PrintInlining -XX:+TraceDependencies -verbose:class -XX:CompileCommand=quiet
  *                   -XX:CompileCommand=compileonly,*::test -XX:CompileCommand=compileonly,*::m -XX:CompileCommand=dontinline,*::test
  *                   -Xbatch -XX:+WhiteBoxAPI -Xmixed

--- a/test/hotspot/jtreg/compiler/cha/StrengthReduceInterfaceCall.java
+++ b/test/hotspot/jtreg/compiler/cha/StrengthReduceInterfaceCall.java
@@ -32,6 +32,7 @@
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  *
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+UseVtableBasedCHA
  *                   -XX:+PrintCompilation -XX:+PrintInlining -XX:+TraceDependencies -verbose:class -XX:CompileCommand=quiet
  *                   -XX:CompileCommand=compileonly,*::test -XX:CompileCommand=compileonly,*::m -XX:CompileCommand=dontinline,*::test
  *                   -Xbatch -XX:+WhiteBoxAPI -Xmixed
@@ -39,6 +40,7 @@
  *                      compiler.cha.StrengthReduceInterfaceCall
  *
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+UseVtableBasedCHA
  *                   -XX:+PrintCompilation -XX:+PrintInlining -XX:+TraceDependencies -verbose:class -XX:CompileCommand=quiet
  *                   -XX:CompileCommand=compileonly,*::test -XX:CompileCommand=compileonly,*::m -XX:CompileCommand=dontinline,*::test
  *                   -Xbatch -XX:+WhiteBoxAPI -Xmixed
@@ -263,7 +265,8 @@ public class StrengthReduceInterfaceCall {
 
         interface K1 extends I {}
         interface K2 extends I { Object m(); }
-        interface K3 extends I { default Object m() { return WRONG; }}
+        interface K3 extends I { default Object m() { return WRONG;   }}
+        interface K4 extends I { default Object m() { return CORRECT; }}
 
         static class D implements I { public Object m() { return WRONG;   }}
 
@@ -318,19 +321,43 @@ public class StrengthReduceInterfaceCall {
 
             checkInvalidReceiver(); // ensure proper type check on receiver is preserved
 
-            // 1. Dependency invalidation
+            // 1. No invalidation: interfaces don't participate in CHA.
             initialize(K3.class); // intf K3.m DEFAULT <: intf I.m ABSTRACT <: intf J.m DEFAULT
-            assertNotCompiled();
+            assertCompiled();
 
-            // 2. Recompilation: still inlines
-            // FIXME: no default method support in CHA yet
-            compile(megamorphic());
+            // 2. Dependency invalidation on K3n <: I with concrete method.
             call(new K3() { public Object m() { return CORRECT; }}); // K3n.m <: intf K3.m DEFAULT <: intf I.m ABSTRACT <: intf J.m ABSTRACT
             assertNotCompiled();
 
             // 3. Recompilation: no inlining, no dependencies
             compile(megamorphic());
-            call(new K3() { public Object m() { return CORRECT; }}); // Kn.m <: intf K3.m DEFAULT  <: intf I.m ABSTRACT <: intf J.m DEFAULT
+            call(new K3() { public Object m() { return CORRECT; }}); // K3n.m <: intf K3.m DEFAULT  <: intf I.m ABSTRACT <: intf J.m DEFAULT
+            assertCompiled();
+
+            checkInvalidReceiver(); // ensure proper type check on receiver is preserved
+        }
+
+        @TestCase
+        public void testMega3() {
+            // 0. Trigger compilation of a megamorphic call site
+            compile(megamorphic()); // C1,C2,C3 <: C.m <: intf I.m ABSTRACT <: intf J.m DEFAULT
+            assertCompiled();
+
+            // Dependency: type = unique_concrete_method, context = I, method = C.m
+
+            checkInvalidReceiver(); // ensure proper type check on receiver is preserved
+
+            // 1. No invalidation: interfaces don't participate in CHA.
+            initialize(K4.class); // intf K4.m DEFAULT <: intf I.m ABSTRACT <: intf J.m DEFAULT
+            assertCompiled();
+
+            // 2. Dependency invalidation on K4n <: I with default method.
+            call(new K4() { /* default method K4.m */ }); // K4n <: intf K4.m DEFAULT <: intf I.m ABSTRACT <: intf J.m ABSTRACT
+            assertNotCompiled();
+
+            // 3. Recompilation: no inlining, no dependencies
+            compile(megamorphic());
+            call(new K4() { /* default method K4.m */  }); // K4n <: intf K3.m DEFAULT  <: intf I.m ABSTRACT <: intf J.m DEFAULT
             assertCompiled();
 
             checkInvalidReceiver(); // ensure proper type check on receiver is preserved
@@ -360,7 +387,8 @@ public class StrengthReduceInterfaceCall {
 
         interface K1 extends I {}
         interface K2 extends I { Object m(); }
-        interface K3 extends I { default Object m() { return WRONG; }}
+        interface K3 extends I { default Object m() { return WRONG;   }}
+        interface K4 extends I { default Object m() { return CORRECT; }}
 
         static class C  implements I { public Object m() { return CORRECT; }}
 
@@ -413,12 +441,8 @@ public class StrengthReduceInterfaceCall {
 
             checkInvalidReceiver(); // ensure proper type check on receiver is preserved
 
-            // Dependency invalidation
+            // No invalidation: interfaces don't participate in CHA.
             initialize(K3.class); // intf K3.m DEFAULT <: intf I;
-            assertNotCompiled(); // FIXME: default methods in sub-interfaces shouldn't be taken into account by CHA
-
-            // Recompilation with a dependency
-            compile(megamorphic());
             assertCompiled();
 
             // Dependency: type = unique_concrete_method, context = I, method = C.m
@@ -426,6 +450,34 @@ public class StrengthReduceInterfaceCall {
             checkInvalidReceiver(); // ensure proper type check on receiver is preserved
 
             call(new K3() { public Object m() { return CORRECT; }}); // Kn.m <: K3.m DEFAULT <: intf I <: intf J.m ABSTRACT
+            assertNotCompiled();
+
+            // Recompilation w/o a dependency
+            compile(megamorphic());
+            // Dependency: none
+            checkInvalidReceiver(); // ensure proper type check on receiver is preserved
+            call(new C() { public Object m() { return CORRECT; }}); // Cn.m <: C.m <: intf I <: intf J.m ABSTRACT
+            assertCompiled();
+        }
+
+        @TestCase
+        public void testMega3() {
+            compile(megamorphic()); // C1,C2,C3 <: C.m <: intf I <: intf J.m ABSTRACT
+            assertCompiled();
+
+            // Dependency: type = unique_concrete_method, context = I, method = C.m
+
+            checkInvalidReceiver(); // ensure proper type check on receiver is preserved
+
+            // No invalidation: interfaces don't participate in CHA.
+            initialize(K4.class); // intf K3.m DEFAULT <: intf I;
+            assertCompiled();
+
+            // Dependency: type = unique_concrete_method, context = I, method = C.m
+
+            checkInvalidReceiver(); // ensure proper type check on receiver is preserved
+
+            call(new K4() { /* default method K4.m */ }); // K4n <: K4.m DEFAULT <: intf I <: intf J.m ABSTRACT
             assertNotCompiled();
 
             // Recompilation w/o a dependency


### PR DESCRIPTION
As of now, Class Hierarchy Analysis (CHA) employs an approximate algorithm to enumerate all non-abstract methods in a class hierarchy.

It served quite well for many years, but it accumulated significant complexity
to support different corner cases over time and inevitable evolution of the JVM
stretched the whole approach way too much (to the point where it become almost
impossible to extend the analysis any further).

It turns out the root problem is the decision to reimplement method resolution
and method selection logic from scratch and to perform it on JVM internal
representation. It makes it very hard to reason about correctness and the
implementation becomes sensitive to changes in internal representation.

So, the main motivation for the redesign is twofold: 
 * reduce maintenance burden and increase confidence in the code;
 * unlock some long-awaited enhancements.

Though I did experiment with relaxing existing constraints (e.g., enable default method support), 
any possible enhancements are deliberately kept out of scope for the current PR.
(It does deliver a bit of minor enhancements front as the changes in
compiler/cha/StrengthReduceInterfaceCall.java manifest, but it's a side effect
of the other changes and was not the goal of the current work.)

Proposed implementation (`LinkedConcreteMethodFinder`) mimics method invocation
and relies on vtable/itable information to detect target method for every
subclass it visits. It removes all the complexity associated with method
resolution and method selection logic and leaves only essential logic to prepare for method selection.

Vtables are filled during class linkage, so new logic doesn't work on not yet linked classed. 
Instead of supporting not yet linked case, it is simply ignored. It is safe to
skip them (treat as "effectively non-concrete") since it is guaranteed there
are no instances created yet. But it requires VM to check dependencies once a
class is linked.

I ended up with 2 separate dependency validation passes (when class is loaded
and when it is linked). To avoid duplicated work, only dependencies
which may be affected by class initialization state change
(`unique_concrete_method_4`) are visited. 

(I experimented with merging passes into a single pass (delay the pass until
linkage is over), but it severely affected other class-related dependencies and
relevant optimizations.code.)

Compiler Interface (CI) is changed to require users to provide complete information about the call site being analyzed.

Old implementation is kept intact for now (will be removed later) to:
  - JVMCI hasn't been migrated to the new implementation yet;
  - enable verification that 2 implementations (old and new) agree on the results;
  - temporarily keep an option to revert to the original implementation in case any regressions show up.

Testing:
- [x] hs-tier1 - hs-tier9
- [x] hs-tier1 - hs-tier4 w/ `-XX:-UseVtableBasedCHA`
- [x] performance testing
  
Thanks!

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266074](https://bugs.openjdk.java.net/browse/JDK-8266074): Vtable-based CHA implementation


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [John R Rose](https://openjdk.java.net/census#jrose) (@rose00 - **Reviewer**) ⚠️ Review applies to 3063f97d04dbc62d50fb13d591ca64421892aa97
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3727/head:pull/3727` \
`$ git checkout pull/3727`

Update a local copy of the PR: \
`$ git checkout pull/3727` \
`$ git pull https://git.openjdk.java.net/jdk pull/3727/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3727`

View PR using the GUI difftool: \
`$ git pr show -t 3727`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3727.diff">https://git.openjdk.java.net/jdk/pull/3727.diff</a>

</details>
