### PR TITLE
8266642: improve ResolvedMethodTable hash function

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -327,6 +327,10 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   const char* loader_name_and_id() const;
   Symbol* name_and_id() const { return _name_and_id; }
 
+  unsigned identity_hash() const {
+    return (unsigned)((uintptr_t)this >> (LogMinObjAlignmentInBytes + 3));
+  }
+
   JFR_ONLY(DEFINE_TRACE_ID_METHODS;)
 };
 

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -328,7 +328,7 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   Symbol* name_and_id() const { return _name_and_id; }
 
   unsigned identity_hash() const {
-    return (unsigned)((uintptr_t)this >> (LogMinObjAlignmentInBytes + 3));
+    return (unsigned)((uintptr_t)this >> 3);
   }
 
   JFR_ONLY(DEFINE_TRACE_ID_METHODS;)

--- a/src/hotspot/share/prims/resolvedMethodTable.cpp
+++ b/src/hotspot/share/prims/resolvedMethodTable.cpp
@@ -56,6 +56,11 @@ unsigned int method_hash(const Method* method) {
   unsigned int hash = method->klass_name()->identity_hash();
   hash = (hash * 31) ^ method->name()->identity_hash();
   hash = (hash * 31) ^ method->signature()->identity_hash();
+  uintptr_t cld = (uintptr_t)method->method_holder()->class_loader_data();
+  hash = (hash * 31) ^ (unsigned int)cld;
+#ifdef _LP64
+  hash = hash ^ (unsigned int)(cld >> 32);
+#endif
   return hash;
 }
 

--- a/src/hotspot/share/prims/resolvedMethodTable.cpp
+++ b/src/hotspot/share/prims/resolvedMethodTable.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "classfile/classLoaderData.hpp"
 #include "classfile/javaClasses.hpp"
 #include "gc/shared/oopStorage.inline.hpp"
 #include "gc/shared/oopStorageSet.hpp"

--- a/src/hotspot/share/prims/resolvedMethodTable.cpp
+++ b/src/hotspot/share/prims/resolvedMethodTable.cpp
@@ -56,12 +56,7 @@ unsigned int method_hash(const Method* method) {
   unsigned int hash = method->klass_name()->identity_hash();
   hash = (hash * 31) ^ method->name()->identity_hash();
   hash = (hash * 31) ^ method->signature()->identity_hash();
-  uintptr_t cld = (uintptr_t)method->method_holder()->class_loader_data();
-  hash = (hash * 31) ^ (unsigned int)cld;
-#ifdef _LP64
-  hash = hash ^ (unsigned int)(cld >> 32);
-#endif
-  return hash;
+  return hash ^ (unsigned)((uintptr_t)method >> (LogMinObjAlignmentInBytes + 3));
 }
 
 typedef ConcurrentHashTable<ResolvedMethodTableConfig,

--- a/src/hotspot/share/prims/resolvedMethodTable.cpp
+++ b/src/hotspot/share/prims/resolvedMethodTable.cpp
@@ -53,11 +53,11 @@ static const size_t GROW_HINT = 32;
 static const size_t ResolvedMethodTableSizeLog = 10;
 
 unsigned int method_hash(const Method* method) {
-  unsigned int hash = method->klass_name()->identity_hash();
+  unsigned int hash = method->method_holder()->class_loader_data()->identity_hash();
+  hash = (hash * 31) ^ method->klass_name()->identity_hash();
   hash = (hash * 31) ^ method->name()->identity_hash();
   hash = (hash * 31) ^ method->signature()->identity_hash();
-  return hash ^ (unsigned)((uintptr_t)(method->method_holder()->class_loader_data())
-                                       >> (LogMinObjAlignmentInBytes + 3));
+  return hash;
 }
 
 typedef ConcurrentHashTable<ResolvedMethodTableConfig,

--- a/src/hotspot/share/prims/resolvedMethodTable.cpp
+++ b/src/hotspot/share/prims/resolvedMethodTable.cpp
@@ -56,7 +56,8 @@ unsigned int method_hash(const Method* method) {
   unsigned int hash = method->klass_name()->identity_hash();
   hash = (hash * 31) ^ method->name()->identity_hash();
   hash = (hash * 31) ^ method->signature()->identity_hash();
-  return hash ^ (unsigned)((uintptr_t)method >> (LogMinObjAlignmentInBytes + 3));
+  return hash ^ (unsigned)((uintptr_t)(method->method_holder()->class_loader_data())
+                                       >> (LogMinObjAlignmentInBytes + 3));
 }
 
 typedef ConcurrentHashTable<ResolvedMethodTableConfig,

