### PR TITLE
8264472: Add a test group for running CDS tests with -XX:+VerifySharedSpaces

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -358,6 +358,23 @@ hotspot_cds_relocation = \
   serviceability/sa \
  -runtime/cds/DeterministicDump.java
 
+hotspot_cds_verify_shared_spaces = \
+  runtime/cds/appcds/ArchiveRelocationTest.java \
+  runtime/cds/appcds/BootClassPathMismatch.java \
+  runtime/cds/appcds/HelloTest.java \
+  runtime/cds/appcds/VerifierTest_0.java \
+  runtime/cds/appcds/dynamicArchive/BasicLambdaTest.java \
+  runtime/cds/appcds/dynamicArchive/DynamicArchiveRelocationTest.java \
+  runtime/cds/appcds/dynamicArchive/HelloDynamic.java \
+  runtime/cds/appcds/dynamicArchive/LinkClassTest.java \
+  runtime/cds/appcds/dynamicArchive/MismatchedBaseArchive.java \
+  runtime/cds/appcds/customLoader/HelloCustom.java \
+  runtime/cds/appcds/customLoader/LoaderSegregationTest.java \
+  runtime/cds/appcds/javaldr/ArrayTest.java \
+  runtime/cds/appcds/jigsaw/modulepath/ExportModule.java \
+  runtime/cds/appcds/jvmti/dumpingWithAgent/DumpingWithJavaAgent.java \
+  runtime/cds/appcds/sharedStrings/SharedStringsBasic.java
+
 # needs -nativepath:<output>/images/test/hotspot/jtreg/native/
 hotspot_metaspace = \
   gtest/MetaspaceGtests.java \


### PR DESCRIPTION
Add a new test group `hotspot_cds_verify_shared_spaces` for running some CDS tests with the `-XX:+VerifySharedSpaces` option.

Testing: hs-tier4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264472](https://bugs.openjdk.java.net/browse/JDK-8264472): Add a test group for running CDS tests with -XX:+VerifySharedSpaces


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3771/head:pull/3771` \
`$ git checkout pull/3771`

Update a local copy of the PR: \
`$ git checkout pull/3771` \
`$ git pull https://git.openjdk.java.net/jdk pull/3771/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3771`

View PR using the GUI difftool: \
`$ git pr show -t 3771`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3771.diff">https://git.openjdk.java.net/jdk/pull/3771.diff</a>

</details>
