### PR TITLE
8266422: GC ergo tests should not write cores

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java
@@ -43,6 +43,7 @@ public class TestCompressedClassFlags {
         if (Platform.is64bit()) {
             OutputAnalyzer output = runJava("-XX:CompressedClassSpaceSize=1g",
                                             "-XX:-UseCompressedClassPointers",
+                                            "-XX:-CreateCoredumpOnCrash",
                                             "-version");
             output.shouldContain("warning");
             output.shouldNotContain("error");

--- a/test/hotspot/jtreg/gc/arguments/TestMaxHeapSizeTools.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMaxHeapSizeTools.java
@@ -117,7 +117,7 @@ class TestMaxHeapSizeTools {
 
   private static void getNewOldSize(String gcflag, long[] values) throws Exception {
     ProcessBuilder pb = GCArguments.createJavaProcessBuilder(gcflag,
-      "-XX:+PrintFlagsFinal", "-version");
+      "-XX:-CreateCoredumpOnCrash", "-XX:+PrintFlagsFinal", "-version");
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(0);
 

--- a/test/hotspot/jtreg/gc/arguments/TestMaxRAMFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMaxRAMFlags.java
@@ -59,6 +59,7 @@ public class TestMaxRAMFlags {
       args.add("-XX:+UseCompressedOops");
     }
 
+    args.add("-XX:-CreateCoredumpOnCrash");
     args.add("-XX:+PrintFlagsFinal");
     args.add("-version");
 

--- a/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsErgoTools.java
+++ b/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsErgoTools.java
@@ -140,6 +140,7 @@ class TestUseCompressedOopsErgoTools {
      finalargs.addAll(Arrays.asList(args));
      finalargs.add("-Xmx" + heapsize);
      finalargs.add("-XX:+PrintFlagsFinal");
+     finalargs.add("-XX:-CreateCoredumpOnCrash");
      finalargs.add("-version");
 
      String output = expectValid(finalargs.toArray(new String[0]));


### PR DESCRIPTION
Hi,

unrelated crashes in GC tests showed timeouts and large core files on AIX, which unfortunately has no concept of committing memory - reserved memory counts toward the commit charge right away and hence are reflected in core file size.

Therefore I would like to run these tests without cores. Note that it is not my intention to fix up all potential tests which do this, which would be a much larger task, or would require a change at a lower layer (e.g. always pass -CreateCoredumpOnCrash to createJavaProcessBuilder).

Thanks, Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8266422](https://bugs.openjdk.java.net/browse/JDK-8266422): GC ergo tests should not write cores


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3836/head:pull/3836` \
`$ git checkout pull/3836`

Update a local copy of the PR: \
`$ git checkout pull/3836` \
`$ git pull https://git.openjdk.java.net/jdk pull/3836/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3836`

View PR using the GUI difftool: \
`$ git pr show -t 3836`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3836.diff">https://git.openjdk.java.net/jdk/pull/3836.diff</a>

</details>
