### PR TITLE
8266545: 8261169 broke Harfbuzz build with gcc 7 and 8

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -465,7 +465,7 @@ else
 
    HARFBUZZ_DISABLED_WARNINGS_gcc := type-limits missing-field-initializers strict-aliasing
    HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := reorder delete-non-virtual-dtor strict-overflow \
-        maybe-uninitialized class-memaccess unused-result
+        maybe-uninitialized class-memaccess unused-result extra
    HARFBUZZ_DISABLED_WARNINGS_clang := unused-value incompatible-pointer-types \
         tautological-constant-out-of-range-compare int-to-pointer-cast \
         undef missing-field-initializers range-loop-analysis \

--- a/src/java.desktop/share/native/libharfbuzz/hb-ot-shape-complex-use-machine.hh
+++ b/src/java.desktop/share/native/libharfbuzz/hb-ot-shape-complex-use-machine.hh
@@ -375,7 +375,7 @@ hb_iter_with_fallback_t<machine_index_t<Iter>,
 typename Iter::item_t>
 {
         machine_index_t (const Iter& it) : it (it) {}
-        machine_index_t (const machine_index_t& o) : hb_iter_with_fallback_t<machine_index_t<Iter>, typename Iter::item_t>(o), it (o.it) {}
+        machine_index_t (const machine_index_t& o) : it (o.it) {}
 
         static constexpr bool is_random_access_iterator = Iter::is_random_access_iterator;
         static constexpr bool is_sorted_iterator = Iter::is_sorted_iterator;

--- a/src/java.desktop/share/native/libharfbuzz/hb-ot-shape-complex-use-machine.hh
+++ b/src/java.desktop/share/native/libharfbuzz/hb-ot-shape-complex-use-machine.hh
@@ -375,7 +375,7 @@ hb_iter_with_fallback_t<machine_index_t<Iter>,
 typename Iter::item_t>
 {
         machine_index_t (const Iter& it) : it (it) {}
-        machine_index_t (const machine_index_t& o) : it (o.it) {}
+        machine_index_t (const machine_index_t& o) : hb_iter_with_fallback_t<machine_index_t<Iter>, typename Iter::item_t>(o), it (o.it) {}
 
         static constexpr bool is_random_access_iterator = Iter::is_random_access_iterator;
         static constexpr bool is_sorted_iterator = Iter::is_sorted_iterator;


### PR DESCRIPTION
Harfbuzz upgrade broke Linux x64 build on older gccs. For details see JBS issue.

I fixed the issue in the harfbuzz sources, but I am not sure of the policy here. Do we modify the harfbuzz sources or leave them untouched? Advice is welcome.

The patch fixes linux x64 fastdebug and opt build for me.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266545](https://bugs.openjdk.java.net/browse/JDK-8266545): 8261169 broke Harfbuzz build with gcc 7 and 8


### Reviewers
 * [Matthias Baesken](https://openjdk.java.net/census#mbaesken) (@MBaesken - **Reviewer**) ⚠️ Review applies to dd0f4d295f4a1f0f1e9263909e838dc7fd5009d5
 * [Richard Reingruber](https://openjdk.java.net/census#rrich) (@reinrich - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3873/head:pull/3873` \
`$ git checkout pull/3873`

Update a local copy of the PR: \
`$ git checkout pull/3873` \
`$ git pull https://git.openjdk.java.net/jdk pull/3873/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3873`

View PR using the GUI difftool: \
`$ git pr show -t 3873`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3873.diff">https://git.openjdk.java.net/jdk/pull/3873.diff</a>

</details>
