### PR TITLE
8266265: mark hotspot compiler/vectorization tests which ignore VM flags

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorization/TestBufferVectorization.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestBufferVectorization.java
@@ -26,8 +26,11 @@
  * @bug 8257531
  * @summary Test vectorization for Buffer operations.
  * @library /test/lib /
+ *
+ * @requires vm.flagless
  * @requires vm.compiler2.enabled & vm.debug == true
  * @requires os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ *
  * @run driver compiler.vectorization.TestBufferVectorization array
  * @run driver compiler.vectorization.TestBufferVectorization arrayOffset
  * @run driver compiler.vectorization.TestBufferVectorization buffer


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch that adds `@requires vm.flagless` to `compiler/vectorization ` tests that ignore VM flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266265](https://bugs.openjdk.java.net/browse/JDK-8266265): mark hotspot compiler/vectorization tests which ignore VM flags


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3785/head:pull/3785` \
`$ git checkout pull/3785`

Update a local copy of the PR: \
`$ git checkout pull/3785` \
`$ git pull https://git.openjdk.java.net/jdk pull/3785/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3785`

View PR using the GUI difftool: \
`$ git pr show -t 3785`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3785.diff">https://git.openjdk.java.net/jdk/pull/3785.diff</a>

</details>
