### PR TITLE
8266220: keytool still prompt for store password on a password-less pkcs12 file if -storetype pkcs12 is specified

### DIFF
--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -933,16 +933,26 @@ public final class Main {
             }
         }
 
-        // Create new keystore
-        // Probe for keystore type when filename is available
         if (ksfile != null && ksStream != null && providerName == null &&
-                storetype == null && !inplaceImport) {
-            keyStore = KeyStore.getInstance(ksfile, storePass);
-            storetype = keyStore.getType();
+                !inplaceImport) {
+            // existing keystore
+            if (storetype == null) {
+                // Probe for keystore type when filename is available
+                keyStore = KeyStore.getInstance(ksfile, storePass);
+                storetype = keyStore.getType();
+            } else {
+                keyStore = KeyStore.getInstance(storetype);
+                keyStore.load(ksStream, storePass);
+            }
             if (storetype.equalsIgnoreCase("pkcs12")) {
-                isPasswordlessKeyStore = PKCS12KeyStore.isPasswordless(ksfile);
+                try {
+                    isPasswordlessKeyStore = PKCS12KeyStore.isPasswordless(ksfile);
+                } catch (IOException ioe) {
+                    // This must be a JKS keystore that's opened as a PKCS12
+                }
             }
         } else {
+            // Create new keystore
             if (storetype == null) {
                 storetype = KeyStore.getDefaultType();
             }

--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -942,6 +942,7 @@ public final class Main {
                 storetype = keyStore.getType();
             } else {
                 keyStore = KeyStore.getInstance(storetype);
+                // storePass might be null here, will probably prompt later
                 keyStore.load(ksStream, storePass);
             }
             if (storetype.equalsIgnoreCase("pkcs12")) {
@@ -995,10 +996,8 @@ public final class Main {
                 if (inplaceImport) {
                     keyStore.load(null, storePass);
                 } else {
+                    // both ksStream and storePass could be null
                     keyStore.load(ksStream, storePass);
-                }
-                if (ksStream != null) {
-                    ksStream.close();
                 }
             }
         }
@@ -1096,9 +1095,10 @@ public final class Main {
             if (nullStream) {
                 keyStore.load(null, storePass);
             } else if (ksStream != null) {
-                ksStream = new FileInputStream(ksfile);
-                keyStore.load(ksStream, storePass);
-                ksStream.close();
+                // Reload with user-provided password
+                try (FileInputStream fis = new FileInputStream(ksfile)) {
+                    keyStore.load(fis, storePass);
+                }
             }
         }
 

--- a/test/jdk/sun/security/tools/keytool/PKCS12Passwd.java
+++ b/test/jdk/sun/security/tools/keytool/PKCS12Passwd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8192988
+ * @bug 8192988 8266220
  * @summary keytool should support -storepasswd for pkcs12 keystores
  * @library /test/lib
  * @build jdk.test.lib.SecurityTools
@@ -134,6 +134,21 @@ public class PKCS12Passwd {
                 .shouldHaveExitValue(0);
 
         check("jks", "newpass", "newerpass");
+
+        // A password-less keystore
+        ktFull("-keystore nopass -genkeypair -keyalg EC "
+                + "-storepass changeit -alias no -dname CN=no "
+                + "-J-Dkeystore.pkcs12.certProtectionAlgorithm=NONE "
+                + "-J-Dkeystore.pkcs12.macAlgorithm=NONE")
+                .shouldHaveExitValue(0);
+
+        ktFull("-keystore nopass -list")
+                .shouldHaveExitValue(0)
+                .shouldNotContain("Enter keystore password:");
+
+        ktFull("-keystore nopass -list -storetype pkcs12")
+                .shouldHaveExitValue(0)
+                .shouldNotContain("Enter keystore password:");
     }
 
     // Makes sure we can load entries in a keystore


### PR DESCRIPTION
It's awkward that for a password-less pkcs12 keystore, `keytool -list` does not prompt for a password but `keytool -list -storetype pkcs12` does.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266220](https://bugs.openjdk.java.net/browse/JDK-8266220): keytool still prompt for store password on a password-less pkcs12 file if -storetype pkcs12 is specified


### Reviewers
 * [Sean Coffey](https://openjdk.java.net/census#coffeys) (@coffeys - **Reviewer**)
 * [Hai-May Chao](https://openjdk.java.net/census#hchao) (@haimaychao - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3764/head:pull/3764` \
`$ git checkout pull/3764`

Update a local copy of the PR: \
`$ git checkout pull/3764` \
`$ git pull https://git.openjdk.java.net/jdk pull/3764/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3764`

View PR using the GUI difftool: \
`$ git pr show -t 3764`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3764.diff">https://git.openjdk.java.net/jdk/pull/3764.diff</a>

</details>
