### PR TITLE
8252237: C2: Call to compute_separating_interferences has wrong argument order

### DIFF
--- a/src/hotspot/share/opto/coalesce.cpp
+++ b/src/hotspot/share/opto/coalesce.cpp
@@ -535,7 +535,7 @@ void PhaseConservativeCoalesce::union_helper( Node *lr1_node, Node *lr2_node, ui
 
 // Factored code from copy_copy that computes extra interferences from
 // lengthening a live range by double-coalescing.
-uint PhaseConservativeCoalesce::compute_separating_interferences(Node *dst_copy, Node *src_copy, Block *b, uint bindex, RegMask &rm, uint reg_degree, uint rm_size, uint lr1, uint lr2 ) {
+uint PhaseConservativeCoalesce::compute_separating_interferences(Node *dst_copy, Node *src_copy, Block *b, uint bindex, RegMask &rm, uint rm_size, uint reg_degree, uint lr1, uint lr2 ) {
 
   assert(!lrgs(lr1)._fat_proj, "cannot coalesce fat_proj");
   assert(!lrgs(lr2)._fat_proj, "cannot coalesce fat_proj");


### PR DESCRIPTION
`https://bugs.openjdk.java.net/browse/JDK-8252237`

<Copying details from Old PR - `https://github.com/openjdk/jdk/pull/1533`>
      (**NOTE: This old PR was approved then.
      But we did not commit the changes then because of last stage of JDK 16 
      and waited for more tests, performance runs. 
      Results of multiple test run, performance benchmarks are available now and confirmed no issues)


[`src/hotspot/share/opto/coalesce.hpp`] -
`112 uint compute_separating_interferences(Node *dst_copy, Node *src_copy, Block *b, uint bindex, RegMask &rm, uint rm_size, uint reg_degree, uint lr1, uint lr2);`


[`src/hotspot/share/opto/coalesce.cpp`] -
```
..........
538 uint PhaseConservativeCoalesce::compute_separating_interferences(Node *dst_copy, Node *src_copy, Block *b, uint bindex, RegMask &rm, uint reg_degree, uint rm_size, uint lr1, uint lr2 ) {
.................
747 reg_degree = compute_separating_interferences(dst_copy, src_copy, b, bindex, rm, rm_size, reg_degree, lr1, lr2 );
```


So fixing the argument order - [`/src/hotspot/share/opto/coalesce.cpp`]
```
-uint PhaseConservativeCoalesce::compute_separating_interferences(Node *dst_copy, Node *src_copy, Block *b, uint bindex, RegMask &rm, uint reg_degree, uint rm_size, uint lr1, uint lr2 ) {
+uint PhaseConservativeCoalesce::compute_separating_interferences(Node *dst_copy, Node *src_copy, Block *b, uint bindex, RegMask &rm, uint rm_size, uint reg_degree, uint lr1, uint lr2 ) {
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252237](https://bugs.openjdk.java.net/browse/JDK-8252237): C2: Call to compute_separating_interferences has wrong argument order


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * thartmann - **Reviewer** ⚠️ Added manually

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3820/head:pull/3820` \
`$ git checkout pull/3820`

Update a local copy of the PR: \
`$ git checkout pull/3820` \
`$ git pull https://git.openjdk.java.net/jdk pull/3820/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3820`

View PR using the GUI difftool: \
`$ git pr show -t 3820`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3820.diff">https://git.openjdk.java.net/jdk/pull/3820.diff</a>

</details>
