### PR TITLE
8266165: TestNoWarningLoopStripMiningIterSet is runnable only on VM w/ G1, Shenandoah, Z and Epsilon

### DIFF
--- a/test/hotspot/jtreg/compiler/loopstripmining/TestNoWarningLoopStripMiningIterSet.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestNoWarningLoopStripMiningIterSet.java
@@ -22,15 +22,49 @@
  */
 
 /*
- * @test
+ * @test id=G1
  * @bug 8241486
  * @summary G1/Z give warning when using LoopStripMiningIter and turn off LoopStripMiningIter (0)
  * @requires vm.flagless
  * @requires vm.flavor == "server" & !vm.graal.enabled
- * @requires vm.gc.G1 & vm.gc.Shenandoah & vm.gc.Z & vm.gc.Epsilon
+ * @requires vm.gc.G1
  * @library /test/lib
- * @run driver TestNoWarningLoopStripMiningIterSet
+ * @run driver TestNoWarningLoopStripMiningIterSet G1
  */
+
+/*
+ * @test id=Shenandoah
+ * @bug 8241486
+ * @summary G1/Z give warning when using LoopStripMiningIter and turn off LoopStripMiningIter (0)
+ * @requires vm.flagless
+ * @requires vm.flavor == "server" & !vm.graal.enabled
+ * @requires vm.gc.Shenandoah
+ * @library /test/lib
+ * @run driver TestNoWarningLoopStripMiningIterSet Shenandoah
+ */
+
+/*
+ * @test id=Z
+ * @bug 8241486
+ * @summary G1/Z give warning when using LoopStripMiningIter and turn off LoopStripMiningIter (0)
+ * @requires vm.flagless
+ * @requires vm.flavor == "server" & !vm.graal.enabled
+ * @requires vm.gc.Z
+ * @library /test/lib
+ * @run driver TestNoWarningLoopStripMiningIterSet Z
+ */
+
+/*
+ * @test id=Epsilon
+ * @bug 8241486
+ * @summary G1/Z give warning when using LoopStripMiningIter and turn off LoopStripMiningIter (0)
+ * @requires vm.flagless
+ * @requires vm.flavor == "server" & !vm.graal.enabled
+ * @requires vm.gc.Epsilon
+ * @library /test/lib
+ * @run driver TestNoWarningLoopStripMiningIterSet Epsilon
+ */
+
 
 import jdk.test.lib.Asserts;
 import jdk.test.lib.process.ProcessTools;
@@ -60,11 +94,10 @@ public class TestNoWarningLoopStripMiningIterSet {
     }
 
     public static void main(String[] args) throws Exception {
-        for (String gc : List.of("-XX:+UseG1GC", "-XX:+UseZGC", "-XX:+UseShenandoahGC", "-XX:+UseEpsilonGC")) {
-            testWith(output -> output.shouldNotContain(CLSOffLSMGreaterZero), "should have CLS and LSM enabled", true, 100, "-XX:LoopStripMiningIter=100", gc);
-            testWith(output -> output.shouldContain(CLSOffLSMGreaterZero), "should have CLS and LSM disabled", false, 0, "-XX:-UseCountedLoopSafepoints", "-XX:LoopStripMiningIter=100", gc);
-            testWith(output -> output.shouldContain(CLSOnLSMEqualZero), "should have CLS and LSM enabled", true, 1, "-XX:LoopStripMiningIter=0", gc);
-            testWith(output -> output.shouldNotContain(CLSOnLSMEqualZero), "should have CLS and LSM disabled", false, 0, "-XX:-UseCountedLoopSafepoints", "-XX:LoopStripMiningIter=0", gc);
-        }
+        String gc = "-XX:+Use" + args[0] + "GC";
+        testWith(output -> output.shouldNotContain(CLSOffLSMGreaterZero), "should have CLS and LSM enabled", true, 100, "-XX:LoopStripMiningIter=100", gc);
+        testWith(output -> output.shouldContain(CLSOffLSMGreaterZero), "should have CLS and LSM disabled", false, 0, "-XX:-UseCountedLoopSafepoints", "-XX:LoopStripMiningIter=100", gc);
+        testWith(output -> output.shouldContain(CLSOnLSMEqualZero), "should have CLS and LSM enabled", true, 1, "-XX:LoopStripMiningIter=0", gc);
+        testWith(output -> output.shouldNotContain(CLSOnLSMEqualZero), "should have CLS and LSM disabled", false, 0, "-XX:-UseCountedLoopSafepoints", "-XX:LoopStripMiningIter=0", gc);
     }
 }


### PR DESCRIPTION
Hi all,

could you please review the patch which splits `TestNoWarningLoopStripMiningIterSet` test into several "subtests", one for each GCs?

from JBS:
> `TestNoWarningLoopStripMiningIterSet` test uses `@requires vm.gc.G1 & vm.gc.Shenandoah & vm.gc.Z & vm.gc.Epsilon` to make sure all GCs in its loop are available. this exlcudes this test from execution on VMs which don't have at least one of the listed GCs.

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266165](https://bugs.openjdk.java.net/browse/JDK-8266165): TestNoWarningLoopStripMiningIterSet is runnable only on VM w/ G1, Shenandoah, Z and Epsilon


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3767/head:pull/3767` \
`$ git checkout pull/3767`

Update a local copy of the PR: \
`$ git checkout pull/3767` \
`$ git pull https://git.openjdk.java.net/jdk pull/3767/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3767`

View PR using the GUI difftool: \
`$ git pr show -t 3767`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3767.diff">https://git.openjdk.java.net/jdk/pull/3767.diff</a>

</details>
