### PR TITLE
8266646: Add more diagnostic to java/lang/System/LoggerFinder/modules

### DIFF
--- a/test/jdk/java/lang/System/LoggerFinder/modules/boot_client/BootClient.java
+++ b/test/jdk/java/lang/System/LoggerFinder/modules/boot_client/BootClient.java
@@ -23,6 +23,8 @@
 
 import java.lang.reflect.Method;
 import java.lang.System.Logger;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.ResourceBundle;
 import java.util.ListResourceBundle;
 
@@ -36,9 +38,13 @@ public final class BootClient {
         String loggerMode = args[0];
         String loggerClassName = args[1];
         String underlyingLoggerClassName = args.length >= 3 ? args[2] : null;
-
-        testLogger(loggerMode, loggerClassName, underlyingLoggerClassName);
-        testLog(underlyingLoggerClassName);
+        System.err.println("BootClient starting at " + DateTimeFormatter.ISO_INSTANT.format(Instant.now()));
+        try {
+            testLogger(loggerMode, loggerClassName, underlyingLoggerClassName);
+            testLog(underlyingLoggerClassName);
+        } finally {
+            System.err.println("BootClient finished at " + DateTimeFormatter.ISO_INSTANT.format(Instant.now()));
+        }
     }
 
     /*

--- a/test/jdk/java/lang/System/LoggerFinder/modules/named_client/m.t.a/pkg/a/t/TestA.java
+++ b/test/jdk/java/lang/System/LoggerFinder/modules/named_client/m.t.a/pkg/a/t/TestA.java
@@ -25,6 +25,8 @@ package pkg.a.t;
 
 import java.lang.reflect.Method;
 import java.lang.System.Logger;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.ResourceBundle;
 import java.util.ListResourceBundle;
 
@@ -37,9 +39,13 @@ public class TestA {
         assertTrue(args.length == 2);
         String loggerMode = args[0];
         String loggerClassName = args[1];
-
-        testLogger(loggerMode, loggerClassName);
-        testLog(loggerClassName);
+        System.err.println("TestA starting at " + DateTimeFormatter.ISO_INSTANT.format(Instant.now()));
+        try {
+            testLogger(loggerMode, loggerClassName);
+            testLog(loggerClassName);
+        } finally {
+            System.err.println("TestA finished at " + DateTimeFormatter.ISO_INSTANT.format(Instant.now()));
+        }
     }
 
     /*

--- a/test/jdk/java/lang/System/LoggerFinder/modules/patched_client/PatchedClient.java
+++ b/test/jdk/java/lang/System/LoggerFinder/modules/patched_client/PatchedClient.java
@@ -23,6 +23,8 @@
 
 import java.lang.reflect.Method;
 import java.lang.System.Logger;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.ResourceBundle;
 import java.util.ListResourceBundle;
 
@@ -36,9 +38,14 @@ public class PatchedClient {
         String loggerMode = args[0];
         String loggerClassName = args[1];
         String underlyingLoggerClassName = args.length >= 3 ? args[2] : null;
+        System.err.println("PatchedClient starting at " + DateTimeFormatter.ISO_INSTANT.format(Instant.now()));
+        try {
+            testLogger(loggerMode, loggerClassName, underlyingLoggerClassName);
+            testLog(underlyingLoggerClassName);
+        } finally {
+            System.err.println("PatchedClient finished at " + DateTimeFormatter.ISO_INSTANT.format(Instant.now()));
+        }
 
-        testLogger(loggerMode, loggerClassName, underlyingLoggerClassName);
-        testLog(underlyingLoggerClassName);
     }
 
     /*

--- a/test/jdk/java/lang/System/LoggerFinder/modules/unnamed_client/pkg/b/t/TestB.java
+++ b/test/jdk/java/lang/System/LoggerFinder/modules/unnamed_client/pkg/b/t/TestB.java
@@ -25,6 +25,8 @@ package pkg.b.t;
 
 import java.lang.reflect.Method;
 import java.lang.System.Logger;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.ResourceBundle;
 import java.util.ListResourceBundle;
 
@@ -37,9 +39,13 @@ public class TestB {
         assertTrue(args.length == 2);
         String loggerMode = args[0];
         String loggerClassName = args[1];
-
-        testLogger(loggerMode, loggerClassName);
-        testLog(loggerClassName);
+        System.err.println("TestB starting at " + DateTimeFormatter.ISO_INSTANT.format(Instant.now()));
+        try {
+            testLogger(loggerMode, loggerClassName);
+            testLog(loggerClassName);
+        } finally {
+            System.err.println("TestB finished at " + DateTimeFormatter.ISO_INSTANT.format(Instant.now()));
+        }
     }
 
     /*


### PR DESCRIPTION
Hi, please find here a trivial test change that adds some diagnostic (time stamps) to the LoggerFinder/modules subprocess test logs.