### PR TITLE
8262376: ReplaceCriticalClassesForSubgraphs.java fails if --with-build-jdk is used

### DIFF
--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -561,7 +561,15 @@ void ArchivedKlassSubGraphInfoRecord::init(KlassSubGraphInfo* info) {
   _entry_field_records = NULL;
   _subgraph_object_klasses = NULL;
   _is_full_module_graph = info->is_full_module_graph();
-  _has_non_early_klasses = info->has_non_early_klasses();
+
+  if (_is_full_module_graph) {
+    // Consider all classes referenced by the full module graph as early -- we will be
+    // allocating objects of these classes during JVMTI early phase, so they cannot
+    // be processed by (non-early) JVMTI ClassFileLoadHook
+    _has_non_early_klasses = false;
+  } else {
+    _has_non_early_klasses = info->has_non_early_klasses();
+  }
 
   if (_has_non_early_klasses) {
     ResourceMark rm;

--- a/test/hotspot/jtreg/runtime/cds/serviceability/ReplaceCriticalClasses.java
+++ b/test/hotspot/jtreg/runtime/cds/serviceability/ReplaceCriticalClasses.java
@@ -48,15 +48,16 @@ public class ReplaceCriticalClasses {
 
     public void process(String args[]) throws Throwable {
         if (args.length == 0) {
+            // Add an extra class to provoke JDK-8262376. This will be ignored if this class doesn't exist
+            // in the JDK that's being tested (e.g., if the "jdk.localedata" module is somehow missing).
+            String extraClasses[] = {"sun/util/resources/cldr/provider/CLDRLocaleDataMetaInfo"};
+
             // Dump the shared archive in case it was not generated during the JDK build.
             // Put the archive at separate file to avoid clashes with concurrent tests.
             CDSOptions opts = new CDSOptions()
-                .setXShareMode("dump")
-                .setArchiveName(ReplaceCriticalClasses.class.getName() + ".jsa")
-                .setUseVersion(false)
-                .addSuffix("-showversion")
-                .addSuffix("-Xlog:cds");
-            CDSTestUtils.run(opts).assertNormalExit("");
+                .setClassList(extraClasses)
+                .setArchiveName(ReplaceCriticalClasses.class.getName() + ".jsa");
+            CDSTestUtils.createArchiveAndCheck(opts);
 
             launchChildProcesses(getTests());
         } else if (args.length == 3 && args[0].equals("child")) {


### PR DESCRIPTION
When CDS tries to load sun.util.resources.cldr.provider.CLDRLocaleDataMetaInfo from the classlist, the VM has already finished the "early" bootup phase. To load this class, the module system tries to create an instance of jdk.internal.module.SystemModuleFinders$SystemModuleReader and store that into the ArchivedBootLayer. However, the SystemModuleReader class is also not yet loaded, so the VM loads it on demand. As a result, SystemModuleReader is treated as a "non-early class".

The problem is now ArchivedBootLayer refers to a non-early class. At runtime, if JVMTI ClassLoadHook is enabled, HeapShared will refuse to load ArchivedBootLayer from the archived heap. The reason is explained by this in heapShared.cpp:

```
// Note: if a ArchivedKlassSubGraphInfoRecord contains non-early classes, and JVMTI
// ClassFileLoadHook is enabled, it's possible for this class to be dynamically replaced. In
// this case, we will not load the ArchivedKlassSubGraphInfoRecord and will clear its roots.
```

However, this doesn't make sense for ArchivedBootLayer -- it's loaded in the early phase at runtime, so any classes referenced by ArchivedBootLayer will also be loaded in the early phase. This means JVMTI ClassLoadHook cannot replace SystemModuleReader.

Hence, the fix is simple -- for any classes referenced by the 3 "full-module-graph" subgraphs, we always treat them as "early" classes, regardless of when they are loaded during dump time.

```
// Entry fields for subgraphs archived in the open archive heap region (full module graph).
static ArchivableStaticFieldInfo fmg_open_archive_subgraph_entry_fields[] = {
  {"jdk/internal/loader/ArchivedClassLoaders", "archivedClassLoaders"},
  {"jdk/internal/module/ArchivedBootLayer", "archivedBootLayer"},
  {"java/lang/Module$ArchivedData", "archivedData"},
};
```

The validate the fix, I modified the test case to always load CLDRLocaleDataMetaInfo during dump time. The test failed without the fix and passed with the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262376](https://bugs.openjdk.java.net/browse/JDK-8262376): ReplaceCriticalClassesForSubgraphs.java fails if --with-build-jdk is used


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3780/head:pull/3780` \
`$ git checkout pull/3780`

Update a local copy of the PR: \
`$ git checkout pull/3780` \
`$ git pull https://git.openjdk.java.net/jdk pull/3780/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3780`

View PR using the GUI difftool: \
`$ git pr show -t 3780`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3780.diff">https://git.openjdk.java.net/jdk/pull/3780.diff</a>

</details>
