### PR TITLE
8266295: Remove unused _concurrent_iteration_safe_limit

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -650,9 +650,6 @@ void DefNewGeneration::collect(bool   full,
   }
   // We should have processed and cleared all the preserved marks.
   _preserved_marks_set.reclaim();
-  // set new iteration safe limit for the survivor spaces
-  from()->set_concurrent_iteration_safe_limit(from()->top());
-  to()->set_concurrent_iteration_safe_limit(to()->top());
 
   heap->trace_heap_after_gc(&gc_tracer);
 

--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -264,8 +264,7 @@ void Space::clear(bool mangle_space) {
   }
 }
 
-ContiguousSpace::ContiguousSpace(): CompactibleSpace(), _top(NULL),
-    _concurrent_iteration_safe_limit(NULL) {
+ContiguousSpace::ContiguousSpace(): CompactibleSpace(), _top(NULL) {
   _mangler = new GenSpaceMangler(this);
 }
 
@@ -278,7 +277,6 @@ void ContiguousSpace::initialize(MemRegion mr,
                                  bool mangle_space)
 {
   CompactibleSpace::initialize(mr, clear_space, mangle_space);
-  set_concurrent_iteration_safe_limit(top());
 }
 
 void ContiguousSpace::clear(bool mangle_space) {

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -499,7 +499,6 @@ class ContiguousSpace: public CompactibleSpace {
 
  protected:
   HeapWord* _top;
-  HeapWord* _concurrent_iteration_safe_limit;
   // A helper for mangling the unused area of the space in debug builds.
   GenSpaceMangler* _mangler;
 
@@ -564,24 +563,10 @@ class ContiguousSpace: public CompactibleSpace {
   void oop_iterate(OopIterateClosure* cl);
   void object_iterate(ObjectClosure* blk);
 
-  HeapWord* concurrent_iteration_safe_limit() {
-    assert(_concurrent_iteration_safe_limit <= top(),
-           "_concurrent_iteration_safe_limit update missed");
-    return _concurrent_iteration_safe_limit;
-  }
-  // changes the safe limit, all objects from bottom() to the new
-  // limit should be properly initialized
-  void set_concurrent_iteration_safe_limit(HeapWord* new_limit) {
-    assert(new_limit <= top(), "uninitialized objects in the safe range");
-    _concurrent_iteration_safe_limit = new_limit;
-  }
-
   // Compaction support
   virtual void reset_after_compaction() {
     assert(compaction_top() >= bottom() && compaction_top() <= end(), "should point inside space");
     set_top(compaction_top());
-    // set new iteration safe limit
-    set_concurrent_iteration_safe_limit(compaction_top());
   }
 
   // Override.

--- a/src/hotspot/share/gc/shared/vmStructs_gc.hpp
+++ b/src/hotspot/share/gc/shared/vmStructs_gc.hpp
@@ -130,7 +130,6 @@
   nonstatic_field(CompactibleSpace,            _end_of_live,                                  HeapWord*)                             \
                                                                                                                                      \
   nonstatic_field(ContiguousSpace,             _top,                                          HeapWord*)                             \
-  nonstatic_field(ContiguousSpace,             _concurrent_iteration_safe_limit,              HeapWord*)                             \
   nonstatic_field(ContiguousSpace,             _saved_mark_word,                              HeapWord*)                             \
                                                                                                                                      \
   nonstatic_field(Generation,                  _reserved,                                     MemRegion)                             \


### PR DESCRIPTION
Small change of removing an unused field; possible leftover of CMS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266295](https://bugs.openjdk.java.net/browse/JDK-8266295): Remove unused _concurrent_iteration_safe_limit


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3795/head:pull/3795` \
`$ git checkout pull/3795`

Update a local copy of the PR: \
`$ git checkout pull/3795` \
`$ git pull https://git.openjdk.java.net/jdk pull/3795/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3795`

View PR using the GUI difftool: \
`$ git pr show -t 3795`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3795.diff">https://git.openjdk.java.net/jdk/pull/3795.diff</a>

</details>
