### PR TITLE
8264395: WB_EnqueueInitializerForCompilation fails with "method holder must be initialized" when called for uninitialized class

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1039,12 +1039,8 @@ WB_END
 WB_ENTRY(jboolean, WB_EnqueueInitializerForCompilation(JNIEnv* env, jobject o, jclass klass, jint comp_level))
   InstanceKlass* ik = InstanceKlass::cast(java_lang_Class::as_Klass(JNIHandles::resolve(klass)));
   Method* clinit = ik->class_initializer();
-  if (clinit == NULL) {
+  if (clinit == NULL || clinit->method_holder()->is_not_initialized()) {
     return false;
-  }
-  methodHandle mh(THREAD, clinit);
-  if (mh->method_holder()->is_not_initialized()) {
-    return false; // Bail out if not initialized
   }
   return WhiteBox::compile_method(clinit, comp_level, InvocationEntryBci, THREAD);
 WB_END

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1042,6 +1042,10 @@ WB_ENTRY(jboolean, WB_EnqueueInitializerForCompilation(JNIEnv* env, jobject o, j
   if (clinit == NULL) {
     return false;
   }
+  methodHandle mh(THREAD, clinit);
+  if (mh->method_holder()->is_not_initialized()) {
+    return false; // Bail out if not initialized
+  }
   return WhiteBox::compile_method(clinit, comp_level, InvocationEntryBci, THREAD);
 WB_END
 

--- a/test/hotspot/jtreg/compiler/whitebox/EnqueueInitializerForCompilationTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/EnqueueInitializerForCompilationTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8264395
+ * @summary testing of WB::enqueueInitializerForCompilation()
+ * @library /test/lib /
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm/timeout=300 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *      -XX:+WhiteBoxAPI compiler.whitebox.EnqueueInitializerForCompilationTest
+ */
+
+package compiler.whitebox;
+
+import sun.hotspot.WhiteBox;
+
+public class EnqueueInitializerForCompilationTest {
+
+    public static void main(String[] args) {
+        WhiteBox.getWhiteBox().enqueueInitializerForCompilation(LongWrapper.class, 4);
+    }
+
+    static class LongWrapper {
+        final static LongWrapper ZERO = new LongWrapper(0);
+        private long val;
+
+        LongWrapper(long val) {
+            this.val = val;
+        }
+
+        static LongWrapper wrap(long val) {
+            return (val == 0L) ? ZERO : new LongWrapper(val);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/whitebox/TestEnqueueInitializerForCompilation.java
+++ b/test/hotspot/jtreg/compiler/whitebox/TestEnqueueInitializerForCompilation.java
@@ -24,11 +24,11 @@
 /*
  * @test
  * @bug 8264395
- * @summary testing of WB::enqueueInitializerForCompilation()
- * @library /test/lib /
+ * @summary testing compilation of the class initializer of a class that is not initialized yet
+ * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm/timeout=300 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *      -XX:+WhiteBoxAPI compiler.whitebox.TestEnqueueInitializerForCompilation
  */
 
@@ -43,15 +43,6 @@ public class TestEnqueueInitializerForCompilation {
     }
 
     static class LongWrapper {
-        final static LongWrapper ZERO = new LongWrapper(0);
-        private long val;
-
-        LongWrapper(long val) {
-            this.val = val;
-        }
-
-        static LongWrapper wrap(long val) {
-            return (val == 0L) ? ZERO : new LongWrapper(val);
-        }
+        final static LongWrapper ZERO = new LongWrapper();
     }
 }

--- a/test/hotspot/jtreg/compiler/whitebox/TestEnqueueInitializerForCompilation.java
+++ b/test/hotspot/jtreg/compiler/whitebox/TestEnqueueInitializerForCompilation.java
@@ -29,14 +29,14 @@
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm/timeout=300 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI compiler.whitebox.EnqueueInitializerForCompilationTest
+ *      -XX:+WhiteBoxAPI compiler.whitebox.TestEnqueueInitializerForCompilation
  */
 
 package compiler.whitebox;
 
 import sun.hotspot.WhiteBox;
 
-public class EnqueueInitializerForCompilationTest {
+public class TestEnqueueInitializerForCompilation {
 
     public static void main(String[] args) {
         WhiteBox.getWhiteBox().enqueueInitializerForCompilation(LongWrapper.class, 4);


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8264395

Reported assert failure, during compilation triggered by Whitebox API `enqueueInitializerForCompilation` method,
is fixed by adding support to to bail out if a class not initialized yet.

Confirmed the new `compiler/whitebox/TestEnqueueInitializerForCompilation.java` test passes with the proposed `whitebox.cpp` changes and fails with reported assert without this fix.
No issues with tier tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264395](https://bugs.openjdk.java.net/browse/JDK-8264395): WB_EnqueueInitializerForCompilation fails with "method holder must be initialized" when called for uninitialized class


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to 5a737641dd552fa177a54e5ff33dc3b48255e2c9
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3757/head:pull/3757` \
`$ git checkout pull/3757`

Update a local copy of the PR: \
`$ git checkout pull/3757` \
`$ git pull https://git.openjdk.java.net/jdk pull/3757/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3757`

View PR using the GUI difftool: \
`$ git pr show -t 3757`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3757.diff">https://git.openjdk.java.net/jdk/pull/3757.diff</a>

</details>
