### PR TITLE
8266169: mark hotspot compiler/jvmci tests which ignore VM flags

### DIFF
--- a/test/hotspot/jtreg/compiler/jvmci/TestEnableJVMCIProduct.java
+++ b/test/hotspot/jtreg/compiler/jvmci/TestEnableJVMCIProduct.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/jvmci/TestEnableJVMCIProduct.java
+++ b/test/hotspot/jtreg/compiler/jvmci/TestEnableJVMCIProduct.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8235539 8245717
  * @summary Tests effect of -XX:+EnableJVMCIProduct on EnableJVMCI and UseJVMCICompiler
+ * @requires vm.flagless
  * @requires vm.jvmci
  * @library /test/lib
  * @run driver TestEnableJVMCIProduct

--- a/test/hotspot/jtreg/compiler/jvmci/TestInvalidJVMCIOption.java
+++ b/test/hotspot/jtreg/compiler/jvmci/TestInvalidJVMCIOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/jvmci/TestInvalidJVMCIOption.java
+++ b/test/hotspot/jtreg/compiler/jvmci/TestInvalidJVMCIOption.java
@@ -25,11 +25,13 @@
  * @test TestInvalidJVMCIOption
  * @bug 8257220
  * @summary Ensures invalid JVMCI options do not crash the VM with a hs-err log.
- * @requires vm.jvmci & vm.compMode == "Xmixed"
+ * @requires vm.flagless
+ * @requires vm.jvmci
  * @library /test/lib
  * @run driver TestInvalidJVMCIOption
  */
 
+import jdk.test.lib.Asserts;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 
@@ -45,13 +47,10 @@ public class TestInvalidJVMCIOption {
         String expectStdout = String.format(
             "Error parsing JVMCI options: Could not find option jvmci.XXXXXXXXX%n" +
             "Error: A fatal exception has occurred. Program will exit.%n");
-        String actualStdout = output.getStdout();
-        if (!actualStdout.equals(expectStdout)) {
-            throw new RuntimeException(String.format("Invalid STDOUT:%nExpect:%n%s%nActual:%n%s", expectStdout, actualStdout));
-        }
-        if (!output.getStderr().isEmpty()) {
-            throw new RuntimeException("STDERR was not empty: " + output.getStderr());
-        }
+
+        Asserts.assertEQ(expectStdout, output.getStdout());
+        output.stderrShouldBeEmpty();
+
         output.shouldHaveExitValue(1);
     }
 }

--- a/test/hotspot/jtreg/compiler/jvmci/TestJVMCIPrintProperties.java
+++ b/test/hotspot/jtreg/compiler/jvmci/TestJVMCIPrintProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/jvmci/TestJVMCIPrintProperties.java
+++ b/test/hotspot/jtreg/compiler/jvmci/TestJVMCIPrintProperties.java
@@ -25,7 +25,8 @@
  * @test TestBasicLogOutput
  * @bug 8203370
  * @summary Ensure -XX:-JVMCIPrintProperties can be enabled and successfully prints expected output to stdout.
- * @requires vm.jvmci & !vm.graal.enabled & vm.compMode == "Xmixed"
+ * @requires vm.flagless
+ * @requires vm.jvmci
  * @library /test/lib
  * @run driver TestJVMCIPrintProperties
  */

--- a/test/hotspot/jtreg/compiler/jvmci/errors/TestInvalidTieredStopAtLevel.java
+++ b/test/hotspot/jtreg/compiler/jvmci/errors/TestInvalidTieredStopAtLevel.java
@@ -24,10 +24,10 @@
 /**
  * @test
  * @bug 8241232
+ * @requires vm.flagless
  * @requires vm.jvmci
  * @library /test/lib
- * @build TestInvalidTieredStopAtLevel jdk.test.lib.process.*
- * @run main TestInvalidTieredStopAtLevel
+ * @run driver TestInvalidTieredStopAtLevel
  */
 
 import jdk.test.lib.process.ProcessTools;


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch that adds `@requires vm.flagless` to `compiler/jvmci ` tests that ignore VM flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266169](https://bugs.openjdk.java.net/browse/JDK-8266169): mark hotspot compiler/jvmci tests which ignore VM flags


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3739/head:pull/3739` \
`$ git checkout pull/3739`

Update a local copy of the PR: \
`$ git checkout pull/3739` \
`$ git pull https://git.openjdk.java.net/jdk pull/3739/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3739`

View PR using the GUI difftool: \
`$ git pr show -t 3739`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3739.diff">https://git.openjdk.java.net/jdk/pull/3739.diff</a>

</details>
