### PR TITLE
8255566: Initialize JDK_Version direct from the build system 

### DIFF
--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -70,6 +70,10 @@ CFLAGS_VM_VERSION := \
     -DCPU='"$(OPENJDK_TARGET_CPU_VM_VERSION)"' \
     #
 
+CFLAGS_JDK_VERSION := \
+    $(VERSION_CFLAGS) \
+    -DVERSION_RUNTIME_NAME='"$(RUNTIME_NAME)"'
+
 ifneq ($(HOTSPOT_BUILD_TIME), )
   CFLAGS_VM_VERSION += -DHOTSPOT_BUILD_TIME='"$(HOTSPOT_BUILD_TIME)"'
 endif
@@ -149,6 +153,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     CFLAGS := $(JVM_CFLAGS), \
     abstract_vm_version.cpp_CXXFLAGS := $(CFLAGS_VM_VERSION), \
     arguments.cpp_CXXFLAGS := $(CFLAGS_VM_VERSION), \
+    java.cpp_CXXFLAGS := $(CFLAGS_JDK_VERSION), \
     DISABLED_WARNINGS_gcc := $(DISABLED_WARNINGS_gcc), \
     DISABLED_WARNINGS_clang := $(DISABLED_WARNINGS_clang), \
     DISABLED_WARNINGS_xlc := $(DISABLED_WARNINGS_xlc), \

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -146,14 +146,6 @@
   template(jdk_internal_loader_ClassLoaders_AppClassLoader,      "jdk/internal/loader/ClassLoaders$AppClassLoader")      \
   template(jdk_internal_loader_ClassLoaders_PlatformClassLoader, "jdk/internal/loader/ClassLoaders$PlatformClassLoader") \
                                                                                                   \
-  /* Java runtime version access */                                                               \
-  template(java_lang_VersionProps,                    "java/lang/VersionProps")                   \
-  template(java_version_name,                         "java_version")                             \
-  template(java_runtime_name_name,                    "java_runtime_name")                        \
-  template(java_runtime_version_name,                 "java_runtime_version")                     \
-  template(java_runtime_vendor_version_name,          "VENDOR_VERSION")                           \
-  template(java_runtime_vendor_vm_bug_url_name,       "VENDOR_URL_VM_BUG")                        \
-                                                                                                  \
   /* system initialization */                                                                     \
   template(initPhase1_name,                           "initPhase1")                               \
   template(initPhase2_name,                           "initPhase2")                               \

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -705,11 +705,13 @@ void vm_shutdown_during_initialization(const char* error, const char* message) {
 }
 
 JDK_Version JDK_Version::_current;
-const char* JDK_Version::_java_version;
-const char* JDK_Version::_runtime_name;
-const char* JDK_Version::_runtime_version;
-const char* JDK_Version::_runtime_vendor_version;
-const char* JDK_Version::_runtime_vendor_vm_bug_url;
+
+// All version information is set at build/configure time
+const char* JDK_Version::_java_version = VERSION_SHORT;
+const char* JDK_Version::_runtime_name = VERSION_RUNTIME_NAME;
+const char* JDK_Version::_runtime_version = VERSION_STRING;
+const char* JDK_Version::_runtime_vendor_version = VENDOR_VERSION_STRING;
+const char* JDK_Version::_runtime_vendor_vm_bug_url = VENDOR_URL_VM_BUG;
 
 void JDK_Version::initialize() {
   assert(!_current.is_valid(), "Don't initialize twice");

--- a/src/hotspot/share/runtime/java.hpp
+++ b/src/hotspot/share/runtime/java.hpp
@@ -139,38 +139,22 @@ class JDK_Version {
   static const char* java_version() {
     return _java_version;
   }
-  static void set_java_version(const char* version) {
-    _java_version = version;
-  }
 
   static const char* runtime_name() {
     return _runtime_name;
-  }
-  static void set_runtime_name(const char* name) {
-    _runtime_name = name;
   }
 
   static const char* runtime_version() {
     return _runtime_version;
   }
-  static void set_runtime_version(const char* version) {
-    _runtime_version = version;
-  }
 
   static const char* runtime_vendor_version() {
     return _runtime_vendor_version;
-  }
-  static void set_runtime_vendor_version(const char* vendor_version) {
-    _runtime_vendor_version = vendor_version;
   }
 
   static const char* runtime_vendor_vm_bug_url() {
     return _runtime_vendor_vm_bug_url;
   }
-  static void set_runtime_vendor_vm_bug_url(const char* vendor_vm_bug_url) {
-    _runtime_vendor_vm_bug_url = vendor_vm_bug_url;
-  }
-
 };
 
 #endif // SHARE_RUNTIME_JAVA_HPP


### PR DESCRIPTION
The existing logic does:

build system -> java.lang.VersionProps -> VM thread.cpp fixed-size static buffers -> JDK_Version class

we can simply do:

build system -> JDK_Version class

reduces footprint, loc and startup time.

Testing tiers 1-3 and manual visual inspection of version strings

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8255566](https://bugs.openjdk.java.net/browse/JDK-8255566): Initialize JDK_Version direct from the build system


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3812/head:pull/3812` \
`$ git checkout pull/3812`

Update a local copy of the PR: \
`$ git checkout pull/3812` \
`$ git pull https://git.openjdk.java.net/jdk pull/3812/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3812`

View PR using the GUI difftool: \
`$ git pr show -t 3812`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3812.diff">https://git.openjdk.java.net/jdk/pull/3812.diff</a>

</details>
