### PR TITLE
8266798: C1: More types of instruction can also apply LoopInvariantCodeMotion

### DIFF
--- a/src/hotspot/share/c1/c1_ValueMap.cpp
+++ b/src/hotspot/share/c1/c1_ValueMap.cpp
@@ -318,7 +318,6 @@ class LoopInvariantCodeMotion : public StackObj  {
   ValueStack *          _state;
   bool                  _insert_is_pred;
 
-  void set_invariant(Value v) const    { _gvn->set_processed(v); }
   bool is_invariant(Value v) const     { return _gvn->is_processed(v); }
 
   void process_block(BlockBegin* block);
@@ -367,7 +366,6 @@ void LoopInvariantCodeMotion::process_block(BlockBegin* block) {
   Instruction* cur = block->next();
 
   while (cur != NULL) {
-
     // determine if cur instruction is loop invariant
     // only selected instruction types are processed here
     bool cur_invariant = false;
@@ -388,6 +386,12 @@ void LoopInvariantCodeMotion::process_block(BlockBegin* block) {
     } else if (cur->as_LoadIndexed() != NULL) {
       LoadIndexed *li = (LoadIndexed *)cur->as_LoadIndexed();
       cur_invariant = !_short_loop_optimizer->has_indexed_store(as_BasicType(cur->type())) && is_invariant(li->array()) && is_invariant(li->index()) && _insert_is_pred;
+    } else if (cur->as_NegateOp() != NULL) {
+      NegateOp* neg = (NegateOp*)cur->as_NegateOp();
+      cur_invariant = is_invariant(neg->x());
+    } else if (cur->as_Convert() != NULL) {
+      Convert* cvt = (Convert*)cur->as_Convert();
+      cur_invariant = is_invariant(cvt->value());
     }
 
     if (cur_invariant) {
@@ -412,6 +416,7 @@ void LoopInvariantCodeMotion::process_block(BlockBegin* block) {
       cur->set_exception_handlers(NULL);
 
       TRACE_VALUE_NUMBERING(tty->print_cr("Instruction %c%d is loop invariant", cur->type()->tchar(), cur->id()));
+      TRACE_VALUE_NUMBERING(cur->print_line());
 
       if (cur->state_before() != NULL) {
         cur->set_state_before(_state->copy());
@@ -421,7 +426,6 @@ void LoopInvariantCodeMotion::process_block(BlockBegin* block) {
       }
 
       cur = prev->set_next(next);
-
     } else {
       prev = cur;
       cur = cur->next();
@@ -585,7 +589,7 @@ void GlobalValueNumbering::substitute(Instruction* instr) {
   if (subst != instr) {
     assert(!subst->has_subst(), "can't have a substitution");
 
-    TRACE_VALUE_NUMBERING(tty->print_cr("substitution for %d set to %d", instr->id(), subst->id()));
+    TRACE_VALUE_NUMBERING(tty->print_cr("substitution for %c%d set to %c%d", instr->type()->tchar(), instr->id(), subst->id(), subst->type()->tchar()));
     instr->set_subst(subst);
     _has_substitutions = true;
   }

--- a/src/hotspot/share/c1/c1_ValueMap.cpp
+++ b/src/hotspot/share/c1/c1_ValueMap.cpp
@@ -589,7 +589,7 @@ void GlobalValueNumbering::substitute(Instruction* instr) {
   if (subst != instr) {
     assert(!subst->has_subst(), "can't have a substitution");
 
-    TRACE_VALUE_NUMBERING(tty->print_cr("substitution for %c%d set to %c%d", instr->type()->tchar(), instr->id(), subst->id(), subst->type()->tchar()));
+    TRACE_VALUE_NUMBERING(tty->print_cr("substitution for %c%d set to %c%d", instr->type()->tchar(), instr->id(), subst->type()->tchar(), subst->id()));
     instr->set_subst(subst);
     _has_substitutions = true;
   }


### PR DESCRIPTION
C1 only applies LoopInvariantCodeMotion for instructions whose types are Constant/ArithmeticOp/LoadField/ArrayLength/LoadIndexed. We are possible to apply this optimization for more types of instruction.

Candidates: NegateOp,Convert.

Due to the lack of verification at IR level, it is difficult to write jtreg to check if it transformed, so I can only demonstrate it with a simple program:
```java
// run with -XX:+PrintValueNumbering
static int foo10(int t){
    int sum=12;
    for(int i=0;i<100;i++){
        sum += 12;
        sum += -t;
        sum += (long)t;
    }
    return sum;
}
```
Before:
```
[...]
* loop invariant code motion for short loop B1
processing block B1
Value Numbering: insert Constant i10  (size 11, entries 3, nesting 2)
Instruction i10 is loop invariant
processing block B2
Value Numbering: Constant i12 equal to i5  (size 11, entries 3, nesting-diff 1)
substitution for 12 set to 5
Instruction i12 is loop invariant   // only 12 is recongized
Value Numbering: insert Constant i20  (size 11, entries 4, nesting 2)
Instruction i20 is loop invariant
** loop successfully optimized
[...]
```
After:
```
[...]
** loop invariant code motion for short loop B1
processing block B1
Value Numbering: insert Constant i10  (size 11, entries 3, nesting 2)
Instruction i10 is loop invariant
  6    0    i10    100
processing block B2
Value Numbering: Constant i12 equal to i5  (size 11, entries 3, nesting-diff 1)
substitution for i12 set to 105
Instruction i12 is loop invariant
  11   0    i12    12
Instruction i14 is loop invariant
. 16   0    i14    -i4
Value Numbering: insert Convert l17  (size 11, entries 4, nesting 2)
Instruction l17 is loop invariant
. 22   0    l17    i2l(i4)
Value Numbering: insert Constant i20  (size 11, entries 5, nesting 2)
Instruction i20 is loop invariant
  26   0    i20    1
[...]
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266798](https://bugs.openjdk.java.net/browse/JDK-8266798): C1: More types of instruction can also apply LoopInvariantCodeMotion


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3965/head:pull/3965` \
`$ git checkout pull/3965`

Update a local copy of the PR: \
`$ git checkout pull/3965` \
`$ git pull https://git.openjdk.java.net/jdk pull/3965/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3965`

View PR using the GUI difftool: \
`$ git pr show -t 3965`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3965.diff">https://git.openjdk.java.net/jdk/pull/3965.diff</a>

</details>
