### PR TITLE
8266744: Make AbstractGangTask stack-allocatable only

### DIFF
--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.hpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.hpp
@@ -25,6 +25,7 @@
 #ifndef SHARE_GC_G1_G1YOUNGGCPOSTEVACUATETASKS_HPP
 #define SHARE_GC_G1_G1YOUNGGCPOSTEVACUATETASKS_HPP
 
+#include "gc/shared/preservedMarks.hpp"
 #include "gc/g1/g1BatchedGangTask.hpp"
 #include "gc/g1/g1EvacFailure.hpp"
 
@@ -98,7 +99,7 @@ class G1PostEvacuateCollectionSetCleanupTask2 : public G1BatchedGangTask {
 #endif
 
   class RedirtyLoggedCardsTask;
-  class RestorePreservedMarksTask;
+  class RestorePreservedMarksTaskProxy;
   class FreeCollectionSetTask;
 
 public:
@@ -148,13 +149,12 @@ public:
   void do_work(uint worker_id) override;
 };
 
-class G1PostEvacuateCollectionSetCleanupTask2::RestorePreservedMarksTask : public G1AbstractSubTask {
+class G1PostEvacuateCollectionSetCleanupTask2::RestorePreservedMarksTaskProxy : public G1AbstractSubTask {
   PreservedMarksSet* _preserved_marks;
-  AbstractGangTask* _task;
+  RestorePreservedMarksTask _task;
 
 public:
-  RestorePreservedMarksTask(PreservedMarksSet* preserved_marks);
-  virtual ~RestorePreservedMarksTask();
+  RestorePreservedMarksTaskProxy(PreservedMarksSet* preserved_marks);
 
   static bool should_execute();
 

--- a/src/hotspot/share/gc/shared/workgroup.hpp
+++ b/src/hotspot/share/gc/shared/workgroup.hpp
@@ -54,7 +54,7 @@ class GangTaskDispatcher;
 
 // An abstract task to be worked on by a gang.
 // You subclass this to supply your own work() method
-class AbstractGangTask : public CHeapObj<mtInternal> {
+class AbstractGangTask {
   const char* _name;
   const uint _gc_id;
 


### PR DESCRIPTION
Remove the inheritance relation in `class AbstractGangTask : public CHeapObj<mtInternal>`, and export necessary classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8266744](https://bugs.openjdk.java.net/browse/JDK-8266744): Make AbstractGangTask stack-allocatable only


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3918/head:pull/3918` \
`$ git checkout pull/3918`

Update a local copy of the PR: \
`$ git checkout pull/3918` \
`$ git pull https://git.openjdk.java.net/jdk pull/3918/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3918`

View PR using the GUI difftool: \
`$ git pr show -t 3918`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3918.diff">https://git.openjdk.java.net/jdk/pull/3918.diff</a>

</details>
