### PR TITLE
8266720: Wrong implementation in LibraryCallKit::inline_vector_shuffle_iota

### DIFF
--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -383,10 +383,10 @@ bool LibraryCallKit::inline_vector_shuffle_iota() {
     // Wrap the indices greater than lane count.
     res = gvn().transform(VectorNode::make(Op_AndI, res, bcast_mod, num_elem, elem_bt));
   } else {
-    ConINode* pred_node = (ConINode*)gvn().makecon(TypeInt::make(1));
+    ConINode* pred_node = (ConINode*)gvn().makecon(TypeInt::make(BoolTest::gt));
     Node * lane_cnt  = gvn().makecon(TypeInt::make(num_elem));
     Node * bcast_lane_cnt = gvn().transform(VectorNode::scalar2vector(lane_cnt, num_elem, type_bt));
-    Node* mask = gvn().transform(new VectorMaskCmpNode(BoolTest::ge, bcast_lane_cnt, res, pred_node, vt));
+    Node* mask = gvn().transform(new VectorMaskCmpNode(BoolTest::gt, bcast_lane_cnt, res, pred_node, vt));
 
     // Make the indices greater than lane count as -ve values. This matches the java side implementation.
     res = gvn().transform(VectorNode::make(Op_AndI, res, bcast_mod, num_elem, elem_bt));

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorShuffleIotaByteWrongImpl.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorShuffleIotaByteWrongImpl.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021, Huawei Technologies Co. Ltd. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import jdk.incubator.vector.ByteVector;
+import jdk.incubator.vector.VectorSpecies;
+import jdk.incubator.vector.VectorShuffle;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/*
+ * @test
+ * @bug 8266720
+ * @modules jdk.incubator.vector
+ * @run testng/othervm compiler.vectorapi.TestVectorShuffleIotaByteWrongImpl
+ */
+
+@Test
+public class TestVectorShuffleIotaByteWrongImpl {
+    static final VectorSpecies<Byte> SPECIESb_64 = ByteVector.SPECIES_64;
+    static final int INVOC_COUNT = Integer.getInteger("jdk.incubator.vector.test.loop-iterations", 50000);
+
+    static byte[] ab_64 = {87, 65, 78, 71, 72, 69, 82, 69};
+    static byte[] expected_64 = {0, 2, 4, 6, -8, -6, -4, -2};
+
+    @Test
+    static void testShuffleIota_64() {
+        for (int ic = 0; ic < INVOC_COUNT; ic++) {
+            ByteVector bv = (ByteVector) VectorShuffle.iota(SPECIESb_64, 0, 2, false).toVector();
+            bv.intoArray(ab_64, 0);
+        }
+        Assert.assertEquals(ab_64, expected_64);
+    }
+}


### PR DESCRIPTION
Dear All,
  Here is the patch of JDK-8266720. Could you do me a favor to review this?
* Reproduce:
   * cherry-pick JDK-8265956 
   * run patch's `TestVectorShuffleIotaByteWrongImpl.java`
   * However, this wrong of this code is obvious.
* Reason :
 1. In interpreter: 
```java
static int partiallyWrapIndex(int index, int laneCount) {
    return checkIndex0(index, laneCount, (byte)-1);
}

@ForceInline
static int checkIndex0(int index, int laneCount, byte mode) {
    int wrapped = VectorIntrinsics.wrapToRange(index, laneCount);
    if (mode == 0 || wrapped == index) { // NOTE here
        return wrapped;
    }
    if (mode < 0) {
        return wrapped - laneCount;  // special mode for internal storage
    }
    throw checkIndexFailed(index, laneCount);
}

@ForceInline
static int wrapToRange(int index, int size) {
    if ((size & (size - 1)) == 0) {
        // Size is zero or a power of two, so we got this.
        return index & (size - 1);
    } else {
        return wrapToRangeNPOT(index, size);
    }
}
```
2. However, we have this intrinsics in   
src/hotspot/share/opto/vectorIntrinsics.cpp [jdk/jdk]
```c++
 386   } else {
 387     ConINode* pred_node = (ConINode*)gvn().makecon(TypeInt::make(1)); // BoolTest::gt here
 388     Node * lane_cnt  = gvn().makecon(TypeInt::make(num_elem));
 389     Node * bcast_lane_cnt = gvn().transform(VectorNode::scalar2vector(lane_cnt, num_elem, type_bt));
// here BoolTest::ge != 1 (which means BoolTest::gt)
 390     Node* mask = gvn().transform(new VectorMaskCmpNode(BoolTest::ge, bcast_lane_cnt, res, pred_node, vt));
```
3. In `aarch64` neon backend, we use `BoolTest::ge` for generated code:
```c++
// cond is useless here
instruct vcmge8B(vecD dst, vecD src1, vecD src2, immI cond)
%{
  predicate(n->as_Vector()->length() == 8 &&
            n->as_VectorMaskCmp()->get_predicate() == BoolTest::ge &&
            n->in(1)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_BYTE);
  match(Set dst (VectorMaskCmp (Binary src1 src2) cond));
  format %{ "cmge  $dst, T8B, $src1, $src2\t# vector cmp (8B)" %}
  ins_cost(INSN_COST);
  ins_encode %{
    __ cmge(as_FloatRegister($dst$$reg), __ T8B,
            as_FloatRegister($src1$$reg), as_FloatRegister($src2$$reg));
  %}
  ins_pipe(vdop64);
%}
```

However, we use cond (=1 or BoolTest::gt). So X86 is **right** on jdk/jdk
```c++
instruct vcmp(legVec dst, legVec src1, legVec src2, immI8 cond, rRegP scratch) %{
  predicate(vector_length_in_bytes(n->in(1)->in(1)) >=  8 && // src1
            vector_length_in_bytes(n->in(1)->in(1)) <= 32 && // src1
            is_integral_type(vector_element_basic_type(n->in(1)->in(1)))); // src1
  match(Set dst (VectorMaskCmp (Binary src1 src2) cond));
  effect(TEMP scratch);
  format %{ "vector_compare $dst,$src1,$src2,$cond\t! using $scratch as TEMP" %}
  ins_encode %{
    int vlen_enc = vector_length_encoding(this, $src1);
    Assembler::ComparisonPredicate cmp = booltest_pred_to_comparison_pred($cond$$constant);
    Assembler::Width ww = widthForType(vector_element_basic_type(this, $src1));
    __ vpcmpCCW($dst$$XMMRegister, $src1$$XMMRegister, $src2$$XMMRegister, cmp, ww, vlen_enc, $scratch$$Register);
  %}
  ins_pipe( pipe_slow );
%}
```
4. In repo `panama-vector`, both of them are wrong, because the IR is fixed:
```c++
 455   } else {
 456     ConINode* pred_node = (ConINode*)gvn().makecon(TypeInt::make(BoolTest::ge));// WRONG here
 457     Node * lane_cnt  = gvn().makecon(TypeInt::make(num_elem));
 458     Node * bcast_lane_cnt = gvn().transform(VectorNode::scalar2vector(lane_cnt, num_elem, type_bt));
 459     Node* mask = gvn().transform(new VectorMaskCmpNode(BoolTest::ge, bcast_lane_cnt, res, pred_node, vt));
```
Yours, 
Wang Huang

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8266720](https://bugs.openjdk.java.net/browse/JDK-8266720): Wrong implementation in LibraryCallKit::inline_vector_shuffle_iota


### Contributors
 * Wang Huang `<whuang@openjdk.org>`
 * Ai Jiaming `<aijiaming1@huawei.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3933/head:pull/3933` \
`$ git checkout pull/3933`

Update a local copy of the PR: \
`$ git checkout pull/3933` \
`$ git pull https://git.openjdk.java.net/jdk pull/3933/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3933`

View PR using the GUI difftool: \
`$ git pr show -t 3933`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3933.diff">https://git.openjdk.java.net/jdk/pull/3933.diff</a>

</details>
