### PR TITLE
8266622: Optimize Class.descriptorString() and Class.getCanonicalName0()

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -4374,7 +4374,7 @@ public final class Class<T> implements java.io.Serializable,
                     .append('L')
                     .append(name.substring(0, index).replace('.', '/'))
                     .append('.')
-                    .append(name.substring(index + 1))
+                    .append(name, index + 1, name.length())
                     .append(';')
                     .toString();
         } else {

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -1722,7 +1722,12 @@ public final class Class<T> implements java.io.Serializable,
             String enclosingName = enclosingClass.getCanonicalName();
             if (enclosingName == null)
                 return ReflectionData.NULL_SENTINEL;
-            return enclosingName + "." + getSimpleName();
+            String simpleName = getSimpleName();
+            return new StringBuilder(enclosingName.length() + simpleName.length() + 1)
+                    .append(enclosingName)
+                    .append('.')
+                    .append(simpleName)
+                    .toString();
         }
     }
 
@@ -4365,10 +4370,20 @@ public final class Class<T> implements java.io.Serializable,
         } else if (isHidden()) {
             String name = getName();
             int index = name.indexOf('/');
-            return "L" + name.substring(0, index).replace('.', '/')
-                       + "." + name.substring(index+1) + ";";
+            return new StringBuilder(name.length() + 2)
+                    .append('L')
+                    .append(name.substring(0, index).replace('.', '/'))
+                    .append('.')
+                    .append(name.substring(index + 1))
+                    .append(';')
+                    .toString();
         } else {
-            return "L" + getName().replace('.', '/') + ";";
+            String name = getName().replace('.', '/');
+            return new StringBuilder(name.length() + 2)
+                    .append('L')
+                    .append(name)
+                    .append(';')
+                    .toString();
         }
     }
 


### PR DESCRIPTION
Hello, from discussion in https://github.com/openjdk/jdk/pull/3464 and https://github.com/openjdk/jdk/pull/2212 it appears, that in `j.l.Class` expressions like
```java
String str = baseName.replace('.', '/') + '/' + name;
```
are not compiled into invokedynamic-based code, but into one using `StringBuilder`.

This happens due to some bootstraping issues. Currently the bytecode for the last (most often used) branch of `Class.descriptorString()` looks like
```
public sb()Ljava/lang/String;
   L0
    LINENUMBER 21 L0
    NEW java/lang/StringBuilder
    DUP
    INVOKESPECIAL java/lang/StringBuilder.<init> ()V
    ASTORE 1
   L1
    LINENUMBER 23 L1
    ALOAD 1
    LDC "a"
    INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
    POP
   L2
    LINENUMBER 24 L2
    ALOAD 1
    LDC "b"
    INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
    POP
   L3
    LINENUMBER 26 L3
    ALOAD 1
    INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
    ARETURN
```
Here the `StringBuilder` is created with default constructor and then expands if necessary while appending. 

This can be improved by manually allocating `StringBuilder` of exact size. The benchmark demonstrates measurable improvement:
```java
@State(Scope.Benchmark)
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@Fork(jvmArgsAppend = {"-Xms2g", "-Xmx2g"})
public class ClassDescriptorStringBenchmark {

    private final Class<?> clazzWithShortDescriptor = Object.class;
    private final Class<?> clazzWithLongDescriptor = getClass();

    @Benchmark
    public String descriptorString_short() {
        return clazzWithShortDescriptor.descriptorString();
    }

    @Benchmark
    public String descriptorString_long() {
        return clazzWithLongDescriptor.descriptorString();
    }
}
```

```
original
-Xint
                                               Mode     Score     Error   Units
descriptorString_long                          avgt  6326.478 ± 107.251   ns/op
descriptorString_short                         avgt  5220.729 ± 103.545   ns/op
descriptorString_long:·gc.alloc.rate.norm      avgt   528.089 ±   0.021    B/op
descriptorString_short:·gc.alloc.rate.norm     avgt   232.036 ±   0.015    B/op

-XX:TieredStopAtLevel=1
                                               Mode      Score    Error   Units
descriptorString_long                          avgt    230.223 ±  1.254   ns/op
descriptorString_short                         avgt    164.255 ±  0.755   ns/op
descriptorString_long:·gc.alloc.rate.norm      avgt    528.046 ±  0.002    B/op
descriptorString_short:·gc.alloc.rate.norm     avgt    232.022 ±  0.001    B/op

full
                                               Mode      Score     Error   Units
descriptorString_long                          avgt     74.835 ±   0.262   ns/op
descriptorString_short                         avgt     43.822 ±   0.788   ns/op
descriptorString_long:·gc.alloc.rate.norm      avgt    504.010 ±   0.001    B/op
descriptorString_short:·gc.alloc.rate.norm     avgt    208.004 ±   0.001    B/op

------------------------
patched
-Xint
                                               Mode      Score     Error   Units
descriptorString_long                          avgt   4485.994 ±  60.173   ns/op
descriptorString_short                         avgt   3949.965 ± 278.143   ns/op
descriptorString_long:·gc.alloc.rate.norm      avgt    336.051 ±   0.004    B/op
descriptorString_short:·gc.alloc.rate.norm     avgt    184.027 ±   0.010    B/op

-XX:TieredStopAtLevel=1
                                               Mode        Score    Error   Units
descriptorString_long                          avgt      185.774 ±  1.100   ns/op
descriptorString_short                         avgt      135.338 ±  1.066   ns/op
descriptorString_long:·gc.alloc.rate.norm      avgt      336.030 ±  0.001    B/op
descriptorString_short:·gc.alloc.rate.norm     avgt      184.019 ±  0.001    B/op

full
                                               Mode      Score     Error   Units
descriptorString_long                          avgt     42.864 ±   0.160   ns/op
descriptorString_short                         avgt     27.255 ±   0.381   ns/op
descriptorString_long:·gc.alloc.rate.norm      avgt    224.005 ±   0.001    B/op
descriptorString_short:·gc.alloc.rate.norm     avgt    120.002 ±   0.001    B/op
```
Same can be done also for Class.isHidden() branch in Class.descriptorString() and for Class.getCanonicalName0()

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266622](https://bugs.openjdk.java.net/browse/JDK-8266622): Optimize Class.descriptorString() and Class.getCanonicalName0()


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to 7c26095e9ffa5616d048e115074cd4c5063cb2a3


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3903/head:pull/3903` \
`$ git checkout pull/3903`

Update a local copy of the PR: \
`$ git checkout pull/3903` \
`$ git pull https://git.openjdk.java.net/jdk pull/3903/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3903`

View PR using the GUI difftool: \
`$ git pr show -t 3903`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3903.diff">https://git.openjdk.java.net/jdk/pull/3903.diff</a>

</details>
