### PR TITLE
8266388: C2: Improve constant ShiftCntV on x86

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -2119,6 +2119,10 @@ bool Matcher::pd_clone_node(Node* n, Node* m, Matcher::MStack& mstack) {
     mstack.push(m, Visit);
     return true;
   }
+  if (is_vshift_con_pattern(n, m)) { // ShiftV src (ShiftCntV con)
+    mstack.push(m, Visit);           // m = ShiftCntV
+    return true;
+  }
   return false;
 }
 

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -2033,7 +2033,7 @@ OptoReg::Name Matcher::find_receiver() {
   return OptoReg::as_OptoReg(regs.first());
 }
 
-bool Matcher::is_vshift_con_pattern(Node *n, Node *m) {
+bool Matcher::is_vshift_con_pattern(Node* n, Node* m) {
   if (n != NULL && m != NULL) {
     return VectorNode::is_vector_shift(n) &&
            VectorNode::is_vector_shift_count(m) && m->in(1)->is_Con();

--- a/src/hotspot/share/opto/matcher.hpp
+++ b/src/hotspot/share/opto/matcher.hpp
@@ -121,7 +121,7 @@ private:
   bool find_shared_visit(MStack& mstack, Node* n, uint opcode, bool& mem_op, int& mem_addr_idx);
   void find_shared_post_visit(Node* n, uint opcode);
 
-  bool is_vshift_con_pattern(Node *n, Node *m);
+  bool is_vshift_con_pattern(Node* n, Node* m);
 
   // Debug and profile information for nodes in old space:
   GrowableArray<Node_Notes*>* _old_node_note_array;


### PR DESCRIPTION
Clone ShiftCntV w/ a constant input during matching on x86. 
It enables `vshiftI_imm`/`vshiftL_imm` when ShiftCntV is shared.

Testing:
- [x] hs-tier1 - hs-tier4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266388](https://bugs.openjdk.java.net/browse/JDK-8266388): C2: Improve constant ShiftCntV on x86


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3823/head:pull/3823` \
`$ git checkout pull/3823`

Update a local copy of the PR: \
`$ git checkout pull/3823` \
`$ git pull https://git.openjdk.java.net/jdk pull/3823/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3823`

View PR using the GUI difftool: \
`$ git pr show -t 3823`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3823.diff">https://git.openjdk.java.net/jdk/pull/3823.diff</a>

</details>
