### PR TITLE
8266153: mark hotspot compiler/onSpinWait tests which ignore VM flags

### DIFF
--- a/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWait.java
+++ b/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWait.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2016 Azul Systems, Inc.  All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWait.java
+++ b/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWait.java
@@ -27,8 +27,10 @@
  * @summary (x86 only) checks that java.lang.Thread.onSpinWait is intrinsified
  * @bug 8147844
  * @library /test/lib
- * @modules java.base/jdk.internal.misc
+ *
+ * @requires vm.flagless
  * @requires os.arch=="x86" | os.arch=="amd64" | os.arch=="x86_64"
+ *
  * @run driver compiler.onSpinWait.TestOnSpinWait
  */
 

--- a/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitC1.java
+++ b/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitC1.java
@@ -27,9 +27,11 @@
  * @summary (x86 only) checks that java.lang.Thread.onSpinWait is intrinsified
  * @bug 8147844
  * @library /test/lib
- * @modules java.base/jdk.internal.misc
+ *
+ * @requires vm.flagless
  * @requires os.arch=="x86" | os.arch=="amd64" | os.arch=="x86_64"
  * @requires vm.compiler1.enabled
+ *
  * @run driver compiler.onSpinWait.TestOnSpinWaitC1
  */
 

--- a/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitC1.java
+++ b/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitC1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2016 Azul Systems, Inc.  All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch that adds `@requires vm.flagless` to `compiler/onSpinWait` tests that ignore VM flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266153](https://bugs.openjdk.java.net/browse/JDK-8266153): mark hotspot compiler/onSpinWait tests which ignore VM flags


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3731/head:pull/3731` \
`$ git checkout pull/3731`

Update a local copy of the PR: \
`$ git checkout pull/3731` \
`$ git pull https://git.openjdk.java.net/jdk pull/3731/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3731`

View PR using the GUI difftool: \
`$ git pr show -t 3731`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3731.diff">https://git.openjdk.java.net/jdk/pull/3731.diff</a>

</details>
