### PR TITLE
8266773: Release VM is broken with GCC 9 after JDK-8214237

### DIFF
--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
@@ -331,7 +331,7 @@ void G1GCPhaseTimes::log_phase(WorkerDataArray<double>* phase, uint indent_level
 
   for (uint i = 0; i < phase->MaxThreadWorkItems; i++) {
     WorkerDataArray<size_t>* work_items = phase->thread_work_items(i);
-    if (work_items != NULL) {
+    if (work_items != NULL && indent(indent_level + 1) != NULL) {
       out->print("%s", indent(indent_level + 1));
       work_items->print_summary_on(out, true);
       details(work_items, indent(indent_level + 1));


### PR DESCRIPTION
Hi all,

Release VM is broken with GCC 9 due to -Werror=format-overflow=.
And if this assert[1] is removed, fastdebug VM can also reproduce the same bug.
The key to reproduce it is to compile with -O3.

IMO, it seems like a false positive gcc bug.
But we'd better fix it since gcc 9 is assumed to be supported to build OpenJDK.

Thanks.
Best regards,
Jie


[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp#L47