### PR TITLE
8262952: [macos_aarch64] os::commit_memory failure

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1703,6 +1703,11 @@ static char* anon_mmap(char* requested_addr, size_t bytes, bool exec) {
   // MAP_FIXED is intentionally left out, to leave existing mappings intact.
   const int flags = MAP_PRIVATE | MAP_NORESERVE | MAP_ANONYMOUS
       MACOS_ONLY(| (exec ? MAP_JIT : 0));
+#if defined(__APPLE__)
+  // On macOS aarch64 MAP_JIT is required if we want to commit an executable chunk
+  // later, so always reserve executable memory right from the start
+  MACOS_AARCH64_ONLY(exec = true);
+#endif
 
   // Map reserved/uncommitted pages PROT_NONE so we fail early if we
   // touch an uncommitted page. Otherwise, the read/write might

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1700,14 +1700,13 @@ bool os::remove_stack_guard_pages(char* addr, size_t size) {
 // may not start from the requested address. Unlike Bsd mmap(), this
 // function returns NULL to indicate failure.
 static char* anon_mmap(char* requested_addr, size_t bytes, bool exec) {
-  // MAP_FIXED is intentionally left out, to leave existing mappings intact.
-  const int flags = MAP_PRIVATE | MAP_NORESERVE | MAP_ANONYMOUS
-      MACOS_ONLY(| (exec ? MAP_JIT : 0));
-#if defined(__APPLE__)
   // On macOS aarch64 MAP_JIT is required if we want to commit an executable chunk
   // later, so always reserve executable memory right from the start
   MACOS_AARCH64_ONLY(exec = true);
-#endif
+
+  // MAP_FIXED is intentionally left out, to leave existing mappings intact.
+  const int flags = MAP_PRIVATE | MAP_NORESERVE | MAP_ANONYMOUS
+      MACOS_ONLY(| (exec ? MAP_JIT : 0));
 
   // Map reserved/uncommitted pages PROT_NONE so we fail early if we
   // touch an uncommitted page. Otherwise, the read/write might

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1700,13 +1700,12 @@ bool os::remove_stack_guard_pages(char* addr, size_t size) {
 // may not start from the requested address. Unlike Bsd mmap(), this
 // function returns NULL to indicate failure.
 static char* anon_mmap(char* requested_addr, size_t bytes, bool exec) {
-  // On macOS aarch64 MAP_JIT is required if we want to commit an executable chunk
-  // later, so always reserve executable memory right from the start
-  MACOS_AARCH64_ONLY(exec = true);
-
   // MAP_FIXED is intentionally left out, to leave existing mappings intact.
   const int flags = MAP_PRIVATE | MAP_NORESERVE | MAP_ANONYMOUS
-      MACOS_ONLY(| (exec ? MAP_JIT : 0));
+      MACOS_ONLY(| (exec ? MAP_JIT : 0))
+      // On macOS aarch64 MAP_JIT is required if we want to commit an executable chunk
+      // later, so always reserve executable memory right from the start
+      MACOS_AARCH64_ONLY(| MAP_JIT);
 
   // Map reserved/uncommitted pages PROT_NONE so we fail early if we
   // touch an uncommitted page. Otherwise, the read/write might

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1702,10 +1702,7 @@ bool os::remove_stack_guard_pages(char* addr, size_t size) {
 static char* anon_mmap(char* requested_addr, size_t bytes, bool exec) {
   // MAP_FIXED is intentionally left out, to leave existing mappings intact.
   const int flags = MAP_PRIVATE | MAP_NORESERVE | MAP_ANONYMOUS
-      MACOS_ONLY(| (exec ? MAP_JIT : 0))
-      // On macOS aarch64 MAP_JIT is required if we want to commit an executable chunk
-      // later, so always reserve executable memory right from the start
-      MACOS_AARCH64_ONLY(| MAP_JIT);
+      MACOS_ONLY(| (exec ? MAP_JIT : 0));
 
   // Map reserved/uncommitted pages PROT_NONE so we fail early if we
   // touch an uncommitted page. Otherwise, the read/write might

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -368,7 +368,7 @@ static address reserve_multiple(int num_stripes, size_t stripe_len) {
   // ... re-reserve in the same spot multiple areas...
   for (int stripe = 0; stripe < num_stripes; stripe++) {
     address q = p + (stripe * stripe_len);
-    q = (address)os::attempt_reserve_memory_at((char*)q, stripe_len);
+    q = (address)os::attempt_reserve_memory_at((char*)q, stripe_len, true);
     EXPECT_NE(q, (address)NULL);
     // Commit, alternatingly with or without exec permission,
     //  to prevent kernel from folding these mappings.

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -412,11 +412,7 @@ struct NUMASwitcher {
 #endif
 
 #ifndef _AIX // JDK-8257041
-#if defined(__APPLE__) && defined(AARCH64)
-TEST_VM(os, DISABLED_release_multi_mappings) {
-#else
 TEST_VM(os, release_multi_mappings) {
-#endif
   // Test that we can release an area created with multiple reservation calls
   const size_t stripe_len = 4 * M;
   const int num_stripes = 4;

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -368,11 +368,11 @@ static address reserve_multiple(int num_stripes, size_t stripe_len) {
   // ... re-reserve in the same spot multiple areas...
   for (int stripe = 0; stripe < num_stripes; stripe++) {
     address q = p + (stripe * stripe_len);
-    q = (address)os::attempt_reserve_memory_at((char*)q, stripe_len, true);
-    EXPECT_NE(q, (address)NULL);
     // Commit, alternatingly with or without exec permission,
     //  to prevent kernel from folding these mappings.
     const bool executable = stripe % 2 == 0;
+    q = (address)os::attempt_reserve_memory_at((char*)q, stripe_len, executable);
+    EXPECT_NE(q, (address)NULL);
     EXPECT_TRUE(os::commit_memory((char*)q, stripe_len, executable));
   }
   return p;


### PR DESCRIPTION
On x86_64 macOS the following sequence works just fine:

attempt_reserve_memory_at(executable=false)
commit_memory(executable=true)

however, on aarch64 macOS it fails.

We fix the test itself to explicitly ask for executable memory when reserving it since it later commits it as executable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262952](https://bugs.openjdk.java.net/browse/JDK-8262952): [macos_aarch64] os::commit_memory failure


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to ad3467b4e466e0ba86529993ac1baeb402aa879d
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3865/head:pull/3865` \
`$ git checkout pull/3865`

Update a local copy of the PR: \
`$ git checkout pull/3865` \
`$ git pull https://git.openjdk.java.net/jdk pull/3865/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3865`

View PR using the GUI difftool: \
`$ git pr show -t 3865`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3865.diff">https://git.openjdk.java.net/jdk/pull/3865.diff</a>

</details>
