### PR TITLE
8266232: compiler.c1.TestRangeCheckEliminated should be run in driver mode

### DIFF
--- a/test/hotspot/jtreg/compiler/c1/TestRangeCheckEliminated.java
+++ b/test/hotspot/jtreg/compiler/c1/TestRangeCheckEliminated.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/c1/TestRangeCheckEliminated.java
+++ b/test/hotspot/jtreg/compiler/c1/TestRangeCheckEliminated.java
@@ -25,17 +25,17 @@
  * @test
  * @bug 8263707
  * @summary Test range check for constant array and NewMultiArray is removed properly
+ * @author Hui Shi
+ *
  * @requires vm.debug == true & vm.compiler1.enabled
  *
  * @library /test/lib
- * @run main/othervm compiler.c1.TestRangeCheckEliminated
  *
- * @author Hui Shi
-*/
+ * @run driver compiler.c1.TestRangeCheckEliminated
+ */
 
 package compiler.c1;
 
-import jdk.test.lib.Asserts;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
@@ -48,8 +48,8 @@ public class TestRangeCheckEliminated {
             "-XX:TieredStopAtLevel=1",
             "-XX:+TraceRangeCheckElimination",
             "-XX:-BackgroundCompilation",
-            "compiler.c1.TestRangeCheckEliminated$test_constant_array"
-            };
+            test_constant_array.class.getName()
+         };
 
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(procArgs);
         String output = new OutputAnalyzer(pb.start()).getOutput();
@@ -67,8 +67,8 @@ public class TestRangeCheckEliminated {
             "-XX:TieredStopAtLevel=1",
             "-XX:+TraceRangeCheckElimination",
             "-XX:-BackgroundCompilation",
-            "compiler.c1.TestRangeCheckEliminated$test_multi_constant_array"
-            };
+            test_multi_constant_array.class.getName()
+        };
 
         pb = ProcessTools.createJavaProcessBuilder(procArgs);
         output = new OutputAnalyzer(pb.start()).getOutput();
@@ -86,8 +86,8 @@ public class TestRangeCheckEliminated {
             "-XX:TieredStopAtLevel=1",
             "-XX:+TraceRangeCheckElimination",
             "-XX:-BackgroundCompilation",
-            "compiler.c1.TestRangeCheckEliminated$test_multi_new_array"
-            };
+            test_multi_new_array.class.getName()
+         };
 
         pb = ProcessTools.createJavaProcessBuilder(procArgs);
         output = new OutputAnalyzer(pb.start()).getOutput();


### PR DESCRIPTION
Hi all,

could you please review this small patch that changes `compiler.c1.TestRangeCheckEliminated` to be run in driver mode (as the actual testing is done in the JVMs spawned by it, `TestRangeCheckEliminated` just verifies their output)? the patch also makes a few small code style changes.

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266232](https://bugs.openjdk.java.net/browse/JDK-8266232): compiler.c1.TestRangeCheckEliminated should be run in driver mode


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3772/head:pull/3772` \
`$ git checkout pull/3772`

Update a local copy of the PR: \
`$ git checkout pull/3772` \
`$ git pull https://git.openjdk.java.net/jdk pull/3772/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3772`

View PR using the GUI difftool: \
`$ git pr show -t 3772`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3772.diff">https://git.openjdk.java.net/jdk/pull/3772.diff</a>

</details>
