### PR TITLE
8266874: Clean up C1 canonicalizer for TableSwitch/LookupSwitch

### DIFF
--- a/src/hotspot/share/c1/c1_Canonicalizer.cpp
+++ b/src/hotspot/share/c1/c1_Canonicalizer.cpp
@@ -837,23 +837,6 @@ void Canonicalizer::do_TableSwitch(TableSwitch* x) {
       sux = x->sux_at(v - x->lo_key());
     }
     set_canonical(new Goto(sux, x->state_before(), is_safepoint(x, sux)));
-  } else if (x->number_of_sux() == 1) {
-    // NOTE: Code permanently disabled for now since the switch statement's
-    //       tag expression may produce side-effects in which case it must
-    //       be executed.
-    return;
-    // simplify to Goto
-    set_canonical(new Goto(x->default_sux(), x->state_before(), x->is_safepoint()));
-  } else if (x->number_of_sux() == 2) {
-    // NOTE: Code permanently disabled for now since it produces two new nodes
-    //       (Constant & If) and the Canonicalizer cannot return them correctly
-    //       yet. For now we copied the corresponding code directly into the
-    //       GraphBuilder (i.e., we should never reach here).
-    return;
-    // simplify to If
-    assert(x->lo_key() == x->hi_key(), "keys must be the same");
-    Constant* key = new Constant(new IntConstant(x->lo_key()));
-    set_canonical(new If(x->tag(), If::eql, true, key, x->sux_at(0), x->default_sux(), x->state_before(), x->is_safepoint()));
   }
 }
 
@@ -868,23 +851,6 @@ void Canonicalizer::do_LookupSwitch(LookupSwitch* x) {
       }
     }
     set_canonical(new Goto(sux, x->state_before(), is_safepoint(x, sux)));
-  } else if (x->number_of_sux() == 1) {
-    // NOTE: Code permanently disabled for now since the switch statement's
-    //       tag expression may produce side-effects in which case it must
-    //       be executed.
-    return;
-    // simplify to Goto
-    set_canonical(new Goto(x->default_sux(), x->state_before(), x->is_safepoint()));
-  } else if (x->number_of_sux() == 2) {
-    // NOTE: Code permanently disabled for now since it produces two new nodes
-    //       (Constant & If) and the Canonicalizer cannot return them correctly
-    //       yet. For now we copied the corresponding code directly into the
-    //       GraphBuilder (i.e., we should never reach here).
-    return;
-    // simplify to If
-    assert(x->length() == 1, "length must be the same");
-    Constant* key = new Constant(new IntConstant(x->key_at(0)));
-    set_canonical(new If(x->tag(), If::eql, true, key, x->sux_at(0), x->default_sux(), x->state_before(), x->is_safepoint()));
   }
 }
 


### PR DESCRIPTION
Clean up C1 canonicalizer for TableSwitch/LookupSwitch

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266874](https://bugs.openjdk.java.net/browse/JDK-8266874): Clean up C1 canonicalizer for TableSwitch/LookupSwitch


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3966/head:pull/3966` \
`$ git checkout pull/3966`

Update a local copy of the PR: \
`$ git checkout pull/3966` \
`$ git pull https://git.openjdk.java.net/jdk pull/3966/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3966`

View PR using the GUI difftool: \
`$ git pr show -t 3966`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3966.diff">https://git.openjdk.java.net/jdk/pull/3966.diff</a>

</details>
