### PR TITLE
8266567: Fix javadoc tag references in sun.management.jmxremote.ConnectorBootstrap

### DIFF
--- a/src/jdk.management.agent/share/classes/sun/management/jmxremote/ConnectorBootstrap.java
+++ b/src/jdk.management.agent/share/classes/sun/management/jmxremote/ConnectorBootstrap.java
@@ -275,9 +275,9 @@ public final class ConnectorBootstrap {
         private final String accessFile;
     }
 
-    // The variable below is here to support stop functionality
+    // The variable below is here to support stop functionality.
     // It would be overwritten if you call startRemoteConnectorServer second
-    // time. It's OK for now as logic in Agent.java forbids multiple agents
+    // time. It's OK for now as logic in Agent.java forbids multiple agents.
     private static Registry registry = null;
 
     public static void unexportRegistry() {

--- a/src/jdk.management.agent/share/classes/sun/management/jmxremote/ConnectorBootstrap.java
+++ b/src/jdk.management.agent/share/classes/sun/management/jmxremote/ConnectorBootstrap.java
@@ -288,7 +288,7 @@ public final class ConnectorBootstrap {
                 registry = null;
             }
         } catch(NoSuchObjectException ex) {
-            // This exception can appears only if we attempt
+            // This exception can appear only if we attempt
             // to unexportRegistry second time. So it's safe
             // to ignore it without additional messages.
         }
@@ -297,7 +297,7 @@ public final class ConnectorBootstrap {
      /**
       * Initializes and starts the JMX Connector Server.
       * If the com.sun.management.jmxremote.port property is not defined,
-      * simply return. Otherwise, attempts to load the config file, and
+      * simply returns. Otherwise, attempts to load the config file, and
       * then calls {@link #startRemoteConnectorServer(java.lang.String,
       * java.util.Properties)}.
       *
@@ -305,7 +305,7 @@ public final class ConnectorBootstrap {
       **/
       public static synchronized JMXConnectorServer initialize() {
 
-         // Load a new management properties
+         // Load new management properties
          final Properties props = Agent.loadManagementProperties();
          if (props == null) {
               return null;

--- a/src/jdk.management.agent/share/classes/sun/management/jmxremote/ConnectorBootstrap.java
+++ b/src/jdk.management.agent/share/classes/sun/management/jmxremote/ConnectorBootstrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -174,7 +174,7 @@ public final class ConnectorBootstrap {
      *
      * <p>Objects are exported using {@link
      * UnicastServerRef#exportObject(Remote, Object, boolean)}.  The
-     * boolean parameter is called <code>permanent</code> and means
+     * boolean parameter is called {@code permanent} and means
      * both that the object is not eligible for Distributed Garbage
      * Collection, and that its continued existence will not prevent
      * the JVM from exiting.  It is the latter semantics we want (we
@@ -276,8 +276,8 @@ public final class ConnectorBootstrap {
     }
 
     // The variable below is here to support stop functionality
-    // It would be overriten if you call startRemoteCommectionServer second
-    // time. It's OK for now as logic in Agent.java forbids mutiple agents
+    // It would be overwritten if you call startRemoteConnectorServer second
+    // time. It's OK for now as logic in Agent.java forbids multiple agents
     private static Registry registry = null;
 
     public static void unexportRegistry() {
@@ -298,8 +298,8 @@ public final class ConnectorBootstrap {
       * Initializes and starts the JMX Connector Server.
       * If the com.sun.management.jmxremote.port property is not defined,
       * simply return. Otherwise, attempts to load the config file, and
-      * then calls {@link #startRemoteConnectorServer
-      *                            (java.lang.String, java.util.Properties)}.
+      * then calls {@link #startRemoteConnectorServer(java.lang.String,
+      * java.util.Properties)}.
       *
       * This method is used by some jtreg tests.
       **/
@@ -318,8 +318,7 @@ public final class ConnectorBootstrap {
     /**
      * This method is used by some jtreg tests.
      *
-     * @see #startRemoteConnectorServer
-     *             (String portStr, Properties props)
+     * @see #startRemoteConnectorServer(String portStr, Properties props)
      */
     public static synchronized JMXConnectorServer initialize(String portStr, Properties props)  {
          return startRemoteConnectorServer(portStr, props);
@@ -516,7 +515,7 @@ public final class ConnectorBootstrap {
      * and management.
      */
     public static JMXConnectorServer startLocalConnectorServer() {
-        // Ensure cryptographically strong random number generater used
+        // Ensure cryptographically strong random number generator used
         // to choose the object number - see java.rmi.server.ObjID
         System.setProperty("java.rmi.server.randomIDs", "true");
 

--- a/src/jdk.management.agent/share/classes/sun/management/jmxremote/ConnectorBootstrap.java
+++ b/src/jdk.management.agent/share/classes/sun/management/jmxremote/ConnectorBootstrap.java
@@ -305,7 +305,7 @@ public final class ConnectorBootstrap {
       **/
       public static synchronized JMXConnectorServer initialize() {
 
-         // Load new management properties
+         // Load a new management properties
          final Properties props = Agent.loadManagementProperties();
          if (props == null) {
               return null;


### PR DESCRIPTION
This fixes two javadoc tag references and several typos. References are fixed by removing whitespace before the opening `(`. That whitespace caused the opening `(` and the rest of the reference to be parsed as a link label.

Since we are here, I think this class could also benefit from using modern APIs. This should be done in a separate PR though. For example:

1. Numerous instances of `Boolean.valueOf( <var> ).booleanValue()` could be changed to `Boolean.parseBoolean( <var> )`
2. `throw (IllegalArgumentException) new IllegalArgumentException(msg).initCause(e);` could be changed to `throw new IllegalArgumentException(msg, e);`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266567](https://bugs.openjdk.java.net/browse/JDK-8266567): Fix javadoc tag references in sun.management.jmxremote.ConnectorBootstrap


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3885/head:pull/3885` \
`$ git checkout pull/3885`

Update a local copy of the PR: \
`$ git checkout pull/3885` \
`$ git pull https://git.openjdk.java.net/jdk pull/3885/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3885`

View PR using the GUI difftool: \
`$ git pr show -t 3885`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3885.diff">https://git.openjdk.java.net/jdk/pull/3885.diff</a>

</details>
