### PR TITLE
8266579: Update test/jdk/java/lang/ProcessHandle/PermissionTest.java & test/jdk/java/sql/testng/util/TestPolicy.java

### DIFF
--- a/test/jdk/java/lang/ProcessHandle/PermissionTest.java
+++ b/test/jdk/java/lang/ProcessHandle/PermissionTest.java
@@ -215,6 +215,7 @@ class TestPolicy extends Policy {
         permissions.add(new PropertyPermission("testng.show.stack.frames",
                 "read"));
         permissions.add(new PropertyPermission("testng.thread.affinity", "read"));
+        permissions.add(new PropertyPermission("testng.memory.friendly", "read"));
         permissions.add(new PropertyPermission("testng.mode.dryrun", "read"));
         permissions.add(new PropertyPermission("testng.report.xml.name", "read"));
         permissions.add(new PropertyPermission("testng.timezone", "read"));

--- a/test/jdk/java/sql/testng/util/TestPolicy.java
+++ b/test/jdk/java/sql/testng/util/TestPolicy.java
@@ -110,6 +110,7 @@ public class TestPolicy extends Policy {
         permissions.add(new PropertyPermission("testng.show.stack.frames",
                 "read"));
         permissions.add(new PropertyPermission("testng.thread.affinity", "read"));
+        permissions.add(new PropertyPermission("testng.memory.friendly", "read"));
         permissions.add(new PropertyPermission("testng.mode.dryrun", "read"));
         permissions.add(new PropertyPermission("testng.report.xml.name", "read"));
         permissions.add(new PropertyPermission("testng.timezone", "read"));


### PR DESCRIPTION
Hi all,

Please review this patch which updates  test/jdk/java/lang/ProcessHandle/PermissionTest.java & test/jdk/java/sql/testng/util/TestPolicy.java to include : 

`new PropertyPermission("testng.memory.friendly", "read"); 
`
Which will be needed by TestNG 7.4

Best,
Lance

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266579](https://bugs.openjdk.java.net/browse/JDK-8266579): Update test/jdk/java/lang/ProcessHandle/PermissionTest.java & test/jdk/java/sql/testng/util/TestPolicy.java


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3888/head:pull/3888` \
`$ git checkout pull/3888`

Update a local copy of the PR: \
`$ git checkout pull/3888` \
`$ git pull https://git.openjdk.java.net/jdk pull/3888/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3888`

View PR using the GUI difftool: \
`$ git pr show -t 3888`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3888.diff">https://git.openjdk.java.net/jdk/pull/3888.diff</a>

</details>
