### PR TITLE
8266453: Shenandoah: Disable write protections before patching nmethod in nmethod_barrier on MacOSX/AArch64

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetNMethod.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2019, 2021, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@
 #include "gc/shenandoah/shenandoahThreadLocalData.hpp"
 #include "memory/iterator.hpp"
 #include "memory/resourceArea.hpp"
+#include "runtime/threadWXSetters.inline.hpp"
 
 bool ShenandoahBarrierSetNMethod::nmethod_entry_barrier(nmethod* nm) {
   ShenandoahReentrantLock* lock = ShenandoahNMethod::lock_for_nmethod(nm);
@@ -44,6 +45,8 @@ bool ShenandoahBarrierSetNMethod::nmethod_entry_barrier(nmethod* nm) {
     // and disarmed the nmethod.
     return true;
   }
+
+  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, Thread::current());)
 
   if (nm->is_unloading()) {
     // We don't need to take the lock when unlinking nmethods from


### PR DESCRIPTION
Some of tier1/tier2 tests failed on MacOSX/AArch64. The fix is similar to what JDK-8265984 does for ZGC, that disable write protections when patching code.

Test:
  tier1 and tier2 with Shenandoah GC on MacOSX/AArch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266453](https://bugs.openjdk.java.net/browse/JDK-8266453): Shenandoah: Disable write protections before patching nmethod in nmethod_barrier on MacOSX/AArch64


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3843/head:pull/3843` \
`$ git checkout pull/3843`

Update a local copy of the PR: \
`$ git checkout pull/3843` \
`$ git pull https://git.openjdk.java.net/jdk pull/3843/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3843`

View PR using the GUI difftool: \
`$ git pr show -t 3843`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3843.diff">https://git.openjdk.java.net/jdk/pull/3843.diff</a>

</details>
