### PR TITLE
8268549: Typo in file name in example for -Xlint:processing

### DIFF
--- a/src/jdk.compiler/share/man/javac.1
+++ b/src/jdk.compiler/share/man/javac.1
@@ -2115,14 +2115,14 @@ type of exception.
 For example, the following is a simple annotation processor:
 .RS
 .PP
-\f[B]Source file AnnocProc.java\f[R]:
+\f[B]Source file AnnoProc.java\f[R]:
 .IP
 .nf
 \f[CB]
 import\ java.util.*;
 import\ javax.annotation.processing.*;
 import\ javax.lang.model.*;
-import\ javaz.lang.model.element.*;
+import\ javax.lang.model.element.*;
 
 \@SupportedAnnotationTypes("NotAnno")
 public\ class\ AnnoProc\ extends\ AbstractProcessor\ {


### PR DESCRIPTION
Presented class is public, hence it has to be defined in AnnoProc.java.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8268549](https://bugs.openjdk.java.net/browse/JDK-8268549): Typo in file name in example for -Xlint:processing


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3937/head:pull/3937` \
`$ git checkout pull/3937`

Update a local copy of the PR: \
`$ git checkout pull/3937` \
`$ git pull https://git.openjdk.java.net/jdk pull/3937/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3937`

View PR using the GUI difftool: \
`$ git pr show -t 3937`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3937.diff">https://git.openjdk.java.net/jdk/pull/3937.diff</a>

</details>
