### PR TITLE
8261395: C1 crash "cannot make java calls from the native compiler" 

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -185,9 +185,7 @@ bool InstanceKlass::has_nest_member(InstanceKlass* k, TRAPS) const {
   for (int i = 0; i < _nest_members->length(); i++) {
     int cp_index = _nest_members->at(i);
     if (_constants->tag_at(cp_index).is_klass()) {
-      Klass* k2 = _constants->klass_at(cp_index, THREAD);
-      assert(!HAS_PENDING_EXCEPTION || PENDING_EXCEPTION->is_a(vmClasses::VirtualMachineError_klass()),
-             "Exceptions should not be possible here");
+      Klass* k2 = _constants->resolved_klass_at(cp_index);
       if (k2 == k) {
         log_trace(class, nestmates)("- class is listed at nest_members[%d] => cp[%d]", i, cp_index);
         return true;

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -480,7 +480,7 @@ class InstanceKlass: public Klass {
 
 private:
   // Called to verify that k is a member of this nest - does not look at k's nest-host
-  bool has_nest_member(InstanceKlass* k, TRAPS) const;
+  bool has_nest_member(InstanceKlass* k, bool can_resolve, TRAPS) const;
 
 public:
   // Used to construct informative IllegalAccessError messages at a higher level,


### PR DESCRIPTION
DRAFT

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8261395](https://bugs.openjdk.java.net/browse/JDK-8261395): C1 crash "cannot make java calls from the native compiler"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3895/head:pull/3895` \
`$ git checkout pull/3895`

Update a local copy of the PR: \
`$ git checkout pull/3895` \
`$ git pull https://git.openjdk.java.net/jdk pull/3895/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3895`

View PR using the GUI difftool: \
`$ git pr show -t 3895`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3895.diff">https://git.openjdk.java.net/jdk/pull/3895.diff</a>

</details>
