### PR TITLE
8266189: Remove C1 "IfInstanceOf" instruction

### DIFF
--- a/src/hotspot/share/c1/c1_Canonicalizer.cpp
+++ b/src/hotspot/share/c1/c1_Canonicalizer.cpp
@@ -468,8 +468,6 @@ void Canonicalizer::do_CompareOp      (CompareOp*       x) {
 }
 
 
-void Canonicalizer::do_IfInstanceOf(IfInstanceOf*    x) {}
-
 void Canonicalizer::do_IfOp(IfOp* x) {
   // Caution: do not use do_Op2(x) here for now since
   //          we map the condition to the op for now!
@@ -795,23 +793,6 @@ void Canonicalizer::do_If(If* x) {
           set_bci(cmp->state_before()->bci());
           set_canonical(canon);
         }
-      }
-    } else if (l->as_InstanceOf() != NULL) {
-      // NOTE: Code permanently disabled for now since it leaves the old InstanceOf
-      //       instruction in the graph (it is pinned). Need to fix this at some point.
-      //       It should also be left in the graph when generating a profiled method version or Goto
-      //       has to know that it was an InstanceOf.
-      return;
-      // pattern: If ((obj instanceof klass) cond rc) => simplify to: IfInstanceOf or: Goto
-      InstanceOf* inst = l->as_InstanceOf();
-      BlockBegin* is_inst_sux = x->sux_for(is_true(1, x->cond(), rc)); // successor for instanceof == 1
-      BlockBegin* no_inst_sux = x->sux_for(is_true(0, x->cond(), rc)); // successor for instanceof == 0
-      if (is_inst_sux == no_inst_sux && inst->is_loaded()) {
-        // both successors identical and klass is loaded => simplify to: Goto
-        set_canonical(new Goto(is_inst_sux, x->state_before(), x->is_safepoint()));
-      } else {
-        // successors differ => simplify to: IfInstanceOf
-        set_canonical(new IfInstanceOf(inst->klass(), inst->obj(), true, inst->state_before()->bci(), is_inst_sux, no_inst_sux));
       }
     }
   } else if (rt == objectNull &&

--- a/src/hotspot/share/c1/c1_Canonicalizer.hpp
+++ b/src/hotspot/share/c1/c1_Canonicalizer.hpp
@@ -75,7 +75,6 @@ class Canonicalizer: InstructionVisitor {
   virtual void do_LogicOp        (LogicOp*         x);
   virtual void do_CompareOp      (CompareOp*       x);
   virtual void do_IfOp           (IfOp*            x);
-  virtual void do_IfInstanceOf   (IfInstanceOf*    x);
   virtual void do_Convert        (Convert*         x);
   virtual void do_NullCheck      (NullCheck*       x);
   virtual void do_TypeCast       (TypeCast*        x);

--- a/src/hotspot/share/c1/c1_InstructionPrinter.cpp
+++ b/src/hotspot/share/c1/c1_InstructionPrinter.cpp
@@ -740,11 +740,6 @@ void InstructionPrinter::do_If(If* x) {
 }
 
 
-void InstructionPrinter::do_IfInstanceOf(IfInstanceOf* x) {
-  output()->print("<IfInstanceOf>");
-}
-
-
 void InstructionPrinter::do_TableSwitch(TableSwitch* x) {
   output()->print("tableswitch ");
   if (x->is_safepoint()) output()->print("(safepoint) ");

--- a/src/hotspot/share/c1/c1_InstructionPrinter.hpp
+++ b/src/hotspot/share/c1/c1_InstructionPrinter.hpp
@@ -115,7 +115,6 @@ class InstructionPrinter: public InstructionVisitor {
   virtual void do_BlockBegin     (BlockBegin*      x);
   virtual void do_Goto           (Goto*            x);
   virtual void do_If             (If*              x);
-  virtual void do_IfInstanceOf   (IfInstanceOf*    x);
   virtual void do_TableSwitch    (TableSwitch*     x);
   virtual void do_LookupSwitch   (LookupSwitch*    x);
   virtual void do_Return         (Return*          x);

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1186,11 +1186,6 @@ void LIRGenerator::do_Local(Local* x) {
 }
 
 
-void LIRGenerator::do_IfInstanceOf(IfInstanceOf* x) {
-  Unimplemented();
-}
-
-
 void LIRGenerator::do_Return(Return* x) {
   if (compilation()->env()->dtrace_method_probes()) {
     BasicTypeList signature;

--- a/src/hotspot/share/c1/c1_LIRGenerator.hpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.hpp
@@ -575,7 +575,6 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
   virtual void do_BlockBegin     (BlockBegin*      x);
   virtual void do_Goto           (Goto*            x);
   virtual void do_If             (If*              x);
-  virtual void do_IfInstanceOf   (IfInstanceOf*    x);
   virtual void do_TableSwitch    (TableSwitch*     x);
   virtual void do_LookupSwitch   (LookupSwitch*    x);
   virtual void do_Return         (Return*          x);

--- a/src/hotspot/share/c1/c1_Optimizer.cpp
+++ b/src/hotspot/share/c1/c1_Optimizer.cpp
@@ -521,7 +521,6 @@ public:
   void do_BlockBegin     (BlockBegin*      x);
   void do_Goto           (Goto*            x);
   void do_If             (If*              x);
-  void do_IfInstanceOf   (IfInstanceOf*    x);
   void do_TableSwitch    (TableSwitch*     x);
   void do_LookupSwitch   (LookupSwitch*    x);
   void do_Return         (Return*          x);
@@ -707,7 +706,6 @@ void NullCheckVisitor::do_Intrinsic      (Intrinsic*       x) { nce()->handle_In
 void NullCheckVisitor::do_BlockBegin     (BlockBegin*      x) {}
 void NullCheckVisitor::do_Goto           (Goto*            x) {}
 void NullCheckVisitor::do_If             (If*              x) {}
-void NullCheckVisitor::do_IfInstanceOf   (IfInstanceOf*    x) {}
 void NullCheckVisitor::do_TableSwitch    (TableSwitch*     x) {}
 void NullCheckVisitor::do_LookupSwitch   (LookupSwitch*    x) {}
 void NullCheckVisitor::do_Return         (Return*          x) {}

--- a/src/hotspot/share/c1/c1_RangeCheckElimination.hpp
+++ b/src/hotspot/share/c1/c1_RangeCheckElimination.hpp
@@ -155,7 +155,6 @@ public:
     void do_BlockBegin     (BlockBegin*      x) { /* nothing to do */ };
     void do_Goto           (Goto*            x) { /* nothing to do */ };
     void do_If             (If*              x) { /* nothing to do */ };
-    void do_IfInstanceOf   (IfInstanceOf*    x) { /* nothing to do */ };
     void do_TableSwitch    (TableSwitch*     x) { /* nothing to do */ };
     void do_LookupSwitch   (LookupSwitch*    x) { /* nothing to do */ };
     void do_Return         (Return*          x) { /* nothing to do */ };

--- a/src/hotspot/share/c1/c1_ValueMap.hpp
+++ b/src/hotspot/share/c1/c1_ValueMap.hpp
@@ -194,7 +194,6 @@ class ValueNumberingVisitor: public InstructionVisitor {
   void do_BlockBegin     (BlockBegin*      x) { /* nothing to do */ }
   void do_Goto           (Goto*            x) { /* nothing to do */ }
   void do_If             (If*              x) { /* nothing to do */ }
-  void do_IfInstanceOf   (IfInstanceOf*    x) { /* nothing to do */ }
   void do_TableSwitch    (TableSwitch*     x) { /* nothing to do */ }
   void do_LookupSwitch   (LookupSwitch*    x) { /* nothing to do */ }
   void do_Return         (Return*          x) { /* nothing to do */ }


### PR DESCRIPTION
Remove IfInstanceOf instruction, it has been there for a long while(13yrs) and not implemented yet.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266189](https://bugs.openjdk.java.net/browse/JDK-8266189): Remove C1 "IfInstanceOf" instruction


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3935/head:pull/3935` \
`$ git checkout pull/3935`

Update a local copy of the PR: \
`$ git checkout pull/3935` \
`$ git pull https://git.openjdk.java.net/jdk pull/3935/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3935`

View PR using the GUI difftool: \
`$ git pr show -t 3935`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3935.diff">https://git.openjdk.java.net/jdk/pull/3935.diff</a>

</details>
