### PR TITLE
8255566: Add size validation when parsing values from VersionProps 

### DIFF
--- a/src/hotspot/share/runtime/java.hpp
+++ b/src/hotspot/share/runtime/java.hpp
@@ -25,6 +25,7 @@
 #ifndef SHARE_RUNTIME_JAVA_HPP
 #define SHARE_RUNTIME_JAVA_HPP
 
+#include "runtime/os.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 class Handle;

--- a/src/hotspot/share/runtime/java.hpp
+++ b/src/hotspot/share/runtime/java.hpp
@@ -140,35 +140,35 @@ class JDK_Version {
     return _java_version;
   }
   static void set_java_version(const char* version) {
-    _java_version = version;
+    _java_version = os::strdup(version);
   }
 
   static const char* runtime_name() {
     return _runtime_name;
   }
   static void set_runtime_name(const char* name) {
-    _runtime_name = name;
+    _runtime_name = os::strdup(name);
   }
 
   static const char* runtime_version() {
     return _runtime_version;
   }
   static void set_runtime_version(const char* version) {
-    _runtime_version = version;
+    _runtime_version = os::strdup(version);
   }
 
   static const char* runtime_vendor_version() {
     return _runtime_vendor_version;
   }
   static void set_runtime_vendor_version(const char* vendor_version) {
-    _runtime_vendor_version = vendor_version;
+    _runtime_vendor_version = os::strdup(vendor_version);
   }
 
   static const char* runtime_vendor_vm_bug_url() {
     return _runtime_vendor_vm_bug_url;
   }
   static void set_runtime_vendor_vm_bug_url(const char* vendor_vm_bug_url) {
-    _runtime_vendor_vm_bug_url = vendor_vm_bug_url;
+    _runtime_vendor_vm_bug_url = os::strdup(vendor_vm_bug_url);
   }
 
 };


### PR DESCRIPTION
java.lang.VersionProps defines a number of JDK version properties that are read by the VM and stored in JDK_Version or VM_Version. These values are read into fixed size buffers with no guarantee that the value will actually fit. The proposed solution is to get rid of the fixed size buffers, allocate initially into the thread's resource area then make a permanent copy using os::strdup.

Testing: tiers 1-3

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255566](https://bugs.openjdk.java.net/browse/JDK-8255566): Add size validation when parsing values from VersionProps


### Reviewers
 * [Robbin Ehn](https://openjdk.java.net/census#rehn) (@robehn - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3848/head:pull/3848` \
`$ git checkout pull/3848`

Update a local copy of the PR: \
`$ git checkout pull/3848` \
`$ git pull https://git.openjdk.java.net/jdk pull/3848/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3848`

View PR using the GUI difftool: \
`$ git pr show -t 3848`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3848.diff">https://git.openjdk.java.net/jdk/pull/3848.diff</a>

</details>
