### PR TITLE
8265984: Concurrent GC: Some tests fail "assert(is_frame_safe(f)) failed: Frame must be safe"

### DIFF
--- a/src/hotspot/share/gc/z/zBarrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/z/zBarrierSetNMethod.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@
 #include "gc/z/zNMethod.hpp"
 #include "gc/z/zThreadLocalData.hpp"
 #include "logging/log.hpp"
+#include "runtime/threadWXSetters.inline.hpp"
 
 bool ZBarrierSetNMethod::nmethod_entry_barrier(nmethod* nm) {
   ZLocker<ZReentrantLock> locker(ZNMethod::lock_for_nmethod(nm));
@@ -39,6 +40,8 @@ bool ZBarrierSetNMethod::nmethod_entry_barrier(nmethod* nm) {
     // and disarmed the nmethod.
     return true;
   }
+
+  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, Thread::current()));
 
   if (nm->is_unloading()) {
     // We don't need to take the lock when unlinking nmethods from

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -1377,7 +1377,7 @@ address OptoRuntime::handle_exception_C(JavaThread* current) {
   // deoptimized frame
 
   if (nm != NULL) {
-    RegisterMap map(current, false /* update_map */, false /* process_frames */);
+    RegisterMap map(current, false);
     frame caller = current->last_frame().sender(&map);
 #ifdef ASSERT
     assert(caller.is_compiled_frame(), "must be");


### PR DESCRIPTION
JDK-8265702 introduced a change in `OptoRuntime::handle_exception_C()` where it no longer processed frames when asking for the caller. This change turned out to cause intermittent test failures. We shouldn't have to process frames here, since we're not touching any oops, but it seems that processing frames here avoids some other issue. To avoid noise in out testing I suggest we revert to processing frames here for now (and add the required ThreadWXEnable for macos/aarch64), while we continue to investigate why this is needed.

Testing: Passed tier1-7 on linux/x86 and macos/aarch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265984](https://bugs.openjdk.java.net/browse/JDK-8265984): Concurrent GC: Some tests fail "assert(is_frame_safe(f)) failed: Frame must be safe"


### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3814/head:pull/3814` \
`$ git checkout pull/3814`

Update a local copy of the PR: \
`$ git checkout pull/3814` \
`$ git pull https://git.openjdk.java.net/jdk pull/3814/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3814`

View PR using the GUI difftool: \
`$ git pr show -t 3814`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3814.diff">https://git.openjdk.java.net/jdk/pull/3814.diff</a>

</details>
