### PR TITLE
8266206: Build failure after JDK-8264752 with older GCCs

### DIFF
--- a/src/hotspot/share/jfr/recorder/service/jfrOptionSet.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrOptionSet.cpp
@@ -395,8 +395,9 @@ static julong divide_with_user_unit(Argument& memory_argument, julong value) {
 
 static const char higher_than_msg[] = "This value is higher than the maximum size limited ";
 static const char lower_than_msg[] = "This value is lower than the minimum size required ";
-template <typename Argument, char const *msg>
+template <typename Argument, bool lower>
 static void log_out_of_range_value(Argument& memory_argument, julong min_value) {
+  const char* msg = lower ? lower_than_msg : higher_than_msg;
   if (memory_argument.value()._size != memory_argument.value()._val) {
     // has multiplier
     log_error(arguments) (
@@ -619,7 +620,7 @@ template <typename Argument>
 static bool ensure_gteq(Argument& memory_argument, const jlong value) {
   if ((jlong)memory_argument.value()._size < value) {
     log_set_value(memory_argument);
-    log_out_of_range_value<Argument, lower_than_msg>(memory_argument, value);
+    log_out_of_range_value<Argument, true>(memory_argument, value);
     return false;
   }
   return true;
@@ -654,7 +655,7 @@ template <typename Argument>
 static bool ensure_lteq(Argument& memory_argument, const jlong value) {
   if ((jlong)memory_argument.value()._size > value) {
     log_set_value(memory_argument);
-    log_out_of_range_value<Argument, higher_than_msg>(memory_argument, value);
+    log_out_of_range_value<Argument, false>(memory_argument, value);
     return false;
   }
   return true;


### PR DESCRIPTION
See the bug report for error log. It seems older GCCs dislike `const char*` as template argument without it being the `constexpr`. Since the bug is marked for eventual backports to 8u and 11u, I think we better play it safe and drop the template argument to `bool`, and select the message in the method body.

Additional testing:
 - [x] build passes with GCC 6.3.0
 - [x] build passes with GCC 9.3.0
 - [x] `jdk_jfr` passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266206](https://bugs.openjdk.java.net/browse/JDK-8266206): Build failure after JDK-8264752 with older GCCs


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3759/head:pull/3759` \
`$ git checkout pull/3759`

Update a local copy of the PR: \
`$ git checkout pull/3759` \
`$ git pull https://git.openjdk.java.net/jdk pull/3759/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3759`

View PR using the GUI difftool: \
`$ git pr show -t 3759`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3759.diff">https://git.openjdk.java.net/jdk/pull/3759.diff</a>

</details>
