### PR TITLE
8266412: Remove redundant TemplateInterpreter entries

### DIFF
--- a/src/hotspot/share/interpreter/templateInterpreterGenerator.cpp
+++ b/src/hotspot/share/interpreter/templateInterpreterGenerator.cpp
@@ -124,7 +124,6 @@ void TemplateInterpreterGenerator::generate_all() {
   }
 
   { CodeletMark cm(_masm, "earlyret entry points");
-    address earlyret_entry_itos = generate_earlyret_entry_for(itos);
     Interpreter::_earlyret_entry =
       EntryPoint(
                  generate_earlyret_entry_for(atos),
@@ -235,7 +234,6 @@ void TemplateInterpreterGenerator::generate_all() {
     Interpreter::_deopt_entry[0] = EntryPoint();
     Interpreter::_deopt_entry[0].set_entry(vtos, generate_deopt_entry_for(vtos, 0));
     for (int i = 1; i < Interpreter::number_of_deopt_entries; i++) {
-      address deopt_itos = generate_deopt_entry_for(itos, i);
       Interpreter::_deopt_entry[i] =
         EntryPoint(
                    generate_deopt_entry_for(atos, i),


### PR DESCRIPTION
This patch trivially removes two redundant entry point generation calls that I accidentally forgot to remove after a refactoring in https://bugs.openjdk.java.net/browse/JDK-8255271 

A very slim improvement (~70k fewer instructions executed on bootstrap), but still..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266412](https://bugs.openjdk.java.net/browse/JDK-8266412): Remove redundant TemplateInterpreter entries


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - Committer)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3833/head:pull/3833` \
`$ git checkout pull/3833`

Update a local copy of the PR: \
`$ git checkout pull/3833` \
`$ git pull https://git.openjdk.java.net/jdk pull/3833/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3833`

View PR using the GUI difftool: \
`$ git pr show -t 3833`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3833.diff">https://git.openjdk.java.net/jdk/pull/3833.diff</a>

</details>
