### PR TITLE
JDK-8249903: jdk/javadoc/doclet/testSerializedForm/TestSerializedForm.java needs to be updated after 8146022 got closed

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testSerializedForm/TestSerializedForm.java
+++ b/test/langtools/jdk/javadoc/doclet/testSerializedForm/TestSerializedForm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,38 +38,38 @@
  * @run main TestSerializedForm
  */
 
-import java.io.*;
-
 import javadoc.tester.JavadocTester;
 
 public class TestSerializedForm extends JavadocTester {
     public static void main(String... args) throws Exception {
         TestSerializedForm tester = new TestSerializedForm();
         tester.runTests();
-//        tester.run(ARGS, TEST, NEGATED_TEST);
-//        tester.run(ARGS_PRIVATE, TEST_PRIVATE, NEGATED_TEST_PRIVATE);
-//        tester.printSummary();
     }
 
-    // @ignore 8146022
-    // @Test
+    @Test
     public void testDefault() {
         javadoc("-d", "out-default", "-serialwarn", "-Xdoclint:none",
-                "-sourcepath", testSrc,
+                "--no-platform-links", "-sourcepath", testSrc,
                 testSrc("SerializedForm.java"), testSrc("ExternalizedForm.java"), "pkg1");
         checkExit(Exit.OK);
 
         checkOutput("serialized-form.html", true,
-                "protected&nbsp;java.lang.Object&nbsp;readResolve()",
-                "protected&nbsp;java.lang.Object&nbsp;writeReplace()",
-                "protected&nbsp;java.lang.Object&nbsp;readObjectNoData()",
                 """
-                    <h3>Serialization Overview</h3>
+                    <span class="modifiers">protected</span>&nbsp;<span class="return-type">java.lan\
+                    g.Object</span>&nbsp;<span class="element-name">readResolve</span>()""",
+                """
+                    <span class="modifiers">protected</span>&nbsp;<span class="return-type">java.lan\
+                    g.Object</span>&nbsp;<span class="element-name">writeReplace</span>()""",
+                """
+                    <span class="modifiers">protected</span>&nbsp;<span class="return-type">java.lan\
+                    g.Object</span>&nbsp;<span class="element-name">readObjectNoData</span>()""",
+                """
+                    <h4>Serialization Overview</h4>
                     <ul class="block-list">
                     <li class="block-list">
-                    <div class="block"><span class="deprecated-label">Deprecated.</span>&nbsp;</div>
-                    <dl>
-                    <dt><span class="seeLabel">See Also:</span></dt>
+                    <div class="deprecation-block"><span class="deprecated-label">Deprecated.</span></div>
+                    <dl class="notes">
+                    <dt>See Also:</dt>
                     <dd><code>TestSerializedForm</code></dd>
                     </dl>""",
                 "<h3>Class pkg1.NestedInnerClass.InnerClass.ProNestedInnerClass "
@@ -97,15 +97,15 @@ public class TestSerializedForm extends JavadocTester {
 
         checkOutput("serialized-form.html", true,
                 """
-                    <h3>Serialized Fields</h3>
+                    <h4>Serialized Fields</h4>
                     <ul class="block-list">
                     <li class="block-list">
-                    <h4>longs</h4>
+                    <h5>longs</h5>
                     <pre>Long[] longs</pre>
                     <div class="block">the longs</div>
                     </li>
                     <li class="block-list">
-                    <h4>name</h4>
+                    <h5>name</h5>
                     <pre>java.lang.String name</pre>
                     <div class="block">a test</div>""");
     }


### PR DESCRIPTION
I don't know why this test was disabled because of JDK-8146022, in fact I wasn't able to understand what JDK-8146022 was all about as I didn't find a commit for it. However, the test runs fine when updated to the current output format, so I guess whatever bug caused it to fail has been fixed in the meantime. I also removed some vestiges of an old test framework nearby that has been commented out from time immemorial.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8249903](https://bugs.openjdk.java.net/browse/JDK-8249903): jdk/javadoc/doclet/testSerializedForm/TestSerializedForm.java needs to be updated after 8146022 got closed


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3791/head:pull/3791` \
`$ git checkout pull/3791`

Update a local copy of the PR: \
`$ git checkout pull/3791` \
`$ git pull https://git.openjdk.java.net/jdk pull/3791/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3791`

View PR using the GUI difftool: \
`$ git pr show -t 3791`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3791.diff">https://git.openjdk.java.net/jdk/pull/3791.diff</a>

</details>
