### PR TITLE
8266784: java/text/Collator/RuleBasedCollatorTest.java fails with jtreg 6

### DIFF
--- a/test/jdk/java/text/Collator/RuleBasedCollatorTest.java
+++ b/test/jdk/java/text/Collator/RuleBasedCollatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4406815 8222969
+ * @bug 4406815 8222969 8266784
  * @summary RuleBasedCollatorTest uses very limited but selected test data
  *  to test basic functionalities provided by RuleBasedCollator.
  * @run testng/othervm RuleBasedCollatorTest
@@ -37,7 +37,7 @@ import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Locale;
 
-import org.testng.annotations.BeforeGroups;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.SkipException;
@@ -48,7 +48,7 @@ public class RuleBasedCollatorTest {
     static RuleBasedCollator USC;
     static String US_RULES;
 
-    @BeforeGroups("USC")
+    @BeforeClass
     public void setup() {
         Collator c = Collator.getInstance(Locale.US);
         if (!(c instanceof RuleBasedCollator)) {
@@ -91,7 +91,7 @@ public class RuleBasedCollatorTest {
         };
     }
 
-    @Test(dataProvider = "rulesData", groups = "USC")
+    @Test(dataProvider = "rulesData")
     public void testRules(String rules, String[] testData, String[] expected)
             throws ParseException {
         Arrays.sort(testData, new RuleBasedCollator(rules));
@@ -111,7 +111,7 @@ public class RuleBasedCollatorTest {
                 { "a", "\u1ea1", -1 } };
     }
 
-    @Test(dataProvider = "FrenchSecondarySort", groups = "USC")
+    @Test(dataProvider = "FrenchSecondarySort")
     public void testFrenchSecondarySort(String sData, String tData,
             int expected) throws ParseException {
         String french_rule = "@";
@@ -129,7 +129,7 @@ public class RuleBasedCollatorTest {
         };
     }
 
-    @Test(dataProvider = "ThaiLaoVowelConsonantSwapping", groups = "USC")
+    @Test(dataProvider = "ThaiLaoVowelConsonantSwapping")
     public void testThaiLaoVowelConsonantSwapping(String sData, String tData,
             int expected) throws ParseException {
         String thai_rule = "& Z < \u0e01 < \u0e2e <\u0e40 < \u0e44!";
@@ -162,7 +162,7 @@ public class RuleBasedCollatorTest {
         };
     }
 
-    @Test(dataProvider = "Normalization", groups = "USC")
+    @Test(dataProvider = "Normalization")
     public void testNormalization(String sData, String tData, int decomp,
             int result) {
         RuleBasedCollator rc = (RuleBasedCollator)USC.clone();


### PR DESCRIPTION
Please review this test case fix for the upcoming jtreg 6. The test was using `@BeforeGroups` annotation, and the behavior of it has changed in TestNG 7.1 so that it is only issued when the test was configured with filtering. Changed to use `@BeforeClass` instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266784](https://bugs.openjdk.java.net/browse/JDK-8266784): java/text/Collator/RuleBasedCollatorTest.java fails with jtreg 6


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3959/head:pull/3959` \
`$ git checkout pull/3959`

Update a local copy of the PR: \
`$ git checkout pull/3959` \
`$ git pull https://git.openjdk.java.net/jdk pull/3959/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3959`

View PR using the GUI difftool: \
`$ git pr show -t 3959`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3959.diff">https://git.openjdk.java.net/jdk/pull/3959.diff</a>

</details>
