### PR TITLE
8266330: itableMethodEntry::initialize() asserts with archived old classes

### DIFF
--- a/src/hotspot/share/oops/klassVtable.cpp
+++ b/src/hotspot/share/oops/klassVtable.cpp
@@ -1094,7 +1094,8 @@ void itableMethodEntry::initialize(InstanceKlass* klass, Method* m) {
 #ifdef ASSERT
   if (MetaspaceShared::is_in_shared_metaspace((void*)&_method) &&
      !MetaspaceShared::remapped_readwrite() &&
-     !MetaspaceShared::is_old_class(m->method_holder()) && !MetaspaceShared::is_old_class(klass)) {
+     !MetaspaceShared::is_old_class(m->method_holder()) &&
+     !MetaspaceShared::is_old_class(klass)) {
     // At runtime initialize_itable is rerun as part of link_class_impl()
     // for a shared class loaded by the non-boot loader.
     // The dumptime itable method entry should be the same as the runtime entry.

--- a/src/hotspot/share/oops/klassVtable.cpp
+++ b/src/hotspot/share/oops/klassVtable.cpp
@@ -1088,16 +1088,18 @@ void klassVtable::dump_vtable() {
 // Itable code
 
 // Initialize a itableMethodEntry
-void itableMethodEntry::initialize(Method* m) {
+void itableMethodEntry::initialize(InstanceKlass* klass, Method* m) {
   if (m == NULL) return;
 
 #ifdef ASSERT
   if (MetaspaceShared::is_in_shared_metaspace((void*)&_method) &&
      !MetaspaceShared::remapped_readwrite() &&
-     !MetaspaceShared::is_old_class(m->method_holder())) {
+     !MetaspaceShared::is_old_class(m->method_holder()) && !MetaspaceShared::is_old_class(klass)) {
     // At runtime initialize_itable is rerun as part of link_class_impl()
     // for a shared class loaded by the non-boot loader.
     // The dumptime itable method entry should be the same as the runtime entry.
+    // For a shared old class which was not linked during dump time, we can't compare the dumptime
+    // itable method entry with the runtime entry.
     assert(_method == m, "sanity");
   }
 #endif
@@ -1336,7 +1338,7 @@ void klassItable::initialize_itable_for_interface(int method_table_offset, Insta
       if (!(target == NULL) && !target->is_public()) {
         // Stuff an IllegalAccessError throwing method in there instead.
         itableOffsetEntry::method_entry(_klass, method_table_offset)[m->itable_index()].
-            initialize(Universe::throw_illegal_access_error());
+            initialize(_klass, Universe::throw_illegal_access_error());
       }
     } else {
 
@@ -1349,7 +1351,7 @@ void klassItable::initialize_itable_for_interface(int method_table_offset, Insta
         supers->at_put(start_offset + ime_num, m);
       }
 
-      itableOffsetEntry::method_entry(_klass, method_table_offset)[ime_num].initialize(target);
+      itableOffsetEntry::method_entry(_klass, method_table_offset)[ime_num].initialize(_klass, target);
       if (log_develop_is_enabled(Trace, itables)) {
         ResourceMark rm;
         if (target != NULL) {
@@ -1381,7 +1383,7 @@ void klassItable::adjust_method_entries(bool * trace_name_printed) {
     }
     assert(!old_method->is_deleted(), "itable methods may not be deleted");
     Method* new_method = old_method->get_new_method();
-    ime->initialize(new_method);
+    ime->initialize(_klass, new_method);
 
     if (!(*trace_name_printed)) {
       log_info(redefine, class, update)("adjust: name=%s", old_method->method_holder()->external_name());

--- a/src/hotspot/share/oops/klassVtable.hpp
+++ b/src/hotspot/share/oops/klassVtable.hpp
@@ -249,7 +249,7 @@ class itableMethodEntry {
 
   void clear()             { _method = NULL; }
 
-  void initialize(Method* method);
+  void initialize(InstanceKlass* klass, Method* method);
 
   // Static size and offset accessors
   static int size()                         { return sizeof(itableMethodEntry) / wordSize; }  // size in words

--- a/test/hotspot/jtreg/runtime/cds/appcds/OldSuperInfIndirect.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/OldSuperInfIndirect.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+/*
+ * @test
+ * @bug 8266330
+ * @summary CDS support of old classes with major version < JDK_6 (50) for static archive.
+ *          Test a scenario that a class implements an old interface but the
+ *          implementation is in another class.
+ * @requires vm.cds
+ * @library /test/lib
+ * @compile test-classes/OldInf.jasm
+ * @compile test-classes/InfMethod.java
+ * @compile test-classes/IndirectImpInf.java
+ * @compile test-classes/IndirectImpInfApp.java
+ * @run driver OldSuperInfIndirect
+ */
+
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class OldSuperInfIndirect {
+
+    public static void main(String[] args) throws Exception {
+        String mainClass = "IndirectImpInfApp";
+        String namePrefix = "indirectimpinfapp";
+        String appClasses[] = TestCommon.list("OldInf", "InfMethod", "IndirectImpInf", mainClass);
+        JarBuilder.build(namePrefix, appClasses);
+
+        String appJar = TestCommon.getTestJar(namePrefix + ".jar");
+        String archiveName = namePrefix + ".jsa";
+
+        boolean dynamicMode = CDSTestUtils.DYNAMIC_DUMP;
+
+        // create archive with class list
+        OutputAnalyzer output = TestCommon.dump(appJar, appClasses, "-Xlog:class+load,cds=debug,verification=trace");
+        TestCommon.checkExecReturn(output, 0,
+                                   dynamicMode ? true : false,
+                                   "Pre JDK 6 class not supported by CDS: 49.0 OldInf",
+                                   "Skipping IndirectImpInf: Old class has been linked");
+
+        // run with archive
+        TestCommon.run(
+            "-cp", appJar,
+            "-Xlog:class+load,cds=debug,verification=trace",
+            mainClass)
+          .assertNormalExit(out -> {
+              out.shouldContain("Verifying class OldInf with old format")
+                 .shouldContain("Verifying class IndirectImpInf with new format");
+              if (!dynamicMode) {
+                  out.shouldContain("OldInf source: shared objects file")
+                     .shouldContain("InfMethod source: shared objects file")
+                     .shouldContain("IndirectImpInf source: shared objects file");
+              } else {
+                  // Old classes were already linked before dynamic dump happened,
+                  // so they couldn't be archived.
+                  out.shouldMatch(".class.load.*OldInf source:.*indirectimpinfapp.jar")
+                     .shouldMatch(".class.load.*IndirectImpInf source:.*indirectimpinfapp.jar")
+                     .shouldContain("InfMethod source: shared objects file (top)");
+              }
+          });
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/IndirectImpInf.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/IndirectImpInf.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+public class IndirectImpInf extends InfMethod implements OldInf {
+    // This class implements an old interface (OldInf) but the implementation
+    // is in InfMethod.
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/IndirectImpInfApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/IndirectImpInfApp.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+public class IndirectImpInfApp {
+    public static void main(String args[]) {
+        IndirectImpInf i = new IndirectImpInf();
+        System.out.println(i.doit());
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/InfMethod.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/InfMethod.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+public class InfMethod {
+    public String doit() {
+        return "doit from InfMethod";
+    }
+}


### PR DESCRIPTION
```
#ifdef ASSERT 
  if (MetaspaceShared::is_in_shared_metaspace((void*)&_method) && 
     !MetaspaceShared::remapped_readwrite() && 
     !MetaspaceShared::is_old_class(m->method_holder())) { 
    // At runtime initialize_itable is rerun as part of link_class_impl() 
    // for a shared class loaded by the non-boot loader. 
    // The dumptime itable method entry should be the same as the runtime entry. 
    assert(_method == m, "sanity"); 
  } 
#endif
```

The above includes the check for !MetaspaceShared::is_old_class(m->method_holder()).
While the method_holder() is not an old class, the _klass in the klassITable could be an old class.
The proposed fix is to have the caller of the above function pass in the _klass and add another check
making sure the _klass is not an old class before the assert.

Testing:
- [x] tiers 1 and 2 (including the new test)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266330](https://bugs.openjdk.java.net/browse/JDK-8266330): itableMethodEntry::initialize() asserts with archived old classes


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to 6b83ea9ff5793897f5e6bcf348e151b940583679
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**) ⚠️ Review applies to 6b83ea9ff5793897f5e6bcf348e151b940583679


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3930/head:pull/3930` \
`$ git checkout pull/3930`

Update a local copy of the PR: \
`$ git checkout pull/3930` \
`$ git pull https://git.openjdk.java.net/jdk pull/3930/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3930`

View PR using the GUI difftool: \
`$ git pr show -t 3930`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3930.diff">https://git.openjdk.java.net/jdk/pull/3930.diff</a>

</details>
