### PR TITLE
8226384: Implement a better logic to switch between OpenGL and Metal pipeline

### DIFF
--- a/src/java.desktop/macosx/classes/sun/java2d/metal/MTLLayer.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/metal/MTLLayer.java
@@ -29,11 +29,8 @@ import sun.java2d.NullSurfaceData;
 import sun.java2d.SurfaceData;
 import sun.lwawt.LWWindowPeer;
 import sun.lwawt.macosx.CFLayer;
-
 import java.awt.GraphicsConfiguration;
 import java.awt.Insets;
-import java.awt.Rectangle;
-import java.awt.Transparency;
 
 public class MTLLayer extends CFLayer {
 
@@ -45,7 +42,6 @@ public class MTLLayer extends CFLayer {
     private static native void validate(long layerPtr, MTLSurfaceData mtlsd);
     private static native void blitTexture(long layerPtr);
 
-    private LWWindowPeer peer;
     private int scale = 1;
 
     public MTLLayer(LWWindowPeer peer) {
@@ -53,26 +49,6 @@ public class MTLLayer extends CFLayer {
 
         setPtr(nativeCreateLayer());
         this.peer = peer;
-    }
-
-    public Rectangle getBounds() {
-        return peer.getBounds();
-    }
-
-    public GraphicsConfiguration getGraphicsConfiguration() {
-        return peer.getGraphicsConfiguration();
-    }
-
-    public boolean isOpaque() {
-        return !peer.isTranslucent();
-    }
-
-    public int getTransparency() {
-        return isOpaque() ? Transparency.OPAQUE : Transparency.TRANSLUCENT;
-    }
-
-    public Object getDestination() {
-        return peer.getTarget();
     }
 
     public SurfaceData replaceSurfaceData() {

--- a/src/java.desktop/macosx/classes/sun/java2d/metal/MTLLayer.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/metal/MTLLayer.java
@@ -28,14 +28,14 @@ package sun.java2d.metal;
 import sun.java2d.NullSurfaceData;
 import sun.java2d.SurfaceData;
 import sun.lwawt.LWWindowPeer;
-import sun.lwawt.macosx.CFRetainedResource;
+import sun.lwawt.macosx.CFLayer;
 
 import java.awt.GraphicsConfiguration;
 import java.awt.Insets;
 import java.awt.Rectangle;
 import java.awt.Transparency;
 
-public class MTLLayer extends CFRetainedResource {
+public class MTLLayer extends CFLayer {
 
     private native long nativeCreateLayer();
     private static native void nativeSetScale(long layerPtr, double scale);
@@ -48,17 +48,11 @@ public class MTLLayer extends CFRetainedResource {
     private LWWindowPeer peer;
     private int scale = 1;
 
-    private SurfaceData surfaceData; // represents intermediate buffer (texture)
-
     public MTLLayer(LWWindowPeer peer) {
         super(0, true);
 
         setPtr(nativeCreateLayer());
         this.peer = peer;
-    }
-
-    public long getPointer() {
-        return ptr;
     }
 
     public Rectangle getBounds() {
@@ -102,10 +96,6 @@ public class MTLLayer extends CFRetainedResource {
             validate((MTLSurfaceData)surfaceData);
         }
 
-        return surfaceData;
-    }
-
-    public SurfaceData getSurfaceData() {
         return surfaceData;
     }
 

--- a/src/java.desktop/macosx/classes/sun/java2d/opengl/CGLLayer.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/opengl/CGLLayer.java
@@ -33,9 +33,9 @@ import sun.awt.CGraphicsConfig;
 import sun.java2d.NullSurfaceData;
 import sun.java2d.SurfaceData;
 import sun.lwawt.LWWindowPeer;
-import sun.lwawt.macosx.CFRetainedResource;
+import sun.lwawt.macosx.CFLayer;
 
-public class CGLLayer extends CFRetainedResource {
+public class CGLLayer extends CFLayer {
 
     private native long nativeCreateLayer();
     private static native void nativeSetScale(long layerPtr, double scale);
@@ -45,17 +45,11 @@ public class CGLLayer extends CFRetainedResource {
     private LWWindowPeer peer;
     private int scale = 1;
 
-    private SurfaceData surfaceData; // represents intermediate buffer (texture)
-
     public CGLLayer(LWWindowPeer peer) {
         super(0, true);
 
         setPtr(nativeCreateLayer());
         this.peer = peer;
-    }
-
-    public long getPointer() {
-        return ptr;
     }
 
     public Rectangle getBounds() {
@@ -95,10 +89,6 @@ public class CGLLayer extends CFRetainedResource {
             validate((CGLSurfaceData)surfaceData);
         }
 
-        return surfaceData;
-    }
-
-    public SurfaceData getSurfaceData() {
         return surfaceData;
     }
 

--- a/src/java.desktop/macosx/classes/sun/java2d/opengl/CGLLayer.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/opengl/CGLLayer.java
@@ -26,13 +26,10 @@
 package sun.java2d.opengl;
 
 import java.awt.GraphicsConfiguration;
-import java.awt.Rectangle;
-import java.awt.Transparency;
-
 import sun.awt.CGraphicsConfig;
 import sun.java2d.NullSurfaceData;
-import sun.java2d.SurfaceData;
 import sun.lwawt.LWWindowPeer;
+import sun.java2d.SurfaceData;
 import sun.lwawt.macosx.CFLayer;
 
 public class CGLLayer extends CFLayer {
@@ -42,7 +39,6 @@ public class CGLLayer extends CFLayer {
     private static native void validate(long layerPtr, CGLSurfaceData cglsd);
     private static native void blitTexture(long layerPtr);
 
-    private LWWindowPeer peer;
     private int scale = 1;
 
     public CGLLayer(LWWindowPeer peer) {
@@ -50,26 +46,6 @@ public class CGLLayer extends CFLayer {
 
         setPtr(nativeCreateLayer());
         this.peer = peer;
-    }
-
-    public Rectangle getBounds() {
-        return peer.getBounds();
-    }
-
-    public GraphicsConfiguration getGraphicsConfiguration() {
-        return peer.getGraphicsConfiguration();
-    }
-
-    public boolean isOpaque() {
-        return !peer.isTranslucent();
-    }
-
-    public int getTransparency() {
-        return isOpaque() ? Transparency.OPAQUE : Transparency.TRANSLUCENT;
-    }
-
-    public Object getDestination() {
-        return peer.getTarget();
     }
 
     public SurfaceData replaceSurfaceData() {

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CFLayer.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CFLayer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.lwawt.macosx;
+
+import sun.java2d.SurfaceData;
+import sun.java2d.NullSurfaceData;
+
+/**
+ * Common layer class between OpenGl and Metal.
+ */
+public abstract class CFLayer extends CFRetainedResource {
+    protected SurfaceData surfaceData; // represents intermediate buffer (texture)
+
+    protected CFLayer(long ptr, boolean disposeOnAppKitThread) {
+        super(ptr, disposeOnAppKitThread);
+    }
+
+    public abstract SurfaceData replaceSurfaceData();
+
+    @Override
+    public void dispose() {
+        super.dispose();
+    }
+
+    public long getPointer() {
+        return ptr;
+    }
+
+    public SurfaceData getSurfaceData() {
+        return surfaceData;
+    }
+}

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CFLayer.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CFLayer.java
@@ -27,12 +27,17 @@ package sun.lwawt.macosx;
 
 import sun.java2d.SurfaceData;
 import sun.java2d.NullSurfaceData;
+import java.awt.GraphicsConfiguration;
+import java.awt.Rectangle;
+import java.awt.Transparency;
+import sun.lwawt.LWWindowPeer;
 
 /**
  * Common layer class between OpenGl and Metal.
  */
 public abstract class CFLayer extends CFRetainedResource {
     protected SurfaceData surfaceData; // represents intermediate buffer (texture)
+    protected LWWindowPeer peer;
 
     protected CFLayer(long ptr, boolean disposeOnAppKitThread) {
         super(ptr, disposeOnAppKitThread);
@@ -51,5 +56,25 @@ public abstract class CFLayer extends CFRetainedResource {
 
     public SurfaceData getSurfaceData() {
         return surfaceData;
+    }
+
+    public Rectangle getBounds() {
+        return peer.getBounds();
+    }
+
+    public GraphicsConfiguration getGraphicsConfiguration() {
+        return peer.getGraphicsConfiguration();
+    }
+
+    public boolean isOpaque() {
+        return !peer.isTranslucent();
+    }
+
+    public int getTransparency() {
+        return isOpaque() ? Transparency.OPAQUE : Transparency.TRANSLUCENT;
+    }
+
+    public Object getDestination() {
+        return peer.getTarget();
     }
 }

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformEmbeddedFrame.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformEmbeddedFrame.java
@@ -32,9 +32,9 @@ import sun.awt.CGraphicsDevice;
 import sun.java2d.SurfaceData;
 import sun.java2d.metal.MTLLayer;
 import sun.java2d.opengl.CGLLayer;
+import sun.lwawt.macosx.CFLayer;
 import sun.lwawt.LWWindowPeer;
 import sun.lwawt.PlatformWindow;
-import sun.lwawt.macosx.CFRetainedResource;
 import sun.util.logging.PlatformLogger;
 
 
@@ -46,7 +46,7 @@ public class CPlatformEmbeddedFrame implements PlatformWindow {
     private static final PlatformLogger focusLogger = PlatformLogger.getLogger(
             "sun.lwawt.macosx.focus.CPlatformEmbeddedFrame");
 
-    private CFRetainedResource windowLayer;
+    private CFLayer windowLayer;
     private LWWindowPeer peer;
     private CEmbeddedFrame target;
 
@@ -71,20 +71,12 @@ public class CPlatformEmbeddedFrame implements PlatformWindow {
 
     @Override
     public long getLayerPtr() {
-        if (CGraphicsDevice.usingMetalPipeline()) {
-            return ((MTLLayer)windowLayer).getPointer();
-        } else {
-            return ((CGLLayer)windowLayer).getPointer();
-        }
+        return windowLayer.getPointer();
     }
 
     @Override
     public void dispose() {
-        if (CGraphicsDevice.usingMetalPipeline()) {
-            ((MTLLayer)windowLayer).dispose();
-        } else {
-            ((CGLLayer)windowLayer).dispose();
-        }
+        windowLayer.dispose();
     }
 
     @Override
@@ -115,20 +107,12 @@ public class CPlatformEmbeddedFrame implements PlatformWindow {
 
     @Override
     public SurfaceData getScreenSurface() {
-        if ( CGraphicsDevice.usingMetalPipeline()) {
-            return ((MTLLayer)windowLayer).getSurfaceData();
-        } else {
-            return ((CGLLayer)windowLayer).getSurfaceData();
-        }
+        return windowLayer.getSurfaceData();
     }
 
     @Override
     public SurfaceData replaceSurfaceData() {
-        if (CGraphicsDevice.usingMetalPipeline()) {
-            return ((MTLLayer)windowLayer).replaceSurfaceData();
-        } else {
-            return ((CGLLayer)windowLayer).replaceSurfaceData();
-        }
+        return windowLayer.replaceSurfaceData();
     }
 
     @Override

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformView.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformView.java
@@ -41,6 +41,7 @@ import sun.lwawt.LWWindowPeer;
 
 import sun.java2d.SurfaceData;
 import sun.java2d.opengl.CGLLayer;
+import sun.lwawt.macosx.CFLayer;
 
 public class CPlatformView extends CFRetainedResource {
     private native long nativeCreateView(int x, int y, int width, int height, long windowLayerPtr);
@@ -51,7 +52,7 @@ public class CPlatformView extends CFRetainedResource {
 
     private LWWindowPeer peer;
     private SurfaceData surfaceData;
-    private CFRetainedResource windowLayer;
+    private CFLayer windowLayer;
     private CPlatformResponder responder;
 
     public CPlatformView() {
@@ -104,10 +105,7 @@ public class CPlatformView extends CFRetainedResource {
     // PAINTING METHODS
     // ----------------------------------------------------------------------
     public SurfaceData replaceSurfaceData() {
-        surfaceData = (CGraphicsDevice.usingMetalPipeline()) ?
-                    ((MTLLayer)windowLayer).replaceSurfaceData() :
-                    ((CGLLayer)windowLayer).replaceSurfaceData()
-        ;
+        surfaceData = windowLayer.replaceSurfaceData();
         return surfaceData;
     }
 
@@ -122,9 +120,7 @@ public class CPlatformView extends CFRetainedResource {
     }
 
     public long getWindowLayerPtr() {
-        return CGraphicsDevice.usingMetalPipeline() ?
-                ((MTLLayer)windowLayer).getPointer() :
-                ((CGLLayer)windowLayer).getPointer();
+        return windowLayer.getPointer();
     }
 
     public void setAutoResizable(boolean toResize) {


### PR DESCRIPTION
We have many if else conditions to select OpenGL/Metal pipeline objects.
Apart from initialization phase we should not fetch these objects everytime checking whether we are using OpenGL/Metal pipeline.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8226384](https://bugs.openjdk.java.net/browse/JDK-8226384): Implement a better logic to switch between OpenGL and Metal pipeline


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3851/head:pull/3851` \
`$ git checkout pull/3851`

Update a local copy of the PR: \
`$ git checkout pull/3851` \
`$ git pull https://git.openjdk.java.net/jdk pull/3851/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3851`

View PR using the GUI difftool: \
`$ git pr show -t 3851`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3851.diff">https://git.openjdk.java.net/jdk/pull/3851.diff</a>

</details>
