### PR TITLE
8266603: jpackage: Add missing copyright file in Java runtime .deb installers

### DIFF
--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxDebBundler.java
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxDebBundler.java
@@ -46,7 +46,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import static jdk.jpackage.internal.OverridableResource.createResource;
-import static jdk.jpackage.internal.StandardBundlerParam.APP_NAME;
 import static jdk.jpackage.internal.StandardBundlerParam.INSTALLER_NAME;
 import static jdk.jpackage.internal.StandardBundlerParam.VERSION;
 import static jdk.jpackage.internal.StandardBundlerParam.RELEASE;
@@ -411,8 +410,11 @@ public class LinuxDebBundler extends LinuxPackageBundler {
         debianFiles.add(new DebianFile(
                 configDir.resolve("postrm"),
                 "resource.deb-postrm-script").setExecutable());
+        
+        final String installDir = LINUX_INSTALL_DIR.fetchFrom(params);
 
-        if (!StandardBundlerParam.isRuntimeInstaller(params)) {
+        if (!StandardBundlerParam.isRuntimeInstaller(params)
+                || (isInstallDirInUsrTree(installDir) || installDir.startsWith("/usr/"))) {
             debianFiles.add(new DebianFile(
                     getConfig_CopyrightFile(params),
                     "resource.copyright-file"));

--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxDebBundler.java
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxDebBundler.java
@@ -410,7 +410,7 @@ public class LinuxDebBundler extends LinuxPackageBundler {
         debianFiles.add(new DebianFile(
                 configDir.resolve("postrm"),
                 "resource.deb-postrm-script").setExecutable());
-        
+
         final String installDir = LINUX_INSTALL_DIR.fetchFrom(params);
 
         if (!StandardBundlerParam.isRuntimeInstaller(params)

--- a/test/jdk/tools/jpackage/share/RuntimePackageTest.java
+++ b/test/jdk/tools/jpackage/share/RuntimePackageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,12 +27,16 @@ import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import jdk.jpackage.test.PackageType;
 import jdk.jpackage.test.PackageTest;
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.TKit;
 import jdk.jpackage.test.Annotations.Test;
+import jdk.jpackage.test.LinuxHelper;
+import static jdk.jpackage.test.TKit.assertTrue;
+import static jdk.jpackage.test.TKit.assertFalse;
 
 /**
  * Test --runtime-image parameter.
@@ -121,6 +125,23 @@ public class RuntimePackageTest {
 
             assertFileListEmpty(srcRuntime, "Missing");
             assertFileListEmpty(dstRuntime, "Unexpected");
+        })
+        .forTypes(PackageType.LINUX_DEB)
+        .addInstallVerifier(cmd -> {
+            String installDir = cmd.getArgumentValue("--install-dir", () -> "/opt");
+            Path copyright = Path.of("/usr/share/doc",
+                    LinuxHelper.getPackageName(cmd), "copyright");
+            boolean withCopyright = LinuxHelper.getPackageFiles(cmd).anyMatch(
+                    Predicate.isEqual(copyright));
+            if (installDir.startsWith("/usr/") || installDir.equals("/usr")) {
+                assertTrue(withCopyright, String.format(
+                        "Check the package delivers [%s] copyright file",
+                        copyright));
+            } else {
+                assertFalse(withCopyright, String.format(
+                        "Check the package doesn't deliver [%s] copyright file",
+                        copyright));
+            }
         });
     }
 


### PR DESCRIPTION
jpackage should create copyright file in /usr/share/doc directory tree when building .deb package for Java runtime with installation directory in /usr directory tree.

jpackage creates share/doc/copyright file in installation directory for apps installed outside of /usr tree.

jpackage creates /usr/share/doc/${package_name}/copyright file for apps installed in /usr tree .

jpackage doesn't create copyright file at all for Java runtime. The reason for this behavior was that jpackage should not place additional files in installation directory of Java runtime. However when installing Java runtime or app in /usr tree, copyright file will be placed outside of installation directory. Thus copyright file should be always created if package installation directory is inside of /usr tree.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266603](https://bugs.openjdk.java.net/browse/JDK-8266603): jpackage: Add missing copyright file in Java runtime .deb installers


### Reviewers
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - Committer)
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3894/head:pull/3894` \
`$ git checkout pull/3894`

Update a local copy of the PR: \
`$ git checkout pull/3894` \
`$ git pull https://git.openjdk.java.net/jdk pull/3894/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3894`

View PR using the GUI difftool: \
`$ git pr show -t 3894`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3894.diff">https://git.openjdk.java.net/jdk/pull/3894.diff</a>

</details>
