### PR TITLE
8266171: -Warray-bounds happens in imageioJPEG.c

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -339,7 +339,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJAVAJPEG, \
     OPTIMIZATION := HIGHEST, \
     CFLAGS := $(CFLAGS_JDKLIB), \
     HEADERS_FROM_SRC := $(LIBJPEG_HEADERS_FROM_SRC), \
-    DISABLED_WARNINGS_gcc := clobbered implicit-fallthrough shift-negative-value, \
+    DISABLED_WARNINGS_gcc := clobbered implicit-fallthrough shift-negative-value array-bounds, \
     LDFLAGS := $(LDFLAGS_JDKLIB) \
         $(call SET_SHARED_LIBRARY_ORIGIN), \
     LIBS := $(LIBJPEG_LIBS) $(JDKLIB_LIBS), \

--- a/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
+++ b/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -670,8 +670,17 @@ static void imageio_dispose(j_common_ptr info) {
         info->err = NULL;
         if (info->is_decompressor) {
             j_decompress_ptr dinfo = (j_decompress_ptr) info;
+#ifdef __GNUC__
+// GCC might falsely detect that `dinfo` is allocated as `j_compress_ptr`.
+// See JDK-8266171 for more details.
+_Pragma("GCC diagnostic push")
+_Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
+#endif
             free(dinfo->src);
             dinfo->src = NULL;
+#ifdef __GNUC__
+_Pragma("GCC diagnostic pop")
+#endif
         } else {
             j_compress_ptr cinfo = (j_compress_ptr) info;
             free(cinfo->dest);

--- a/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
+++ b/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -670,17 +670,8 @@ static void imageio_dispose(j_common_ptr info) {
         info->err = NULL;
         if (info->is_decompressor) {
             j_decompress_ptr dinfo = (j_decompress_ptr) info;
-#ifdef __GNUC__
-// GCC might falsely detect that `dinfo` is allocated as `j_compress_ptr`.
-// See JDK-8266171 for more details.
-_Pragma("GCC diagnostic push")
-_Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
-#endif
             free(dinfo->src);
             dinfo->src = NULL;
-#ifdef __GNUC__
-_Pragma("GCC diagnostic pop")
-#endif
         } else {
             j_compress_ptr cinfo = (j_compress_ptr) info;
             free(cinfo->dest);


### PR DESCRIPTION
We can see following compiler warnings in imageioJPEG.c on GCC 11.

```
/home/ysuenaga/github-forked/jdk/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c: In function 'Java_com_sun_imageio_plugins_jpeg_JPEGImageWriter_initJPEGImageWriter':
/home/ysuenaga/github-forked/jdk/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c:673:23: warning: array subscript 'struct jpeg_decompress_struct[0]' is partly outside array bounds of 'unsigned char[520]' [-Warray-bounds]
  673 |             free(dinfo->src);
      |                  ~~~~~^~~~~
/home/ysuenaga/github-forked/jdk/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c:2538:9: note: referencing an object of size 520 allocated by 'malloc'
 2538 |         malloc(sizeof(struct jpeg_compress_struct));
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/ysuenaga/github-forked/jdk/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c:674:24: warning: array subscript 'struct jpeg_decompress_struct[0]' is partly outside array bounds of 'unsigned char[520]' [-Warray-bounds]
  674 |             dinfo->src = NULL;
      |                        ^
/home/ysuenaga/github-forked/jdk/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c:2538:9: note: referencing an object of size 520 allocated by 'malloc'
 2538 |         malloc(sizeof(struct jpeg_compress_struct));
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

GCC reports disposing resource for "j_decompress_ptr" in L673-634, however GCC confused it is allocated for "j_compress_ptr".
The code is correct, so we can avoid this warning with pragma.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266171](https://bugs.openjdk.java.net/browse/JDK-8266171): -Warray-bounds happens in imageioJPEG.c


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3788/head:pull/3788` \
`$ git checkout pull/3788`

Update a local copy of the PR: \
`$ git checkout pull/3788` \
`$ git pull https://git.openjdk.java.net/jdk pull/3788/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3788`

View PR using the GUI difftool: \
`$ git pr show -t 3788`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3788.diff">https://git.openjdk.java.net/jdk/pull/3788.diff</a>

</details>
