### PR TITLE
8266187: Memory leak in appendBootClassPath()

### DIFF
--- a/src/java.instrument/share/native/libinstrument/InvocationAdapter.c
+++ b/src/java.instrument/share/native/libinstrument/InvocationAdapter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.instrument/share/native/libinstrument/InvocationAdapter.c
+++ b/src/java.instrument/share/native/libinstrument/InvocationAdapter.c
@@ -949,6 +949,7 @@ appendBootClassPath( JPLISAgent* agent,
 
             resolved = resolve(parent, path);
             jvmtierr = (*jvmtienv)->AddToBootstrapClassLoaderSearch(jvmtienv, resolved);
+            free(resolved);
         }
 
         /* print warning if boot class path not updated */


### PR DESCRIPTION
Dear All, 
    I find a memory leak in `appendBootClassPath()`
https://github.com/openjdk/jdk/blob/75a2354dc276e107d64516d20fc72bc7ef3d5f86/src/java.instrument/share/native/libinstrument/InvocationAdapter.c#L950
* we malloc `resolved` from resolve(parent, path)
* we use `resolved` in line 951 
* we don't free() this memory after using.

I think we can fix this bug by adding a free() after line 951 as my commit.
Thank you for your review. Any suggestion is welcome.

Yours , 
Wang Huang

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266187](https://bugs.openjdk.java.net/browse/JDK-8266187): Memory leak in appendBootClassPath()


### Reviewers
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to c973192e250dc45fc3a42358b23f31ce7c911c3b
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**) ⚠️ Review applies to c973192e250dc45fc3a42358b23f31ce7c911c3b
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to c973192e250dc45fc3a42358b23f31ce7c911c3b


### Contributors
 * Wang Huang `<whuang@openjdk.org>`
 * Sun Jianye `<sunjianye@huawei.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3751/head:pull/3751` \
`$ git checkout pull/3751`

Update a local copy of the PR: \
`$ git checkout pull/3751` \
`$ git pull https://git.openjdk.java.net/jdk pull/3751/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3751`

View PR using the GUI difftool: \
`$ git pr show -t 3751`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3751.diff">https://git.openjdk.java.net/jdk/pull/3751.diff</a>

</details>
