### PR TITLE
8266299: ProblemList runtime/stringtable/StringTableCleaningTest.java on linux-aarch64 with ZGC

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -63,3 +63,4 @@ serviceability/sa/TestSysProps.java                           8220624   generic-
 serviceability/sa/sadebugd/DebugdConnectTest.java             8220624   generic-all
 serviceability/sa/sadebugd/DisableRegistryTest.java           8220624   generic-all
 vmTestbase/jit/escape/AdaptiveBlocking/AdaptiveBlocking001/AdaptiveBlocking001.java 8260303 windows-x64
+runtime/stringtable/StringTableCleaningTest.java              8266056   linux-aarch64


### PR DESCRIPTION
A trivial fix to ProblemList runtime/stringtable/StringTableCleaningTest.java on linux-aarch64 with ZGC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266299](https://bugs.openjdk.java.net/browse/JDK-8266299): ProblemList runtime/stringtable/StringTableCleaningTest.java on linux-aarch64 with ZGC


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3797/head:pull/3797` \
`$ git checkout pull/3797`

Update a local copy of the PR: \
`$ git checkout pull/3797` \
`$ git pull https://git.openjdk.java.net/jdk pull/3797/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3797`

View PR using the GUI difftool: \
`$ git pr show -t 3797`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3797.diff">https://git.openjdk.java.net/jdk/pull/3797.diff</a>

</details>
