### PR TITLE
8263124: Missed initialization of baselineY in sun.font.StrikeMetrics

### DIFF
--- a/src/java.desktop/share/classes/sun/font/StrikeMetrics.java
+++ b/src/java.desktop/share/classes/sun/font/StrikeMetrics.java
@@ -88,7 +88,7 @@ public final class StrikeMetrics {
     StrikeMetrics() {
         ascentX = ascentY = Integer.MAX_VALUE;
         descentX = descentY = leadingX = leadingY = Integer.MIN_VALUE;
-        baselineX = baselineX = maxAdvanceX = maxAdvanceY = Integer.MIN_VALUE;
+        baselineX = baselineY = maxAdvanceX = maxAdvanceY = Integer.MIN_VALUE;
     }
 
     StrikeMetrics(float ax, float ay, float dx, float dy, float bx, float by,


### PR DESCRIPTION
This is just clean up. The value will be zero by default and explicitly (if you follow along far enough) zero.
The no-args constructor just merges physical fonts and those are set up with zero anyway

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263124](https://bugs.openjdk.java.net/browse/JDK-8263124): Missed initialization of baselineY in sun.font.StrikeMetrics


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3846/head:pull/3846` \
`$ git checkout pull/3846`

Update a local copy of the PR: \
`$ git checkout pull/3846` \
`$ git pull https://git.openjdk.java.net/jdk pull/3846/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3846`

View PR using the GUI difftool: \
`$ git pr show -t 3846`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3846.diff">https://git.openjdk.java.net/jdk/pull/3846.diff</a>

</details>