--- a/test/hotspot/jtreg/runtime/MemberName/ResolvedMethodTableHash.java
+++ b/test/hotspot/jtreg/runtime/MemberName/ResolvedMethodTableHash.java
@@ -26,7 +26,6 @@
  * @bug 8249719
  * @summary ResolvedMethodTable hash function should take method class into account
  * @modules java.base/jdk.internal.misc
- *
  * @run main/othervm/manual -Xmx256m -XX:MaxMetaspaceSize=256m ResolvedMethodTableHash 200000
  */
 
@@ -93,6 +92,7 @@ public class ResolvedMethodTableHash extends ClassLoader {
         int count = args.length > 0 ? Integer.parseInt(args[0]) : 200000;
 
         for (int i = 0; i < count; i++) {
+            // prevents metaspace oom
             if (i % 5 != 0) {
                 handles.add(generator.generate("MH$" + i));
             } else {

--- a/test/hotspot/jtreg/runtime/MemberName/ResolvedMethodTableHash.java
+++ b/test/hotspot/jtreg/runtime/MemberName/ResolvedMethodTableHash.java
@@ -36,7 +36,6 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import jdk.internal.misc.Unsafe;
 
 // The test generates thousands MethodHandles to the methods of the same name
 // and the same signature. This should not take too long, unless Method hash
@@ -54,7 +53,7 @@ public class ResolvedMethodTableHash extends ClassLoader {
     private MethodHandle generateWithSameName() throws ReflectiveOperationException {
         byte[] buf = new byte[100];
         int size = writeClass(buf, "MH$$");
-        Class<?> cls = Unsafe.getUnsafe().defineAnonymousClass(ResolvedMethodTableHash.class, Arrays.copyOf(buf, size), null);
+        Class<?> cls = new ResolvedMethodTableHash().defineClass(null, buf, 0, size);
         return MethodHandles.publicLookup().findStatic(cls, "m", MethodType.methodType(void.class));
     }
 
@@ -93,7 +92,7 @@ public class ResolvedMethodTableHash extends ClassLoader {
 
         for (int i = 0; i < count; i++) {
             // prevents metaspace oom
-            if (i % 5 != 0) {
+            if (i % 20 != 0) {
                 handles.add(generator.generate("MH$" + i));
             } else {
                 handles.add(generator.generateWithSameName());

--- a/test/hotspot/jtreg/runtime/MemberName/ResolvedMethodTableHash.java
+++ b/test/hotspot/jtreg/runtime/MemberName/ResolvedMethodTableHash.java
@@ -51,6 +51,7 @@ public class ResolvedMethodTableHash extends ClassLoader {
     private MethodHandle generateWithSameName() throws ReflectiveOperationException {
         byte[] buf = new byte[100];
         int size = writeClass(buf, "MH$$");
+        // use different classloader instances to load the classes with the same name
         Class<?> cls = new ResolvedMethodTableHash().defineClass(null, buf, 0, size);
         return MethodHandles.publicLookup().findStatic(cls, "m", MethodType.methodType(void.class));
     }

--- a/test/hotspot/jtreg/runtime/MemberName/ResolvedMethodTableHash.java
+++ b/test/hotspot/jtreg/runtime/MemberName/ResolvedMethodTableHash.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8249719
  * @summary ResolvedMethodTable hash function should take method class into account
- * @modules java.base/jdk.internal.misc
  * @run main/othervm/manual -Xmx256m -XX:MaxMetaspaceSize=256m ResolvedMethodTableHash 200000
  */
 
@@ -34,7 +33,6 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 // The test generates thousands MethodHandles to the methods of the same name


### PR DESCRIPTION
JDK-8249719 has fixed the bad hash function problem, however, the performance problem still exists when there are a large number of classes with the same name.
Adding the address of the corresponding ClassLoaderData as a factor of hash can solve the problem.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266642](https://bugs.openjdk.java.net/browse/JDK-8266642): Improve ResolvedMethodTable hash function


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**) ⚠️ Review applies to e9c674ca56dfe221fce634dd10ec26568fe3cef3
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to b02705f0f2d527904b548e8771ff8446ef423ecc


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3901/head:pull/3901` \
`$ git checkout pull/3901`

Update a local copy of the PR: \
`$ git checkout pull/3901` \
`$ git pull https://git.openjdk.java.net/jdk pull/3901/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3901`

View PR using the GUI difftool: \
`$ git pr show -t 3901`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3901.diff">https://git.openjdk.java.net/jdk/pull/3901.diff</a>

</details>
