### PR TITLE
8266264: mark hotspot compiler/eliminateAutobox tests which ignore VM flags

### DIFF
--- a/test/hotspot/jtreg/compiler/eliminateAutobox/TestEliminateBoxInDebugInfo.java
+++ b/test/hotspot/jtreg/compiler/eliminateAutobox/TestEliminateBoxInDebugInfo.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8261137
+ * @requires vm.flagless
  * @requires vm.debug == true & vm.compiler2.enabled
  * @summary Verify that box object is scalarized in case it is directly referenced by debug info.
  * @library /test/lib


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch that adds `@requires vm.flagless` to `compiler/eliminateAutobox` tests that ignore VM flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266264](https://bugs.openjdk.java.net/browse/JDK-8266264): mark hotspot compiler/eliminateAutobox tests which ignore VM flags


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3783/head:pull/3783` \
`$ git checkout pull/3783`

Update a local copy of the PR: \
`$ git checkout pull/3783` \
`$ git pull https://git.openjdk.java.net/jdk pull/3783/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3783`

View PR using the GUI difftool: \
`$ git pr show -t 3783`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3783.diff">https://git.openjdk.java.net/jdk/pull/3783.diff</a>

</details>
