### PR TITLE
8266180: compiler/vectorapi/TestVectorErgonomics should be run in driver mode

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorErgonomics.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorErgonomics.java
@@ -29,7 +29,7 @@ package compiler.vectorapi;
  * @requires vm.compiler2.enabled
  * @summary Check ergonomics for Vector API
  * @library /test/lib
- * @run main/othervm compiler.vectorapi.TestVectorErgonomics
+ * @run driver compiler.vectorapi.TestVectorErgonomics
  */
 
 import jdk.test.lib.process.ProcessTools;


### PR DESCRIPTION
Hi all,

could you please review this one-liner?

from JBS:
> `compiler/vectorapi/TestVectorErgonomics` class just spawns new JVMs and verifies their output, there is no need for `TestVectorErgonomics` to be run w/ all external flags.

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266180](https://bugs.openjdk.java.net/browse/JDK-8266180): compiler/vectorapi/TestVectorErgonomics should be run in driver mode


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - Committer)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * epavlova - Committer ⚠️ Added manually

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3745/head:pull/3745` \
`$ git checkout pull/3745`

Update a local copy of the PR: \
`$ git checkout pull/3745` \
`$ git pull https://git.openjdk.java.net/jdk pull/3745/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3745`

View PR using the GUI difftool: \
`$ git pr show -t 3745`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3745.diff">https://git.openjdk.java.net/jdk/pull/3745.diff</a>

</details>
