### PR TITLE
8266087: Move 'buffer' declaration in get_user_name_slow() inside of linux specific code

### DIFF
--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -527,10 +527,10 @@ static char* get_user_name_slow(int vmid, int nspid, TRAPS) {
   // directory search
   char* oldest_user = NULL;
   time_t oldest_ctime = 0;
-  char buffer[MAXPATHLEN + 1];
   int searchpid;
   char* tmpdirname = (char *)os::get_temp_directory();
 #if defined(LINUX)
+  char buffer[MAXPATHLEN + 1];
   assert(strlen(tmpdirname) == 4, "No longer using /tmp - update buffer size");
 
   // On Linux, if nspid != -1, look in /proc/{vmid}/root/tmp for directories


### PR DESCRIPTION
Please review this very small fix for JDK-8266087.  The fix was tested by running Mach5 tiers 1 and 2 on Linux, Mac OS, and Windows.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266087](https://bugs.openjdk.java.net/browse/JDK-8266087): Move 'buffer' declaration in get_user_name_slow() inside of linux specific code


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3761/head:pull/3761` \
`$ git checkout pull/3761`

Update a local copy of the PR: \
`$ git checkout pull/3761` \
`$ git pull https://git.openjdk.java.net/jdk pull/3761/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3761`

View PR using the GUI difftool: \
`$ git pr show -t 3761`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3761.diff">https://git.openjdk.java.net/jdk/pull/3761.diff</a>

</details>
