### PR TITLE
8265767: compiler/eliminateAutobox/TestIntBoxing.java crashes on arm32 after 8264649 in debug VMs

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1439,6 +1439,7 @@ Node* LoadNode::eliminate_autobox(PhaseGVN* phase) {
             if (result->Opcode() == Op_LShiftX && result->in(2) == phase->intcon(shift)) {
               // Peel the shift off directly but wrap it in a dummy node
               // since Ideal can't return existing nodes
+              phase->is_IterGVN()->_worklist.push(result);
               result = new RShiftXNode(result->in(1), phase->intcon(0));
             } else if (result->is_Add() && result->in(2)->is_Con() &&
                        result->in(1)->Opcode() == Op_LShiftX &&
@@ -1446,6 +1447,7 @@ Node* LoadNode::eliminate_autobox(PhaseGVN* phase) {
               // We can't do general optimization: ((X<<Z) + Y) >> Z ==> X + (Y>>Z)
               // but for boxing cache access we know that X<<Z will not overflow
               // (there is range check) so we do this optimizatrion by hand here.
+              phase->is_IterGVN()->_worklist.push(result);
               Node* add_con = new RShiftXNode(result->in(2), phase->intcon(shift));
               result = new AddXNode(result->in(1)->in(1), phase->transform(add_con));
             } else {

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1367,10 +1367,10 @@ Node* StoreNode::convert_to_reinterpret_store(PhaseGVN& gvn, Node* val, const Ty
 // merging a newly allocated object and a load from the cache.
 // We want to replace this load with the original incoming
 // argument to the valueOf call.
-Node* LoadNode::eliminate_autobox(PhaseGVN* phase) {
-  assert(phase->C->eliminate_boxing(), "sanity");
+Node* LoadNode::eliminate_autobox(PhaseIterGVN* igvn) {
+  assert(igvn->C->eliminate_boxing(), "sanity");
   intptr_t ignore = 0;
-  Node* base = AddPNode::Ideal_base_and_offset(in(Address), phase, ignore);
+  Node* base = AddPNode::Ideal_base_and_offset(in(Address), igvn, ignore);
   if ((base == NULL) || base->is_Phi()) {
     // Push the loads from the phi that comes from valueOf up
     // through it to allow elimination of the loads and the recovery
@@ -1404,7 +1404,7 @@ Node* LoadNode::eliminate_autobox(PhaseGVN* phase) {
         if (count > 0 && elements[0]->is_Con() &&
             (count == 1 ||
              (count == 2 && elements[1]->Opcode() == Op_LShiftX &&
-                            elements[1]->in(2) == phase->intcon(shift)))) {
+                            elements[1]->in(2) == igvn->intcon(shift)))) {
           ciObjArray* array = base_type->const_oop()->as_obj_array();
           // Fetch the box object cache[0] at the base of the array and get its value
           ciInstance* box = array->obj_at(0)->as_instance();
@@ -1431,45 +1431,45 @@ Node* LoadNode::eliminate_autobox(PhaseGVN* phase) {
            // Add up all the offsets making of the address of the load
             Node* result = elements[0];
             for (int i = 1; i < count; i++) {
-              result = phase->transform(new AddXNode(result, elements[i]));
+              result = igvn->transform(new AddXNode(result, elements[i]));
             }
             // Remove the constant offset from the address and then
-            result = phase->transform(new AddXNode(result, phase->MakeConX(-(int)offset)));
+            result = igvn->transform(new AddXNode(result, igvn->MakeConX(-(int)offset)));
             // remove the scaling of the offset to recover the original index.
-            if (result->Opcode() == Op_LShiftX && result->in(2) == phase->intcon(shift)) {
+            if (result->Opcode() == Op_LShiftX && result->in(2) == igvn->intcon(shift)) {
               // Peel the shift off directly but wrap it in a dummy node
               // since Ideal can't return existing nodes
-              phase->is_IterGVN()->_worklist.push(result);
-              result = new RShiftXNode(result->in(1), phase->intcon(0));
+              igvn->_worklist.push(result); // remove dead node later
+              result = new RShiftXNode(result->in(1), igvn->intcon(0));
             } else if (result->is_Add() && result->in(2)->is_Con() &&
                        result->in(1)->Opcode() == Op_LShiftX &&
-                       result->in(1)->in(2) == phase->intcon(shift)) {
+                       result->in(1)->in(2) == igvn->intcon(shift)) {
               // We can't do general optimization: ((X<<Z) + Y) >> Z ==> X + (Y>>Z)
               // but for boxing cache access we know that X<<Z will not overflow
               // (there is range check) so we do this optimizatrion by hand here.
-              phase->is_IterGVN()->_worklist.push(result);
-              Node* add_con = new RShiftXNode(result->in(2), phase->intcon(shift));
-              result = new AddXNode(result->in(1)->in(1), phase->transform(add_con));
+              igvn->_worklist.push(result); // remove dead node later
+              Node* add_con = new RShiftXNode(result->in(2), igvn->intcon(shift));
+              result = new AddXNode(result->in(1)->in(1), igvn->transform(add_con));
             } else {
-              result = new RShiftXNode(result, phase->intcon(shift));
+              result = new RShiftXNode(result, igvn->intcon(shift));
             }
 #ifdef _LP64
             if (bt != T_LONG) {
-              result = new ConvL2INode(phase->transform(result));
+              result = new ConvL2INode(igvn->transform(result));
             }
 #else
             if (bt == T_LONG) {
-              result = new ConvI2LNode(phase->transform(result));
+              result = new ConvI2LNode(igvn->transform(result));
             }
 #endif
             // Boxing/unboxing can be done from signed & unsigned loads (e.g. LoadUB -> ... -> LoadB pair).
             // Need to preserve unboxing load type if it is unsigned.
             switch(this->Opcode()) {
               case Op_LoadUB:
-                result = new AndINode(phase->transform(result), phase->intcon(0xFF));
+                result = new AndINode(igvn->transform(result), igvn->intcon(0xFF));
                 break;
               case Op_LoadUS:
-                result = new AndINode(phase->transform(result), phase->intcon(0xFFFF));
+                result = new AndINode(igvn->transform(result), igvn->intcon(0xFFFF));
                 break;
             }
             return result;
@@ -1762,7 +1762,8 @@ Node *LoadNode::Ideal(PhaseGVN *phase, bool can_reshape) {
         (t_oop->is_known_instance_field() ||
          t_oop->is_ptr_to_boxed_value())) {
       PhaseIterGVN *igvn = phase->is_IterGVN();
-      if (igvn != NULL && igvn->_worklist.member(opt_mem)) {
+      assert(igvn != NULL, "must be PhaseIterGVN when can_reshape is true");
+      if (igvn->_worklist.member(opt_mem)) {
         // Delay this transformation until memory Phi is processed.
         igvn->_worklist.push(this);
         return NULL;
@@ -1772,7 +1773,7 @@ Node *LoadNode::Ideal(PhaseGVN *phase, bool can_reshape) {
       if (result != NULL) return result;
 
       if (t_oop->is_ptr_to_boxed_value()) {
-        Node* result = eliminate_autobox(phase);
+        Node* result = eliminate_autobox(igvn);
         if (result != NULL) return result;
       }
     }

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -248,7 +248,7 @@ public:
   Node* split_through_phi(PhaseGVN *phase);
 
   // Recover original value from boxed values
-  Node *eliminate_autobox(PhaseGVN *phase);
+  Node *eliminate_autobox(PhaseIterGVN *igvn);
 
   // Compute a new Type for this node.  Basically we just do the pre-check,
   // then call the virtual add() to set the type.


### PR DESCRIPTION
This patch fix failure exposed by JDK-8264649.

compiler/eliminateAutobox/TestIntBoxing.java crashes on arm32 in Compile::check_no_dead_use assertion.
In LoadNode::eliminate_autobox, early "result" is dead after line 1450 but not added into PhaseGVN worklist for optimization.
Its out_cnt is 0. If it isn't removed, will trigger assertion in Compile::check_no_dead_use.

```
1443             } else if (result->is_Add() && result->in(2)->is_Con() &&
1444                        result->in(1)->Opcode() == Op_LShiftX &&
1445                        result->in(1)->in(2) == phase->intcon(shift)) {
1446               // We can't do general optimization: ((X<<Z) + Y) >> Z ==> X + (Y>>Z)
1447               // but for boxing cache access we know that X<<Z will not overflow
1448               // (there is range check) so we do this optimizatrion by hand here.
1449               Node* add_con = new RShiftXNode(result->in(2), phase->intcon(shift));
                       --- result before is  dead and might not removed
1450               result = new AddXNode(result->in(1)->in(1), phase->transform(add_con)); 
1451             } else 
```

Detail analysis is in https://bugs.openjdk.java.net/browse/JDK-8265767 

@mychris  I have verified compiler/eliminateAutobox/TestIntBoxing.java on qemu, it failed with same assertion and now passes with this fix. Would you please help verify it on arm32 machine?

Testing:
- Passed Tier1-3 on Linux x86_64, release and fastdebug build,  default option and -XX:-TieredCompilation.
- compiler/eliminateAutobox/TestIntBoxing.java on arm32 release/fastdebug/slowdebug

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265767](https://bugs.openjdk.java.net/browse/JDK-8265767): compiler/eliminateAutobox/TestIntBoxing.java crashes on arm32 after 8264649 in debug VMs


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3818/head:pull/3818` \
`$ git checkout pull/3818`

Update a local copy of the PR: \
`$ git checkout pull/3818` \
`$ git pull https://git.openjdk.java.net/jdk pull/3818/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3818`

View PR using the GUI difftool: \
`$ git pr show -t 3818`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3818.diff">https://git.openjdk.java.net/jdk/pull/3818.diff</a>

</details>
