### PR TITLE
8266465: Add wildcard to JTwork/JTreport exclude in jib-profiles.js 

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -205,7 +205,7 @@ var getJibProfiles = function (input) {
 
     // Exclude list to use when Jib creates a source bundle
     data.src_bundle_excludes = [
-        "build", "{,**/}webrev*", "{,**/}.hg", "{,**/}JTwork", "{,**/}JTreport",
+        "build", "{,**/}webrev*", "{,**/}.hg", "{,**/}JTwork*", "{,**/}JTreport*",
         "{,**/}.git"
     ];
     // Include list to use when creating a minimal jib source bundle which


### PR DESCRIPTION
If you stash away jtreg test results in a specific JTwork directory this can causes problem creating a jib source bundle. Simple fix is to add a wildcard to the JTwork and JTreport exclude entries.

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266465](https://bugs.openjdk.java.net/browse/JDK-8266465): Add wildcard to JTwork/JTreport exclude in jib-profiles.js


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3847/head:pull/3847` \
`$ git checkout pull/3847`

Update a local copy of the PR: \
`$ git checkout pull/3847` \
`$ git pull https://git.openjdk.java.net/jdk pull/3847/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3847`

View PR using the GUI difftool: \
`$ git pr show -t 3847`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3847.diff">https://git.openjdk.java.net/jdk/pull/3847.diff</a>

</details>
