### PR TITLE
8266249: javax/swing/JPopupMenu/7156657/bug7156657.java fails on macOS

### DIFF
--- a/test/jdk/javax/swing/JPopupMenu/7156657/bug7156657.java
+++ b/test/jdk/javax/swing/JPopupMenu/7156657/bug7156657.java
@@ -25,12 +25,18 @@ import java.awt.AlphaComposite;
 import java.awt.Color;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.Window;
 import java.awt.image.BufferedImage;
+import java.io.File;
 import java.util.concurrent.Callable;
 
+import javax.imageio.ImageIO;
 import javax.swing.JFrame;
 import javax.swing.JMenuItem;
 import javax.swing.JPanel;
@@ -103,24 +109,58 @@ public class bug7156657 {
         Rectangle popupRectangle = Util.invokeOnEDT(new Callable<Rectangle>() {
             @Override
             public Rectangle call() throws Exception {
-                return popupMenu.getBounds();
+                Rectangle bounds = popupMenu.getBounds();
+                Point anchor = popupMenu.getLocationOnScreen();
+                Point location = popupMenu.getLocation();
+                int offsetX = anchor.x - location.x;
+                int offsetY = anchor.y - location.y;
+                bounds.setLocation(bounds.x + offsetX, bounds.y + offsetY);
+                return bounds;
             }
         });
 
         BufferedImage redBackgroundCapture = robot.createScreenCapture(popupRectangle);
+        BufferedImage redFrame = robot.createScreenCapture(frame.getBounds());
 
         SwingUtilities.invokeAndWait(new Runnable() {
             @Override
             public void run() {
                 lowerFrame.getContentPane().setBackground(Color.GREEN);
+                lowerFrame.invalidate();
             }
         });
 
         robot.waitForIdle();
 
         BufferedImage greenBackgroundCapture = robot.createScreenCapture(popupRectangle);
+        BufferedImage greenFrame = robot.createScreenCapture(frame.getBounds());
 
         if (Util.compareBufferedImages(redBackgroundCapture, greenBackgroundCapture)) {
+            try {
+                GraphicsDevice[] devices = GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices();
+                for (int i = 0; i < devices.length; i++) {
+                    GraphicsConfiguration[] screens = devices[i].getConfigurations();
+                    for (int j = 0; j < screens.length; j++) {
+                        BufferedImage fullScreen = robot.createScreenCapture(screens[j].getBounds());
+                        if (screens[j].getBounds().intersects(popupRectangle)) {
+                            Graphics g = fullScreen.getGraphics();
+                            g.setColor(Color.CYAN);
+                            g.drawRect(popupRectangle.x - 1, popupRectangle.y - 1,
+                                    popupRectangle.width + 2, popupRectangle.height + 2);
+                            g.dispose();
+                        }
+                        ImageIO.write(fullScreen, "png", new File("dev" + i + "scr" + j + ".png"));
+                    }
+                }
+                ImageIO.write(redFrame, "png", new File("redframe.png"));
+                ImageIO.write(redBackgroundCapture, "png", new File("redbg.png"));
+                ImageIO.write(greenFrame, "png", new File("greenframe.png"));
+                ImageIO.write(greenBackgroundCapture, "png", new File("greenbg.png"));
+            } finally {
+                frame.dispose();
+                lowerFrame.dispose();
+            }
+            robot.waitForIdle();
             throw new RuntimeException("The test failed");
         }
 

--- a/test/jdk/javax/swing/JPopupMenu/7156657/bug7156657.java
+++ b/test/jdk/javax/swing/JPopupMenu/7156657/bug7156657.java
@@ -153,8 +153,10 @@ public class bug7156657 {
                 ImageIO.write(greenFrame, "png", new File("greenframe.png"));
                 ImageIO.write(greenBackgroundCapture, "png", new File("greenbg.png"));
             } finally {
-                frame.dispose();
-                lowerFrame.dispose();
+                SwingUtilities.invokeAndWait(() -> {
+                    frame.dispose();
+                    lowerFrame.dispose();
+                });
             }
             robot.waitForIdle();
             throw new RuntimeException("The test failed");
@@ -184,8 +186,8 @@ public class bug7156657 {
     private static JFrame createFrame() {
         JFrame result = new JFrame();
 
-        result.setLocation(0, 0);
         result.setSize(400, 300);
+        result.setLocationRelativeTo(null);
         result.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         result.setUndecorated(true);
 

--- a/test/jdk/javax/swing/JPopupMenu/7156657/bug7156657.java
+++ b/test/jdk/javax/swing/JPopupMenu/7156657/bug7156657.java
@@ -131,6 +131,7 @@ public class bug7156657 {
         });
 
         robot.waitForIdle();
+        robot.delay(1000); // Give frame time to repaint
 
         BufferedImage greenBackgroundCapture = robot.createScreenCapture(popupRectangle);
         BufferedImage greenFrame = robot.createScreenCapture(frame.getBounds());

--- a/test/jdk/javax/swing/JPopupMenu/7156657/bug7156657.java
+++ b/test/jdk/javax/swing/JPopupMenu/7156657/bug7156657.java
@@ -109,13 +109,8 @@ public class bug7156657 {
         Rectangle popupRectangle = Util.invokeOnEDT(new Callable<Rectangle>() {
             @Override
             public Rectangle call() throws Exception {
-                Rectangle bounds = popupMenu.getBounds();
-                Point anchor = popupMenu.getLocationOnScreen();
-                Point location = popupMenu.getLocation();
-                int offsetX = anchor.x - location.x;
-                int offsetY = anchor.y - location.y;
-                bounds.setLocation(bounds.x + offsetX, bounds.y + offsetY);
-                return bounds;
+                return new Rectangle(popupMenu.getLocationOnScreen(),
+                        popupMenu.getSize());
             }
         });
 


### PR DESCRIPTION
Fixed popup position taking into account its offset
Added a lot of screenshots taking to better understand failures should they happen down the line

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266249](https://bugs.openjdk.java.net/browse/JDK-8266249): javax/swing/JPopupMenu/7156657/bug7156657.java fails on macOS


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**) ⚠️ Review applies to f3589c68d1fd7dc7fb4fa2aa255315828860c29d
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3844/head:pull/3844` \
`$ git checkout pull/3844`

Update a local copy of the PR: \
`$ git checkout pull/3844` \
`$ git pull https://git.openjdk.java.net/jdk pull/3844/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3844`

View PR using the GUI difftool: \
`$ git pr show -t 3844`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3844.diff">https://git.openjdk.java.net/jdk/pull/3844.diff</a>

</details>
