### PR TITLE
8266438: Compile::remove_useless_nodes does not remove opaque nodes

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -427,7 +427,9 @@ void Compile::remove_useless_nodes(Unique_Node_List &useful) {
     }
   }
 
-  remove_useless_nodes(_macro_nodes,        useful); // remove useless macro and predicate opaq nodes
+  remove_useless_nodes(_macro_nodes,        useful); // remove useless macro nodes
+  remove_useless_nodes(_predicate_opaqs,    useful); // remove useless predicate opaque nodes
+  remove_useless_nodes(_skeleton_predicate_opaqs, useful);
   remove_useless_nodes(_expensive_nodes,    useful); // remove useless expensive nodes
   remove_useless_nodes(_for_post_loop_igvn, useful); // remove useless node recorded for post loop opts IGVN pass
 


### PR DESCRIPTION
[JDK-8255026](https://bugs.openjdk.java.net/browse/JDK-8255026) refactored the code in `Compile::remove_useless_nodes` and as a result, useless nodes are no longer removed from the `_predicate_opaqs` list. Before the [change](https://github.com/openjdk/jdk/commit/27230fae#diff-f076857d7da81f56709da3de1511b1105727032186cde4d02c678667761f46eaL382), the call to `remove_macro_node` took care of this:
https://github.com/openjdk/jdk/blob/194bceca3a4d13d4528b86359ee9d5eead3ce7ac/src/hotspot/share/opto/compile.hpp#L676-L684

But the new code only removes nodes from the `_macro_nodes` list. Useless nodes should be removed from the `_skeleton_predicate_opaqs` list as well.

I've seen failures due to this with a change in Valhalla (where we call `remove_useless_nodes` more often) but not in mainline. I think this should still be fixed in mainline.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266438](https://bugs.openjdk.java.net/browse/JDK-8266438): Compile::remove_useless_nodes does not remove opaque nodes


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3840/head:pull/3840` \
`$ git checkout pull/3840`

Update a local copy of the PR: \
`$ git checkout pull/3840` \
`$ git pull https://git.openjdk.java.net/jdk pull/3840/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3840`

View PR using the GUI difftool: \
`$ git pr show -t 3840`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3840.diff">https://git.openjdk.java.net/jdk/pull/3840.diff</a>

</details>
