### PR TITLE
8266598: Exception values for AnnotationTypeMismatchException are not always informative

### DIFF
--- a/src/java.base/share/classes/sun/reflect/annotation/AnnotationParser.java
+++ b/src/java.base/share/classes/sun/reflect/annotation/AnnotationParser.java
@@ -355,11 +355,18 @@ public class AnnotationParser {
 
         if (result == null) {
             result = new AnnotationTypeMismatchExceptionProxy(
-                memberType.getClass().getName());
+                Proxy.isProxyClass(memberType)
+                        ? memberType.getInterfaces()[0].getName()
+                        : memberType.getName());
         } else if (!(result instanceof ExceptionProxy) &&
             !memberType.isInstance(result)) {
-            result = new AnnotationTypeMismatchExceptionProxy(
-                result.getClass() + "[" + result + "]");
+            if (result instanceof Annotation) {
+                result = new AnnotationTypeMismatchExceptionProxy(
+                    result.toString());
+            } else {
+                result = new AnnotationTypeMismatchExceptionProxy(
+                    result.getClass().getName() + "[" + result + "]");
+            }
         }
         return result;
     }
@@ -462,12 +469,9 @@ public class AnnotationParser {
         String typeName  = constPool.getUTF8At(typeNameIndex);
         int constNameIndex = buf.getShort() & 0xFFFF;
         String constName = constPool.getUTF8At(constNameIndex);
-        if (!enumType.isEnum()) {
+        if (!enumType.isEnum() || enumType != parseSig(typeName, container)) {
             return new AnnotationTypeMismatchExceptionProxy(
-                typeName + "." + constName);
-        } else if (enumType != parseSig(typeName, container)) {
-            return new AnnotationTypeMismatchExceptionProxy(
-                typeName + "." + constName);
+                    typeName.substring(1, typeName.length() - 1).replace('/', '.') + "." + constName);
         }
 
         try {
@@ -754,7 +758,7 @@ public class AnnotationParser {
      */
     private static ExceptionProxy exceptionProxy(int tag) {
         return new AnnotationTypeMismatchExceptionProxy(
-            "Array with component tag: " + tag);
+            "Array with component tag: " + (tag == 0 ? "0" : (char) tag));
     }
 
     /**

--- a/test/jdk/java/lang/annotation/AnnotationTypeMismatchException/AnnotationTypeMismatchTest.java
+++ b/test/jdk/java/lang/annotation/AnnotationTypeMismatchException/AnnotationTypeMismatchTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8228988
+ * @bug 8228988 8266598
  * @summary An annotation-typed property of an annotation that is represented as an
  *          incompatible property of another type should yield an AnnotationTypeMismatchException.
  * @modules java.base/jdk.internal.org.objectweb.asm
@@ -59,7 +59,11 @@ public class AnnotationTypeMismatchTest {
             Value value = sample.value();
             throw new IllegalStateException("Found value: " + value);
         } catch (AnnotationTypeMismatchException e) {
-            // correct
+            if (!e.element().getName().equals("value")) {
+                throw new IllegalStateException("Unexpected element: " + e.element());
+            } else if (!e.foundType().equals(AnEnum.class.getName() + "." + AnEnum.VALUE.name())) {
+                throw new IllegalStateException("Unexpected type: " + e.foundType());
+            }
         }
     }
 

--- a/test/jdk/java/lang/annotation/AnnotationTypeMismatchException/EnumTypeMismatchTest.java
+++ b/test/jdk/java/lang/annotation/AnnotationTypeMismatchException/EnumTypeMismatchTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8228988
+ * @bug 8228988 8266598
  * @summary An enumeration-typed property of an annotation that is represented as an
  *          incompatible property of another type should yield an AnnotationTypeMismatchException.
  * @modules java.base/jdk.internal.org.objectweb.asm
@@ -59,7 +59,11 @@ public class EnumTypeMismatchTest {
             AnEnum value = sample.value();
             throw new IllegalStateException("Found value: " + value);
         } catch (AnnotationTypeMismatchException e) {
-            // correct
+            if (!e.element().getName().equals("value")) {
+                throw new IllegalStateException("Unexpected element: " + e.element());
+            } else if (!e.foundType().equals("@" + AnAnnotation.class.getName() + "(" + AnEnum.VALUE.name() + ")")) {
+                throw new IllegalStateException("Unexpected type: " + e.foundType());
+            }
         }
     }
 


### PR DESCRIPTION
This improves the messages that are provided by `AnnotationTypeMismatchException`s. The message provided by AnnotationTypeMismatchExceptions is deliberately undefined such that this should not break any contract.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266598](https://bugs.openjdk.java.net/browse/JDK-8266598): Exception values for AnnotationTypeMismatchException are not always informative


### Reviewers
 * [Joel Borggrén-Franck](https://openjdk.java.net/census#jfranck) (@jbf - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3892/head:pull/3892` \
`$ git checkout pull/3892`

Update a local copy of the PR: \
`$ git checkout pull/3892` \
`$ git pull https://git.openjdk.java.net/jdk pull/3892/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3892`

View PR using the GUI difftool: \
`$ git pr show -t 3892`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3892.diff">https://git.openjdk.java.net/jdk/pull/3892.diff</a>

</details>
