### PR TITLE
8266251: compiler.inlining.InlineAccessors shouldn't do testing in driver VM

### DIFF
--- a/test/hotspot/jtreg/compiler/inlining/InlineAccessors.java
+++ b/test/hotspot/jtreg/compiler/inlining/InlineAccessors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 8140650
  * @summary Method::is_accessor should cover getters and setters for all types
- * @modules java.base/jdk.internal.misc
  * @library /test/lib
  *
  * @run driver compiler.inlining.InlineAccessors
@@ -38,14 +37,11 @@ import jdk.test.lib.process.ProcessTools;
 
 public class InlineAccessors {
     public static void main(String[] args) throws Exception {
-        // try some sanity checks first
-        doTest();
-
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
                 "-XX:+IgnoreUnrecognizedVMOptions", "-showversion",
                 "-server", "-XX:-TieredCompilation", "-Xbatch",
                 "-XX:+PrintCompilation", "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintInlining",
-                    Launcher.class.getName());
+                 Launcher.class.getName());
 
         OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
 


### PR DESCRIPTION
Hi all,

could you please review the patch which removes redundant and "incorrect" testing from `InlineAccessors` test? as `InlineAccessors::doTest` is called by the JVM which runs `Launcher` class, we aren't actually losing any coverage.

from JBS:
> `compiler.inlining.InlineAccessors` test executes `doTest` method in its `InlineAccessors::main`, but InlineAccessors is run in driver mode (so it's not expected to do actual testing and strictly speaking can be executed in JVM other than JVM under test).

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266251](https://bugs.openjdk.java.net/browse/JDK-8266251): compiler.inlining.InlineAccessors shouldn't do testing in driver VM


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * epavlova - Committer ⚠️ Added manually

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3774/head:pull/3774` \
`$ git checkout pull/3774`

Update a local copy of the PR: \
`$ git checkout pull/3774` \
`$ git pull https://git.openjdk.java.net/jdk pull/3774/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3774`

View PR using the GUI difftool: \
`$ git pr show -t 3774`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3774.diff">https://git.openjdk.java.net/jdk/pull/3774.diff</a>

</details>
