### PR TITLE
8266164: mark hotspot compiler/loopstripmining tests which ignore VM flags

### DIFF
--- a/test/hotspot/jtreg/compiler/loopstripmining/CheckLoopStripMiningIterShortLoop.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/CheckLoopStripMiningIterShortLoop.java
@@ -25,10 +25,9 @@
  * @test
  * @bug 8196294
  * @summary when loop strip is enabled, LoopStripMiningIterShortLoop should be not null
+ * @requires vm.flagless
  * @requires vm.flavor == "server"
  * @library /test/lib /
- * @modules java.base/jdk.internal.misc
- *          java.management
  * @run driver CheckLoopStripMiningIterShortLoop
  */
 
@@ -40,6 +39,7 @@ public class CheckLoopStripMiningIterShortLoop {
     public static void main(String[] args) throws Exception {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:+UseG1GC", "-XX:+PrintFlagsFinal", "-version");
         OutputAnalyzer out = new OutputAnalyzer(pb.start());
+        out.shouldHaveExitValue(0);
 
         long iter = Long.parseLong(out.firstMatch("uintx LoopStripMiningIter                      = (\\d+)", 1));
         long iterShort = Long.parseLong(out.firstMatch("uintx LoopStripMiningIterShortLoop             = (\\d+)", 1));

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestNoWarningLoopStripMiningIterSet.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestNoWarningLoopStripMiningIterSet.java
@@ -25,11 +25,10 @@
  * @test
  * @bug 8241486
  * @summary G1/Z give warning when using LoopStripMiningIter and turn off LoopStripMiningIter (0)
+ * @requires vm.flagless
  * @requires vm.flavor == "server" & !vm.graal.enabled
  * @requires vm.gc.G1 & vm.gc.Shenandoah & vm.gc.Z & vm.gc.Epsilon
  * @library /test/lib
- * @modules java.base/jdk.internal.misc
- *          java.management
  * @run driver TestNoWarningLoopStripMiningIterSet
  */
 


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch that adds `@requires vm.flagless` to `compiler/loopstripmining` tests that ignore VM flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266164](https://bugs.openjdk.java.net/browse/JDK-8266164): mark hotspot compiler/loopstripmining tests which ignore VM flags


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3737/head:pull/3737` \
`$ git checkout pull/3737`

Update a local copy of the PR: \
`$ git checkout pull/3737` \
`$ git pull https://git.openjdk.java.net/jdk pull/3737/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3737`

View PR using the GUI difftool: \
`$ git pr show -t 3737`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3737.diff">https://git.openjdk.java.net/jdk/pull/3737.diff</a>

</details>
