### PR TITLE
8266255: compiler/eliminateAutobox/TestEliminateBoxInDebugInfo.java uses wrong package name

### DIFF
--- a/test/hotspot/jtreg/compiler/eliminateAutobox/TestEliminateBoxInDebugInfo.java
+++ b/test/hotspot/jtreg/compiler/eliminateAutobox/TestEliminateBoxInDebugInfo.java
@@ -28,9 +28,9 @@
  * @summary Verify that box object is scalarized in case it is directly referenced by debug info.
  * @library /test/lib
  *
- * @run driver compiler.c2.TestEliminateBoxInDebugInfo
+ * @run driver compiler.eliminateAutobox.TestEliminateBoxInDebugInfo
  */
-package compiler.c2;
+package compiler.eliminateAutobox;
 
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
@@ -38,8 +38,8 @@ import jdk.test.lib.process.ProcessTools;
 public class TestEliminateBoxInDebugInfo {
     public static void runTest() throws Exception {
         String[] arguments = {
-            "-XX:CompileCommand=compileonly,compiler/c2/TestEliminateBoxInDebugInfo$Test.foo",
-            "-XX:CompileCommand=dontinline,compiler/c2/TestEliminateBoxInDebugInfo$Test.black",
+            "-XX:CompileCommand=compileonly,compiler/eliminateAutobox/TestEliminateBoxInDebugInfo$Test.foo",
+            "-XX:CompileCommand=dontinline,compiler/eliminateAutobox/TestEliminateBoxInDebugInfo$Test.black",
             "-Xbatch",
             "-XX:+PrintEliminateAllocations",
             Test.class.getName()


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch that fixes the package name used in `compiler/eliminateAutobox/TestEliminateBoxInDebugInfo.java`?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266255](https://bugs.openjdk.java.net/browse/JDK-8266255): compiler/eliminateAutobox/TestEliminateBoxInDebugInfo.java uses wrong package name


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3775/head:pull/3775` \
`$ git checkout pull/3775`

Update a local copy of the PR: \
`$ git checkout pull/3775` \
`$ git pull https://git.openjdk.java.net/jdk pull/3775/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3775`

View PR using the GUI difftool: \
`$ git pr show -t 3775`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3775.diff">https://git.openjdk.java.net/jdk/pull/3775.diff</a>

</details>
