### PR TITLE
8266256: compiler.vectorization.TestBufferVectorization does testing twice

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorization/TestBufferVectorization.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestBufferVectorization.java
@@ -45,6 +45,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.IntBuffer;
 
+import jdk.test.lib.Platform;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 
@@ -224,7 +225,7 @@ public class TestBufferVectorization {
                                                        "-XX:+TraceNewVectors",
                                                        "compiler.vectorization.TestBufferVectorization",
                                                        testName,
-                                                       "skip_verify");
+                                                       "run");
             out = new OutputAnalyzer(pb.start());
         } catch (Exception e) {
             throw new RuntimeException(" Exception launching Java process: " + e);
@@ -236,7 +237,7 @@ public class TestBufferVectorization {
             return; // bufferDirect uses Unsafe memory accesses which are not vectorized currently
         }
 
-        if (testName.equals("bufferHeap") && (arch.equals("x86") || arch.equals("i386"))) {
+        if (testName.equals("bufferHeap") && (Platform.is32bit())) {
             return; // bufferHeap uses Long type for memory accesses which are not vectorized in 32-bit VM
         }
 

--- a/test/hotspot/jtreg/compiler/vectorization/TestBufferVectorization.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestBufferVectorization.java
@@ -28,12 +28,12 @@
  * @library /test/lib /
  * @requires vm.compiler2.enabled & vm.debug == true
  * @requires os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
- * @run main compiler.vectorization.TestBufferVectorization array
- * @run main compiler.vectorization.TestBufferVectorization arrayOffset
- * @run main compiler.vectorization.TestBufferVectorization buffer
- * @run main compiler.vectorization.TestBufferVectorization bufferHeap
- * @run main compiler.vectorization.TestBufferVectorization bufferDirect
- * @run main compiler.vectorization.TestBufferVectorization arrayView
+ * @run driver compiler.vectorization.TestBufferVectorization array
+ * @run driver compiler.vectorization.TestBufferVectorization arrayOffset
+ * @run driver compiler.vectorization.TestBufferVectorization buffer
+ * @run driver compiler.vectorization.TestBufferVectorization bufferHeap
+ * @run driver compiler.vectorization.TestBufferVectorization bufferDirect
+ * @run driver compiler.vectorization.TestBufferVectorization arrayView
  */
 
 package compiler.vectorization;

--- a/test/hotspot/jtreg/compiler/vectorization/TestBufferVectorization.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestBufferVectorization.java
@@ -197,29 +197,15 @@ public class TestBufferVectorization {
         } else if (args.length == 1) {
             verify_vectors(args[0]);
         } else {
-            Test te;
-            switch (args[0]) {
-                case "array":
-                    te = new TestArray();
-                    break;
-                case "arrayOffset":
-                    te = new TestArrayOffset(offset);
-                    break;
-                case "buffer":
-                    te = new TestBuffer(buffer);
-                    break;
-                case "bufferHeap":
-                    te = new TestBuffer(heap_buffer_byte_to_int);
-                    break;
-                case "bufferDirect":
-                    te = new TestBuffer(direct_buffer_byte_to_int);
-                    break;
-                case "arrayView":
-                    te = new TestArrayView();
-                    break;
-                default:
-                    throw new RuntimeException(" Unknown test: " + args[0]);
-            }
+            Test te = switch (args[0]) {
+                case "array" -> new TestArray();
+                case "arrayOffset" -> new TestArrayOffset(offset);
+                case "buffer" -> new TestBuffer(buffer);
+                case "bufferHeap" -> new TestBuffer(heap_buffer_byte_to_int);
+                case "bufferDirect" -> new TestBuffer(direct_buffer_byte_to_int);
+                case "arrayView" -> new TestArrayView();
+                default -> throw new RuntimeException(" Unknown test: " + args[0]);
+            };
 
             te.init();
             for (int i = 0; i < ITER; i++) {


### PR DESCRIPTION
Hi all,

could you please review this patch that removes work duplication within `TestBufferVectorization` test? 

from JBS:
> `compiler.vectorization.TestBufferVectorization` runs the testing twice, one time in the JVM created by jtreg, and once again by the JVM created by TestBufferVectorization.

after the duplication was removed, it became possible to change the execution mode to `driver`, which is done as part of this patch as well as small refactoring.

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266256](https://bugs.openjdk.java.net/browse/JDK-8266256): compiler.vectorization.TestBufferVectorization does testing twice


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3781/head:pull/3781` \
`$ git checkout pull/3781`

Update a local copy of the PR: \
`$ git checkout pull/3781` \
`$ git pull https://git.openjdk.java.net/jdk pull/3781/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3781`

View PR using the GUI difftool: \
`$ git pr show -t 3781`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3781.diff">https://git.openjdk.java.net/jdk/pull/3781.diff</a>

</details>
