### PR TITLE
8197821: Test java/awt/font/TextLayout/LigatureCaretTest.java fails on Windows

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -260,7 +260,6 @@ sun/java2d/SunGraphics2D/SourceClippingBlitTest/SourceClippingBlitTest.java 8196
 
 sun/java2d/X11SurfaceData/SharedMemoryPixmapsTest/SharedMemoryPixmapsTest.sh 8221451 linux-all
 java/awt/FullScreen/DisplayChangeVITest/DisplayChangeVITest.java 8169469 windows-all
-java/awt/Graphics2D/DrawString/DrawRotatedStringUsingRotatedFont.java 8197796 generic-all
 java/awt/print/PrinterJob/PSQuestionMark.java 7003378 generic-all
 java/awt/print/PrinterJob/GlyphPositions.java 7003378 generic-all
 java/awt/Choice/ChoiceMouseWheelTest/ChoiceMouseWheelTest.java 7100044 macosx-all,linux-all
@@ -473,7 +472,6 @@ java/awt/Modal/OnTop/OnTopTKModal6Test.java 8198666 macosx-all
 java/awt/List/SingleModeDeselect/SingleModeDeselect.java 8196367 windows-all
 java/awt/SplashScreen/MultiResolutionSplash/MultiResolutionSplashTest.java 8061235 macosx-all
 javax/print/PrintSEUmlauts/PrintSEUmlauts.java 8135174 generic-all
-java/awt/font/TextLayout/LigatureCaretTest.java 8197821 generic-all
 java/awt/image/VolatileImage/CustomCompositeTest.java 8199002 windows-all,linux-all
 java/awt/image/VolatileImage/GradientPaints.java 8199003 linux-all
 java/awt/JAWT/JAWT.sh 8197798 windows-all,linux-all


### PR DESCRIPTION
2 tests java/awt/font/TextLayout/LigatureCaretTest.java and java/awt/Graphics2D/DrawString/DrawRotatedStringUsingRotatedFont.java used to fail on windows in CI testing citing "wrong text location" and " right hit failed within layout " which is due to some layout  issue. 
We have made harfbuzz upgrades after that and these tests are not failing neither locally nor in CI testing.

Several iterations of these tests in all platforms are working fine, so we can remove from problemlist.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8197821](https://bugs.openjdk.java.net/browse/JDK-8197821): Test java/awt/font/TextLayout/LigatureCaretTest.java fails on Windows
 * [JDK-8197796](https://bugs.openjdk.java.net/browse/JDK-8197796): Test java/awt/Graphics2D/DrawString/DrawRotatedStringUsingRotatedFont.java  fails on Windows


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3760/head:pull/3760` \
`$ git checkout pull/3760`

Update a local copy of the PR: \
`$ git checkout pull/3760` \
`$ git pull https://git.openjdk.java.net/jdk pull/3760/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3760`

View PR using the GUI difftool: \
`$ git pr show -t 3760`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3760.diff">https://git.openjdk.java.net/jdk/pull/3760.diff</a>

</details>
