### PR TITLE
8266190: mark hotspot compiler/codecache tests which ignore VM flags

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/CheckReservedInitialCodeCacheSizeArgOrder.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckReservedInitialCodeCacheSizeArgOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/codecache/CheckReservedInitialCodeCacheSizeArgOrder.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckReservedInitialCodeCacheSizeArgOrder.java
@@ -27,8 +27,7 @@
  * @summary Test checks that the order in which ReversedCodeCacheSize and
  *          InitialCodeCacheSize are passed to the VM is irrelevant.
  * @library /test/lib
- * @modules java.base/jdk.internal.misc
- *          java.management
+ * @requires vm.flagless
  *
  * @run driver compiler.codecache.CheckReservedInitialCodeCacheSizeArgOrder
  */

--- a/test/hotspot/jtreg/compiler/codecache/CheckSegmentedCodeCache.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckSegmentedCodeCache.java
@@ -26,8 +26,7 @@
  * @bug 8015774
  * @summary Checks VM options related to the segmented code cache
  * @library /test/lib
- * @modules java.base/jdk.internal.misc
- *          java.management
+ * @requires vm.flagless
  *
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
@@ -59,10 +58,10 @@ public class CheckSegmentedCodeCache {
                 out.shouldContain(NON_METHOD);
             } catch (RuntimeException e) {
                 // Check if TieredCompilation is disabled (in a client VM)
-                if(!out.getOutput().contains("-XX:+TieredCompilation not supported in this VM")) {
+                if (!out.getOutput().contains("-XX:+TieredCompilation not supported in this VM")) {
                     // Code cache is not segmented
                     throw new RuntimeException("No code cache segmentation.");
-                    }
+                }
             }
         } else {
             out.shouldNotContain(NON_METHOD);

--- a/test/hotspot/jtreg/compiler/codecache/CheckUpperLimit.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckUpperLimit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/codecache/CheckUpperLimit.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckUpperLimit.java
@@ -26,8 +26,7 @@
  * @bug 8015635
  * @summary Test ensures that the ReservedCodeCacheSize is at most MAXINT
  * @library /test/lib
- * @modules java.base/jdk.internal.misc
- *          java.management
+ * @requires vm.flagless
  *
  * @run driver compiler.codecache.CheckUpperLimit
  */


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch that adds `@requires vm.flagless` to `compiler/codecache ` tests that ignore VM flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266190](https://bugs.openjdk.java.net/browse/JDK-8266190): mark hotspot compiler/codecache tests which ignore VM flags


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3769/head:pull/3769` \
`$ git checkout pull/3769`

Update a local copy of the PR: \
`$ git checkout pull/3769` \
`$ git pull https://git.openjdk.java.net/jdk pull/3769/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3769`

View PR using the GUI difftool: \
`$ git pr show -t 3769`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3769.diff">https://git.openjdk.java.net/jdk/pull/3769.diff</a>

</details>
