### PR TITLE
8266528: Optimize C2 VerifyIterativeGVN execution time

### DIFF
--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1161,6 +1161,10 @@ public:
 #ifndef PRODUCT
  private:
   int _indent;
+  // used in VerifyIterativeGVN, indicate if Node is processed in this iteration.
+  jint _igvn_verify_depth_cur;
+  jint _igvn_verify_depth_prev;
+  julong _igvn_verify_epoch;
 
  public:
   void set_indent(int indent) { _indent = indent; }
@@ -1201,7 +1205,7 @@ public:
   void collect_nodes_out_all_ctrl_boundary(GrowableArray<Node*> *ns) const;
 
   void verify_edges(Unique_Node_List &visited); // Verify bi-directional edges
-  static void verify(Node* n, int verify_depth);
+  static void verify(Node* n, jint verify_depth, julong verify_epoch);
 
   // This call defines a class-unique string used to identify class instances
   virtual const char *Name() const;

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -555,6 +555,7 @@ protected:
   // Sub-quadratic implementation of VerifyIterativeGVN.
   julong _verify_counter;
   julong _verify_full_passes;
+  julong _verify_epoch;
   enum { _verify_window_size = 30 };
   Node* _verify_window[_verify_window_size];
   void verify_step(Node* n);


### PR DESCRIPTION
Optimization for VerifyIterativeGVN, motiviation is running with -XX:+VerifyIterativeGVN is extremly slow.

In simple test "-Xcomp -XX:+VerifyIterativeGVN -XX:-TieredCompilation -version", time reduced from 8.67s to 2.4s.
In extreme case hotspot/test/jtreg/compiler/escapeAnalysis/Test6689060.java, time reduced from 20000s to 92s.
Detail data in JBS description.

Optimizations includes:
1. Optimize redundant verfications in PhaseIterGVN::verify_step. Nodes might verified multiple times.
    Redundant verifications between full pass and _verify_window single node process.
    Redundant verifications between different nodes in _verify_window

2. Optimize def-use edge checking: 
    Skip multiple checks for same x->n input edges.
    Skip redundant check in inner loop when counting how many x in n's input edges, skip current index.

3. Optimize field access
    Replace "n->in(j)" with "n->_in[j]", skipping unuseful assert when invoking Node::in(int index).

Optimization#2/#3 decrease execution time and no other overhead. 
optimization#1 adds 3 fields in class Node in debug build,  they can be squeezed into an "int/long" if needed.
```
  jint _igvn_verify_depth_cur;
  jint _igvn_verify_depth_prev;
  julong _igvn_verify_epoch;
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8266528](https://bugs.openjdk.java.net/browse/JDK-8266528): Optimize C2 VerifyIterativeGVN execution time


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3872/head:pull/3872` \
`$ git checkout pull/3872`

Update a local copy of the PR: \
`$ git checkout pull/3872` \
`$ git pull https://git.openjdk.java.net/jdk pull/3872/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3872`

View PR using the GUI difftool: \
`$ git pr show -t 3872`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3872.diff">https://git.openjdk.java.net/jdk/pull/3872.diff</a>

</details>
