### PR TITLE
8266175: mark hotspot compiler/jsr292 tests which ignore VM flags

### DIFF
--- a/test/hotspot/jtreg/compiler/jsr292/ContinuousCallSiteTargetChange.java
+++ b/test/hotspot/jtreg/compiler/jsr292/ContinuousCallSiteTargetChange.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @library /test/lib /
+ * @requires vm.flagless
  *
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/compiler/jsr292/MHInlineTest.java
+++ b/test/hotspot/jtreg/compiler/jsr292/MHInlineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/jsr292/MHInlineTest.java
+++ b/test/hotspot/jtreg/compiler/jsr292/MHInlineTest.java
@@ -25,6 +25,8 @@
  * @test
  * @bug 8062280
  * @summary C2: inlining failure due to access checks being too strict
+ *
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
  *
@@ -50,7 +52,7 @@ public class MHInlineTest {
                 "-XX:-TieredCompilation", "-Xbatch",
                 "-XX:+PrintCompilation", "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintInlining",
                 "-XX:CompileCommand=dontinline,compiler.jsr292.MHInlineTest::test*",
-                    Launcher.class.getName());
+                 Launcher.class.getName());
 
         OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
 

--- a/test/hotspot/jtreg/compiler/jsr292/PollutedTrapCounts.java
+++ b/test/hotspot/jtreg/compiler/jsr292/PollutedTrapCounts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/jsr292/PollutedTrapCounts.java
+++ b/test/hotspot/jtreg/compiler/jsr292/PollutedTrapCounts.java
@@ -24,9 +24,11 @@
 /**
  * @test
  * @bug 8074551
+ *
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
- * @build jdk.test.lib.* jdk.test.lib.process.*
+ *
  * @run driver compiler.jsr292.PollutedTrapCounts
  */
 
@@ -46,7 +48,7 @@ public class PollutedTrapCounts {
                 "-XX:-TieredCompilation", "-Xbatch",
                 "-XX:PerBytecodeRecompilationCutoff=10", "-XX:PerMethodRecompilationCutoff=10",
                 "-XX:+PrintCompilation", "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintInlining",
-                    Test.class.getName());
+                Test.class.getName());
 
         OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
 


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch that adds `@requires vm.flagless` to `compiler/jsr292 ` tests that ignore VM flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266175](https://bugs.openjdk.java.net/browse/JDK-8266175): mark hotspot compiler/jsr292 tests which ignore VM flags


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3740/head:pull/3740` \
`$ git checkout pull/3740`

Update a local copy of the PR: \
`$ git checkout pull/3740` \
`$ git pull https://git.openjdk.java.net/jdk pull/3740/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3740`

View PR using the GUI difftool: \
`$ git pr show -t 3740`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3740.diff">https://git.openjdk.java.net/jdk/pull/3740.diff</a>

</details>
