### PR TITLE
8266675: Optimize IntHashTable for encapsulation and ease of use

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -4815,8 +4815,7 @@ public class JavacParser implements Parser {
         }
 
         public void storeEnd(JCTree tree, int endpos) {
-            endPosMap.putAtIndex(tree, errorEndPos > endpos ? errorEndPos : endpos,
-                                 endPosMap.lookup(tree));
+            endPosMap.put(tree, errorEndPos > endpos ? errorEndPos : endpos);
         }
 
         protected <T extends JCTree> T to(T t) {
@@ -4830,7 +4829,7 @@ public class JavacParser implements Parser {
         }
 
         public int getEndPos(JCTree tree) {
-            int value = endPosMap.getFromIndex(endPosMap.lookup(tree));
+            int value = endPosMap.get(tree);
             // As long as Position.NOPOS==-1, this just returns value.
             return (value == -1) ? Position.NOPOS : value;
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/IntHashTable.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/IntHashTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/IntHashTable.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/IntHashTable.java
@@ -74,20 +74,20 @@ public class IntHashTable {
      * @param key The object whose hash code is to be computed.
      * @return zero if the object is null, otherwise the identityHashCode
      */
-    public int hash(Object key) {
+    protected int hash(Object key) {
         return System.identityHashCode(key);
     }
 
     /**
      * Find either the index of a key's value, or the index of an available space.
      *
-     * @param key The key to whose value you want to find.
-     * @param hash The hash code of this key.
+     * @param key The key to whose index you want to find.
      * @return Either the index of the key's value, or an index pointing to
      * unoccupied space.
      */
-    public int lookup(Object key, int hash) {
+    protected int lookup(Object key) {
         Object node;
+        int hash = hash(key);
         int hash1 = hash ^ (hash >>> 15);
         int hash2 = (hash ^ (hash << 6)) | 1; //ensure coprimeness
         int deleted = -1;
@@ -103,24 +103,14 @@ public class IntHashTable {
     }
 
     /**
-     * Lookup a given key's value in the hash table.
+     * Return the value to which the specified key is mapped.
      *
-     * @param key The key whose value you want to find.
-     * @return Either the index of the key's value, or an index pointing to
-     * unoccupied space.
+     * @param key The key to whose value you want to find.
+     * @return A non-negative integer if the value is found.
+     *         Otherwise, it is -1.
      */
-    public int lookup(Object key) {
-        return lookup(key, hash(key));
-    }
-
-    /**
-     * Return the value stored at the specified index in the table.
-     *
-     * @param index The index to inspect, as returned from {@link #lookup}
-     * @return A non-negative integer if the index contains a non-null
-     *         value, or -1 if it does.
-     */
-    public int getFromIndex(int index) {
+    public int get(Object key) {
+        int index = lookup(key);
         Object node = objs[index];
         return node == null || node == DELETED ? -1 : ints[index];
     }
@@ -130,12 +120,11 @@ public class IntHashTable {
      *
      * @param key key with which the specified value is to be associated.
      * @param value value to be associated with the specified key.
-     * @param index the index at which to place this binding, as returned
-     *              from {@link #lookup}.
      * @return previous value associated with specified key, or -1 if there was
      * no mapping for key.
      */
-    public int putAtIndex(Object key, int value, int index) {
+    public int put(Object key, int value) {
+        int index = lookup(key);
         Object old = objs[index];
         if (old == null || old == DELETED) {
             objs[index] = key;
@@ -152,6 +141,13 @@ public class IntHashTable {
         }
     }
 
+    /**
+     * Remove the mapping(key and value) of the specified key.
+     *
+     * @param key the key to whose value you want to remove.
+     * @return the removed value associated with the specified key,
+     *         or -1 if there was no mapping for the specified key.
+     */
     public int remove(Object key) {
         int index = lookup(key);
         Object old = objs[index];
@@ -169,20 +165,16 @@ public class IntHashTable {
     protected void rehash() {
         Object[] oldObjsTable = objs;
         int[] oldIntsTable = ints;
-        int oldCapacity = oldObjsTable.length;
-        int newCapacity = oldCapacity << 1;
-        Object[] newObjTable = new Object[newCapacity];
-        int[] newIntTable = new int[newCapacity];
-        int newMask = newCapacity - 1;
-        objs = newObjTable;
-        ints = newIntTable;
-        mask = newMask;
+        int newCapacity = oldObjsTable.length << 1;
+        objs = new Object[newCapacity];
+        ints = new int[newCapacity];
+        mask = newCapacity - 1;
         num_bindings = 0; // this is recomputed below
         Object key;
         for (int i = oldIntsTable.length; --i >= 0;) {
             key = oldObjsTable[i];
             if (key != null && key != DELETED)
-                putAtIndex(key, oldIntsTable[i], lookup(key, hash(key)));
+                put(key, oldIntsTable[i]);
         }
     }
 


### PR DESCRIPTION
Hi all,

Currently, the class `com.sun.tools.javac.util.IntHashTable` exposes methods `hash(Object key)` and `lookup(Object key)` to users. It is not good because they are internal methods to achieve the features.

On the other hand, the index of the mapping (key or value) is the internal data struct. The users should not know or use it actually. So the parameters of the following methods should be revised.

1. lookup(Object key, int hash) -> lookup(Object key)
2. getFromIndex(int index) -> get(Object key)
3. putAtIndex(Object key, int value, int index) -> put(Object key, int value)

And the corresponding places where they are used need to be adjusted too.

The patch optimizes them, adds some comments and cleans the code.
Thank you for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266675](https://bugs.openjdk.java.net/browse/JDK-8266675): Optimize IntHashTable for encapsulation and ease of use


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3912/head:pull/3912` \
`$ git checkout pull/3912`

Update a local copy of the PR: \
`$ git checkout pull/3912` \
`$ git pull https://git.openjdk.java.net/jdk pull/3912/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3912`

View PR using the GUI difftool: \
`$ git pr show -t 3912`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3912.diff">https://git.openjdk.java.net/jdk/pull/3912.diff</a>

</details>
