### PR TITLE
8266056: runtime/stringtable/StringTableCleaningTest.java failed with "RuntimeException: Missing Callback in [10, 11]"

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -63,4 +63,3 @@ serviceability/sa/TestSysProps.java                           8220624   generic-
 serviceability/sa/sadebugd/DebugdConnectTest.java             8220624   generic-all
 serviceability/sa/sadebugd/DisableRegistryTest.java           8220624   generic-all
 vmTestbase/jit/escape/AdaptiveBlocking/AdaptiveBlocking001/AdaptiveBlocking001.java 8260303 windows-x64
-runtime/stringtable/StringTableCleaningTest.java              8266056   linux-aarch64

--- a/test/hotspot/jtreg/runtime/stringtable/StringTableCleaningTest.java
+++ b/test/hotspot/jtreg/runtime/stringtable/StringTableCleaningTest.java
@@ -59,8 +59,6 @@ public class StringTableCleaningTest {
         subargs.add(Tester.class.getName());
         subargs.addAll(Arrays.asList(args));
         OutputAnalyzer output = ProcessTools.executeTestJvm(subargs);
-        output.outputTo(System.out);
-        output.errorTo(System.out);
         output.shouldHaveExitValue(0);
         checkOutput(output);
     }

--- a/test/hotspot/jtreg/runtime/stringtable/StringTableCleaningTest.java
+++ b/test/hotspot/jtreg/runtime/stringtable/StringTableCleaningTest.java
@@ -59,6 +59,8 @@ public class StringTableCleaningTest {
         subargs.add(Tester.class.getName());
         subargs.addAll(Arrays.asList(args));
         OutputAnalyzer output = ProcessTools.executeTestJvm(subargs);
+        output.outputTo(System.out);
+        output.errorTo(System.out);
         output.shouldHaveExitValue(0);
         checkOutput(output);
     }
@@ -82,7 +84,8 @@ public class StringTableCleaningTest {
     private static final String g1Suffix = "Pause(?! Cleanup)";
 
     // Suffix for ZGC.
-    private static final String zSuffix = "Garbage Collection";
+    private static final String zStartSuffix = "Garbage Collection (.*)$";
+    private static final String zEndSuffix = "Garbage Collection (.*) .*->.*$";
 
     // Suffix for Shenandoah.
     private static final String shenSuffix = "Concurrent weak roots";
@@ -93,7 +96,7 @@ public class StringTableCleaningTest {
         } else if (GC.G1.isSelected()) {
             return gcStartPrefix + g1Suffix;
         } else if (GC.Z.isSelected()) {
-            return gcStartPrefix + zSuffix;
+            return gcStartPrefix + zStartSuffix;
         } else if (GC.Shenandoah.isSelected()) {
             return gcStartPrefix + shenSuffix;
         } else {
@@ -107,7 +110,7 @@ public class StringTableCleaningTest {
         } else if (GC.G1.isSelected()) {
             return gcEndPrefix + g1Suffix;
         } else if (GC.Z.isSelected()) {
-            return gcEndPrefix + zSuffix;
+            return gcEndPrefix + zEndSuffix;
         } else if (GC.Shenandoah.isSelected()) {
             return gcEndPrefix + shenSuffix;
         } else {
@@ -183,7 +186,7 @@ public class StringTableCleaningTest {
                 fail("Two Starts: " + gcStart + ", " + i);
             }
         }
-        return fail("Missing Callback for Start: " + gcStart);
+        return -1;
     }
 
     // Search the lines for the first GC end log line in lines, starting


### PR DESCRIPTION
This patch addresses two issues with the StringTableCleaningTest test.

1) The test doesn't fully take into account that a concurrent GC might not complete (it can abort if the VM wants to terminate). findCallback() should return -1 if no callbacks are found, instead of failing the test.

2) The regexp patterns used for ZGC needs to be more exact. The end pattern now also matches aborted GCs, which it shouldn't. This leads to "Garbage Collection (*) Aborted" being incorrectly matched as a GC end.

This patch also makes sure the output from the test VM ends up in the test log, otherwise it's impossible to tell what went wrong if this test fails in the future.

This patch also removes the test from the ProblemList.

Testing:
* Passed Tier1-3.
* Manual testing of StringTableCleaningTest with various GCs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266056](https://bugs.openjdk.java.net/browse/JDK-8266056): runtime/stringtable/StringTableCleaningTest.java failed with "RuntimeException: Missing Callback in [10, 11]"


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to f98123cec25641467ffc63e30ac765c6cb8cb8b8
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3815/head:pull/3815` \
`$ git checkout pull/3815`

Update a local copy of the PR: \
`$ git checkout pull/3815` \
`$ git pull https://git.openjdk.java.net/jdk pull/3815/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3815`

View PR using the GUI difftool: \
`$ git pr show -t 3815`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3815.diff">https://git.openjdk.java.net/jdk/pull/3815.diff</a>

</details>
