### PR TITLE
8266332: Adler32 intrinsic for x86 64-bit platforms

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -7859,9 +7859,8 @@ void Assembler::vbroadcastf128(XMMRegister dst, Address src, int vector_len) {
   assert(vector_len == AVX_256bit || vector_len == AVX_512bit, "");
   assert(dst != xnoreg, "sanity");
   InstructionMark im(this);
-  InstructionAttr attributes(vector_len, /* vex_w */ VM_Version::supports_evex(), /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
-  attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_64bit);
-  attributes.set_rex_vex_w_reverted();
+  InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
+  attributes.set_address_attributes(/* tuple_type */ EVEX_T4, /* input_size_in_bits */ EVEX_32bit);
   // swap src<->dst for encoding
   vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8(0x1A);

--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -7854,6 +7854,19 @@ void Assembler::vbroadcastsd(XMMRegister dst, Address src, int vector_len) {
   emit_operand(dst, src);
 }
 
+void Assembler::vbroadcastf128(XMMRegister dst, Address src, int vector_len) {
+  assert(VM_Version::supports_avx(), "");
+  assert(vector_len == AVX_256bit || vector_len == AVX_512bit, "");
+  assert(dst != xnoreg, "sanity");
+  InstructionMark im(this);
+  InstructionAttr attributes(vector_len, /* vex_w */ VM_Version::supports_evex(), /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
+  attributes.set_address_attributes(/* tuple_type */ EVEX_T1S, /* input_size_in_bits */ EVEX_64bit);
+  attributes.set_rex_vex_w_reverted();
+  // swap src<->dst for encoding
+  vex_prefix(src, 0, dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
+  emit_int8(0x1A);
+  emit_operand(dst, src);
+}
 
 // gpr source broadcast forms
 

--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -7856,7 +7856,7 @@ void Assembler::vbroadcastsd(XMMRegister dst, Address src, int vector_len) {
 
 void Assembler::vbroadcastf128(XMMRegister dst, Address src, int vector_len) {
   assert(VM_Version::supports_avx(), "");
-  assert(vector_len == AVX_256bit || vector_len == AVX_512bit, "");
+  assert(vector_len == AVX_256bit, "");
   assert(dst != xnoreg, "sanity");
   InstructionMark im(this);
   InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -2394,11 +2394,12 @@ private:
   void evbroadcasti64x2(XMMRegister dst, XMMRegister src, int vector_len);
   void evbroadcasti64x2(XMMRegister dst, Address src, int vector_len);
 
-  // scalar single/double precision replicate
+  // scalar single/double/128bit precision replicate
   void vbroadcastss(XMMRegister dst, XMMRegister src, int vector_len);
   void vbroadcastss(XMMRegister dst, Address src, int vector_len);
   void vbroadcastsd(XMMRegister dst, XMMRegister src, int vector_len);
   void vbroadcastsd(XMMRegister dst, Address src, int vector_len);
+  void vbroadcastf128(XMMRegister dst, Address src, int vector_len);
 
   // gpr sourced byte/word/dword/qword replicate
   void evpbroadcastb(XMMRegister dst, Register src, int vector_len);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -3245,7 +3245,7 @@ void MacroAssembler::vpmullw(XMMRegister dst, XMMRegister nds, Address src, int 
 }
 
 void MacroAssembler::vpmulld(XMMRegister dst, XMMRegister nds, AddressLiteral src, int vector_len, Register scratch_reg) {
-  assert((UseAVX > 0), "SSE mode requires address alignment 16 bytes");
+  assert((UseAVX > 0), "AVX support is needed");
   if (reachable(src)) {
     Assembler::vpmulld(dst, nds, as_Address(src), vector_len);
   } else {

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -3244,15 +3244,14 @@ void MacroAssembler::vpmullw(XMMRegister dst, XMMRegister nds, Address src, int 
   Assembler::vpmullw(dst, nds, src, vector_len);
 }
 
-void MacroAssembler::vpmulld(XMMRegister dst, XMMRegister nds, AddressLiteral src, int vector_len) {
+void MacroAssembler::vpmulld(XMMRegister dst, XMMRegister nds, AddressLiteral src, int vector_len, Register scratch_reg) {
   // Used in sign-bit flipping with aligned address.
-  bool aligned_adr = (((intptr_t)src.target() & 15) == 0);
-  assert((UseAVX > 0) || aligned_adr, "SSE mode requires address alignment 16 bytes");
+  assert((UseAVX > 0), "SSE mode requires address alignment 16 bytes");
   if (reachable(src)) {
     Assembler::vpmulld(dst, nds, as_Address(src), vector_len);
   } else {
-    lea(rscratch1, src);
-    Assembler::vpmulld(dst, nds, Address(rscratch1, 0), vector_len);
+    lea(scratch_reg, src);
+    Assembler::vpmulld(dst, nds, Address(scratch_reg, 0), vector_len);
   }
 }
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -3245,7 +3245,6 @@ void MacroAssembler::vpmullw(XMMRegister dst, XMMRegister nds, Address src, int 
 }
 
 void MacroAssembler::vpmulld(XMMRegister dst, XMMRegister nds, AddressLiteral src, int vector_len, Register scratch_reg) {
-  // Used in sign-bit flipping with aligned address.
   assert((UseAVX > 0), "SSE mode requires address alignment 16 bytes");
   if (reachable(src)) {
     Assembler::vpmulld(dst, nds, as_Address(src), vector_len);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -3244,6 +3244,18 @@ void MacroAssembler::vpmullw(XMMRegister dst, XMMRegister nds, Address src, int 
   Assembler::vpmullw(dst, nds, src, vector_len);
 }
 
+void MacroAssembler::vpmulld(XMMRegister dst, XMMRegister nds, AddressLiteral src, int vector_len) {
+  // Used in sign-bit flipping with aligned address.
+  bool aligned_adr = (((intptr_t)src.target() & 15) == 0);
+  assert((UseAVX > 0) || aligned_adr, "SSE mode requires address alignment 16 bytes");
+  if (reachable(src)) {
+    Assembler::vpmulld(dst, nds, as_Address(src), vector_len);
+  } else {
+    lea(rscratch1, src);
+    Assembler::vpmulld(dst, nds, Address(rscratch1, 0), vector_len);
+  }
+}
+
 void MacroAssembler::vpsubb(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
   assert(((dst->encoding() < 16 && src->encoding() < 16 && nds->encoding() < 16) || VM_Version::supports_avx512vlbw()),"XMM register should be 0-15");
   Assembler::vpsubb(dst, nds, src, vector_len);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -1313,6 +1313,13 @@ public:
 
   void vpmullw(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
   void vpmullw(XMMRegister dst, XMMRegister nds, Address src, int vector_len);
+  void vpmulld(XMMRegister dst, XMMRegister nds, Address src, int vector_len) {
+    Assembler::vpmulld(dst, nds, src, vector_len);
+  };
+  void vpmulld(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
+    Assembler::vpmulld(dst, nds, src, vector_len);
+  }
+  void vpmulld(XMMRegister dst, XMMRegister nds, AddressLiteral src, int vector_len);
 
   void vpsubb(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
   void vpsubb(XMMRegister dst, XMMRegister nds, Address src, int vector_len);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -1319,7 +1319,7 @@ public:
   void vpmulld(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
     Assembler::vpmulld(dst, nds, src, vector_len);
   }
-  void vpmulld(XMMRegister dst, XMMRegister nds, AddressLiteral src, int vector_len);
+  void vpmulld(XMMRegister dst, XMMRegister nds, AddressLiteral src, int vector_len, Register scratch_reg = rscratch1);
 
   void vpsubb(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
   void vpsubb(XMMRegister dst, XMMRegister nds, Address src, int vector_len);
@@ -1777,6 +1777,7 @@ public:
   void kernel_crc32_avx512_256B(Register crc, Register buf, Register len, Register key, Register pos,
                                 Register tmp1, Register tmp2, Label& L_barrett, Label& L_16B_reduction_loop,
                                 Label& L_get_last_two_xmms, Label& L_128_done, Label& L_cleanup);
+  void updateBytesAdler32(Register adler32, Register buf, Register length, XMMRegister shuf0, XMMRegister shuf1, ExternalAddress scale);
 #endif // _LP64
 
   // CRC32C code for java.util.zip.CRC32C::updateBytes() intrinsic

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -1319,7 +1319,7 @@ public:
   void vpmulld(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
     Assembler::vpmulld(dst, nds, src, vector_len);
   }
-  void vpmulld(XMMRegister dst, XMMRegister nds, AddressLiteral src, int vector_len, Register scratch_reg = rscratch1);
+  void vpmulld(XMMRegister dst, XMMRegister nds, AddressLiteral src, int vector_len, Register scratch_reg);
 
   void vpsubb(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
   void vpsubb(XMMRegister dst, XMMRegister nds, Address src, int vector_len);

--- a/src/hotspot/cpu/x86/macroAssembler_x86_adler.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_adler.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2016, Intel Corporation.
+* Copyright (c) 2021, Intel Corporation.
 *
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *

--- a/src/hotspot/cpu/x86/macroAssembler_x86_adler.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_adler.cpp
@@ -29,7 +29,7 @@
 #include "runtime/stubRoutines.hpp"
 #include "macroAssembler_x86.hpp"
 
-
+#ifdef _LP64
 void MacroAssembler::updateBytesAdler32(Register init_d, Register data, Register size, XMMRegister yshuf0, XMMRegister yshuf1, ExternalAddress ascaletab)
 {
       const int LIMIT = 5552;
@@ -206,4 +206,4 @@ void MacroAssembler::updateBytesAdler32(Register init_d, Register data, Register
       pop(r13);
       pop(r12);
   }
-
+#endif

--- a/src/hotspot/cpu/x86/macroAssembler_x86_adler.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_adler.cpp
@@ -80,6 +80,7 @@ void MacroAssembler::updateBytesAdler32(Register init_d, Register data, Register
       cmpptr(data, end);
       jcc(Assembler::aboveEqual, SKIP_LOOP_1A);
 
+      align(32);
       bind(SLOOP1A);
       vbroadcastf128(ydata, Address(data, 0), Assembler::AVX_256bit);
       addptr(data, CHUNKSIZE);
@@ -108,9 +109,9 @@ void MacroAssembler::updateBytesAdler32(Register init_d, Register data, Register
       vextracti128(xtmp0, ya, 1);
       vextracti128(xtmp1, yb, 1);
       vextracti128(xtmp2, ysa, 1);
-      vpaddd(xa, xa, xtmp0, Assembler::AVX_256bit);
-      vpaddd(xb, xb, xtmp1, Assembler::AVX_256bit);
-      vpaddd(xsa, xsa, xtmp2, Assembler::AVX_256bit);
+      vpaddd(xa, xa, xtmp0, Assembler::AVX_128bit);
+      vpaddd(xb, xb, xtmp1, Assembler::AVX_128bit);
+      vpaddd(xsa, xsa, xtmp2, Assembler::AVX_128bit);
       vphaddd(xa, xa, xa, Assembler::AVX_128bit);
       vphaddd(xb, xb, xb, Assembler::AVX_128bit);
       vphaddd(xsa, xsa, xsa, Assembler::AVX_128bit);
@@ -177,10 +178,11 @@ void MacroAssembler::updateBytesAdler32(Register init_d, Register data, Register
       movdl(rax, xb);
       addl(b_d, rax);
 
+      align(32);
       bind(FINAL_LOOP);
       movzbl(rax, Address(data, 0)); //movzx   eax, byte[data]
       addl(a_d, rax);
-      incl(data);
+      addptr(data, 1);
       addl(b_d, a_d);
       cmpptr(data, end);
       jcc(Assembler::below, FINAL_LOOP);

--- a/src/hotspot/cpu/x86/macroAssembler_x86_adler.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_adler.cpp
@@ -1,0 +1,209 @@
+/*
+* Copyright (c) 2016, Intel Corporation.
+*
+* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+*
+* This code is free software; you can redistribute it and/or modify it
+* under the terms of the GNU General Public License version 2 only, as
+* published by the Free Software Foundation.
+*
+* This code is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+* version 2 for more details (a copy is included in the LICENSE file that
+* accompanied this code).
+*
+* You should have received a copy of the GNU General Public License version
+* 2 along with this work; if not, write to the Free Software Foundation,
+* Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+* or visit www.oracle.com if you need additional information or have any
+* questions.
+*
+*/
+
+#include "precompiled.hpp"
+#include "asm/assembler.hpp"
+#include "asm/assembler.inline.hpp"
+#include "runtime/stubRoutines.hpp"
+#include "macroAssembler_x86.hpp"
+
+
+void MacroAssembler::updateBytesAdler32(Register init_d, Register data, Register size, XMMRegister yshuf0, XMMRegister yshuf1, ExternalAddress ascaletab)
+{
+      const int LIMIT = 5552;
+      const int BASE = 65521;
+      const int CHUNKSIZE =  16;
+      const int CHUNKSIZE_M1 = CHUNKSIZE - 1;
+
+      const Register s = r11;
+      const Register a_d = r12; //r12d
+      const Register b_d = r8; //r8d
+      const Register end = r13;
+
+      const XMMRegister ya = xmm0;
+      const XMMRegister yb = xmm1;
+      const XMMRegister ydata0 = xmm2;
+      const XMMRegister ydata1 = xmm3;
+      const XMMRegister ysa = xmm4;
+      const XMMRegister ydata = ysa;
+      const XMMRegister ytmp0 = ydata0;
+      const XMMRegister ytmp1 = ydata1;
+      const XMMRegister ytmp2 = xmm5;
+      const XMMRegister xa = xmm0;
+      const XMMRegister xb = xmm1;
+      const XMMRegister xtmp0 = xmm2;
+      const XMMRegister xtmp1 = xmm3;
+      const XMMRegister xsa = xmm4;
+      const XMMRegister xtmp2 = xmm5;
+      assert_different_registers(init_d, data, size, s, a_d, b_d, end, rax);
+
+      Label SLOOP1, SLOOP1A, SKIP_LOOP_1A, FINISH, LT64, DO_FINAL, FINAL_LOOP, ZERO_SIZE, END;
+
+      push(r12);
+      push(r13);
+      push(r14);
+      movl(b_d, init_d); //adler
+      shrl(b_d, 16);
+      andl(init_d, 0xFFFF);
+      cmpl(size, 32);
+      jcc(Assembler::below, LT64);
+      movdl(xa, init_d); //vmovd - 32bit
+      vpxor(yb, yb, yb, Assembler::AVX_256bit);
+
+      bind(SLOOP1);
+      movl(s, LIMIT);
+      cmpl(s, size);
+      cmovl(Assembler::above, s, size); // s = min(size, LIMIT)
+      lea(end, Address(s, data, Address::times_1, -CHUNKSIZE_M1));
+      cmpptr(data, end);
+      jcc(Assembler::aboveEqual, SKIP_LOOP_1A);
+
+      bind(SLOOP1A);
+      vbroadcastf128(ydata, Address(data, 0), Assembler::AVX_256bit);
+      addptr(data, CHUNKSIZE);
+      vpshufb(ydata0, ydata, yshuf0, Assembler::AVX_256bit);
+      vpaddd(ya, ya, ydata0, Assembler::AVX_256bit);
+      vpaddd(yb, yb, ya, Assembler::AVX_256bit);
+      vpshufb(ydata1, ydata, yshuf1, Assembler::AVX_256bit);
+      vpaddd(ya, ya, ydata1, Assembler::AVX_256bit);
+      vpaddd(yb, yb, ya, Assembler::AVX_256bit);
+      cmpptr(data, end);
+      jcc(Assembler::below, SLOOP1A);
+
+      bind(SKIP_LOOP_1A);
+      addptr(end, CHUNKSIZE_M1);
+      testl(s, CHUNKSIZE_M1);
+      jcc(Assembler::notEqual, DO_FINAL);
+
+      // either we're done, or we just did LIMIT
+      subl(size, s);
+
+      // reduce
+      vpslld(yb, yb, 3, Assembler::AVX_256bit); //b is scaled by 8
+      vpmulld(ysa, ya, ascaletab, Assembler::AVX_256bit, r14);
+
+      // compute horizontal sums of ya, yb, ysa
+      vextracti128(xtmp0, ya, 1);
+      vextracti128(xtmp1, yb, 1);
+      vextracti128(xtmp2, ysa, 1);
+      vpaddd(xa, xa, xtmp0, Assembler::AVX_256bit);
+      vpaddd(xb, xb, xtmp1, Assembler::AVX_256bit);
+      vpaddd(xsa, xsa, xtmp2, Assembler::AVX_256bit);
+      vphaddd(xa, xa, xa, Assembler::AVX_128bit);
+      vphaddd(xb, xb, xb, Assembler::AVX_128bit);
+      vphaddd(xsa, xsa, xsa, Assembler::AVX_128bit);
+      vphaddd(xa, xa, xa, Assembler::AVX_128bit);
+      vphaddd(xb, xb, xb, Assembler::AVX_128bit);
+      vphaddd(xsa, xsa, xsa, Assembler::AVX_128bit);
+
+      movdl(rax, xa);
+      xorl(rdx, rdx);
+      movl(rcx, BASE);
+      divl(rcx); // divide edx:eax by ecx, quot->eax, rem->edx
+      movl(a_d, rdx);
+
+      vpsubd(xb, xb, xsa, Assembler::AVX_128bit);
+      movdl(rax, xb);
+      addl(rax, b_d);
+      xorl(rdx, rdx);
+      movl(rcx, BASE);
+      divl(rcx); // divide edx:eax by ecx, quot->eax, rem->edx
+      movl(b_d, rdx);
+
+      testl(size, size);
+      jcc(Assembler::zero, FINISH);
+
+      // continue loop
+      movdl(xa, a_d);
+      vpxor(yb, yb, yb, Assembler::AVX_256bit);
+      jmp(SLOOP1);
+
+      bind(FINISH);
+      movl(rax, b_d);
+      shll(rax, 16);
+      orl(rax, a_d);
+      jmp(END);
+
+      bind(LT64);
+      movl(a_d, init_d);
+      lea(end, Address(data, size, Address::times_1));
+      testl(size, size);
+      jcc(Assembler::notZero, FINAL_LOOP);
+      jmp(ZERO_SIZE);
+
+      // handle remaining 1...15 bytes
+      bind(DO_FINAL);
+      // reduce
+      vpslld(yb, yb, 3, Assembler::AVX_256bit); //b is scaled by 8
+      vpmulld(ysa, ya, ascaletab, Assembler::AVX_256bit, r14); //scaled a
+
+      vextracti128(xtmp0, ya, 1);
+      vextracti128(xtmp1, yb, 1);
+      vextracti128(xtmp2, ysa, 1);
+      vpaddd(xa, xa, xtmp0, Assembler::AVX_128bit);
+      vpaddd(xb, xb, xtmp1, Assembler::AVX_128bit);
+      vpaddd(xsa, xsa, xtmp2, Assembler::AVX_128bit);
+      vphaddd(xa, xa, xa, Assembler::AVX_128bit);
+      vphaddd(xb, xb, xb, Assembler::AVX_128bit);
+      vphaddd(xsa, xsa, xsa, Assembler::AVX_128bit);
+      vphaddd(xa, xa, xa, Assembler::AVX_128bit);
+      vphaddd(xb, xb, xb, Assembler::AVX_128bit);
+      vphaddd(xsa, xsa, xsa, Assembler::AVX_128bit);
+      vpsubd(xb, xb, xsa, Assembler::AVX_128bit);
+
+      movdl(a_d, xa);
+      movdl(rax, xb);
+      addl(b_d, rax);
+
+      bind(FINAL_LOOP);
+      movzbl(rax, Address(data, 0)); //movzx   eax, byte[data]
+      addl(a_d, rax);
+      incl(data);
+      addl(b_d, a_d);
+      cmpptr(data, end);
+      jcc(Assembler::below, FINAL_LOOP);
+
+      bind(ZERO_SIZE);
+
+      movl(rax, a_d);
+      xorl(rdx, rdx);
+      movl(rcx, BASE);
+      divl(rcx); // div ecx -- divide edx:eax by ecx, quot->eax, rem->edx
+      movl(a_d, rdx);
+
+      movl(rax, b_d);
+      xorl(rdx, rdx);
+      movl(rcx, BASE);
+      divl(rcx); // divide edx:eax by ecx, quot->eax, rem->edx
+      shll(rdx, 16);
+      orl(rdx, a_d);
+      movl(rax, rdx);
+
+      bind(END);
+      pop(r14);
+      pop(r13);
+      pop(r12);
+  }
+

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -6796,7 +6796,7 @@ address generate_avx_ghash_processBlocks() {
       StubRoutines::_updateBytesCRC32C = generate_updateBytesCRC32C(supports_clmul);
     }
 
-    if (VM_Version::supports_avx2() && UseAdler32Intrinsics) {
+    if (UseAdler32Intrinsics) {
        StubRoutines::_updateBytesAdler32 = generate_updateBytesAdler32();
     }
 

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -5811,189 +5811,21 @@ address generate_avx_ghash_processBlocks() {
 
       address start = __ pc();
 
-      const int LIMIT = 5552;
-      const int BASE = 65521;
-      const int CHUNKSIZE =  16;
-      const int CHUNKSIZE_M1 = CHUNKSIZE - 1;
-
-      const Register init_d = c_rarg0; //init adler
       const Register data = r9;
       const Register size = r10;
-      const Register s = r11;
-      const Register a_d = r12; //r12d
-      const Register b_d = r8; //r8d
-      const Register end = r13;
 
-      const XMMRegister ya = xmm0;
-      const XMMRegister yb = xmm1;
-      const XMMRegister ydata0 = xmm2;
-      const XMMRegister ydata1 = xmm3;
-      const XMMRegister ysa = xmm4;
-      const XMMRegister ydata = ysa;
-      const XMMRegister ytmp0 = ydata0;
-      const XMMRegister ytmp1 = ydata1;
-      const XMMRegister ytmp2 = xmm5;
-      const XMMRegister xa = xmm0;
-      const XMMRegister xb = xmm1;
-      const XMMRegister xtmp0 = xmm2;
-      const XMMRegister xtmp1 = xmm3;
-      const XMMRegister xsa = xmm4;
-      const XMMRegister xtmp2 = xmm5;
       const XMMRegister yshuf0 = xmm6;
       const XMMRegister yshuf1 = xmm7;
-      assert_different_registers(init_d, c_rarg1, c_rarg2, data, size, s, a_d, b_d, end, rax);
-
-      Label SLOOP1, SLOOP1A, SKIP_LOOP_1A, FINISH, LT64, DO_FINAL, FINAL_LOOP, ZERO_SIZE, END;
+      assert_different_registers(c_rarg0, c_rarg1, c_rarg2, data, size);
 
       BLOCK_COMMENT("Entry:");
       __ enter(); // required for proper stackwalking of RuntimeStub frame
 
-      __ push(r12);
-      __ push(r13);
       __ vmovdqu(yshuf0, ExternalAddress((address) StubRoutines::x86::_adler32_shuf0_table));
       __ vmovdqu(yshuf1, ExternalAddress((address) StubRoutines::x86::_adler32_shuf1_table));
       __ movptr(data, c_rarg1); //data
       __ movl(size, c_rarg2); //length
-      __ movl(b_d, init_d); //adler
-      __ shrl(b_d, 16);
-      __ andl(init_d, 0xFFFF);
-      __ cmpl(size, 32);
-      __ jcc(Assembler::below, LT64);
-      __ movdl(xa, init_d); //vmovd - 32bit
-      __ vpxor(yb, yb, yb, Assembler::AVX_256bit);
-
-      __ BIND(SLOOP1);
-      __ movl(s, LIMIT);
-      __ cmpl(s, size);
-      __ cmovl(Assembler::above, s, size); // s = min(size, LIMIT)
-      __ lea(end, Address(s, data, Address::times_1, -CHUNKSIZE_M1));
-      __ cmpq(data, end);
-      __ jcc(Assembler::aboveEqual, SKIP_LOOP_1A);
-
-      __ BIND(SLOOP1A);
-      __ vbroadcastf128(ydata, Address(data, 0), Assembler::AVX_256bit);
-      __ addptr(data, CHUNKSIZE);
-      __ vpshufb(ydata0, ydata, yshuf0, Assembler::AVX_256bit);
-      __ vpaddd(ya, ya, ydata0, Assembler::AVX_256bit);
-      __ vpaddd(yb, yb, ya, Assembler::AVX_256bit);
-      __ vpshufb(ydata1, ydata, yshuf1, Assembler::AVX_256bit);
-      __ vpaddd(ya, ya, ydata1, Assembler::AVX_256bit);
-      __ vpaddd(yb, yb, ya, Assembler::AVX_256bit);
-      __ cmpptr(data, end);
-      __ jcc(Assembler::below, SLOOP1A);
-
-      __ BIND(SKIP_LOOP_1A);
-      __ addptr(end, CHUNKSIZE_M1);
-      __ testl(s, CHUNKSIZE_M1);
-      __ jcc(Assembler::notEqual, DO_FINAL);
-
-      // either we're done, or we just did LIMIT
-      __ subl(size, s);
-
-      // reduce
-      __ vpslld(yb, yb, 3, Assembler::AVX_256bit); //b is scaled by 8
-      __ vpmulld(ysa, ya, ExternalAddress((address) StubRoutines::x86::_adler32_ascale_table), Assembler::AVX_256bit); //need scratch register??
-
-      // compute horizontal sums of ya, yb, ysa
-      __ vextracti128(xtmp0, ya, 1);
-      __ vextracti128(xtmp1, yb, 1);
-      __ vextracti128(xtmp2, ysa, 1);
-      __ vpaddd(xa, xa, xtmp0, Assembler::AVX_256bit);
-      __ vpaddd(xb, xb, xtmp1, Assembler::AVX_256bit);
-      __ vpaddd(xsa, xsa, xtmp2, Assembler::AVX_256bit);
-      __ vphaddd(xa, xa, xa, Assembler::AVX_128bit);
-      __ vphaddd(xb, xb, xb, Assembler::AVX_128bit);
-      __ vphaddd(xsa, xsa, xsa, Assembler::AVX_128bit);
-      __ vphaddd(xa, xa, xa, Assembler::AVX_128bit);
-      __ vphaddd(xb, xb, xb, Assembler::AVX_128bit);
-      __ vphaddd(xsa, xsa, xsa, Assembler::AVX_128bit);
-
-      __ movdl(rax, xa);
-      __ xorl(rdx, rdx);
-      __ movl(rcx, BASE);
-      __ divl(rcx); // divide edx:eax by ecx, quot->eax, rem->edx
-      __ movl(a_d, rdx);
-
-      __ vpsubd(xb, xb, xsa, Assembler::AVX_128bit);
-      __ movdl(rax, xb);
-      __ addl(rax, b_d);
-      __ xorl(rdx, rdx);
-      __ movl(rcx, BASE);
-      __ divl(rcx); // divide edx:eax by ecx, quot->eax, rem->edx
-      __ movl(b_d, rdx);
-
-      __ testl(size, size);
-      __ jcc(Assembler::zero, FINISH);
-
-      // continue loop
-      __ movdl(xa, a_d);
-      __ vpxor(yb, yb, yb, Assembler::AVX_256bit);
-      __ jmp(SLOOP1);
-
-      __ BIND(FINISH);
-      __ movl(rax, b_d);
-      __ shll(rax, 16);
-      __ orl(rax, a_d);
-      __ jmp(END);
-
-      __ BIND(LT64);
-      __ movl(a_d, init_d);
-      __ lea(end, Address(data, size, Address::times_1));
-      __ testl(size, size);
-      __ jcc(Assembler::notZero, FINAL_LOOP);
-      __ jmp(ZERO_SIZE);
-
-      // handle remaining 1...15 bytes
-      __ BIND(DO_FINAL);
-      // reduce
-      __ vpslld(yb, yb, 3, Assembler::AVX_256bit); //b is scaled by 8
-      __ vpmulld(ysa, ya, ExternalAddress((address) StubRoutines::x86::_adler32_ascale_table), Assembler::AVX_256bit); //scaled a
-
-      __ vextracti128(xtmp0, ya, 1);
-      __ vextracti128(xtmp1, yb, 1);
-      __ vextracti128(xtmp2, ysa, 1);
-      __ vpaddd(xa, xa, xtmp0, Assembler::AVX_128bit);
-      __ vpaddd(xb, xb, xtmp1, Assembler::AVX_128bit);
-      __ vpaddd(xsa, xsa, xtmp2, Assembler::AVX_128bit);
-      __ vphaddd(xa, xa, xa, Assembler::AVX_128bit);
-      __ vphaddd(xb, xb, xb, Assembler::AVX_128bit);
-      __ vphaddd(xsa, xsa, xsa, Assembler::AVX_128bit);
-      __ vphaddd(xa, xa, xa, Assembler::AVX_128bit);
-      __ vphaddd(xb, xb, xb, Assembler::AVX_128bit);
-      __ vphaddd(xsa, xsa, xsa, Assembler::AVX_128bit);
-      __ vpsubd(xb, xb, xsa, Assembler::AVX_128bit);
-
-      __ movdl(a_d, xa);
-      __ movdl(rax, xb);
-      __ addl(b_d, rax);
-
-      __ BIND(FINAL_LOOP);
-      __ movzbl(rax, Address(data, 0)); //movzx   eax, byte[data]
-      __ addl(a_d, rax);
-      __ incl(data);
-      __ addl(b_d, a_d);
-      __ cmpptr(data, end);
-      __ jcc(Assembler::below, FINAL_LOOP);
-
-      __ BIND(ZERO_SIZE);
-
-      __ movl(rax, a_d);
-      __ xorl(rdx, rdx);
-      __ movl(rcx, BASE);
-      __ divl(rcx); // div ecx -- divide edx:eax by ecx, quot->eax, rem->edx
-      __ movl(a_d, rdx);
-
-      __ movl(rax, b_d);
-      __ xorl(rdx, rdx);
-      __ movl(rcx, BASE);
-      __ divl(rcx); // divide edx:eax by ecx, quot->eax, rem->edx
-      __ shll(rdx, 16);
-      __ orl(rdx, a_d);
-      __ movl(rax, rdx);
-
-      __ BIND(END);
-      __ pop(r13);
-      __ pop(r12);
+      __ updateBytesAdler32(c_rarg0, data, size, yshuf0, yshuf1, ExternalAddress((address) StubRoutines::x86::_adler32_ascale_table));
       __ leave();
       __ ret(0);
       return start;

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -5821,8 +5821,8 @@ address generate_avx_ghash_processBlocks() {
       BLOCK_COMMENT("Entry:");
       __ enter(); // required for proper stackwalking of RuntimeStub frame
 
-      __ vmovdqu(yshuf0, ExternalAddress((address) StubRoutines::x86::_adler32_shuf0_table));
-      __ vmovdqu(yshuf1, ExternalAddress((address) StubRoutines::x86::_adler32_shuf1_table));
+      __ vmovdqu(yshuf0, ExternalAddress((address) StubRoutines::x86::_adler32_shuf0_table), r9);
+      __ vmovdqu(yshuf1, ExternalAddress((address) StubRoutines::x86::_adler32_shuf1_table), r9);
       __ movptr(data, c_rarg1); //data
       __ movl(size, c_rarg2); //length
       __ updateBytesAdler32(c_rarg0, data, size, yshuf0, yshuf1, ExternalAddress((address) StubRoutines::x86::_adler32_ascale_table));

--- a/src/hotspot/cpu/x86/stubRoutines_x86.cpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86.cpp
@@ -224,6 +224,25 @@ juint StubRoutines::x86::_shuf_table_crc32_avx512[] =
     0x83828100UL, 0x87868584UL, 0x8b8a8988UL, 0x8f8e8d8cUL,
     0x03020100UL, 0x07060504UL, 0x0b0a0908UL, 0x000e0d0cUL
 };
+
+juint StubRoutines::x86::_adler32_ascale_table[] =
+{
+    0x00000000UL, 0x00000001UL, 0x00000002UL, 0x00000003UL,
+    0x00000004UL, 0x00000005UL, 0x00000006UL, 0x00000007UL
+};
+
+juint StubRoutines::x86::_adler32_shuf0_table[] =
+{
+    0xFFFFFF00UL, 0xFFFFFF01UL, 0xFFFFFF02UL, 0xFFFFFF03UL,
+    0xFFFFFF04UL, 0xFFFFFF05UL, 0xFFFFFF06UL, 0xFFFFFF07UL
+};
+
+juint StubRoutines::x86::_adler32_shuf1_table[] =
+{
+    0xFFFFFF08UL, 0xFFFFFF09, 0xFFFFFF0AUL, 0xFFFFFF0BUL,
+    0xFFFFFF0CUL, 0xFFFFFF0D, 0xFFFFFF0EUL, 0xFFFFFF0FUL
+};
+
 #endif // _LP64
 
 #define D 32

--- a/src/hotspot/cpu/x86/stubRoutines_x86.hpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86.hpp
@@ -119,6 +119,9 @@ class x86 {
   static juint    _crc_by128_masks_avx512[];
   static juint    _crc_table_avx512[];
   static juint    _shuf_table_crc32_avx512[];
+  static juint    _adler32_shuf0_table[];
+  static juint    _adler32_shuf1_table[];
+  static juint    _adler32_ascale_table[];
 #endif // _LP64
   // table for CRC32C
   static juint* _crc32c_table;

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -904,8 +904,9 @@ void VM_Version::get_processor_features() {
       UseAdler32Intrinsics = true;
     }
   } else if (UseAdler32Intrinsics) {
-    if (!FLAG_IS_DEFAULT(UseAdler32Intrinsics))
+    if (!FLAG_IS_DEFAULT(UseAdler32Intrinsics)) {
       warning("Adler32 Intrinsics requires avx2 instructions (not available on this CPU)");
+    }
     FLAG_SET_DEFAULT(UseAdler32Intrinsics, false);
   }
 #else

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -898,6 +898,7 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseCRC32Intrinsics, false);
   }
 
+#ifdef _LP64
   if (supports_avx2() && UseAdler32Intrinsics) {
     if (FLAG_IS_DEFAULT(UseAdler32Intrinsics)) {
       UseAdler32Intrinsics = true;
@@ -907,6 +908,12 @@ void VM_Version::get_processor_features() {
       warning("Adler32 Intrinsics requires avx2 instructions (not available on this CPU)");
     FLAG_SET_DEFAULT(UseAdler32Intrinsics, false);
   }
+#else
+  if (UseAdler32Intrinsics) {
+    warning("Adler32Intrinsics not available on this CPU.");
+    FLAG_SET_DEFAULT(UseAdler32Intrinsics, false);
+  }
+#endif
 
   if (supports_sse4_2() && supports_clmul()) {
     if (FLAG_IS_DEFAULT(UseCRC32CIntrinsics)) {

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -898,6 +898,16 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseCRC32Intrinsics, false);
   }
 
+  if (supports_avx2() && UseAdler32Intrinsics) {
+    if (FLAG_IS_DEFAULT(UseAdler32Intrinsics)) {
+      UseAdler32Intrinsics = true;
+    }
+  } else if (UseAdler32Intrinsics) {
+    if (!FLAG_IS_DEFAULT(UseAdler32Intrinsics))
+      warning("Adler32 Intrinsics requires avx2 instructions (not available on this CPU)");
+    FLAG_SET_DEFAULT(UseAdler32Intrinsics, false);
+  }
+
   if (supports_sse4_2() && supports_clmul()) {
     if (FLAG_IS_DEFAULT(UseCRC32CIntrinsics)) {
       UseCRC32CIntrinsics = true;
@@ -991,11 +1001,6 @@ void VM_Version::get_processor_features() {
 
   if (!(UseSHA1Intrinsics || UseSHA256Intrinsics || UseSHA512Intrinsics)) {
     FLAG_SET_DEFAULT(UseSHA, false);
-  }
-
-  if (UseAdler32Intrinsics) {
-    warning("Adler32Intrinsics not available on this CPU.");
-    FLAG_SET_DEFAULT(UseAdler32Intrinsics, false);
   }
 
   if (!supports_rtm() && UseRTMLocking) {

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -899,7 +899,7 @@ void VM_Version::get_processor_features() {
   }
 
 #ifdef _LP64
-  if (supports_avx2() && UseAdler32Intrinsics) {
+  if (supports_avx2()) {
     if (FLAG_IS_DEFAULT(UseAdler32Intrinsics)) {
       UseAdler32Intrinsics = true;
     }

--- a/src/hotspot/share/classfile/vmIntrinsics.cpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.cpp
@@ -93,6 +93,7 @@ bool vmIntrinsics::preserves_state(vmIntrinsics::ID id) {
   case vmIntrinsics::_updateCRC32:
   case vmIntrinsics::_updateBytesCRC32:
   case vmIntrinsics::_updateByteBufferCRC32:
+  case vmIntrinsics::_updateBytesAdler32:
   case vmIntrinsics::_vectorizedMismatch:
   case vmIntrinsics::_fmaD:
   case vmIntrinsics::_fmaF:

--- a/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
@@ -231,6 +231,7 @@ JVMCIObjectArray CompilerToVM::initialize_intrinsics(JVMCI_TRAPS) {
   X86_ONLY(do_intx_flag(UseAVX))                                           \
   do_bool_flag(UseBiasedLocking)                                           \
   do_bool_flag(UseCRC32Intrinsics)                                         \
+  do_bool_flag(UseAdler32Intrinsics)                                       \
   do_bool_flag(UseCompressedClassPointers)                                 \
   do_bool_flag(UseCompressedOops)                                          \
   X86_ONLY(do_bool_flag(UseCountLeadingZerosInstruction))                  \

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -575,6 +575,7 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
      static_field(StubRoutines,                _crc_table_adr,                                address)                               \
      static_field(StubRoutines,                _crc32c_table_addr,                            address)                               \
      static_field(StubRoutines,                _updateBytesCRC32C,                            address)                               \
+     static_field(StubRoutines,                _updateBytesAdler32,                           address)                               \
      static_field(StubRoutines,                _multiplyToLen,                                address)                               \
      static_field(StubRoutines,                _squareToLen,                                  address)                               \
      static_field(StubRoutines,                _bigIntegerRightShiftWorker,                   address)                               \

--- a/test/hotspot/jtreg/compiler/intrinsics/zip/TestAdler32.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/zip/TestAdler32.java
@@ -24,9 +24,12 @@
 /**
  * @test
  * @bug 8132081
+ * @bug 8266332
  * @summary C2 support for Adler32 on SPARC
+ * @comment 8266332: -XX:+UnlockDiagnosticVMOptions -XX:+UseAdler32Intrinsics shows performance gain
  *
  * @run main/othervm/timeout=600 -Xbatch compiler.intrinsics.zip.TestAdler32 -m
+ * @run main/othervm/timeout=600 -XX:+UnlockDiagnosticVMOptions -XX:+UseAdler32Intrinsics compiler.intrinsics.zip.TestAdler32 -m
  */
 
 package compiler.intrinsics.zip;

--- a/test/hotspot/jtreg/compiler/intrinsics/zip/TestAdler32.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/zip/TestAdler32.java
@@ -24,12 +24,9 @@
 /**
  * @test
  * @bug 8132081
- * @bug 8266332
  * @summary C2 support for Adler32 on SPARC
- * @comment 8266332: -XX:+UnlockDiagnosticVMOptions -XX:+UseAdler32Intrinsics shows performance gain
  *
  * @run main/othervm/timeout=600 -Xbatch compiler.intrinsics.zip.TestAdler32 -m
- * @run main/othervm/timeout=600 -XX:+UnlockDiagnosticVMOptions -XX:+UseAdler32Intrinsics compiler.intrinsics.zip.TestAdler32 -m
  */
 
 package compiler.intrinsics.zip;

--- a/test/micro/org/openjdk/bench/java/util/TestAdler32.java
+++ b/test/micro/org/openjdk/bench/java/util/TestAdler32.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.util;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.Adler32;
+import org.openjdk.jmh.annotations.*;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 2, jvmArgsAppend = { "-XX:+UnlockDiagnosticVMOptions", "-XX:+UseAdler32Intrinsics", "-Xms4g", "-Xmx4g", "-Xint" })
+@Warmup(iterations = 2, time = 30, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 120, timeUnit = TimeUnit.SECONDS)
+
+public class TestAdler32 {
+
+    private Adler32 adler32;
+    private Random random;
+    private byte[] bytes;
+
+    @Param({"64", "128", "256", "512", "1024", "2048", "4096", "8192", "16384", "32768", "65536"})
+    private int count;
+
+    public TestAdler32() {
+        adler32 = new Adler32();
+        random = new Random(2147483648L);
+        bytes = new byte[1000000];
+        random.nextBytes(bytes);
+    }
+
+    @Setup(Level.Iteration)
+    public void setupBytes() {
+        adler32.reset();
+    }
+
+    @Benchmark
+    public void testAdler32Update() {
+        adler32.update(bytes, 0, count);
+    }
+}

--- a/test/micro/org/openjdk/bench/java/util/TestAdler32.java
+++ b/test/micro/org/openjdk/bench/java/util/TestAdler32.java
@@ -30,9 +30,9 @@ import org.openjdk.jmh.annotations.*;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Benchmark)
-@Fork(value = 2, jvmArgsAppend = { "-XX:+UnlockDiagnosticVMOptions", "-XX:+UseAdler32Intrinsics", "-Xms4g", "-Xmx4g", "-Xint" })
+@Fork(value = 2)
 @Warmup(iterations = 2, time = 30, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 3, time = 120, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 60, timeUnit = TimeUnit.SECONDS)
 
 public class TestAdler32 {
 


### PR DESCRIPTION
Implement Adler32 intrinsic for x86 64-bit platform using vector instructions.

The benchmark test/micro/org/openjdk/bench/java/util/TestAdler32.java is contributed by Pengfei Li (pli, Pengfei.Li@arm.com).

For this benchmark,  the optimization shows ~5x improvement.

Base:
Benchmark (count) Mode Cnt Score Error Units
TestAdler32Perf.testAdler32Update 64 avgt 25 0.084 ± 0.001 us/op
TestAdler32Perf.testAdler32Update 128 avgt 25 0.104 ± 0.001 us/op
TestAdler32Perf.testAdler32Update 256 avgt 25 0.146 ± 0.002 us/op
TestAdler32Perf.testAdler32Update 512 avgt 25 0.226 ± 0.002 us/op
TestAdler32Perf.testAdler32Update 1024 avgt 25 0.390 ± 0.005 us/op
TestAdler32Perf.testAdler32Update 2048 avgt 25 0.714 ± 0.007 us/op
TestAdler32Perf.testAdler32Update 4096 avgt 25 1.359 ± 0.014 us/op
TestAdler32Perf.testAdler32Update 8192 avgt 25 2.751 ± 0.023 us/op
TestAdler32Perf.testAdler32Update 16384 avgt 25 5.494 ± 0.077 us/op
TestAdler32Perf.testAdler32Update 32768 avgt 25 11.058 ± 0.160 us/op
TestAdler32Perf.testAdler32Update 65536 avgt 25 22.198 ± 0.319 us/op


With patch:
Benchmark (count) Mode Cnt Score Error Units
TestAdler32Perf.testAdler32Update 64 avgt 25 0.020 ± 0.001 us/op
TestAdler32Perf.testAdler32Update 128 avgt 25 0.025 ± 0.001 us/op
TestAdler32Perf.testAdler32Update 256 avgt 25 0.031 ± 0.001 us/op
TestAdler32Perf.testAdler32Update 512 avgt 25 0.048 ± 0.001 us/op
TestAdler32Perf.testAdler32Update 1024 avgt 25 0.078 ± 0.001 us/op
TestAdler32Perf.testAdler32Update 2048 avgt 25 0.139 ± 0.002 us/op
TestAdler32Perf.testAdler32Update 4096 avgt 25 0.262 ± 0.004 us/op
TestAdler32Perf.testAdler32Update 8192 avgt 25 0.524 ± 0.010 us/op
TestAdler32Perf.testAdler32Update 16384 avgt 25 1.017 ± 0.022 us/op
TestAdler32Perf.testAdler32Update 32768 avgt 25 2.058 ± 0.052 us/op
TestAdler32Perf.testAdler32Update 65536 avgt 25 3.994 ± 0.013 us/op

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266332](https://bugs.openjdk.java.net/browse/JDK-8266332): Adler32 intrinsic for x86 64-bit platforms


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.java.net/census#sviswanathan) (@sviswa7 - Committer) ⚠️ Review applies to 72a0d3f39a8fbaf741ad3479cfbf65dd11cf53fa
 * [Jatin Bhateja](https://openjdk.java.net/census#jbhateja) (@jatin-bhateja - Committer) ⚠️ Review applies to 72a0d3f39a8fbaf741ad3479cfbf65dd11cf53fa
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Contributors
 * Xubo Zhang `<xubo.zhang@intel.com>`
 * Greg B Tucker `<greg.b.tucker@intel.com>`
 * Pengfei Li `<pli@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3806/head:pull/3806` \
`$ git checkout pull/3806`

Update a local copy of the PR: \
`$ git checkout pull/3806` \
`$ git pull https://git.openjdk.java.net/jdk pull/3806/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3806`

View PR using the GUI difftool: \
`$ git pr show -t 3806`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3806.diff">https://git.openjdk.java.net/jdk/pull/3806.diff</a>

</details>
