### PR TITLE
8266610: Method RandomAccessFile#length() returns 0 for block devices on linux.

### DIFF
--- a/src/java.base/unix/native/libjava/io_util_md.c
+++ b/src/java.base/unix/native/libjava/io_util_md.c
@@ -252,8 +252,10 @@ handleGetLength(FD fd)
     }
     #ifdef BLKGETSIZE64
     if (S_ISBLK(sb.st_mode)) {
-        uint64_t size = -1;
-        ioctl(fd, BLKGETSIZE64, &size);
+        uint64_t size;
+        if(ioctl(fd, BLKGETSIZE64, &size) < 0) {
+            return -1;
+        }
         return (jlong)size;
     }
     #endif

--- a/src/java.base/unix/native/libjava/io_util_md.c
+++ b/src/java.base/unix/native/libjava/io_util_md.c
@@ -32,6 +32,8 @@
 
 #if defined(__linux__) || defined(_ALLBSD_SOURCE) || defined(_AIX)
 #include <sys/ioctl.h>
+#include <linux/fs.h>
+#include <sys/stat.h>
 #endif
 
 #ifdef MACOSX
@@ -245,9 +247,15 @@ handleGetLength(FD fd)
     struct stat64 sb;
     int result;
     RESTARTABLE(fstat64(fd, &sb), result);
-    if (result == 0) {
-        return sb.st_size;
-    } else {
+    if (result < 0) {
         return -1;
     }
+    #ifdef BLKGETSIZE64
+    if (S_ISBLK(sb.st_mode)) {
+        uint64_t size = -1;
+        ioctl(fd, BLKGETSIZE64, &size);
+        return (jlong)size;
+    }
+    #endif
+    return sb.st_size;
 }


### PR DESCRIPTION
RandomAccessFile.length() method for block device return always 0

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266610](https://bugs.openjdk.java.net/browse/JDK-8266610): Method RandomAccessFile#length() returns 0 for block devices on linux.


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3914/head:pull/3914` \
`$ git checkout pull/3914`

Update a local copy of the PR: \
`$ git checkout pull/3914` \
`$ git pull https://git.openjdk.java.net/jdk pull/3914/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3914`

View PR using the GUI difftool: \
`$ git pr show -t 3914`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3914.diff">https://git.openjdk.java.net/jdk/pull/3914.diff</a>

</details>
