### PR TITLE
JDK-8266129: tools/jpackage/windows/WinInstallerIconTest.java hangs with fastdebug

### DIFF
--- a/test/jdk/tools/jpackage/windows/WinInstallerIconTest.java
+++ b/test/jdk/tools/jpackage/windows/WinInstallerIconTest.java
@@ -47,9 +47,16 @@ import jdk.jpackage.test.TKit;
  * @build jdk.jpackage.test.*
  * @build WinInstallerIconTest
  * @requires (os.family == "windows")
+ * @requires !vm.debug
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @run main/othervm/timeout=360 -Xmx512m  jdk.jpackage.test.Main
  *  --jpt-run=WinInstallerIconTest
+ */
+
+/*
+ * note: AWT can throw assertion from GetDiBits() extracting icon
+ * bits in fastdebug mode on windows headless systems. That is why
+ * we have @requires !vm.debug" above.
  */
 public class WinInstallerIconTest {
 


### PR DESCRIPTION
JDK-8266129: tools/jpackage/windows/WinInstallerIconTest.java hangs with fastdebug

just disabling this test when vm.debug

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266129](https://bugs.openjdk.java.net/browse/JDK-8266129): tools/jpackage/windows/WinInstallerIconTest.java hangs with fastdebug


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3827/head:pull/3827` \
`$ git checkout pull/3827`

Update a local copy of the PR: \
`$ git checkout pull/3827` \
`$ git pull https://git.openjdk.java.net/jdk pull/3827/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3827`

View PR using the GUI difftool: \
`$ git pr show -t 3827`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3827.diff">https://git.openjdk.java.net/jdk/pull/3827.diff</a>

</details>
