### PR TITLE
8266618: Remove broken -XX:-OptoRemoveUseless

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -158,9 +158,6 @@
   develop_pd(bool, OptoPeephole,                                            \
           "Apply peephole optimizations after register allocation")         \
                                                                             \
-  develop(bool, OptoRemoveUseless, true,                                    \
-          "Remove useless nodes after parsing")                             \
-                                                                            \
   notproduct(bool, PrintFrameConverterAssembly, false,                      \
           "Print New compiler assembly output for frame converters")        \
                                                                             \

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -2290,7 +2290,7 @@ void Parse::add_safepoint() {
 
   // Provide an edge from root to safepoint.  This makes the safepoint
   // appear useful until the parse has completed.
-  if( OptoRemoveUseless && transformed_sfpnt->is_SafePoint() ) {
+  if (transformed_sfpnt->is_SafePoint()) {
     assert(C->root() != NULL, "Expect parse is still valid");
     C->root()->add_prec(transformed_sfpnt);
   }

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -409,9 +409,6 @@ void NodeHash::operator=(const NodeHash& nh) {
 PhaseRemoveUseless::PhaseRemoveUseless(PhaseGVN* gvn, Unique_Node_List* worklist, PhaseNumber phase_num) : Phase(phase_num) {
   // Implementation requires an edge from root to each SafePointNode
   // at a backward branch. Inserted in add_safepoint().
-  if (!OptoRemoveUseless) {
-    return;
-  }
 
   // Identify nodes that are reachable from below, useful.
   C->identify_useful_nodes(_useful);
@@ -994,7 +991,7 @@ PhaseIterGVN::PhaseIterGVN(PhaseGVN* gvn) : PhaseGVN(gvn),
     if(n != NULL && n != _table.sentinel() && n->outcnt() == 0) {
       if( n->is_top() ) continue;
       // If remove_useless_nodes() has run, we expect no such nodes left.
-      assert(!OptoRemoveUseless, "remove_useless_nodes missed this node");
+      assert(false, "remove_useless_nodes missed this node");
       hash_delete(n);
     }
   }


### PR DESCRIPTION
Similar to [JDK-8266542](https://bugs.openjdk.java.net/browse/JDK-8266542), simply running `java -XX:-OptoRemoveUseless` already crashes the VM. I propose to remove this debug flag.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266618](https://bugs.openjdk.java.net/browse/JDK-8266618): Remove broken -XX:-OptoRemoveUseless


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3896/head:pull/3896` \
`$ git checkout pull/3896`

Update a local copy of the PR: \
`$ git checkout pull/3896` \
`$ git pull https://git.openjdk.java.net/jdk pull/3896/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3896`

View PR using the GUI difftool: \
`$ git pr show -t 3896`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3896.diff">https://git.openjdk.java.net/jdk/pull/3896.diff</a>

</details>
