### PR TITLE
8265465: jcmd VM.cds should keep already dumped archive when exception happens

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -315,7 +315,7 @@ hotspot_appcds_dynamic = \
  -runtime/cds/appcds/javaldr/LockDuringDump.java \
  -runtime/cds/appcds/jcmd/JCmdTestStaticDump.java \
  -runtime/cds/appcds/jcmd/JCmdTestDynamicDump.java \
- -runtime/cds/appcds/jcmd/JCmdTestFileSecurity.java \
+ -runtime/cds/appcds/jcmd/JCmdTestFileSafety.java \
  -runtime/cds/appcds/methodHandles \
  -runtime/cds/appcds/sharedStrings \
  -runtime/cds/appcds/ArchiveRelocationTest.java \

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -315,6 +315,7 @@ hotspot_appcds_dynamic = \
  -runtime/cds/appcds/javaldr/LockDuringDump.java \
  -runtime/cds/appcds/jcmd/JCmdTestStaticDump.java \
  -runtime/cds/appcds/jcmd/JCmdTestDynamicDump.java \
+ -runtime/cds/appcds/jcmd/JCmdTestFileSecurity.java \
  -runtime/cds/appcds/methodHandles \
  -runtime/cds/appcds/sharedStrings \
  -runtime/cds/appcds/ArchiveRelocationTest.java \

--- a/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDumpBase.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDumpBase.java
@@ -178,16 +178,11 @@ public abstract class JCmdTestDumpBase {
         String archiveFileName = fileName != null ? fileName :
             ("java_pid" + pid + (isStatic ? "_static.jsa" : "_dynamic.jsa"));
 
-        // Use a temporay file name
-        String tempArchiveFileName = archiveFileName;
         File archiveFile = new File(archiveFileName);
-        if (keepArchive && archiveFile.exists()) {
-             tempArchiveFileName = archiveFileName + ".jcmd";
-        }
 
         String jcmd = "VM.cds " + (isStatic ? "static_dump" : "dynamic_dump");
         if (archiveFileName  != null) {
-          jcmd +=  " " + tempArchiveFileName;
+          jcmd +=  " " + archiveFileName;
         }
 
         PidJcmdExecutor cmdExecutor = new PidJcmdExecutor(String.valueOf(pid));
@@ -195,18 +190,15 @@ public abstract class JCmdTestDumpBase {
 
         if (expectOK) {
             output.shouldHaveExitValue(0);
-            checkFileExistence(tempArchiveFileName, true);
-            runWithArchiveFile(tempArchiveFileName, useBoot, messages);
-            File tempArchiveFile = new File(tempArchiveFileName);
+            checkFileExistence(archiveFileName, true);
+            runWithArchiveFile(archiveFileName, useBoot, messages);
             if (!keepArchive) {
-		tempArchiveFile.delete();
-            } else {
-                if (tempArchiveFileName != archiveFileName) {
-                    tempArchiveFile.renameTo(archiveFile);
-                }
+		archiveFile.delete();
             }
         } else {
-            checkFileExistence(tempArchiveFileName, false);
+            if (!keepArchive) {
+                checkFileExistence(archiveFileName, false);
+            }
         }
     }
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDumpBase.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDumpBase.java
@@ -193,7 +193,7 @@ public abstract class JCmdTestDumpBase {
             checkFileExistence(archiveFileName, true);
             runWithArchiveFile(archiveFileName, useBoot, messages);
             if (!keepArchive) {
-		archiveFile.delete();
+                archiveFile.delete();
             }
         } else {
             if (!keepArchive) {

--- a/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestFileSecurity.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestFileSecurity.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8265465
+ * @summary Test jcmd to dump static shared archive.
+ * @requires vm.cds
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
+ * @modules jdk.jcmd/sun.tools.common:+open
+ * @compile ../test-classes/Hello.java JCmdTestDumpBase.java
+ * @build sun.hotspot.WhiteBox
+ * @build JCmdTestLingeredApp JCmdTestFileSecurity
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm/timeout=480 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI JCmdTestFileSecurity
+ */
+
+import java.io.File;
+import java.io.IOException;
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.Platform;
+
+public class JCmdTestFileSecurity extends JCmdTestDumpBase {
+
+    static void test() throws Exception {
+        buildJars();
+
+        LingeredApp app = null;
+        long pid;
+
+        int  test_count = 1;
+        // Set target dir not accessible, do static dump
+        setIsStatic(true);
+        print2ln(test_count++ + " Set target dir not accessible, do static dump");
+        setKeepArchive(true);
+        app = createLingeredApp("-cp", allJars);
+        pid = app.getPid();
+        String localFileName = "MyStaticDump.jsa";
+        test(localFileName, pid, noBoot,  EXPECT_PASS);
+        File targetFile = CDSTestUtils.getOutputDirAsFile();
+        targetFile.setWritable(false);
+        test(localFileName, pid, noBoot,  EXPECT_FAIL);
+        targetFile.setWritable(true);
+        app.stopApp();
+        // MyStaticDump.jsa should exist
+        checkFileExistence(localFileName, true);
+
+        // test dynamic versoin
+        setIsStatic(false);
+        print2ln(test_count++ + " Set target dir not accessible, do dynamic dump");
+        setKeepArchive(true);
+        app = createLingeredApp("-cp", allJars, "-XX:+RecordDynamicDumpInfo");
+        pid = app.getPid();
+        localFileName = "MyDynamicDump.jsa";
+        test(localFileName, pid, noBoot,  EXPECT_PASS);
+        app.stopApp();
+        // cannot dynamically dump twice, restart
+        app = createLingeredApp("-cp", allJars, "-XX:+RecordDynamicDumpInfo");
+        pid = app.getPid();
+        targetFile.setWritable(false);
+        test(localFileName, pid, noBoot,  EXPECT_FAIL);
+        targetFile.setWritable(true);
+        app.stopApp();
+        // MyDynamicDump.jsa should exist
+        checkFileExistence(localFileName, true);
+    }
+
+    public static void main(String... args) throws Exception {
+        if (Platform.isWindows()) {
+            // ON windows, File operation resulted difference from other OS.
+            throw new jtreg.SkippedException("Test skipped on Windows");
+        }
+        runTest(JCmdTestFileSecurity::test);
+    }
+}


### PR DESCRIPTION
Hi, Please review 
  When using jcmd to dump shared archive, if the archive name exists,  it will be deleted first. If exception happens during dumping process, there is no new archive created. This PR changes to first dump the archive with  a temporary file name. With successful dump, the temporary file will be rename to its given name. This way the old archive will not be touched on exception.
  The newly added test case skipped testing on Windows since File operation result is not same as on Linux.
  
   Tests: tier1,tier2,tier3,tier4

Thanks
Yumin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265465](https://bugs.openjdk.java.net/browse/JDK-8265465): jcmd VM.cds should keep already dumped archive when exception happens


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3886/head:pull/3886` \
`$ git checkout pull/3886`

Update a local copy of the PR: \
`$ git checkout pull/3886` \
`$ git pull https://git.openjdk.java.net/jdk pull/3886/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3886`

View PR using the GUI difftool: \
`$ git pr show -t 3886`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3886.diff">https://git.openjdk.java.net/jdk/pull/3886.diff</a>

</details>
