### PR TITLE
8266176: -Wmaybe-uninitialized happens in libArrayIndexOutOfBoundsExceptionTest.c

### DIFF
--- a/test/hotspot/jtreg/runtime/exceptionMsgs/ArrayIndexOutOfBoundsException/libArrayIndexOutOfBoundsExceptionTest.c
+++ b/test/hotspot/jtreg/runtime/exceptionMsgs/ArrayIndexOutOfBoundsException/libArrayIndexOutOfBoundsExceptionTest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -47,7 +47,7 @@ JNIEXPORT void JNICALL \
 JNIEXPORT void JNICALL \
   Java_ArrayIndexOutOfBoundsExceptionTest_doNative##NameType##ArrayRegionStore(JNIEnv *env, jclass klass, \
                                                                       ElementType##Array array, jint start, jint len) { \
-  ElementType content[100]; \
+  ElementType content[100] = {0}; \
   (*env)->Set##NameType##ArrayRegion(env, array, start, len, content); \
 }
 

--- a/test/hotspot/jtreg/runtime/exceptionMsgs/ArrayIndexOutOfBoundsException/libArrayIndexOutOfBoundsExceptionTest.c
+++ b/test/hotspot/jtreg/runtime/exceptionMsgs/ArrayIndexOutOfBoundsException/libArrayIndexOutOfBoundsExceptionTest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *


### PR DESCRIPTION
We can see some compiler warnings in libArrayIndexOutOfBoundsExceptionTest.c as following on GCC 11. `content` should be initialized.

```
/home/ysuenaga/git-forked/jdk/test/hotspot/jtreg/runtime/exceptionMsgs/ArrayIndexOutOfBoundsException/libArrayIndexOutOfBoundsExceptionTest.c: In function 'Java_ArrayIndexOutOfBoundsExceptionTest_doNativeBooleanArrayRegionStore':
/home/ysuenaga/git-forked/jdk/test/hotspot/jtreg/runtime/exceptionMsgs/ArrayIndexOutOfBoundsException/libArrayIndexOutOfBoundsExceptionTest.c:51:4: warning: 'content' may be used uninitialized [-Wmaybe-uninitialized]
   51 | (*env)->Set##NameType##ArrayRegion(env, array, start, len, content); \
      | ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/ysuenaga/git-forked/jdk/test/hotspot/jtreg/runtime/exceptionMsgs/ArrayIndexOutOfBoundsException/libArrayIndexOutOfBoundsExceptionTest.c:54:1: note: in expansion of macro 'REGIONACCESS'
   54 | REGIONACCESS(jboolean, Boolean)
      | ^~~~~~~~~~~~
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266176](https://bugs.openjdk.java.net/browse/JDK-8266176): -Wmaybe-uninitialized happens in libArrayIndexOutOfBoundsExceptionTest.c


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to d6a34320d20510c7a007be80bf711a415316dad8


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3744/head:pull/3744` \
`$ git checkout pull/3744`

Update a local copy of the PR: \
`$ git checkout pull/3744` \
`$ git pull https://git.openjdk.java.net/jdk pull/3744/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3744`

View PR using the GUI difftool: \
`$ git pr show -t 3744`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3744.diff">https://git.openjdk.java.net/jdk/pull/3744.diff</a>

</details>
