### PR TITLE
8266496: WBIsKlassAliveClosure.do_klass() fails for hidden classes

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -180,6 +180,25 @@ public:
       Symbol* ksym = k->name();
       if (ksym->fast_compare(_name) == 0) {
         _count++;
+      } else if (k->is_instance_klass()) {
+        // Need special handling for hidden classes because the JVM
+        // appends "+<hex-address>" to hidden class names.
+        InstanceKlass *ik = InstanceKlass::cast(k);
+        if (ik->is_hidden()) {
+          ResourceMark rm;
+          char* k_name = ksym->as_C_string();
+          // Find the first '+' char and truncate the string at that point.
+          // NOTE: This will not work correctly if the original hidden class
+          // name contains a '+'.
+          char* plus_char = strchr(k_name, '+');
+          if (plus_char != NULL) {
+            *plus_char = 0;
+            char* c_name = _name->as_C_string();
+            if (strcmp(c_name, k_name) == 0) {
+              _count++;
+            }
+          }
+        }
       }
     }
 

--- a/test/hotspot/jtreg/runtime/whitebox/TestHiddenClassIsAlive.java
+++ b/test/hotspot/jtreg/runtime/whitebox/TestHiddenClassIsAlive.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8266496
+ * @summary Test that Whitebox.isClassAlive() works with hidden classes.
+ * @modules java.base/jdk.internal.misc java.base/jdk.internal.org.objectweb.asm
+ * @library /test/lib
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI TestHiddenClassIsAlive
+ */
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.invoke.MethodType;
+import jdk.internal.org.objectweb.asm.*;
+import static jdk.internal.org.objectweb.asm.Opcodes.*;
+
+import sun.hotspot.WhiteBox;
+
+public class TestHiddenClassIsAlive {
+
+    static final String CLASS_NAME = "MyClass";
+
+    public static void main(String[] args) throws Throwable {
+        byte[] classBytes = dumpClass();
+        Lookup lookup = MethodHandles.lookup();
+        Class<?> c = lookup.defineHiddenClass(classBytes, true).lookupClass();
+        if (!WhiteBox.getWhiteBox().isClassAlive(CLASS_NAME)) {
+            throw new RuntimeException("Hidden class should be alive");
+        }
+    }
+
+    /*
+     * Constructs bytecode for the following class:
+     * public class MyClass {
+     *     MyClass() {}
+     *     public Object get(int i) { return null; }
+     * }
+     */
+    public static byte[] dumpClass() {
+        ClassWriter cw = new ClassWriter(0);
+        MethodVisitor mv;
+
+        cw.visit(52, ACC_SUPER | ACC_PUBLIC, CLASS_NAME, null, "java/lang/Object", null);
+        {
+            mv = cw.visitMethod(0, "<init>", "()V", null, null);
+            mv.visitCode();
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+            mv.visitInsn(RETURN);
+            mv.visitMaxs(1, 1);
+            mv.visitEnd();
+        }
+        {
+            mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "get", "(I)Ljava/lang/Object;", null, null);
+            mv.visitCode();
+            mv.visitInsn(ACONST_NULL);
+            mv.visitInsn(ARETURN);
+            mv.visitMaxs(1, 1);
+            mv.visitEnd();
+        }
+        cw.visitEnd();
+        return cw.toByteArray();
+    }
+}

--- a/test/hotspot/jtreg/runtime/whitebox/TestHiddenClassIsAlive.java
+++ b/test/hotspot/jtreg/runtime/whitebox/TestHiddenClassIsAlive.java
@@ -21,68 +21,53 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
  * @bug 8266496
  * @summary Test that Whitebox.isClassAlive() works with hidden classes.
- * @modules java.base/jdk.internal.misc java.base/jdk.internal.org.objectweb.asm
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI TestHiddenClassIsAlive
  */
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.invoke.MethodType;
-import jdk.internal.org.objectweb.asm.*;
-import static jdk.internal.org.objectweb.asm.Opcodes.*;
 
 import sun.hotspot.WhiteBox;
 
+final class MyClass {
+    MyClass() {}
+    public Object get(int i) { return null; }
+}
+
 public class TestHiddenClassIsAlive {
 
-    static final String CLASS_NAME = "MyClass";
 
     public static void main(String[] args) throws Throwable {
-        byte[] classBytes = dumpClass();
+        byte[] classBytes = readClassFile("MyClass.class");
         Lookup lookup = MethodHandles.lookup();
         Class<?> c = lookup.defineHiddenClass(classBytes, true).lookupClass();
-        if (!WhiteBox.getWhiteBox().isClassAlive(CLASS_NAME)) {
+        if (!WhiteBox.getWhiteBox().isClassAlive("MyClass")) {
             throw new RuntimeException("Hidden class should be alive");
         }
     }
 
-    /*
-     * Constructs bytecode for the following class:
-     * public class MyClass {
-     *     MyClass() {}
-     *     public Object get(int i) { return null; }
-     * }
-     */
-    public static byte[] dumpClass() {
-        ClassWriter cw = new ClassWriter(0);
-        MethodVisitor mv;
-
-        cw.visit(52, ACC_SUPER | ACC_PUBLIC, CLASS_NAME, null, "java/lang/Object", null);
+    static byte[] readClassFile(String classFileName) throws Exception {
+        File classFile = new File(System.getProperty("test.classes") + File.separator + classFileName);
+        try (FileInputStream in = new FileInputStream(classFile);
+             ByteArrayOutputStream out = new ByteArrayOutputStream())
         {
-            mv = cw.visitMethod(0, "<init>", "()V", null, null);
-            mv.visitCode();
-            mv.visitVarInsn(ALOAD, 0);
-            mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
-            mv.visitInsn(RETURN);
-            mv.visitMaxs(1, 1);
-            mv.visitEnd();
+            int b;
+            while ((b = in.read()) != -1) {
+                out.write(b);
+            }
+            return out.toByteArray();
         }
-        {
-            mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "get", "(I)Ljava/lang/Object;", null, null);
-            mv.visitCode();
-            mv.visitInsn(ACONST_NULL);
-            mv.visitInsn(ARETURN);
-            mv.visitMaxs(1, 1);
-            mv.visitEnd();
-        }
-        cw.visitEnd();
-        return cw.toByteArray();
     }
 }


### PR DESCRIPTION
Please review this small fix for JDK-8266496.  The fix changes WBIsKlassAliveClosure.do_klass() so that when it compares the specified name with the name of a hidden class, it truncates the hidden class's name at the first '+' character before doing the comparison.  This should work except in the rare case when the pre-mangled hidden class name contains a '+' character.

The fix was tested with Mach5 tiers 1 and 2 on Linux, Mac OS, and Windows, and tiers 3-5 on Linux x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266496](https://bugs.openjdk.java.net/browse/JDK-8266496): WBIsKlassAliveClosure.do_klass() fails for hidden classes


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to c5e96925bc96e89837bc57a6fb592eceec549183
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3882/head:pull/3882` \
`$ git checkout pull/3882`

Update a local copy of the PR: \
`$ git checkout pull/3882` \
`$ git pull https://git.openjdk.java.net/jdk pull/3882/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3882`

View PR using the GUI difftool: \
`$ git pr show -t 3882`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3882.diff">https://git.openjdk.java.net/jdk/pull/3882.diff</a>

</details>
