### PR TITLE
8266813: Shenandoah: Use shorter instruction sequence for checking if marking in progress

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
@@ -686,9 +686,7 @@ void ShenandoahBarrierSetAssembler::generate_c1_pre_barrier_runtime_stub(StubAss
   // Is marking still active?
   Address gc_state(thread, in_bytes(ShenandoahThreadLocalData::gc_state_offset()));
   __ ldrb(tmp, gc_state);
-  __ mov(rscratch2, ShenandoahHeap::MARKING);
-  __ tst(tmp, rscratch2);
-  __ br(Assembler::EQ, done);
+  __ tbz(tmp, ShenandoahHeap::MARKING_BITPOS, done);
 
   // Can we store original value in the thread's buffer?
   __ ldr(tmp, queue_index);


### PR DESCRIPTION
ShenandoahBarrierSetAssembler::generate_c1_pre_barrier_runtime_stub() on aarch64, we can replace ld, tst, br instruction sequence with a single tbz.

Test:
- [x] hotspot_gc_shenandoah on Linux aarch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266813](https://bugs.openjdk.java.net/browse/JDK-8266813): Shenandoah: Use shorter instruction sequence for checking if marking in progress


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3948/head:pull/3948` \
`$ git checkout pull/3948`

Update a local copy of the PR: \
`$ git checkout pull/3948` \
`$ git pull https://git.openjdk.java.net/jdk pull/3948/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3948`

View PR using the GUI difftool: \
`$ git pr show -t 3948`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3948.diff">https://git.openjdk.java.net/jdk/pull/3948.diff</a>

</details>
