### PR TITLE
8266449: cleanup jtreg tags in compiler/intrinsics/sha/cli tests

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseMD5IntrinsicsOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseMD5IntrinsicsOptionOnSupportedCPU.java
@@ -25,10 +25,8 @@
  * @test
  * @bug 8035968
  * @summary Verify UseMD5Intrinsics option processing on supported CPU.
- * @library /test/lib testcases /
+ * @library /test/lib /
  * @requires vm.flagless
- * @modules java.base/jdk.internal.misc
- *          java.management
  *
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseMD5IntrinsicsOptionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseMD5IntrinsicsOptionOnUnsupportedCPU.java
@@ -25,10 +25,8 @@
  * @test
  * @bug 8035968
  * @summary Verify UseMD5Intrinsics option processing on unsupported CPU.
- * @library /test/lib testcases /
+ * @library /test/lib /
  * @requires vm.flagless
- * @modules java.base/jdk.internal.misc
- *          java.management
  *
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA1IntrinsicsOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA1IntrinsicsOptionOnSupportedCPU.java
@@ -25,10 +25,8 @@
  * @test
  * @bug 8035968
  * @summary Verify UseSHA1Intrinsics option processing on supported CPU.
- * @library /test/lib testcases /
+ * @library /test/lib /
  * @requires vm.flagless
- * @modules java.base/jdk.internal.misc
- *          java.management
  *
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA1IntrinsicsOptionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA1IntrinsicsOptionOnUnsupportedCPU.java
@@ -25,10 +25,8 @@
  * @test
  * @bug 8035968
  * @summary Verify UseSHA1Intrinsics option processing on unsupported CPU.
- * @library /test/lib testcases /
+ * @library /test/lib /
  * @requires vm.flagless
- * @modules java.base/jdk.internal.misc
- *          java.management
  *
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA256IntrinsicsOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA256IntrinsicsOptionOnSupportedCPU.java
@@ -25,10 +25,8 @@
  * @test
  * @bug 8035968
  * @summary Verify UseSHA256Intrinsics option processing on supported CPU.
- * @library /test/lib testcases /
+ * @library /test/lib /
  * @requires vm.flagless
- * @modules java.base/jdk.internal.misc
- *          java.management
  *
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA256IntrinsicsOptionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA256IntrinsicsOptionOnUnsupportedCPU.java
@@ -25,10 +25,8 @@
  * @test
  * @bug 8035968
  * @summary Verify UseSHA256Intrinsics option processing on unsupported CPU.
- * @library /test/lib testcases /
+ * @library /test/lib /
  * @requires vm.flagless
- * @modules java.base/jdk.internal.misc
- *          java.management
  *
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA3IntrinsicsOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA3IntrinsicsOptionOnSupportedCPU.java
@@ -26,10 +26,8 @@
  * @test
  * @bug 8252204
  * @summary Verify UseSHA3Intrinsics option processing on supported CPU.
- * @library /test/lib testcases /
+ * @library /test/lib /
  * @requires vm.flagless
- * @modules java.base/jdk.internal.misc
- *          java.management
  *
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA3IntrinsicsOptionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA3IntrinsicsOptionOnUnsupportedCPU.java
@@ -26,10 +26,8 @@
  * @test
  * @bug 8252204
  * @summary Verify UseSHA3Intrinsics option processing on unsupported CPU.
- * @library /test/lib testcases /
+ * @library /test/lib /
  * @requires vm.flagless
- * @modules java.base/jdk.internal.misc
- *          java.management
  *
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnSupportedCPU.java
@@ -26,10 +26,8 @@
  * @bug 8035968
  * @summary Verify UseSHA512Intrinsics option processing on supported CPU.
  * @requires os.arch!="x86" & os.arch!="i386"
- * @library /test/lib testcases /
+ * @library /test/lib /
  * @requires vm.flagless
- * @modules java.base/jdk.internal.misc
- *          java.management
  *
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnUnsupportedCPU.java
@@ -25,10 +25,8 @@
  * @test
  * @bug 8035968
  * @summary Verify UseSHA512Intrinsics option processing on unsupported CPU.
- * @library /test/lib testcases /
+ * @library /test/lib /
  * @requires vm.flagless
- * @modules java.base/jdk.internal.misc
- *          java.management
  *
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHAOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHAOptionOnSupportedCPU.java
@@ -25,10 +25,8 @@
  * @test
  * @bug 8035968
  * @summary Verify UseSHA option processing on supported CPU.
- * @library /test/lib testcases /
+ * @library /test/lib /
  * @requires vm.flagless
- * @modules java.base/jdk.internal.misc
- *          java.management
  *
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHAOptionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHAOptionOnUnsupportedCPU.java
@@ -25,10 +25,9 @@
  * @test
  * @bug 8035968
  * @summary Verify UseSHA option processing on unsupported CPU.
- * @library /test/lib testcases /
+ * @library /test/lib /
  * @requires vm.flagless
- * @modules java.base/jdk.internal.misc
- *          java.management
+ *
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions


### PR DESCRIPTION
Hi all,

could you please review this small cleanup of jtreg tags in compiler/intrinsics/sha/cli tests? 
- `@modules` tags are not needed since we have changed the used test libraries not to depend on `java.management` module and `jdk.internal.misc.*` classes;
- `testcases`  isn't required in `@library` b/c the files this directory contains are accessible from `/` `@library`.

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266449](https://bugs.openjdk.java.net/browse/JDK-8266449): cleanup jtreg tags in compiler/intrinsics/sha/cli tests


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3841/head:pull/3841` \
`$ git checkout pull/3841`

Update a local copy of the PR: \
`$ git checkout pull/3841` \
`$ git pull https://git.openjdk.java.net/jdk pull/3841/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3841`

View PR using the GUI difftool: \
`$ git pr show -t 3841`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3841.diff">https://git.openjdk.java.net/jdk/pull/3841.diff</a>

</details>
