### PR TITLE
8266149: mark hotspot compiler/startup tests which ignore VM flags

### DIFF
--- a/test/hotspot/jtreg/compiler/startup/NumCompilerThreadsCheck.java
+++ b/test/hotspot/jtreg/compiler/startup/NumCompilerThreadsCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/startup/NumCompilerThreadsCheck.java
+++ b/test/hotspot/jtreg/compiler/startup/NumCompilerThreadsCheck.java
@@ -26,6 +26,7 @@
  * @bug 8034775
  * @summary Ensures correct minimal number of compiler threads (provided by -XX:CICompilerCount=)
  * @library /test/lib
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *

--- a/test/hotspot/jtreg/compiler/startup/SmallCodeCacheStartup.java
+++ b/test/hotspot/jtreg/compiler/startup/SmallCodeCacheStartup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/startup/SmallCodeCacheStartup.java
+++ b/test/hotspot/jtreg/compiler/startup/SmallCodeCacheStartup.java
@@ -28,6 +28,7 @@
  *          to initialize all compiler threads. The option -Xcomp gives the VM more time to
  *          trigger the old bug.
  * @library /test/lib
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *

--- a/test/hotspot/jtreg/compiler/startup/StartupOutput.java
+++ b/test/hotspot/jtreg/compiler/startup/StartupOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/startup/StartupOutput.java
+++ b/test/hotspot/jtreg/compiler/startup/StartupOutput.java
@@ -26,6 +26,7 @@
  * @bug 8026949 8164091
  * @summary Test ensures correct VM output during startup
  * @library /test/lib
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch that adds `@requires vm.flagless` to `compiler/startup` tests that ignore VM flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266149](https://bugs.openjdk.java.net/browse/JDK-8266149): mark hotspot compiler/startup tests which ignore VM flags


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3729/head:pull/3729` \
`$ git checkout pull/3729`

Update a local copy of the PR: \
`$ git checkout pull/3729` \
`$ git pull https://git.openjdk.java.net/jdk pull/3729/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3729`

View PR using the GUI difftool: \
`$ git pr show -t 3729`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3729.diff">https://git.openjdk.java.net/jdk/pull/3729.diff</a>

</details>
