### PR TITLE
JDK-8266797: Fix for 8266610 breaks the build on macos

### DIFF
--- a/src/java.base/unix/native/libjava/io_util_md.c
+++ b/src/java.base/unix/native/libjava/io_util_md.c
@@ -253,7 +253,7 @@ handleGetLength(FD fd)
     if (result < 0) {
         return -1;
     }
-    #ifdef BLKGETSIZE64
+    #if defined(__linux__) && defined(BLKGETSIZE64)
     if (S_ISBLK(sb.st_mode)) {
         uint64_t size;
         if(ioctl(fd, BLKGETSIZE64, &size) < 0) {

--- a/src/java.base/unix/native/libjava/io_util_md.c
+++ b/src/java.base/unix/native/libjava/io_util_md.c
@@ -253,7 +253,7 @@ handleGetLength(FD fd)
     if (result < 0) {
         return -1;
     }
-    #if defined(__linux__) && defined(BLKGETSIZE64)
+#if defined(__linux__) && defined(BLKGETSIZE64)
     if (S_ISBLK(sb.st_mode)) {
         uint64_t size;
         if(ioctl(fd, BLKGETSIZE64, &size) < 0) {
@@ -261,6 +261,6 @@ handleGetLength(FD fd)
         }
         return (jlong)size;
     }
-    #endif
+#endif
     return sb.st_size;
 }

--- a/src/java.base/unix/native/libjava/io_util_md.c
+++ b/src/java.base/unix/native/libjava/io_util_md.c
@@ -32,6 +32,9 @@
 
 #if defined(__linux__) || defined(_ALLBSD_SOURCE) || defined(_AIX)
 #include <sys/ioctl.h>
+#endif
+
+#if defined(__linux__)
 #include <linux/fs.h>
 #include <sys/stat.h>
 #endif


### PR DESCRIPTION
this change will  include  the below headers files to Linux only. 
#include <linux/fs.h>
#include <sys/stat.h>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266797](https://bugs.openjdk.java.net/browse/JDK-8266797): Fix for 8266610 breaks the build on macos


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to b389921ca20b7e22176d208de41e0f65eae9b946
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3943/head:pull/3943` \
`$ git checkout pull/3943`

Update a local copy of the PR: \
`$ git checkout pull/3943` \
`$ git pull https://git.openjdk.java.net/jdk pull/3943/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3943`

View PR using the GUI difftool: \
`$ git pr show -t 3943`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3943.diff">https://git.openjdk.java.net/jdk/pull/3943.diff</a>

</details>
