### PR TITLE
8266173: -Wmaybe-uninitialized happens in jni_util.c

### DIFF
--- a/src/java.base/share/native/libjava/jni_util.c
+++ b/src/java.base/share/native/libjava/jni_util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -462,7 +462,7 @@ static jstring
 newString646_US(JNIEnv *env, const char *str)
 {
     int len = (int)strlen(str);
-    jchar buf[512];
+    jchar buf[512] = {0};
     jchar *str1;
     jstring result;
     int i;


### PR DESCRIPTION
We can see compiler warnings in jni_util.c as following on GCC 11. `buf` should be initialized.

```
/home/ysuenaga/git-forked/jdk/src/java.base/share/native/libjava/jni_util.c: In function 'newString646_US':
/home/ysuenaga/git-forked/jdk/src/java.base/share/native/libjava/jni_util.c:487:15: warning: 'buf' may be used uninitialized [-Wmaybe-uninitialized]
  487 | result = (*env)->NewString(env, str1, len);
      | ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/ysuenaga/git-forked/jdk/src/java.base/share/native/libjava/jni_util.c:487:15: note: by argument 2 of type 'const jchar *' {aka 'const short unsigned int *'} to 'struct _jobject *(const struct JNINativeInterface_ **, const jchar *, jsize)' {aka 'struct _jobject *(const struct JNINativeInterface_ **, const short unsigned int *, int)'}
/home/ysuenaga/git-forked/jdk/src/java.base/share/native/libjava/jni_util.c:465:11: note: 'buf' declared here
  465 | jchar buf[512];
      | ^~~
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266173](https://bugs.openjdk.java.net/browse/JDK-8266173): -Wmaybe-uninitialized happens in jni_util.c


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3742/head:pull/3742` \
`$ git checkout pull/3742`

Update a local copy of the PR: \
`$ git checkout pull/3742` \
`$ git pull https://git.openjdk.java.net/jdk pull/3742/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3742`

View PR using the GUI difftool: \
`$ git pr show -t 3742`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3742.diff">https://git.openjdk.java.net/jdk/pull/3742.diff</a>

</details>
