### PR TITLE
8266456: Replace direct TKit.run() calls with jdk.jpackage.test.Annotations.Test annotation

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/Functional.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/Functional.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -156,6 +156,10 @@ public class Functional {
 
         if (throwable instanceof InvocationTargetException) {
             new ExceptionBox(throwable.getCause());
+        }
+
+        if (throwable.getClass().getName().equals("jtreg.SkippedException")) {
+            throw (RuntimeException)throwable;
         }
 
         throw new ExceptionBox(throwable);

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/Functional.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/Functional.java
@@ -150,16 +150,12 @@ public class Functional {
 
     @SuppressWarnings("unchecked")
     public static void rethrowUnchecked(Throwable throwable) throws ExceptionBox {
-        if (throwable instanceof ExceptionBox) {
-            throw (ExceptionBox)throwable;
+        if (throwable instanceof RuntimeException) {
+            throw (RuntimeException)throwable;
         }
 
         if (throwable instanceof InvocationTargetException) {
-            new ExceptionBox(throwable.getCause());
-        }
-
-        if (throwable.getClass().getName().equals("jtreg.SkippedException")) {
-            throw (RuntimeException)throwable;
+            throw new ExceptionBox(throwable.getCause());
         }
 
         throw new ExceptionBox(throwable);

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -99,20 +99,6 @@ final public class TKit {
 
         throw throwUnknownPlatformError();
     }).get();
-
-    public static void run(String args[], ThrowingRunnable testBody) {
-        if (currentTest != null) {
-            throw new IllegalStateException(
-                    "Unexpeced nested or concurrent Test.run() call");
-        }
-
-        TestInstance test = new TestInstance(testBody);
-        ThrowingRunnable.toRunnable(() -> runTests(List.of(test))).run();
-        test.rethrowIfSkipped();
-        if (!test.passed()) {
-            throw new RuntimeException();
-        }
-    }
 
     static void withExtraLogStream(ThrowingRunnable action) {
         if (extraLogStream != null) {

--- a/test/jdk/tools/jpackage/linux/AppCategoryTest.java
+++ b/test/jdk/tools/jpackage/linux/AppCategoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-import jdk.jpackage.test.TKit;
+import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.PackageTest;
 import jdk.jpackage.test.PackageType;
 
@@ -49,25 +49,25 @@ import jdk.jpackage.test.PackageType;
  * @build AppCategoryTest
  * @requires (os.family == "linux")
  * @modules jdk.jpackage/jdk.jpackage.internal
- * @run main/othervm/timeout=360 -Xmx512m AppCategoryTest
+ * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=AppCategoryTest
  */
 public class AppCategoryTest {
 
-    public static void main(String[] args) {
+    @Test
+    public static void test() {
         final String CATEGORY = "Foo";
 
-        TKit.run(args, () -> {
-            new PackageTest()
-            .forTypes(PackageType.LINUX)
-            .configureHelloApp()
-            .addInitializer(cmd -> {
-                cmd.addArguments("--linux-app-category", CATEGORY);
-            })
-            .forTypes(PackageType.LINUX_DEB)
-            .addBundlePropertyVerifier("Section", CATEGORY)
-            .forTypes(PackageType.LINUX_RPM)
-            .addBundlePropertyVerifier("Group", CATEGORY)
-            .run();
-        });
+        new PackageTest()
+                .forTypes(PackageType.LINUX)
+                .configureHelloApp()
+                .addInitializer(cmd -> {
+                    cmd.addArguments("--linux-app-category", CATEGORY);
+                })
+                .forTypes(PackageType.LINUX_DEB)
+                .addBundlePropertyVerifier("Section", CATEGORY)
+                .forTypes(PackageType.LINUX_RPM)
+                .addBundlePropertyVerifier("Group", CATEGORY)
+                .run();
     }
 }

--- a/test/jdk/tools/jpackage/linux/LicenseTypeTest.java
+++ b/test/jdk/tools/jpackage/linux/LicenseTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-import jdk.jpackage.test.TKit;
+import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.PackageTest;
 import jdk.jpackage.test.PackageType;
 
@@ -44,20 +44,20 @@ import jdk.jpackage.test.PackageType;
  * @build LicenseTypeTest
  * @requires (os.family == "linux")
  * @modules jdk.jpackage/jdk.jpackage.internal
- * @run main/othervm/timeout=360 -Xmx512m LicenseTypeTest
+ * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=LicenseTypeTest
  */
 public class LicenseTypeTest {
 
-    public static void main(String[] args) {
+    @Test
+    public static void test() {
         final String LICENSE_TYPE = "JP_LICENSE_TYPE";
 
-        TKit.run(args, () -> {
-            new PackageTest().forTypes(PackageType.LINUX_RPM).configureHelloApp()
-            .addInitializer(cmd -> {
-                cmd.addArguments("--linux-rpm-license-type", LICENSE_TYPE);
-            })
-            .addBundlePropertyVerifier("License", LICENSE_TYPE)
-            .run();
-        });
+        new PackageTest().forTypes(PackageType.LINUX_RPM).configureHelloApp()
+                .addInitializer(cmd -> {
+                    cmd.addArguments("--linux-rpm-license-type", LICENSE_TYPE);
+                })
+                .addBundlePropertyVerifier("License", LICENSE_TYPE)
+                .run();
     }
 }

--- a/test/jdk/tools/jpackage/linux/LinuxBundleNameTest.java
+++ b/test/jdk/tools/jpackage/linux/LinuxBundleNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-import jdk.jpackage.test.TKit;
+import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.PackageTest;
 import jdk.jpackage.test.PackageType;
 
@@ -49,25 +49,25 @@ import jdk.jpackage.test.PackageType;
  * @build LinuxBundleNameTest
  * @requires (os.family == "linux")
  * @modules jdk.jpackage/jdk.jpackage.internal
- * @run main/othervm/timeout=360 -Xmx512m LinuxBundleNameTest
+ * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=LinuxBundleNameTest
  */
 public class LinuxBundleNameTest {
 
-    public static void main(String[] args) {
+    @Test
+    public static void test() {
         final String PACKAGE_NAME = "quickbrownfox2";
 
-        TKit.run(args, () -> {
-            new PackageTest()
-            .forTypes(PackageType.LINUX)
-            .configureHelloApp()
-            .addInitializer(cmd -> {
-                cmd.addArguments("--linux-package-name", PACKAGE_NAME);
-            })
-            .forTypes(PackageType.LINUX_DEB)
-            .addBundlePropertyVerifier("Package", PACKAGE_NAME)
-            .forTypes(PackageType.LINUX_RPM)
-            .addBundlePropertyVerifier("Name", PACKAGE_NAME)
-            .run();
-        });
+        new PackageTest()
+                .forTypes(PackageType.LINUX)
+                .configureHelloApp()
+                .addInitializer(cmd -> {
+                    cmd.addArguments("--linux-package-name", PACKAGE_NAME);
+                })
+                .forTypes(PackageType.LINUX_DEB)
+                .addBundlePropertyVerifier("Package", PACKAGE_NAME)
+                .forTypes(PackageType.LINUX_RPM)
+                .addBundlePropertyVerifier("Name", PACKAGE_NAME)
+                .run();
     }
 }

--- a/test/jdk/tools/jpackage/linux/MaintainerTest.java
+++ b/test/jdk/tools/jpackage/linux/MaintainerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 import jdk.jpackage.test.PackageTest;
 import jdk.jpackage.test.PackageType;
-import jdk.jpackage.test.TKit;
+import jdk.jpackage.test.Annotations.Test;
 
 
 /**
@@ -45,23 +45,23 @@ import jdk.jpackage.test.TKit;
  * @build MaintainerTest
  * @requires (os.family == "linux")
  * @modules jdk.jpackage/jdk.jpackage.internal
- * @run main/othervm/timeout=360 -Xmx512m MaintainerTest
+ * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=MaintainerTest
  */
 public class MaintainerTest {
 
-    public static void main(String[] args) {
+    @Test
+    public static void test() {
         final String MAINTAINER = "jpackage-test@java.com";
 
-        TKit.run(args, () -> {
-            new PackageTest().forTypes(PackageType.LINUX_DEB).configureHelloApp()
-            .addInitializer(cmd -> {
-                cmd.addArguments("--linux-deb-maintainer", MAINTAINER);
-            })
-            .addBundlePropertyVerifier("Maintainer", value -> {
-                String lookupValue = "<" + MAINTAINER + ">";
-                return value.endsWith(lookupValue);
-            }, "ends with")
-            .run();
-        });
+        new PackageTest().forTypes(PackageType.LINUX_DEB).configureHelloApp()
+                .addInitializer(cmd -> {
+                    cmd.addArguments("--linux-deb-maintainer", MAINTAINER);
+                })
+                .addBundlePropertyVerifier("Maintainer", value -> {
+                    String lookupValue = "<" + MAINTAINER + ">";
+                    return value.endsWith(lookupValue);
+                }, "ends with")
+                .run();
     }
 }

--- a/test/jdk/tools/jpackage/linux/ReleaseTest.java
+++ b/test/jdk/tools/jpackage/linux/ReleaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 import jdk.jpackage.test.PackageType;
 import jdk.jpackage.test.PackageTest;
-import jdk.jpackage.test.TKit;
+import jdk.jpackage.test.Annotations.Test;
 
 
 /**
@@ -48,27 +48,27 @@ import jdk.jpackage.test.TKit;
  * @build ReleaseTest
  * @requires (os.family == "linux")
  * @modules jdk.jpackage/jdk.jpackage.internal
- * @run main/othervm/timeout=360 -Xmx512m ReleaseTest
+ * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=ReleaseTest
  */
 public class ReleaseTest {
 
-    public static void main(String[] args) {
+    @Test
+    public static void test() {
         final String RELEASE = "Rc3";
 
-        TKit.run(args, () -> {
-            new PackageTest()
-            .forTypes(PackageType.LINUX)
-            .configureHelloApp()
-            .addInitializer(cmd -> {
-                cmd.addArguments("--linux-app-release", RELEASE);
-            })
-            .forTypes(PackageType.LINUX_RPM)
-            .addBundlePropertyVerifier("Release", RELEASE)
-            .forTypes(PackageType.LINUX_DEB)
-            .addBundlePropertyVerifier("Version", propValue -> {
-                return propValue.endsWith("-" + RELEASE);
-            }, "ends with")
-            .run();
-        });
+        new PackageTest()
+                .forTypes(PackageType.LINUX)
+                .configureHelloApp()
+                .addInitializer(cmd -> {
+                    cmd.addArguments("--linux-app-release", RELEASE);
+                })
+                .forTypes(PackageType.LINUX_RPM)
+                .addBundlePropertyVerifier("Release", RELEASE)
+                .forTypes(PackageType.LINUX_DEB)
+                .addBundlePropertyVerifier("Version", propValue -> {
+                    return propValue.endsWith("-" + RELEASE);
+                }, "ends with")
+                .run();
     }
 }

--- a/test/jdk/tools/jpackage/macosx/MacFileAssociationsTest.java
+++ b/test/jdk/tools/jpackage/macosx/MacFileAssociationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.TKit;
 import jdk.jpackage.test.MacHelper;
 import jdk.jpackage.test.MacHelper.PListWrapper;
+import jdk.jpackage.test.Annotations.Test;
 
 /**
  * Tests generation of app image with --file-associations and mac additional file
@@ -44,34 +45,34 @@ import jdk.jpackage.test.MacHelper.PListWrapper;
  * @build MacFileAssociationsTest
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @requires (os.family == "mac")
- * @run main/othervm -Xmx512m MacFileAssociationsTest
+ * @run main/othervm -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=MacFileAssociationsTest
  */
 public class MacFileAssociationsTest {
 
-    public static void main(String[] args) throws Exception {
-        TKit.run(args, () -> {
-            final Path propFile = TKit.workDir().resolve("fa.properties");
-            Map<String,String> map = Map.ofEntries(
-                    entry("mime-type", "application/x-jpackage-foo"),
-                    entry("extension", "foo"),
-                    entry("description", "bar"),
-                    entry("mac.CFBundleTypeRole", "Viewer"),
-                    entry("mac.LSHandlerRank", "Default"),
-                    entry("mac.NSDocumentClass", "SomeClass"),
-                    entry("mac.LSTypeIsPackage", "true"),
-                    entry("mac.LSSupportsOpeningDocumentsInPlace", "false"),
-                    entry("mac.UISupportsDocumentBrowser", "false"),
-                    entry("mac.NSExportableTypes", "public.png, public.jpg"),
-                    entry("mac.UTTypeConformsTo", "public.image, public.data"));
-            TKit.createPropertiesFile(propFile, map);
+    @Test
+    public static void test() throws Exception {
+        final Path propFile = TKit.workDir().resolve("fa.properties");
+        Map<String, String> map = Map.ofEntries(
+                entry("mime-type", "application/x-jpackage-foo"),
+                entry("extension", "foo"),
+                entry("description", "bar"),
+                entry("mac.CFBundleTypeRole", "Viewer"),
+                entry("mac.LSHandlerRank", "Default"),
+                entry("mac.NSDocumentClass", "SomeClass"),
+                entry("mac.LSTypeIsPackage", "true"),
+                entry("mac.LSSupportsOpeningDocumentsInPlace", "false"),
+                entry("mac.UISupportsDocumentBrowser", "false"),
+                entry("mac.NSExportableTypes", "public.png, public.jpg"),
+                entry("mac.UTTypeConformsTo", "public.image, public.data"));
+        TKit.createPropertiesFile(propFile, map);
 
-            JPackageCommand cmd = JPackageCommand.helloAppImage();
-            cmd.addArguments("--file-associations", propFile);
-            cmd.executeAndAssertHelloAppImageCreated();
+        JPackageCommand cmd = JPackageCommand.helloAppImage();
+        cmd.addArguments("--file-associations", propFile);
+        cmd.executeAndAssertHelloAppImageCreated();
 
-            Path appImage = cmd.outputBundle();
-            verifyPList(appImage);
-        });
+        Path appImage = cmd.outputBundle();
+        verifyPList(appImage);
     }
 
     private static void checkStringValue(PListWrapper plist, String key, String value) {

--- a/test/jdk/tools/jpackage/macosx/SigningAppImageTest.java
+++ b/test/jdk/tools/jpackage/macosx/SigningAppImageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 import java.nio.file.Path;
 import jdk.jpackage.test.JPackageCommand;
-import jdk.jpackage.test.TKit;
+import jdk.jpackage.test.Annotations.Test;
 
 /**
  * Tests generation of app image with --mac-sign and related arguments. Test will
@@ -52,26 +52,26 @@ import jdk.jpackage.test.TKit;
  * @build SigningAppImageTest
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @requires (os.family == "mac")
- * @run main/othervm -Xmx512m SigningAppImageTest
+ * @run main/othervm -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=SigningAppImageTest
  */
 public class SigningAppImageTest {
 
-    public static void main(String[] args) throws Exception {
-        TKit.run(args, () -> {
-            SigningCheck.checkCertificates();
+    @Test
+    public static void test() throws Exception {
+        SigningCheck.checkCertificates();
 
-            JPackageCommand cmd = JPackageCommand.helloAppImage();
-            cmd.addArguments("--mac-sign", "--mac-signing-key-user-name",
-                    SigningBase.DEV_NAME, "--mac-signing-keychain",
-                    SigningBase.KEYCHAIN);
-            cmd.executeAndAssertHelloAppImageCreated();
+        JPackageCommand cmd = JPackageCommand.helloAppImage();
+        cmd.addArguments("--mac-sign", "--mac-signing-key-user-name",
+                SigningBase.DEV_NAME, "--mac-signing-keychain",
+                SigningBase.KEYCHAIN);
+        cmd.executeAndAssertHelloAppImageCreated();
 
-            Path launcherPath = cmd.appLauncherPath();
-            SigningBase.verifyCodesign(launcherPath, true);
+        Path launcherPath = cmd.appLauncherPath();
+        SigningBase.verifyCodesign(launcherPath, true);
 
-            Path appImage = cmd.outputBundle();
-            SigningBase.verifyCodesign(appImage, true);
-            SigningBase.verifySpctl(appImage, "exec");
-        });
+        Path appImage = cmd.outputBundle();
+        SigningBase.verifyCodesign(appImage, true);
+        SigningBase.verifySpctl(appImage, "exec");
     }
 }

--- a/test/jdk/tools/jpackage/macosx/SigningPackageTest.java
+++ b/test/jdk/tools/jpackage/macosx/SigningPackageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@ import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.PackageTest;
 import jdk.jpackage.test.PackageType;
 import jdk.jpackage.test.MacHelper;
-import jdk.jpackage.test.TKit;
+import jdk.jpackage.test.Annotations.Test;
 
 /**
  * Tests generation of dmg and pkg with --mac-sign and related arguments.
@@ -57,7 +57,8 @@ import jdk.jpackage.test.TKit;
  * @build SigningPackageTest
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @requires (os.family == "mac")
- * @run main/othervm -Xmx512m SigningPackageTest
+ * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=SigningPackageTest
  */
 public class SigningPackageTest {
 
@@ -81,24 +82,23 @@ public class SigningPackageTest {
         });
     }
 
-    public static void main(String[] args) throws Exception {
-        TKit.run(args, () -> {
-            SigningCheck.checkCertificates();
+    @Test
+    public static void test() throws Exception {
+        SigningCheck.checkCertificates();
 
-            new PackageTest()
-                    .configureHelloApp()
-                    .forTypes(PackageType.MAC)
-                    .addInitializer(cmd -> {
-                        cmd.addArguments("--mac-sign",
-                                "--mac-signing-key-user-name", SigningBase.DEV_NAME,
-                                "--mac-signing-keychain", SigningBase.KEYCHAIN);
-                    })
-                    .forTypes(PackageType.MAC_PKG)
-                    .addBundleVerifier(SigningPackageTest::verifyPKG)
-                    .forTypes(PackageType.MAC_DMG)
-                    .addBundleVerifier(SigningPackageTest::verifyDMG)
-                    .addBundleVerifier(SigningPackageTest::verifyAppImageInDMG)
-                    .run();
-        });
+        new PackageTest()
+                .configureHelloApp()
+                .forTypes(PackageType.MAC)
+                .addInitializer(cmd -> {
+                    cmd.addArguments("--mac-sign",
+                            "--mac-signing-key-user-name", SigningBase.DEV_NAME,
+                            "--mac-signing-keychain", SigningBase.KEYCHAIN);
+                })
+                .forTypes(PackageType.MAC_PKG)
+                .addBundleVerifier(SigningPackageTest::verifyPKG)
+                .forTypes(PackageType.MAC_DMG)
+                .addBundleVerifier(SigningPackageTest::verifyDMG)
+                .addBundleVerifier(SigningPackageTest::verifyAppImageInDMG)
+                .run();
     }
 }

--- a/test/jdk/tools/jpackage/share/EmptyFolderPackageTest.java
+++ b/test/jdk/tools/jpackage/share/EmptyFolderPackageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@ import java.nio.file.Path;
 import jdk.jpackage.internal.ApplicationLayout;
 import jdk.jpackage.test.PackageTest;
 import jdk.jpackage.test.PackageType;
-import jdk.jpackage.test.TKit;
+import jdk.jpackage.test.Annotations.Test;
 
 /**
  * Tests generation of packages with input folder containing empty folders.
@@ -41,30 +41,30 @@ import jdk.jpackage.test.TKit;
  * @build jdk.jpackage.test.*
  * @build EmptyFolderPackageTest
  * @modules jdk.jpackage/jdk.jpackage.internal
- * @run main/othervm/timeout=720 -Xmx512m EmptyFolderPackageTest
+ * @run main/othervm/timeout=720 -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=EmptyFolderPackageTest
  */
 public class EmptyFolderPackageTest {
 
-    public static void main(String[] args) throws Exception {
-        TKit.run(args, () -> {
-            new PackageTest().configureHelloApp()
-                    .addInitializer(cmd -> {
-                        Path input = cmd.inputDir();
-                        EmptyFolderBase.createDirStrcture(input);
-                    })
-                    .addInstallVerifier(cmd -> {
-                        if (cmd.packageType() == PackageType.WIN_MSI) {
-                            if (cmd.isPackageUnpacked("Not running file "
-                                    + "structure check for empty folders")) {
-                                return;
-                            }
+    @Test
+    public static void test() throws Exception {
+        new PackageTest().configureHelloApp()
+                .addInitializer(cmd -> {
+                    Path input = cmd.inputDir();
+                    EmptyFolderBase.createDirStrcture(input);
+                })
+                .addInstallVerifier(cmd -> {
+                    if (cmd.packageType() == PackageType.WIN_MSI) {
+                        if (cmd.isPackageUnpacked("Not running file "
+                                + "structure check for empty folders")) {
+                            return;
                         }
+                    }
 
-                        ApplicationLayout appLayout = cmd.appLayout();
-                        Path appDir = appLayout.appDirectory();
-                        EmptyFolderBase.validateDirStrcture(appDir);
-                    })
-                    .run();
-        });
+                    ApplicationLayout appLayout = cmd.appLayout();
+                    Path appDir = appLayout.appDirectory();
+                    EmptyFolderBase.validateDirStrcture(appDir);
+                })
+                .run();
     }
 }

--- a/test/jdk/tools/jpackage/share/EmptyFolderTest.java
+++ b/test/jdk/tools/jpackage/share/EmptyFolderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 import java.nio.file.Path;
 import jdk.jpackage.test.JPackageCommand;
-import jdk.jpackage.test.TKit;
+import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.internal.ApplicationLayout;
 
 /**
@@ -39,26 +39,26 @@ import jdk.jpackage.internal.ApplicationLayout;
  * @build jdk.jpackage.test.*
  * @build EmptyFolderTest
  * @modules jdk.jpackage/jdk.jpackage.internal
- * @run main/othervm -Xmx512m EmptyFolderTest
+ * @run main/othervm -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=EmptyFolderTest
  */
 public class EmptyFolderTest {
 
-    public static void main(String[] args) throws Exception {
-        TKit.run(args, () -> {
-            JPackageCommand cmd = JPackageCommand.helloAppImage();
+    @Test
+    public static void test() throws Exception {
+        JPackageCommand cmd = JPackageCommand.helloAppImage();
 
-            // Add more files into input folder
-            Path input = cmd.inputDir();
-            EmptyFolderBase.createDirStrcture(input);
+        // Add more files into input folder
+        Path input = cmd.inputDir();
+        EmptyFolderBase.createDirStrcture(input);
 
-            // Create app image
-            cmd.executeAndAssertHelloAppImageCreated();
+        // Create app image
+        cmd.executeAndAssertHelloAppImageCreated();
 
-            // Verify directory strcture
-            ApplicationLayout appLayout = cmd.appLayout();
-            Path appDir = appLayout.appDirectory();
-            EmptyFolderBase.validateDirStrcture(appDir);
-        });
+        // Verify directory strcture
+        ApplicationLayout appLayout = cmd.appLayout();
+        Path appDir = appLayout.appDirectory();
+        EmptyFolderBase.validateDirStrcture(appDir);
     }
 
 }

--- a/test/jdk/tools/jpackage/windows/WinDirChooserTest.java
+++ b/test/jdk/tools/jpackage/windows/WinDirChooserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-import jdk.jpackage.test.TKit;
+import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.PackageTest;
 import jdk.jpackage.test.PackageType;
 
@@ -42,16 +42,18 @@ import jdk.jpackage.test.PackageType;
  * @build WinDirChooserTest
  * @requires (os.family == "windows")
  * @modules jdk.jpackage/jdk.jpackage.internal
- * @run main/othervm/timeout=360 -Xmx512m WinDirChooserTest
+ * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=WinDirChooserTest
  */
 
 public class WinDirChooserTest {
-    public static void main(String[] args) {
-        TKit.run(args, () -> {
-            new PackageTest()
-            .forTypes(PackageType.WINDOWS)
-            .configureHelloApp()
-            .addInitializer(cmd -> cmd.addArgument("--win-dir-chooser")).run();
-        });
+
+    @Test
+    public static void test() {
+        new PackageTest()
+                .forTypes(PackageType.WINDOWS)
+                .configureHelloApp()
+                .addInitializer(cmd -> cmd.addArgument("--win-dir-chooser"))
+                .run();
     }
 }


### PR DESCRIPTION
- Replaced direct TKit.run() calls with Test annotation.
 - Increased timeout for SigningPackageTest from default to 360 due to timeout. This is regression from JDK-8248904 due to changes done in signing and --remove-signature adds additional time since it is run per file.
 - Fixed issue with jtreg.SkippedException which caused test to fail instead of being skipped, since it was wrapped in ExceptionBox.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266456](https://bugs.openjdk.java.net/browse/JDK-8266456): Replace direct TKit.run() calls with jdk.jpackage.test.Annotations.Test annotation


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**) ⚠️ Review applies to b382561f22eeff0b536987114f6713a214065f65


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3911/head:pull/3911` \
`$ git checkout pull/3911`

Update a local copy of the PR: \
`$ git checkout pull/3911` \
`$ git pull https://git.openjdk.java.net/jdk pull/3911/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3911`

View PR using the GUI difftool: \
`$ git pr show -t 3911`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3911.diff">https://git.openjdk.java.net/jdk/pull/3911.diff</a>

</details>
