### PR TITLE
8266179: [macos] jpackage should specify architecture for produced pkg files

### DIFF
--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacPkgBundler.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacPkgBundler.java
@@ -284,6 +284,8 @@ public class MacPkgBundler extends MacBaseInstallerBundler {
             xml.writeStartElement("options");
             xml.writeAttribute("customize", "never");
             xml.writeAttribute("require-scripts", "false");
+            xml.writeAttribute("hostArchitectures",
+                    Platform.isArmMac() ? "arm64" : "x86_64");
             xml.writeEndElement(); // </options>
             xml.writeStartElement("choices-outline");
             xml.writeStartElement("line");

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Platform.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -109,6 +109,10 @@ enum Platform {UNKNOWN, WINDOWS, LINUX, MAC;
 
     static boolean isMac() {
         return getPlatform() == MAC;
+    }
+
+    static boolean isArmMac() {
+        return (isMac() && "aarch64".equals(System.getProperty("os.arch")));
     }
 
     static boolean isLinux() {

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -416,7 +416,7 @@ public final class JPackageCommand extends CommandArguments<JPackageCommand> {
         return unpackDir.resolve(TKit.removeRootFromAbsolutePath(path));
     }
 
-    public Path unpackedPackageDirectory() {
+    Path unpackedPackageDirectory() {
         verifyIsOfType(PackageType.NATIVE);
         return getArgumentValue(UNPACKED_PATH_ARGNAME, () -> null, Path::of);
     }

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -416,7 +416,7 @@ public final class JPackageCommand extends CommandArguments<JPackageCommand> {
         return unpackDir.resolve(TKit.removeRootFromAbsolutePath(path));
     }
 
-    Path unpackedPackageDirectory() {
+    public Path unpackedPackageDirectory() {
         verifyIsOfType(PackageType.NATIVE);
         return getArgumentValue(UNPACKED_PATH_ARGNAME, () -> null, Path::of);
     }

--- a/test/jdk/tools/jpackage/macosx/HostArchPkgTest.java
+++ b/test/jdk/tools/jpackage/macosx/HostArchPkgTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+import jdk.jpackage.test.JPackageCommand;
+import jdk.jpackage.test.PackageTest;
+import jdk.jpackage.test.PackageType;
+import jdk.jpackage.test.TKit;
+
+/**
+ * Test will generation default pkg package and will validate "hostArchitectures"
+ * attribute in unpacked pkg package inside Distribution file. See JDK-8266179.
+ */
+
+/*
+ * @test
+ * @summary jpackage test to validate "hostArchitectures" attribute
+ * @library ../helpers
+ * @build jdk.jpackage.test.*
+ * @modules jdk.jpackage/jdk.jpackage.internal
+ * @compile HostArchPkgTest.java
+ * @requires (os.family == "mac")
+ * @key jpackagePlatformPackage
+ * @run main/othervm -Xmx512m HostArchPkgTest
+ */
+public class HostArchPkgTest {
+
+    private static void verifyHostArch(JPackageCommand cmd) throws Exception {
+        Path distributionFile = cmd.unpackedPackageDirectory()
+                .toAbsolutePath()
+                .getParent()
+                .resolve("data")
+                .resolve("Distribution");
+
+        DocumentBuilderFactory dbf
+                = DocumentBuilderFactory.newDefaultInstance();
+        dbf.setFeature("http://apache.org/xml/features/" +
+                       "nonvalidating/load-external-dtd", false);
+        DocumentBuilder b = dbf.newDocumentBuilder();
+        org.w3c.dom.Document doc
+                = b.parse(Files.newInputStream(distributionFile));
+
+        XPath xPath = XPathFactory.newInstance().newXPath();
+
+        String v = (String) xPath.evaluate(
+                    "/installer-gui-script/options/@hostArchitectures",
+                    doc, XPathConstants.STRING);
+
+        if ("aarch64".equals(System.getProperty("os.arch"))) {
+            TKit.assertEquals(v, "arm64",
+                    "Check value of \"hostArchitectures\" attribute");
+        } else {
+            TKit.assertEquals(v, "x86_64",
+                    "Check value of \"hostArchitectures\" attribute");
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        TKit.run(args, () -> {
+            new PackageTest()
+                    .excludeTypes(PackageType.MAC_DMG) // Not valid case
+                    .configureHelloApp()
+                    .forTypes(PackageType.MAC_PKG)
+                    .addInstallVerifier(HostArchPkgTest::verifyHostArch)
+                    .run();
+        });
+    }
+}

--- a/test/jdk/tools/jpackage/macosx/HostArchPkgTest.java
+++ b/test/jdk/tools/jpackage/macosx/HostArchPkgTest.java
@@ -32,6 +32,7 @@ import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.PackageTest;
 import jdk.jpackage.test.PackageType;
 import jdk.jpackage.test.TKit;
+import jdk.jpackage.test.Annotations.Test;
 
 /**
  * Test will generation default pkg package and will validate "hostArchitectures"
@@ -47,12 +48,13 @@ import jdk.jpackage.test.TKit;
  * @compile HostArchPkgTest.java
  * @requires (os.family == "mac")
  * @key jpackagePlatformPackage
- * @run main/othervm -Xmx512m HostArchPkgTest
+ * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=HostArchPkgTest
  */
 public class HostArchPkgTest {
 
     private static void verifyHostArch(JPackageCommand cmd) throws Exception {
-        Path distributionFile = cmd.unpackedPackageDirectory()
+        Path distributionFile = cmd.pathToUnpackedPackageFile(Path.of("/"))
                 .toAbsolutePath()
                 .getParent()
                 .resolve("data")
@@ -81,14 +83,13 @@ public class HostArchPkgTest {
         }
     }
 
-    public static void main(String[] args) throws Exception {
-        TKit.run(args, () -> {
-            new PackageTest()
-                    .excludeTypes(PackageType.MAC_DMG) // Not valid case
-                    .configureHelloApp()
-                    .forTypes(PackageType.MAC_PKG)
-                    .addInstallVerifier(HostArchPkgTest::verifyHostArch)
-                    .run();
-        });
+    @Test
+    public static void test() {
+        new PackageTest()
+                .excludeTypes(PackageType.MAC_DMG) // Not valid case
+                .configureHelloApp()
+                .forTypes(PackageType.MAC_PKG)
+                .addInstallVerifier(HostArchPkgTest::verifyHostArch)
+                .run();
     }
 }

--- a/test/jdk/tools/jpackage/macosx/HostArchPkgTest.java
+++ b/test/jdk/tools/jpackage/macosx/HostArchPkgTest.java
@@ -86,10 +86,9 @@ public class HostArchPkgTest {
     @Test
     public static void test() {
         new PackageTest()
-                .excludeTypes(PackageType.MAC_DMG) // Not valid case
-                .configureHelloApp()
                 .forTypes(PackageType.MAC_PKG)
+                .configureHelloApp()
                 .addInstallVerifier(HostArchPkgTest::verifyHostArch)
-                .run();
+                .run(PackageTest.Action.CREATE_AND_UNPACK);
     }
 }


### PR DESCRIPTION
jpackage should specify architecture for produced PKG files via hostArchitectures="x86_x64 or arm64". aarch64 installer will be installable on x64 without specifying hostArchitectures which is not correct and if install on arm Mac it will request Rosetta 2. With proposed fix by setting hostArchitectures="x86_x64" if installer contains x64 binaries, it will be installable on x64 Mac and will require Rosetta 2 on arm Mac. hostArchitectures will be set to arm64 if installer contain aarch64 binaries and will gave error when run on x64 Mac and will be installable on arm Mac without triggering installation of Rosetta 2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266179](https://bugs.openjdk.java.net/browse/JDK-8266179): [macos] jpackage should specify architecture for produced pkg files


### Reviewers
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**) ⚠️ Review applies to 1937e9e19856e63b5d4a3c83b3ac534018aa00d9
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Author)
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3807/head:pull/3807` \
`$ git checkout pull/3807`

Update a local copy of the PR: \
`$ git checkout pull/3807` \
`$ git pull https://git.openjdk.java.net/jdk pull/3807/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3807`

View PR using the GUI difftool: \
`$ git pr show -t 3807`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3807.diff">https://git.openjdk.java.net/jdk/pull/3807.diff</a>

</details>
