### PR TITLE
8265940: Enable C2's optimization for Math.pow(x, 0.5) on all platforms

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86_pow.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_pow.cpp
@@ -2571,6 +2571,9 @@ void MacroAssembler::fast_pow(XMMRegister xmm0, XMMRegister xmm1, XMMRegister xm
   jccb(Assembler::notEqual, L_NOT_DOUBLE0DOT5);
   jccb(Assembler::parity, L_NOT_DOUBLE0DOT5);
   ucomisd(xmm0, ExternalAddress(DOUBLE0));
+  // According to the API specs, pow(-0.0, 0.5) = 0.0 and sqrt(-0.0) = -0.0.
+  // So pow(-0.0, 0.5) shouldn't be replaced with sqrt(-0.0).
+  // -0.0/+0.0 are both excluded since floating-point comparison doesn't distinguish -0.0 from +0.0.
   jccb(Assembler::belowEqual, L_NOT_DOUBLE0DOT5); // pow(x, 0.5) => sqrt(x) only for x > 0.0
   sqrtsd(xmm0, xmm0);
   jmp(L_2TAG_PACKET_21_0_2);

--- a/src/hotspot/cpu/x86/macroAssembler_x86_pow.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_pow.cpp
@@ -2516,6 +2516,8 @@ ATTRIBUTE_ALIGNED(16) juint _static_const_table_pow[] =
 };
 
 ATTRIBUTE_ALIGNED(8) double _DOUBLE2 = 2.0;
+ATTRIBUTE_ALIGNED(8) double _DOUBLE0 = 0.0;
+ATTRIBUTE_ALIGNED(8) double _DOUBLE0DOT5 = 0.5;
 
 //registers,
 // input: xmm0, xmm1
@@ -2540,12 +2542,14 @@ void MacroAssembler::fast_pow(XMMRegister xmm0, XMMRegister xmm1, XMMRegister xm
   Label L_2TAG_PACKET_48_0_2, L_2TAG_PACKET_49_0_2, L_2TAG_PACKET_50_0_2, L_2TAG_PACKET_51_0_2;
   Label L_2TAG_PACKET_52_0_2, L_2TAG_PACKET_53_0_2, L_2TAG_PACKET_54_0_2, L_2TAG_PACKET_55_0_2;
   Label L_2TAG_PACKET_56_0_2, L_2TAG_PACKET_57_0_2, L_2TAG_PACKET_58_0_2, start;
-  Label L_NOT_DOUBLE2;
+  Label L_NOT_DOUBLE2, L_NOT_DOUBLE0DOT5;
 
   assert_different_registers(tmp, eax, ecx, edx);
 
   address static_const_table_pow = (address)_static_const_table_pow;
   address DOUBLE2 = (address) &_DOUBLE2;
+  address DOUBLE0 = (address) &_DOUBLE0;
+  address DOUBLE0DOT5 = (address) &_DOUBLE0DOT5;
 
   bind(start);
   subl(rsp, 120);
@@ -2562,6 +2566,16 @@ void MacroAssembler::fast_pow(XMMRegister xmm0, XMMRegister xmm1, XMMRegister xm
   jmp(L_2TAG_PACKET_21_0_2);
 
   bind(L_NOT_DOUBLE2);
+  // Special case: pow(x, 0.5) => sqrt(x)
+  ucomisd(xmm1, ExternalAddress(DOUBLE0DOT5)); // For pow(x, y), check whether y == 0.5
+  jccb(Assembler::notEqual, L_NOT_DOUBLE0DOT5);
+  jccb(Assembler::parity, L_NOT_DOUBLE0DOT5);
+  ucomisd(xmm0, ExternalAddress(DOUBLE0));
+  jccb(Assembler::belowEqual, L_NOT_DOUBLE0DOT5); // pow(x, 0.5) => sqrt(x) only for x > 0.0
+  sqrtsd(xmm0, xmm0);
+  jmp(L_2TAG_PACKET_21_0_2);
+
+  bind(L_NOT_DOUBLE0DOT5);
   xorpd(xmm2, xmm2);
   movl(eax, 16368);
   pinsrw(xmm2, eax, 3);

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -1652,6 +1652,9 @@ bool LibraryCallKit::inline_math_pow() {
       Node* phi = new PhiNode(region, Type::DOUBLE);
 
       Node* cmp  = _gvn.transform(new CmpDNode(base, zero));
+      // According to the API specs, pow(-0.0, 0.5) = 0.0 and sqrt(-0.0) = -0.0.
+      // So pow(-0.0, 0.5) shouldn't be replaced with sqrt(-0.0).
+      // -0.0/+0.0 are both excluded since floating-point comparison doesn't distinguish -0.0 from +0.0.
       Node* test = _gvn.transform(new BoolNode(cmp, BoolTest::le));
 
       Node* if_pow = generate_slow_guard(test, NULL);

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -1643,9 +1643,7 @@ bool LibraryCallKit::inline_math_pow() {
       Node* base = round_double_node(argument(0));
       set_result(_gvn.transform(new MulDNode(base, base)));
       return true;
-    }
-#if defined(X86) && defined(_LP64)
-    else if (d->getd() == 0.5 && Matcher::match_rule_supported(Op_SqrtD)) {
+    } else if (d->getd() == 0.5 && Matcher::match_rule_supported(Op_SqrtD)) {
       // Special case: pow(x, 0.5) => sqrt(x)
       Node* base = round_double_node(argument(0));
       Node* zero = _gvn.zerocon(T_DOUBLE);
@@ -1684,7 +1682,6 @@ bool LibraryCallKit::inline_math_pow() {
 
       return true;
     }
-#endif // defined(X86) && defined(_LP64)
   }
 
   return StubRoutines::dpow() != NULL ?

--- a/test/hotspot/jtreg/compiler/intrinsics/math/TestPow0Dot5Opt.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/math/TestPow0Dot5Opt.java
@@ -23,9 +23,8 @@
 
 /*
  * @test
- * @bug 8265325
+ * @bug 8265325 8265940
  * @summary test the optimization of pow(x, 0.5)
- * @requires os.arch=="amd64" | os.arch=="x86_64"
  * @run main/othervm TestPow0Dot5Opt
  * @run main/othervm -Xint TestPow0Dot5Opt
  * @run main/othervm -Xbatch -XX:TieredStopAtLevel=1 TestPow0Dot5Opt


### PR DESCRIPTION
Hi all,

I'd like to enable C2's optimization for Math.pow(x, 0.5) on all platforms.

This is fine because:
 1) For x86, it will call the assembly stubs.
    This opt has already been implemented for x86_64 [1]. 
    And the x86_32 version is added in this patch.
 2) For non-x86, it will call the shared runtime c code [2], which does the same opt too.

Testing:
  - tier1~3 on Linux/{x86_32, x86_64}, no regression

Thanks,
Best regards,
Jie


[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/x86/macroAssembler_x86_pow.cpp#L838
[2] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/runtime/sharedRuntimeTrans.cpp#L497

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265940](https://bugs.openjdk.java.net/browse/JDK-8265940): Enable C2's optimization for Math.pow(x, 0.5) on all platforms


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**) ⚠️ Review applies to bb88f24f1c07632724d1903747b80eeb2c5be2b6
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3755/head:pull/3755` \
`$ git checkout pull/3755`

Update a local copy of the PR: \
`$ git checkout pull/3755` \
`$ git pull https://git.openjdk.java.net/jdk pull/3755/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3755`

View PR using the GUI difftool: \
`$ git pr show -t 3755`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3755.diff">https://git.openjdk.java.net/jdk/pull/3755.diff</a>

</details>
