### PR TITLE
8266819: Separate the stop policies from the compile policies completely

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
@@ -161,17 +161,6 @@ public class JavaCompiler {
      */
     protected static enum CompilePolicy {
         /**
-         * Just attribute the parse trees.
-         */
-        ATTR_ONLY,
-
-        /**
-         * Just attribute and do flow analysis on the parse trees.
-         * This should catch most user errors.
-         */
-        CHECK_ONLY,
-
-        /**
          * Attribute everything, then do flow analysis for everything,
          * then desugar everything, and only then generate output.
          * This means no output will be generated if there are any
@@ -198,10 +187,6 @@ public class JavaCompiler {
         static CompilePolicy decode(String option) {
             if (option == null)
                 return DEFAULT_COMPILE_POLICY;
-            else if (option.equals("attr"))
-                return ATTR_ONLY;
-            else if (option.equals("check"))
-                return CHECK_ONLY;
             else if (option.equals("simple"))
                 return SIMPLE;
             else if (option.equals("byfile"))
@@ -443,11 +428,7 @@ public class JavaCompiler {
 
         verboseCompilePolicy = options.isSet("verboseCompilePolicy");
 
-        if (options.isSet("should-stop.at") &&
-            CompileState.valueOf(options.get("should-stop.at")) == CompileState.ATTR)
-            compilePolicy = CompilePolicy.ATTR_ONLY;
-        else
-            compilePolicy = CompilePolicy.decode(options.get("compilePolicy"));
+        compilePolicy = CompilePolicy.decode(options.get("compilePolicy"));
 
         implicitSourcePolicy = ImplicitSourcePolicy.decode(options.get("-implicit"));
 
@@ -948,14 +929,6 @@ public class JavaCompiler {
 
             if (!CompileState.ATTR.isAfter(shouldStopPolicyIfNoError)) {
                 switch (compilePolicy) {
-                case ATTR_ONLY:
-                    attribute(todo);
-                    break;
-
-                case CHECK_ONLY:
-                    flow(attribute(todo));
-                    break;
-
                 case SIMPLE:
                     generate(desugar(flow(attribute(todo))));
                     break;

--- a/test/langtools/tools/javac/6199662/Tree.java
+++ b/test/langtools/tools/javac/6199662/Tree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,11 +38,11 @@
  * @compile -XDcompilePolicy=simple Tree.java TreeScanner.java TreeInfo.java
  * @compile -XDcompilePolicy=simple TreeInfo.java TreeScanner.java Tree.java
  *
- * @compile -XDcompilePolicy=check  Tree.java TreeScanner.java TreeInfo.java
- * @compile -XDcompilePolicy=check  TreeInfo.java TreeScanner.java Tree.java
+ * @compile -XDshould-stop.ifError=FLOW -XDshould-stop.ifNoError=FLOW  Tree.java TreeScanner.java TreeInfo.java
+ * @compile -XDshould-stop.ifError=FLOW -XDshould-stop.ifNoError=FLOW  TreeInfo.java TreeScanner.java Tree.java
  *
- * @compile -XDcompilePolicy=attr   Tree.java TreeScanner.java TreeInfo.java
- * @compile -XDcompilePolicy=attr   TreeInfo.java TreeScanner.java Tree.java
+ * @compile -XDshould-stop.ifError=ATTR -XDshould-stop.ifNoError=ATTR  Tree.java TreeScanner.java TreeInfo.java
+ * @compile -XDshould-stop.ifError=ATTR -XDshould-stop.ifNoError=ATTR  TreeInfo.java TreeScanner.java Tree.java
  */
 
 package p;

--- a/test/langtools/tools/javac/failover/CheckAttributedTree.java
+++ b/test/langtools/tools/javac/failover/CheckAttributedTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -315,7 +315,8 @@ public class CheckAttributedTree {
             totalNumberOfCompilations++;
             newCompilationTask()
                 .withWriter(pw)
-                    .withOption("--should-stop=at=ATTR")
+                    .withOption("--should-stop=ifError=ATTR")
+                    .withOption("--should-stop=ifNoError=ATTR")
                     .withOption("-XDverboseCompilePolicy")
                     .withOption("-Xdoclint:none")
                     .withSource(files.iterator().next())

--- a/test/langtools/tools/javac/importscope/T8193717.java
+++ b/test/langtools/tools/javac/importscope/T8193717.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,7 +94,8 @@ public class T8193717 {
         try (StandardJavaFileManager fm = compiler.getStandardFileManager(null, null, null)) {
             fm.setLocationFromPaths(StandardLocation.CLASS_OUTPUT, List.of(Paths.get(".")));
             new JavacTask(tb).sources(source)
-                             .options("-XDshould-stop.at=ATTR") //the source is too big for a classfile
+                             .options("-XDshould-stop.ifError=ATTR",
+                                      "-XDshould-stop.ifNoError=ATTR") //the source is too big for a classfile
                              .fileManager(new TestJFM(fm))
                              .run();
         }

--- a/test/langtools/tools/javac/lambda/MostSpecific09.java
+++ b/test/langtools/tools/javac/lambda/MostSpecific09.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @bug 8029718 8065800
  * @summary Should always use lambda body structure to disambiguate overload resolution
- * @compile/fail/ref=MostSpecific09.out -XDrawDiagnostics --should-stop=at=ATTR --debug=verboseResolution=applicable,success MostSpecific09.java
+ * @compile/fail/ref=MostSpecific09.out -XDrawDiagnostics --should-stop=ifError=ATTR --should-stop=ifNoError=ATTR --debug=verboseResolution=applicable,success MostSpecific09.java
  */
 
 class MostSpecific09 {

--- a/test/langtools/tools/javac/modules/AnnotationProcessing.java
+++ b/test/langtools/tools/javac/modules/AnnotationProcessing.java
@@ -1716,7 +1716,8 @@ public class AnnotationProcessing extends ModuleTestBase {
                          "-AlookupClass=+test.Test",
                          "-AlookupPackage=+test",
                          "--add-modules=m2x",
-                         "-XDshould-stop.at=ATTR",
+                         "-XDshould-stop.ifError=ATTR",
+                         "-XDshould-stop.ifNoError=ATTR",
                          "-XDrawDiagnostics")
                 .outdir(srcClasses)
                 .files(findJavaFiles(src))

--- a/test/langtools/tools/javac/resolve/ResolveHarness.java
+++ b/test/langtools/tools/javac/resolve/ResolveHarness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -131,9 +131,9 @@ public class ResolveHarness implements javax.tools.DiagnosticListener<JavaFileOb
     }
 
     protected void check() throws Exception {
-        String[] options = {
-            "--should-stop=at=ATTR",
-            "--debug=verboseResolution=success,failure,applicable,inapplicable,deferred-inference,predef"
+        String[][] options = {
+                {"--should-stop=ifError=ATTR", "--should-stop=ifNoError=ATTR"},
+                {"--debug=verboseResolution=success,failure,applicable,inapplicable,deferred-inference,predef"}
         };
 
         AbstractProcessor[] processors = { new ResolveCandidateFinder(), null };

--- a/test/langtools/tools/javac/switchexpr/WarnWrongYieldTest.java
+++ b/test/langtools/tools/javac/switchexpr/WarnWrongYieldTest.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @bug 8223305 8226522
  * @summary Verify correct warnings w.r.t. yield
- * @compile/ref=WarnWrongYieldTest.out -Xlint:-options -source 13 -XDrawDiagnostics -XDshould-stop.at=ATTR WarnWrongYieldTest.java
+ * @compile/ref=WarnWrongYieldTest.out -Xlint:-options -source 13 -XDrawDiagnostics -XDshould-stop.ifError=ATTR -XDshould-stop.ifNoError=ATTR WarnWrongYieldTest.java
  */
 
 package t;

--- a/test/langtools/tools/javac/switchexpr/WrongYieldTest.java
+++ b/test/langtools/tools/javac/switchexpr/WrongYieldTest.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @bug 8223305 8226522
  * @summary Ensure proper errors are returned for yields.
- * @compile/fail/ref=WrongYieldTest.out -XDrawDiagnostics -XDshould-stop.at=ATTR WrongYieldTest.java
+ * @compile/fail/ref=WrongYieldTest.out -XDrawDiagnostics -XDshould-stop.ifError=ATTR -XDshould-stop.ifNoError=ATTR WrongYieldTest.java
  */
 
 package t;


### PR DESCRIPTION
Hi all,

This patch removes the compile policies `ATTR_ONLY` and `CHECK_ONLY` so that the compile policies can be separated from the stop policies. And some corresponding tests need to be adjusted, too.

Please see [JDK-8266819](https://bugs.openjdk.java.net/browse/JDK-8266819) and the [original discussion](https://mail.openjdk.java.net/pipermail/compiler-dev/2021-May/016759.html) for more information.

Thank you for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266819](https://bugs.openjdk.java.net/browse/JDK-8266819): Separate the stop policies from the compile policies completely


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3961/head:pull/3961` \
`$ git checkout pull/3961`

Update a local copy of the PR: \
`$ git checkout pull/3961` \
`$ git pull https://git.openjdk.java.net/jdk pull/3961/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3961`

View PR using the GUI difftool: \
`$ git pr show -t 3961`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3961.diff">https://git.openjdk.java.net/jdk/pull/3961.diff</a>

</details>
