### PR TITLE
8198616: java/awt/Focus/6378278/InputVerifierTest.java fails on mac

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -193,7 +193,6 @@ java/awt/EventDispatchThread/HandleExceptionOnEDT/HandleExceptionOnEDT.java 8203
 java/awt/EventDispatchThread/LoopRobustness/LoopRobustness.java 8073636 macosx-all
 java/awt/FullScreen/FullScreenInsets/FullScreenInsets.java 7019055 windows-all,linux-all
 java/awt/Focus/8013611/JDK8013611.java 8175366 windows-all,macosx-all
-java/awt/Focus/6378278/InputVerifierTest.java 8198616 macosx-all
 java/awt/Focus/6981400/Test1.java 8029675 windows-all,macosx-all
 java/awt/Focus/6981400/Test3.java 8173264 generic-all
 java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java 8169476 windows-all,macosx-all

--- a/test/jdk/java/awt/Focus/6378278/InputVerifierTest.java
+++ b/test/jdk/java/awt/Focus/6378278/InputVerifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
   @key headful
   @bug 6378278
   @summary Apparent missing key events causing Bugster to break
-  @author oleg.sukhodolsky: area=awt.focus
   @run main InputVerifierTest
 */
 
@@ -52,84 +51,101 @@ import javax.swing.InputVerifier;
 import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
 
 public class InputVerifierTest
 {
 
     //*** test-writer defined static variables go here ***
     static volatile boolean ivWasCalled = false;
+    static JFrame frame;
+    static JTextField t1;
+    static JTextField t2;
 
-    private static void init()
+    private static void init() throws Exception
     {
-        JFrame frame = new JFrame();
-        JTextField t1 = new JTextField();
-        t1.setInputVerifier(new InputVerifier() {
-            public boolean verify(JComponent input) {
-                System.out.println("verify(" + input + ")");
-                ivWasCalled = true;
-                return true;
-            }
-        });
-        JTextField t2 = new JTextField();
-
-        frame.getContentPane().add(t1, BorderLayout.NORTH);
-        frame.getContentPane().add(t2, BorderLayout.SOUTH);
-        frame.setSize(200, 200);
-        frame.setVisible(true);
-
-        Robot r = null;
         try {
-            r = new Robot();
-        } catch (AWTException e) {
-            e.printStackTrace();
-            InputVerifierTest.fail(e.toString());
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame();
+                t1 = new JTextField();
+                t1.setInputVerifier(new InputVerifier() {
+                    public boolean verify(JComponent input) {
+                        System.out.println("verify(" + input + ")");
+                        ivWasCalled = true;
+                        return true;
+                    }
+                });
+                t2 = new JTextField();
+
+                frame.getContentPane().add(t1, BorderLayout.NORTH);
+                frame.getContentPane().add(t2, BorderLayout.SOUTH);
+                frame.setLocationRelativeTo(null);
+                frame.setSize(200, 200);
+                frame.setVisible(true);
+            });
+
+            Robot r = null;
+            try {
+                r = new Robot();
+            } catch (AWTException e) {
+                e.printStackTrace();
+                InputVerifierTest.fail(e.toString());
+            }
+
+            try {
+                r.setAutoDelay(100);
+                r.waitForIdle();
+                r.delay(1000);
+
+                mouseClickOnComp(r, t1);
+                r.waitForIdle();
+
+                if (!t1.isFocusOwner()) {
+                    throw new RuntimeException("t1 is not a focus owner");
+                }
+                ivWasCalled = false;
+                r.keyPress(KeyEvent.VK_TAB);
+                r.keyRelease(KeyEvent.VK_TAB);
+                r.waitForIdle();
+                r.delay(500);
+
+                if (!t2.isFocusOwner()) {
+                    throw new RuntimeException("t2 is not a focus owner 1");
+                }
+                if (!ivWasCalled) {
+                    throw new RuntimeException("InputVerifier was not called after tabbing");
+                }
+
+                mouseClickOnComp(r, t1);
+                r.waitForIdle();
+
+                if (!t1.isFocusOwner()) {
+                    throw new RuntimeException("t1 is not a focus owner");
+                }
+
+                ivWasCalled = false;
+                mouseClickOnComp(r, t2);
+                r.waitForIdle();
+                r.delay(500);
+                if (!t2.isFocusOwner()) {
+                    throw new RuntimeException("t2 is not a focus owner 2");
+                }
+                if (!ivWasCalled) {
+                    throw new RuntimeException("InputVErifier was not called after mouse press");
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+                InputVerifierTest.fail(e.toString());
+            }
+
+            InputVerifierTest.pass();
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
         }
-
-        try {
-            r.waitForIdle();
-
-            mouseClickOnComp(r, t1);
-            r.waitForIdle();
-
-            if (!t1.isFocusOwner()) {
-                throw new RuntimeException("t1 is not a focus owner");
-            }
-            ivWasCalled = false;
-            r.keyPress(KeyEvent.VK_TAB);
-            r.delay(10);
-            r.keyRelease(KeyEvent.VK_TAB);
-            r.waitForIdle();
-
-            if (!t2.isFocusOwner()) {
-                throw new RuntimeException("t2 is not a focus owner");
-            }
-            if (!ivWasCalled) {
-                throw new RuntimeException("InputVerifier was not called after tabbing");
-            }
-
-            mouseClickOnComp(r, t1);
-            r.waitForIdle();
-
-            if (!t1.isFocusOwner()) {
-                throw new RuntimeException("t1 is not a focus owner");
-            }
-
-            ivWasCalled = false;
-            mouseClickOnComp(r, t2);
-            r.waitForIdle();
-            if (!t2.isFocusOwner()) {
-                throw new RuntimeException("t2 is not a focus owner");
-            }
-            if (!ivWasCalled) {
-                throw new RuntimeException("InputVErifier was not called after mouse press");
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-            InputVerifierTest.fail(e.toString());
-        }
-
-        InputVerifierTest.pass();
-
     }//End  init()
 
     static void mouseClickOnComp(Robot r, Component comp) {
@@ -137,10 +153,9 @@ public class InputVerifierTest
         loc.x += comp.getWidth() / 2;
         loc.y += comp.getHeight() / 2;
         r.mouseMove(loc.x, loc.y);
-        r.delay(10);
-        r.mousePress(InputEvent.BUTTON1_MASK);
-        r.delay(10);
-        r.mouseRelease(InputEvent.BUTTON1_MASK);
+        r.waitForIdle();
+        r.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        r.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
     }
 
     /*****************************************************
@@ -167,7 +182,7 @@ public class InputVerifierTest
     //  instantiated in the same VM.  Being static (and using
     //  static vars), it aint gonna work.  Not worrying about
     //  it for now.
-    public static void main( String args[] ) throws InterruptedException
+    public static void main( String args[] ) throws Exception
     {
         mainThread = Thread.currentThread();
         try


### PR DESCRIPTION
This test was failing earlier in our nightly testing citing "jjava.lang.RuntimeException: t2 is not a focus owner 

Updated test to
use swing components in EDT,
setAutoDelay for mouse events,
add a delay after frame is made visible,
move the frame to center of screen
and dispose of the frame finally.

Several iterations of the test pass in all platforms. Link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8198616](https://bugs.openjdk.java.net/browse/JDK-8198616): java/awt/Focus/6378278/InputVerifierTest.java fails on mac


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3792/head:pull/3792` \
`$ git checkout pull/3792`

Update a local copy of the PR: \
`$ git checkout pull/3792` \
`$ git pull https://git.openjdk.java.net/jdk pull/3792/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3792`

View PR using the GUI difftool: \
`$ git pr show -t 3792`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3792.diff">https://git.openjdk.java.net/jdk/pull/3792.diff</a>

</details>
