### PR TITLE
8266401: mark hotspot compiler/intrinsics/sha/cli tests which ignore VM flags

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseMD5IntrinsicsOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseMD5IntrinsicsOptionOnSupportedCPU.java
@@ -26,6 +26,7 @@
  * @bug 8035968
  * @summary Verify UseMD5Intrinsics option processing on supported CPU.
  * @library /test/lib testcases /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseMD5IntrinsicsOptionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseMD5IntrinsicsOptionOnUnsupportedCPU.java
@@ -26,6 +26,7 @@
  * @bug 8035968
  * @summary Verify UseMD5Intrinsics option processing on unsupported CPU.
  * @library /test/lib testcases /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA1IntrinsicsOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA1IntrinsicsOptionOnSupportedCPU.java
@@ -26,6 +26,7 @@
  * @bug 8035968
  * @summary Verify UseSHA1Intrinsics option processing on supported CPU.
  * @library /test/lib testcases /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA1IntrinsicsOptionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA1IntrinsicsOptionOnUnsupportedCPU.java
@@ -26,6 +26,7 @@
  * @bug 8035968
  * @summary Verify UseSHA1Intrinsics option processing on unsupported CPU.
  * @library /test/lib testcases /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA256IntrinsicsOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA256IntrinsicsOptionOnSupportedCPU.java
@@ -26,6 +26,7 @@
  * @bug 8035968
  * @summary Verify UseSHA256Intrinsics option processing on supported CPU.
  * @library /test/lib testcases /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA256IntrinsicsOptionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA256IntrinsicsOptionOnUnsupportedCPU.java
@@ -26,6 +26,7 @@
  * @bug 8035968
  * @summary Verify UseSHA256Intrinsics option processing on unsupported CPU.
  * @library /test/lib testcases /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA3IntrinsicsOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA3IntrinsicsOptionOnSupportedCPU.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +27,7 @@
  * @bug 8252204
  * @summary Verify UseSHA3Intrinsics option processing on supported CPU.
  * @library /test/lib testcases /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA3IntrinsicsOptionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA3IntrinsicsOptionOnUnsupportedCPU.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +27,7 @@
  * @bug 8252204
  * @summary Verify UseSHA3Intrinsics option processing on unsupported CPU.
  * @library /test/lib testcases /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnSupportedCPU.java
@@ -27,6 +27,7 @@
  * @summary Verify UseSHA512Intrinsics option processing on supported CPU.
  * @requires os.arch!="x86" & os.arch!="i386"
  * @library /test/lib testcases /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnUnsupportedCPU.java
@@ -26,6 +26,7 @@
  * @bug 8035968
  * @summary Verify UseSHA512Intrinsics option processing on unsupported CPU.
  * @library /test/lib testcases /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHAOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHAOptionOnSupportedCPU.java
@@ -26,6 +26,7 @@
  * @bug 8035968
  * @summary Verify UseSHA option processing on supported CPU.
  * @library /test/lib testcases /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHAOptionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHAOptionOnUnsupportedCPU.java
@@ -26,6 +26,7 @@
  * @bug 8035968
  * @summary Verify UseSHA option processing on unsupported CPU.
  * @library /test/lib testcases /
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build sun.hotspot.WhiteBox


### PR DESCRIPTION
Hi all,

Could you please review this small and trivial patch that adds `@requires vm.flagless` to `compiler/intrinsics/sha/cli ` tests that ignore VM flags?

This change makes sense since it will fix some test failures when testing with extra VM flags.

For example, the following three failures will be fixed when testing with UseAVX<2 on Intel CPUs.
```
compiler/intrinsics/sha/cli/TestUseSHA256IntrinsicsOptionOnUnsupportedCPU.java
compiler/intrinsics/sha/cli/TestUseSHAOptionOnUnsupportedCPU.java
compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnUnsupportedCPU.java
```

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266401](https://bugs.openjdk.java.net/browse/JDK-8266401): mark hotspot compiler/intrinsics/sha/cli tests which ignore VM flags


### Reviewers
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3829/head:pull/3829` \
`$ git checkout pull/3829`

Update a local copy of the PR: \
`$ git checkout pull/3829` \
`$ git pull https://git.openjdk.java.net/jdk pull/3829/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3829`

View PR using the GUI difftool: \
`$ git pr show -t 3829`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3829.diff">https://git.openjdk.java.net/jdk/pull/3829.diff</a>

</details>
