### PR TITLE
8264950: Set opaque for JTooltip in config file of NimbusLookAndFeel

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/nimbus/skin.laf
+++ b/src/java.desktop/share/classes/javax/swing/plaf/nimbus/skin.laf
@@ -27248,7 +27248,7 @@
          <borderStates/>
          <regions/>
       </uiComponent>
-      <uiComponent opaque="false" type="javax.swing.JToolTip" name="ToolTip" ui="ToolTipUI" subregion="false">
+      <uiComponent opaque="true" type="javax.swing.JToolTip" name="ToolTip" ui="ToolTipUI" subregion="false">
          <stateTypes/>
          <contentMargins top="4" bottom="4" left="4" right="4"/>
          <style>

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthToolTipUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthToolTipUI.java
@@ -70,7 +70,6 @@ public class SynthToolTipUI extends BasicToolTipUI
     @Override
     protected void installDefaults(JComponent c) {
         updateStyle(c);
-        LookAndFeel.installProperty(c, "opaque", Boolean.TRUE);
     }
 
     private void updateStyle(JComponent c) {

--- a/test/jdk/javax/swing/JList/TestOpaqueListTable.java
+++ b/test/jdk/javax/swing/JList/TestOpaqueListTable.java
@@ -33,7 +33,7 @@ import javax.swing.UnsupportedLookAndFeelException;
 
 /**
  *  @test
- *  @bug 8253266
+ *  @bug 8253266 8264950
  *  @summary setUIProperty should work when opaque property is not set by
  *  client
  *  @key headful


### PR DESCRIPTION
Set the opaque property for JToolTip in config file (skin.laf) of NimbusLookAndFeel instead of setting up in the SynthToolTipUI.
This is related to the discussion on PR  https://github.com/openjdk/jdk/pull/3167.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264950](https://bugs.openjdk.java.net/browse/JDK-8264950): Set opaque for JTooltip in config file of NimbusLookAndFeel


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3837/head:pull/3837` \
`$ git checkout pull/3837`

Update a local copy of the PR: \
`$ git checkout pull/3837` \
`$ git pull https://git.openjdk.java.net/jdk pull/3837/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3837`

View PR using the GUI difftool: \
`$ git pr show -t 3837`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3837.diff">https://git.openjdk.java.net/jdk/pull/3837.diff</a>

</details>
