### PR TITLE
8266168: -Wmaybe-uninitialized happens in check_code.c

### DIFF
--- a/src/java.base/share/native/libverify/check_code.c
+++ b/src/java.base/share/native/libverify/check_code.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3821,7 +3821,7 @@ signature_to_fieldtype(context_type *context,
                 assert(finish >= p);
                 length = (int)(finish - p);
                 if (length + 1 > (int)sizeof(buffer_space)) {
-                    buffer = malloc(length + 1);
+                    buffer = calloc(length + 1, sizeof(char));
                     check_and_push(context, buffer, VM_MALLOC_BLK);
                 }
                 memcpy(buffer, p, length);


### PR DESCRIPTION
We can see following compiler warning in check_code.c on GCC 11.

```
/home/ysuenaga/github-forked/jdk/src/java.base/share/native/libverify/check_code.c: In function 'signature_to_fieldtype':
/home/ysuenaga/github-forked/jdk/src/java.base/share/native/libverify/check_code.c:3825:21: warning: 'buffer' may be used uninitialized [-Wmaybe-uninitialized]
 3825 |                     check_and_push(context, buffer, VM_MALLOC_BLK);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/ysuenaga/github-forked/jdk/src/java.base/share/native/libverify/check_code.c:4144:13: note: by argument 2 of type 'const void *' to 'check_and_push' declared here
 4144 | static void check_and_push(context_type *context, const void *ptr, int kind)
      |             ^~~~~~~~~~~~~~
```

It is caused by the change in GCC 11. -Wmaybe-uninitialized diagnoses passing pointers or references to uninitialized memory to functions taking `const`-qualified arguments.

  https://gcc.gnu.org/gcc-11/changes.html

`check_and_push()` has `const` in its argument, and related functions ( `free_block()` ) does not modify the argument. We can avoid this issue to use `calloc()`, and it would not be any side-effect at here.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266168](https://bugs.openjdk.java.net/browse/JDK-8266168): -Wmaybe-uninitialized happens in check_code.c


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3787/head:pull/3787` \
`$ git checkout pull/3787`

Update a local copy of the PR: \
`$ git checkout pull/3787` \
`$ git pull https://git.openjdk.java.net/jdk pull/3787/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3787`

View PR using the GUI difftool: \
`$ git pr show -t 3787`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3787.diff">https://git.openjdk.java.net/jdk/pull/3787.diff</a>

</details>
