### PR TITLE
8266436: Synthetic constructor trees have non-null return type

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
@@ -996,7 +996,7 @@ public class TreeMaker implements JCTree.Factory {
             new JCMethodDecl(
                 Modifiers(m.flags(), Annotations(m.getRawAttributes())),
                 m.name,
-                Type(mtype.getReturnType()),
+                m.name != names.init ? Type(mtype.getReturnType()) : null,
                 TypeParams(mtype.getTypeArguments()),
                 null, // receiver type
                 Params(mtype.getParameterTypes(), m),

--- a/test/langtools/tools/javac/parser/JavacParserTest.java
+++ b/test/langtools/tools/javac/parser/JavacParserTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7073631 7159445 7156633 8028235 8065753 8205418 8205913 8228451 8237041 8253584 8246774 8256411 8256149 8259050
+ * @bug 7073631 7159445 7156633 8028235 8065753 8205418 8205913 8228451 8237041 8253584 8246774 8256411 8256149 8259050 8266436
  * @summary tests error and diagnostics positions
  * @author  Jan Lahoda
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -1758,6 +1758,23 @@ public class JavacParserTest extends TestCase {
                 codes);
     }
 
+    @Test //JDK-8266436
+    void testSyntheticConstructorReturnType() throws IOException {
+        String code = """
+                      package test;
+                      public class Test {
+                      }
+                      """;
+
+        JavacTaskImpl ct = (JavacTaskImpl) tool.getTask(null, fm, null,
+                null, null, Arrays.asList(new MyFileObject(code)));
+        CompilationUnitTree cut = ct.parse().iterator().next();
+        ct.analyze();
+        ClassTree clazz = (ClassTree) cut.getTypeDecls().get(0);
+        MethodTree constr = (MethodTree) clazz.getMembers().get(0);
+        assertEquals("expected null as constructor return type", constr.getReturnType(), null);
+    }
+
     void run(String[] args) throws Exception {
         int passed = 0, failed = 0;
         final Pattern p = (args != null && args.length > 0)
@@ -1816,10 +1833,7 @@ abstract class TestCase {
     }
 
     void assertEquals(String message, Object o1, Object o2) {
-        if (o1 != null && o2 != null && !o1.equals(o2)) {
-            fail(message);
-        }
-        if (o1 == null && o2 != null) {
+        if (!Objects.equals(o1, o2)) {
             fail(message);
         }
     }


### PR DESCRIPTION
When javac generates the AST for default (synthetic) constructor, it will create a return type `void` for them, while for ordinary constructors, it uses `null` as the return type. This change proposes to consistently use `null` as the return type of constructors. (Eventually, we might want to avoid generating the synthetic constructor tree.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266436](https://bugs.openjdk.java.net/browse/JDK-8266436): Synthetic constructor trees have non-null return type


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3842/head:pull/3842` \
`$ git checkout pull/3842`

Update a local copy of the PR: \
`$ git checkout pull/3842` \
`$ git pull https://git.openjdk.java.net/jdk pull/3842/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3842`

View PR using the GUI difftool: \
`$ git pr show -t 3842`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3842.diff">https://git.openjdk.java.net/jdk/pull/3842.diff</a>

</details>
