### PR TITLE
8266225: jarsigner is using incorrect security property to show weakness of certs

### DIFF
--- a/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
+++ b/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
@@ -97,9 +97,13 @@ public class Main {
     private static final long SIX_MONTHS = 180*24*60*60*1000L; //milliseconds
     private static final long ONE_YEAR = 366*24*60*60*1000L;
 
-    private static final DisabledAlgorithmConstraints DISABLED_CHECK =
+    private static final DisabledAlgorithmConstraints JAR_DISABLED_CHECK =
             new DisabledAlgorithmConstraints(
                     DisabledAlgorithmConstraints.PROPERTY_JAR_DISABLED_ALGS);
+
+    private static final DisabledAlgorithmConstraints CERTPATH_DISABLED_CHECK =
+            new DisabledAlgorithmConstraints(
+                    DisabledAlgorithmConstraints.PROPERTY_CERTPATH_DISABLED_ALGS);
 
     private static final DisabledAlgorithmConstraints LEGACY_CHECK =
             new DisabledAlgorithmConstraints(
@@ -1321,7 +1325,7 @@ public class Main {
     }
 
     private String verifyWithWeak(String alg, Set<CryptoPrimitive> primitiveSet, boolean tsa) {
-        if (DISABLED_CHECK.permits(primitiveSet, alg, null)) {
+        if (JAR_DISABLED_CHECK.permits(primitiveSet, alg, null)) {
             if (LEGACY_CHECK.permits(primitiveSet, alg, null)) {
                 return alg;
             } else {
@@ -1347,7 +1351,7 @@ public class Main {
 
     private String verifyWithWeak(PublicKey key) {
         int kLen = KeyUtil.getKeySize(key);
-        if (DISABLED_CHECK.permits(SIG_PRIMITIVE_SET, key)) {
+        if (JAR_DISABLED_CHECK.permits(SIG_PRIMITIVE_SET, key)) {
             if (LEGACY_CHECK.permits(SIG_PRIMITIVE_SET, key)) {
                 if (kLen >= 0) {
                     return String.format(rb.getString("key.bit"), kLen);
@@ -1366,7 +1370,7 @@ public class Main {
     }
 
     private void checkWeakSign(String alg, Set<CryptoPrimitive> primitiveSet, boolean tsa) {
-        if (DISABLED_CHECK.permits(primitiveSet, alg, null)) {
+        if (JAR_DISABLED_CHECK.permits(primitiveSet, alg, null)) {
             if (!LEGACY_CHECK.permits(primitiveSet, alg, null)) {
                 if (primitiveSet == SIG_PRIMITIVE_SET) {
                    legacyAlg |= 2;
@@ -1392,7 +1396,7 @@ public class Main {
     }
 
     private void checkWeakSign(PrivateKey key) {
-        if (DISABLED_CHECK.permits(SIG_PRIMITIVE_SET, key)) {
+        if (JAR_DISABLED_CHECK.permits(SIG_PRIMITIVE_SET, key)) {
             if (!LEGACY_CHECK.permits(SIG_PRIMITIVE_SET, key)) {
                 legacyAlg |= 8;
             }
@@ -1403,7 +1407,7 @@ public class Main {
 
     private static String checkWeakKey(PublicKey key) {
         int kLen = KeyUtil.getKeySize(key);
-        if (DISABLED_CHECK.permits(SIG_PRIMITIVE_SET, key)) {
+        if (CERTPATH_DISABLED_CHECK.permits(SIG_PRIMITIVE_SET, key)) {
             if (LEGACY_CHECK.permits(SIG_PRIMITIVE_SET, key)) {
                 if (kLen >= 0) {
                     return String.format(rb.getString("key.bit"), kLen);
@@ -1419,7 +1423,7 @@ public class Main {
     }
 
     private static String checkWeakAlg(String alg) {
-        if (DISABLED_CHECK.permits(SIG_PRIMITIVE_SET, alg, null)) {
+        if (CERTPATH_DISABLED_CHECK.permits(SIG_PRIMITIVE_SET, alg, null)) {
             if (LEGACY_CHECK.permits(SIG_PRIMITIVE_SET, alg, null)) {
                 return alg;
             } else {

--- a/test/jdk/sun/security/tools/jarsigner/CheckSignerCertChain.java
+++ b/test/jdk/sun/security/tools/jarsigner/CheckSignerCertChain.java
@@ -32,9 +32,13 @@ import jdk.test.lib.SecurityTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.util.JarUtils;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public class CheckSignerCertChain {
+
+    private static final String JAVA_SECURITY_FILE = "java.security";
 
     static OutputAnalyzer kt(String cmd, String ks) throws Exception {
         return SecurityTools.keytool("-storepass changeit " + cmd +
@@ -97,9 +101,31 @@ public class CheckSignerCertChain {
         kt("-genkeypair -keyalg rsa -alias ee -dname CN=EE -ext bc:c ", "ks");
         gencert("ee", "-alias cacert -ext san=dns:ee -sigalg MD5withRSA");
 
+        Files.writeString(Files.createFile(Paths.get(JAVA_SECURITY_FILE)),
+                "jdk.certpath.disabledAlgorithms=\n" +
+                "jdk.jar.disabledAlgorithms=MD5\n");
+
         SecurityTools.jarsigner("-keystore ks -storepass changeit " +
                 "-signedjar signeda.jar " +
-                "-verbose" +
+                "-verbose " +
+                "-J-Djava.security.properties=" +
+                JAVA_SECURITY_FILE +
+                " a.jar ee")
+                .shouldNotContain("Signature algorithm: MD5withRSA (disabled), 2048-bit key")
+                .shouldContain("Signature algorithm: SHA256withRSA, 2048-bit key")
+                .shouldNotContain("Invalid certificate chain: Algorithm constraints check failed on signature algorithm: MD5withRSA")
+                .shouldHaveExitValue(0);
+
+        Files.deleteIfExists(Paths.get(JAVA_SECURITY_FILE));
+        Files.writeString(Files.createFile(Paths.get(JAVA_SECURITY_FILE)),
+                "jdk.certpath.disabledAlgorithms=MD5\n" +
+                "jdk.jar.disabledAlgorithms=\n");
+
+        SecurityTools.jarsigner("-keystore ks -storepass changeit " +
+                "-signedjar signeda.jar " +
+                "-verbose " +
+                "-J-Djava.security.properties=" +
+                JAVA_SECURITY_FILE +
                 " a.jar ee")
                 .shouldContain("Signature algorithm: MD5withRSA (disabled), 2048-bit key")
                 .shouldContain("Signature algorithm: SHA256withRSA, 2048-bit key")


### PR DESCRIPTION
Please review the change to jarsigner so it uses certpath security property in order to properly display the weakness of the certificate algorithms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266225](https://bugs.openjdk.java.net/browse/JDK-8266225): jarsigner is using incorrect security property to show weakness of certs


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3905/head:pull/3905` \
`$ git checkout pull/3905`

Update a local copy of the PR: \
`$ git checkout pull/3905` \
`$ git pull https://git.openjdk.java.net/jdk pull/3905/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3905`

View PR using the GUI difftool: \
`$ git pr show -t 3905`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3905.diff">https://git.openjdk.java.net/jdk/pull/3905.diff</a>

</details>
