### PR TITLE
8266293: Key protection using PBEWithMD5AndDES fails with "java.security.InvalidAlgorithmParameterException: Salt must be 8 bytes long"

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
+++ b/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
@@ -804,11 +804,17 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
      */
     private AlgorithmParameters getPBEAlgorithmParameters(
             String algorithm, int iterationCount) throws IOException {
-        AlgorithmParameters algParams = null;
+        AlgorithmParameters algParams;
+
+        byte[] salt = getSalt();
+        if (KnownOIDs.findMatch(algorithm) == KnownOIDs.PBEWithMD5AndDES) {
+            // PBEWithMD5AndDES requires a 8-byte salt
+            salt = Arrays.copyOf(salt, 8);
+        }
 
         // create PBE parameters from salt and iteration count
         PBEParameterSpec paramSpec =
-                new PBEParameterSpec(getSalt(), iterationCount);
+                new PBEParameterSpec(salt, iterationCount);
         try {
            algParams = AlgorithmParameters.getInstance(algorithm);
            algParams.init(paramSpec);

--- a/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
+++ b/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
@@ -808,7 +808,7 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
 
         byte[] salt = getSalt();
         if (KnownOIDs.findMatch(algorithm) == KnownOIDs.PBEWithMD5AndDES) {
-            // PBEWithMD5AndDES requires a 8-byte salt
+            // PBES1 scheme such as PBEWithMD5AndDES requires a 8-byte salt
             salt = Arrays.copyOf(salt, 8);
         }
 

--- a/test/jdk/sun/security/pkcs12/ParamsPreferences.java
+++ b/test/jdk/sun/security/pkcs12/ParamsPreferences.java
@@ -35,7 +35,7 @@ import static sun.security.util.KnownOIDs.*;
 
 /*
  * @test
- * @bug 8076190 8242151 8153005
+ * @bug 8076190 8242151 8153005 8266293
  * @library /test/lib
  * @modules java.base/sun.security.pkcs
  *          java.base/sun.security.util
@@ -192,6 +192,15 @@ public class ParamsPreferences {
                         "keystore.pkcs12.keyProtectionAlgorithm", "PBEWithSHA1AndRC2_40"),
                 PBES2, HmacSHA256, AES_256$CBC$NoPadding, 10000,
                 PBEWithSHA1AndRC4_40, 10000,
+                SHA_256, 10000);
+
+        // 8266293
+        test(c++,
+                Map.of("keystore.pkcs12.keyProtectionAlgorithm", "PBEWithMD5AndDES",
+                        "keystore.pkcs12.certProtectionAlgorithm", "PBEWithMD5AndDES"),
+                Map.of(),
+                PBEWithMD5AndDES, 10000,
+                PBEWithMD5AndDES, 10000,
                 SHA_256, 10000);
     }
 


### PR DESCRIPTION
`PKCS12KeyStore` always uses a 20-byte salt in encryption but PBEWithMD5AndDES only accepts 8-byte salt. With this code change, the salt used for this algorithm will be 8 bytes.

RFC 2898 only requires the salt to be at least 8 bytes, but I don't intend to modify the `PBES1Core.java` to accept a long salt. Otherwise, a newly generated PKCS #⁠12 file using a long salt will not be recognized by an old JDK.

Also, although `PBES1Core.java` also take cares of another algorithm named PBEWithMD5AndDESede but it's not usable in a PKCS #⁠12 keystore as we have not defined its Object Identifier anywhere.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266293](https://bugs.openjdk.java.net/browse/JDK-8266293): Key protection using PBEWithMD5AndDES fails with "java.security.InvalidAlgorithmParameterException: Salt must be 8 bytes long"


### Reviewers
 * [Valerie Peng](https://openjdk.java.net/census#valeriep) (@valeriepeng - **Reviewer**) ⚠️ Review applies to 6726d0be77396f2ff79065b6822b5c306fb77d68


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3822/head:pull/3822` \
`$ git checkout pull/3822`

Update a local copy of the PR: \
`$ git checkout pull/3822` \
`$ git pull https://git.openjdk.java.net/jdk pull/3822/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3822`

View PR using the GUI difftool: \
`$ git pr show -t 3822`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3822.diff">https://git.openjdk.java.net/jdk/pull/3822.diff</a>

</details>
