### PR TITLE
8265528: Specification of BasicSplitPaneDivider::getMinimumSize,getPreferredSize doesn't match with its behavior.

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
@@ -299,7 +299,7 @@ public class BasicSplitPaneDivider extends Container
     }
 
     /**
-     * Returns the preferrred {@code Dimension} of the divider.
+     * Returns the preferred size of the divider.
      * @implSpec In current implementation,
      * if the splitpane is HORIZONTAL_SPLIT, the preferred size is obtained from
      * width of {@code getDividerSize} pixels and height of 1 pixel
@@ -321,7 +321,7 @@ public class BasicSplitPaneDivider extends Container
     }
 
     /**
-     * Returns the minimum {@code Dimension} of the divider.
+     * Returns the minimum size of the divider.
      * @implSpec In current implementation,
      * if the splitpane is HORIZONTAL_SPLIT, the minimum size is obtained from
      * width of {@code getDividerSize} pixels and height of 1 pixel

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
@@ -300,7 +300,7 @@ public class BasicSplitPaneDivider extends Container
 
     /**
      * Returns the preferred size of the divider.
-     * @implSpec In current implementation,
+     * @implNote In current implementation,
      * if the splitpane is HORIZONTAL_SPLIT, the preferred size is obtained from
      * width of {@code getDividerSize} pixels and height of 1 pixel
      * If the splitpane is VERTICAL_SPLIT, the preferred size is obtained from
@@ -322,7 +322,7 @@ public class BasicSplitPaneDivider extends Container
 
     /**
      * Returns the minimum size of the divider.
-     * @implSpec In current implementation,
+     * @implNote In current implementation,
      * if the splitpane is HORIZONTAL_SPLIT, the minimum size is obtained from
      * width of {@code getDividerSize} pixels and height of 1 pixel
      * If the splitpane is VERTICAL_SPLIT, the minimum size is obtained from

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
@@ -300,7 +300,8 @@ public class BasicSplitPaneDivider extends Container
 
     /**
      * Returns the preferrred {@code Dimension} of the divider.
-     * If the splitpane is HORIZONTAL_SPLIT, the preferred size is obtained from
+     * @implSpec In current implementation,
+     * if the splitpane is HORIZONTAL_SPLIT, the preferred size is obtained from
      * width of {@code getDividerSize} pixels and height of 1 pixel
      * If the splitpane is VERTICAL_SPLIT, the preferred size is obtained from
      * height of {@code getDividerSize} pixels and width of 1 pixel
@@ -321,7 +322,8 @@ public class BasicSplitPaneDivider extends Container
 
     /**
      * Returns the minimum {@code Dimension} of the divider.
-     * If the splitpane is HORIZONTAL_SPLIT, the minimum size is obtained from
+     * @implSpec In current implementation,
+     * if the splitpane is HORIZONTAL_SPLIT, the minimum size is obtained from
      * width of {@code getDividerSize} pixels and height of 1 pixel
      * If the splitpane is VERTICAL_SPLIT, the minimum size is obtained from
      * height of {@code getDividerSize} pixels and width of 1 pixel

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -299,7 +299,14 @@ public class BasicSplitPaneDivider extends Container
     }
 
     /**
-     * Returns dividerSize x dividerSize
+     * Returns the preferrred {@code Dimension} of the divider.
+     * If the splitpane is HORIZONTAL_SPLIT, the preferred size is obtained from
+     * width of {@code getDividerSize} pixels and height of 1 pixel
+     * If the splitpane is VERTICAL_SPLIT, the preferred size is obtained from
+     * height of {@code getDividerSize} pixels and width of 1 pixel
+     *
+     * @return a {@code Dimension} object containing the preferred size of
+     *         {@code BasicSplitPaneDivider}
      */
     public Dimension getPreferredSize() {
         // Ideally this would return the size from the layout manager,
@@ -313,7 +320,14 @@ public class BasicSplitPaneDivider extends Container
     }
 
     /**
-     * Returns dividerSize x dividerSize
+     * Returns the minimum {@code Dimension} of the divider.
+     * If the splitpane is HORIZONTAL_SPLIT, the minimum size is obtained from
+     * width of {@code getDividerSize} pixels and height of 1 pixel
+     * If the splitpane is VERTICAL_SPLIT, the minimum size is obtained from
+     * height of {@code getDividerSize} pixels and width of 1 pixel
+     *
+     * @return a {@code Dimension} object containing the minimum size of
+     *         {@code BasicSplitPaneDivider}
      */
     public Dimension getMinimumSize() {
         return getPreferredSize();


### PR DESCRIPTION
The current specification of these 2 methods
api/java.desktop/javax/swing/plaf/basic/BasicSplitPaneDivider.html#getPreferredSize().
and
api/java.desktop/javax/swing/plaf/basic/BasicSplitPaneDivider.html#getMinimumSize()
does not specify correct return values. Also, the spec is not very intuitive and clear.

Rectified the spec to specify correct behaviour.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265528](https://bugs.openjdk.java.net/browse/JDK-8265528): Specification of BasicSplitPaneDivider::getMinimumSize,getPreferredSize doesn't match with its behavior.


### Reviewers
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**) ⚠️ Review applies to 5e816095b58a6c87f82791f33863a158b61476c8


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3870/head:pull/3870` \
`$ git checkout pull/3870`

Update a local copy of the PR: \
`$ git checkout pull/3870` \
`$ git pull https://git.openjdk.java.net/jdk pull/3870/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3870`

View PR using the GUI difftool: \
`$ git pr show -t 3870`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3870.diff">https://git.openjdk.java.net/jdk/pull/3870.diff</a>

</details>
