### PR TITLE
8266184: a few compiler/debug tests don't check exit code

### DIFF
--- a/test/hotspot/jtreg/compiler/debug/TestGenerateStressSeed.java
+++ b/test/hotspot/jtreg/compiler/debug/TestGenerateStressSeed.java
@@ -26,7 +26,6 @@ package compiler.debug;
 import java.nio.file.Paths;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
-import jdk.test.lib.Asserts;
 
 /*
  * @test
@@ -58,7 +57,8 @@ public class TestGenerateStressSeed {
                 "-Xcomp", "-XX:-TieredCompilation", "-XX:+UnlockDiagnosticVMOptions",
                 "-XX:CompileOnly=" + className + "::sum", "-XX:+" + stressOpt,
                 "-XX:+LogCompilation", "-XX:LogFile=" + log, className, "10"};
-            ProcessTools.createJavaProcessBuilder(procArgs).start().waitFor();
+            new OutputAnalyzer(ProcessTools.createJavaProcessBuilder(procArgs).start())
+                .shouldHaveExitValue(0);
             new OutputAnalyzer(Paths.get(log))
                 .shouldContain("stress_test seed");
         } else {

--- a/test/hotspot/jtreg/compiler/debug/TestStressCM.java
+++ b/test/hotspot/jtreg/compiler/debug/TestStressCM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/debug/TestStressCM.java
+++ b/test/hotspot/jtreg/compiler/debug/TestStressCM.java
@@ -49,6 +49,7 @@ public class TestStressCM {
             "-XX:StressSeed=" + stressSeed, className, "10"};
         ProcessBuilder pb  = ProcessTools.createJavaProcessBuilder(procArgs);
         OutputAnalyzer out = new OutputAnalyzer(pb.start());
+        out.shouldHaveExitValue(0);
         // Extract the trace of our method (the last one after those of all
         // mandatory stubs such as _new_instance_Java, etc.).
         String [] traces = out.getStdout().split("\\R");

--- a/test/hotspot/jtreg/compiler/debug/TestStressIGVNAndCCP.java
+++ b/test/hotspot/jtreg/compiler/debug/TestStressIGVNAndCCP.java
@@ -49,11 +49,12 @@ public class TestStressIGVNAndCCP {
             className, "10"};
         ProcessBuilder pb  = ProcessTools.createJavaProcessBuilder(procArgs);
         OutputAnalyzer out = new OutputAnalyzer(pb.start());
+        out.shouldHaveExitValue(0);
         return out.getStdout();
     }
 
     static String igvnTrace(int stressSeed) throws Exception {
-        return phaseTrace("StressIGVN", "TraceIterativeIGVN", stressSeed);
+        return phaseTrace("StressIGVN", "TraceIterativeGVN", stressSeed);
     }
 
     static String ccpTrace(int stressSeed) throws Exception {


### PR DESCRIPTION
Hi all,

could you please review this small fix for `compiler/debug` tests?
from JBS:
> `compiler/debug/TestGenerateStressSeed.java`, `TestStressCM.java`, and `TestStressIGVNAndCCP.java` don't check the exit code of spawned JVMs, as a result, they might miss misconfiguration and/or defects. in fact, `TestStressIGVNAndCCP.java` uses a wrong flag name (`TraceIterativeIGVN` instead of `TraceIterativeGVN`) and this was unnoticed b/c we didn't check the exit code.

the patch adds calls to `OutputAnalyzer::shouldHaveExitValue` and fixes `TestStressIGVNAndCCP.java` to use the right flag.

testing:
- [x] `test/hotspot/jtreg/compiler/debug` on `linux-x64-debug`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266184](https://bugs.openjdk.java.net/browse/JDK-8266184): a few compiler/debug tests don't check exit code


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3748/head:pull/3748` \
`$ git checkout pull/3748`

Update a local copy of the PR: \
`$ git checkout pull/3748` \
`$ git pull https://git.openjdk.java.net/jdk pull/3748/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3748`

View PR using the GUI difftool: \
`$ git pr show -t 3748`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3748.diff">https://git.openjdk.java.net/jdk/pull/3748.diff</a>

</details>
