### PR TITLE
JDK-8266044: Nested class summary should show kind of class or interface

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
@@ -192,7 +192,13 @@ public abstract class AbstractMemberWriter implements MemberSummaryWriter, Membe
         HtmlTree code = new HtmlTree(TagName.CODE);
         addModifier(member, code);
         if (type == null) {
-            code.add(utils.isClass(member) ? "class" : "interface");
+            code.add(switch (member.getKind()) {
+                case ENUM -> "enum";
+                case INTERFACE -> "interface";
+                case ANNOTATION_TYPE -> "@interface";
+                case RECORD -> "record";
+                default -> "class";
+            });
             code.add(Entity.NO_BREAK_SPACE);
         } else {
             List<? extends TypeParameterElement> list = utils.isExecutableElement(member)

--- a/test/langtools/jdk/javadoc/doclet/testMemberSummary/TestMemberSummary.java
+++ b/test/langtools/jdk/javadoc/doclet/testMemberSummary/TestMemberSummary.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug      4951228 6290760 8025633 8026567 8081854 8162363 8175200 8177417 8186332 8182765
- *           8258602
+ *           8258602 8266044
  * @summary  Test the case where the overridden method returns a different
  *           type than the method in the child class.  Make sure the
  *           documentation is inherited but the return type isn't.
@@ -96,19 +96,19 @@ public class TestMemberSummary extends JavadocTester {
                     <div class="table-header col-first">Modifier and Type</div>
                     <div class="table-header col-second">Class</div>
                     <div class="table-header col-last">Description</div>
-                    <div class="col-first even-row-color"><code>private static interface&nbsp;</code></div>
+                    <div class="col-first even-row-color"><code>private static @interface&nbsp;</code></div>
                     <div class="col-second even-row-color"><code><a href="Members.A.html" class="type-name-link" title="annotation interface in pkg3">Members.A</a></code></div>
                     <div class="col-last even-row-color">&nbsp;</div>
                     <div class="col-first odd-row-color"><code>private static final class&nbsp;</code></div>
                     <div class="col-second odd-row-color"><code><a href="Members.C.html" class="type-name-link" title="class in pkg3">Members.C</a></code></div>
                     <div class="col-last odd-row-color">&nbsp;</div>
-                    <div class="col-first even-row-color"><code>private static class&nbsp;</code></div>
+                    <div class="col-first even-row-color"><code>private static enum&nbsp;</code></div>
                     <div class="col-second even-row-color"><code><a href="Members.E.html" class="type-name-link" title="enum class in pkg3">Members.E</a></code></div>
                     <div class="col-last even-row-color">&nbsp;</div>
                     <div class="col-first odd-row-color"><code>private static interface&nbsp;</code></div>
                     <div class="col-second odd-row-color"><code><a href="Members.I.html" class="type-name-link" title="interface in pkg3">Members.I</a></code></div>
                     <div class="col-last odd-row-color">&nbsp;</div>
-                    <div class="col-first even-row-color"><code>private static final class&nbsp;</code></div>
+                    <div class="col-first even-row-color"><code>private static final record&nbsp;</code></div>
                     <div class="col-second even-row-color"><code><a href="Members.R.html" class="type-name-link" title="class in pkg3">Members.R</a></code></div>
                     <div class="col-last even-row-color">&nbsp;</div>
                     </div>""",


### PR DESCRIPTION
This is a simple fix to display the actual kind of nested class in the nested class summary table. This is not using `Utils#getTypeElementKindName` since we want to display the signature-like source level kind name (e.g. "enum" rather than "enum class").

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266044](https://bugs.openjdk.java.net/browse/JDK-8266044): Nested class summary should show kind of class or interface


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3897/head:pull/3897` \
`$ git checkout pull/3897`

Update a local copy of the PR: \
`$ git checkout pull/3897` \
`$ git pull https://git.openjdk.java.net/jdk pull/3897/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3897`

View PR using the GUI difftool: \
`$ git pr show -t 3897`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3897.diff">https://git.openjdk.java.net/jdk/pull/3897.diff</a>

</details>
