### PR TITLE
8196743: jstatd doesn't see new Java processes inside Docker container

### DIFF
--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/LocalVmManager.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/LocalVmManager.java
@@ -45,7 +45,6 @@ import java.io.*;
  */
 public class LocalVmManager {
     private String userName;                 // user name for monitored jvm
-    private List<String> tmpdirs;
     private Pattern userPattern;
     private Matcher userMatcher;
     private FilenameFilter userFilter;
@@ -76,7 +75,6 @@ public class LocalVmManager {
      */
     public LocalVmManager(String user) {
         this.userName = user;
-        setTempDirs();
 
         if (userName == null) {
             userPattern = Pattern.compile(PerfDataFile.userDirNamePattern);
@@ -111,10 +109,6 @@ public class LocalVmManager {
         };
     }
 
-    private void setTempDirs() {
-        tmpdirs = PerfDataFile.getTempDirectories(userName, 0);
-    }
-
     /**
      * Return the current set of monitorable Java Virtual Machines.
      * <p>
@@ -135,7 +129,7 @@ public class LocalVmManager {
          * we'd see strange file names being matched by the matcher.
          */
         Set<Integer> jvmSet = new HashSet<Integer>();
-        setTempDirs(); // Refresh temp dirs to find new JVMs.
+        List<String> tmpdirs = PerfDataFile.getTempDirectories(userName, 0);
 
         for (String dir : tmpdirs) {
             File tmpdir = new File(dir);

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/LocalVmManager.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/LocalVmManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,10 +76,9 @@ public class LocalVmManager {
      */
     public LocalVmManager(String user) {
         this.userName = user;
-
+        setTempDirs();
 
         if (userName == null) {
-            tmpdirs = PerfDataFile.getTempDirectories(null, 0);
             userPattern = Pattern.compile(PerfDataFile.userDirNamePattern);
             userMatcher = userPattern.matcher("");
 
@@ -89,8 +88,6 @@ public class LocalVmManager {
                     return userMatcher.lookingAt();
                 }
             };
-        } else {
-            tmpdirs = PerfDataFile.getTempDirectories(userName, 0);
         }
 
         filePattern = Pattern.compile(PerfDataFile.fileNamePattern);
@@ -114,6 +111,10 @@ public class LocalVmManager {
         };
     }
 
+    private void setTempDirs() {
+        tmpdirs = PerfDataFile.getTempDirectories(userName, 0);
+    }
+
     /**
      * Return the current set of monitorable Java Virtual Machines.
      * <p>
@@ -134,6 +135,7 @@ public class LocalVmManager {
          * we'd see strange file names being matched by the matcher.
          */
         Set<Integer> jvmSet = new HashSet<Integer>();
+        setTempDirs(); // Refresh temp dirs to find new JVMs.
 
         for (String dir : tmpdirs) {
             File tmpdir = new File(dir);


### PR DESCRIPTION
This is a merge request to fix the issue where a running jstatd does not see JVMs in docker containers started since the jstatd itself started.

jstatd was using the set of temp directories gathered on startup to scan for VMs, by reading their perfdata file.  That includes existing running VMs in docker instances using tmp dirs such as /proc/PID/root/tmp/.  But it needs to re-evaluate that set of temp dirs continually to see new VMs in docker containers.  Rescanning also means it "forgets" about tmp dirs which have disappeared, for containers that have shutdown, and it will now not be scanning those directories forever.

Have been testing this manually, watching jps connecting to jstatd and show newly created JVMs in docker containers come and go.  Running existing tests OK so far.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8196743](https://bugs.openjdk.java.net/browse/JDK-8196743): jstatd doesn't see new Java processes inside Docker container


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to 658a9e27255c6a9e7cb414437a0669684d118472
 * [Yasumasa Suenaga](https://openjdk.java.net/census#ysuenaga) (@YaSuenag - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3908/head:pull/3908` \
`$ git checkout pull/3908`

Update a local copy of the PR: \
`$ git checkout pull/3908` \
`$ git pull https://git.openjdk.java.net/jdk pull/3908/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3908`

View PR using the GUI difftool: \
`$ git pr show -t 3908`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3908.diff">https://git.openjdk.java.net/jdk/pull/3908.diff</a>

</details>
