### PR TITLE
8266609: AArch64: include FP/LR space in LIR_Assembler::initial_frame_size_in_bytes()

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1886,7 +1886,6 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
 
   // n.b. frame size includes space for return pc and rfp
   const int framesize = C->output()->frame_size_in_bytes();
-  assert(framesize%(2*wordSize) == 0, "must preserve 2*wordSize alignment");
 
   // insert a nop at the start of the prolog so we can patch in a
   // branch if we need to invalidate the method later

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -374,10 +374,7 @@ void LIR_Assembler::jobject2reg_with_patching(Register reg, CodeEmitInfo *info) 
 int LIR_Assembler::initial_frame_size_in_bytes() const {
   // if rounding, must let FrameMap know!
 
-  // The frame_map records size in slots (32bit word)
-
-  // subtract two words to account for return address and link
-  return (frame_map()->framesize() - (2*VMRegImpl::slots_per_word))  * VMRegImpl::stack_slot_size;
+  return in_bytes(frame_map()->framesize_in_bytes());
 }
 
 

--- a/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
@@ -341,9 +341,9 @@ void C1_MacroAssembler::inline_cache_check(Register receiver, Register iCache) {
 void C1_MacroAssembler::build_frame(int framesize, int bang_size_in_bytes) {
   assert(bang_size_in_bytes >= framesize, "stack bang size incorrect");
   // Make sure there is enough stack space for this method's activation.
-  // Note that we do this before doing an enter().
+  // Note that we do this before creating a frame.
   generate_stack_overflow_check(bang_size_in_bytes);
-  MacroAssembler::build_frame(framesize + 2 * wordSize);
+  MacroAssembler::build_frame(framesize);
 
   // Insert nmethod entry barrier into frame.
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
@@ -351,7 +351,7 @@ void C1_MacroAssembler::build_frame(int framesize, int bang_size_in_bytes) {
 }
 
 void C1_MacroAssembler::remove_frame(int framesize) {
-  MacroAssembler::remove_frame(framesize + 2 * wordSize);
+  MacroAssembler::remove_frame(framesize);
 }
 
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -4438,7 +4438,8 @@ void MacroAssembler::load_byte_map_base(Register reg) {
 }
 
 void MacroAssembler::build_frame(int framesize) {
-  assert(framesize > 0, "framesize must be > 0");
+  assert(framesize >= 2 * wordSize, "framesize must include space for FP/LR");
+  assert(framesize % (2*wordSize) == 0, "must preserve 2*wordSize alignment");
   if (framesize < ((1 << 9) + 2 * wordSize)) {
     sub(sp, sp, framesize);
     stp(rfp, lr, Address(sp, framesize - 2 * wordSize));
@@ -4457,7 +4458,8 @@ void MacroAssembler::build_frame(int framesize) {
 }
 
 void MacroAssembler::remove_frame(int framesize) {
-  assert(framesize > 0, "framesize must be > 0");
+  assert(framesize >= 2 * wordSize, "framesize must include space for FP/LR");
+  assert(framesize % (2*wordSize) == 0, "must preserve 2*wordSize alignment");
   if (framesize < ((1 << 9) + 2 * wordSize)) {
     ldp(rfp, lr, Address(sp, framesize - 2 * wordSize));
     add(sp, sp, framesize);


### PR DESCRIPTION
LIR_Assembler::initial_frame_size_in_bytes() returns the frame size
without the additional 2\*wordSize needed to store FP/LR (i.e. just the
space required for the C1 locals).  When we pass this value to
MacroAssembler build_frame and remove_frame we need to remember to add
back the 2\*wordSize.  This patch changes initial_frame_size_in_bytes()
to return the full frame size including the space for FP/LR.  The PPC
and S390 ports already do this, and it also matches the behaviour of
C->output()->frame_size_in_bytes() in C2.

This change may seem a bit trivial in mainline but the Valhalla lworld
branch makes more calls to build_frame/remove_frame in C1 and keeping
track of whether "framesize" is with or without FP/LR quickly becomes
confusing.

Tested tier1 on AArch64.  The only use of this function is as input to
C1_MacroAssembler build_frame() and remove_frame() so seems safe.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266609](https://bugs.openjdk.java.net/browse/JDK-8266609): AArch64: include FP/LR space in LIR_Assembler::initial_frame_size_in_bytes()


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3898/head:pull/3898` \
`$ git checkout pull/3898`

Update a local copy of the PR: \
`$ git checkout pull/3898` \
`$ git pull https://git.openjdk.java.net/jdk pull/3898/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3898`

View PR using the GUI difftool: \
`$ git pr show -t 3898`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3898.diff">https://git.openjdk.java.net/jdk/pull/3898.diff</a>

</details>
