### PR TITLE
JDK-8266527 RandomTestCoverage.java failing due to API removal

### DIFF
--- a/test/jdk/java/util/Random/RandomTestCoverage.java
+++ b/test/jdk/java/util/Random/RandomTestCoverage.java
@@ -187,25 +187,30 @@ public class RandomTestCoverage {
                     coverFactory(factory);
                     coverOf(factory.name());
                  });
-        RandomGeneratorFactory.all(StreamableGenerator.class)
+        RandomGeneratorFactory.all()
+                .filter(f -> f.isStreamable())
                 .forEach(factory -> {
-                    coverStreamable(factory.create());
+                    coverStreamable((StreamableGenerator)factory.create());
                 });
-        RandomGeneratorFactory.all(SplittableGenerator.class)
+        RandomGeneratorFactory.all()
+                .filter(f -> f.isSplittable())
                 .forEach(factory -> {
-                    coverSplittable(factory.create());
+                    coverSplittable((SplittableGenerator)factory.create());
                 });
-        RandomGeneratorFactory.all(JumpableGenerator.class)
+        RandomGeneratorFactory.all()
+                .filter(f -> f.isJumpable())
                 .forEach(factory -> {
-                    coverJumpable(factory.create());
+                    coverJumpable((JumpableGenerator)factory.create());
                 });
-        RandomGeneratorFactory.all(LeapableGenerator.class)
+        RandomGeneratorFactory.all()
+                .filter(f -> f.isLeapable())
                 .forEach(factory -> {
-                    coverLeapable(factory.create());
+                    coverLeapable((LeapableGenerator)factory.create());
                 });
-        RandomGeneratorFactory.all(ArbitrarilyJumpableGenerator.class)
+        RandomGeneratorFactory.all()
+                .filter(f -> f.isArbitrarilyJumpable())
                 .forEach(factory -> {
-                    coverArbitrarilyJumpable(factory.create());
+                    coverArbitrarilyJumpable((ArbitrarilyJumpableGenerator)factory.create());
                 });
 
         coverRandomGenerator(new SecureRandom());


### PR DESCRIPTION
RandomTestCoverage.java was overlooked when doing local test. Apologies.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266527](https://bugs.openjdk.java.net/browse/JDK-8266527): RandomTestCoverage.java failing due to API removal


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3867/head:pull/3867` \
`$ git checkout pull/3867`

Update a local copy of the PR: \
`$ git checkout pull/3867` \
`$ git pull https://git.openjdk.java.net/jdk pull/3867/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3867`

View PR using the GUI difftool: \
`$ git pr show -t 3867`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3867.diff">https://git.openjdk.java.net/jdk/pull/3867.diff</a>

</details>
