### PR TITLE
8266250: WebSocketTest and WebSocketProxyTest call assertEquals(List<byte[]>, List<byte[]>)

### DIFF
--- a/test/jdk/java/net/httpclient/websocket/WebSocketProxyTest.java
+++ b/test/jdk/java/net/httpclient/websocket/WebSocketProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/httpclient/websocket/WebSocketProxyTest.java
+++ b/test/jdk/java/net/httpclient/websocket/WebSocketProxyTest.java
@@ -172,6 +172,13 @@ public class WebSocketProxyTest {
         return bytes.stream().map(bytes::new).toList();
     }
 
+    static String diagnose(List<byte[]> a, List<byte[]> b) {
+        var actual = ofBytes(a);
+        var expected = ofBytes(b);
+        var problem = actual.equals(expected) ? "match" : "differ";
+        return "%s and %s %s".formatted(actual, expected, problem);
+    }
+
     @Test(dataProvider = "servers")
     public void simpleAggregatingBinaryMessages
             (Function<int[],DummySecureWebSocketServer> serverSupplier,
@@ -260,7 +267,7 @@ public class WebSocketProxyTest {
                     .join();
 
             List<byte[]> a = actual.join();
-            assertEquals(ofBytes(a), ofBytes(expected));
+            assertEquals(ofBytes(a), ofBytes(expected), diagnose(a, expected));
         }
     }
 

--- a/test/jdk/java/net/httpclient/websocket/WebSocketProxyTest.java
+++ b/test/jdk/java/net/httpclient/websocket/WebSocketProxyTest.java
@@ -175,8 +175,8 @@ public class WebSocketProxyTest {
     static String diagnose(List<byte[]> a, List<byte[]> b) {
         var actual = ofBytes(a);
         var expected = ofBytes(b);
-        var problem = actual.equals(expected) ? "match" : "differ";
-        return "%s and %s %s".formatted(actual, expected, problem);
+        var message = actual.equals(expected) ? "match" : "differ";
+        return "%s and %s %s".formatted(actual, expected, message);
     }
 
     @Test(dataProvider = "servers")

--- a/test/jdk/java/net/httpclient/websocket/WebSocketProxyTest.java
+++ b/test/jdk/java/net/httpclient/websocket/WebSocketProxyTest.java
@@ -49,7 +49,9 @@ import java.net.http.WebSocketHandshakeException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -148,6 +150,28 @@ public class WebSocketProxyTest {
         };
     }
 
+    record bytes(byte[] bytes) {
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o instanceof bytes other) {
+                return Arrays.equals(bytes(), other.bytes());
+            }
+            return false;
+        }
+        @Override
+        public int hashCode() { return Arrays.hashCode(bytes()); }
+        public String toString() {
+            return "0x" + HexFormat.of()
+                    .withUpperCase()
+                    .formatHex(bytes());
+        }
+    }
+
+    static List<bytes> ofBytes(List<byte[]> bytes) {
+        return bytes.stream().map(bytes::new).toList();
+    }
+
     @Test(dataProvider = "servers")
     public void simpleAggregatingBinaryMessages
             (Function<int[],DummySecureWebSocketServer> serverSupplier,
@@ -236,7 +260,7 @@ public class WebSocketProxyTest {
                     .join();
 
             List<byte[]> a = actual.join();
-            assertEquals(a, expected);
+            assertEquals(ofBytes(a), ofBytes(expected));
         }
     }
 

--- a/test/jdk/java/net/httpclient/websocket/WebSocketTest.java
+++ b/test/jdk/java/net/httpclient/websocket/WebSocketTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/httpclient/websocket/WebSocketTest.java
+++ b/test/jdk/java/net/httpclient/websocket/WebSocketTest.java
@@ -459,8 +459,8 @@ public class WebSocketTest {
     static String diagnose(List<byte[]> a, List<byte[]> b) {
         var actual = ofBytes(a);
         var expected = ofBytes(b);
-        var problem = actual.equals(expected) ? "match" : "differ";
-        return "%s and %s %s".formatted(actual, expected, problem);
+        var message = actual.equals(expected) ? "match" : "differ";
+        return "%s and %s %s".formatted(actual, expected, message);
     }
 
     @Test(dataProvider = "servers")

--- a/test/jdk/java/net/httpclient/websocket/WebSocketTest.java
+++ b/test/jdk/java/net/httpclient/websocket/WebSocketTest.java
@@ -456,6 +456,13 @@ public class WebSocketTest {
         return bytes.stream().map(bytes::new).toList();
     }
 
+    static String diagnose(List<byte[]> a, List<byte[]> b) {
+        var actual = ofBytes(a);
+        var expected = ofBytes(b);
+        var problem = actual.equals(expected) ? "match" : "differ";
+        return "%s and %s %s".formatted(actual, expected, problem);
+    }
+
     @Test(dataProvider = "servers")
     public void simpleAggregatingBinaryMessages
             (Function<int[],DummyWebSocketServer> serverSupplier)
@@ -549,7 +556,7 @@ public class WebSocketTest {
                     .join();
             try {
                 List<byte[]> a = actual.join();
-                assertEquals(ofBytes(a), ofBytes(expected));
+                assertEquals(ofBytes(a), ofBytes(expected), diagnose(a, expected));
             } finally {
                 webSocket.abort();
             }

--- a/test/jdk/java/net/httpclient/websocket/WebSocketTest.java
+++ b/test/jdk/java/net/httpclient/websocket/WebSocketTest.java
@@ -41,7 +41,9 @@ import java.net.http.WebSocketHandshakeException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -432,6 +434,28 @@ public class WebSocketTest {
         };
     }
 
+    record bytes(byte[] bytes) {
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o instanceof bytes other) {
+                return Arrays.equals(bytes(), other.bytes());
+            }
+            return false;
+        }
+        @Override
+        public int hashCode() { return Arrays.hashCode(bytes()); }
+        public String toString() {
+            return "0x" + HexFormat.of()
+                    .withUpperCase()
+                    .formatHex(bytes());
+        }
+    }
+
+    static List<bytes> ofBytes(List<byte[]> bytes) {
+        return bytes.stream().map(bytes::new).toList();
+    }
+
     @Test(dataProvider = "servers")
     public void simpleAggregatingBinaryMessages
             (Function<int[],DummyWebSocketServer> serverSupplier)
@@ -525,7 +549,7 @@ public class WebSocketTest {
                     .join();
             try {
                 List<byte[]> a = actual.join();
-                assertEquals(a, expected);
+                assertEquals(ofBytes(a), ofBytes(expected));
             } finally {
                 webSocket.abort();
             }


### PR DESCRIPTION
Please find here an almost trivial test fix that should improve diagnostic in case of failures. 
It also avoids relying on an unspecified behavior of `Assert.assertEquals`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266250](https://bugs.openjdk.java.net/browse/JDK-8266250): WebSocketTest and WebSocketProxyTest call assertEquals(List<byte[]>, List<byte[]>)


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**) ⚠️ Review applies to 22dc80600672ffdd1cb8555439363bb47e5eac36


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3776/head:pull/3776` \
`$ git checkout pull/3776`

Update a local copy of the PR: \
`$ git checkout pull/3776` \
`$ git pull https://git.openjdk.java.net/jdk pull/3776/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3776`

View PR using the GUI difftool: \
`$ git pr show -t 3776`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3776.diff">https://git.openjdk.java.net/jdk/pull/3776.diff</a>

</details>
