### PR TITLE
8266154: mark hotspot compiler/oracle tests which ignore VM flags

### DIFF
--- a/test/hotspot/jtreg/compiler/oracle/CheckCompileCommandOption.java
+++ b/test/hotspot/jtreg/compiler/oracle/CheckCompileCommandOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/oracle/CheckCompileCommandOption.java
+++ b/test/hotspot/jtreg/compiler/oracle/CheckCompileCommandOption.java
@@ -28,6 +28,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @requires vm.flagless
  * @requires vm.debug == true
  * @run driver compiler.oracle.CheckCompileCommandOption
  */

--- a/test/hotspot/jtreg/compiler/oracle/TestCompileCommand.java
+++ b/test/hotspot/jtreg/compiler/oracle/TestCompileCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/oracle/TestCompileCommand.java
+++ b/test/hotspot/jtreg/compiler/oracle/TestCompileCommand.java
@@ -28,6 +28,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @requires vm.flagless
  * @run driver compiler.oracle.TestCompileCommand
  */
 

--- a/test/hotspot/jtreg/compiler/oracle/TestInvalidCompileCommand.java
+++ b/test/hotspot/jtreg/compiler/oracle/TestInvalidCompileCommand.java
@@ -26,6 +26,7 @@
  * @bug 8263206 8263353
  * @summary Regression tests of -XX:CompileCommand
  * @library /test/lib
+ * @requires vm.flagless
  * @run driver compiler.oracle.TestInvalidCompileCommand
  */
 


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch that adds `@requires vm.flagless` to `compiler/oracle` tests that ignore VM flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266154](https://bugs.openjdk.java.net/browse/JDK-8266154): mark hotspot compiler/oracle tests which ignore VM flags


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3733/head:pull/3733` \
`$ git checkout pull/3733`

Update a local copy of the PR: \
`$ git checkout pull/3733` \
`$ git pull https://git.openjdk.java.net/jdk pull/3733/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3733`

View PR using the GUI difftool: \
`$ git pr show -t 3733`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3733.diff">https://git.openjdk.java.net/jdk/pull/3733.diff</a>

</details>
