### PR TITLE
8266440: Shenandoah: TestReferenceShortcutCycle.java test failed on AArch64

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
@@ -246,13 +246,13 @@ void ShenandoahBarrierSetAssembler::load_reference_barrier(MacroAssembler* masm,
     __ tbz(rscratch2, ShenandoahHeap::HAS_FORWARDED_BITPOS, heap_stable);
   } else {
     if (dst == rscratch1) {
-      __ push(rscratch1);
+      __ push(rscratch1, sp);
     }
     __ mov(rscratch1, ShenandoahHeap::HAS_FORWARDED | ShenandoahHeap::WEAK_ROOTS);
     __ tst(rscratch1, rscratch2);
 
     if (dst == rscratch1) {
-      __ pop(rscratch1);
+      __ pop(rscratch1, sp);
     }
 
     __ br(Assembler::EQ, heap_stable);

--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
@@ -245,17 +245,10 @@ void ShenandoahBarrierSetAssembler::load_reference_barrier(MacroAssembler* masm,
   if (is_strong) {
     __ tbz(rscratch2, ShenandoahHeap::HAS_FORWARDED_BITPOS, heap_stable);
   } else {
-    if (dst == rscratch1) {
-      __ push(rscratch1, sp);
-    }
-    __ mov(rscratch1, ShenandoahHeap::HAS_FORWARDED | ShenandoahHeap::WEAK_ROOTS);
-    __ tst(rscratch1, rscratch2);
-
-    if (dst == rscratch1) {
-      __ pop(rscratch1, sp);
-    }
-
-    __ br(Assembler::EQ, heap_stable);
+    Label lrb;
+    __ tbnz(rscratch2, ShenandoahHeap::WEAK_ROOTS_BITPOS, lrb);
+    __ tbz(rscratch2, ShenandoahHeap::HAS_FORWARDED_BITPOS, heap_stable);
+    __ bind(lrb);
   }
 
   // use r1 for load address


### PR DESCRIPTION
JDK-8263427 missed corresponding changes for aarch64.

LRB needs to be enabled during weak roots/references processing, regardless if heap is stable.

Test:

- [x] hotspot_gc_shenandoah on Macosx/AArch64
- [ ] hotspot_gc_shenandoah on Linux 64/AArch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266440](https://bugs.openjdk.java.net/browse/JDK-8266440): Shenandoah: TestReferenceShortcutCycle.java test failed on AArch64


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3902/head:pull/3902` \
`$ git checkout pull/3902`

Update a local copy of the PR: \
`$ git checkout pull/3902` \
`$ git pull https://git.openjdk.java.net/jdk pull/3902/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3902`

View PR using the GUI difftool: \
`$ git pr show -t 3902`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3902.diff">https://git.openjdk.java.net/jdk/pull/3902.diff</a>

</details>
