### PR TITLE
8266284: ProblemList java/awt/Graphics2D/DrawString/DrawRotatedStringUsingRotatedFont.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -526,6 +526,9 @@ java/awt/security/WarningWindowDisposeTest/WarningWindowDisposeTest.java 8266059
 java/awt/Robot/Delay/InterruptOfDelay.java 8265986 macosx-all
 java/awt/MenuBar/TestNoScreenMenuBar.java 8265987 macosx-all
 
+#linux-aarch64 failure
+java/awt/Graphics2D/DrawString/DrawRotatedStringUsingRotatedFont.java 8266283 linux-aarch64
+
 ############################################################################
 
 # jdk_beans


### PR DESCRIPTION
It seems the newly deproblemlisted test DrawRotatedStringUsingRotatedFont.java which is paasing in windows,linux-x64 and macos-x64 is failing in newly added linux-aarch64 systems.
Problemlisting the test for now as it is font layout issue which might need some upgrade in harfbuzz library in those CI systems or maybe in product.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266284](https://bugs.openjdk.java.net/browse/JDK-8266284): ProblemList java/awt/Graphics2D/DrawString/DrawRotatedStringUsingRotatedFont.java


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3790/head:pull/3790` \
`$ git checkout pull/3790`

Update a local copy of the PR: \
`$ git checkout pull/3790` \
`$ git pull https://git.openjdk.java.net/jdk pull/3790/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3790`

View PR using the GUI difftool: \
`$ git pr show -t 3790`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3790.diff">https://git.openjdk.java.net/jdk/pull/3790.diff</a>

</details>
