### PR TITLE
JDK-8265773: incorrect jdeps message "jdk8internals" to describe a removed JDK internal API

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/Analyzer.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/Analyzer.java
@@ -405,6 +405,14 @@ public class Analyzer {
             }
         }
 
+        /*
+         * Ignore the module name which should not be shown in the output
+         */
+        @Override
+        public String name() {
+            return getName();
+        }
+
         public boolean contains(Location location) {
             String cn = location.getClassName();
             int i = cn.lastIndexOf('.');

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsWriter.java
@@ -312,7 +312,7 @@ public abstract class JdepsWriter {
      * For non-JDK archives, this method returns the file name of the archive.
      */
     String toTag(Archive source, String name, Archive target) {
-        if (source == target || !target.getModule().isNamed()) {
+        if (source == target || !target.getModule().isNamed() || Analyzer.notFound(target)) {
             return target.getName();
         }
 


### PR DESCRIPTION
jdeps should print "JDK removed internal APIs" to give an informative description when a JDK internal API that is being referenced has been removed.  JDK-8213909 incorrectly changed it to print `jdk8internals`.

An example output is:

```
classes -> jdk8internals
   p.Main                                             -> sun.misc.Service                                      JDK removed internal API
   p.Main                                             -> sun.misc.SoftCache                                 JDK removed internal API
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265773](https://bugs.openjdk.java.net/browse/JDK-8265773): incorrect jdeps message "jdk8internals" to describe a removed JDK internal API


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3741/head:pull/3741` \
`$ git checkout pull/3741`

Update a local copy of the PR: \
`$ git checkout pull/3741` \
`$ git pull https://git.openjdk.java.net/jdk pull/3741/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3741`

View PR using the GUI difftool: \
`$ git pr show -t 3741`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3741.diff">https://git.openjdk.java.net/jdk/pull/3741.diff</a>

</details>
