### PR TITLE
8266252: Streamline AbstractInterpreter::method_kind

### DIFF
--- a/src/hotspot/share/interpreter/abstractInterpreter.cpp
+++ b/src/hotspot/share/interpreter/abstractInterpreter.cpp
@@ -39,7 +39,7 @@
 #include "oops/constantPool.hpp"
 #include "oops/cpCache.inline.hpp"
 #include "oops/methodData.hpp"
-#include "oops/method.hpp"
+#include "oops/method.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "prims/forte.hpp"
 #include "prims/jvmtiExport.hpp"
@@ -110,36 +110,55 @@ AbstractInterpreter::MethodKind AbstractInterpreter::method_kind(const methodHan
   if (m->is_abstract()) return abstract;
 
   // Method handle primitive?
-  if (m->is_method_handle_intrinsic()) {
-    vmIntrinsics::ID id = m->intrinsic_id();
-    assert(MethodHandles::is_signature_polymorphic(id), "must match an intrinsic");
-    MethodKind kind = (MethodKind)(method_handle_invoke_FIRST +
-                                   vmIntrinsics::as_int(id) -
-                                   static_cast<int>(vmIntrinsics::FIRST_MH_SIG_POLY));
-    assert(kind <= method_handle_invoke_LAST, "parallel enum ranges");
-    return kind;
-  }
+  vmIntrinsics::ID id = m->intrinsic_id();
+  if (id != vmIntrinsics::_none) {
+    if (m->is_method_handle_intrinsic()) {
+      assert(MethodHandles::is_signature_polymorphic(id), "must match an intrinsic");
+      MethodKind kind = (MethodKind)(method_handle_invoke_FIRST +
+                                    vmIntrinsics::as_int(id) -
+                                    static_cast<int>(vmIntrinsics::FIRST_MH_SIG_POLY));
+      assert(kind <= method_handle_invoke_LAST, "parallel enum ranges");
+      return kind;
+    }
 
 #ifndef ZERO
-  switch (m->intrinsic_id()) {
-    // Use optimized stub code for CRC32 native methods.
-    case vmIntrinsics::_updateCRC32            : return java_util_zip_CRC32_update;
-    case vmIntrinsics::_updateBytesCRC32       : return java_util_zip_CRC32_updateBytes;
-    case vmIntrinsics::_updateByteBufferCRC32  : return java_util_zip_CRC32_updateByteBuffer;
-    // Use optimized stub code for CRC32C methods.
-    case vmIntrinsics::_updateBytesCRC32C             : return java_util_zip_CRC32C_updateBytes;
-    case vmIntrinsics::_updateDirectByteBufferCRC32C  : return java_util_zip_CRC32C_updateDirectByteBuffer;
-    case vmIntrinsics::_intBitsToFloat:      return java_lang_Float_intBitsToFloat;
-    case vmIntrinsics::_floatToRawIntBits:   return java_lang_Float_floatToRawIntBits;
-    case vmIntrinsics::_longBitsToDouble:    return java_lang_Double_longBitsToDouble;
-    case vmIntrinsics::_doubleToRawLongBits: return java_lang_Double_doubleToRawLongBits;
-    default:                                 break;
-  }
+    switch (m->intrinsic_id()) {
+      // Use optimized stub code for CRC32 native methods.
+      case vmIntrinsics::_updateCRC32: return java_util_zip_CRC32_update;
+      case vmIntrinsics::_updateBytesCRC32: return java_util_zip_CRC32_updateBytes;
+      case vmIntrinsics::_updateByteBufferCRC32: return java_util_zip_CRC32_updateByteBuffer;
+      // Use optimized stub code for CRC32C methods.
+      case vmIntrinsics::_updateBytesCRC32C: return java_util_zip_CRC32C_updateBytes;
+      case vmIntrinsics::_updateDirectByteBufferCRC32C: return java_util_zip_CRC32C_updateDirectByteBuffer;
+      case vmIntrinsics::_intBitsToFloat: return java_lang_Float_intBitsToFloat;
+      case vmIntrinsics::_floatToRawIntBits: return java_lang_Float_floatToRawIntBits;
+      case vmIntrinsics::_longBitsToDouble: return java_lang_Double_longBitsToDouble;
+      case vmIntrinsics::_doubleToRawLongBits: return java_lang_Double_doubleToRawLongBits;
+      case vmIntrinsics::_dsin: return java_lang_math_sin;
+      case vmIntrinsics::_dcos: return java_lang_math_cos;
+      case vmIntrinsics::_dtan: return java_lang_math_tan;
+      case vmIntrinsics::_dabs: return java_lang_math_abs;
+      case vmIntrinsics::_dsqrt: return java_lang_math_sqrt;
+      case vmIntrinsics::_dlog: return java_lang_math_log;
+      case vmIntrinsics::_dlog10: return java_lang_math_log10;
+      case vmIntrinsics::_dpow: return java_lang_math_pow;
+      case vmIntrinsics::_dexp: return java_lang_math_exp;
+      case vmIntrinsics::_fmaD: return java_lang_math_fmaD;
+      case vmIntrinsics::_fmaF: return java_lang_math_fmaF;
+      case vmIntrinsics::_Reference_get: return java_lang_ref_reference_get;
+      case vmIntrinsics::_Object_init:
+        if (RegisterFinalizersAtInit && m->code_size() == 1) {
+          // We need to execute the special return bytecode to check for
+          // finalizer registration so create a normal frame.
+          return zerolocals;
+        }
+        break;
+      default: break;
+    }
 #endif // ZERO
+  }
 
   // Native method?
-  // Note: This test must come _before_ the test for intrinsic
-  //       methods. See also comments below.
   if (m->is_native()) {
     assert(!m->is_method_handle_intrinsic(), "overlapping bits here, watch out");
     return m->is_synchronized() ? native_synchronized : native;
@@ -150,39 +169,9 @@ AbstractInterpreter::MethodKind AbstractInterpreter::method_kind(const methodHan
     return zerolocals_synchronized;
   }
 
-  if (RegisterFinalizersAtInit && m->code_size() == 1 &&
-      m->intrinsic_id() == vmIntrinsics::_Object_init) {
-    // We need to execute the special return bytecode to check for
-    // finalizer registration so create a normal frame.
-    return zerolocals;
-  }
-
   // Empty method?
   if (m->is_empty_method()) {
     return empty;
-  }
-
-  // Special intrinsic method?
-  // Note: This test must come _after_ the test for native methods,
-  //       otherwise we will run into problems with JDK 1.2, see also
-  //       TemplateInterpreterGenerator::generate_method_entry() for
-  //       for details.
-  switch (m->intrinsic_id()) {
-    case vmIntrinsics::_dsin  : return java_lang_math_sin  ;
-    case vmIntrinsics::_dcos  : return java_lang_math_cos  ;
-    case vmIntrinsics::_dtan  : return java_lang_math_tan  ;
-    case vmIntrinsics::_dabs  : return java_lang_math_abs  ;
-    case vmIntrinsics::_dsqrt : return java_lang_math_sqrt ;
-    case vmIntrinsics::_dlog  : return java_lang_math_log  ;
-    case vmIntrinsics::_dlog10: return java_lang_math_log10;
-    case vmIntrinsics::_dpow  : return java_lang_math_pow  ;
-    case vmIntrinsics::_dexp  : return java_lang_math_exp  ;
-    case vmIntrinsics::_fmaD  : return java_lang_math_fmaD ;
-    case vmIntrinsics::_fmaF  : return java_lang_math_fmaF ;
-
-    case vmIntrinsics::_Reference_get
-                              : return java_lang_ref_reference_get;
-    default                   : break;
   }
 
   // Getter method?

--- a/src/hotspot/share/interpreter/abstractInterpreter.cpp
+++ b/src/hotspot/share/interpreter/abstractInterpreter.cpp
@@ -138,7 +138,8 @@ AbstractInterpreter::MethodKind AbstractInterpreter::method_kind(const methodHan
       case vmIntrinsics::_dcos: return java_lang_math_cos;
       case vmIntrinsics::_dtan: return java_lang_math_tan;
       case vmIntrinsics::_dabs: return java_lang_math_abs;
-      case vmIntrinsics::_dsqrt: return java_lang_math_sqrt;
+      // _dsqrt will be selected for java.lang.StrictMath::sqrt - which is still native
+      case vmIntrinsics::_dsqrt: return m->is_native() ? native : java_lang_math_sqrt;
       case vmIntrinsics::_dlog: return java_lang_math_log;
       case vmIntrinsics::_dlog10: return java_lang_math_log10;
       case vmIntrinsics::_dpow: return java_lang_math_pow;

--- a/src/hotspot/share/interpreter/abstractInterpreter.cpp
+++ b/src/hotspot/share/interpreter/abstractInterpreter.cpp
@@ -138,7 +138,8 @@ AbstractInterpreter::MethodKind AbstractInterpreter::method_kind(const methodHan
       case vmIntrinsics::_dcos: return java_lang_math_cos;
       case vmIntrinsics::_dtan: return java_lang_math_tan;
       case vmIntrinsics::_dabs: return java_lang_math_abs;
-      // _dsqrt will be selected for java.lang.StrictMath::sqrt - which is still native
+      // _dsqrt will be selected for both Math::sqrt and StrictMath::sqrt, but the latter
+      // is native. Keep treating it like a native method in the interpreter
       case vmIntrinsics::_dsqrt: return m->is_native() ? native : java_lang_math_sqrt;
       case vmIntrinsics::_dlog: return java_lang_math_log;
       case vmIntrinsics::_dlog10: return java_lang_math_log10;

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -620,11 +620,6 @@ void Method::compute_from_signature(Symbol* sig) {
   constMethod()->set_fingerprint(fp.fingerprint());
 }
 
-bool Method::is_empty_method() const {
-  return  code_size() == 1
-      && *code_base() == Bytecodes::_return;
-}
-
 bool Method::is_vanilla_constructor() const {
   // Returns true if this method is a vanilla constructor, i.e. an "<init>" "()V" method
   // which only calls the superclass vanilla constructor and possibly does stores of

--- a/src/hotspot/share/oops/method.inline.hpp
+++ b/src/hotspot/share/oops/method.inline.hpp
@@ -83,4 +83,9 @@ inline void CompressedLineNumberWriteStream::write_pair(int bci, int line) {
 
 inline bool Method::has_compiled_code() const { return code() != NULL; }
 
+inline bool Method::is_empty_method() const {
+  return  code_size() == 1
+      && *code_base() == Bytecodes::_return;
+}
+
 #endif // SHARE_OOPS_METHOD_INLINE_HPP


### PR DESCRIPTION
This patch refactors AbstractInterpreter::method_kind to reduce branches on average while better compartmentalizing the exceptional cases.

Additionally Method::is_empty_method is trivial enough that making it inlineable helps reduce cost while reducing size of the libjvm.

Result is a 40% speed-up, or a reduction of .25% of instructions on Hello World that scales to larger applications. 