### PR TITLE
8265292:  [macos_aarch64] java/foreign/TestDowncall.java crashes with SIGBUS

### DIFF
--- a/src/hotspot/share/prims/universalNativeInvoker.cpp
+++ b/src/hotspot/share/prims/universalNativeInvoker.cpp
@@ -32,6 +32,9 @@ ProgrammableInvoker::Generator::Generator(CodeBuffer* code, const ABIDescriptor*
 
 void ProgrammableInvoker::invoke_native(Stub stub, address buff, JavaThread* thread) {
   ThreadToNativeFromVM ttnfvm(thread);
+  // We need WXExec because we are about to call a generated stub. Like in VM
+  // entries, the thread state should be changed while we are still in WXWrite.
+  // See JDK-8265292.
   MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXExec, thread));
   stub(buff);
 }

--- a/src/hotspot/share/prims/universalNativeInvoker.cpp
+++ b/src/hotspot/share/prims/universalNativeInvoker.cpp
@@ -31,8 +31,8 @@ ProgrammableInvoker::Generator::Generator(CodeBuffer* code, const ABIDescriptor*
     _layout(layout) {}
 
 void ProgrammableInvoker::invoke_native(Stub stub, address buff, JavaThread* thread) {
-  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXExec, thread));
   ThreadToNativeFromVM ttnfvm(thread);
+  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXExec, thread));
   stub(buff);
 }
 

--- a/src/hotspot/share/runtime/interfaceSupport.inline.hpp
+++ b/src/hotspot/share/runtime/interfaceSupport.inline.hpp
@@ -290,6 +290,14 @@ class VMNativeEntryWrapper {
 
 // LEAF routines do not lock, GC or throw exceptions
 
+// On macos/aarch64 we need to maintain the W^X state of the thread.  So we
+// take WXWrite on the enter to VM from the "outside" world, so the rest of JVM
+// code can assume writing (but not executing) codecache is always possible
+// without preliminary actions.
+// JavaThread state should be changed only after taking WXWrite. The state
+// change may trigger a safepoint, that would need WXWrite to do bookkeeping
+// in the codecache.
+
 #define VM_LEAF_BASE(result_type, header)                            \
   debug_only(NoHandleMark __hm;)                                     \
   MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite,                    \

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -544,9 +544,6 @@ java/beans/XMLEncoder/Test6570354.java 8015593 macosx-all
 java/foreign/TestMismatch.java 8249684 macosx-all
 
 java/foreign/StdLibTest.java 8263512 macosx-aarch64
-java/foreign/TestDowncall.java 8265292 macosx-aarch64
-java/foreign/TestIntrinsics.java 8265183 macosx-aarch64
-java/foreign/TestUpcall.java 8265182 macosx-aarch64
 java/foreign/TestVarArgs.java 8263512 macosx-aarch64
 java/foreign/valist/VaListTest.java 8263512 macosx-aarch64
 


### PR DESCRIPTION
Please review a fix for the intermittent crash. It is caused by a mistake in the ProgrammableInvoker::invoke_native, the wrong order of W^X and JavaThread state transition. We need WXExec since we are about to call a generated stub. But we need to switch to WXExec only after JavaThread state change. The thread state change may trigger a safepoint, that would need to do bookkeeping in the codecache (MarkActivationClosure::do_code_blob from the bug). So the fix is to change JavaThread state first, then change WX.

The fix was verified with the help of https://bugs.openjdk.java.net/browse/JDK-8266742. The new check catches all test failures reported by 8265292, 8265183, 8265182. I've verified tests pass after the fix with that new check enabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8265292](https://bugs.openjdk.java.net/browse/JDK-8265292): [macos_aarch64] java/foreign/TestDowncall.java crashes with SIGBUS
 * [JDK-8265183](https://bugs.openjdk.java.net/browse/JDK-8265183): [macos_aarch64] java/foreign/TestIntrinsics.java crashes with SIGBUS
 * [JDK-8265182](https://bugs.openjdk.java.net/browse/JDK-8265182): [macos_aarch64] java/foreign/TestUpcall.java crashes with SIGBUS


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to cb9723b742ce12bbab1a156d41b08c72dfd2ff46


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3921/head:pull/3921` \
`$ git checkout pull/3921`

Update a local copy of the PR: \
`$ git checkout pull/3921` \
`$ git pull https://git.openjdk.java.net/jdk pull/3921/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3921`

View PR using the GUI difftool: \
`$ git pr show -t 3921`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3921.diff">https://git.openjdk.java.net/jdk/pull/3921.diff</a>

</details>
