### PR TITLE
8266181: compiler/eliminateAutobox/TestEliminateBoxInDebugInfo should be in driver mode

### DIFF
--- a/test/hotspot/jtreg/compiler/eliminateAutobox/TestEliminateBoxInDebugInfo.java
+++ b/test/hotspot/jtreg/compiler/eliminateAutobox/TestEliminateBoxInDebugInfo.java
@@ -46,8 +46,8 @@ public class TestEliminateBoxInDebugInfo {
         };
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(arguments);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        String pattern = ".*Eliminated.*";
-        output.stdoutShouldContain(pattern);
+        output.shouldHaveExitValue(0)
+              .stdoutShouldContain("++++ Eliminated: ");
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/eliminateAutobox/TestEliminateBoxInDebugInfo.java
+++ b/test/hotspot/jtreg/compiler/eliminateAutobox/TestEliminateBoxInDebugInfo.java
@@ -28,37 +28,26 @@
  * @summary Verify that box object is scalarized in case it is directly referenced by debug info.
  * @library /test/lib
  *
- * @run main/othervm compiler.c2.TestEliminateBoxInDebugInfo
+ * @run driver compiler.c2.TestEliminateBoxInDebugInfo
  */
 package compiler.c2;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
-import jdk.test.lib.Asserts;
-
 public class TestEliminateBoxInDebugInfo {
     public static void runTest() throws Exception {
-        final String[] arguments = {
+        String[] arguments = {
             "-XX:CompileCommand=compileonly,compiler/c2/TestEliminateBoxInDebugInfo$Test.foo",
             "-XX:CompileCommand=dontinline,compiler/c2/TestEliminateBoxInDebugInfo$Test.black",
             "-Xbatch",
             "-XX:+PrintEliminateAllocations",
             Test.class.getName()
-            };
+        };
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(arguments);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        System.out.println(output.getStdout());
         String pattern = ".*Eliminated.*";
-        Pattern r = Pattern.compile(pattern);
-        Matcher m = r.matcher(output.getStdout());
-        if (!m.find()) {
-            throw new RuntimeException("Could not find Elimination output");
-        }
+        output.stdoutShouldContain(pattern);
     }
 
     public static void main(String[] args) throws Exception {
@@ -68,7 +57,7 @@ public class TestEliminateBoxInDebugInfo {
     static class Test {
         public static void main(String[] args) throws Exception {
             // warmup
-            for(int i = 0; i < 100000; i++) {
+            for (int i = 0; i < 100000; i++) {
                foo(1000 + (i % 1000));
             }
         }


### PR DESCRIPTION
Hi all,

could you please review this small patch that switches the execution mode of TestEliminateBoxInDebugInfo to driver mode and makes a few small cleanups?

from JBS:
> TestEliminateBoxInDebugInfo creates a new JVM and verifies its output, hence it doesn't have to be run in the JDK in test configuration and can be run in driver mode.

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266181](https://bugs.openjdk.java.net/browse/JDK-8266181): compiler/eliminateAutobox/TestEliminateBoxInDebugInfo should be in driver mode


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3746/head:pull/3746` \
`$ git checkout pull/3746`

Update a local copy of the PR: \
`$ git checkout pull/3746` \
`$ git pull https://git.openjdk.java.net/jdk pull/3746/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3746`

View PR using the GUI difftool: \
`$ git pr show -t 3746`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3746.diff">https://git.openjdk.java.net/jdk/pull/3746.diff</a>

</details>
