### PR TITLE
8266625: The method DiagnosticSource#findLine returns wrong results when using the boundary values

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/AbstractDiagnosticFormatter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/AbstractDiagnosticFormatter.java
@@ -313,11 +313,17 @@ public abstract class AbstractDiagnosticFormatter implements DiagnosticFormatter
         int pos = d.getIntPosition();
         if (d.getIntPosition() == Position.NOPOS)
             throw new AssertionError();
-        String line = (source == null ? null : source.getLine(pos));
+        String line;
+        if (source == null)
+            line = null;
+        else if ((line = source.getLine(pos)) == null)
+            line = source.getLine(pos - 1);
         if (line == null)
             return "";
         buf.append(indent(line, nSpaces));
         int col = source.getColumnNumber(pos, false);
+        if (col == 0)
+            col = source.getColumnNumber(pos - 1, false);
         if (config.isCaretEnabled()) {
             buf.append("\n");
             for (int i = 0; i < col - 1; i++)  {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/DiagnosticSource.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/DiagnosticSource.java
@@ -172,7 +172,7 @@ public class DiagnosticSource {
                     break;
                 }
             }
-            return bp <= bufLen;
+            return bp < bufLen;
         } catch (IOException e) {
             log.directError("source.unavailable");
             buf = new char[0];

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/JCDiagnostic.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/JCDiagnostic.java
@@ -459,8 +459,15 @@ public class JCDiagnostic implements Diagnostic<JavaFileObject> {
             if (n == Position.NOPOS || source == null)
                 line = column = -1;
             else {
-                line = source.getLineNumber(n);
-                column = source.getColumnNumber(n, true);
+                int lineNum = source.getLineNumber(n);
+                int colNum = source.getColumnNumber(n, true);
+                if (lineNum == 0) {
+                    line = source.getLineNumber(n - 1);
+                    column = source.getColumnNumber(n - 1, true);
+                } else {
+                    line = lineNum;
+                    column = colNum;
+                }
             }
         }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
@@ -587,10 +587,16 @@ public class Log extends AbstractLog {
      *  @param pos   Buffer index of the error position, must be on current line
      */
     private void printErrLine(int pos, PrintWriter writer) {
-        String line = (source == null ? null : source.getLine(pos));
+        String line;
+        if (source == null)
+            line = null;
+        else if ((line = source.getLine(pos)) == null)
+            line = source.getLine(pos - 1);
         if (line == null)
             return;
         int col = source.getColumnNumber(pos, false);
+        if (col == 0)
+            col = source.getColumnNumber(pos - 1, false);
 
         printRawLines(writer, line);
         for (int i = 0; i < col - 1; i++) {
@@ -846,6 +852,8 @@ public class Log extends AbstractLog {
             printRawLines(pw, prefix + msg);
         } else {
             int line = source.getLineNumber(pos);
+            if (line == 0)
+                line = source.getLineNumber(pos - 1);
             JavaFileObject file = source.getFile();
             if (file != null)
                 printRawLines(pw,

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/RawDiagnosticFormatter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/RawDiagnosticFormatter.java
@@ -77,6 +77,10 @@ public final class RawDiagnosticFormatter extends AbstractDiagnosticFormatter {
             long diagLine = diag.getLineNumber();
             long expLine = diagSource.getLineNumber(exp.pos);
             long expCol = diagSource.getColumnNumber(exp.pos, false);
+            if (expLine == 0) {
+                expLine = diagSource.getLineNumber(exp.pos - 1);
+                expCol = diagSource.getColumnNumber(exp.pos - 1, false);
+            }
             return (expLine == diagLine) ?
                     String.valueOf(expCol) :
                     expLine + ":" + expCol;

--- a/test/langtools/tools/javac/diags/DiagnosticSourceTest.java
+++ b/test/langtools/tools/javac/diags/DiagnosticSourceTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8266625
+ * @summary The method DiagnosticSource#findLine returns wrong results when using the boundary values
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.util
+ * @build toolbox.ToolBox
+ * @run main DiagnosticSourceTest
+ */
+
+import javax.tools.ToolProvider;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import com.sun.tools.javac.util.DiagnosticSource;
+import static com.sun.tools.javac.util.LayoutCharacters.*;
+import toolbox.ToolBox;
+
+public class DiagnosticSourceTest {
+    public static void main(String[] args) {
+        ToolBox tb = new ToolBox();
+
+        String code = "public class T {\n}"; // 18 characters
+        var fileObject = new ToolBox.JavaSource(code);
+        DiagnosticSource ds = new DiagnosticSource(fileObject, null);
+        tb.checkEqual(Arrays.asList("1", "1", "public class T {"),
+                Arrays.asList(Integer.toString(ds.getLineNumber(0)),
+                        Integer.toString(ds.getColumnNumber(0, false)), ds.getLine(0)));
+        tb.checkEqual(Arrays.asList("1", "4", "public class T {"),
+                Arrays.asList(Integer.toString(ds.getLineNumber(3)),
+                        Integer.toString(ds.getColumnNumber(3, false)), ds.getLine(3)));
+        tb.checkEqual(Arrays.asList("2", "1", "}"),
+                Arrays.asList(Integer.toString(ds.getLineNumber(17)),
+                        Integer.toString(ds.getColumnNumber(17, false)), ds.getLine(17)));
+        tb.checkEqual(Arrays.asList("0", "0", null),
+                Arrays.asList(Integer.toString(ds.getLineNumber(18)),
+                        Integer.toString(ds.getColumnNumber(18, false)), ds.getLine(18)));
+        tb.checkEqual(Arrays.asList("0", "0", null),
+                Arrays.asList(Integer.toString(ds.getLineNumber(19)),
+                        Integer.toString(ds.getColumnNumber(19, false)), ds.getLine(19)));
+        tb.checkEqual(Arrays.asList("0", "0", null),
+                Arrays.asList(Integer.toString(ds.getLineNumber(20)),
+                        Integer.toString(ds.getColumnNumber(20, false)), ds.getLine(20)));
+
+        code = "public class T {\n}\n"; // 19 characters
+        fileObject = new ToolBox.JavaSource(code);
+        ds = new DiagnosticSource(fileObject, null);
+        tb.checkEqual(Arrays.asList("1", "1", "public class T {"),
+                Arrays.asList(Integer.toString(ds.getLineNumber(0)),
+                        Integer.toString(ds.getColumnNumber(0, false)), ds.getLine(0)));
+        tb.checkEqual(Arrays.asList("1", "4", "public class T {"),
+                Arrays.asList(Integer.toString(ds.getLineNumber(3)),
+                        Integer.toString(ds.getColumnNumber(3, false)), ds.getLine(3)));
+        tb.checkEqual(Arrays.asList("2", "1", "}"),
+                Arrays.asList(Integer.toString(ds.getLineNumber(17)),
+                        Integer.toString(ds.getColumnNumber(17, false)), ds.getLine(17)));
+        tb.checkEqual(Arrays.asList("2", "2", "}"),
+                Arrays.asList(Integer.toString(ds.getLineNumber(18)),
+                        Integer.toString(ds.getColumnNumber(18, false)), ds.getLine(18)));
+        tb.checkEqual(Arrays.asList("0", "0", null),
+                Arrays.asList(Integer.toString(ds.getLineNumber(19)),
+                        Integer.toString(ds.getColumnNumber(19, false)), ds.getLine(19)));
+        tb.checkEqual(Arrays.asList("0", "0", null),
+                Arrays.asList(Integer.toString(ds.getLineNumber(20)),
+                        Integer.toString(ds.getColumnNumber(20, false)), ds.getLine(20)));
+    }
+}

--- a/test/langtools/tools/javac/diags/DiagnosticSourceTest.java
+++ b/test/langtools/tools/javac/diags/DiagnosticSourceTest.java
@@ -36,6 +36,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import com.sun.tools.javac.util.DiagnosticSource;
 import static com.sun.tools.javac.util.LayoutCharacters.*;
@@ -48,45 +49,28 @@ public class DiagnosticSourceTest {
         String code = "public class T {\n}"; // 18 characters
         var fileObject = new ToolBox.JavaSource(code);
         DiagnosticSource ds = new DiagnosticSource(fileObject, null);
-        tb.checkEqual(Arrays.asList("1", "1", "public class T {"),
-                Arrays.asList(Integer.toString(ds.getLineNumber(0)),
-                        Integer.toString(ds.getColumnNumber(0, false)), ds.getLine(0)));
-        tb.checkEqual(Arrays.asList("1", "4", "public class T {"),
-                Arrays.asList(Integer.toString(ds.getLineNumber(3)),
-                        Integer.toString(ds.getColumnNumber(3, false)), ds.getLine(3)));
-        tb.checkEqual(Arrays.asList("2", "1", "}"),
-                Arrays.asList(Integer.toString(ds.getLineNumber(17)),
-                        Integer.toString(ds.getColumnNumber(17, false)), ds.getLine(17)));
-        tb.checkEqual(Arrays.asList("0", "0", null),
-                Arrays.asList(Integer.toString(ds.getLineNumber(18)),
-                        Integer.toString(ds.getColumnNumber(18, false)), ds.getLine(18)));
-        tb.checkEqual(Arrays.asList("0", "0", null),
-                Arrays.asList(Integer.toString(ds.getLineNumber(19)),
-                        Integer.toString(ds.getColumnNumber(19, false)), ds.getLine(19)));
-        tb.checkEqual(Arrays.asList("0", "0", null),
-                Arrays.asList(Integer.toString(ds.getLineNumber(20)),
-                        Integer.toString(ds.getColumnNumber(20, false)), ds.getLine(20)));
+        tb.checkEqual(Arrays.asList("1", "1", "public class T {"), getActualOutputList(ds, 0));
+        tb.checkEqual(Arrays.asList("1", "4", "public class T {"), getActualOutputList(ds, 3));
+        tb.checkEqual(Arrays.asList("2", "1", "}"), getActualOutputList(ds, 17));
+        tb.checkEqual(Arrays.asList("0", "0", null), getActualOutputList(ds,18));
+        tb.checkEqual(Arrays.asList("0", "0", null), getActualOutputList(ds, 19));
+        tb.checkEqual(Arrays.asList("0", "0", null), getActualOutputList(ds, 20));
 
         code = "public class T {\n}\n"; // 19 characters
         fileObject = new ToolBox.JavaSource(code);
         ds = new DiagnosticSource(fileObject, null);
-        tb.checkEqual(Arrays.asList("1", "1", "public class T {"),
-                Arrays.asList(Integer.toString(ds.getLineNumber(0)),
-                        Integer.toString(ds.getColumnNumber(0, false)), ds.getLine(0)));
-        tb.checkEqual(Arrays.asList("1", "4", "public class T {"),
-                Arrays.asList(Integer.toString(ds.getLineNumber(3)),
-                        Integer.toString(ds.getColumnNumber(3, false)), ds.getLine(3)));
-        tb.checkEqual(Arrays.asList("2", "1", "}"),
-                Arrays.asList(Integer.toString(ds.getLineNumber(17)),
-                        Integer.toString(ds.getColumnNumber(17, false)), ds.getLine(17)));
-        tb.checkEqual(Arrays.asList("2", "2", "}"),
-                Arrays.asList(Integer.toString(ds.getLineNumber(18)),
-                        Integer.toString(ds.getColumnNumber(18, false)), ds.getLine(18)));
-        tb.checkEqual(Arrays.asList("0", "0", null),
-                Arrays.asList(Integer.toString(ds.getLineNumber(19)),
-                        Integer.toString(ds.getColumnNumber(19, false)), ds.getLine(19)));
-        tb.checkEqual(Arrays.asList("0", "0", null),
-                Arrays.asList(Integer.toString(ds.getLineNumber(20)),
-                        Integer.toString(ds.getColumnNumber(20, false)), ds.getLine(20)));
+        tb.checkEqual(Arrays.asList("1", "1", "public class T {"), getActualOutputList(ds, 0));
+        tb.checkEqual(Arrays.asList("1", "4", "public class T {"), getActualOutputList(ds, 3));
+        tb.checkEqual(Arrays.asList("2", "1", "}"), getActualOutputList(ds, 17));
+        tb.checkEqual(Arrays.asList("2", "2", "}"), getActualOutputList(ds, 18));
+        tb.checkEqual(Arrays.asList("0", "0", null), getActualOutputList(ds, 19));
+        tb.checkEqual(Arrays.asList("0", "0", null), getActualOutputList(ds, 20));
+    }
+
+    public static List<String> getActualOutputList(DiagnosticSource ds, int pos) {
+        return Arrays.asList(
+                Integer.toString(ds.getLineNumber(pos)),
+                Integer.toString(ds.getColumnNumber(pos, false)),
+                ds.getLine(pos));
     }
 }

--- a/test/langtools/tools/javac/launcher/SourceLauncherTest.java
+++ b/test/langtools/tools/javac/launcher/SourceLauncherTest.java
@@ -416,7 +416,7 @@ public class SourceLauncherTest extends TestRunner {
         testError(file,
                 file + ":1: error: reached end of file while parsing\n" +
                 "class SyntaxErr {\n" +
-                "                 ^\n" +
+                "                ^\n" +
                 "1 error\n",
                 "error: compilation failed");
     }

--- a/test/langtools/tools/javac/rawDiags/Error.out
+++ b/test/langtools/tools/javac/rawDiags/Error.out
@@ -1,2 +1,2 @@
-Error.java:10:1: compiler.err.premature.eof
+Error.java:9:22: compiler.err.premature.eof
 1 error


### PR DESCRIPTION
Hi all,

Currently, when the file object has N characters, the method `DiagnosticSource#findLine(N)` returns true, which is a wrong result. Becase the position is zero-based, the max index is `N-1`.

The methods `getLineNumber`, `getColumnNumber` and `getLine`, which use `findLine` internally, would also return wrong results when using the boundary values.

This patch mainly fixes `DiagnosticSource#findLine(N)` by using the following code.

```
-            return bp <= bufLen;
+            return bp < bufLen;
```

A corresponding test `DiagnosticSourceTest.java` is added. Then, the usages of  `getLineNumber`, `getColumnNumber` and `getLine` need to revised. And two existing tests need to be adjusted.

Thank you for taking the time to review.

Best Regards,
--- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8266625](https://bugs.openjdk.java.net/browse/JDK-8266625): The method DiagnosticSource#findLine returns wrong results when using the boundary values


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3899/head:pull/3899` \
`$ git checkout pull/3899`

Update a local copy of the PR: \
`$ git checkout pull/3899` \
`$ git pull https://git.openjdk.java.net/jdk pull/3899/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3899`

View PR using the GUI difftool: \
`$ git pr show -t 3899`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3899.diff">https://git.openjdk.java.net/jdk/pull/3899.diff</a>

</details>
