### PR TITLE
8266576: dynamicArchive/ParallelLambdaLoadTest.java crashes in tier2 testing

### DIFF
--- a/src/hotspot/share/cds/dynamicArchive.cpp
+++ b/src/hotspot/share/cds/dynamicArchive.cpp
@@ -368,11 +368,6 @@ void DynamicArchive::dump(TRAPS) {
     return;
   }
 
-  // regenerate lambdaform holder classes
-  log_info(cds, dynamic)("Regenerate lambdaform holder classes ...");
-  LambdaFormInvokers::regenerate_holder_classes(CHECK);
-  log_info(cds, dynamic)("Regenerate lambdaform holder classes ...done");
-
   VM_PopulateDynamicDumpSharedSpace op;
   VMThread::execute(&op);
 }

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -622,6 +622,15 @@ bool MetaspaceShared::link_class_for_cds(InstanceKlass* ik, TRAPS) {
 void MetaspaceShared::link_and_cleanup_shared_classes(TRAPS) {
   // Collect all loaded ClassLoaderData.
   ResourceMark rm;
+
+  if (DynamicDumpSharedSpaces) {
+    // regenerate lambdaform holder classes
+    log_info(cds, dynamic)("Regenerate lambdaform holder classes ...");
+    LambdaFormInvokers::regenerate_holder_classes(CHECK);
+    log_info(cds, dynamic)("Regenerate lambdaform holder classes ...done");
+  }
+
+
   CollectCLDClosure collect_cld;
   {
     // ClassLoaderDataGraph::loaded_cld_do requires ClassLoaderDataGraph_lock.


### PR DESCRIPTION
Hi, Please review

  In dynamic dump, the lambda invoker holder classes are regenerated in DynamicArchive::dump, which is after shutdown hook executed. The returned objects from the regeneration may contain invalid contents which caused crash like in this bug. It is late to execute java code, the fix is to move the call into MetaspaceShared::link_and_cleanup_shared_classes which is before shutdown hook, before halt.
  JDK-8266585 and JDK-8266594 failed in different patterns, could be the same reason.

  Tests: tier1,tier2

Thanks
Yumin
