### PR TITLE
8265989: System property for the native character encoding name

### DIFF
--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -699,6 +699,9 @@ public final class System {
      *     <td>User's home directory</td></tr>
      * <tr><th scope="row">{@systemProperty user.dir}</th>
      *     <td>User's current working directory</td></tr>
+     * <tr><th scope="row">{@systemProperty native.encoding}</th>
+     *     <td>Character encoding name derived from the host environment and/or
+     *     the user's settings. Setting this system property has no effect.</td></tr>
      * </tbody>
      * </table>
      * <p>

--- a/src/java.base/share/classes/jdk/internal/util/StaticProperty.java
+++ b/src/java.base/share/classes/jdk/internal/util/StaticProperty.java
@@ -178,7 +178,7 @@ public final class StaticProperty {
      * in this method. The caller of this method should take care to ensure
      * that the returned property is not made accessible to untrusted code.</strong>
      *
-     * @return the {@code user.name} system property
+     * @return the {@code jdk.serialFilter} system property
      */
     public static String jdkSerialFilter() {
         return JDK_SERIAL_FILTER;

--- a/src/java.base/share/classes/jdk/internal/util/StaticProperty.java
+++ b/src/java.base/share/classes/jdk/internal/util/StaticProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,7 @@ public final class StaticProperty {
     private static final String SUN_BOOT_LIBRARY_PATH;
     private static final String JDK_SERIAL_FILTER;
     private static final String JAVA_IO_TMPDIR;
+    private static final String NATIVE_ENCODING;
 
     private StaticProperty() {}
 
@@ -61,6 +62,7 @@ public final class StaticProperty {
         JAVA_LIBRARY_PATH = getProperty(props, "java.library.path", "");
         SUN_BOOT_LIBRARY_PATH = getProperty(props, "sun.boot.library.path", "");
         JDK_SERIAL_FILTER = getProperty(props, "jdk.serialFilter", null);
+        NATIVE_ENCODING = getProperty(props, "native.encoding");
     }
 
     private static String getProperty(Properties props, String key) {
@@ -180,5 +182,18 @@ public final class StaticProperty {
      */
     public static String jdkSerialFilter() {
         return JDK_SERIAL_FILTER;
+    }
+
+    /**
+     * Return the {@code native.encoding} system property.
+     *
+     * <strong>{@link SecurityManager#checkPropertyAccess} is NOT checked
+     * in this method. The caller of this method should take care to ensure
+     * that the returned property is not made accessible to untrusted code.</strong>
+     *
+     * @return the {@code native.encoding} system property
+     */
+    public static String nativeEncoding() {
+        return NATIVE_ENCODING;
     }
 }

--- a/src/java.base/share/classes/jdk/internal/util/SystemProps.java
+++ b/src/java.base/share/classes/jdk/internal/util/SystemProps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,12 +63,13 @@ public final class SystemProps {
 
         // Platform defined encoding cannot be overridden on the command line
         put(props, "sun.jnu.encoding", raw.propDefault(Raw._sun_jnu_encoding_NDX));
+        var nativeEncoding = ((raw.propDefault(Raw._file_encoding_NDX) == null)
+                ? raw.propDefault(Raw._sun_jnu_encoding_NDX)
+                : raw.propDefault(Raw._file_encoding_NDX));
+        put(props, "native.encoding", nativeEncoding);
 
         // Add properties that have not been overridden on the cmdline
-        putIfAbsent(props, "file.encoding",
-                ((raw.propDefault(Raw._file_encoding_NDX) == null)
-                        ? raw.propDefault(Raw._sun_jnu_encoding_NDX)
-                        : raw.propDefault(Raw._file_encoding_NDX)));
+        putIfAbsent(props, "file.encoding", nativeEncoding);
 
         // Use platform values if not overridden by a commandline -Dkey=value
         // In no particular order

--- a/test/jdk/java/lang/System/PropertyTest.java
+++ b/test/jdk/java/lang/System/PropertyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ import org.testng.annotations.Test;
 
 /*
  * @test
- * @bug 4463345 4244670 8030781
+ * @bug 4463345 4244670 8030781 8265989
  * @summary Simple test of System getProperty, setProperty, clearProperty,
  *      getProperties, and setProperties
  * @run testng/othervm PropertyTest
@@ -80,6 +80,7 @@ public class PropertyTest {
                 {"user.dir"},
                 {"java.runtime.version"},
                 {"java.runtime.name"},
+                {"native.encoding"},
         };
     }
 


### PR DESCRIPTION
After some internal discussion, we thought it was good to expose the native environment's default character encoding, which Charset.defaultCharset() is currently based on. This way applications will have a better migration path after the [JEP 400](https://openjdk.java.net/jeps/400) is implemented, in which Charset.defaultCharset() will return UTF-8, but the value of this new system property will remain intact. A [CSR](https://bugs.openjdk.java.net/browse/JDK-8266075) has been filed with more detailed information.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265989](https://bugs.openjdk.java.net/browse/JDK-8265989): System property for the native character encoding name


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**) ⚠️ Review applies to fa5246c8a49cdc85075a3d67e1a29717d4c9aad9
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3777/head:pull/3777` \
`$ git checkout pull/3777`

Update a local copy of the PR: \
`$ git checkout pull/3777` \
`$ git pull https://git.openjdk.java.net/jdk pull/3777/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3777`

View PR using the GUI difftool: \
`$ git pr show -t 3777`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3777.diff">https://git.openjdk.java.net/jdk/pull/3777.diff</a>

</details>
