### PR TITLE
8266349: Pass down requested page size to reserve_memory_special

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -2126,7 +2126,7 @@ void os::large_page_init() {
   return; // Nothing to do. See query_multipage_support and friends.
 }
 
-char* os::pd_reserve_memory_special(size_t bytes, size_t alignment, char* req_addr, bool exec) {
+char* os::pd_reserve_memory_special(size_t bytes, size_t alignment, size_t page_size, char* req_addr, bool exec) {
   fatal("os::reserve_memory_special should not be called on AIX.");
   return NULL;
 }

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1776,7 +1776,7 @@ void os::large_page_init() {
 }
 
 
-char* os::pd_reserve_memory_special(size_t bytes, size_t alignment, char* req_addr, bool exec) {
+char* os::pd_reserve_memory_special(size_t bytes, size_t alignment, size_t page_size, char* req_addr, bool exec) {
   fatal("os::reserve_memory_special should not be called on BSD.");
   return NULL;
 }

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3964,7 +3964,7 @@ char* os::Linux::reserve_memory_special_huge_tlbfs(size_t bytes,
   assert(is_aligned(req_addr, alignment), "Must be");
   assert(is_aligned(req_addr, page_size), "Must be");
   assert(is_aligned(alignment, os::vm_allocation_granularity()), "Must be");
-  assert(is_power_of_2(page_size), "Must be");
+  assert(_page_sizes.contains(page_size), "Must be a valid page size");
   assert(bytes >= page_size, "Shouldn't allocate large pages for small sizes");
 
   // We only end up here when at least 1 large page can be used.

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3957,14 +3957,15 @@ bool os::Linux::commit_memory_special(size_t bytes,
 
 char* os::Linux::reserve_memory_special_huge_tlbfs(size_t bytes,
                                                    size_t alignment,
+                                                   size_t page_size,
                                                    char* req_addr,
                                                    bool exec) {
   assert(UseLargePages && UseHugeTLBFS, "only for Huge TLBFS large pages");
   assert(is_aligned(req_addr, alignment), "Must be");
-  assert(is_aligned(req_addr, os::large_page_size()), "Must be");
+  assert(is_aligned(req_addr, page_size), "Must be");
   assert(is_aligned(alignment, os::vm_allocation_granularity()), "Must be");
-  assert(is_power_of_2(os::large_page_size()), "Must be");
-  assert(bytes >= os::large_page_size(), "Shouldn't allocate large pages for small sizes");
+  assert(is_power_of_2(page_size), "Must be");
+  assert(bytes >= page_size, "Shouldn't allocate large pages for small sizes");
 
   // We only end up here when at least 1 large page can be used.
   // If the size is not a multiple of the large page size, we
@@ -3974,15 +3975,15 @@ char* os::Linux::reserve_memory_special_huge_tlbfs(size_t bytes,
   // a requested address is given it will be used and it must be
   // aligned to both the large page size and the given alignment.
   // The larger of the two will be used.
-  size_t required_alignment = MAX(os::large_page_size(), alignment);
+  size_t required_alignment = MAX(page_size, alignment);
   char* const aligned_start = anon_mmap_aligned(req_addr, bytes, required_alignment);
   if (aligned_start == NULL) {
     return NULL;
   }
 
   // First commit using large pages.
-  size_t large_bytes = align_down(bytes, os::large_page_size());
-  bool large_committed = commit_memory_special(large_bytes, os::large_page_size(), aligned_start, exec);
+  size_t large_bytes = align_down(bytes, page_size);
+  bool large_committed = commit_memory_special(large_bytes, page_size, aligned_start, exec);
 
   if (large_committed && bytes == large_bytes) {
     // The size was large page aligned so no additional work is
@@ -4011,16 +4012,17 @@ char* os::Linux::reserve_memory_special_huge_tlbfs(size_t bytes,
   return aligned_start;
 }
 
-char* os::pd_reserve_memory_special(size_t bytes, size_t alignment,
+char* os::pd_reserve_memory_special(size_t bytes, size_t alignment, size_t page_size,
                                     char* req_addr, bool exec) {
   assert(UseLargePages, "only for large pages");
 
   char* addr;
   if (UseSHM) {
+    // No support for using specific page sizes with SHM.
     addr = os::Linux::reserve_memory_special_shm(bytes, alignment, req_addr, exec);
   } else {
     assert(UseHugeTLBFS, "must be");
-    addr = os::Linux::reserve_memory_special_huge_tlbfs(bytes, alignment, req_addr, exec);
+    addr = os::Linux::reserve_memory_special_huge_tlbfs(bytes, alignment, page_size, req_addr, exec);
   }
 
   if (addr != NULL) {

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -90,7 +90,7 @@ class Linux {
   static int hugetlbfs_page_size_flag(size_t page_size);
 
   static char* reserve_memory_special_shm(size_t bytes, size_t alignment, char* req_addr, bool exec);
-  static char* reserve_memory_special_huge_tlbfs(size_t bytes, size_t alignment, char* req_addr, bool exec);
+  static char* reserve_memory_special_huge_tlbfs(size_t bytes, size_t alignment, size_t page_size, char* req_addr, bool exec);
   static bool commit_memory_special(size_t bytes, size_t page_size, char* req_addr, bool exec);
 
   static bool release_memory_special_impl(char* base, size_t bytes);

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3274,11 +3274,12 @@ bool os::can_execute_large_page_memory() {
   return true;
 }
 
-char* os::pd_reserve_memory_special(size_t bytes, size_t alignment, char* addr,
+char* os::pd_reserve_memory_special(size_t bytes, size_t alignment, size_t page_size, char* addr,
                                     bool exec) {
   assert(UseLargePages, "only for large pages");
+  assert(page_size == os::large_page_size(), "Currently only support one large page size on Windows");
 
-  if (!is_aligned(bytes, os::large_page_size()) || alignment > os::large_page_size()) {
+  if (!is_aligned(bytes, page_size) || alignment > page_size) {
     return NULL; // Fallback to small pages.
   }
 

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -169,14 +169,14 @@ static char* reserve_memory(char* requested_address, const size_t size,
 }
 
 static char* reserve_memory_special(char* requested_address, const size_t size,
-                                    const size_t alignment,  bool exec) {
+                                    const size_t alignment, const size_t page_size, bool exec) {
 
   log_trace(pagesize)("Attempt special mapping: size: " SIZE_FORMAT "%s, "
                       "alignment: " SIZE_FORMAT "%s",
                       byte_size_in_exact_unit(size), exact_unit_for_byte_size(size),
                       byte_size_in_exact_unit(alignment), exact_unit_for_byte_size(alignment));
 
-  char* base = os::reserve_memory_special(size, alignment, requested_address, exec);
+  char* base = os::reserve_memory_special(size, alignment, page_size, requested_address, exec);
   if (base != NULL) {
     // Check alignment constraints.
     assert(is_aligned(base, alignment),
@@ -236,7 +236,7 @@ void ReservedSpace::reserve(size_t size,
     // explicit large pages and these have to be committed up front to ensure
     // no reservations are lost.
 
-    char* base = reserve_memory_special(requested_address, size, alignment, executable);
+    char* base = reserve_memory_special(requested_address, size, alignment, page_size, executable);
     if (base != NULL) {
       // Successful reservation using large pages.
       initialize_members(base, size, alignment, page_size, true, executable);

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1888,12 +1888,12 @@ void os::realign_memory(char *addr, size_t bytes, size_t alignment_hint) {
   pd_realign_memory(addr, bytes, alignment_hint);
 }
 
-char* os::reserve_memory_special(size_t size, size_t alignment,
+char* os::reserve_memory_special(size_t size, size_t alignment, size_t page_size,
                                  char* addr, bool executable) {
 
   assert(is_aligned(addr, alignment), "Unaligned request address");
 
-  char* result = pd_reserve_memory_special(size, alignment, addr, executable);
+  char* result = pd_reserve_memory_special(size, alignment, page_size, addr, executable);
   if (result != NULL) {
     // The memory is committed
     MemTracker::record_virtual_memory_reserve_and_commit((address)result, size, CALLER_PC);

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -159,7 +159,8 @@ class os: AllStatic {
   static void   pd_free_memory(char *addr, size_t bytes, size_t alignment_hint);
   static void   pd_realign_memory(char *addr, size_t bytes, size_t alignment_hint);
 
-  static char*  pd_reserve_memory_special(size_t size, size_t alignment,
+  static char*  pd_reserve_memory_special(size_t size, size_t alignment, size_t page_size,
+
                                           char* addr, bool executable);
   static bool   pd_release_memory_special(char* addr, size_t bytes);
 
@@ -418,7 +419,7 @@ class os: AllStatic {
 
   static char*  non_memory_address_word();
   // reserve, commit and pin the entire memory region
-  static char*  reserve_memory_special(size_t size, size_t alignment,
+  static char*  reserve_memory_special(size_t size, size_t alignment, size_t page_size,
                                        char* addr, bool executable);
   static bool   release_memory_special(char* addr, size_t bytes);
   static void   large_page_init();

--- a/test/hotspot/gtest/runtime/test_os_windows.cpp
+++ b/test/hotspot/gtest/runtime/test_os_windows.cpp
@@ -64,7 +64,7 @@ void TestReserveMemorySpecial_test() {
   FLAG_SET_CMDLINE(UseNUMAInterleaving, false);
 
   const size_t large_allocation_size = os::large_page_size() * 4;
-  char* result = os::reserve_memory_special(large_allocation_size, os::large_page_size(), NULL, false);
+  char* result = os::reserve_memory_special(large_allocation_size, os::large_page_size(), os::large_page_size(), NULL, false);
   if (result != NULL) {
       // failed to allocate memory, skipping the test
       return;
@@ -75,7 +75,7 @@ void TestReserveMemorySpecial_test() {
   // we managed to get it once.
   const size_t expected_allocation_size = os::large_page_size();
   char* expected_location = result + os::large_page_size();
-  char* actual_location = os::reserve_memory_special(expected_allocation_size, os::large_page_size(), expected_location, false);
+  char* actual_location = os::reserve_memory_special(expected_allocation_size, os::large_page_size(), os::large_page_size(), expected_location, false);
   if (actual_location != NULL) {
       // failed to allocate memory, skipping the test
       return;


### PR DESCRIPTION
Please review this enhancement that passes the requested page size in `ReservedSpace` down to the OS-layer.

**Summary**
After recent refactoring `ReservedSpace` now store the page size used for a reservation. To make this more consistent this change passes down the page size from the `ReservedSpace` down to the OS-layer when using explicit large pages. Currently this is not really needed because we only support one large page size during the lifetime of the JVM, but this will change with PR #1153. That PR will be simpler to implement if the requested page size is passed down from the layers above. 

**Testing**
Local testing together with parts of PR #1153. Mach5 tier 1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266349](https://bugs.openjdk.java.net/browse/JDK-8266349): Pass down requested page size to reserve_memory_special


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to fc36939e96db796060ac662ed696c410c623238a
 * [Marcus G K Williams](https://openjdk.java.net/census#mgkwill) (@mgkwill - Author) ⚠️ Review applies to fc36939e96db796060ac662ed696c410c623238a


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3878/head:pull/3878` \
`$ git checkout pull/3878`

Update a local copy of the PR: \
`$ git checkout pull/3878` \
`$ git pull https://git.openjdk.java.net/jdk pull/3878/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3878`

View PR using the GUI difftool: \
`$ git pr show -t 3878`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3878.diff">https://git.openjdk.java.net/jdk/pull/3878.diff</a>

</details>
