### PR TITLE
8266172: -Wstringop-overflow happens in vmError.cpp

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1770,8 +1770,8 @@ static void crash_with_sigfpe() {
 // crash with sigsegv at non-null address.
 static void crash_with_segfault() {
 
-  char* const crash_addr = (char*)VMError::segfault_address;
-  *crash_addr = 'X';
+  int* crash_addr = reinterpret_cast<int*>(VMError::segfault_address);
+  *crash_addr = 1;
 
 } // end: crash_with_segfault
 


### PR DESCRIPTION
We can see following compiler warnings in vmError.cpp on GCC 11.

```
In function 'void crash_with_segfault()',
    inlined from 'static void VMError::controlled_crash(int)' at /home/ysuenaga/github-forked/jdk/src/hotspot/share/utilities/vmError.cpp:1804:33:
/home/ysuenaga/github-forked/jdk/src/hotspot/share/utilities/vmError.cpp:1774:15: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
 1774 |   *crash_addr = 'X';
      |   ~~~~~~~~~~~~^~~~~
```

According to [GCC documents](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wstringop-overflow), -Wstringop-overflow  is meaningful only for functions that operate on character arrays, and also this point is correct because it is a test code for the crash on non-null address. So we can replace to use `int`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266172](https://bugs.openjdk.java.net/browse/JDK-8266172): -Wstringop-overflow happens in vmError.cpp


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3789/head:pull/3789` \
`$ git checkout pull/3789`

Update a local copy of the PR: \
`$ git checkout pull/3789` \
`$ git pull https://git.openjdk.java.net/jdk pull/3789/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3789`

View PR using the GUI difftool: \
`$ git pr show -t 3789`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3789.diff">https://git.openjdk.java.net/jdk/pull/3789.diff</a>

</details>
