### PR TITLE
8266188: mark hotspot compiler/cpuflags tests which ignore VM flags

### DIFF
--- a/test/hotspot/jtreg/compiler/cpuflags/RestoreMXCSR.java
+++ b/test/hotspot/jtreg/compiler/cpuflags/RestoreMXCSR.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/cpuflags/RestoreMXCSR.java
+++ b/test/hotspot/jtreg/compiler/cpuflags/RestoreMXCSR.java
@@ -26,8 +26,7 @@
  * @bug 8020433
  * @summary Crash when using -XX:+RestoreMXCSROnJNICalls
  * @library /test/lib
- * @modules java.base/jdk.internal.misc
- *          java.management
+ * @requires vm.flagless
  *
  * @run driver compiler.cpuflags.RestoreMXCSR
  */


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch that adds `@requires vm.flagless` to `compiler/cpuflags ` tests that ignore VM flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266188](https://bugs.openjdk.java.net/browse/JDK-8266188): mark hotspot compiler/cpuflags tests which ignore VM flags


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3752/head:pull/3752` \
`$ git checkout pull/3752`

Update a local copy of the PR: \
`$ git checkout pull/3752` \
`$ git pull https://git.openjdk.java.net/jdk pull/3752/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3752`

View PR using the GUI difftool: \
`$ git pr show -t 3752`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3752.diff">https://git.openjdk.java.net/jdk/pull/3752.diff</a>

</details>
