### PR TITLE
8266637: CHT: Add insert_and_get method

### DIFF
--- a/src/hotspot/share/utilities/concurrentHashTable.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.hpp
@@ -412,7 +412,7 @@ class ConcurrentHashTable : public CHeapObj<F> {
   }
 
   // Returns true if the item was inserted, duplicates are found with
-  // LOOKUP_FUNC and FOUND_FUNC is called.
+  // LOOKUP_FUNC then FOUND_FUNC is called.
   template <typename LOOKUP_FUNC, typename FOUND_FUNC>
   bool insert_get(Thread* thread, LOOKUP_FUNC& lookup_f, VALUE& value, FOUND_FUNC& foundf,
                   bool* grow_hint = NULL, bool* clean_hint = NULL) {

--- a/src/hotspot/share/utilities/concurrentHashTable.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.hpp
@@ -307,10 +307,10 @@ class ConcurrentHashTable : public CHeapObj<F> {
   VALUE* internal_get(Thread* thread, LOOKUP_FUNC& lookup_f,
                       bool* grow_hint = NULL);
 
-  // Plain insert.
-  template <typename LOOKUP_FUNC>
-  bool internal_insert(Thread* thread, LOOKUP_FUNC& lookup_f, const VALUE& value,
-                       bool* grow_hint, bool* clean_hint);
+  // Insert and get current value.
+  template <typename LOOKUP_FUNC, typename FOUND_FUNC>
+  bool internal_insert_get(Thread* thread, LOOKUP_FUNC& lookup_f, const VALUE& value,
+                           FOUND_FUNC& foundf, bool* grow_hint, bool* clean_hint);
 
   // Returns true if an item matching LOOKUP_FUNC is removed.
   // Calls DELETE_FUNC before destroying the node.
@@ -405,7 +405,18 @@ class ConcurrentHashTable : public CHeapObj<F> {
   template <typename LOOKUP_FUNC>
   bool insert(Thread* thread, LOOKUP_FUNC& lookup_f, const VALUE& value,
               bool* grow_hint = NULL, bool* clean_hint = NULL) {
-    return internal_insert(thread, lookup_f, value, grow_hint, clean_hint);
+    struct NOP {
+        void operator()(...) const {}
+    } nop;
+    return internal_insert_get(thread, lookup_f, value, nop, grow_hint, clean_hint);
+  }
+
+  // Returns true if the item was inserted, duplicates are found with
+  // LOOKUP_FUNC and FOUND_FUNC is called.
+  template <typename LOOKUP_FUNC, typename FOUND_FUNC>
+  bool insert_get(Thread* thread, LOOKUP_FUNC& lookup_f, VALUE& value, FOUND_FUNC& foundf,
+                  bool* grow_hint = NULL, bool* clean_hint = NULL) {
+    return internal_insert_get(thread, lookup_f, value, foundf, grow_hint, clean_hint);
   }
 
   // This does a fast unsafe insert and can thus only be used when there is no

--- a/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
@@ -866,10 +866,10 @@ inline typename CONFIG::Value* ConcurrentHashTable<CONFIG, F>::
 }
 
 template <typename CONFIG, MEMFLAGS F>
-template <typename LOOKUP_FUNC>
+template <typename LOOKUP_FUNC, typename FOUND_FUNC>
 inline bool ConcurrentHashTable<CONFIG, F>::
-  internal_insert(Thread* thread, LOOKUP_FUNC& lookup_f, const VALUE& value,
-                  bool* grow_hint, bool* clean_hint)
+  internal_insert_get(Thread* thread, LOOKUP_FUNC& lookup_f, const VALUE& value,
+                      FOUND_FUNC& foundf, bool* grow_hint, bool* clean_hint)
 {
   bool ret = false;
   bool clean = false;
@@ -888,6 +888,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
       if (old == NULL) {
         new_node->set_next(first_at_start);
         if (bucket->cas_first(new_node, first_at_start)) {
+          foundf(new_node->value());
           JFR_ONLY(_stats_rate.add();)
           new_node = NULL;
           ret = true;
@@ -897,6 +898,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
         locked = bucket->is_locked();
       } else {
         // There is a duplicate.
+        foundf(old->value());
         break; /* leave critical section */
       }
     } /* leave critical section */

--- a/test/hotspot/gtest/utilities/test_concurrentHashtable.cpp
+++ b/test/hotspot/gtest/utilities/test_concurrentHashtable.cpp
@@ -115,7 +115,7 @@ static void cht_insert_get(Thread* thr) {
   EXPECT_EQ(val, vg.get_value()) << "Getting an inserted value failed.";
   ValueGet vg_dup;
   EXPECT_FALSE(cht->insert_get(thr, stl, val, vg_dup)) << "Insert duplicate value succeeded.";
-  EXPECT_EQ(val, vg_dup.get_value()) << "Getting an inserted value failed.";
+  EXPECT_EQ(val, vg_dup.get_value()) << "Getting an existing value failed.";
 }
 
 static void cht_get_insert(Thread* thr) {

--- a/test/hotspot/gtest/utilities/test_concurrentHashtable.cpp
+++ b/test/hotspot/gtest/utilities/test_concurrentHashtable.cpp
@@ -106,6 +106,18 @@ static void cht_insert(Thread* thr) {
   delete cht;
 }
 
+static void cht_insert_get(Thread* thr) {
+  uintptr_t val = 0x2;
+  SimpleTestLookup stl(val);
+  SimpleTestTable* cht = new SimpleTestTable();
+  ValueGet vg;
+  EXPECT_TRUE(cht->insert_get(thr, stl, val, vg)) << "Insert unique value failed.";
+  EXPECT_EQ(val, vg.get_value()) << "Getting an inserted value failed.";
+  ValueGet vg_dup;
+  EXPECT_FALSE(cht->insert_get(thr, stl, val, vg_dup)) << "Insert duplicate value succeeded.";
+  EXPECT_EQ(val, vg_dup.get_value()) << "Getting an inserted value failed.";
+}
+
 static void cht_get_insert(Thread* thr) {
   uintptr_t val = 0x2;
   SimpleTestLookup stl(val);
@@ -380,6 +392,10 @@ TEST_VM(ConcurrentHashTable, basic_insert) {
 
 TEST_VM(ConcurrentHashTable, basic_get_insert) {
   nomt_test_doer(cht_get_insert);
+}
+
+TEST_VM(ConcurrentHashTable, basic_insert_get) {
+  nomt_test_doer(cht_insert_get);
 }
 
 TEST_VM(ConcurrentHashTable, basic_scope) {

--- a/test/hotspot/gtest/utilities/test_concurrentHashtable.cpp
+++ b/test/hotspot/gtest/utilities/test_concurrentHashtable.cpp
@@ -116,6 +116,7 @@ static void cht_insert_get(Thread* thr) {
   ValueGet vg_dup;
   EXPECT_FALSE(cht->insert_get(thr, stl, val, vg_dup)) << "Insert duplicate value succeeded.";
   EXPECT_EQ(val, vg_dup.get_value()) << "Getting an existing value failed.";
+  delete cht;
 }
 
 static void cht_get_insert(Thread* thr) {


### PR DESCRIPTION
Hi all,

Please review this change to add an `insert_get` method to the CHT.  The method combines `insert()` and `get()` methods to decrease the amount of global synchronization needed for `get()` calls after an `insert` call. 

Testing: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266637](https://bugs.openjdk.java.net/browse/JDK-8266637): CHT: Add insert_and_get method


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Robbin Ehn](https://openjdk.java.net/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3915/head:pull/3915` \
`$ git checkout pull/3915`

Update a local copy of the PR: \
`$ git checkout pull/3915` \
`$ git pull https://git.openjdk.java.net/jdk pull/3915/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3915`

View PR using the GUI difftool: \
`$ git pr show -t 3915`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3915.diff">https://git.openjdk.java.net/jdk/pull/3915.diff</a>

</details>
