### PR TITLE
JDK-8266503: [ul] Make Decorations safely copy-able and reduce their size (first attempt, closed)

### DIFF
--- a/src/hotspot/share/logging/logDecorations.cpp
+++ b/src/hotspot/share/logging/logDecorations.cpp
@@ -57,10 +57,10 @@ void LogDecorations::create_decorations(const LogDecorators &decorators) {
   char* position = _decorations_buffer;
   #define DECORATOR(full_name, abbr) \
   if (decorators.is_decorator(LogDecorators::full_name##_decorator)) { \
-    _decoration_offset[LogDecorators::full_name##_decorator] = position; \
+    _decoration_offset[LogDecorators::full_name##_decorator] = (offset_t)(position - _decorations_buffer); \
     position = create_##full_name##_decoration(position) + 1; \
   } else { \
-    _decoration_offset[LogDecorators::full_name##_decorator] = NULL; \
+    _decoration_offset[LogDecorators::full_name##_decorator] = invalid_offset; \
   }
   DECORATOR_LIST
 #undef DECORATOR


### PR DESCRIPTION
In Universal Logging, class LogDecorations keeps resolved decorations as well as a lookup table of pointers to the start of each resolved decoration, by decorator. This is dangerous, since it makes object copy non-trivial (the pointers would need to be relocated). It is also wasteful since we spend 8 bytes per pointer per index.

Better would be to use a numerical index array of offset values, which could be safely copied. 

And since the resolve buffer is 256 char, we can easily make this index an 8-bit value, which reduces the size of a LogDecorations object down to 280 bytes (from 368). Size matters especially in the context of JDK-8229517.

The patch also adds a gtest, which tests that decorations are safely copy-able and that decorator resolution works as expected.

Testing:
- manually jtreg runtime/logging
- manually gtests
- Will run more tests tonight

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8266503](https://bugs.openjdk.java.net/browse/JDK-8266503): [ul] Make Decorations safely copy-able and reduce their size


### Reviewers
 * [Xin Liu](https://openjdk.java.net/census#xliu) (@navyxliu - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3855/head:pull/3855` \
`$ git checkout pull/3855`

Update a local copy of the PR: \
`$ git checkout pull/3855` \
`$ git pull https://git.openjdk.java.net/jdk pull/3855/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3855`

View PR using the GUI difftool: \
`$ git pr show -t 3855`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3855.diff">https://git.openjdk.java.net/jdk/pull/3855.diff</a>

</details>
