### PR TITLE
8266645: javac should not check for sealed supertypes in intersection types

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5197,16 +5197,18 @@ public class Attr extends JCTree.Visitor {
                     log.error(TreeInfo.diagnosticPositionFor(c, env.tree), Errors.LocalClassesCantExtendSealed(c.isAnonymous() ? Fragments.Anonymous : Fragments.Local));
                 }
 
-                for (ClassSymbol supertypeSym : sealedSupers) {
-                    if (!supertypeSym.permitted.contains(c.type.tsym)) {
-                        log.error(TreeInfo.diagnosticPositionFor(c.type.tsym, env.tree), Errors.CantInheritFromSealed(supertypeSym));
+                if (!c.type.isCompound()) {
+                    for (ClassSymbol supertypeSym : sealedSupers) {
+                        if (!supertypeSym.permitted.contains(c.type.tsym)) {
+                            log.error(TreeInfo.diagnosticPositionFor(c.type.tsym, env.tree), Errors.CantInheritFromSealed(supertypeSym));
+                        }
                     }
-                }
-                if (!c.isNonSealed() && !c.isFinal() && !c.isSealed()) {
-                    log.error(TreeInfo.diagnosticPositionFor(c, env.tree),
-                            c.isInterface() ?
-                                    Errors.NonSealedOrSealedExpected :
-                                    Errors.NonSealedSealedOrFinalExpected);
+                    if (!c.isNonSealed() && !c.isFinal() && !c.isSealed()) {
+                        log.error(TreeInfo.diagnosticPositionFor(c, env.tree),
+                                c.isInterface() ?
+                                        Errors.NonSealedOrSealedExpected :
+                                        Errors.NonSealedSealedOrFinalExpected);
+                    }
                 }
             }
 

--- a/test/langtools/tools/javac/sealed/SealedCompilationTests.java
+++ b/test/langtools/tools/javac/sealed/SealedCompilationTests.java
@@ -1254,4 +1254,16 @@ public class SealedCompilationTests extends CompilationTestCase {
             assertOK(s);
         }
     }
+
+    public void testIntersectionWithSealedClasses() {
+        assertOK(
+                """
+                class A { }
+                sealed interface I permits B { }
+                final class B extends A implements I { }
+
+                class Foo<X extends A & I> {}
+                """
+        );
+    }
 }


### PR DESCRIPTION
While trying to convert the hierarchy under package java.lang.constant to a sealed one we discovered that the compiler was issuing an error for intersection types when at least one of the types is sealed. The reason for this is that javac creates a synthetic anonymous class that extends and implements the classes and interfaces in the intersection type and then it attributes that synthetic class. The current implementation for sealed classes then issues an error for this anonymous class. The fix is to do not check for sealed supertypes for classes with an intersection type.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266645](https://bugs.openjdk.java.net/browse/JDK-8266645): javac should not check for sealed supertypes in intersection types


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3907/head:pull/3907` \
`$ git checkout pull/3907`

Update a local copy of the PR: \
`$ git checkout pull/3907` \
`$ git pull https://git.openjdk.java.net/jdk pull/3907/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3907`

View PR using the GUI difftool: \
`$ git pr show -t 3907`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3907.diff">https://git.openjdk.java.net/jdk/pull/3907.diff</a>

</details>
