### PR TITLE
8266522: Shenandoah: Shenandoah LRB calls wrong runtime barrier on aarch64

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
@@ -281,7 +281,7 @@ void ShenandoahBarrierSetAssembler::load_reference_barrier(MacroAssembler* masm,
   } else {
     assert(is_phantom, "only remaining strength");
     assert(!is_narrow, "phantom access cannot be narrow");
-    __ mov(lr, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_weak));
+    __ mov(lr, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_phantom));
   }
   __ blr(lr);
   __ mov(rscratch1, r0);


### PR DESCRIPTION
Shsenandoah LRB calls ShenandoahRuntime::load_reference_barrier_weak() on phantom access, which is wrong.

Should call ShenandoahRuntime::load_reference_barrier_phantom() instead.

Test:
  - [x] hotspot_gc_shenandoah on Linux aarch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266522](https://bugs.openjdk.java.net/browse/JDK-8266522): Shenandoah: Shenandoah LRB calls wrong runtime barrier on aarch64


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3864/head:pull/3864` \
`$ git checkout pull/3864`

Update a local copy of the PR: \
`$ git checkout pull/3864` \
`$ git pull https://git.openjdk.java.net/jdk pull/3864/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3864`

View PR using the GUI difftool: \
`$ git pr show -t 3864`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3864.diff">https://git.openjdk.java.net/jdk/pull/3864.diff</a>

</details>
