### PR TITLE
JDK-8266506: [aix] Treat mapping attempt too close to BRK as a mapping error

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1574,8 +1574,7 @@ static char* reserve_shmated_memory (size_t bytes, char* requested_addr) {
   // We must prevent anyone from attaching too close to the
   // BRK because that may cause malloc OOM.
   if (requested_addr != NULL && is_close_to_brk((address)requested_addr)) {
-    trcVerbose("Wish address " PTR_FORMAT " is too close to the BRK segment. "
-      "Will attach anywhere.", p2i(requested_addr));
+    trcVerbose("Wish address " PTR_FORMAT " is too close to the BRK segment.", p2i(requested_addr));
     // Since we treat an attach to the wrong address as an error later anyway,
     // we return NULL here
     return NULL;
@@ -1704,8 +1703,7 @@ static char* reserve_mmaped_memory(size_t bytes, char* requested_addr) {
   // We must prevent anyone from attaching too close to the
   // BRK because that may cause malloc OOM.
   if (requested_addr != NULL && is_close_to_brk((address)requested_addr)) {
-    trcVerbose("Wish address " PTR_FORMAT " is too close to the BRK segment. "
-      "Will attach anywhere.", p2i(requested_addr));
+    trcVerbose("Wish address " PTR_FORMAT " is too close to the BRK segment.", p2i(requested_addr));
     // Since we treat an attach to the wrong address as an error later anyway,
     // we return NULL here
     return NULL;

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1576,8 +1576,9 @@ static char* reserve_shmated_memory (size_t bytes, char* requested_addr) {
   if (requested_addr != NULL && is_close_to_brk((address)requested_addr)) {
     trcVerbose("Wish address " PTR_FORMAT " is too close to the BRK segment. "
       "Will attach anywhere.", p2i(requested_addr));
-    // Act like the OS refused to attach there.
-    requested_addr = NULL;
+    // Since we treat an attach to the wrong address as an error later anyway,
+    // we return NULL here
+    return NULL;
   }
 
   // For old AS/400's (V5R4 and older) we should not even be here - System V shared memory is not
@@ -1705,8 +1706,9 @@ static char* reserve_mmaped_memory(size_t bytes, char* requested_addr) {
   if (requested_addr != NULL && is_close_to_brk((address)requested_addr)) {
     trcVerbose("Wish address " PTR_FORMAT " is too close to the BRK segment. "
       "Will attach anywhere.", p2i(requested_addr));
-    // Act like the OS refused to attach there.
-    requested_addr = NULL;
+    // Since we treat an attach to the wrong address as an error later anyway,
+    // we return NULL here
+    return NULL;
   }
 
   // In 64K mode, we lie and claim the global page size (os::vm_page_size()) is 64K


### PR DESCRIPTION
On AIX, in os::attempt_reserve_memory_at(), if the user specified a wish address too close to the BRK segment, we silently ignore the wish address and just map anywhere.

This is not the right behavior since the normal behavior when failing to map to a wish address is to return NULL (see JDK-8266419). Therefore we should return NULL in these cases instead.

This is a day zero bug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266506](https://bugs.openjdk.java.net/browse/JDK-8266506): [aix] Treat mapping attempt too close to BRK as a mapping error


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to 6e65b6b582bddb520aef10fb2dbf07f5cbac13a1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3859/head:pull/3859` \
`$ git checkout pull/3859`

Update a local copy of the PR: \
`$ git checkout pull/3859` \
`$ git pull https://git.openjdk.java.net/jdk pull/3859/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3859`

View PR using the GUI difftool: \
`$ git pr show -t 3859`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3859.diff">https://git.openjdk.java.net/jdk/pull/3859.diff</a>

</details>
