### PR TITLE
8265918: java/io/Console/CharsetTest.java failed with "expect: spawn id exp6 not open"

### DIFF
--- a/test/jdk/java/io/Console/CharsetTest.java
+++ b/test/jdk/java/io/Console/CharsetTest.java
@@ -30,7 +30,7 @@ import jdk.test.lib.process.ProcessTools;
 
 /**
  * @test
- * @bug 8264208
+ * @bug 8264208 8265918
  * @summary Tests Console.charset() method. "expect" command in Windows/Cygwin
  *          does not work as expected. Ignoring tests on Windows.
  * @requires (os.family == "linux") | (os.family == "mac")
@@ -38,7 +38,6 @@ import jdk.test.lib.process.ProcessTools;
  * @run main CharsetTest en_US.ISO8859-1 ISO-8859-1
  * @run main CharsetTest en_US.US-ASCII US-ASCII
  * @run main CharsetTest en_US.UTF-8 UTF-8
- * @run main CharsetTest en_US.FOO ignored
  */
 public class CharsetTest {
     public static void main(String... args) throws Throwable {

--- a/test/jdk/java/io/Console/script.exp
+++ b/test/jdk/java/io/Console/script.exp
@@ -28,15 +28,5 @@ set args [lrange $argv 3 end]
 regexp {([a-zA-Z_]*).([a-zA-Z0-9\-]*)} $locale dummy lang_region encoding
 
 eval spawn $java -Dsun.stdout.encoding=$encoding -classpath $args CharsetTest
-if {$encoding == "FOO"} then \
-    {expect "UTF-8"} \
-else \
-    {expect $expected}
-
-eval spawn env LANG=$locale LC_ALL=$locale $java -classpath $args CharsetTest
-if {$encoding == "FOO"} then \
-    {expect "US-ASCII"} \
-else \
-    {expect $expected}
-
+expect $expected
 expect eof


### PR DESCRIPTION
This new regression test was introduced with the Console::charset(), but it fails on ubuntu platforms assuming its locales/encoding incorrectly. To not make false-alarm/noise on test runs, this fix minimizes the tests not depending on the underlying OS's environment variables.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265918](https://bugs.openjdk.java.net/browse/JDK-8265918): java/io/Console/CharsetTest.java failed with "expect: spawn id exp6 not open"


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3768/head:pull/3768` \
`$ git checkout pull/3768`

Update a local copy of the PR: \
`$ git checkout pull/3768` \
`$ git pull https://git.openjdk.java.net/jdk pull/3768/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3768`

View PR using the GUI difftool: \
`$ git pr show -t 3768`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3768.diff">https://git.openjdk.java.net/jdk/pull/3768.diff</a>

</details>
