### PR TITLE
8266170: -Wnonnull happens in classLoaderData.inline.hpp

### DIFF
--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -632,9 +632,8 @@ void Dictionary::verify() {
   ClassLoaderData* cld = loader_data();
   // class loader must be present;  a null class loader is the
   // boostrap loader
-  guarantee(cld != NULL ||
-            cld->class_loader() == NULL ||
-            cld->class_loader()->is_instance(),
+  guarantee(cld != NULL &&
+            (cld->the_null_class_loader_data() || cld->class_loader()->is_instance()),
             "checking type of class_loader");
 
   ResourceMark rm;


### PR DESCRIPTION
We can see compiler warnings in dictionary.cpp as following on GCC 11. Conditions in `guarantee` should be changed.

```
In file included from /home/ysuenaga/git-forked/jdk/src/hotspot/share/utilities/globalDefinitions.hpp:29,
                 from /home/ysuenaga/git-forked/jdk/src/hotspot/share/memory/allocation.hpp:29,
                 from /home/ysuenaga/git-forked/jdk/src/hotspot/share/classfile/classLoaderData.hpp:28,
                 from /home/ysuenaga/git-forked/jdk/src/hotspot/share/precompiled/precompiled.hpp:34:
In member function 'oop ClassLoaderData::class_loader() const',
    inlined from 'void Dictionary::verify()' at /home/ysuenaga/git-forked/jdk/src/hotspot/share/classfile/dictionary.cpp:635:3:
/home/ysuenaga/git-forked/jdk/src/hotspot/share/classfile/classLoaderData.inline.hpp:37:50: warning: 'this' pointer is null [-Wnonnull]
   37 |   assert(_holder.is_null() || holder_no_keepalive() != NULL , "This class loader data holder must be alive");
      |                               ~~~~~~~~~~~~~~~~~~~^~
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266170](https://bugs.openjdk.java.net/browse/JDK-8266170): -Wnonnull happens in classLoaderData.inline.hpp


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3753/head:pull/3753` \
`$ git checkout pull/3753`

Update a local copy of the PR: \
`$ git checkout pull/3753` \
`$ git pull https://git.openjdk.java.net/jdk pull/3753/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3753`

View PR using the GUI difftool: \
`$ git pr show -t 3753`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3753.diff">https://git.openjdk.java.net/jdk/pull/3753.diff</a>

</details>
