### PR TITLE
JDK-8266779: Use <wbr> instead of ZERO_WIDTH_SPACE

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
@@ -41,6 +41,7 @@ import jdk.javadoc.internal.doclets.formats.html.markup.ContentBuilder;
 import jdk.javadoc.internal.doclets.formats.html.markup.Entity;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlStyle;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlTree;
+import jdk.javadoc.internal.doclets.formats.html.markup.TagName;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 import jdk.javadoc.internal.doclets.toolkit.util.DocletConstants;
 
@@ -91,7 +92,7 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
         }
         String signature = utils.flatSignature((ExecutableElement) member, typeElement);
         if (signature.length() > 2) {
-            content.add(Entity.ZERO_WIDTH_SPACE);
+            content.add(new HtmlTree(TagName.WBR));
         }
         content.add(signature);
 
@@ -210,7 +211,7 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
         Content paramTree = getParameters(member, false);
         if (paramTree.charCount() > 2) {
             // only add zero-width-space for non-empty parameters
-            htmltree.add(Entity.ZERO_WIDTH_SPACE);
+            htmltree.add(new HtmlTree(TagName.WBR));
         }
         htmltree.add(paramTree);
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
@@ -210,7 +210,7 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
     protected void addParameters(ExecutableElement member, Content htmltree) {
         Content paramTree = getParameters(member, false);
         if (paramTree.charCount() > 2) {
-            // only add zero-width-space for non-empty parameters
+            // only add <wbr> for non-empty parameters
             htmltree.add(new HtmlTree(TagName.WBR));
         }
         htmltree.add(paramTree);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkFactory.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkFactory.java
@@ -37,8 +37,8 @@ import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 
 import jdk.javadoc.internal.doclets.formats.html.markup.ContentBuilder;
-import jdk.javadoc.internal.doclets.formats.html.markup.Entity;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlTree;
+import jdk.javadoc.internal.doclets.formats.html.markup.TagName;
 import jdk.javadoc.internal.doclets.toolkit.BaseConfiguration;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 import jdk.javadoc.internal.doclets.toolkit.Resources;
@@ -171,7 +171,7 @@ public class HtmlLinkFactory extends LinkFactory {
             for (TypeMirror t : vars) {
                 if (many) {
                     links.add(",");
-                    links.add(Entity.ZERO_WIDTH_SPACE);
+                    links.add(new HtmlTree(TagName.WBR));
                     if (((HtmlLinkInfo) linkInfo).getContext() == HtmlLinkInfo.Kind.MEMBER_TYPE_PARAMS) {
                         links.add(DocletConstants.NL);
                     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Signatures.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Signatures.java
@@ -457,7 +457,7 @@ public class Signatures {
                 // empty parameters are added without packing
                 htmlTree.add(parameters);
             } else {
-                htmlTree.add(Entity.ZERO_WIDTH_SPACE)
+                htmlTree.add(new HtmlTree(TagName.WBR))
                         .add(HtmlTree.SPAN(HtmlStyle.parameters, parameters));
             }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Entity.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Entity.java
@@ -38,12 +38,6 @@ public class Entity extends Content {
     public static final Entity GREATER_THAN = new Entity("&gt;");
     public static final Entity AMPERSAND = new Entity("&amp;");
     public static final Entity NO_BREAK_SPACE = new Entity("&nbsp;");
-    public static final Entity ZERO_WIDTH_SPACE = new Entity("&#8203;") {
-        @Override
-        public int charCount() {
-            return 0;
-        }
-    };
 
     public final String text;
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlTree.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlTree.java
@@ -926,6 +926,8 @@ public class HtmlTree extends Content {
                         (hasAttr(HtmlAttr.TYPE) && hasContent()));
             case SPAN:
                 return (hasAttr(HtmlAttr.ID) || hasContent());
+            case WBR:
+                return (!hasContent());
             default :
                 return hasContent();
         }
@@ -942,6 +944,7 @@ public class HtmlTree extends Content {
         switch (tagName) {
             case A: case BUTTON: case BR: case CODE: case EM: case I: case IMG:
             case LABEL: case SMALL: case SPAN: case STRONG: case SUB: case SUP:
+            case WBR:
                 return true;
             default:
                 return false;
@@ -957,7 +960,7 @@ public class HtmlTree extends Content {
      */
     public boolean isVoid() {
         switch (tagName) {
-            case BR: case HR: case IMG: case INPUT: case LINK: case META:
+            case BR: case HR: case IMG: case INPUT: case LINK: case META: case WBR:
                 return true;
             default:
                 return false;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/TagName.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/TagName.java
@@ -91,7 +91,8 @@ public enum TagName {
     TH,
     TITLE,
     TR,
-    UL;
+    UL,
+    WBR;
 
     public final String value;
 

--- a/test/langtools/jdk/javadoc/doclet/testConstructors/TestConstructors.java
+++ b/test/langtools/jdk/javadoc/doclet/testConstructors/TestConstructors.java
@@ -69,7 +69,7 @@ public class TestConstructors extends JavadocTester {
                 """
                     <section class="detail" id="&lt;init&gt;()">""",
                 """
-                    <a href="#%3Cinit%3E(int)" class="member-name-link">Outer</a>&#8203;(int&nbsp;i)""",
+                    <a href="#%3Cinit%3E(int)" class="member-name-link">Outer</a><wbr>(int&nbsp;i)""",
                 """
                     <section class="detail" id="&lt;init&gt;(int)">""");
 
@@ -79,7 +79,7 @@ public class TestConstructors extends JavadocTester {
                 """
                     <section class="detail" id="&lt;init&gt;()">""",
                 """
-                    <a href="#%3Cinit%3E(int)" class="member-name-link">Inner</a>&#8203;(int&nbsp;i)""",
+                    <a href="#%3Cinit%3E(int)" class="member-name-link">Inner</a><wbr>(int&nbsp;i)""",
                 """
                     <section class="detail" id="&lt;init&gt;(int)">""");
 
@@ -89,7 +89,7 @@ public class TestConstructors extends JavadocTester {
                 """
                     <section class="detail" id="&lt;init&gt;()">""",
                 """
-                    <a href="#%3Cinit%3E(int)" class="member-name-link">NestedInner</a>&#8203;(int&nbsp;i)""",
+                    <a href="#%3Cinit%3E(int)" class="member-name-link">NestedInner</a><wbr>(int&nbsp;i)""",
                 """
                     <section class="detail" id="&lt;init&gt;(int)">""");
 

--- a/test/langtools/jdk/javadoc/doclet/testDeprecatedDocs/TestDeprecatedDocs.java
+++ b/test/langtools/jdk/javadoc/doclet/testDeprecatedDocs/TestDeprecatedDocs.java
@@ -355,11 +355,11 @@ public class TestDeprecatedDocs extends JavadocTester {
                     <div class="col-last odd-row-color">
                     <div class="deprecation-comment">class_test5 passes. This is the second sentence of deprecated description for a method.</div>
                     </div>
-                    <div class="col-summary-item-name even-row-color"><a href="pkg/TestClass.html#overloadedMethod(int)">pkg.TestClass.overloadedMethod&#8203;(int)</a></div>
+                    <div class="col-summary-item-name even-row-color"><a href="pkg/TestClass.html#overloadedMethod(int)">pkg.TestClass.overloadedMethod<wbr>(int)</a></div>
                     <div class="col-last even-row-color">
                     <div class="deprecation-comment">class_test7 passes. Overloaded method 2.</div>
                     </div>
-                    <div class="col-summary-item-name odd-row-color"><a href="pkg/TestClass.html#overloadedMethod(java.lang.String)">pkg.TestClass.overloadedMethod&#8203;(String)</a></div>
+                    <div class="col-summary-item-name odd-row-color"><a href="pkg/TestClass.html#overloadedMethod(java.lang.String)">pkg.TestClass.overloadedMethod<wbr>(String)</a></div>
                     <div class="col-last odd-row-color">
                     <div class="deprecation-comment">class_test6 passes. Overloaded method 1.</div>
                     </div>""",
@@ -375,7 +375,7 @@ public class TestDeprecatedDocs extends JavadocTester {
                     <div class="col-last odd-row-color">
                     <div class="deprecation-comment">class_test3 passes. This is the second sentence of deprecated description for a constructor.</div>
                     </div>
-                    <div class="col-summary-item-name even-row-color"><a href="pkg/TestClass.html#%3Cinit%3E(java.lang.String)">pkg.TestClass&#8203;(String)</a></div>
+                    <div class="col-summary-item-name even-row-color"><a href="pkg/TestClass.html#%3Cinit%3E(java.lang.String)">pkg.TestClass<wbr>(String)</a></div>
                     <div class="col-last even-row-color">
                     <div class="deprecation-comment">class_test4 passes. Overloaded constructor.</div>
                     </div>""");

--- a/test/langtools/jdk/javadoc/doclet/testEnumConstructor/TestEnumConstructor.java
+++ b/test/langtools/jdk/javadoc/doclet/testEnumConstructor/TestEnumConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testEnumConstructor/TestEnumConstructor.java
+++ b/test/langtools/jdk/javadoc/doclet/testEnumConstructor/TestEnumConstructor.java
@@ -68,7 +68,7 @@ public class TestEnumConstructor extends JavadocTester {
                 "Constructor Summary",
                 "Modifier", "Constructor",
                 "private", """
-                    <a href="#%3Cinit%3E(int)" class="member-name-link">TestEnum</a>&#8203;(int&nbsp;val)""");
+                    <a href="#%3Cinit%3E(int)" class="member-name-link">TestEnum</a><wbr>(int&nbsp;val)""");
         checkOutput("index-all.html", true,
                 """
                     <a href="pkg/TestEnum.html#%3Cinit%3E(int)" class="member-name-link">TestEnum(int)</a>""");

--- a/test/langtools/jdk/javadoc/doclet/testGenericTypeLink/TestGenericTypeLink.java
+++ b/test/langtools/jdk/javadoc/doclet/testGenericTypeLink/TestGenericTypeLink.java
@@ -74,18 +74,18 @@ public class TestGenericTypeLink extends JavadocTester {
                     <li><code><a href="http://example.com/docs/api/java.base/java/util/Map.html" title="\
                     class or interface in java.util" class="external-link">Map</a>&lt;<a href="http://ex\
                     ample.com/docs/api/java.base/java/lang/String.html" title="class or interface in jav\
-                    a.lang" class="external-link">String</a>,&#8203;? extends <a href="http://example.co\
-                    m/docs/api/java.base/java/lang/CharSequence.html" title="class or interface in java.\
-                    lang" class="external-link">CharSequence</a>&gt;</code></li>
+                    a.lang" class="external-link">String</a>,<wbr>? extends <a href="http://example.com/\
+                    docs/api/java.base/java/lang/CharSequence.html" title="class or interface in java.la\
+                    ng" class="external-link">CharSequence</a>&gt;</code></li>
                     <li><code><a href="http://example.com/docs/api/java.base/java/util/Map.html" title="\
                     class or interface in java.util" class="external-link">Map</a>&lt;<a href="http://ex\
                     ample.com/docs/api/java.base/java/lang/String.html" title="class or interface in jav\
-                    a.lang" class="external-link">String</a>,&#8203;? super <a href="A.html" title="clas\
-                    s in pkg1">A</a>&lt;<a href="http://example.com/docs/api/java.base/java/lang/String.\
-                    html" title="class or interface in java.lang" class="external-link">String</a>,&#820\
-                    3;? extends <a href="http://example.com/docs/api/java.base/java/lang/RuntimeExceptio\
-                    n.html" title="class or interface in java.lang" class="external-link">RuntimeExcepti\
-                    on</a>&gt;&gt;</code></li>
+                    a.lang" class="external-link">String</a>,<wbr>? super <a href="A.html" title="class \
+                    in pkg1">A</a>&lt;<a href="http://example.com/docs/api/java.base/java/lang/String.ht\
+                    ml" title="class or interface in java.lang" class="external-link">String</a>,<wbr>? \
+                    extends <a href="http://example.com/docs/api/java.base/java/lang/RuntimeException.ht\
+                    ml" title="class or interface in java.lang" class="external-link">RuntimeException</\
+                    a>&gt;&gt;</code></li>
                     <li><a href="#someMethod(java.util.List,int)"><code>someMethod(List&lt;Number&gt;, i\
                     nt)</code></a></li>
                     <li><a href="#otherMethod(java.util.Map,double)"><code>otherMethod(Map&lt;String, ? \
@@ -97,8 +97,8 @@ public class TestGenericTypeLink extends JavadocTester {
                 """
                     <div class="block"><code><a href="A.html" title="class in pkg1">A</a>&lt;<a href="h\
                     ttp://example.com/docs/api/java.base/java/lang/String.html" title="class or interfa\
-                    ce in java.lang" class="external-link">String</a>,&#8203;<a href="A.SomeException.h\
-                    tml" title="class in pkg1">A.SomeException</a>&gt;</code>
+                    ce in java.lang" class="external-link">String</a>,<wbr><a href="A.SomeException.htm\
+                    l" title="class in pkg1">A.SomeException</a>&gt;</code>
                      <a href="http://example.com/docs/api/java.base/java/util/Map.html" title="class or\
                      interface in java.util" class="external-link">link to generic type with label</a>\
                     </div>""",
@@ -109,8 +109,8 @@ public class TestGenericTypeLink extends JavadocTester {
                     <ul class="see-list-long">
                     <li><code><a href="A.html" title="class in pkg1">A</a>&lt;<a href="http://example.c\
                     om/docs/api/java.base/java/lang/String.html" title="class or interface in java.lang\
-                    " class="external-link">String</a>,&#8203;<a href="A.SomeException.html" title="cla\
-                    ss in pkg1">A.SomeException</a>&gt;</code></li>
+                    " class="external-link">String</a>,<wbr><a href="A.SomeException.html" title="class\
+                     in pkg1">A.SomeException</a>&gt;</code></li>
                     <li><a href="http://example.com/docs/api/java.base/java/util/List.html" title="clas\
                     s or interface in java.util" class="external-link"><code>Link to generic type with \
                     label</code></a></li>

--- a/test/langtools/jdk/javadoc/doclet/testHtmlTableTags/TestHtmlTableTags.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlTableTags/TestHtmlTableTags.java
@@ -611,7 +611,7 @@ public class TestHtmlTableTags extends JavadocTester {
                     ab2 method-summary-table-tab4"><code>void</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
                     tab2 method-summary-table-tab4"><code><a href="#method1(int,int)" class="member-\
-                    name-link">method1</a>&#8203;(int&nbsp;a,
+                    name-link">method1</a><wbr>(int&nbsp;a,
                      int&nbsp;b)</code></div>
                     <div class="col-last even-row-color method-summary-table method-summary-table-ta\
                     b2 method-summary-table-tab4">
@@ -631,8 +631,8 @@ public class TestHtmlTableTags extends JavadocTester {
                     kg1">C1</a></code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
                     tab2 method-summary-table-tab4"><code><a href="#method(pkg1.C1)" class="member-n\
-                    ame-link">method</a>&#8203;(<a href="../pkg1/C1.html" title="class \
-                    in pkg1">C1</a>&nbsp;param)</code></div>
+                    ame-link">method</a><wbr>(<a href="../pkg1/C1.html" title="class in pkg1">C1</a>\
+                    &nbsp;param)</code></div>
                     <div class="col-last even-row-color method-summary-table method-summary-table-ta\
                     b2 method-summary-table-tab4">
                     <div class="block">A sample method.</div>
@@ -680,8 +680,8 @@ public class TestHtmlTableTags extends JavadocTester {
                     <div class="col-first even-row-color"><code><a href="../C2.html" title="class in pkg2">C2</a></code></div>
                     <div class="col-second even-row-color"><span class="type-name-label">C1.</span><\
                     code><a href="../../pkg1/C1.html#method(pkg2.C2)" class="member-name-link">metho\
-                    d</a>&#8203;(<a href="../C2.html" title="class in pkg2">C2</a>&nbsp\
-                    ;param)</code></div>
+                    d</a><wbr>(<a href="../C2.html" title="class in pkg2">C2</a>&nbsp;param)</code><\
+                    /div>
                     <div class="col-last even-row-color">
                     <div class="block">Method thats does some processing.</div>
                     </div>""");
@@ -769,7 +769,7 @@ public class TestHtmlTableTags extends JavadocTester {
                     ab2 method-summary-table-tab4"><code>void</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
                     tab2 method-summary-table-tab4"><code><a href="#method1(int,int)" class="member-\
-                    name-link">method1</a>&#8203;(int&nbsp;a,
+                    name-link">method1</a><wbr>(int&nbsp;a,
                      int&nbsp;b)</code></div>
                     <div class="col-last even-row-color method-summary-table method-summary-table-ta\
                     b2 method-summary-table-tab4"></div>""");
@@ -785,8 +785,8 @@ public class TestHtmlTableTags extends JavadocTester {
                     kg1">C1</a></code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
                     tab2 method-summary-table-tab4"><code><a href="#method(pkg1.C1)" class="member-n\
-                    ame-link">method</a>&#8203;(<a href="../pkg1/C1.html" title="class in pkg1">C1</\
-                    a>&nbsp;param)</code></div>
+                    ame-link">method</a><wbr>(<a href="../pkg1/C1.html" title="class in pkg1">C1</a>\
+                    &nbsp;param)</code></div>
                     <div class="col-last even-row-color method-summary-table method-summary-table-ta\
                     b2 method-summary-table-tab4"></div>""");
 
@@ -827,7 +827,7 @@ public class TestHtmlTableTags extends JavadocTester {
                     <div class="col-first even-row-color"><code><a href="../C2.html" title="class in pkg2">C2</a></code></div>
                     <div class="col-second even-row-color"><span class="type-name-label">C1.</span><\
                     code><a href="../../pkg1/C1.html#method(pkg2.C2)" class="member-name-link">metho\
-                    d</a>&#8203;(<a href="../C2.html" title="class in pkg2">C2</a>&nbsp;param)</code></div>
+                    d</a><wbr>(<a href="../C2.html" title="class in pkg2">C2</a>&nbsp;param)</code></div>
                     <div class="col-last even-row-color"></div>""");
 
         // Package use documentation

--- a/test/langtools/jdk/javadoc/doclet/testIndentation/TestIndentation.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndentation/TestIndentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testIndentation/TestIndentation.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndentation/TestIndentation.java
@@ -52,7 +52,7 @@ public class TestIndentation extends JavadocTester {
                 """
                     <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
                     lass="type-parameters">&lt;T&gt;</span>&nbsp;<span class="return-type">void</spa\
-                    n>&nbsp;<span class="element-name">m</span>&#8203;<span class="parameters">(T&nbsp;t1,
+                    n>&nbsp;<span class="element-name">m</span><wbr><span class="parameters">(T&nbsp;t1,
                      T&nbsp;t2)</span>
                                throws <span class="exceptions">java.lang.Exception</span></div>""");
 

--- a/test/langtools/jdk/javadoc/doclet/testInterface/TestInterface.java
+++ b/test/langtools/jdk/javadoc/doclet/testInterface/TestInterface.java
@@ -199,14 +199,14 @@ public class TestInterface extends JavadocTester {
                 ator.OfInt</a>&lt;<a href="Spliterator.OfInt.html" title="type parameter in Spli\
                 terator.OfInt">Integer</a>&gt;, <a href="Spliterator.OfPrimitive.html" title="in\
                 terface in pkg2">Spliterator.OfPrimitive</a>&lt;<a href="Spliterator.OfPrimitive\
-                .html" title="type parameter in Spliterator.OfPrimitive">T</a>,&#8203;<a href="S\
-                pliterator.OfPrimitive.html" title="type parameter in Spliterator.OfPrimitive">T\
-                _CONS</a>,&#8203;<a href="Spliterator.OfPrimitive.html" title="type parameter in\
-                 Spliterator.OfPrimitive">T_SPLITR</a> extends <a href="Spliterator.OfPrimitive.\
-                html" title="interface in pkg2">Spliterator.OfPrimitive</a>&lt;<a href="Splitera\
-                tor.OfPrimitive.html" title="type parameter in Spliterator.OfPrimitive">T</a>,&#\
-                8203;<a href="Spliterator.OfPrimitive.html" title="type parameter in Spliterator\
-                .OfPrimitive">T_CONS</a>,&#8203;<a href="Spliterator.OfPrimitive.html" title="ty\
-                pe parameter in Spliterator.OfPrimitive">T_SPLITR</a>&gt;&gt;</code>""");
+                .html" title="type parameter in Spliterator.OfPrimitive">T</a>,<wbr><a href="Spl\
+                iterator.OfPrimitive.html" title="type parameter in Spliterator.OfPrimitive">T_C\
+                ONS</a>,<wbr><a href="Spliterator.OfPrimitive.html" title="type parameter in Spl\
+                iterator.OfPrimitive">T_SPLITR</a> extends <a href="Spliterator.OfPrimitive.html\
+                " title="interface in pkg2">Spliterator.OfPrimitive</a>&lt;<a href="Spliterator.\
+                OfPrimitive.html" title="type parameter in Spliterator.OfPrimitive">T</a>,<wbr><\
+                a href="Spliterator.OfPrimitive.html" title="type parameter in Spliterator.OfPri\
+                mitive">T_CONS</a>,<wbr><a href="Spliterator.OfPrimitive.html" title="type param\
+                eter in Spliterator.OfPrimitive">T_SPLITR</a>&gt;&gt;</code>""");
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFX.java
+++ b/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFX.java
@@ -69,8 +69,8 @@ public class TestJavaFX extends JavadocTester {
                     </dd>""",
                 """
                     <div class="member-signature"><span class="modifiers">public final</span>&nbsp;<\
-                    span class="return-type">void</span>&nbsp;<span class="element-name">setRate</span>&#820\
-                    3;<span class="parameters">(double&nbsp;value)</span></div>
+                    span class="return-type">void</span>&nbsp;<span class="element-name">setRate</span><wbr>\
+                    <span class="parameters">(double&nbsp;value)</span></div>
                     <div class="block">Sets the value of the property rate.</div>
                     <dl class="notes">
                     <dt>Property description:</dt>""",
@@ -114,15 +114,15 @@ public class TestJavaFX extends JavadocTester {
                     <section class="detail" id="isPaused()">
                     <h3>isPaused</h3>
                     <div class="member-signature"><span class="modifiers">public final</span>&nbsp;<\
-                    span class="return-type">double</span>&nbsp;<span class="element-name">isPaused</span>()\
-                    </div>
+                    span class="return-type">double</span>&nbsp;<span class="element-name">isPaused<\
+                    /span>()</div>
                     <div class="block">Gets the value of the property paused.</div>""",
                 """
                     <section class="detail" id="setPaused(boolean)">
                     <h3>setPaused</h3>
                     <div class="member-signature"><span class="modifiers">public final</span>&nbsp;<\
-                    span class="return-type">void</span>&nbsp;<span class="element-name">setPaused</span>&#8\
-                    203;<span class="parameters">(boolean&nbsp;value)</span></div>
+                    span class="return-type">void</span>&nbsp;<span class="element-name">setPaused</\
+                    span><wbr><span class="parameters">(boolean&nbsp;value)</span></div>
                     <div class="block">Sets the value of the property paused.</div>
                     <dl class="notes">
                     <dt>Property description:</dt>
@@ -133,8 +133,8 @@ public class TestJavaFX extends JavadocTester {
                     <section class="detail" id="isPaused()">
                     <h3>isPaused</h3>
                     <div class="member-signature"><span class="modifiers">public final</span>&nbsp;<\
-                    span class="return-type">double</span>&nbsp;<span class="element-name">isPaused</span>()\
-                    </div>
+                    span class="return-type">double</span>&nbsp;<span class="element-name">isPaused<\
+                    /span>()</div>
                     <div class="block">Gets the value of the property paused.</div>
                     <dl class="notes">
                     <dt>Property description:</dt>
@@ -153,8 +153,8 @@ public class TestJavaFX extends JavadocTester {
                     <section class="detail" id="setRate(double)">
                     <h3>setRate</h3>
                     <div class="member-signature"><span class="modifiers">public final</span>&nbsp;<\
-                    span class="return-type">void</span>&nbsp;<span class="element-name">setRate</span>&#820\
-                    3;<span class="parameters">(double&nbsp;value)</span></div>
+                    span class="return-type">void</span>&nbsp;<span class="element-name">setRate</sp\
+                    an><wbr><span class="parameters">(double&nbsp;value)</span></div>
                     <div class="block">Sets the value of the property rate.</div>
                     <dl class="notes">
                     <dt>Property description:</dt>
@@ -327,8 +327,8 @@ public class TestJavaFX extends JavadocTester {
                     ab2 method-summary-table-tab4"><code>&lt;T&gt;&nbsp;java.lang.Object</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
                     tab2 method-summary-table-tab4"><code><a href="#alphaProperty(java.util.List)" c\
-                    lass="member-name-link">alphaProperty</a>&#8203;(java.util.List&lt;T&gt;&nbsp;fo\
-                    o)</code></div>
+                    lass="member-name-link">alphaProperty</a><wbr>(java.util.List&lt;T&gt;&nbsp;foo)\
+                    </code></div>
                     <div class="col-last even-row-color method-summary-table method-summary-table-ta\
                     b2 method-summary-table-tab4">&nbsp;</div>
                     <div class="col-first odd-row-color method-summary-table method-summary-table-ta\

--- a/test/langtools/jdk/javadoc/doclet/testMemberInheritance/TestMemberInheritance.java
+++ b/test/langtools/jdk/javadoc/doclet/testMemberInheritance/TestMemberInheritance.java
@@ -106,8 +106,8 @@ public class TestMemberInheritance extends JavadocTester {
                     ab1 method-summary-table-tab4"><code>static java.time.Period</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
                     tab1 method-summary-table-tab4"><code><a href="#between(java.time.LocalDate,java\
-                    .time.LocalDate)" class="member-name-link">between</a>&#8203;(java.time.LocalDat\
-                    e&nbsp;startDateInclusive,
+                    .time.LocalDate)" class="member-name-link">between</a><wbr>(java.time.LocalDate&\
+                    nbsp;startDateInclusive,
                      java.time.LocalDate&nbsp;endDateExclusive)</code></div>""");
 
         checkOutput("pkg1/Implementer.html", false,
@@ -132,7 +132,7 @@ public class TestMemberInheritance extends JavadocTester {
                     ethod-summary-table-tab3"><code>protected abstract java.lang.String</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-tab2 \
                     method-summary-table-tab3"><code><a href="#parentMethod(T)" class="member-name-link">\
-                    parentMethod</a>&#8203;(java.lang.String&nbsp;t)</code></div>
+                    parentMethod</a><wbr>(java.lang.String&nbsp;t)</code></div>
                     <div class="col-last even-row-color method-summary-table method-summary-table-tab2 me\
                     thod-summary-table-tab3">
                     <div class="block">Returns some value with an inherited search tag.</div>
@@ -143,9 +143,9 @@ public class TestMemberInheritance extends JavadocTester {
                     <section class="detail" id="parentMethod(T)">
                     <h3 id="parentMethod(java.lang.Object)">parentMethod</h3>
                     <div class="member-signature"><span class="modifiers">protected abstract</span>&\
-                    nbsp;<span class="return-type">java.lang.String</span>&nbsp;<span class="element-name">p\
-                    arentMethod</span>&#8203;<span class="parameters">(java.lang.String&nbsp;\
-                    t)</span>
+                    nbsp;<span class="return-type">java.lang.String</span>&nbsp;<span class="element\
+                    -name">parentMethod</span><wbr><span class="parameters">(java.lang.String&nbsp;t\
+                    )</span>
                                                               throws <span class="exceptions">java.lang.IllegalArgumentException,
                     java.lang.InterruptedException,
                     java.lang.IllegalStateException</span></div>
@@ -181,13 +181,13 @@ public class TestMemberInheritance extends JavadocTester {
                     ab2 method-summary-table-tab4"><code>java.lang.String</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
                     tab2 method-summary-table-tab4"><code><a href="#method(T)" class="member-name-li\
-                    nk">method</a>&#8203;(java.lang.String&nbsp;t)</code></div>""",
+                    nk">method</a><wbr>(java.lang.String&nbsp;t)</code></div>""",
                 """
                     <section class="detail" id="method(T)">
                     <h3 id="method(java.lang.Object)">method</h3>
                     <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
                     lass="return-type">java.lang.String</span>&nbsp;<span class="element-name">metho\
-                    d</span>&#8203;<span class="parameters">(java.lang.String&nbsp;t)</span></div>
+                    d</span><wbr><span class="parameters">(java.lang.String&nbsp;t)</span></div>
                     </section>""");
 
         checkOutput("index-all.html", true,
@@ -232,9 +232,9 @@ public class TestMemberInheritance extends JavadocTester {
                     <section class="detail" id="parentMethod(T)">
                     <h3 id="parentMethod(java.lang.Object)">parentMethod</h3>
                     <div class="member-signature"><span class="modifiers">protected abstract</span>&\
-                    nbsp;<span class="return-type">java.lang.String</span>&nbsp;<span class="element-name">p\
-                    arentMethod</span>&#8203;<span class="parameters">(java.lang.String&nbsp;\
-                    t)</span>
+                    nbsp;<span class="return-type">java.lang.String</span>&nbsp;<span class="element\
+                    -name">parentMethod</span><wbr><span class="parameters">(java.lang.String&nbsp;t\
+                    )</span>
                                                               throws <span class="exceptions">java.lang.IllegalArgumentException,
                     java.lang.InterruptedException,
                     java.lang.IllegalStateException</span></div>

--- a/test/langtools/jdk/javadoc/doclet/testMemberSummary/TestMemberSummary.java
+++ b/test/langtools/jdk/javadoc/doclet/testMemberSummary/TestMemberSummary.java
@@ -72,7 +72,7 @@ public class TestMemberSummary extends JavadocTester {
                 """
                     <div class="col-first even-row-color"><code>private </code></div>
                     <div class="col-constructor-name even-row-color"><code><a href="#%3Cinit%3E(int)\
-                    " class="member-name-link">PrivateParent</a>&#8203;(int&nbsp;i)</code></div>""");
+                    " class="member-name-link">PrivateParent</a><wbr>(int&nbsp;i)</code></div>""");
 
         // Legacy anchor dimensions (6290760)
         checkOutput("pkg2/A.html", true,

--- a/test/langtools/jdk/javadoc/doclet/testMethodId/TestMethodId.java
+++ b/test/langtools/jdk/javadoc/doclet/testMethodId/TestMethodId.java
@@ -72,7 +72,7 @@ public class TestMethodId extends JavadocTester {
         checkOutput("p/C.html",
                 true,
                 """
-                    <code><a href="#m(int)" class="member-name-link">m</a>&#8203;(int&nbsp;i)</code>""",
+                    <code><a href="#m(int)" class="member-name-link">m</a><wbr>(int&nbsp;i)</code>""",
                 """
                     <section class="detail" id="m(int)">
                     <h3>m</h3>""");

--- a/test/langtools/jdk/javadoc/doclet/testMethodSignature/TestMethodSignature.java
+++ b/test/langtools/jdk/javadoc/doclet/testMethodSignature/TestMethodSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testMethodSignature/TestMethodSignature.java
+++ b/test/langtools/jdk/javadoc/doclet/testMethodSignature/TestMethodSignature.java
@@ -55,8 +55,8 @@ public class TestMethodSignature extends JavadocTester {
 
                 """
                     <div class="member-signature"><span class="modifiers">public static</span>&nbsp;\
-                    <span class="return-type">void</span>&nbsp;<span class="element-name">simpleMetho\
-                    d</span>&#8203;<span class="parameters">(int&nbsp;i,
+                    <span class="return-type">void</span>&nbsp;<span class="element-name">simpleMeth\
+                    od</span><wbr><span class="parameters">(int&nbsp;i,
                      java.lang.String&nbsp;s,
                      boolean&nbsp;b)</span></div>""",
 
@@ -65,27 +65,26 @@ public class TestMethodSignature extends JavadocTester {
                                date="a date",
                                comments="some comment about the method below")
                     </span><span class="modifiers">public static</span>&nbsp;<span class="return-typ\
-                    e">void</span>&nbsp;<span class="element-name">annotatedMethod</span>&#8203;<span class=\
-                    "parameters">(int&nbsp;i,
+                    e">void</span>&nbsp;<span class="element-name">annotatedMethod</span><wbr><span \
+                    class="parameters">(int&nbsp;i,
                      java.lang.String&nbsp;s,
                      boolean&nbsp;b)</span></div>""",
 
                 """
                     <div class="member-signature"><span class="modifiers">public static</span>&nbsp;\
-                    <span class="type-parameters-long">&lt;T1 extends java.lang.AutoCloseable,&#8203\
-                    ;
-                    T2 extends java.lang.AutoCloseable,&#8203;
-                    T3 extends java.lang.AutoCloseable,&#8203;
-                    T4 extends java.lang.AutoCloseable,&#8203;
-                    T5 extends java.lang.AutoCloseable,&#8203;
-                    T6 extends java.lang.AutoCloseable,&#8203;
-                    T7 extends java.lang.AutoCloseable,&#8203;
+                    <span class="type-parameters-long">&lt;T1 extends java.lang.AutoCloseable,<wbr>
+                    T2 extends java.lang.AutoCloseable,<wbr>
+                    T3 extends java.lang.AutoCloseable,<wbr>
+                    T4 extends java.lang.AutoCloseable,<wbr>
+                    T5 extends java.lang.AutoCloseable,<wbr>
+                    T6 extends java.lang.AutoCloseable,<wbr>
+                    T7 extends java.lang.AutoCloseable,<wbr>
                     T8 extends java.lang.AutoCloseable&gt;</span>
                     <span class="return-type"><a href="C.With8Types.html" title="class in pkg">C.Wit\
-                    h8Types</a>&lt;T1,&#8203;T2,&#8203;T3,&#8203;T4,&#8203;T5,&#8203;T6,&#8203;T7,&#\
-                    8203;T8&gt;</span>&nbsp;<span class="element-name">bigGenericMethod</span>&#8203;<span c\
-                    lass="parameters">(<a href="C.F0.html" title="interface in pkg">C.F0</a>&lt;? ex\
-                    tends T1&gt;&nbsp;t1,
+                    h8Types</a>&lt;T1,<wbr>T2,<wbr>T3,<wbr>T4,<wbr>T5,<wbr>T6,<wbr>T7,<wbr>T8&gt;</s\
+                    pan>&nbsp;<span class="element-name">bigGenericMethod</span><wbr><span class="pa\
+                    rameters">(<a href="C.F0.html" title="interface in pkg">C.F0</a>&lt;? extends T1\
+                    &gt;&nbsp;t1,
                      <a href="C.F0.html" title="interface in pkg">C.F0</a>&lt;? extends T2&gt;&nbsp;t2,
                      <a href="C.F0.html" title="interface in pkg">C.F0</a>&lt;? extends T3&gt;&nbsp;t3,
                      <a href="C.F0.html" title="interface in pkg">C.F0</a>&lt;? extends T4&gt;&nbsp;t4,
@@ -101,19 +100,19 @@ public class TestMethodSignature extends JavadocTester {
                                date="a date",
                                comments="some comment about the method below")
                     </span><span class="modifiers">public static</span>&nbsp;<span class="type-param\
-                    eters-long">&lt;T1 extends java.lang.AutoCloseable,&#8203;
-                    T2 extends java.lang.AutoCloseable,&#8203;
-                    T3 extends java.lang.AutoCloseable,&#8203;
-                    T4 extends java.lang.AutoCloseable,&#8203;
-                    T5 extends java.lang.AutoCloseable,&#8203;
-                    T6 extends java.lang.AutoCloseable,&#8203;
-                    T7 extends java.lang.AutoCloseable,&#8203;
+                    eters-long">&lt;T1 extends java.lang.AutoCloseable,<wbr>
+                    T2 extends java.lang.AutoCloseable,<wbr>
+                    T3 extends java.lang.AutoCloseable,<wbr>
+                    T4 extends java.lang.AutoCloseable,<wbr>
+                    T5 extends java.lang.AutoCloseable,<wbr>
+                    T6 extends java.lang.AutoCloseable,<wbr>
+                    T7 extends java.lang.AutoCloseable,<wbr>
                     T8 extends java.lang.AutoCloseable&gt;</span>
                     <span class="return-type"><a href="C.With8Types.html" title="class in pkg">C.Wit\
-                    h8Types</a>&lt;T1,&#8203;T2,&#8203;T3,&#8203;T4,&#8203;T5,&#8203;T6,&#8203;T7,&#\
-                    8203;T8&gt;</span>&nbsp;<span class="element-name">bigGenericAnnotatedMethod</span>&#820\
-                    3;<span class="parameters">(<a href="C.F0.html" title="interface in pkg">C.F0</a\
-                    >&lt;? extends T1&gt;&nbsp;t1,
+                    h8Types</a>&lt;T1,<wbr>T2,<wbr>T3,<wbr>T4,<wbr>T5,<wbr>T6,<wbr>T7,<wbr>T8&gt;</s\
+                    pan>&nbsp;<span class="element-name">bigGenericAnnotatedMethod</span><wbr><span \
+                    class="parameters">(<a href="C.F0.html" title="interface in pkg">C.F0</a>&lt;? e\
+                    xtends T1&gt;&nbsp;t1,
                      <a href="C.F0.html" title="interface in pkg">C.F0</a>&lt;? extends T2&gt;&nbsp;t2,
                      <a href="C.F0.html" title="interface in pkg">C.F0</a>&lt;? extends T3&gt;&nbsp;t3,
                      <a href="C.F0.html" title="interface in pkg">C.F0</a>&lt;? extends T4&gt;&nbsp;t4,

--- a/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/TestNewLanguageFeatures.java
+++ b/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/TestNewLanguageFeatures.java
@@ -85,9 +85,9 @@ public class TestNewLanguageFeatures extends JavadocTester {
                 "Overloaded values method  has correct documentation.",
                 """
                     <div class="member-signature"><span class="modifiers">public static</span>&nbsp;\
-                    <span class="return-type"><a href="Coin.html" title="enum class in pkg">Coin</a></span\
-                    >&nbsp;<span class="element-name">valueOf</span>&#8203;<span class="parameters">(java.la\
-                    ng.String&nbsp;name)</span></div>
+                    <span class="return-type"><a href="Coin.html" title="enum class in pkg">Coin</a>\
+                    </span>&nbsp;<span class="element-name">valueOf</span><wbr><span class="paramete\
+                    rs">(java.lang.String&nbsp;name)</span></div>
                     <div class="block">Returns the enum constant of this class with the specified name.
                     The string must match <i>exactly</i> an identifier used to declare an
                     enum constant in this class.  (Extraneous whitespace characters are\s
@@ -139,10 +139,10 @@ public class TestNewLanguageFeatures extends JavadocTester {
                 // Signature of method with type parameters
                 """
                     <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
-                    lass="type-parameters">&lt;T extends java.util.List,&#8203;
+                    lass="type-parameters">&lt;T extends java.util.List,<wbr>
                     V&gt;</span>
                     <span class="return-type">java.lang.String[]</span>&nbsp;<span class="element-name">meth\
-                    odThatHasTypeParameters</span>&#8203;<span class="parameters">(T&nbsp;param1,
+                    odThatHasTypeParameters</span><wbr><span class="parameters">(T&nbsp;param1,
                      V&nbsp;param2)</span></div>""",
                 // Method that returns TypeParameters
                 """
@@ -151,14 +151,15 @@ public class TestNewLanguageFeatures extends JavadocTester {
                     arameter in TypeParameters">E</a>[]</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
                     tab2 method-summary-table-tab4"><code><a href="#methodThatReturnsTypeParameterA(\
-                    E%5B%5D)" class="member-name-link">methodThatReturnsTypeParameterA</a>&#8203;(<a\
-                     href="TypeParameters.html" title="type parameter in TypeParameters">E</a>[]&nbsp;e)</code>""",
+                    E%5B%5D)" class="member-name-link">methodThatReturnsTypeParameterA</a><wbr>(<a h\
+                    ref="TypeParameters.html" title="type parameter in TypeParameters">E</a>[]&nbsp;\
+                    e)</code>""",
                 """
                     <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
                     lass="return-type"><a href="TypeParameters.html" title="type parameter in TypePa\
-                    rameters">E</a>[]</span>&nbsp;<span class="element-name">methodThatReturnsTypeParameterA\
-                    </span>&#8203;<span class="parameters">(<a href="TypeParameters.html" tit\
-                    le="type parameter in TypeParameters">E</a>[]&nbsp;e)</span></div>
+                    rameters">E</a>[]</span>&nbsp;<span class="element-name">methodThatReturnsTypePa\
+                    rameterA</span><wbr><span class="parameters">(<a href="TypeParameters.html" titl\
+                    e="type parameter in TypeParameters">E</a>[]&nbsp;e)</span></div>
                     """,
                 """
                     <div class="col-first even-row-color method-summary-table method-summary-table-t\
@@ -167,19 +168,20 @@ public class TestNewLanguageFeatures extends JavadocTester {
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
                     tab2 method-summary-table-tab4"><code><a href="#methodtThatReturnsTypeParameters\
                     B(java.util.Collection)" class="member-name-link">methodtThatReturnsTypeParamete\
-                    rsB</a>&#8203;(java.util.Collection&lt;? extends T&gt;&nbsp;coll)</code>""",
+                    rsB</a><wbr>(java.util.Collection&lt;? extends T&gt;&nbsp;coll)</code>""",
                 """
                     <div class="block">Returns TypeParameters</div>
                     """,
                 // Method takes a TypeVariable
                 """
                     <div class="col-first odd-row-color method-summary-table method-summary-table-ta\
-                    b2 method-summary-table-tab4"><code>&lt;X extends java.lang.Throwable&gt;<br><a href\
-                    ="TypeParameters.html" title="type parameter in TypeParameters">E</a></code></div>
-                    <div class="col-second odd-row-color method-summary-table method-summary-table-t\
-                    ab2 method-summary-table-tab4"><code><a href="#orElseThrow(java.util.function.Su\
-                    pplier)" class="member-name-link">orElseThrow</a>&#8203;(java.util.function.Supp\
-                    lier&lt;? extends X&gt;&nbsp;exceptionSupplier)</code>"""
+                    b2 method-summary-table-tab4"><code>&lt;X extends java.lang.Throwable&gt;<br><a \
+                    href="TypeParameters.html" title="type parameter in TypeParameters">E</a></code>\
+                    </div>
+                    <div class="col-second odd-row-color method-summary-table method-summary-t\
+                    able-tab2 method-summary-table-tab4"><code><a href="#orElseThrow(java.util.funct\
+                    ion.Supplier)" class="member-name-link">orElseThrow</a><wbr>(java.util.function.\
+                    Supplier&lt;? extends X&gt;&nbsp;exceptionSupplier)</code>"""
                 );
 
         checkOutput("pkg/Wildcards.html", true,
@@ -239,8 +241,8 @@ public class TestNewLanguageFeatures extends JavadocTester {
                     <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
                     lass="type-parameters">&lt;T extends java.lang.Number &amp; java.lang.Runnable&g\
                     t;</span>
-                    <span class="return-type">T</span>&nbsp;<span class="element-name">foo</span>&#8203;<spa\
-                    n class="parameters">(T&nbsp;t)</span></div>""");
+                    <span class="return-type">T</span>&nbsp;<span class="element-name">foo</span><wb\
+                    r><span class="parameters">(T&nbsp;t)</span></div>""");
 
         //==============================================================
         // Test Class-Use Documentation for Type Parameters.
@@ -263,7 +265,7 @@ public class TestNewLanguageFeatures extends JavadocTester {
                 """
                     <div class="col-second even-row-color"><span class="type-name-label">ClassUseTes\
                     t1.</span><code><a href="../ClassUseTest1.html#method(T)" class="member-name-lin\
-                    k">method</a>&#8203;(T&nbsp;t)</code></div>""",
+                    k">method</a><wbr>(T&nbsp;t)</code></div>""",
                 """
                     <div class="caption"><span>Fields in <a href="../package-summary.html">pkg2</a>\
                      with type parameters of type <a href="../Foo.html" title="class in pkg2">Foo</a\
@@ -302,7 +304,7 @@ public class TestNewLanguageFeatures extends JavadocTester {
                 """
                     <div class="col-second even-row-color"><span class="type-name-label">ClassUseTes\
                     t1.</span><code><a href="../ClassUseTest1.html#method(T)" class="member-name-lin\
-                    k">method</a>&#8203;(T&nbsp;t)</code></div>"""
+                    k">method</a><wbr>(T&nbsp;t)</code></div>"""
         );
 
         // ClassUseTest2: <T extends ParamTest<Foo3>>
@@ -323,7 +325,7 @@ public class TestNewLanguageFeatures extends JavadocTester {
                 """
                     <div class="col-second even-row-color"><span class="type-name-label">ClassUseTes\
                     t2.</span><code><a href="../ClassUseTest2.html#method(T)" class="member-name-lin\
-                    k">method</a>&#8203;(T&nbsp;t)</code></div>""",
+                    k">method</a><wbr>(T&nbsp;t)</code></div>""",
                 """
                     <div class="caption"><span>Fields in <a href="../package-summary.html">pkg2</a>\
                      declared as <a href="../ParamTest.html" title="class in pkg2">ParamTest</a></s\
@@ -361,7 +363,7 @@ public class TestNewLanguageFeatures extends JavadocTester {
                 """
                     <div class="col-second even-row-color"><span class="type-name-label">ClassUseTes\
                     t2.</span><code><a href="../ClassUseTest2.html#method(T)" class="member-name-lin\
-                    k">method</a>&#8203;(T&nbsp;t)</code></div>""",
+                    k">method</a><wbr>(T&nbsp;t)</code></div>""",
                 """
                     <div class="caption"><span>Methods in <a href="../package-summary.html">pkg2</a\
                     > that return types with arguments of type <a href="../Foo3.html" title="class\
@@ -393,7 +395,7 @@ public class TestNewLanguageFeatures extends JavadocTester {
                 """
                     <div class="col-second even-row-color"><span class="type-name-label">ClassUseTes\
                     t3.</span><code><a href="../ClassUseTest3.html#method(T)" class="member-name-lin\
-                    k">method</a>&#8203;(T&nbsp;t)</code></div>""",
+                    k">method</a><wbr>(T&nbsp;t)</code></div>""",
                 """
                     <div class="col-first even-row-color"><code>&lt;T extends <a href="../ParamTest2.htm\
                     l" title="class in pkg2">ParamTest2</a>&lt;java.util.List&lt;? extends <a href=\
@@ -420,7 +422,7 @@ public class TestNewLanguageFeatures extends JavadocTester {
                 """
                     <div class="col-second even-row-color"><span class="type-name-label">ClassUseTes\
                     t3.</span><code><a href="../ClassUseTest3.html#method(T)" class="member-name-lin\
-                    k">method</a>&#8203;(T&nbsp;t)</code></div>""",
+                    k">method</a><wbr>(T&nbsp;t)</code></div>""",
                 """
                     <div class="caption"><span>Methods in <a href="../package-summary.html">pkg2</a\
                     > that return types with arguments of type <a href="../Foo4.html" title="class\
@@ -446,8 +448,8 @@ public class TestNewLanguageFeatures extends JavadocTester {
                     <div class="col-first even-row-color"><code>void</code></div>
                     <div class="col-second even-row-color"><span class="type-name-label">ClassUseTes\
                     t3.</span><code><a href="../ClassUseTest3.html#method(java.util.Set)" class="mem\
-                    ber-name-link">method</a>&#8203;(java.util.Set&lt;<a href="../Foo4.html" title="\
-                    class in pkg2">Foo4</a>&gt;&nbsp;p)</code></div>
+                    ber-name-link">method</a><wbr>(java.util.Set&lt;<a href="../Foo4.html" title="cl\
+                    ass in pkg2">Foo4</a>&gt;&nbsp;p)</code></div>
                     <div class="col-last even-row-color">&nbsp;</div>""",
                 """
                     <div class="caption"><span>Constructor parameters in <a href="../package-summary.html">pkg2<\
@@ -567,20 +569,20 @@ public class TestNewLanguageFeatures extends JavadocTester {
                 // METHOD PARAMS
                 """
                     <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
-                    lass="return-type">void</span>&nbsp;<span class="element-name">methodWithParams</span>&#\
-                    8203;<span class="parameters">(<a href="AnnotationType.html" title="annotation i\
-                    nterface in pkg">@AnnotationType</a>(<a href="AnnotationType.html#optional()">op\
-                    tional</a>="Parameter Annotation",<a href="AnnotationType.html#required()">requi\
-                    red</a>=1994)
+                    lass="return-type">void</span>&nbsp;<span class="element-name">methodWithParams<\
+                    /span><wbr><span class="parameters">(<a href="AnnotationType.html" title="annota\
+                    tion interface in pkg">@AnnotationType</a>(<a href="AnnotationType.html#optional\
+                    ()">optional</a>="Parameter Annotation",<a href="AnnotationType.html#required()"\
+                    >required</a>=1994)
                      int&nbsp;documented,
                      int&nbsp;undocmented)</span></div>""",
                 // CONSTRUCTOR PARAMS
                 """
                     <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
-                    lass="element-name">AnnotationTypeUsage</span>&#8203;<span class="parameters">(<\
-                    a href="AnnotationType.html" title="annotation interface in pkg">@AnnotationType\
-                    </a>(<a href="AnnotationType.html#optional()">optional</a>="Constructor Param An\
-                    notation",<a href="AnnotationType.html#required()">required</a>=1994)
+                    lass="element-name">AnnotationTypeUsage</span><wbr><span class="parameters">(<a \
+                    href="AnnotationType.html" title="annotation interface in pkg">@AnnotationType</\
+                    a>(<a href="AnnotationType.html#optional()">optional</a>="Constructor Param Anno\
+                    tation",<a href="AnnotationType.html#required()">required</a>=1994)
                      int&nbsp;documented,
                      int&nbsp;undocmented)</span></div>""");
 

--- a/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverrideMethods.java
+++ b/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverrideMethods.java
@@ -409,8 +409,8 @@ public class TestOverrideMethods  extends JavadocTester {
                     annotation interface in pkg7">@A</a>
                     </span><span class="return-type"><a href="A.html" title="annotation interface in\
                      pkg7">@A</a> java.lang.Iterable&lt;java.lang.String&gt;</span>&nbsp;<span class\
-                    ="element-name">m1</span>&#8203;<span class="parameters">(java.lang.Class&lt;? e\
-                    xtends java.lang.CharSequence&gt;&nbsp;p1,
+                    ="element-name">m1</span><wbr><span class="parameters">(java.lang.Class&lt;? ext\
+                    ends java.lang.CharSequence&gt;&nbsp;p1,
                      int[]&nbsp;p2)</span></div>
                     <div class="block"><span class="descfrm-type-label">Description copied from inte\
                     rface:&nbsp;<code><a href="AnnotatedBase.html#m1(java.lang.Class,int%5B%5D)">Ann\
@@ -434,8 +434,8 @@ public class TestOverrideMethods  extends JavadocTester {
                     annotation interface in pkg7">@A</a>
                     </span><span class="return-type"><a href="A.html" title="annotation interface in\
                      pkg7">@A</a> java.lang.Iterable&lt;java.lang.String&gt;</span>&nbsp;<span class\
-                    ="element-name">m1</span>&#8203;<span class="parameters">(java.lang.Class&lt;? e\
-                    xtends java.lang.CharSequence&gt;&nbsp;p1,
+                    ="element-name">m1</span><wbr><span class="parameters">(java.lang.Class&lt;? ext\
+                    ends java.lang.CharSequence&gt;&nbsp;p1,
                      int[]&nbsp;p2)</span></div>
                     <div class="block"><span class="descfrm-type-label">Description copied from inte\
                     rface:&nbsp;<code><a href="AnnotatedBase.html#m1(java.lang.Class,int%5B%5D)">Ann\
@@ -457,8 +457,8 @@ public class TestOverrideMethods  extends JavadocTester {
                 """
                     <div class="member-signature"><span class="return-type">java.lang.Iterable&lt;<a\
                      href="A.html" title="annotation interface in pkg7">@A</a> java.lang.String&gt;<\
-                    /span>&nbsp;<span class="element-name">m1</span>&#8203;<span class="parameters">\
-                    (java.lang.Class&lt;? extends java.lang.CharSequence&gt;&nbsp;p1,
+                    /span>&nbsp;<span class="element-name">m1</span><wbr><span class="parameters">(j\
+                    ava.lang.Class&lt;? extends java.lang.CharSequence&gt;&nbsp;p1,
                      int[]&nbsp;p2)</span></div>
                     <div class="block"><span class="descfrm-type-label">Description copied from inte\
                     rface:&nbsp;<code><a href="AnnotatedBase.html#m1(java.lang.Class,int%5B%5D)">Ann\
@@ -479,8 +479,8 @@ public class TestOverrideMethods  extends JavadocTester {
         checkOutput("pkg7/AnnotatedSub5.html", true,
                 """
                     <div class="member-signature"><span class="return-type">java.lang.Iterable&lt;ja\
-                    va.lang.String&gt;</span>&nbsp;<span class="element-name">m1</span>&#8203;<span \
-                    class="parameters">(<a href="A.html" title="annotation interface in pkg7">@A</a>
+                    va.lang.String&gt;</span>&nbsp;<span class="element-name">m1</span><wbr><span cl\
+                    ass="parameters">(<a href="A.html" title="annotation interface in pkg7">@A</a>
                      <a href="A.html" title="annotation interface in pkg7">@A</a> java.lang.Class&lt\
                     ;? extends java.lang.CharSequence&gt;&nbsp;p1,
                      int[]&nbsp;p2)</span></div>
@@ -503,9 +503,9 @@ public class TestOverrideMethods  extends JavadocTester {
         checkOutput("pkg7/AnnotatedSub6.html", true,
                 """
                     <div class="member-signature"><span class="return-type">java.lang.Iterable&lt;ja\
-                    va.lang.String&gt;</span>&nbsp;<span class="element-name">m1</span>&#8203;<span \
-                    class="parameters">(java.lang.Class&lt;<a href="A.html" title="annotation interf\
-                    ace in pkg7">@A</a> ? extends java.lang.CharSequence&gt;&nbsp;p1,
+                    va.lang.String&gt;</span>&nbsp;<span class="element-name">m1</span><wbr><span cl\
+                    ass="parameters">(java.lang.Class&lt;<a href="A.html" title="annotation interfac\
+                    e in pkg7">@A</a> ? extends java.lang.CharSequence&gt;&nbsp;p1,
                      int[]&nbsp;p2)</span></div>
                     <div class="block"><span class="descfrm-type-label">Description copied from inte\
                     rface:&nbsp;<code><a href="AnnotatedBase.html#m1(java.lang.Class,int%5B%5D)">Ann\
@@ -526,9 +526,9 @@ public class TestOverrideMethods  extends JavadocTester {
         checkOutput("pkg7/AnnotatedSub7.html", true,
                 """
                     <div class="member-signature"><span class="return-type">java.lang.Iterable&lt;ja\
-                    va.lang.String&gt;</span>&nbsp;<span class="element-name">m1</span>&#8203;<span \
-                    class="parameters">(java.lang.Class&lt;? extends <a href="A.html" title="annotat\
-                    ion interface in pkg7">@A</a> java.lang.CharSequence&gt;&nbsp;p1,
+                    va.lang.String&gt;</span>&nbsp;<span class="element-name">m1</span><wbr><span cl\
+                    ass="parameters">(java.lang.Class&lt;? extends <a href="A.html" title="annotatio\
+                    n interface in pkg7">@A</a> java.lang.CharSequence&gt;&nbsp;p1,
                      int[]&nbsp;p2)</span></div>
                     <div class="block"><span class="descfrm-type-label">Description copied from inte\
                     rface:&nbsp;<code><a href="AnnotatedBase.html#m1(java.lang.Class,int%5B%5D)">Ann\
@@ -549,9 +549,8 @@ public class TestOverrideMethods  extends JavadocTester {
         checkOutput("pkg7/AnnotatedSub8.html", true,
                 """
                     <div class="member-signature"><span class="return-type">java.lang.Iterable&lt;ja\
-                    va.lang.String&gt;</span>&nbsp;<span class="element-name">m1</span>&#8203;<span \
-                    class="parameters">(java.lang.Class&lt;? extends java.lang.CharSequence&gt;&nbsp\
-                    ;p1,
+                    va.lang.String&gt;</span>&nbsp;<span class="element-name">m1</span><wbr><span cl\
+                    ass="parameters">(java.lang.Class&lt;? extends java.lang.CharSequence&gt;&nbsp;p1,
                      int <a href="A.html" title="annotation interface in pkg7">@A</a> []&nbsp;p2)</s\
                     pan></div>
                     <div class="block"><span class="descfrm-type-label">Description copied from inte\

--- a/test/langtools/jdk/javadoc/doclet/testPrivateClasses/TestPrivateClasses.java
+++ b/test/langtools/jdk/javadoc/doclet/testPrivateClasses/TestPrivateClasses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testPrivateClasses/TestPrivateClasses.java
+++ b/test/langtools/jdk/javadoc/doclet/testPrivateClasses/TestPrivateClasses.java
@@ -73,8 +73,8 @@ public class TestPrivateClasses extends JavadocTester {
                 // Method is documented as though it is declared in the inheriting method.
                 """
                     <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
-                    lass="return-type">void</span>&nbsp;<span class="element-name">methodInheritedFromParent\
-                    </span>&#8203;<span class="parameters">(int&nbsp;p1)</span>
+                    lass="return-type">void</span>&nbsp;<span class="element-name">methodInheritedFr\
+                    omParent</span><wbr><span class="parameters">(int&nbsp;p1)</span>
                                                    throws <span class="exceptions">java.lang.Exception</span></div>""",
                 """
                     <dl class="notes">
@@ -99,13 +99,13 @@ public class TestPrivateClasses extends JavadocTester {
                 // Should not document comments from private inherited interfaces
                 """
                     <td class="col-last"><code><span class="member-name-link"><a href="#methodInterf\
-                    ace(int)">methodInterface</a></span>&#8203;(int&nbsp;p1)</code>
+                    ace(int)">methodInterface</a></span><wbr>(int&nbsp;p1)</code>
                     <div class="block">Comment from interface.</div>
                     </td>""",
                 // and similarly one more
                 """
                     <td class="col-last"><code><span class="member-name-link"><a href="#methodInterf\
-                    ace2(int)">methodInterface2</a></span>&#8203;(int&nbsp;p1)</code>
+                    ace2(int)">methodInterface2</a></span><wbr>(int&nbsp;p1)</code>
                     <div class="block">Comment from interface.</div>
                     </td>"""
         );

--- a/test/langtools/jdk/javadoc/doclet/testRecordTypes/TestRecordTypes.java
+++ b/test/langtools/jdk/javadoc/doclet/testRecordTypes/TestRecordTypes.java
@@ -77,7 +77,7 @@ public class TestRecordTypes extends JavadocTester {
                 """
                     <span class="modifiers">public record </span><span class="element-name type-name-label">R</span>""",
                 """
-                    <code><a href="#%3Cinit%3E(int)" class="member-name-link">R</a>&#8203;(int&nbsp;r1)</code>""");
+                    <code><a href="#%3Cinit%3E(int)" class="member-name-link">R</a><wbr>(int&nbsp;r1)</code>""");
     }
 
     @Test
@@ -98,7 +98,7 @@ public class TestRecordTypes extends JavadocTester {
                 """
                     <span class="modifiers">public record </span><span class="element-name type-name-label">R</span>""",
                 """
-                    <code><a href="#%3Cinit%3E(int)" class="member-name-link">R</a>&#8203;(int&nbsp;r1)</code>""");
+                    <code><a href="#%3Cinit%3E(int)" class="member-name-link">R</a><wbr>(int&nbsp;r1)</code>""");
     }
 
     @Test
@@ -149,7 +149,7 @@ public class TestRecordTypes extends JavadocTester {
                     <dd><code><span id="param-r1">r1</span></code> - This is a component.</dd>
                     </dl>""",
                 """
-                    <code><a href="#%3Cinit%3E(int)" class="member-name-link">R</a>&#8203;(int&nbsp;r1)</code>""");
+                    <code><a href="#%3Cinit%3E(int)" class="member-name-link">R</a><wbr>(int&nbsp;r1)</code>""");
     }
 
     @Test
@@ -182,7 +182,7 @@ public class TestRecordTypes extends JavadocTester {
                     <dd><code><span id="param-r1">r1</span></code> - This is a component.</dd>
                     </dl>""",
                 """
-                    <code><a href="#%3Cinit%3E(int)" class="member-name-link">R</a>&#8203;(int&nbsp;r1)</code>""");
+                    <code><a href="#%3Cinit%3E(int)" class="member-name-link">R</a><wbr>(int&nbsp;r1)</code>""");
     }
 
     @Test
@@ -484,7 +484,7 @@ public class TestRecordTypes extends JavadocTester {
                             /span>&nbsp;<span class="element-name">i</span></div>""",
                 """
                     <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
-                    lass="element-name">R</span>&#8203;<span class="parameters">("""
+                    lass="element-name">R</span><wbr><span class="parameters">("""
                         + pAnno
                         + "int&nbsp;i)</span></div>",
                 "<div class=\"member-signature\">"

--- a/test/langtools/jdk/javadoc/doclet/testSerializedFormWithClassFile/TestSerializedFormWithClassFile.java
+++ b/test/langtools/jdk/javadoc/doclet/testSerializedFormWithClassFile/TestSerializedFormWithClassFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testSerializedFormWithClassFile/TestSerializedFormWithClassFile.java
+++ b/test/langtools/jdk/javadoc/doclet/testSerializedFormWithClassFile/TestSerializedFormWithClassFile.java
@@ -76,8 +76,8 @@ public class TestSerializedFormWithClassFile extends JavadocTester {
         checkOutput("serialized-form.html", true,
                 """
                     <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
-                    lass="return-type">void</span>&nbsp;<span class="element-name">readObject</span>&\
-                    #8203;<span class="parameters">(java.io.ObjectInputStream&nbsp;arg0)</span>
+                    lass="return-type">void</span>&nbsp;<span class="element-name">readObject</span>\
+                    <wbr><span class="parameters">(java.io.ObjectInputStream&nbsp;arg0)</span>
                                     throws <span class="exceptions">java.lang.ClassNotFoundException,
                     java.io.IOException</span></div>
                     """);

--- a/test/langtools/jdk/javadoc/doclet/testTypeAnnotations/TestTypeAnnotations.java
+++ b/test/langtools/jdk/javadoc/doclet/testTypeAnnotations/TestTypeAnnotations.java
@@ -84,131 +84,133 @@ public class TestTypeAnnotations extends JavadocTester {
                 """
                     <div class="type-signature"><span class="modifiers">class </span><span class="el\
                     ement-name type-name-label">ExtendsGeneric&lt;K extends <a href="ClassParamA.htm\
-                    l" title="annotation interface in typeannos">@ClassParamA</a> <a href="Unannotated.html" t\
-                    itle="class in typeannos">Unannotated</a>&lt;<a href="ClassParamB.html" title="a\
-                    nnotation interface in typeannos">@ClassParamB</a> java.lang.String&gt;&gt;</span>""");
+                    l" title="annotation interface in typeannos">@ClassParamA</a> <a href="Unannotat\
+                    ed.html" title="class in typeannos">Unannotated</a>&lt;<a href="ClassParamB.html\
+                    " title="annotation interface in typeannos">@ClassParamB</a> java.lang.String&gt\
+                    ;&gt;</span>""");
 
         checkOutput("typeannos/TwoBounds.html", true,
                 """
                     <div class="type-signature"><span class="modifiers">class </span><span class="el\
                     ement-name type-name-label">TwoBounds&lt;K extends <a href="ClassParamA.html" ti\
-                    tle="annotation interface in typeannos">@ClassParamA</a> java.lang.String,&#8203;V extends\
-                     <a href="ClassParamB.html" title="annotation interface in typeannos">@ClassParamB</a> jav\
-                    a.lang.String&gt;</span>""");
+                    tle="annotation interface in typeannos">@ClassParamA</a> java.lang.String,<wbr>V\
+                     extends <a href="ClassParamB.html" title="annotation interface in typeannos">@C\
+                    lassParamB</a> java.lang.String&gt;</span>""");
 
         checkOutput("typeannos/Complex1.html", true,
                 """
                     class </span><span class="element-name type-name-label">Complex1&lt;K extends <a\
-                     href="ClassParamA.html" title="annotation interface in typeannos">@ClassParamA</a> java.l\
-                    ang.String &amp; java.lang.Runnable&gt;</span>""");
+                     href="ClassParamA.html" title="annotation interface in typeannos">@ClassParamA<\
+                    /a> java.lang.String &amp; java.lang.Runnable&gt;</span>""");
 
         checkOutput("typeannos/Complex2.html", true,
                 """
                     class </span><span class="element-name type-name-label">Complex2&lt;K extends ja\
-                    va.lang.String &amp; <a href="ClassParamB.html" title="annotation interface in typeannos">\
-                    @ClassParamB</a> java.lang.Runnable&gt;</span>""");
+                    va.lang.String &amp; <a href="ClassParamB.html" title="annotation interface in t\
+                    ypeannos">@ClassParamB</a> java.lang.Runnable&gt;</span>""");
 
         checkOutput("typeannos/ComplexBoth.html", true,
                 """
                     class </span><span class="element-name type-name-label">ComplexBoth&lt;K extends\
-                     <a href="ClassParamA.html" title="annotation interface in typeannos">@ClassParamA</a> jav\
-                    a.lang.String &amp; <a href="ClassParamA.html" title="annotation interface in typeannos">@\
-                    ClassParamA</a> java.lang.Runnable&gt;</span>""");
+                     <a href="ClassParamA.html" title="annotation interface in typeannos">@ClassPara\
+                    mA</a> java.lang.String &amp; <a href="ClassParamA.html" title="annotation inter\
+                    face in typeannos">@ClassParamA</a> java.lang.Runnable&gt;</span>""");
 
         // Test for type annotations on fields (Fields.java).
         checkOutput("typeannos/DefaultScope.html", true,
                 """
                     <div class="member-signature"><span class="return-type"><a href="Parameterized.h\
                     tml" title="class in typeannos">Parameterized</a>&lt;<a href="FldA.html" title="\
-                    annotation interface in typeannos">@FldA</a> java.lang.String,&#8203;<a href="FldB.html" t\
-                    itle="annotation interface in typeannos">@FldB</a> java.lang.String&gt;</span>&nbsp;<span \
-                    class="element-name">bothTypeArgs</span></div>""",
+                    annotation interface in typeannos">@FldA</a> java.lang.String,<wbr><a href="FldB\
+                    .html" title="annotation interface in typeannos">@FldB</a> java.lang.String&gt;<\
+                    /span>&nbsp;<span class="element-name">bothTypeArgs</span></div>""",
 
                 """
                     <div class="member-signature"><span class="return-type"><a href="FldA.html" titl\
-                    e="annotation interface in typeannos">@FldA</a> java.lang.String <a href="FldB.html" title\
-                    ="annotation interface in typeannos">@FldB</a> []</span>&nbsp;<span class="element-name">a\
-                    rray1Deep</span></div>""",
+                    e="annotation interface in typeannos">@FldA</a> java.lang.String <a href="FldB.h\
+                    tml" title="annotation interface in typeannos">@FldB</a> []</span>&nbsp;<span cl\
+                    ass="element-name">array1Deep</span></div>""",
 
                 """
                     <div class="member-signature"><span class="return-type">java.lang.String <a href\
-                    ="FldB.html" title="annotation interface in typeannos">@FldB</a> [][]</span>&nbsp;<span cl\
-                    ass="element-name">array2SecondOld</span></div>""",
+                    ="FldB.html" title="annotation interface in typeannos">@FldB</a> [][]</span>&nbs\
+                    p;<span class="element-name">array2SecondOld</span></div>""",
 
                 // When JDK-8068737, we should change the order
                 """
                     <div class="member-signature"><span class="return-type"><a href="FldD.html" titl\
-                    e="annotation interface in typeannos">@FldD</a> java.lang.String <a href="FldC.html" title\
-                    ="annotation interface in typeannos">@FldC</a> <a href="FldB.html" title="annotation interface in ty\
-                    peannos">@FldB</a> [] <a href="FldC.html" title="annotation interface in typeannos">@FldC<\
-                    /a> <a href="FldA.html" title="annotation interface in typeannos">@FldA</a> []</span>&nbsp\
-                    ;<span class="element-name">array2Deep</span></div>""");
+                    e="annotation interface in typeannos">@FldD</a> java.lang.String <a href="FldC.h\
+                    tml" title="annotation interface in typeannos">@FldC</a> <a href="FldB.html" tit\
+                    le="annotation interface in typeannos">@FldB</a> [] <a href="FldC.html" title="a\
+                    nnotation interface in typeannos">@FldC</a> <a href="FldA.html" title="annotatio\
+                    n interface in typeannos">@FldA</a> []</span>&nbsp;<span class="element-name">ar\
+                    ray2Deep</span></div>""");
 
         checkOutput("typeannos/ModifiedScoped.html", true,
                 """
                     <div class="member-signature"><span class="modifiers">public final</span>&nbsp;<\
                     span class="return-type"><a href="Parameterized.html" title="class in typeannos"\
-                    >Parameterized</a>&lt;<a href="FldA.html" title="annotation interface in typeannos">@FldA<\
-                    /a> <a href="Parameterized.html" title="class in typeannos">Parameterized</a>&lt\
-                    ;<a href="FldA.html" title="annotation interface in typeannos">@FldA</a> java.lang.String,\
-                    &#8203;<a href="FldB.html" title="annotation interface in typeannos">@FldB</a> java.lang.S\
-                    tring&gt;,&#8203;<a href="FldB.html" title="annotation interface in typeannos">@FldB</a> j\
-                    ava.lang.String&gt;</span>&nbsp;<span class="element-name">nestedParameterized</\
-                    span></div>""",
+                    >Parameterized</a>&lt;<a href="FldA.html" title="annotation interface in typeann\
+                    os">@FldA</a> <a href="Parameterized.html" title="class in typeannos">Parameteri\
+                    zed</a>&lt;<a href="FldA.html" title="annotation interface in typeannos">@FldA</\
+                    a> java.lang.String,<wbr><a href="FldB.html" title="annotation interface in type\
+                    annos">@FldB</a> java.lang.String&gt;,<wbr><a href="FldB.html" title="annotation\
+                     interface in typeannos">@FldB</a> java.lang.String&gt;</span>&nbsp;<span class=\
+                    "element-name">nestedParameterized</span></div>""",
 
                 """
                     <div class="member-signature"><span class="modifiers">public final</span>&nbsp;<\
-                    span class="return-type"><a href="FldA.html" title="annotation interface in typeannos">@Fl\
-                    dA</a> java.lang.String[][]</span>&nbsp;<span class="element-name">array2</span>\
-                    </div>""");
+                    span class="return-type"><a href="FldA.html" title="annotation interface in type\
+                    annos">@FldA</a> java.lang.String[][]</span>&nbsp;<span class="element-name">arr\
+                    ay2</span></div>""");
 
         // Test for type annotations on method return types (MethodReturnType.java).
         checkOutput("typeannos/MtdDefaultScope.html", true,
                 """
                     <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
                     lass="type-parameters">&lt;T&gt;</span>&nbsp;<span class="return-type"><a href="\
-                    MRtnA.html" title="annotation interface in typeannos">@MRtnA</a> java.lang.String</span>&n\
-                    bsp;<span class="element-name">method</span>()</div>""",
+                    MRtnA.html" title="annotation interface in typeannos">@MRtnA</a> java.lang.Strin\
+                    g</span>&nbsp;<span class="element-name">method</span>()</div>""",
 
                 // When JDK-8068737 is fixed, we should change the order
                 """
                     <div class="member-signature"><span class="return-type"><a href="MRtnA.html" tit\
-                    le="annotation interface in typeannos">@MRtnA</a> java.lang.String <a href="MRtnB.html" ti\
-                    tle="annotation interface in typeannos">@MRtnB</a> [] <a href="MRtnA.html" title="annotati\
-                    on interface in typeannos">@MRtnA</a> []</span>&nbsp;<span class="element-name">array2Deep\
-                    </span>()</div>""",
+                    le="annotation interface in typeannos">@MRtnA</a> java.lang.String <a href="MRtn\
+                    B.html" title="annotation interface in typeannos">@MRtnB</a> [] <a href="MRtnA.h\
+                    tml" title="annotation interface in typeannos">@MRtnA</a> []</span>&nbsp;<span c\
+                    lass="element-name">array2Deep</span>()</div>""",
 
                 """
                     <div class="member-signature"><span class="return-type"><a href="MRtnA.html" tit\
-                    le="annotation interface in typeannos">@MRtnA</a> java.lang.String[][]</span>&nbsp;<span c\
-                    lass="element-name">array2</span>()</div>""");
+                    le="annotation interface in typeannos">@MRtnA</a> java.lang.String[][]</span>&nb\
+                    sp;<span class="element-name">array2</span>()</div>""");
 
         checkOutput("typeannos/MtdModifiedScoped.html", true,
                 """
                     <div class="member-signature"><span class="modifiers">public final</span>&nbsp;<\
                     span class="return-type"><a href="MtdParameterized.html" title="class in typeann\
-                    os">MtdParameterized</a>&lt;<a href="MRtnA.html" title="annotation interface in typeannos"\
-                    >@MRtnA</a> <a href="MtdParameterized.html" title="class in typeannos">MtdParame\
-                    terized</a>&lt;<a href="MRtnA.html" title="annotation interface in typeannos">@MRtnA</a> j\
-                    ava.lang.String,&#8203;<a href="MRtnB.html" title="annotation interface in typeannos">@MRt\
-                    nB</a> java.lang.String&gt;,&#8203;<a href="MRtnB.html" title="annotation interface in typ\
-                    eannos">@MRtnB</a> java.lang.String&gt;</span>&nbsp;<span class="element-name">n\
-                    estedMtdParameterized</span>()</div>""");
+                    os">MtdParameterized</a>&lt;<a href="MRtnA.html" title="annotation interface in \
+                    typeannos">@MRtnA</a> <a href="MtdParameterized.html" title="class in typeannos"\
+                    >MtdParameterized</a>&lt;<a href="MRtnA.html" title="annotation interface in typ\
+                    eannos">@MRtnA</a> java.lang.String,<wbr><a href="MRtnB.html" title="annotation \
+                    interface in typeannos">@MRtnB</a> java.lang.String&gt;,<wbr><a href="MRtnB.html\
+                    " title="annotation interface in typeannos">@MRtnB</a> java.lang.String&gt;</spa\
+                    n>&nbsp;<span class="element-name">nestedMtdParameterized</span>()</div>""");
 
         // Test for type annotations on method type parameters (MethodTypeParameters.java).
         checkOutput("typeannos/UnscopedUnmodified.html", true,
                 """
                     <div class="member-signature"><span class="type-parameters">&lt;K extends <a hre\
-                    f="MTyParamA.html" title="annotation interface in typeannos">@MTyParamA</a> java.lang.Stri\
-                    ng&gt;</span>&nbsp;<span class="return-type">void</span>&nbsp;<span class="eleme\
-                    nt-name">methodExtends</span>()</div>""",
+                    f="MTyParamA.html" title="annotation interface in typeannos">@MTyParamA</a> java\
+                    .lang.String&gt;</span>&nbsp;<span class="return-type">void</span>&nbsp;<span cl\
+                    ass="element-name">methodExtends</span>()</div>""",
 
                 """
                     <div class="member-signature"><span class="type-parameters-long">&lt;K extends <\
-                    a href="MTyParamA.html" title="annotation interface in typeannos">@MTyParamA</a> <a href="\
-                    MtdTyParameterized.html" title="class in typeannos">MtdTyParameterized</a>&lt;<a\
-                     href="MTyParamB.html" title="annotation interface in typeannos">@MTyParamB</a> java.lang.\
-                    String&gt;&gt;</span>
+                    a href="MTyParamA.html" title="annotation interface in typeannos">@MTyParamA</a>\
+                     <a href="MtdTyParameterized.html" title="class in typeannos">MtdTyParameterized\
+                    </a>&lt;<a href="MTyParamB.html" title="annotation interface in typeannos">@MTyP\
+                    aramB</a> java.lang.String&gt;&gt;</span>
                     <span class="return-type">void</span>&nbsp;<span class="element-name">nestedExtends</span>()</div>""");
 
         checkOutput("typeannos/PublicModifiedMethods.html", true,
@@ -221,47 +223,49 @@ public class TestTypeAnnotations extends JavadocTester {
                 """
                     <div class="member-signature"><span class="modifiers">public final</span>&nbsp;<\
                     span class="type-parameters-long">&lt;K extends <a href="MTyParamA.html" title="\
-                    annotation interface in typeannos">@MTyParamA</a> java.lang.String,&#8203;
-                    V extends <a href="MTyParamA.html" title="annotation interface in typeannos">@MTyParamA</a\
-                    > <a href="MtdTyParameterized.html" title="class in typeannos">MtdTyParameterize\
-                    d</a>&lt;<a href="MTyParamB.html" title="annotation interface in typeannos">@MTyParamB</a>\
-                     java.lang.String&gt;&gt;</span>
+                    annotation interface in typeannos">@MTyParamA</a> java.lang.String,<wbr>
+                    V extends <a href="MTyParamA.html" title="annotation interface in typeannos">@MT\
+                    yParamA</a> <a href="MtdTyParameterized.html" title="class in typeannos">MtdTyPa\
+                    rameterized</a>&lt;<a href="MTyParamB.html" title="annotation interface in typea\
+                    nnos">@MTyParamB</a> java.lang.String&gt;&gt;</span>
                     <span class="return-type">void</span>&nbsp;<span class="element-name">dual</span>()</div>""");
 
         // Test for type annotations on parameters (Parameters.java).
         checkOutput("typeannos/Parameters.html", true,
                 """
                     <div class="member-signature"><span class="return-type">void</span>&nbsp;<span c\
-                    lass="element-name">unannotated</span>&#8203;<span class="parameters">(<a href="\
-                    ParaParameterized.html" title="class in typeannos">ParaParameterized</a>&lt;java\
-                    .lang.String,&#8203;java.lang.String&gt;&nbsp;a)</span></div>""",
+                    lass="element-name">unannotated</span><wbr><span class="parameters">(<a href="Pa\
+                    raParameterized.html" title="class in typeannos">ParaParameterized</a>&lt;java.l\
+                    ang.String,<wbr>java.lang.String&gt;&nbsp;a)</span></div>""",
 
                 """
                     <div class="member-signature"><span class="return-type">void</span>&nbsp;<span c\
-                    lass="element-name">nestedParaParameterized</span>&#8203;<span class="parameters\
-                    ">(<a href="ParaParameterized.html" title="class in typeannos">ParaParameterized\
-                    </a>&lt;<a href="ParamA.html" title="annotation interface in typeannos">@ParamA</a> <a hre\
-                    f="ParaParameterized.html" title="class in typeannos">ParaParameterized</a>&lt;<\
-                    a href="ParamA.html" title="annotation interface in typeannos">@ParamA</a> java.lang.Strin\
-                    g,&#8203;<a href="ParamB.html" title="annotation interface in typeannos">@ParamB</a> java.\
-                    lang.String&gt;,&#8203;<a href="ParamB.html" title="annotation interface in typeannos">@Pa\
-                    ramB</a> java.lang.String&gt;&nbsp;a)</span></div>""",
+                    lass="element-name">nestedParaParameterized</span><wbr><span class="parameters">\
+                    (<a href="ParaParameterized.html" title="class in typeannos">ParaParameterized</\
+                    a>&lt;<a href="ParamA.html" title="annotation interface in typeannos">@ParamA</a\
+                    > <a href="ParaParameterized.html" title="class in typeannos">ParaParameterized<\
+                    /a>&lt;<a href="ParamA.html" title="annotation interface in typeannos">@ParamA</\
+                    a> java.lang.String,<wbr><a href="ParamB.html" title="annotation interface in ty\
+                    peannos">@ParamB</a> java.lang.String&gt;,<wbr><a href="ParamB.html" title="anno\
+                    tation interface in typeannos">@ParamB</a> java.lang.String&gt;&nbsp;a)</span></\
+                    div>""",
 
                 // When JDK-8068737 is fixed, we should change the order
                 """
                     <div class="member-signature"><span class="return-type">void</span>&nbsp;<span c\
-                    lass="element-name">array2Deep</span>&#8203;<span class="parameters">(<a href="P\
-                    aramA.html" title="annotation interface in typeannos">@ParamA</a> java.lang.String <a href\
-                    ="ParamB.html" title="annotation interface in typeannos">@ParamB</a> [] <a href="ParamA.ht\
-                    ml" title="annotation interface in typeannos">@ParamA</a> []&nbsp;a)</span></div>""");
+                    lass="element-name">array2Deep</span><wbr><span class="parameters">(<a href="Par\
+                    amA.html" title="annotation interface in typeannos">@ParamA</a> java.lang.String\
+                     <a href="ParamB.html" title="annotation interface in typeannos">@ParamB</a> [] \
+                    <a href="ParamA.html" title="annotation interface in typeannos">@ParamA</a> []&n\
+                    bsp;a)</span></div>""");
 
         // Test for type annotations on throws (Throws.java).
         checkOutput("typeannos/ThrDefaultUnmodified.html", true,
                 """
                     <div class="member-signature"><span class="return-type">void</span>&nbsp;<span c\
                     lass="element-name">oneException</span>()
-                               throws <span class="exceptions"><a href="ThrA.html" title="annotation interface\
-                     in typeannos">@ThrA</a> java.lang.Exception</span></div>""",
+                               throws <span class="exceptions"><a href="ThrA.html" title="annotation\
+                     interface in typeannos">@ThrA</a> java.lang.Exception</span></div>""",
 
                 """
                     <div class="member-signature"><span class="return-type">void</span>&nbsp;<span c\
@@ -273,15 +277,15 @@ public class TestTypeAnnotations extends JavadocTester {
         checkOutput("typeannos/ThrPublicModified.html", true,
                 """
                     <div class="member-signature"><span class="modifiers">public final</span>&nbsp;<\
-                    span class="return-type">void</span>&nbsp;<span class="element-name">oneException</span>\
-                    &#8203;<span class="parameters">(java.lang.String&nbsp;a)</span>
+                    span class="return-type">void</span>&nbsp;<span class="element-name">oneExceptio\
+                    n</span><wbr><span class="parameters">(java.lang.String&nbsp;a)</span>
                                             throws <span class="exceptions"><a href="ThrA.html" titl\
                     e="annotation interface in typeannos">@ThrA</a> java.lang.Exception</span></div>""",
 
                 """
                     <div class="member-signature"><span class="modifiers">public final</span>&nbsp;<\
-                    span class="return-type">void</span>&nbsp;<span class="element-name">twoExceptions</span\
-                    >&#8203;<span class="parameters">(java.lang.String&nbsp;a)</span>
+                    span class="return-type">void</span>&nbsp;<span class="element-name">twoExceptio\
+                    ns</span><wbr><span class="parameters">(java.lang.String&nbsp;a)</span>
                                              throws <span class="exceptions"><a href="ThrA.html" tit\
                     le="annotation interface in typeannos">@ThrA</a> java.lang.RuntimeException,
                     <a href="ThrA.html" title="annotation interface in typeannos">@ThrA</a> java.lang.Exception</span></div>""");
@@ -290,8 +294,8 @@ public class TestTypeAnnotations extends JavadocTester {
                 """
                     <div class="member-signature"><span class="return-type">void</span>&nbsp;<span c\
                     lass="element-name">oneException</span>()
-                               throws <span class="exceptions"><a href="ThrB.html" title="annotation interface\
-                     in typeannos">@ThrB</a>("m") java.lang.Exception</span></div>""",
+                               throws <span class="exceptions"><a href="ThrB.html" title="annotation\
+                     interface in typeannos">@ThrB</a>("m") java.lang.Exception</span></div>""",
 
                 """
                     <div class="member-signature"><span class="return-type">void</span>&nbsp;<span c\
@@ -303,10 +307,10 @@ public class TestTypeAnnotations extends JavadocTester {
         // Test for type annotations on type parameters (TypeParameters.java).
         checkOutput("typeannos/TestMethods.html", true,
                 """
-                    <div class="member-signature"><span class="type-parameters">&lt;K,&#8203;
-                    <a href="TyParaA.html" title="annotation interface in typeannos">@TyParaA</a> V extends <a\
-                     href="TyParaA.html" title="annotation interface in typeannos">@TyParaA</a> java.lang.Stri\
-                    ng&gt;</span>
+                    <div class="member-signature"><span class="type-parameters">&lt;K,<wbr>
+                    <a href="TyParaA.html" title="annotation interface in typeannos">@TyParaA</a> V \
+                    extends <a href="TyParaA.html" title="annotation interface in typeannos">@TyPara\
+                    A</a> java.lang.String&gt;</span>
                     <span class="return-type">void</span>&nbsp;<span class="element-name">secondAnnotated</span>()</div>"""
         );
 
@@ -314,98 +318,99 @@ public class TestTypeAnnotations extends JavadocTester {
         checkOutput("typeannos/BoundTest.html", true,
                 """
                     <div class="member-signature"><span class="return-type">void</span>&nbsp;<span c\
-                    lass="element-name">wcExtends</span>&#8203;<span class="parameters">(<a href="My\
-                    List.html" title="class in typeannos">MyList</a>&lt;? extends <a href="WldA.html\
-                    " title="annotation interface in typeannos">@WldA</a> java.lang.String&gt;&nbsp;l)</span><\
-                    /div>""",
+                    lass="element-name">wcExtends</span><wbr><span class="parameters">(<a href="MyLi\
+                    st.html" title="class in typeannos">MyList</a>&lt;? extends <a href="WldA.html" \
+                    title="annotation interface in typeannos">@WldA</a> java.lang.String&gt;&nbsp;l)\
+                    </span></div>""",
 
                 """
                     <div class="member-signature"><span class="return-type"><a href="MyList.html" ti\
                     tle="class in typeannos">MyList</a>&lt;? super <a href="WldA.html" title="annota\
-                    tion interface in typeannos">@WldA</a> java.lang.String&gt;</span>&nbsp;<span class="element-name"\
-                    >returnWcSuper</span>()</div>""");
+                    tion interface in typeannos">@WldA</a> java.lang.String&gt;</span>&nbsp;<span cl\
+                    ass="element-name">returnWcSuper</span>()</div>""");
 
         checkOutput("typeannos/BoundWithValue.html", true,
                 """
                     <div class="member-signature"><span class="return-type">void</span>&nbsp;<span c\
-                    lass="element-name">wcSuper</span>&#8203;<span class="parameters">(<a href="MyLi\
-                    st.html" title="class in typeannos">MyList</a>&lt;? super <a href="WldB.html" ti\
-                    tle="annotation interface in typeannos">@WldB</a>("m") java.lang.String&gt;&nbsp;l)</span>\
-                    </div>""",
+                    lass="element-name">wcSuper</span><wbr><span class="parameters">(<a href="MyList\
+                    .html" title="class in typeannos">MyList</a>&lt;? super <a href="WldB.html" titl\
+                    e="annotation interface in typeannos">@WldB</a>("m") java.lang.String&gt;&nbsp;l\
+                    )</span></div>""",
 
                 """
                     <div class="member-signature"><span class="return-type"><a href="MyList.html" ti\
                     tle="class in typeannos">MyList</a>&lt;? extends <a href="WldB.html" title="anno\
-                    tation interface in typeannos">@WldB</a>("m") java.lang.String&gt;</span>&nbsp;<span class\
-                    ="element-name">returnWcExtends</span>()</div>""");
+                    tation interface in typeannos">@WldB</a>("m") java.lang.String&gt;</span>&nbsp;<\
+                    span class="element-name">returnWcExtends</span>()</div>""");
 
         checkOutput("typeannos/SelfTest.html", true,
                 """
                     <div class="member-signature"><span class="return-type"><a href="MyList.html" ti\
-                    tle="class in typeannos">MyList</a>&lt;<a href="WldA.html" title="annotation interface in \
-                    typeannos">@WldA</a> ?&gt;</span>&nbsp;<span class="element-name">returnWcExtends</span>\
-                    ()</div>""",
+                    tle="class in typeannos">MyList</a>&lt;<a href="WldA.html" title="annotation int\
+                    erface in typeannos">@WldA</a> ?&gt;</span>&nbsp;<span class="element-name">retu\
+                    rnWcExtends</span>()</div>""",
                 """
                     <div class="member-signature"><span class="return-type"><a href="MyList.html" ti\
-                    tle="class in typeannos">MyList</a>&lt;<a href="WldA.html" title="annotation interface in \
-                    typeannos">@WldA</a> ? extends <a href="WldA.html" title="annotation interface in typeanno\
-                    s">@WldA</a> <a href="MyList.html" title="class in typeannos">MyList</a>&lt;<a h\
-                    ref="WldB.html" title="annotation interface in typeannos">@WldB</a>("m") ?&gt;&gt;</span>&\
-                    nbsp;<span class="element-name">complex</span>()</div>""");
+                    tle="class in typeannos">MyList</a>&lt;<a href="WldA.html" title="annotation int\
+                    erface in typeannos">@WldA</a> ? extends <a href="WldA.html" title="annotation i\
+                    nterface in typeannos">@WldA</a> <a href="MyList.html" title="class in typeannos\
+                    ">MyList</a>&lt;<a href="WldB.html" title="annotation interface in typeannos">@W\
+                    ldB</a>("m") ?&gt;&gt;</span>&nbsp;<span class="element-name">complex</span>()</\
+                    div>""");
 
         checkOutput("typeannos/SelfWithValue.html", true,
                 """
                     <div class="member-signature"><span class="return-type"><a href="MyList.html" ti\
-                    tle="class in typeannos">MyList</a>&lt;<a href="WldB.html" title="annotation interface in \
-                    typeannos">@WldB</a>("m") ?&gt;</span>&nbsp;<span class="element-name">returnWcExtends</\
-                    span>()</div>""",
+                    tle="class in typeannos">MyList</a>&lt;<a href="WldB.html" title="annotation int\
+                    erface in typeannos">@WldB</a>("m") ?&gt;</span>&nbsp;<span class="element-name"\
+                    >returnWcExtends</span>()</div>""",
                 """
                     <div class="member-signature"><span class="return-type"><a href="MyList.html" ti\
-                    tle="class in typeannos">MyList</a>&lt;<a href="WldB.html" title="annotation interface in \
-                    typeannos">@WldB</a>("m") ? extends <a href="MyList.html" title="class in typean\
-                    nos">MyList</a>&lt;<a href="WldB.html" title="annotation interface in typeannos">@WldB</a>\
-                    ("m") ? super java.lang.String&gt;&gt;</span>&nbsp;<span class="element-name">complex</s\
-                    pan>()</div>""");
+                    tle="class in typeannos">MyList</a>&lt;<a href="WldB.html" title="annotation int\
+                    erface in typeannos">@WldB</a>("m") ? extends <a href="MyList.html" title="class\
+                     in typeannos">MyList</a>&lt;<a href="WldB.html" title="annotation interface in \
+                    typeannos">@WldB</a>("m") ? super java.lang.String&gt;&gt;</span>&nbsp;<span cla\
+                    ss="element-name">complex</span>()</div>""");
 
 
         // Test for receiver annotations (Receivers.java).
         checkOutput("typeannos/DefaultUnmodified.html", true,
                 """
                     <div class="member-signature"><span class="return-type">void</span>&nbsp;<span c\
-                    lass="element-name">withException</span>&#8203;<span class="parameters">(<a href\
-                    ="RcvrA.html" title="annotation interface in typeannos">@RcvrA</a> DefaultUnmodified&\
-                    nbsp;this)</span>
+                    lass="element-name">withException</span><wbr><span class="parameters">(<a href="\
+                    RcvrA.html" title="annotation interface in typeannos">@RcvrA</a> DefaultUnmodifi\
+                    ed&nbsp;this)</span>
                                 throws <span class="exceptions">java.lang.Exception</span></div>""",
 
                 """
                     <div class="member-signature"><span class="return-type">java.lang.String</span>&\
-                    nbsp;<span class="element-name">nonVoid</span>&#8203;<span class="parameters">(<a href="\
-                    RcvrA.html" title="annotation interface in typeannos">@RcvrA</a> <a href="RcvrB.html" titl\
-                    e="annotation interface in typeannos">@RcvrB</a>("m") DefaultUnmodified&nbsp;this)</s\
-                    pan></div>""",
+                    nbsp;<span class="element-name">nonVoid</span><wbr><span class="parameters">(<a \
+                    href="RcvrA.html" title="annotation interface in typeannos">@RcvrA</a> <a href="\
+                    RcvrB.html" title="annotation interface in typeannos">@RcvrB</a>("m") DefaultUnm\
+                    odified&nbsp;this)</span></div>""",
 
                 """
                     <div class="member-signature"><span class="type-parameters">&lt;T extends java.l\
                     ang.Runnable&gt;</span>&nbsp;<span class="return-type">void</span>&nbsp;<span cl\
-                    ass="element-name">accept</span>&#8203;<span class="parameters">(<a href="RcvrA.\
-                    html" title="annotation interface in typeannos">@RcvrA</a> DefaultUnmodified&nbsp;thi\
-                    s,
+                    ass="element-name">accept</span><wbr><span class="parameters">(<a href="RcvrA.ht\
+                    ml" title="annotation interface in typeannos">@RcvrA</a> DefaultUnmodified&nbsp;\
+                    this,
                      T&nbsp;r)</span>
                                                         throws <span class="exceptions">java.lang.Exception</span></div>""");
 
         checkOutput("typeannos/PublicModified.html", true,
                 """
                     <div class="member-signature"><span class="modifiers">public final</span>&nbsp;<\
-                    span class="return-type">java.lang.String</span>&nbsp;<span class="element-name">nonVoid\
-                    </span>&#8203;<span class="parameters">(<a href="RcvrA.html" title="annotation i\
-                    nterface in typeannos">@RcvrA</a> PublicModified&nbsp;this)</span></div>""",
+                    span class="return-type">java.lang.String</span>&nbsp;<span class="element-name"\
+                    >nonVoid</span><wbr><span class="parameters">(<a href="RcvrA.html" title="annota\
+                    tion interface in typeannos">@RcvrA</a> PublicModified&nbsp;this)</span></div>""",
 
                 """
                     <div class="member-signature"><span class="modifiers">public final</span>&nbsp;<\
                     span class="type-parameters">&lt;T extends java.lang.Runnable&gt;</span>&nbsp;<s\
-                    pan class="return-type">void</span>&nbsp;<span class="element-name">accept</span>&#8203;\
-                    <span class="parameters">(<a href="RcvrA.html" title="annotation interface in typea\
-                    nnos">@RcvrA</a> PublicModified&nbsp;this,
+                    pan class="return-type">void</span>&nbsp;<span class="element-name">accept</span\
+                    ><wbr><span class="parameters">(<a href="RcvrA.html" title="annotation interface\
+                     in typeannos">@RcvrA</a> PublicModified&nbsp;this,
                      T&nbsp;r)</span>
                                                                      throws <span class="exceptions">java.lang.Exception</span></div>""");
 
@@ -413,24 +418,25 @@ public class TestTypeAnnotations extends JavadocTester {
                 """
                     <div class="member-signature"><span class="type-parameters">&lt;T extends java.l\
                     ang.Runnable&gt;</span>&nbsp;<span class="return-type">void</span>&nbsp;<span cl\
-                    ass="element-name">accept</span>&#8203;<span class="parameters">(<a href="RcvrB.\
-                    html" title="annotation interface in typeannos">@RcvrB</a>("m") WithValue&nbsp;this,
+                    ass="element-name">accept</span><wbr><span class="parameters">(<a href="RcvrB.ht\
+                    ml" title="annotation interface in typeannos">@RcvrB</a>("m") WithValue&nbsp;this,
                      T&nbsp;r)</span>
                                                         throws <span class="exceptions">java.lang.Exception</span></div>""");
 
         checkOutput("typeannos/WithFinal.html", true,
                 """
                     <div class="member-signature"><span class="return-type">java.lang.String</span>&\
-                    nbsp;<span class="element-name">nonVoid</span>&#8203;<span class="parameters">(<a href="\
-                    RcvrB.html" title="annotation interface in typeannos">@RcvrB</a>("m") <a href="WithFinal.h\
-                    tml" title="class in typeannos">WithFinal</a>&nbsp;afield)</span></div>""");
+                    nbsp;<span class="element-name">nonVoid</span><wbr><span class="parameters">(<a \
+                    href="RcvrB.html" title="annotation interface in typeannos">@RcvrB</a>("m") <a h\
+                    ref="WithFinal.html" title="class in typeannos">WithFinal</a>&nbsp;afield)</span\
+                    ></div>""");
 
         checkOutput("typeannos/WithBody.html", true,
                 """
                     <div class="member-signature"><span class="return-type">void</span>&nbsp;<span c\
-                    lass="element-name">field</span>&#8203;<span class="parameters">(<a href="RcvrA.\
-                    html" title="annotation interface in typeannos">@RcvrA</a> WithBody&nbsp;this)</span>\
-                    </div>""");
+                    lass="element-name">field</span><wbr><span class="parameters">(<a href="RcvrA.ht\
+                    ml" title="annotation interface in typeannos">@RcvrA</a> WithBody&nbsp;this)</sp\
+                    an></div>""");
 
         checkOutput("typeannos/Generic2.html", true,
                 """
@@ -438,29 +444,30 @@ public class TestTypeAnnotations extends JavadocTester {
                     lass="element-name">test1</span>()</div>""",
                 """
                     <div class="member-signature"><span class="return-type">void</span>&nbsp;<span c\
-                    lass="element-name">test2</span>&#8203;<span class="parameters">(<a href="RcvrA.\
-                    html" title="annotation interface in typeannos">@RcvrA</a> Generic2&lt;X&gt;&nbsp;thi\
-                    s)</span></div>""",
+                    lass="element-name">test2</span><wbr><span class="parameters">(<a href="RcvrA.ht\
+                    ml" title="annotation interface in typeannos">@RcvrA</a> Generic2&lt;X&gt;&nbsp;\
+                    this)</span></div>""",
                 """
                     <div class="member-signature"><span class="return-type">void</span>&nbsp;<span c\
-                    lass="element-name">test3</span>&#8203;<span class="parameters">(Generic2&lt;<a \
-                    href="RcvrA.html" title="annotation interface in typeannos">@RcvrA</a> X&gt;&nbsp;this)</s\
-                    pan></div>""",
+                    lass="element-name">test3</span><wbr><span class="parameters">(Generic2&lt;<a hr\
+                    ef="RcvrA.html" title="annotation interface in typeannos">@RcvrA</a> X&gt;&nbsp;\
+                    this)</span></div>""",
                 """
                     <div class="member-signature"><span class="return-type">void</span>&nbsp;<span cl\
-                    ass="element-name">test4</span>&#8203;<span class="parameters">(<a href="RcvrA.ht\
-                    ml" title="annotation interface in typeannos">@RcvrA</a> Generic2&lt;<a href="RcvrA.html" t\
-                    itle="annotation interface in typeannos">@RcvrA</a> X&gt;&nbsp;this)</span></div>""");
+                    ass="element-name">test4</span><wbr><span class="parameters">(<a href="RcvrA.html\
+                    " title="annotation interface in typeannos">@RcvrA</a> Generic2&lt;<a href="RcvrA\
+                    .html" title="annotation interface in typeannos">@RcvrA</a> X&gt;&nbsp;this)</spa\
+                    n></div>""");
 
 
         // Test for repeated type annotations (RepeatedAnnotations.java).
         checkOutput("typeannos/RepeatingAtClassLevel.html", true,
                 """
                     <div class="type-signature"><span class="annotations"><a href="RepTypeA.html" ti\
-                    tle="annotation interface in typeannos">@RepTypeA</a> <a href="RepTypeA.html" title="annot\
-                    ation interface in typeannos">@RepTypeA</a>
-                    <a href="RepTypeB.html" title="annotation interface in typeannos">@RepTypeB</a> <a href="R\
-                    epTypeB.html" title="annotation interface in typeannos">@RepTypeB</a>
+                    tle="annotation interface in typeannos">@RepTypeA</a> <a href="RepTypeA.html" ti\
+                    tle="annotation interface in typeannos">@RepTypeA</a>
+                    <a href="RepTypeB.html" title="annotation interface in typeannos">@RepTypeB</a> \
+                    <a href="RepTypeB.html" title="annotation interface in typeannos">@RepTypeB</a>
                     </span><span class="modifiers">class </span><span class="element-name type-name-\
                     label">RepeatingAtClassLevel</span>
                     <span class="extends-implements">extends java.lang.Object</span></div>""");
@@ -489,11 +496,12 @@ public class TestTypeAnnotations extends JavadocTester {
         checkOutput("typeannos/RepeatingOnConstructor.html", true,
                 """
                     <div class="member-signature"><span class="annotations"><a href="RepConstructorA\
-                    .html" title="annotation interface in typeannos">@RepConstructorA</a> <a href="RepConstruc\
-                    torA.html" title="annotation interface in typeannos">@RepConstructorA</a>
-                    <a href="RepConstructorB.html" title="annotation interface in typeannos">@RepConstructorB<\
-                    /a> <a href="RepConstructorB.html" title="annotation interface in typeannos">@RepConstruct\
-                    orB</a>
+                    .html" title="annotation interface in typeannos">@RepConstructorA</a> <a href="R\
+                    epConstructorA.html" title="annotation interface in typeannos">@RepConstructorA<\
+                    /a>
+                    <a href="RepConstructorB.html" title="annotation interface in typeannos">@RepCon\
+                    structorB</a> <a href="RepConstructorB.html" title="annotation interface in type\
+                    annos">@RepConstructorB</a>
                     </span><span class="element-name">RepeatingOnConstructor</span>()</div>""",
 
                 """
@@ -503,7 +511,7 @@ public class TestTypeAnnotations extends JavadocTester {
                     <a href="RepConstructorB.html" title="annotation interface in typeannos">@RepConstructorB<\
                     /a> <a href="RepConstructorB.html" title="annotation interface in typeannos">@RepConstruct\
                     orB</a>
-                    </span><span class="element-name">RepeatingOnConstructor</span>&#8203;<span class="parameters">(int&nbsp;i,
+                    </span><span class="element-name">RepeatingOnConstructor</span><wbr><span class="parameters">(int&nbsp;i,
                      int&nbsp;j)</span></div>""",
 
                 """
@@ -513,13 +521,13 @@ public class TestTypeAnnotations extends JavadocTester {
                     <a href="RepAllContextsB.html" title="annotation interface in typeannos">@RepAllContextsB<\
                     /a> <a href="RepAllContextsB.html" title="annotation interface in typeannos">@RepAllContex\
                     tsB</a>
-                    </span><span class="element-name">RepeatingOnConstructor</span>&#8203;<span class="parameters">(int&nbsp;i,
+                    </span><span class="element-name">RepeatingOnConstructor</span><wbr><span class="parameters">(int&nbsp;i,
                      int&nbsp;j,
                      int&nbsp;k)</span></div>""",
 
                 """
-                    <div class="member-signature"><span class="element-name">RepeatingOnConstructor</span>&#\
-                    8203;<span class="parameters">(<a href="RepParameterA.html" title="annotation interface in\
+                    <div class="member-signature"><span class="element-name">RepeatingOnConstructor</span>\
+                    <wbr><span class="parameters">(<a href="RepParameterA.html" title="annotation interface in\
                      typeannos">@RepParameterA</a> <a href="RepParameterA.html" title="annotation interface in\
                      typeannos">@RepParameterA</a> <a href="RepParameterB.html" title="annotation interface in\
                      typeannos">@RepParameterB</a> <a href="RepParameterB.html" title="annotation interface in\
@@ -539,14 +547,14 @@ public class TestTypeAnnotations extends JavadocTester {
         checkOutput("typeannos/RepeatingOnConstructor.Inner.html", true,
                 """
                     <code><a href="#%3Cinit%3E(java.lang.String,java.lang.String...)" class="member-\
-                    name-link">Inner</a>&#8203;(java.lang.String&nbsp;parameter,
+                    name-link">Inner</a><wbr>(java.lang.String&nbsp;parameter,
                      java.lang.String <a href="RepTypeUseA.html" title="annotation interface in typeannos">@Rep\
                     TypeUseA</a> <a href="RepTypeUseA.html" title="annotation interface in typeannos">@RepType\
                     UseA</a> <a href="RepTypeUseB.html" title="annotation interface in typeannos">@RepTypeUseB\
                     </a> <a href="RepTypeUseB.html" title="annotation interface in typeannos">@RepTypeUseB</a>\
                      ...&nbsp;vararg)</code>""",
                 """
-                    Inner</span>&#8203;<span class="parameters">(<a href="RepTypeUseA.html" title="a\
+                    Inner</span><wbr><span class="parameters">(<a href="RepTypeUseA.html" title="a\
                     nnotation interface in typeannos">@RepTypeUseA</a> <a href="RepTypeUseA.html" title="annot\
                     ation interface in typeannos">@RepTypeUseA</a> <a href="RepTypeUseB.html" title="annotatio\
                     n interface in typeannos">@RepTypeUseB</a> <a href="RepTypeUseB.html" title="annotation interface in\
@@ -710,7 +718,7 @@ public class TestTypeAnnotations extends JavadocTester {
 
                 """
                     <code><a href="#test5(java.lang.String,java.lang.\
-                    String...)" class="member-name-link">test5</a>&#8203;(java.lang.String&nbsp;parameter,
+                    String...)" class="member-name-link">test5</a><wbr>(java.lang.String&nbsp;parameter,
                      java.lang.String <a href="RepTypeUseA.html" title="annotation interface in typeannos">@Re\
                     pTypeUseA</a> <a href="RepTypeUseA.html" title="annotation interface in typeannos">@RepTyp\
                     eUseA</a> <a href="RepTypeUseB.html" title="annotation interface in typeannos">@RepTypeUse\
@@ -758,12 +766,12 @@ public class TestTypeAnnotations extends JavadocTester {
                     pan class="element-name">test4</span>()""",
 
                 """
-                    java.lang.String</span>&nbsp;<span class="element-name">test5</span>&#8203;<span\
-                     class="parameters">(<a href="RepTypeUseA.html" title="annotation interface in typeannos">@\
-                    RepTypeUseA</a> <a href="RepTypeUseA.html" title="annotation interface in typeannos">@RepT\
-                    ypeUseA</a> <a href="RepTypeUseB.html" title="annotation interface in typeannos">@RepTypeU\
-                    seB</a> <a href="RepTypeUseB.html" title="annotation interface in typeannos">@RepTypeUseB<\
-                    /a> RepeatingOnMethod&nbsp;this,
+                    java.lang.String</span>&nbsp;<span class="element-name">test5</span><wbr><span class="para\
+                    meters">(<a href="RepTypeUseA.html" title="annotation interface in typeannos">@RepTypeUseA\
+                    </a> <a href="RepTypeUseA.html" title="annotation interface in typeannos">@RepTypeUseA</a>\
+                     <a href="RepTypeUseB.html" title="annotation interface in typeannos">@RepTypeUseB</a> <a \
+                    href="RepTypeUseB.html" title="annotation interface in typeannos">@RepTypeUseB</a> Repeati\
+                    ngOnMethod&nbsp;this,
                      <a href="RepParameterA.html" title="annotation interface in typeannos">@RepParameterA</a> \
                     <a href="RepParameterA.html" title="annotation interface in typeannos">@RepParameterA</a> \
                     <a href="RepParameterB.html" title="annotation interface in typeannos">@RepParameterB</a> \
@@ -784,17 +792,17 @@ public class TestTypeAnnotations extends JavadocTester {
                     <code>(package private) &lt;T&gt;&nbsp;java.lang.String</code></div>
                     <div class="col-second even-row-color method-summary-table method-summary-table-\
                     tab2 method-summary-table-tab4"><code><a href="#genericMethod(T)" class="member-\
-                    name-link">genericMethod</a>&#8203;(T&nbsp;t)</code>""",
+                    name-link">genericMethod</a><wbr>(T&nbsp;t)</code>""",
 
                 """
                     <code>(package private) &lt;T&gt;&nbsp;java.lang.String</code></div>
                     <div class="col-second odd-row-color method-summary-table method-summary-table-t\
                     ab2 method-summary-table-tab4"><code><a href="#genericMethod2(T)" class="member-\
-                    name-link">genericMethod2</a>&#8203;(<a href="RepTypeUseA.html" title="annotatio\
-                    n interface in typeannos">@RepTypeUseA</a> <a href="RepTypeUseA.html" title="anno\
-                    tation interface in typeannos">@RepTypeUseA</a> <a href="RepTypeUseB.html" title="annotati\
-                    on interface in typeannos">@RepTypeUseB</a> <a href="RepTypeUseB.html" title="annotation i\
-                    nterface in typeannos">@RepTypeUseB</a> T&nbsp;t)</code>""",
+                    name-link">genericMethod2</a><wbr>(<a href="RepTypeUseA.html" title="annotation \
+                    interface in typeannos">@RepTypeUseA</a> <a href="RepTypeUseA.html" title="annot\
+                    ation interface in typeannos">@RepTypeUseA</a> <a href="RepTypeUseB.html" title=\
+                    "annotation interface in typeannos">@RepTypeUseB</a> <a href="RepTypeUseB.html" \
+                    title="annotation interface in typeannos">@RepTypeUseB</a> T&nbsp;t)</code>""",
 
                 """
                     <code>(package private) java.lang.String</code></div>
@@ -804,16 +812,16 @@ public class TestTypeAnnotations extends JavadocTester {
 
                 """
                     <span class="return-type">java.lang.String</span>&nbsp;<span class="element-name">test</\
-                    span>&#8203;<span class="parameters">(<a href="RepTypeUseA.html" title="annotati\
-                    on interface in typeannos">@RepTypeUseA</a> <a href="RepTypeUseA.html" title="annotation i\
-                    nterface in typeannos">@RepTypeUseA</a> <a href="RepTypeUseB.html" title="annotation interface in ty\
-                    peannos">@RepTypeUseB</a> <a href="RepTypeUseB.html" title="annotation interface in typean\
-                    nos">@RepTypeUseB</a> RepeatingOnTypeParametersBoundsTypeArgumentsOnMethod&\
-                    lt;<a href="RepTypeUseA.html" title="annotation interface in typeannos">@RepTypeUseA</a> <\
-                    a href="RepTypeUseA.html" title="annotation interface in typeannos">@RepTypeUseA</a> <a hr\
-                    ef="RepTypeUseB.html" title="annotation interface in typeannos">@RepTypeUseB</a> <a href="\
-                    RepTypeUseB.html" title="annotation interface in typeannos">@RepTypeUseB</a> T&gt;&nbsp;th\
-                    is)""");
+                    span><wbr><span class="parameters">(<a href="RepTypeUseA.html" title="annotation interfa\
+                    ce in typeannos">@RepTypeUseA</a> <a href="RepTypeUseA.html" title="annotation interface\
+                     in typeannos">@RepTypeUseA</a> <a href="RepTypeUseB.html" title="annotation interface i\
+                    n typeannos">@RepTypeUseB</a> <a href="RepTypeUseB.html" title="annotation interface in \
+                    typeannos">@RepTypeUseB</a> RepeatingOnTypeParametersBoundsTypeArgumentsOnMethod&lt;<a h\
+                    ref="RepTypeUseA.html" title="annotation interface in typeannos">@RepTypeUseA</a> <a hre\
+                    f="RepTypeUseA.html" title="annotation interface in typeannos">@RepTypeUseA</a> <a href=\
+                    "RepTypeUseB.html" title="annotation interface in typeannos">@RepTypeUseB</a> <a href="R\
+                    epTypeUseB.html" title="annotation interface in typeannos">@RepTypeUseB</a> T&gt;&nbsp;t\
+                    his)""");
 
         checkOutput("typeannos/RepeatingOnVoidMethodDeclaration.html", true,
                 """

--- a/test/langtools/jdk/javadoc/doclet/testTypeParams/TestTypeParameters.java
+++ b/test/langtools/jdk/javadoc/doclet/testTypeParams/TestTypeParameters.java
@@ -56,7 +56,7 @@ public class TestTypeParameters extends JavadocTester {
         checkOutput("pkg/C.html", true,
                 """
                     <div class="col-first odd-row-color method-summary-table method-summary-table-ta\
-                    b2 method-summary-table-tab4"><code>&lt;W extends java.lang.String,&#8203;
+                    b2 method-summary-table-tab4"><code>&lt;W extends java.lang.String,<wbr>
                     V extends java.util.List&gt;<br>java.lang.Object</code></div>""",
                 "<code>&lt;T&gt;&nbsp;java.lang.Object</code>");
 


### PR DESCRIPTION
This replaces usages of the zero-width space character (ZWSP, entity `&#8203;`) with the HTML5 `<wbr>` element. `<wbr>` acts as a word break opportunity without adding characters to the text content like ZWSP does. It is supported in all modern browsers, the only browser I  know of which doesn't support is are old versions of Internet Explorer. 

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr
https://caniuse.com/wbr-element

I have tested the output (both layout and copy-paste behaviour) on Firefox, Safari, and Chrome on Mac OS X.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266779](https://bugs.openjdk.java.net/browse/JDK-8266779): Use <wbr> instead of ZERO_WIDTH_SPACE


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**) ⚠️ Review applies to 095f16d2e7a70af39d0c6b5e114194a7632519da


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3946/head:pull/3946` \
`$ git checkout pull/3946`

Update a local copy of the PR: \
`$ git checkout pull/3946` \
`$ git pull https://git.openjdk.java.net/jdk pull/3946/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3946`

View PR using the GUI difftool: \
`$ git pr show -t 3946`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3946.diff">https://git.openjdk.java.net/jdk/pull/3946.diff</a>

</details>
