### PR TITLE
8266426: ZHeapIteratorOopClosure does not handle native access properly

### DIFF
--- a/src/hotspot/share/gc/z/zHeapIterator.cpp
+++ b/src/hotspot/share/gc/z/zHeapIterator.cpp
@@ -167,6 +167,7 @@ public:
 
   virtual void do_cld(ClassLoaderData* cld) {
     class NativeAccessClosure : public OopClosure {
+    private:
       const ZHeapIteratorContext& _context;
 
      public:

--- a/src/hotspot/share/gc/z/zHeapIterator.cpp
+++ b/src/hotspot/share/gc/z/zHeapIterator.cpp
@@ -30,6 +30,7 @@
 #include "gc/z/zGlobals.hpp"
 #include "gc/z/zGranuleMap.inline.hpp"
 #include "gc/z/zHeapIterator.hpp"
+#include "gc/z/zCollectedHeap.hpp"
 #include "gc/z/zLock.inline.hpp"
 #include "gc/z/zNMethod.hpp"
 #include "gc/z/zOop.inline.hpp"
@@ -129,6 +130,10 @@ private:
   const oop                   _base;
 
   oop load_oop(oop* p) {
+    if (!ZCollectedHeap::heap()->is_in(p)) {
+      return NativeAccess<AS_NO_KEEPALIVE>::oop_load(p);
+    }
+
     if (VisitReferents) {
       return HeapAccess<AS_NO_KEEPALIVE | ON_UNKNOWN_OOP_REF>::oop_load_at(_base, _base->field_offset(p));
     }


### PR DESCRIPTION
Change the inheritance hierarchy of `ZHeapIteratorOopClosure` so that we can know whether we are loading oops from in-heap or outside-heap (only CLD iteration).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266426](https://bugs.openjdk.java.net/browse/JDK-8266426): ZHeapIteratorOopClosure does not handle native access properly


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)


### Contributors
 * Per Liden `<pliden@openjdk.org>`
 * Erik Österlund `<eosterlund@openjdk.org>`
 * Stefan Karlsson `<stefank@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3838/head:pull/3838` \
`$ git checkout pull/3838`

Update a local copy of the PR: \
`$ git checkout pull/3838` \
`$ git pull https://git.openjdk.java.net/jdk pull/3838/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3838`

View PR using the GUI difftool: \
`$ git pr show -t 3838`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3838.diff">https://git.openjdk.java.net/jdk/pull/3838.diff</a>

</details>
