### PR TITLE
8266432: ZGC: GC allocation stalls can trigger deadlocks 

### DIFF
--- a/src/hotspot/share/gc/z/zForwarding.cpp
+++ b/src/hotspot/share/gc/z/zForwarding.cpp
@@ -132,12 +132,8 @@ void ZForwarding::release_page() {
 
 bool ZForwarding::wait_page_released() const {
   if (Atomic::load_acquire(&_ref_count) != 0) {
-    ZLocker<ZConditionLock> locker(&_ref_lock);
-    if (_ref_abort) {
-      return false;
-    }
-
     ZStatTimer timer(ZCriticalPhaseRelocationStall);
+    ZLocker<ZConditionLock> locker(&_ref_lock);
     while (Atomic::load_acquire(&_ref_count) != 0) {
       if (_ref_abort) {
         return false;


### PR DESCRIPTION
A deadlock can happen when a relocating thread holds the lock and tries to log information about the current thread, which can trigger a load barrier and a secondary relocation. The first relocation is holding the _ref_lock and the second relocation hangs when trying to reacquiring it. This is the stack trace:
```
#1 0x00007ff375c1fc90 in os::PlatformMonitor::wait
#2 0x00007ff3760cbf92 in ZForwarding::wait_page_released
#3 0x00007ff376118065 in ZRelocate::relocate_object
#4 0x00007ff374f7097b in AccessInternal::PostRuntimeDispatch<ZBarrierSet::AccessBarrier<286790ul, ZBarrierSet>,
#5 0x00007ff375176134 in oopDesc::obj_field
#6 0x00007ff37551c5cb in java_lang_Thread::name
#7 0x00007ff375f2e7ee in JavaThread::get_thread_name_string
#8 0x00007ff376126323 in ZStatPhase::log_end
#9 0x00007ff3761272e8 in ZStatCriticalPhase::register_end
#10 0x00007ff3760cc0b0 in ZForwarding::wait_page_released
#11 0x00007ff376118065 in ZRelocate::relocate_object
#12 0x00007ff3760989c5 in ZLoadBarrierOopClosure::do_oop
#13 0x00007ff375408ca8 in HandleArea::oops_do
#14 0x00007ff375f2e0e9 in JavaThread::oops_do_no_frames
```
This started to happen after:
8261759: ZGC: ZWorker Threads Continue Marking After System.exit() called 

The proposed patch moves the scope of the logging to outside the lock scope. The first _ref_lock check isn't really necessary. It was introduced to limit the allocation stall logging, but if a thread entered wait_page_released it really was on its way to stall.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266432](https://bugs.openjdk.java.net/browse/JDK-8266432): ZGC: GC allocation stalls can trigger deadlocks


### Reviewers
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Committer)
 * @MehdiNosrati (no known github.com user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3839/head:pull/3839` \
`$ git checkout pull/3839`

Update a local copy of the PR: \
`$ git checkout pull/3839` \
`$ git pull https://git.openjdk.java.net/jdk pull/3839/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3839`

View PR using the GUI difftool: \
`$ git pr show -t 3839`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3839.diff">https://git.openjdk.java.net/jdk/pull/3839.diff</a>

</details>
