### PR TITLE
8265291: Error in Javadoc for doAccessibleAction API in AccessibleJSlider class

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JSlider.java
+++ b/src/java.desktop/share/classes/javax/swing/JSlider.java
@@ -1588,7 +1588,7 @@ public class JSlider extends JComponent implements SwingConstants, Accessible {
          * @param i zero-based index of actions. The first action
          * (index 0) is AccessibleAction.INCREMENT and the second
          * action (index 1) is AccessibleAction.DECREMENT.
-         * @return true.
+         * @return true if the action was performed, otherwise false
          * @see #getAccessibleActionCount
          */
         public boolean doAccessibleAction(int i) {


### PR DESCRIPTION
There is a small error in javadoc for doAccessibleAction function added in AccessibleJSlider class under JDK-8262981. The documentation says that the API returns true always, whereas it can return both true or false depending upon the parameter value, same as is the case with same API in AccessibleJSpinner. This error happened do to an oversight and current fix corrects the error.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265291](https://bugs.openjdk.java.net/browse/JDK-8265291): Error in Javadoc for doAccessibleAction API in AccessibleJSlider class


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3832/head:pull/3832` \
`$ git checkout pull/3832`

Update a local copy of the PR: \
`$ git checkout pull/3832` \
`$ git pull https://git.openjdk.java.net/jdk pull/3832/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3832`

View PR using the GUI difftool: \
`$ git pr show -t 3832`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3832.diff">https://git.openjdk.java.net/jdk/pull/3832.diff</a>

</details>
