### PR TITLE
8266267: Remove unnecessary jumps in Intel Math Library StubRoutines

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86_exp.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_exp.cpp
@@ -1,5 +1,6 @@
 /*
 * Copyright (c) 2016, Intel Corporation.
+* Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
 * Intel Math Library (LIBM) Source Code
 *
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -197,7 +198,6 @@ void MacroAssembler::fast_exp(XMMRegister xmm0, XMMRegister xmm1, XMMRegister xm
   Label L_2TAG_PACKET_12_0_2, B1_3, B1_5, start;
 
   assert_different_registers(tmp, eax, ecx, edx);
-  jmp(start);
   address cv = (address)_cv;
   address Shifter = (address)_shifter;
   address mmask = (address)_mmask;
@@ -486,7 +486,6 @@ void MacroAssembler::fast_exp(XMMRegister xmm0, XMMRegister xmm1, XMMRegister xm
   Label L_2TAG_PACKET_12_0_2, start;
 
   assert_different_registers(tmp, eax, ecx, edx);
-  jmp(start);
   address static_const_table = (address)_static_const_table;
 
   bind(start);

--- a/src/hotspot/cpu/x86/macroAssembler_x86_log.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_log.cpp
@@ -1,5 +1,6 @@
 /*
 * Copyright (c) 2016, Intel Corporation.
+* Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
 * Intel Math Library (LIBM) Source Code
 *
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -189,7 +190,6 @@ void MacroAssembler::fast_log(XMMRegister xmm0, XMMRegister xmm1, XMMRegister xm
   Label B1_3, B1_5, start;
 
   assert_different_registers(tmp1, tmp2, eax, ecx, edx);
-  jmp(start);
   address L_tbl = (address)_L_tbl;
   address log2 = (address)_log2;
   address coeff = (address)_coeff;
@@ -485,7 +485,6 @@ void MacroAssembler::fast_log(XMMRegister xmm0, XMMRegister xmm1, XMMRegister xm
   Label L_2TAG_PACKET_10_0_2, start;
 
   assert_different_registers(tmp, eax, ecx, edx);
-  jmp(start);
   address static_const_table = (address)_static_const_table_log;
 
   bind(start);

--- a/src/hotspot/cpu/x86/macroAssembler_x86_pow.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_pow.cpp
@@ -803,7 +803,6 @@ void MacroAssembler::fast_pow(XMMRegister xmm0, XMMRegister xmm1, XMMRegister xm
   Label L_POW;
 
   assert_different_registers(tmp1, tmp2, eax, ecx, edx);
-  jmp(start);
   address HIGHSIGMASK = (address)_HIGHSIGMASK;
   address LOG2_E = (address)_LOG2_E;
   address coeff = (address)_coeff_pow;


### PR DESCRIPTION
Hi all,

May I get reviews for this small change?

If I look at the StubRoutines::libmPow carefully, an unnecessary jump instruction can be found, which is generated here [1].
```
- - - [BEGIN] - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
StubRoutines::libmPow [0x00007f0f8455ddd1, 0x00007f0f8455ef05] (4404 bytes)
--------------------------------------------------------------------------------
  0x00007f0f8455ddd1:   push   %rbp
  0x00007f0f8455ddd2:   mov    %rsp,%rbp
  0x00007f0f8455ddd5:   jmpq   0x00007f0f8455ddda          <--- unnecessary jump
  0x00007f0f8455ddda:   sub    $0x28,%rsp
  0x00007f0f8455ddde:   vmovsd %xmm0,0x8(%rsp)
  0x00007f0f8455dde4:   vmovsd %xmm1,0x10(%rsp)
  ...
```

And similar issues can be found for StubRoutines::libmLog and StubRoutines::libmExp.
```
- - - [BEGIN] - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
StubRoutines::libmLog [0x00007f3fb94d48a6, 0x00007f3fb94d4b22] (636 bytes)
--------------------------------------------------------------------------------
  0x00007f3fb94d48a6:   push   %rbp
  0x00007f3fb94d48a7:   mov    %rsp,%rbp
  0x00007f3fb94d48aa:   jmpq   0x00007f3fb94d48af          <--- unnecessary jump
  0x00007f3fb94d48af:   sub    $0x18,%rsp
  0x00007f3fb94d48b3:   vmovsd %xmm0,(%rsp)
  0x00007f3fb94d48b8:   movabs $0x3ff0000000000000,%rax
  ...
```

```
- - - [BEGIN] - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
StubRoutines::libmExp [0x00007f3fb94d4579, 0x00007f3fb94d48a6] (813 bytes)
--------------------------------------------------------------------------------
  0x00007f3fb94d4579:   push   %rbp
  0x00007f3fb94d457a:   mov    %rsp,%rbp
  0x00007f3fb94d457d:   jmpq   0x00007f3fb94d4582          <--- unnecessary jump
  0x00007f3fb94d4582:   sub    $0x18,%rsp
  0x00007f3fb94d4586:   vmovsd %xmm0,0x8(%rsp)
  0x00007f3fb94d458c:   vunpcklpd %xmm0,%xmm0,%xmm0
```

I can't find a reason why we need an extra jump there.
So I suggest removing them.

Testing:
  - tier1 ~ tier3 on Linux/x64, no regression

Am I missing something?

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266267](https://bugs.openjdk.java.net/browse/JDK-8266267): Remove unnecessary jumps in Intel Math Library StubRoutines


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3784/head:pull/3784` \
`$ git checkout pull/3784`

Update a local copy of the PR: \
`$ git checkout pull/3784` \
`$ git pull https://git.openjdk.java.net/jdk pull/3784/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3784`

View PR using the GUI difftool: \
`$ git pr show -t 3784`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3784.diff">https://git.openjdk.java.net/jdk/pull/3784.diff</a>

</details>
