### PR TITLE
8266217: ZGC: Improve the -Xlog:gc+init output for NUMA

### DIFF
--- a/src/hotspot/os/bsd/gc/z/zNUMA_bsd.cpp
+++ b/src/hotspot/os/bsd/gc/z/zNUMA_bsd.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 #include "gc/z/zNUMA.hpp"
 
 void ZNUMA::pd_initialize() {
-  _enabled = false;
+  _state = Disabled;
 }
 
 uint32_t ZNUMA::count() {

--- a/src/hotspot/os/windows/gc/z/zNUMA_windows.cpp
+++ b/src/hotspot/os/windows/gc/z/zNUMA_windows.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 #include "gc/z/zNUMA.hpp"
 
 void ZNUMA::pd_initialize() {
-  _enabled = false;
+  _state = Disabled;
 }
 
 uint32_t ZNUMA::count() {

--- a/src/hotspot/share/gc/z/zNUMA.cpp
+++ b/src/hotspot/share/gc/z/zNUMA.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,18 +24,28 @@
 #include "precompiled.hpp"
 #include "gc/shared/gcLogPrecious.hpp"
 #include "gc/z/zNUMA.hpp"
+#include "gc/z/zNUMA.inline.hpp"
 
-bool ZNUMA::_enabled;
+ZNUMA::State ZNUMA::_state;
 
 void ZNUMA::initialize() {
   pd_initialize();
 
   log_info_p(gc, init)("NUMA Support: %s", to_string());
-  if (_enabled) {
+  if (is_enabled()) {
     log_info_p(gc, init)("NUMA Nodes: %u", count());
   }
 }
 
 const char* ZNUMA::to_string() {
-  return _enabled ? "Enabled" : "Disabled";
+  switch (_state) {
+  case Enabled:
+    return "Enabled";
+
+  case Unsupported:
+    return "Unsupported";
+
+  default:
+    return "Disabled";
+  }
 }

--- a/src/hotspot/share/gc/z/zNUMA.hpp
+++ b/src/hotspot/share/gc/z/zNUMA.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,13 @@
 
 class ZNUMA : public AllStatic {
 private:
-  static bool _enabled;
+  enum State {
+    Disabled,
+    Enabled,
+    Unsupported
+  };
+
+  static State _state;
 
   static void pd_initialize();
 

--- a/src/hotspot/share/gc/z/zNUMA.inline.hpp
+++ b/src/hotspot/share/gc/z/zNUMA.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
 #include "gc/z/zNUMA.hpp"
 
 inline bool ZNUMA::is_enabled() {
-  return _enabled;
+  return _state == Enabled;
 }
 
 #endif // SHARE_GC_Z_ZNUMA_INLINE_HPP


### PR DESCRIPTION
Hi all,

This patch improves the -Xlog:gc+init output for NUMA, which is suggested by StefanK [1].
The implementation just follows how UseLargePages are setup and printed.

Before (in docker, not support get_mempolicy)
```
[0.007s][info][gc,init] Initializing The Z Garbage Collector
[0.007s][info][gc,init] Version: 17-internal+0-adhoc..jdk (fastdebug)
[0.007s][info][gc,init] NUMA Support: Disabled
...
```

After (in docker, not support get_mempolicy)
```
[0.007s][info][gc,init] Initializing The Z Garbage Collector
[0.007s][info][gc,init] Version: 17-internal+0-adhoc..jdk (fastdebug)
[0.007s][info][gc,init] NUMA Support: Unsupported
...
```

Testing:
  - tier1~3 on Linux/x64, no regression

Thanks.
Best regards,
Jie


[1] https://mail.openjdk.java.net/pipermail/hotspot-gc-dev/2020-March/028927.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266217](https://bugs.openjdk.java.net/browse/JDK-8266217): ZGC: Improve the -Xlog:gc+init output for NUMA


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3778/head:pull/3778` \
`$ git checkout pull/3778`

Update a local copy of the PR: \
`$ git checkout pull/3778` \
`$ git pull https://git.openjdk.java.net/jdk pull/3778/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3778`

View PR using the GUI difftool: \
`$ git pr show -t 3778`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3778.diff">https://git.openjdk.java.net/jdk/pull/3778.diff</a>

</details>
