### PR TITLE
8264777: Overload optimized FileInputStream::readAllBytes

### DIFF
--- a/src/java.base/share/classes/java/io/FileInputStream.java
+++ b/src/java.base/share/classes/java/io/FileInputStream.java
@@ -284,8 +284,8 @@ public class FileInputStream extends InputStream
 
         if (size > (long) Integer.MAX_VALUE) {
             String msg =
-                String.format("Required array size too large: %d = %d - %d",
-                    size, length, position);
+                String.format("Required array size too large for %s: %d = %d - %d",
+                    path, size, length, position);
             throw new OutOfMemoryError(msg);
         }
 
@@ -350,8 +350,15 @@ public class FileInputStream extends InputStream
         return (capacity == nread) ? buf : Arrays.copyOf(buf, nread);
     }
 
-    private native long length() throws IOException;
-    private native long position() throws IOException;
+    private long length() throws IOException {
+        return length0();
+    }
+    private native long length0() throws IOException;
+
+    private long position() throws IOException {
+        return position0();
+    }
+    private native long position0() throws IOException;
 
     /**
      * Skips over and discards {@code n} bytes of data from the

--- a/src/java.base/share/classes/java/io/FileInputStream.java
+++ b/src/java.base/share/classes/java/io/FileInputStream.java
@@ -281,7 +281,7 @@ public class FileInputStream extends InputStream
 
         long size = length - position();
         if (size > (long) Integer.MAX_VALUE) {
-            String msg = String.format("Required array size too large: %d = %d + %d",
+            String msg = String.format("Required array size too large: %d = %d - %d",
                 size, length, position());
             throw new OutOfMemoryError(msg);
         }

--- a/src/java.base/share/classes/java/io/FileInputStream.java
+++ b/src/java.base/share/classes/java/io/FileInputStream.java
@@ -319,6 +319,8 @@ public class FileInputStream extends InputStream
     public byte[] readNBytes(int len) throws IOException {
         if (len < 0)
             throw new IllegalArgumentException("len < 0");
+        if (len == 0)
+            return new byte[0];
 
         long length = length();
         long position = position();

--- a/src/java.base/share/classes/java/io/FileInputStream.java
+++ b/src/java.base/share/classes/java/io/FileInputStream.java
@@ -276,17 +276,18 @@ public class FileInputStream extends InputStream
 
     public byte[] readAllBytes() throws IOException {
         long length = length();
-        if (length <= 0)
+        long position = position();
+        long size = length - position;
+
+        if (length <= 0 || size <= 0)
             return super.readAllBytes();
 
-        long size = length - position();
         if (size > (long) Integer.MAX_VALUE) {
-            String msg = String.format("Required array size too large: %d = %d - %d",
-                size, length, position());
+            String msg =
+                String.format("Required array size too large: %d = %d - %d",
+                    size, length, position);
             throw new OutOfMemoryError(msg);
         }
-        if (size <= 0L)
-            return new byte[0];
 
         int capacity = (int)size;
         byte[] buf = new byte[capacity];
@@ -318,13 +319,13 @@ public class FileInputStream extends InputStream
     public byte[] readNBytes(int len) throws IOException {
         if (len < 0)
             throw new IllegalArgumentException("len < 0");
-        long length = length();
-        if (length <= 0)
-            return super.readNBytes(len);
 
-        long size = length - position();
-        if (size <= 0L)
-            return new byte[0];
+        long length = length();
+        long position = position();
+        long size = length - position;
+
+        if (length <= 0 || size <= 0)
+            return super.readNBytes(len);
 
         int capacity = (int)Math.min(len, size);
         byte[] buf = new byte[capacity];

--- a/src/java.base/share/classes/java/io/FileInputStream.java
+++ b/src/java.base/share/classes/java/io/FileInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,9 @@
 package java.io;
 
 import java.nio.channels.FileChannel;
+import java.util.Arrays;
+import jdk.internal.util.ArraysSupport;
 import sun.nio.ch.FileChannelImpl;
-
 
 /**
  * A {@code FileInputStream} obtains input bytes
@@ -62,6 +63,8 @@ import sun.nio.ch.FileChannelImpl;
  */
 public class FileInputStream extends InputStream
 {
+    private static final int DEFAULT_BUFFER_SIZE = 8192;
+
     /* File Descriptor - handle to the open file */
     private final FileDescriptor fd;
 
@@ -270,6 +273,73 @@ public class FileInputStream extends InputStream
     public int read(byte b[], int off, int len) throws IOException {
         return readBytes(b, off, len);
     }
+
+    public byte[] readAllBytes() throws IOException {
+        long size = length() - position();
+        if (size > (long) Integer.MAX_VALUE)
+            throw new OutOfMemoryError("Required array size too large");
+        if (size <= 0L)
+            return new byte[0];
+
+        int capacity = (int)size;
+        byte[] buf = new byte[capacity];
+
+        int nread = 0;
+        int n;
+        for (;;) {
+            // read to EOF which may read more or less than initial size, e.g.,
+            // file is truncated while we are reading
+            while ((n = read(buf, nread, capacity - nread)) > 0)
+                nread += n;
+
+            // if last call to read() returned -1, we are done; otherwise,
+            // try to read one more byte and if that fails we're done too
+            if (n < 0 || (n = read()) < 0)
+                break;
+
+            // one more byte was read; need to allocate a larger buffer
+            capacity = Math.max(ArraysSupport.newLength(capacity,
+                                                        1,         // min growth
+                                                        capacity), // pref growth
+                                DEFAULT_BUFFER_SIZE);
+            buf = Arrays.copyOf(buf, capacity);
+            buf[nread++] = (byte)n;
+        }
+        return (capacity == nread) ? buf : Arrays.copyOf(buf, nread);
+    }
+
+    public byte[] readNBytes(int len) throws IOException {
+        if (len < 0)
+            throw new IllegalArgumentException("len < 0");
+        long size = length() - position();
+        if (size <= 0L)
+            return new byte[0];
+
+        int capacity = (int)Math.min(len, size);
+        byte[] buf = new byte[capacity];
+
+        int remaining = capacity;
+        int nread = 0;
+        int n;
+        do {
+            n = read(buf, nread, remaining);
+            if (n > 0 ) {
+                nread += n;
+                remaining -= n;
+            } else if (n == 0) {
+                // Block until a byte is read or EOF is detected
+                byte b = (byte)read();
+                if (b == -1 )
+                    break;
+                buf[nread++] = b;
+                remaining--;
+            }
+        } while (n >= 0 && remaining > 0);
+        return (capacity == nread) ? buf : Arrays.copyOf(buf, nread);
+    }
+
+    private native long length() throws IOException;
+    private native long position() throws IOException;
 
     /**
      * Skips over and discards {@code n} bytes of data from the

--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -348,7 +348,7 @@ public abstract class InputStream implements Closeable {
 
     /**
      * Reads up to a specified number of bytes from the input stream. This
-     * method blocks until the requested number of bytes have been read, end
+     * method blocks until the requested number of bytes has been read, end
      * of stream is detected, or an exception is thrown. This method does not
      * close the input stream.
      *
@@ -560,7 +560,7 @@ public abstract class InputStream implements Closeable {
      * If {@code n} is negative, then no bytes are skipped.
      * Subclasses may handle the negative value differently.
      *
-     * <p> This method blocks until the requested number of bytes have been
+     * <p> This method blocks until the requested number of bytes has been
      * skipped, end of file is reached, or an exception is thrown.
      *
      * <p> If end of stream is reached before the stream is at the desired

--- a/src/java.base/share/native/libjava/FileInputStream.c
+++ b/src/java.base/share/native/libjava/FileInputStream.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,6 +70,39 @@ JNIEXPORT jint JNICALL
 Java_java_io_FileInputStream_readBytes(JNIEnv *env, jobject this,
         jbyteArray bytes, jint off, jint len) {
     return readBytes(env, this, bytes, off, len, fis_fd);
+}
+
+JNIEXPORT jlong JNICALL
+Java_java_io_FileInputStream_length(JNIEnv *env, jobject this) {
+
+    FD fd;
+    jlong length = jlong_zero;
+
+    fd = getFD(env, this, fis_fd);
+    if (fd == -1) {
+        JNU_ThrowIOException(env, "Stream Closed");
+        return -1;
+    }
+    if ((length = IO_GetLength(fd)) == -1) {
+        JNU_ThrowIOExceptionWithLastError(env, "GetLength failed");
+    }
+    return length;
+}
+
+JNIEXPORT jlong JNICALL
+Java_java_io_FileInputStream_position(JNIEnv *env, jobject this) {
+    FD fd;
+    jlong ret;
+
+    fd = getFD(env, this, fis_fd);
+    if (fd == -1) {
+        JNU_ThrowIOException(env, "Stream Closed");
+        return -1;
+    }
+    if ((ret = IO_Lseek(fd, 0L, SEEK_CUR)) == -1) {
+        JNU_ThrowIOExceptionWithLastError(env, "Seek failed");
+    }
+    return ret;
 }
 
 JNIEXPORT jlong JNICALL

--- a/src/java.base/share/native/libjava/FileInputStream.c
+++ b/src/java.base/share/native/libjava/FileInputStream.c
@@ -73,7 +73,7 @@ Java_java_io_FileInputStream_readBytes(JNIEnv *env, jobject this,
 }
 
 JNIEXPORT jlong JNICALL
-Java_java_io_FileInputStream_length(JNIEnv *env, jobject this) {
+Java_java_io_FileInputStream_length0(JNIEnv *env, jobject this) {
 
     FD fd;
     jlong length = jlong_zero;
@@ -90,7 +90,7 @@ Java_java_io_FileInputStream_length(JNIEnv *env, jobject this) {
 }
 
 JNIEXPORT jlong JNICALL
-Java_java_io_FileInputStream_position(JNIEnv *env, jobject this) {
+Java_java_io_FileInputStream_position0(JNIEnv *env, jobject this) {
     FD fd;
     jlong ret;
 

--- a/test/jdk/java/io/FileInputStream/ReadXBytes.java
+++ b/test/jdk/java/io/FileInputStream/ReadXBytes.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @library /test/lib
+ * @build jdk.test.lib.RandomFactory
+ * @run main ReadXBytes
+ * @bug 8264777
+ * @summary Test read{All,N}Bytes overrides (use -Dseed=X to set PRNG seed)
+ * @key randomness
+ */
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.util.Arrays;
+import java.util.Random;
+import jdk.test.lib.RandomFactory;
+
+public class ReadXBytes {
+    private static final int ITERATIONS = 10;
+    private static final int MAX_FILE_SIZE = 1_000_000;
+    private static final Random RND = RandomFactory.getRandom();
+
+    public static void main(String args[]) throws IOException {
+        File dir = new File(System.getProperty("test.src", "."));
+        dir.deleteOnExit();
+
+        File empty = File.createTempFile("foo", "bar", dir);
+        empty.deleteOnExit();
+        FileInputStream fis = new FileInputStream(empty);
+        try {
+            fis.readNBytes(-1);
+            throw new RuntimeException("IllegalArgumentException expecte");
+        } catch (IllegalArgumentException expected) {
+        }
+
+        byte[] b = fis.readNBytes(1);
+        fis.close();
+        if (b.length != 0)
+            throw new RuntimeException("Zero-length byte[] expected");
+
+        fis = new FileInputStream(empty);
+        b = fis.readAllBytes();
+        fis.close();
+        if (b.length != 0)
+            throw new RuntimeException("Zero-length byte[] expected");
+
+        empty.delete();
+
+        for (int i = 0; i < ITERATIONS; i++) {
+            File file = File.createTempFile("foo", "bar", dir);
+            file.deleteOnExit();
+
+            int size = 1 + RND.nextInt(MAX_FILE_SIZE);
+            System.out.printf("size %d%n", size);
+            byte[] bytes = new byte[size];
+            RND.nextBytes(bytes);
+            RandomAccessFile raf = new RandomAccessFile(file, "rw");
+            raf.write(bytes);
+            raf.close();
+
+            fis = new FileInputStream(file);
+            int pos = RND.nextInt(size);
+            int len = RND.nextInt(size - pos);
+            fis.getChannel().position(pos);
+            byte[] nbytes = fis.readNBytes(len);
+            if (nbytes.length != len)
+                throw new RuntimeException("readNBytes() length");
+            if (!Arrays.equals(nbytes, 0, len, bytes, pos, pos + len))
+                throw new RuntimeException("readNBytes() content");
+            fis.close();
+
+            fis = new FileInputStream(file);
+            pos = RND.nextInt(size);
+            fis.getChannel().position(pos);
+            byte[] allbytes = fis.readAllBytes();
+            if (allbytes.length != size - pos)
+                throw new RuntimeException("readAllBytes() length");
+            if (!Arrays.equals(allbytes, 0, allbytes.length,
+                               bytes, pos, pos + allbytes.length))
+                throw new RuntimeException("readAllBytes() content");
+            fis.close();
+
+            file.delete();
+        }
+        dir.delete();
+    }
+}

--- a/test/jdk/java/io/FileInputStream/ReadXBytes.java
+++ b/test/jdk/java/io/FileInputStream/ReadXBytes.java
@@ -62,15 +62,11 @@ public class ReadXBytes {
 
             byte[] b = fis.readNBytes(1);
             if (b.length != 0)
-                throw new RuntimeException("Zero-length byte[] expected");
-        }
+                throw new RuntimeException("readNBytes: zero-length byte[] expected");
 
-        try (FileInputStream fis = new FileInputStream(empty)) {
-            byte[] b = fis.readAllBytes();
+            b = fis.readAllBytes();
             if (b.length != 0)
-                throw new RuntimeException("Zero-length byte[] expected");
-        } finally {
-            empty.delete();
+                throw new RuntimeException("readAllBytes: zero-length byte[] expected");
         }
 
         for (int i = 0; i < ITERATIONS; i++) {

--- a/test/jdk/java/io/FileInputStream/ReadXBytes.java
+++ b/test/jdk/java/io/FileInputStream/ReadXBytes.java
@@ -86,7 +86,10 @@ public class ReadXBytes {
             int pos = RND.nextInt(size);
             int len = RND.nextInt(size - pos);
             fis.getChannel().position(pos);
-            byte[] nbytes = fis.readNBytes(len);
+            byte[] nbytes = fis.readNBytes(0);
+            if (nbytes.length != 0)
+                throw new RuntimeException("readNBytes() zero length");
+            nbytes = fis.readNBytes(len);
             if (nbytes.length != len)
                 throw new RuntimeException("readNBytes() length");
             if (!Arrays.equals(nbytes, 0, len, bytes, pos, pos + len))


### PR DESCRIPTION
Please consider this request to override the `java.io.InputStream` methods `readAllBytes()` and `readNBytes(int)` in `FileInputStream` with more performant implementations. The method overrides attempt to read all requested bytes into a single array of the required size rather than composing the result from a sequence of smaller arrays. An example of the performance improvements is as follows.

**readAllBytes**
Before
```
Benchmark                                    (length)   Mode  Cnt      Score     Error  Units
ReadAllBytes.readAllBytesFileInputStream      1000000  thrpt   20   2412.031 ±   7.309  ops/s
ReadAllBytes.readAllBytesFileInputStream     10000000  thrpt   20    212.181 ±   0.369  ops/s
ReadAllBytes.readAllBytesFileInputStream    100000000  thrpt   20     19.860 ±   0.048  ops/s
ReadAllBytes.readAllBytesFileInputStream   1000000000  thrpt   20      1.298 ±   0.183  ops/s
```
After
```
Benchmark                                    (length)   Mode  Cnt      Score     Error  Units
ReadAllBytes.readAllBytesFileInputStream      1000000  thrpt   20   8218.473 ±  43.425  ops/s
ReadAllBytes.readAllBytesFileInputStream     10000000  thrpt   20    302.781 ±   1.273  ops/s
ReadAllBytes.readAllBytesFileInputStream    100000000  thrpt   20     22.461 ±   0.084  ops/s
ReadAllBytes.readAllBytesFileInputStream   1000000000  thrpt   20      1.502 ±   0.003  ops/s
```

**readNBytes**

`N = file_size / 2`

Before
```
Benchmark                                    (length)   Mode  Cnt      Score     Error  Units
ReadAllBytes.readHalfBytesFileInputStream     1000000  thrpt   20   5585.500 ± 153.353  ops/s
ReadAllBytes.readHalfBytesFileInputStream    10000000  thrpt   20    436.164 ±   1.104  ops/s
ReadAllBytes.readHalfBytesFileInputStream   100000000  thrpt   20     40.167 ±   0.141  ops/s
ReadAllBytes.readHalfBytesFileInputStream  1000000000  thrpt   20      3.291 ±   0.211  ops/s
```

After
```
Benchmark                                    (length)   Mode  Cnt      Score     Error  Units
ReadAllBytes.readHalfBytesFileInputStream     1000000  thrpt   20  15463.210 ±  66.045  ops/s
ReadAllBytes.readHalfBytesFileInputStream    10000000  thrpt   20    561.752 ±   0.951  ops/s
ReadAllBytes.readHalfBytesFileInputStream   100000000  thrpt   20     45.043 ±   0.102  ops/s
ReadAllBytes.readHalfBytesFileInputStream  1000000000  thrpt   20      4.629 ±   0.035  ops/s
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264777](https://bugs.openjdk.java.net/browse/JDK-8264777): Overload optimized FileInputStream::readAllBytes


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to 4fae0209f7523a8b2f6f04abb451be913c624881
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3845/head:pull/3845` \
`$ git checkout pull/3845`

Update a local copy of the PR: \
`$ git checkout pull/3845` \
`$ git pull https://git.openjdk.java.net/jdk pull/3845/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3845`

View PR using the GUI difftool: \
`$ git pr show -t 3845`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3845.diff">https://git.openjdk.java.net/jdk/pull/3845.diff</a>

</details>
