### PR TITLE
JDK-8266877: Missing local debug information when debugging JEP-330

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/Main.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/Main.java
@@ -342,6 +342,9 @@ public class Main {
                     }
                     break;
                 default:
+                    if (opt.startsWith("-agentlib:jdwp")) {
+                        javacOpts.add("-g");
+                    }
                     // ignore all other runtime args
             }
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/Main.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/Main.java
@@ -342,7 +342,7 @@ public class Main {
                     }
                     break;
                 default:
-                    if (opt.startsWith("-agentlib:jdwp")) {
+                    if (opt.startsWith("-agentlib:jdwp=") || opt.startsWith("-Xrunjdwp:")) {
                         javacOpts.add("-g");
                     }
                     // ignore all other runtime args


### PR DESCRIPTION
I am polishing support for [JEP-330](https://openjdk.java.net/jeps/330) in NetBeans ([PR-2938](https://github.com/apache/netbeans/pull/2938)) and I have problems with debugging. Local variables aren't visible as the compiler doesn't pass `-g` option when compiling the main class. I'd like to see 

![obrazek](https://user-images.githubusercontent.com/26887752/117578440-a876e000-b0ee-11eb-85b6-3c998f71879f.png)

however, that requires one to pass `-g` option to the compiler somehow. As far as I can say there is no such way and hence I decided to create this pull request. If I invoke:
```
$ java -agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=y x.java
```
it detects JDWP is on and adds `-g` to the compiler arguments. Is this an acceptable improvement? The alternative is to avoid using JEP-330 when debugging and rather generate `.class` by invoking `javac` and then run it as usual, but I'd rather rely on JEP-330 and avoid creation of the `.class` file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266877](https://bugs.openjdk.java.net/browse/JDK-8266877): Missing local debug information when debugging JEP-330


### Reviewers
 * @APA2527 (no known github.com user name / role)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3939/head:pull/3939` \
`$ git checkout pull/3939`

Update a local copy of the PR: \
`$ git checkout pull/3939` \
`$ git pull https://git.openjdk.java.net/jdk pull/3939/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3939`

View PR using the GUI difftool: \
`$ git pr show -t 3939`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3939.diff">https://git.openjdk.java.net/jdk/pull/3939.diff</a>

</details>
