### PR TITLE
8263998: Remove mentions of mc region in comments

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -347,7 +347,7 @@ address ArchiveBuilder::reserve_buffer() {
     vm_direct_exit(0);
   }
 
-  // buffer_bottom is the lowest address of the 3 core regions (mc, rw, ro) when
+  // buffer_bottom is the lowest address of the 2 core regions (rw, ro) when
   // we are copying the class metadata into the buffer.
   address buffer_bottom = (address)rs.base();
   log_info(cds)("Reserved output buffer space at " PTR_FORMAT " [" SIZE_FORMAT " bytes]",
@@ -778,11 +778,11 @@ void ArchiveBuilder::relocate_klass_ptr(oop o) {
   o->set_narrow_klass(nk);
 }
 
-// RelocateBufferToRequested --- Relocate all the pointers in mc/rw/ro,
+// RelocateBufferToRequested --- Relocate all the pointers in rw/ro,
 // so that the archive can be mapped to the "requested" location without runtime relocation.
 //
 // - See ArchiveBuilder header for the definition of "buffer", "mapped" and "requested"
-// - ArchivePtrMarker::ptrmap() marks all the pointers in the mc/rw/ro regions
+// - ArchivePtrMarker::ptrmap() marks all the pointers in the rw/ro regions
 // - Every pointer must have one of the following values:
 //   [a] NULL:
 //       No relocation is needed. Remove this pointer from ptrmap so we don't need to
@@ -885,12 +885,12 @@ void ArchiveBuilder::relocate_to_requested() {
 // consistency, we log everything using runtime addresses.
 class ArchiveBuilder::CDSMapLogger : AllStatic {
   static intx buffer_to_runtime_delta() {
-    // Translate the buffers used by the MC/RW/RO regions to their eventual (requested) locations
+    // Translate the buffers used by the RW/RO regions to their eventual (requested) locations
     // at runtime.
     return ArchiveBuilder::current()->buffer_to_requested_delta();
   }
 
-  // mc/rw/ro regions only
+  // rw/ro regions only
   static void write_dump_region(const char* name, DumpRegion* region) {
     address region_base = address(region->base());
     address region_top  = address(region->top());

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -99,8 +99,8 @@ bool MetaspaceShared::_use_full_module_graph = true;
 //
 //     bm  - bitmap for relocating the above 7 regions.
 //
-// The rw, and ro regions are linearly allocated, in the order of rw->ro.
-// These regions are aligned with MetaspaceShared::reserved_space_alignment().
+// The rw and ro regions are linearly allocated, in the order of rw->ro.
+// These regions are aligned with MetaspaceShared::core_region_alignment().
 //
 // These 2 regions are populated in the following steps:
 // [0] All classes are loaded in MetaspaceShared::preload_classes(). All metadata are

--- a/src/hotspot/share/cds/metaspaceShared.hpp
+++ b/src/hotspot/share/cds/metaspaceShared.hpp
@@ -140,7 +140,7 @@ public:
   static bool is_old_class(InstanceKlass* ik) NOT_CDS_RETURN_(false);
 
 #if INCLUDE_CDS
-  // Alignment for the 3 core CDS regions (MC/RW/RO) only.
+  // Alignment for the 2 core CDS regions (RW/RO) only.
   // (Heap region alignments are decided by GC).
   static size_t core_region_alignment();
   static void rewrite_nofast_bytecodes_and_calculate_fingerprints(Thread* thread, InstanceKlass* ik);


### PR DESCRIPTION
Hi, Please review the simple changes for removing the mc/MC mentioned in comments.  "mc" region was removed in fix of
 https://bugs.openjdk.java.net/browse/JDK-8263002

Tests: local build.

Thanks
Yumin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263998](https://bugs.openjdk.java.net/browse/JDK-8263998): Remove mentions of mc region in comments


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3799/head:pull/3799` \
`$ git checkout pull/3799`

Update a local copy of the PR: \
`$ git checkout pull/3799` \
`$ git pull https://git.openjdk.java.net/jdk pull/3799/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3799`

View PR using the GUI difftool: \
`$ git pr show -t 3799`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3799.diff">https://git.openjdk.java.net/jdk/pull/3799.diff</a>

</details>
