### PR TITLE
8266150: mark hotspot compiler/arguments tests which ignore VM flags

### DIFF
--- a/test/hotspot/jtreg/compiler/arguments/CheckCICompilerCount.java
+++ b/test/hotspot/jtreg/compiler/arguments/CheckCICompilerCount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/arguments/CheckCICompilerCount.java
+++ b/test/hotspot/jtreg/compiler/arguments/CheckCICompilerCount.java
@@ -26,6 +26,7 @@
  * @bug 8130858 8132525 8162881
  * @summary Check that correct range of values for CICompilerCount are allowed depending on whether tiered is enabled or not
  * @library /test/lib /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @run driver compiler.arguments.CheckCICompilerCount

--- a/test/hotspot/jtreg/compiler/arguments/CheckCompileThresholdScaling.java
+++ b/test/hotspot/jtreg/compiler/arguments/CheckCompileThresholdScaling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/arguments/CheckCompileThresholdScaling.java
+++ b/test/hotspot/jtreg/compiler/arguments/CheckCompileThresholdScaling.java
@@ -26,8 +26,10 @@
  * @bug 8059604
  * @summary Add CompileThresholdScaling flag to control when methods are first compiled (with +/-TieredCompilation)
  * @library /test/lib
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
+ *
  * @run driver compiler.arguments.CheckCompileThresholdScaling
  */
 

--- a/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
@@ -27,6 +27,7 @@
  * @bug 8033441
  * @summary Test to ensure that line numbers are now present with the -XX:+PrintOptoAssembly command line option
  *
+ * @requires vm.flagless
  * @requires vm.compiler2.enabled & vm.debug == true
  *
  * @library /test/lib

--- a/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestPrintOptoAssemblyLineNumbers.java
@@ -57,7 +57,7 @@ public class TestPrintOptoAssemblyLineNumbers {
 
         if (oa.getOutput().contains("TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly::main @ bci:11")) {
             // if C2 optimizer invoked ensure output includes line numbers:
-            oa.stdoutShouldContain("TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly::main @ bci:11 (line 71)");
+            oa.stdoutShouldContain("TestPrintOptoAssemblyLineNumbers$CheckC2OptoAssembly::main @ bci:11 (line 72)");
         }
     }
 
@@ -69,7 +69,7 @@ public class TestPrintOptoAssemblyLineNumbers {
         public static void main(String[] args) {
             int count = 0;
             for (int x = 0; x < 200_000; x++) {
-                if (foo("something" + x)) { // <- test expects this line of code to be on line 71
+                if (foo("something" + x)) { // <- test expects this line of code to be on line 72
                     count += 1;
                 }
             }

--- a/test/hotspot/jtreg/compiler/arguments/TestUseBMI1InstructionsOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestUseBMI1InstructionsOnSupportedCPU.java
@@ -27,8 +27,10 @@
  * @summary Verify processing of UseBMI1Instructions option on CPU with
  *          BMI1 feature support.
  * @library /test/lib /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
+ *
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions

--- a/test/hotspot/jtreg/compiler/arguments/TestUseBMI1InstructionsOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestUseBMI1InstructionsOnUnsupportedCPU.java
@@ -27,8 +27,10 @@
  * @summary Verify processing of UseBMI1Instructions option on CPU without
  *          BMI1 feature support.
  * @library /test/lib /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
+ *
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions

--- a/test/hotspot/jtreg/compiler/arguments/TestUseCountLeadingZerosInstructionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestUseCountLeadingZerosInstructionOnSupportedCPU.java
@@ -27,6 +27,7 @@
  * @summary Verify processing of UseCountLeadingZerosInstruction option
  *          on CPU with LZCNT support.
  * @library /test/lib /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *

--- a/test/hotspot/jtreg/compiler/arguments/TestUseCountLeadingZerosInstructionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestUseCountLeadingZerosInstructionOnUnsupportedCPU.java
@@ -27,6 +27,7 @@
  * @summary Verify processing of UseCountLeadingZerosInstruction option
  *          on CPU without LZCNT support.
  * @library /test/lib /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *

--- a/test/hotspot/jtreg/compiler/arguments/TestUseCountTrailingZerosInstructionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestUseCountTrailingZerosInstructionOnSupportedCPU.java
@@ -27,6 +27,7 @@
  * @summary Verify processing of UseCountTrailingZerosInstruction option
  *          on CPU with TZCNT (BMI1 feature) support.
  * @library /test/lib /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *

--- a/test/hotspot/jtreg/compiler/arguments/TestUseCountTrailingZerosInstructionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestUseCountTrailingZerosInstructionOnUnsupportedCPU.java
@@ -27,6 +27,7 @@
  * @summary Verify processing of UseCountTrailingZerosInstruction option
  *          on CPU without TZCNT instruction (BMI1 feature) support.
  * @library /test/lib /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch that adds `@requires vm.flagless` to `compiler/arguments` tests that ignore VM flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266150](https://bugs.openjdk.java.net/browse/JDK-8266150): mark hotspot compiler/arguments tests which ignore VM flags


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3730/head:pull/3730` \
`$ git checkout pull/3730`

Update a local copy of the PR: \
`$ git checkout pull/3730` \
`$ git pull https://git.openjdk.java.net/jdk pull/3730/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3730`

View PR using the GUI difftool: \
`$ git pr show -t 3730`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3730.diff">https://git.openjdk.java.net/jdk/pull/3730.diff</a>

</details>
