### PR TITLE
8266238: mark hotspot compiler/inlining tests which ignore VM flags

### DIFF
--- a/test/hotspot/jtreg/compiler/inlining/InlineAccessors.java
+++ b/test/hotspot/jtreg/compiler/inlining/InlineAccessors.java
@@ -26,6 +26,7 @@
  * @bug 8140650
  * @summary Method::is_accessor should cover getters and setters for all types
  * @library /test/lib
+ * @requires vm.flagless
  *
  * @run driver compiler.inlining.InlineAccessors
  */

--- a/test/hotspot/jtreg/compiler/inlining/PrintInlining.java
+++ b/test/hotspot/jtreg/compiler/inlining/PrintInlining.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/inlining/PrintInlining.java
+++ b/test/hotspot/jtreg/compiler/inlining/PrintInlining.java
@@ -27,6 +27,7 @@
  * @summary PrintInlining as compiler directive doesn't print virtual calls
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
+ * @requires vm.flagless
  *
  * @run driver compiler.inlining.PrintInlining
  */


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch that adds `@requires vm.flagless` to `compiler/inlining` tests that ignore VM flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266238](https://bugs.openjdk.java.net/browse/JDK-8266238): mark hotspot compiler/inlining tests which ignore VM flags


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3782/head:pull/3782` \
`$ git checkout pull/3782`

Update a local copy of the PR: \
`$ git checkout pull/3782` \
`$ git pull https://git.openjdk.java.net/jdk pull/3782/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3782`

View PR using the GUI difftool: \
`$ git pr show -t 3782`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3782.diff">https://git.openjdk.java.net/jdk/pull/3782.diff</a>

</details>
