### PR TITLE
8266166: mark hotspot compiler/linkage tests which ignore VM flags

### DIFF
--- a/test/hotspot/jtreg/compiler/linkage/TestLinkageErrorInGenerateOopMap.java
+++ b/test/hotspot/jtreg/compiler/linkage/TestLinkageErrorInGenerateOopMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/linkage/TestLinkageErrorInGenerateOopMap.java
+++ b/test/hotspot/jtreg/compiler/linkage/TestLinkageErrorInGenerateOopMap.java
@@ -26,8 +26,7 @@
  * @bug 8190797
  * @summary Test OSR compilation with bad operand stack.
  * @library /test/lib /
- * @modules java.base/jdk.internal.misc
- *          java.management
+ * @requires vm.flagless
  * @compile OSRWithBadOperandStack.jasm
  * @run driver compiler.linkage.TestLinkageErrorInGenerateOopMap
  */
@@ -50,7 +49,7 @@ public class TestLinkageErrorInGenerateOopMap {
                     "-XX:CompileCommand=dontinline,compiler/linkage/OSRWithBadOperandStack.m*",
                     "-XX:-CreateCoredumpOnCrash",
                     "-Xmx64m",
-                    "compiler.linkage.TestLinkageErrorInGenerateOopMap",
+                    TestLinkageErrorInGenerateOopMap.class.getName(),
                     "run");
             OutputAnalyzer out = new OutputAnalyzer(pb.start());
             if (out.getExitValue() != 0) {


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch that adds `@requires vm.flagless` to `compiler/linkage ` tests that ignore VM flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266166](https://bugs.openjdk.java.net/browse/JDK-8266166): mark hotspot compiler/linkage tests which ignore VM flags


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3738/head:pull/3738` \
`$ git checkout pull/3738`

Update a local copy of the PR: \
`$ git checkout pull/3738` \
`$ git pull https://git.openjdk.java.net/jdk pull/3738/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3738`

View PR using the GUI difftool: \
`$ git pr show -t 3738`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3738.diff">https://git.openjdk.java.net/jdk/pull/3738.diff</a>

</details>
