### PR TITLE
8266498: Make debug ps() call print_stack

### DIFF
--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -600,14 +600,6 @@ extern "C" JNIEXPORT nmethod* findnm(intptr_t addr) {
   return  CodeCache::find_nmethod((address)addr);
 }
 
-// Another interface that isn't ambiguous in dbx.
-// Can we someday rename the other find to hsfind?
-extern "C" JNIEXPORT void hsfind(intptr_t x) {
-  Command c("hsfind");
-  os::print_location(tty, x, false);
-}
-
-
 extern "C" JNIEXPORT void find(intptr_t x) {
   Command c("find");
   os::print_location(tty, x, false);

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -501,12 +501,9 @@ extern "C" JNIEXPORT void ps() { // print stack
   if (p->has_last_Java_frame()) {
     // If the last_Java_fp is set we are in C land and
     // can call the standard stack_trace function.
-#ifdef PRODUCT
     p->print_stack();
-  } else {
-    tty->print_cr("Cannot find the last Java frame, printing stack disabled.");
-#else // !PRODUCT
-    p->trace_stack();
+#ifndef PRODUCT
+    if (Verbose) p->trace_stack();
   } else {
     frame f = os::current_frame();
     RegisterMap reg_map(p);
@@ -514,9 +511,8 @@ extern "C" JNIEXPORT void ps() { // print stack
     tty->print("(guessing starting frame id=" PTR_FORMAT " based on current fp)\n", p2i(f.id()));
     p->trace_stack_from(vframe::new_vframe(&f, &reg_map, p));
     f.pd_ps();
-#endif // PRODUCT
+#endif
   }
-
 }
 
 extern "C" JNIEXPORT void pfl() {


### PR DESCRIPTION
Fix ps() call print_stack.  Tested manually and with fastdebug and debug.  Also removed hsfind() because find() is the same thing and nobody's using dbx anymore (and the overload that made me add it might be long gone).
Tested with tier1 sanity.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266498](https://bugs.openjdk.java.net/browse/JDK-8266498): Make debug ps() call print_stack


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3861/head:pull/3861` \
`$ git checkout pull/3861`

Update a local copy of the PR: \
`$ git checkout pull/3861` \
`$ git pull https://git.openjdk.java.net/jdk pull/3861/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3861`

View PR using the GUI difftool: \
`$ git pr show -t 3861`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3861.diff">https://git.openjdk.java.net/jdk/pull/3861.diff</a>

</details>
