### PR TITLE
8266230: mark hotspot compiler/c2 tests which ignore VM flags

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/TestBit.java
+++ b/test/hotspot/jtreg/compiler/c2/TestBit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/c2/TestBit.java
+++ b/test/hotspot/jtreg/compiler/c2/TestBit.java
@@ -32,15 +32,16 @@ import jdk.test.lib.process.ProcessTools;
  * @summary C2 should convert ((var&16) == 16) to ((var&16) != 0) for power-of-two constants
  * @library /test/lib /
  *
- * @run driver compiler.c2.TestBit
- *
+ * @requires vm.flagless
  * @requires os.arch=="aarch64" | os.arch=="amd64" | os.arch == "ppc64le"
  * @requires vm.debug == true & vm.compiler2.enabled
+ *
+ * @run driver compiler.c2.TestBit
  */
 public class TestBit {
 
     static void runTest(String testName) throws Exception {
-        String className = "compiler.c2.TestBit";
+        String className = TestBit.class.getName();
         String[] procArgs = {
             "-Xbatch",
             "-XX:-TieredCompilation",

--- a/test/hotspot/jtreg/compiler/c2/aarch64/TestSVEWithJNI.java
+++ b/test/hotspot/jtreg/compiler/c2/aarch64/TestSVEWithJNI.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
 * Copyright (c) 2020, Arm Limited. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *

--- a/test/hotspot/jtreg/compiler/c2/aarch64/TestSVEWithJNI.java
+++ b/test/hotspot/jtreg/compiler/c2/aarch64/TestSVEWithJNI.java
@@ -29,8 +29,9 @@
  * @requires os.arch == "aarch64" & vm.compiler2.enabled & os.family == "linux"
  * @summary Verify VM SVE checking behavior
  * @library /test/lib
- * @run main/othervm/native compiler.c2.aarch64.TestSVEWithJNI
+ * @requires vm.flagless
  *
+ * @run main/othervm/native compiler.c2.aarch64.TestSVEWithJNI
  */
 
 package compiler.c2.aarch64;

--- a/test/hotspot/jtreg/compiler/c2/aarch64/TestVolatilesG1.java
+++ b/test/hotspot/jtreg/compiler/c2/aarch64/TestVolatilesG1.java
@@ -28,6 +28,7 @@
  *
  * @modules java.base/jdk.internal.misc
  *
+ * @requires vm.flagless
  * @requires os.arch=="aarch64" & vm.debug == true &
  *           vm.flavor == "server" & !vm.graal.enabled &
  *           vm.gc.G1

--- a/test/hotspot/jtreg/compiler/c2/aarch64/TestVolatilesParallel.java
+++ b/test/hotspot/jtreg/compiler/c2/aarch64/TestVolatilesParallel.java
@@ -28,6 +28,7 @@
  *
  * @modules java.base/jdk.internal.misc
  *
+ * @requires vm.flagless
  * @requires os.arch=="aarch64" & vm.debug == true &
  *           vm.flavor == "server" & !vm.graal.enabled &
  *           vm.gc.Parallel

--- a/test/hotspot/jtreg/compiler/c2/aarch64/TestVolatilesSerial.java
+++ b/test/hotspot/jtreg/compiler/c2/aarch64/TestVolatilesSerial.java
@@ -28,6 +28,7 @@
  *
  * @modules java.base/jdk.internal.misc
  *
+ * @requires vm.flagless
  * @requires os.arch=="aarch64" & vm.debug == true &
  *           vm.flavor == "server" & !vm.graal.enabled &
  *           vm.gc.Serial

--- a/test/hotspot/jtreg/compiler/c2/aarch64/TestVolatilesShenandoah.java
+++ b/test/hotspot/jtreg/compiler/c2/aarch64/TestVolatilesShenandoah.java
@@ -28,6 +28,7 @@
  *
  * @modules java.base/jdk.internal.misc
  *
+ * @requires vm.flagless
  * @requires os.arch=="aarch64" & vm.debug == true &
  *           vm.flavor == "server" &
  *           vm.gc.Shenandoah


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch that adds `@requires vm.flagless` to `compiler/c2 ` tests that ignore VM flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266230](https://bugs.openjdk.java.net/browse/JDK-8266230): mark hotspot compiler/c2 tests which ignore VM flags


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3770/head:pull/3770` \
`$ git checkout pull/3770`

Update a local copy of the PR: \
`$ git checkout pull/3770` \
`$ git pull https://git.openjdk.java.net/jdk pull/3770/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3770`

View PR using the GUI difftool: \
`$ git pr show -t 3770`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3770.diff">https://git.openjdk.java.net/jdk/pull/3770.diff</a>

</details>
