### PR TITLE
8255227: java/net/httpclient/FlowAdapterPublisherTest.java intermittently failing with TestServer: start exception: java.io.IOException: Invalid preface

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -926,7 +926,6 @@ class Stream<T> extends ExchangeImpl<T> {
                     // handle bytes to send downstream
                     while (item.hasRemaining() && state == 0) {
                         if (debug.on()) debug.log("trySend: %d", item.remaining());
-                        assert !endStreamSent : "internal error, send data after END_STREAM flag";
                         DataFrame df = getDataFrame(item);
                         if (df == null) {
                             if (debug.on())
@@ -947,9 +946,12 @@ class Stream<T> extends ExchangeImpl<T> {
                                 connection.resetStream(streamid, ResetFrame.PROTOCOL_ERROR);
                                 throw new IOException(msg);
                             } else if (remainingContentLength == 0) {
+                                assert !endStreamSent : "internal error, send data after END_STREAM flag";
                                 df.setFlag(DataFrame.END_STREAM);
                                 endStreamSent = true;
                             }
+                        } else {
+                            assert !endStreamSent : "internal error, send data after END_STREAM flag";
                         }
                         if ((state = streamState) != 0) {
                             if (debug.on()) debug.log("trySend: cancelled: %s", String.valueOf(t));

--- a/test/jdk/java/net/httpclient/http2/server/Http2TestServerConnection.java
+++ b/test/jdk/java/net/httpclient/http2/server/Http2TestServerConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,7 @@ import jdk.internal.net.http.hpack.DecodingCallback;
 import jdk.internal.net.http.hpack.Encoder;
 import sun.net.www.http.ChunkedInputStream;
 import sun.net.www.http.HttpClient;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static jdk.internal.net.http.frame.SettingsFrame.HEADER_TABLE_SIZE;
 
@@ -304,9 +305,11 @@ public class Http2TestServerConnection {
     private void readPreface() throws IOException {
         int len = clientPreface.length;
         byte[] bytes = new byte[len];
-        is.readNBytes(bytes, 0, len);
+        int n = is.readNBytes(bytes, 0, len);
         if (Arrays.compare(clientPreface, bytes) != 0) {
-            throw new IOException("Invalid preface: " + new String(bytes, 0, len));
+            System.err.printf("Invalid preface: read %d/%d bytes%n", n, len);
+            throw new IOException("Invalid preface: " +
+                    new String(bytes, 0, len, ISO_8859_1));
         }
     }
 


### PR DESCRIPTION
Hi,

I stumbled on an issue in Stream.java where an assert was misplaced, preventing the proper IOException to be triggered. I believe this is what caused the FlowAdapterPublisherTest.java  to fail with the "Invalid Preface" error on the server side.
In any case - I haven't observed this error again after tweaking the assert.

I have also updated the server side to print better diagnostic in case the Invalid Preface strikes again in the future...

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255227](https://bugs.openjdk.java.net/browse/JDK-8255227): java/net/httpclient/FlowAdapterPublisherTest.java intermittently failing with TestServer: start exception: java.io.IOException: Invalid preface


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3813/head:pull/3813` \
`$ git checkout pull/3813`

Update a local copy of the PR: \
`$ git checkout pull/3813` \
`$ git pull https://git.openjdk.java.net/jdk pull/3813/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3813`

View PR using the GUI difftool: \
`$ git pr show -t 3813`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3813.diff">https://git.openjdk.java.net/jdk/pull/3813.diff</a>

</details>
