### PR TITLE
8266774: System property values for stdout/err on Windows UTF-8

### DIFF
--- a/src/java.base/windows/native/libjava/java_props_md.c
+++ b/src/java.base/windows/native/libjava/java_props_md.c
@@ -147,6 +147,8 @@ static char* getConsoleEncoding()
     cp = GetConsoleCP();
     if (cp >= 874 && cp <= 950)
         sprintf(buf, "ms%d", cp);
+    else if (cp == 65001)
+        sprintf(buf, "UTF-8");
     else
         sprintf(buf, "cp%d", cp);
     return buf;


### PR DESCRIPTION
Please review this small fix to Windows system property init code. This is leftover from the support for `Console.charset()` method, where it lacked to initialize `sun.stdout/err.encoding` to `UTF-8` for the code page `cp65001`.  The fix has been manually verified, but no automated test case is provided, as automatically setting `UTF-8` for the system locale on Windows test machine seems not possible.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266774](https://bugs.openjdk.java.net/browse/JDK-8266774): System property values for stdout/err on Windows UTF-8


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3931/head:pull/3931` \
`$ git checkout pull/3931`

Update a local copy of the PR: \
`$ git checkout pull/3931` \
`$ git pull https://git.openjdk.java.net/jdk pull/3931/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3931`

View PR using the GUI difftool: \
`$ git pr show -t 3931`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3931.diff">https://git.openjdk.java.net/jdk/pull/3931.diff</a>

</details>
