### PR TITLE
8266174: -Wmisleading-indentation happens in libmlib_image sources

### DIFF
--- a/src/java.desktop/share/native/libmlib_image/mlib_ImageAffine.h
+++ b/src/java.desktop/share/native/libmlib_image/mlib_ImageAffine.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -215,7 +215,7 @@ typedef union {
     SRC = MLIB_S32_MAX;                                        \
   if (SRC <= MLIB_S32_MIN)                                     \
     SRC = MLIB_S32_MIN;                                        \
-    DST = (mlib_s32) SRC
+  DST = (mlib_s32) SRC
 
 #endif /* MLIB_USE_FTOI_CLAMPING */
 


### PR DESCRIPTION
We can see following warnings in mlib_ImageAffine_BC_S32.c, mlib_ImageAffine_BL_S32.c, mlib_ImageScanPoly.c . They are caused by indentation in mlib_ImageAffine.h .

```
In file included from /home/ysuenaga/git-forked/jdk/src/java.desktop/share/native/libmlib_image/mlib_ImageAffine_BC_S32.c:65:
/home/ysuenaga/git-forked/jdk/src/java.desktop/share/native/libmlib_image/mlib_ImageAffine_BC_S32.c: In function 'mlib_ImageAffine_s32_1ch_bc':
/home/ysuenaga/git-forked/jdk/src/java.desktop/share/native/libmlib_image/mlib_ImageAffine.h:216:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
  216 | if (SRC <= MLIB_S32_MIN) \
      | ^~
/home/ysuenaga/git-forked/jdk/src/java.desktop/share/native/libmlib_image/mlib_ImageAffine.h:223:20: note: in expansion of macro 'SAT_32'
  223 | #define SAT32(DST) SAT_32(DST, val0)
      | ^~~~~~
/home/ysuenaga/git-forked/jdk/src/java.desktop/share/native/libmlib_image/mlib_ImageAffine_BC_S32.c:77:23: note: in expansion of macro 'SAT32'
   77 | #define STORE(res, x) SAT32(res)
      | ^~~~~
/home/ysuenaga/git-forked/jdk/src/java.desktop/share/native/libmlib_image/mlib_ImageAffine_BC_S32.c:202:9: note: in expansion of macro 'STORE'
  202 | STORE(dstPixelPtr[0], val0);
      | ^~~~~
/home/ysuenaga/git-forked/jdk/src/java.desktop/share/native/libmlib_image/mlib_ImageAffine_BC_S32.c:202:15: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'
  202 | STORE(dstPixelPtr[0], val0);
      | ^~~~~~~~~~~
/home/ysuenaga/git-forked/jdk/src/java.desktop/share/native/libmlib_image/mlib_ImageAffine.h:218:5: note: in definition of macro 'SAT_32'
  218 | DST = (mlib_s32) SRC
      | ^~~
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266174](https://bugs.openjdk.java.net/browse/JDK-8266174): -Wmisleading-indentation happens in libmlib_image sources


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3743/head:pull/3743` \
`$ git checkout pull/3743`

Update a local copy of the PR: \
`$ git checkout pull/3743` \
`$ git pull https://git.openjdk.java.net/jdk pull/3743/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3743`

View PR using the GUI difftool: \
`$ git pr show -t 3743`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3743.diff">https://git.openjdk.java.net/jdk/pull/3743.diff</a>

</details>
