### PR TITLE
8262031: Create implementation for NSAccessibilityNavigableStaticText protocol

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
@@ -28,7 +28,7 @@
 #import "AWTView.h"
 #import "AWTWindow.h"
 #import "JavaComponentAccessibility.h"
-#import "JavaTextAccessibility.h"
+#import "a11y/CommonTextAccessibility.h"
 #import "JavaAccessibilityUtilities.h"
 #import "GeomUtilities.h"
 #import "ThreadUtilities.h"
@@ -684,8 +684,8 @@ static BOOL shouldUsePressAndHold() {
 - (NSString *)accessibleSelectedText
 {
     id focused = [self accessibilityFocusedUIElement];
-    if (![focused isKindOfClass:[JavaTextAccessibility class]]) return nil;
-    return [(JavaTextAccessibility *)focused accessibilitySelectedTextAttribute];
+    if (![focused isKindOfClass:[CommonTextAccessibility class]]) return nil;
+    return [(CommonTextAccessibility *)focused accessibilitySelectedTextAttribute];
 }
 
 // same as above, but converts to RTFD
@@ -704,8 +704,8 @@ static BOOL shouldUsePressAndHold() {
 - (BOOL)replaceAccessibleTextSelection:(NSString *)text
 {
     id focused = [self accessibilityFocusedUIElement];
-    if (![focused isKindOfClass:[JavaTextAccessibility class]]) return NO;
-    [(JavaTextAccessibility *)focused accessibilitySetSelectedTextAttribute:text];
+    if (![focused isKindOfClass:[CommonTextAccessibility class]]) return NO;
+    [(CommonTextAccessibility *)focused accessibilitySetSelectedTextAttribute:text];
     return YES;
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -48,7 +48,7 @@ static jobject sAccessibilityClass = NULL;
     /*
      * Here we should keep all the mapping between the accessibility roles and implementing classes
      */
-    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:27];
+    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:31];
 
     [rolesMap setObject:@"ButtonAccessibility" forKey:@"pushbutton"];
     [rolesMap setObject:@"ImageAccessibility" forKey:@"icon"];
@@ -59,6 +59,10 @@ static jobject sAccessibilityClass = NULL;
     [rolesMap setObject:@"RadiobuttonAccessibility" forKey:@"radiobutton"];
     [rolesMap setObject:@"CheckboxAccessibility" forKey:@"checkbox"];
     [rolesMap setObject:@"SliderAccessibility" forKey:@"slider"];
+    [rolesMap setObject:@"NavigableStaticTextAccessibility" forKey:@"dateeditor"];
+    [rolesMap setObject:@"NavigableStaticTextAccessibility" forKey:@"passwordtext"];
+    [rolesMap setObject:@"NavigableStaticTextAccessibility" forKey:@"text"];
+    [rolesMap setObject:@"NavigableStaticTextAccessibility" forKey:@"textarea"];
 
     /*
      * All the components below should be ignored by the accessibility subsystem,

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonTextAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonTextAccessibility.h
@@ -40,6 +40,8 @@
 - (NSRect)accessibilityBoundsForRangeAttribute:(NSRange)parameter;
 - (int)accessibilityLineForIndexAttribute:(int)index;
 - (NSRange)accessibilityRangeForLineAttribute:(int)index;
+- (NSRange)accessibilityRangeForPositionAttribute:(NSPoint)point;
+- (NSRange)accessibilityRangeForIndexAttribute:(int)index;
 @end
 
 #endif

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonTextAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonTextAccessibility.m
@@ -138,4 +138,54 @@ static NSRange javaIntArrayToNSRange(JNIEnv* env, jintArray array) {
     return str;
 }
 
+- (NSRect)accessibilityBoundsForRangeAttribute:(NSRange)range
+{
+    JNIEnv *env = [ThreadUtilities getJNIEnv];
+    GET_CACCESSIBLETEXT_CLASS_RETURN(DEFAULT_RECT);
+    DECLARE_STATIC_METHOD_RETURN(jm_getBoundsForRange, sjc_CAccessibleText, "getBoundsForRange",
+                         "(Ljavax/accessibility/Accessible;Ljava/awt/Component;II)[D", NSMakeRect(0, 0, 0, 0));
+    jdoubleArray axBounds = (jdoubleArray)(*env)->CallStaticObjectMethod(env, sjc_CAccessibleText, jm_getBoundsForRange,
+                              fAccessible, fComponent, range.location, range.length);
+    CHECK_EXCEPTION();
+    if (axBounds == NULL) return DEFAULT_RECT;
+
+    jdouble *values = (*env)->GetDoubleArrayElements(env, axBounds, 0);
+    CHECK_EXCEPTION();
+    if (values == NULL) {
+        NSLog(@"%s failed calling GetDoubleArrayElements", __FUNCTION__);
+        return DEFAULT_RECT;
+    };
+    NSRect bounds;
+    bounds.origin.x = values[0];
+    bounds.origin.y = [[[[self view] window] screen] frame].size.height - values[1] - values[3];
+    bounds.size.width = values[2];
+    bounds.size.height = values[3];
+    return bounds;
+}
+
+- (int)accessibilityLineForIndexAttribute:(int)index
+{
+    JNIEnv *env = [ThreadUtilities getJNIEnv];
+    GET_CACCESSIBLETEXT_CLASS_RETURN(-1);
+    DECLARE_STATIC_METHOD_RETURN(jm_getLineNumberForIndex, sjc_CAccessibleText, "getLineNumberForIndex",
+                           "(Ljavax/accessibility/Accessible;Ljava/awt/Component;I)I", -1);
+    jint row = (*env)->CallStaticIntMethod(env, sjc_CAccessibleText, jm_getLineNumberForIndex,
+                       fAccessible, fComponent, index);
+    CHECK_EXCEPTION();
+    return row;
+}
+
+- (NSRange)accessibilityRangeForLineAttribute:(int)index
+{
+    JNIEnv *env = [ThreadUtilities getJNIEnv];
+    GET_CACCESSIBLETEXT_CLASS_RETURN(DEFAULT_RANGE);
+    DECLARE_STATIC_METHOD_RETURN(jm_getRangeForLine, sjc_CAccessibleText, "getRangeForLine",
+                 "(Ljavax/accessibility/Accessible;Ljava/awt/Component;I)[I", DEFAULT_RANGE);
+    jintArray axTextRange = (jintArray)(*env)->CallStaticObjectMethod(env, sjc_CAccessibleText,
+                jm_getRangeForLine, fAccessible, fComponent, index);
+    CHECK_EXCEPTION();
+    if (axTextRange == NULL) return DEFAULT_RANGE;
+
+    return javaIntArrayToNSRange(env,axTextRange);
+}
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/NavigableStaticTextAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/NavigableStaticTextAccessibility.h
@@ -23,23 +23,16 @@
  * questions.
  */
 
-#ifndef COMMON_TEXT_ACCESSIBILITY
-#define COMMON_TEXT_ACCESSIBILITY
-
-#import "CommonComponentAccessibility.h"
-#import "JavaAccessibilityUtilities.h"
+#import "StaticTextAccessibility.h"
 
 #import <AppKit/NSAccessibility.h>
 
-@interface CommonTextAccessibility : CommonComponentAccessibility {
 
-}
-- (nullable NSString *)accessibilityValueAttribute;
-- (NSRange)accessibilityVisibleCharacterRangeAttribute;
-- (nullable NSString *)accessibilityStringForRangeAttribute:(NSRange)parameter;
-- (NSRect)accessibilityBoundsForRangeAttribute:(NSRange)parameter;
-- (int)accessibilityLineForIndexAttribute:(int)index;
-- (NSRange)accessibilityRangeForLineAttribute:(int)index;
+@interface NavigableStaticTextAccessibility : StaticTextAccessibility<NSAccessibilityNavigableStaticText> {
+
+};
+- (NSRect)accessibilityFrameForRange:(NSRange)range;
+- (int)accessibilityLineForIndex:(int)index;
+- (NSRange)accessibilityRangeForLine:(int)line;
+- (nullable NSString *)accessibilityStringForRange:(NSRange)range;
 @end
-
-#endif

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/NavigableStaticTextAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/NavigableStaticTextAccessibility.m
@@ -23,23 +23,35 @@
  * questions.
  */
 
-#ifndef COMMON_TEXT_ACCESSIBILITY
-#define COMMON_TEXT_ACCESSIBILITY
+#import "NavigableStaticTextAccessibility.h"
 
-#import "CommonComponentAccessibility.h"
-#import "JavaAccessibilityUtilities.h"
-
-#import <AppKit/NSAccessibility.h>
-
-@interface CommonTextAccessibility : CommonComponentAccessibility {
-
+@implementation NavigableStaticTextAccessibility
+- (NSRect)accessibilityFrameForRange:(NSRange)range
+{
+    NSLog(@"in accessibilityFrameForRange");
+    NSRect rect = [self accessibilityBoundsForRangeAttribute:range];
+    NSLog(@"Frame for range %@ is %@", NSStringFromRange(range), NSStringFromRect(rect));
+    return rect;
 }
-- (nullable NSString *)accessibilityValueAttribute;
-- (NSRange)accessibilityVisibleCharacterRangeAttribute;
-- (nullable NSString *)accessibilityStringForRangeAttribute:(NSRange)parameter;
-- (NSRect)accessibilityBoundsForRangeAttribute:(NSRange)parameter;
-- (int)accessibilityLineForIndexAttribute:(int)index;
-- (NSRange)accessibilityRangeForLineAttribute:(int)index;
+- (int)accessibilityLineForIndex:(int)index
+{
+    NSLog(@"in accessibilityLineForIndex");
+    int line = [self accessibilityLineForIndexAttribute:index];
+    NSLog(@"Line number for index %d is: %d", index, line);
+    return line;
+}
+- (NSRange)accessibilityRangeForLine:(int)line
+{
+    NSLog(@"in accessibilityRangeForLine");
+    NSRange range = [self accessibilityRangeForLineAttribute:line];
+    NSLog(@"Range for line %d is %@", line, NSStringFromRange(range));
+    return range;
+}
+- (nullable NSString *)accessibilityStringForRange:(NSRange)range
+{
+    NSLog(@"in accessibilityStringForRange");
+    NSString * str = [self accessibilityStringForRangeAttribute:range];
+    NSLog(@"String  for range %@ is %@", NSStringFromRange(range), str);
+    return str;
+}
 @end
-
-#endif

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.h
@@ -37,5 +37,8 @@
 - (nullable NSString *)accessibilityAttributedStringForRange:(NSRange)range;
 - (nullable NSString *)accessibilityValue;
 - (NSRange)accessibilityVisibleCharacterRange;
+
+- (NSRange) accessibilityRangeForPosition:(NSPoint)point;
+- (NSRange)accessibilityRangeForIndex:(int)index;
 @end
 #endif

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.m
@@ -42,4 +42,20 @@
     return [self accessibilityVisibleCharacterRangeAttribute];
 }
 
+- (NSRange) accessibilityRangeForPosition:(NSPoint)point
+{
+    NSLog(@"in accessibilityRangeForPoint");
+    NSRange range = [self accessibilityRangeForPositionAttribute:point];
+    NSLog(@"String  for point %@ is %@", NSStringFromRange(range), NSStringFromPoint(point));
+    return range;
+}
+
+- (NSRange)accessibilityRangeForIndex:(int)index
+{
+    NSLog(@"in accessibilityRangeForIndex");
+    NSRange range = [self accessibilityRangeForIndexAttribute:index];
+    //NSLog(@"String  for index %d is %@", index, NSStringFromRange(range));
+    return range;
+}
+
 @end


### PR DESCRIPTION
placeholder

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8262031](https://bugs.openjdk.java.net/browse/JDK-8262031): Create implementation for NSAccessibilityNavigableStaticText protocol


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3835/head:pull/3835` \
`$ git checkout pull/3835`

Update a local copy of the PR: \
`$ git checkout pull/3835` \
`$ git pull https://git.openjdk.java.net/jdk pull/3835/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3835`

View PR using the GUI difftool: \
`$ git pr show -t 3835`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3835.diff">https://git.openjdk.java.net/jdk/pull/3835.diff</a>

</details>
