### PR TITLE
8252758: Lanai: Optimize index calculation while copying glyphs

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLTextRenderer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLTextRenderer.m
@@ -229,13 +229,13 @@ MTLTR_AddToGlyphCache(GlyphInfo *glyph, MTLContext *mtlc,
             unsigned char imageData[imageBytes];
             memset(&imageData, 0, sizeof(imageData));
 
-            for (int i = 0; i < h; i++) {
-                for (int j = 0; j < w; j++) {
-                    imageData[(i * w * 4) + j * 4] = glyph->image[(i * w * 3) + j * 3];
-                    imageData[(i * w * 4) + j * 4 + 1] = glyph->image[(i * w * 3) + j * 3 + 1];
-                    imageData[(i * w * 4) + j * 4 + 2] = glyph->image[(i * w * 3) + j * 3 + 2];
-                    imageData[(i * w * 4) + j * 4 + 3] = 0xFF;
-                }
+            int srcIndex = 0;
+            int dstIndex = 0;
+            for (int i = 0; i < (w * h); i++) {
+                imageData[dstIndex++] = glyph->image[srcIndex++];
+                imageData[dstIndex++] = glyph->image[srcIndex++];
+                imageData[dstIndex++] = glyph->image[srcIndex++];
+                imageData[dstIndex++] = 0xFF;
             }
 
             NSUInteger bytesPerRow = 4 * w;
@@ -530,17 +530,17 @@ MTLTR_DrawLCDGlyphNoCache(MTLContext *mtlc, BMTLSDOps *dstOps,
     encoder = [mtlc.encoderManager getLCDEncoder:dstOps->pTexture isSrcOpaque:YES isDstOpaque:YES];
     MTLTR_SetLCDContrast(mtlc, contrast, encoder);
 
-    unsigned int imageBytes = w * h *4;
+    unsigned int imageBytes = w * h * 4;
     unsigned char imageData[imageBytes];
     memset(&imageData, 0, sizeof(imageData));
 
-    for (int i = 0; i < h; i++) {
-        for (int j = 0; j < w; j++) {
-            imageData[(i * w * 4) + j * 4] = ginfo->image[((i * w * 3) + j * 3) + rowBytesOffset];
-            imageData[(i * w * 4) + j * 4 + 1] = ginfo->image[((i * w * 3) + j * 3 + 1) + rowBytesOffset];
-            imageData[(i * w * 4) + j * 4 + 2] = ginfo->image[((i * w * 3) + j * 3 + 2) + rowBytesOffset];
-            imageData[(i * w * 4) + j * 4 + 3] = 0xFF;
-        }
+    int srcIndex = 0;
+    int dstIndex = 0;
+    for (int i = 0; i < (w * h); i++) {
+        imageData[dstIndex++] = ginfo->image[srcIndex++ + rowBytesOffset];
+        imageData[dstIndex++] = ginfo->image[srcIndex++ + rowBytesOffset];
+        imageData[dstIndex++] = ginfo->image[srcIndex++ + rowBytesOffset];
+        imageData[dstIndex++] = 0xFF;
     }
 
     // copy LCD mask into glyph texture tile


### PR DESCRIPTION
Loop optimization while copying glyph content.
J2DDemo, SwingSet2 and Font2DTest are green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252758](https://bugs.openjdk.java.net/browse/JDK-8252758): Lanai: Optimize index calculation while copying glyphs


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - Committer)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3883/head:pull/3883` \
`$ git checkout pull/3883`

Update a local copy of the PR: \
`$ git checkout pull/3883` \
`$ git pull https://git.openjdk.java.net/jdk pull/3883/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3883`

View PR using the GUI difftool: \
`$ git pr show -t 3883`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3883.diff">https://git.openjdk.java.net/jdk/pull/3883.diff</a>

</details>
