### PR TITLE
8266881: Enable debug log for SSLEngineExplorerMatchedSNI.java

### DIFF
--- a/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java
+++ b/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,7 @@ public class SSLEngineExplorerMatchedSNI extends SSLEngineService {
     /*
      * Turn on SSL debugging?
      */
-    static boolean debug = false;
+    static boolean debug = true;
 
     /*
      * Define the server side of the test.


### PR DESCRIPTION
Hi,

May I have the following test code reviewed?

The test SSLEngineExplorerMatchedSNI.java fails intermittently.  I tried to run the test 500 times, but cannot reproduce the issue.  The cause is unknown to me now. It would could be helpful to fine the root cause to enable the JSSE debugging in the test.

Thanks & Regards,
Xuelei

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266881](https://bugs.openjdk.java.net/browse/JDK-8266881): Enable debug log for SSLEngineExplorerMatchedSNI.java


### Reviewers
 * [Hai-May Chao](https://openjdk.java.net/census#hchao) (@haimaychao - Committer)
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3967/head:pull/3967` \
`$ git checkout pull/3967`

Update a local copy of the PR: \
`$ git checkout pull/3967` \
`$ git pull https://git.openjdk.java.net/jdk pull/3967/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3967`

View PR using the GUI difftool: \
`$ git pr show -t 3967`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3967.diff">https://git.openjdk.java.net/jdk/pull/3967.diff</a>

</details>
