### PR TITLE
8266231: mark hotspot compiler/c1 tests which ignore VM flags

### DIFF
--- a/test/hotspot/jtreg/compiler/c1/TestRangeCheckEliminated.java
+++ b/test/hotspot/jtreg/compiler/c1/TestRangeCheckEliminated.java
@@ -28,6 +28,7 @@
  * @summary Test range check for constant array and NewMultiArray is removed properly
  * @author Hui Shi
  *
+ * @requires vm.flagless
  * @requires vm.debug == true & vm.compiler1.enabled
  *
  * @library /test/lib


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch that adds `@requires vm.flagless` to `compiler/c1 ` tests that ignore VM flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266231](https://bugs.openjdk.java.net/browse/JDK-8266231): mark hotspot compiler/c1 tests which ignore VM flags


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3773/head:pull/3773` \
`$ git checkout pull/3773`

Update a local copy of the PR: \
`$ git checkout pull/3773` \
`$ git pull https://git.openjdk.java.net/jdk pull/3773/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3773`

View PR using the GUI difftool: \
`$ git pr show -t 3773`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3773.diff">https://git.openjdk.java.net/jdk/pull/3773.diff</a>

</details>
