### PR TITLE
8266854: LibraryCallKit::inline_preconditions_checkIndex modifies control flow even if the intrinsic bailed out

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -1046,20 +1046,19 @@ bool LibraryCallKit::inline_preconditions_checkIndex(BasicType bt) {
   if (!rc_bool->is_Con()) {
     record_for_igvn(rc);
   }
-  Node* true_path = _gvn.transform(new IfTrueNode(rc));
-  Node* false_path = _gvn.transform(new IfFalseNode(rc));
-  {
-    PreserveJVMState pjvms(this);
-    set_control(false_path);
-    uncommon_trap(Deoptimization::Reason_range_check,
-                  Deoptimization::Action_make_not_entrant);
-  }
 
   if (stopped()) {
     return false;
   }
 
-  set_control(true_path);
+  set_control(_gvn.transform(new IfTrueNode(rc)));
+
+  {
+    PreserveJVMState pjvms(this);
+    set_control(_gvn.transform(new IfFalseNode(rc)));
+    uncommon_trap(Deoptimization::Reason_range_check,
+                  Deoptimization::Action_make_not_entrant);
+  }
 
   // index is now known to be >= 0 and < length, cast it
   Node* result = ConstraintCastNode::make(control(), index, TypeInteger::make(0, upper_bound, Type::WidenMax, bt), bt);

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -1046,10 +1046,11 @@ bool LibraryCallKit::inline_preconditions_checkIndex(BasicType bt) {
   if (!rc_bool->is_Con()) {
     record_for_igvn(rc);
   }
-  set_control(_gvn.transform(new IfTrueNode(rc)));
+  Node* true_path = _gvn.transform(new IfTrueNode(rc));
+  Node* false_path = _gvn.transform(new IfFalseNode(rc));
   {
     PreserveJVMState pjvms(this);
-    set_control(_gvn.transform(new IfFalseNode(rc)));
+    set_control(false_path);
     uncommon_trap(Deoptimization::Reason_range_check,
                   Deoptimization::Action_make_not_entrant);
   }
@@ -1057,6 +1058,8 @@ bool LibraryCallKit::inline_preconditions_checkIndex(BasicType bt) {
   if (stopped()) {
     return false;
   }
+
+  set_control(true_path);
 
   // index is now known to be >= 0 and < length, cast it
   Node* result = ConstraintCastNode::make(control(), index, TypeInteger::make(0, upper_bound, Type::WidenMax, bt), bt);


### PR DESCRIPTION
LibraryCallKit::inline_preconditions_checkIndex can result in the following assert sometimes:
   "# assert(ctrl == kit.control()) failed: Control flow was added although the intrinsic bailed out"

Consider the following code snippet:
 ...
 set_control(_gvn.transform(new IfTrueNode(rc)));
 {
   PreserveJVMState pjvms(this);
   set_control(_gvn.transform(new IfFalseNode(rc)));
   uncommon_trap(Deoptimization::Reason_range_check,
                 Deoptimization::Action_make_not_entrant);
 }
 ..
 Here the control is being modified by set_control even though a bailout is possible afterwards.
 Moving the set_control later in the intrinsic fixes this.

 This is a small fix. Please review.

Best Regards,
Sandhya

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8266854](https://bugs.openjdk.java.net/browse/JDK-8266854): LibraryCallKit::inline_preconditions_checkIndex modifies control flow even if the intrinsic bailed out


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3958/head:pull/3958` \
`$ git checkout pull/3958`

Update a local copy of the PR: \
`$ git checkout pull/3958` \
`$ git pull https://git.openjdk.java.net/jdk pull/3958/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3958`

View PR using the GUI difftool: \
`$ git pr show -t 3958`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3958.diff">https://git.openjdk.java.net/jdk/pull/3958.diff</a>

</details>
