### PR TITLE
8264678: Incomplete comment in build.tools.generatecharacter.GenerateCharacter

### DIFF
--- a/make/jdk/src/classes/build/tools/generatecharacter/GenerateCharacter.java
+++ b/make/jdk/src/classes/build/tools/generatecharacter/GenerateCharacter.java
@@ -409,7 +409,7 @@ public class GenerateCharacter {
 
         // extract and record the uppercase letter / lowercase letter property into the
         // maskOtherUppercase/-Lowercase bit so that Character.isLower|UpperCase
-        // can use a one-step lookup (this property includes
+        // can use a one-step lookup
         if (resultA == Character.UPPERCASE_LETTER) {
             resultA |= maskOtherUppercase;
         } else if (resultA == Character.LOWERCASE_LETTER) {
@@ -1897,7 +1897,6 @@ OUTER:  for (int i = 0; i < n; i += m) {
                              hex8(maxOffset));
             }
         }
-        catch (FileNotFoundException e) { FAIL(e.toString()); }
         catch (IOException e) { FAIL(e.toString()); }
         catch (Throwable e) {
             System.out.println("Unexpected exception:");


### PR DESCRIPTION
I'm not exactly sure what I intended to say in this partial comment. Removing it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264678](https://bugs.openjdk.java.net/browse/JDK-8264678): Incomplete comment in build.tools.generatecharacter.GenerateCharacter


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3766/head:pull/3766` \
`$ git checkout pull/3766`

Update a local copy of the PR: \
`$ git checkout pull/3766` \
`$ git pull https://git.openjdk.java.net/jdk pull/3766/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3766`

View PR using the GUI difftool: \
`$ git pr show -t 3766`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3766.diff">https://git.openjdk.java.net/jdk/pull/3766.diff</a>

</details>
