### PR TITLE
8266796: Clean up the unnecessary code in the method UnsharedNameTable#fromUtf

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/UnsharedNameTable.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/UnsharedNameTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,10 +96,6 @@ public class UnsharedNameTable extends Name.Table {
         HashEntry firstTableEntry = element;
 
         while (element != null) {
-            if (element == null) {
-                break;
-            }
-
             n = element.get();
 
             if (n == null) {


### PR DESCRIPTION
Hi all,

This little patch cleans up the redundant code. Please see the code below. 

```
        while (element != null) {
            if (element == null) {
                break;
            }
```

The `while (element != null)` has already checked the `element`. So the `if (element == null)` is redundant and unnecessary.

Thank you for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266796](https://bugs.openjdk.java.net/browse/JDK-8266796): Clean up the unnecessary code in the method UnsharedNameTable#fromUtf


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3942/head:pull/3942` \
`$ git checkout pull/3942`

Update a local copy of the PR: \
`$ git checkout pull/3942` \
`$ git pull https://git.openjdk.java.net/jdk pull/3942/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3942`

View PR using the GUI difftool: \
`$ git pr show -t 3942`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3942.diff">https://git.openjdk.java.net/jdk/pull/3942.diff</a>

</details>
