### PR TITLE
8265984: Concurrent GC: Some tests fail "assert(is_frame_safe(f)) failed: Frame must be safe"

### DIFF
--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -1377,7 +1377,11 @@ address OptoRuntime::handle_exception_C(JavaThread* current) {
   // deoptimized frame
 
   if (nm != NULL) {
+#if defined(__APPLE__) && defined(AARCH64)
     RegisterMap map(current, false /* update_map */, false /* process_frames */);
+#else
+    RegisterMap map(current, false /* update_map */);
+#endif
     frame caller = current->last_frame().sender(&map);
 #ifdef ASSERT
     assert(caller.is_compiled_frame(), "must be");


### PR DESCRIPTION
JDK-8265702 made a change that should only apply to MacOSX/AArch64. The change breaks concurrent GC that supports concurrent stack processing on platforms, such as Windows and Linux, etc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8265984](https://bugs.openjdk.java.net/browse/JDK-8265984): Concurrent GC: Some tests fail "assert(is_frame_safe(f)) failed: Frame must be safe"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3796/head:pull/3796` \
`$ git checkout pull/3796`

Update a local copy of the PR: \
`$ git checkout pull/3796` \
`$ git pull https://git.openjdk.java.net/jdk pull/3796/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3796`

View PR using the GUI difftool: \
`$ git pr show -t 3796`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3796.diff">https://git.openjdk.java.net/jdk/pull/3796.diff</a>

</details>
