### PR TITLE
8266589: (fs) Improve performance of Files.copy() on macOS using copyfile(3)

### DIFF
--- a/src/java.base/unix/native/libnio/fs/UnixCopyFile.c
+++ b/src/java.base/unix/native/libnio/fs/UnixCopyFile.c
@@ -55,10 +55,14 @@ static void throwUnixException(JNIEnv* env, int errnum) {
 int fcopyfile_callback(int what, int stage, copyfile_state_t state,
     const char* src, const char* dst, void* cancel)
 {
-    if (what == COPYFILE_COPY_DATA && stage == COPYFILE_PROGRESS &&
-        *((int*)cancel) != 0) {
-        // errno will be set to ECANCELED
-        return COPYFILE_QUIT;
+    if (what == COPYFILE_COPY_DATA) {
+        if (stage == COPYFILE_ERR
+                || (stage == COPYFILE_PROGRESS && *((int*)cancel) != 0)) {
+            // errno will be set to ECANCELED if the operation is cancelled,
+            // or to the appropriate error number if there is an error,
+            // but in either case we need to quit.
+            return COPYFILE_QUIT;
+        }
     }
     return COPYFILE_CONTINUE;
 }

--- a/src/java.base/unix/native/libnio/fs/UnixCopyFile.c
+++ b/src/java.base/unix/native/libnio/fs/UnixCopyFile.c
@@ -32,8 +32,9 @@
 
 #if defined(__linux__)
 #include <sys/sendfile.h>
+#elif defined(_ALLBSD_SOURCE)
+#include <copyfile.h>
 #endif
-
 #include "sun_nio_fs_UnixCopyFile.h"
 
 #define RESTARTABLE(_cmd, _result) do { \
@@ -50,6 +51,19 @@ static void throwUnixException(JNIEnv* env, int errnum) {
     }
 }
 
+#if defined(_ALLBSD_SOURCE)
+int fcopyfile_callback(int what, int stage, copyfile_state_t state,
+    const char* src, const char* dst, void* cancel)
+{
+    if (what == COPYFILE_COPY_DATA && stage == COPYFILE_PROGRESS &&
+        *((int*)cancel) != 0) {
+        // errno will be set to ECANCELED
+        return COPYFILE_QUIT;
+    }
+    return COPYFILE_CONTINUE;
+}
+#endif
+
 /**
  * Transfer all bytes from src to dst within the kernel if possible (Linux),
  * otherwise via user-space buffers
@@ -62,10 +76,11 @@ Java_sun_nio_fs_UnixCopyFile_transfer
 
 #if defined(__linux__)
     // Transfer within the kernel
-    const size_t count = 1048576; // 1 MB to give cancellation a chance
+    const size_t count = cancel != NULL ?
+        1048576 :   // 1 MB to give cancellation a chance
+        0x7ffff000; // maximum number of bytes that sendfile() can transfer
     ssize_t bytes_sent;
     do {
-        // sendfile() can transfer at most 0x7ffff000 bytes
         RESTARTABLE(sendfile64(dst, src, NULL, count), bytes_sent);
         if (bytes_sent == -1) {
             throwUnixException(env, errno);
@@ -76,6 +91,24 @@ Java_sun_nio_fs_UnixCopyFile_transfer
             return;
         }
     } while (bytes_sent > 0);
+#elif defined(_ALLBSD_SOURCE)
+    copyfile_state_t state;
+    if (cancel != NULL) {
+        state = copyfile_state_alloc();
+        copyfile_state_set(state, COPYFILE_STATE_STATUS_CB, fcopyfile_callback);
+        copyfile_state_set(state, COPYFILE_STATE_STATUS_CTX, (void*)cancel);
+    } else {
+        state = NULL;
+    }
+    if (fcopyfile(src, dst, state, COPYFILE_DATA) < 0) {
+        int errno_fcopyfile = errno;
+        if (state != NULL)
+            copyfile_state_free(state);
+        throwUnixException(env, errno_fcopyfile);
+        return;
+    }
+    if (state != NULL)
+        copyfile_state_free(state);
 #else
     // Transfer via user-space buffers
     char buf[8192];


### PR DESCRIPTION
Please consider this request to use `fcopyfile(3)` to copy files via `java.nio.file.Files(Path,Path,CopyOption...)` on macOS. This change would improve the throughput of `Files.copy()` as shown in these results:

**Copy via 8192 byte buffers**

```
Benchmark           (size)   Mode  Cnt     Score     Error  Units
FilesCopy.copy       10240  thrpt    5  5432.671 ± 137.114  ops/s
FilesCopy.copy       51200  thrpt    5  3959.145 ± 157.467  ops/s
FilesCopy.copy      102400  thrpt    5  2931.325 ± 109.200  ops/s
FilesCopy.copy      512000  thrpt    5   655.550 ±  39.919  ops/s
FilesCopy.copy     1048568  thrpt    5   375.127 ±  10.111  ops/s
FilesCopy.copy    10485760  thrpt    5    64.048 ±   5.740  ops/s
FilesCopy.copy   104857600  thrpt    5     6.893 ±   0.415  ops/s
FilesCopy.copy  1073741824  thrpt    5     0.717 ±   0.026  ops/s

```
**Copy via fcopyfile**
```

Benchmark           (size)   Mode  Cnt     Score     Error  Units
FilesCopy.copy       10240  thrpt    5  5070.255 ± 817.419  ops/s
FilesCopy.copy       51200  thrpt    5  4469.218 ±  65.634  ops/s
FilesCopy.copy      102400  thrpt    5  3997.718 ± 301.440  ops/s
FilesCopy.copy      512000  thrpt    5  2064.223 ±  68.893  ops/s
FilesCopy.copy     1048568  thrpt    5   817.743 ±  83.076  ops/s
FilesCopy.copy    10485760  thrpt    5   145.799 ±   3.674  ops/s
FilesCopy.copy   104857600  thrpt    5    24.706 ±  14.178  ops/s
FilesCopy.copy  1073741824  thrpt    5     1.386 ±   0.073  ops/s
```

The smallest size tested shows a small degradation in throughput, but this could be rectified if desired by adding an empirically determined size threshold under which user-space buffers would be used instead of `fcopyfile()`.

A small change is also made to the Linux `sendfile()` portion to use the largest permitted `count` value if the copy is uninterruptible, i.e., `cancel == NULL`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266589](https://bugs.openjdk.java.net/browse/JDK-8266589): (fs) Improve performance of Files.copy() on macOS using copyfile(3)


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3890/head:pull/3890` \
`$ git checkout pull/3890`

Update a local copy of the PR: \
`$ git checkout pull/3890` \
`$ git pull https://git.openjdk.java.net/jdk pull/3890/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3890`

View PR using the GUI difftool: \
`$ git pr show -t 3890`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3890.diff">https://git.openjdk.java.net/jdk/pull/3890.diff</a>

</details>
