### PR TITLE
JDK-8266573: Make sure blackholes are tagged for all JVMCI paths

### DIFF
--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -988,11 +988,12 @@ JVMCIObject JVMCIEnv::get_jvmci_method(const methodHandle& method, JVMCI_TRAPS) 
     return method_object;
   }
 
+  CompilerOracle::tag_blackhole_if_possible(method);
+
   JavaThread* THREAD = JVMCI::compilation_tick(JavaThread::current());
   jmetadata handle = _runtime->allocate_handle(method);
   jboolean exception = false;
   if (is_hotspot()) {
-    CompilerOracle::tag_blackhole_if_possible(method);
     JavaValue result(T_OBJECT);
     JavaCallArguments args;
     args.push_long((jlong) handle);


### PR DESCRIPTION
In post-integration  https://github.com/openjdk/jdk/pull/2024#issuecomment-832834830, Tom says:
 "In this code, 6018336#diff-fa2433a762244542fec57f9d58dd3092bae74f354acf0ef33603a5f8306fd7daR995, the call to `CompilerOracle::tag_blackhole_if_possible` should be outside of the if. As written, methods won't be properly tagged for libgraal, only when used with the pure Java graal."

I am doing this blindly, because Graal is already removed from the codebase with JEP 410.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266573](https://bugs.openjdk.java.net/browse/JDK-8266573): Make sure blackholes are tagged for all JVMCI paths


### Reviewers
 * [Tom Rodriguez](https://openjdk.java.net/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3887/head:pull/3887` \
`$ git checkout pull/3887`

Update a local copy of the PR: \
`$ git checkout pull/3887` \
`$ git pull https://git.openjdk.java.net/jdk pull/3887/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3887`

View PR using the GUI difftool: \
`$ git pr show -t 3887`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3887.diff">https://git.openjdk.java.net/jdk/pull/3887.diff</a>

</details>
