### PR TITLE
8266193:  BasicJMapTest does not include testHistoParallel methods 

### DIFF
--- a/test/jdk/sun/tools/jmap/BasicJMapTest.java
+++ b/test/jdk/sun/tools/jmap/BasicJMapTest.java
@@ -109,6 +109,9 @@ public class BasicJMapTest {
         testHisto();
         testHistoLive();
         testHistoAll();
+        testHistoParallelZero();
+        testHistoParallel();
+        testHistoNonParallel();
         testHistoToFile();
         testHistoLiveToFile();
         testHistoAllToFile();


### PR DESCRIPTION
The testHistoParallel* method are not included in the BasicJMapTest's main() method. They should be included.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266193](https://bugs.openjdk.java.net/browse/JDK-8266193): BasicJMapTest does not include testHistoParallel methods


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to b922efeeaffc8ad8e168a62bde3e05055482a4f9
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3810/head:pull/3810` \
`$ git checkout pull/3810`

Update a local copy of the PR: \
`$ git checkout pull/3810` \
`$ git pull https://git.openjdk.java.net/jdk pull/3810/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3810`

View PR using the GUI difftool: \
`$ git pr show -t 3810`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3810.diff">https://git.openjdk.java.net/jdk/pull/3810.diff</a>

</details>
