### PR TITLE
8266742: Check W^X state on possible safepoint

### DIFF
--- a/src/hotspot/os/bsd/globals_bsd.hpp
+++ b/src/hotspot/os/bsd/globals_bsd.hpp
@@ -28,13 +28,16 @@
 //
 // Declare Bsd specific flags. They are not available on other platforms.
 //
-#define RUNTIME_OS_FLAGS(develop,     \
-                         develop_pd,  \
-                         product,     \
-                         product_pd,  \
-                         notproduct,  \
-                         range,       \
-                         constraint)
+#define RUNTIME_OS_FLAGS(develop,                                       \
+                         develop_pd,                                    \
+                         product,                                       \
+                         product_pd,                                    \
+                         notproduct,                                    \
+                         range,                                         \
+                         constraint)                                    \
+                                                                        \
+  AARCH64_ONLY(develop(bool, WXCheckAtSafepoint, false,                 \
+          "Conservatively check W^X thread state at possible safepoint"))
 
 // end of RUNTIME_OS_FLAGS
 

--- a/src/hotspot/os/bsd/globals_bsd.hpp
+++ b/src/hotspot/os/bsd/globals_bsd.hpp
@@ -36,8 +36,9 @@
                          range,                                         \
                          constraint)                                    \
                                                                         \
-  AARCH64_ONLY(develop(bool, WXCheckAtSafepoint, false,                 \
-          "Conservatively check W^X thread state at possible safepoint"))
+  AARCH64_ONLY(develop(bool, AssertWXAtThreadSync, false,                \
+          "Conservatively check W^X thread state at possible safepoint" \
+          "or handshake"))
 
 // end of RUNTIME_OS_FLAGS
 

--- a/src/hotspot/share/runtime/safepointMechanism.inline.hpp
+++ b/src/hotspot/share/runtime/safepointMechanism.inline.hpp
@@ -70,8 +70,8 @@ void SafepointMechanism::process_if_requested(JavaThread* thread) {
   // deoptimization needs WXWrite).  Crashes caused by the wrong state rarely
   // happens in practice, making such issues hard to find and reproduce.
 #if defined(ASSERT) && defined(__APPLE__) && defined(AARCH64)
-  if (WXCheckAtSafepoint) {
-    thread->check_wx(WXWrite);
+  if (AssertWXAtThreadSync) {
+    thread->assert_wx_state(WXWrite);
   }
 #endif
 

--- a/src/hotspot/share/runtime/safepointMechanism.inline.hpp
+++ b/src/hotspot/share/runtime/safepointMechanism.inline.hpp
@@ -65,6 +65,16 @@ bool SafepointMechanism::should_process(JavaThread* thread) {
 }
 
 void SafepointMechanism::process_if_requested(JavaThread* thread) {
+
+  // Macos/aarch64 should be in the right state for safepoint (e.g.
+  // deoptimization needs WXWrite).  Crashes caused by the wrong state rarely
+  // happens in practice, making such issues hard to find and reproduce.
+#if defined(ASSERT) && defined(__APPLE__) && defined(AARCH64)
+  if (WXCheckAtSafepoint) {
+    thread->check_wx(WXWrite);
+  }
+#endif
+
   if (local_poll_armed(thread)) {
     process_if_requested_slow(thread);
   }

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -685,7 +685,7 @@ protected:
   void init_wx();
   WXMode enable_wx(WXMode new_state);
 
-  void check_wx(WXMode expected) {
+  void assert_wx_state(WXMode expected) {
     assert(_wx_state == expected, "wrong state");
   }
 #endif // __APPLE__ && AARCH64

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -684,6 +684,10 @@ protected:
  public:
   void init_wx();
   WXMode enable_wx(WXMode new_state);
+
+  void check_wx(WXMode expected) {
+    assert(_wx_state == expected, "wrong state");
+  }
 #endif // __APPLE__ && AARCH64
 };
 


### PR DESCRIPTION
Hi,

Please review a check for W^X mode at safepoint. As described in the bug, this explicit check aims to catch the wrong W^X mode that may lead to a crash (such crashes are rather intermittent).

This check helped to verify the fix for https://bugs.openjdk.java.net/browse/JDK-8265292 and should help to discover similar issues. It is disabled by default to avoid unexpected failures in the regular use, but eventually it should be turned on unconditionally.

I still owe a complete W^X approach description. Hope this patch does not depend much on that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266742](https://bugs.openjdk.java.net/browse/JDK-8266742): Check W^X state on possible safepoint


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Gerard Ziemski](https://openjdk.java.net/census#gziemski) (@gerard-ziemski - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3920/head:pull/3920` \
`$ git checkout pull/3920`

Update a local copy of the PR: \
`$ git checkout pull/3920` \
`$ git pull https://git.openjdk.java.net/jdk pull/3920/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3920`

View PR using the GUI difftool: \
`$ git pr show -t 3920`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3920.diff">https://git.openjdk.java.net/jdk/pull/3920.diff</a>

</details>
