### PR TITLE
8265705: aarch64: KlassDecodeMovk mode broken

### DIFF
--- a/src/hotspot/share/oops/compressedOops.cpp
+++ b/src/hotspot/share/oops/compressedOops.cpp
@@ -221,6 +221,16 @@ void CompressedKlassPointers::initialize(address addr, size_t len) {
     base = addr;
     shift = LogKlassAlignmentInBytes;
 
+    // JDK-8265705
+    // This is a temporary fix for aarch64: there, if the range-to-be-encoded is located
+    //  below 32g, either encoding base should be zero or base should be aligned to 4G
+    //  and shift should be zero. The simplest way to fix this for now is to force
+    //  shift to zero for both runtime and dumptime.
+    // Note however that this is not a perfect solution. Ideally this whole function
+    //  should be CDS agnostic, that would simplify it - and testing - alot. See JDK-8267141
+    //  for details.
+    AARCH64_ONLY(shift = 0);
+
     // This must be true since at dumptime cds+ccs is 4G, at runtime it can
     //  only be smaller, see comment above.
     assert(len <= 4 * G, "Encoding range cannot be larger than 4G");

--- a/src/hotspot/share/oops/compressedOops.cpp
+++ b/src/hotspot/share/oops/compressedOops.cpp
@@ -219,7 +219,6 @@ void CompressedKlassPointers::initialize(address addr, size_t len) {
     //  cannot be larger than that).
 
     base = addr;
-    shift = LogKlassAlignmentInBytes;
 
     // JDK-8265705
     // This is a temporary fix for aarch64: there, if the range-to-be-encoded is located
@@ -229,7 +228,7 @@ void CompressedKlassPointers::initialize(address addr, size_t len) {
     // Note however that this is not a perfect solution. Ideally this whole function
     //  should be CDS agnostic, that would simplify it - and testing - alot. See JDK-8267141
     //  for details.
-    AARCH64_ONLY(shift = 0);
+    shift = 0;
 
     // This must be true since at dumptime cds+ccs is 4G, at runtime it can
     //  only be smaller, see comment above.

--- a/test/hotspot/jtreg/runtime/cds/SharedBaseAddress.java
+++ b/test/hotspot/jtreg/runtime/cds/SharedBaseAddress.java
@@ -23,6 +23,7 @@
 
 /**
  * @test SharedBaseAddress
+ * @bug 8265705
  * @summary Test variety of values for SharedBaseAddress, making sure
  *          VM handles normal values as well as edge values w/o a crash.
  * @requires vm.cds
@@ -47,6 +48,8 @@ public class SharedBaseAddress {
         "0xffffffffffffffff", // archive bottom wraps around 64-bit address space -- due to align_up()
         "0xffffffff",         // archive bottom wraps around 32-bit address space -- due to align_up()
         "0x00007ffffff00000", // end of archive will go past the end of user space on linux/x64
+        "0x500000000",        // (20g) below 32g at a 4g aligned address, but cannot be expressed with a logical
+                              //    immediate on aarch64 (0x5_0000_0000) (see JDK-8265705)
         "0",                  // always let OS pick the base address at runtime (ASLR for CDS archive)
     };
 
@@ -55,24 +58,38 @@ public class SharedBaseAddress {
 
     public static void main(String[] args) throws Exception {
 
-        for (String testEntry : testTable) {
-            String filename = "SharedBaseAddress" + testEntry + ".jsa";
-            System.out.println("sharedBaseAddress = " + testEntry);
-            CDSOptions opts = (new CDSOptions())
-                .setArchiveName(filename)
-                .addPrefix("-XX:SharedBaseAddress=" + testEntry)
-                .addPrefix("-Xlog:cds=debug")
-                .addPrefix("-Xlog:cds+reloc=debug")
-                .addPrefix("-Xlog:nmt=debug")
-                .addPrefix("-Xlog:os=debug")
-                .addPrefix("-XX:NativeMemoryTracking=detail");
+        for (int run = 0; run < 2; run ++) {
+            // We run twice:
+            // Once, where we want to increase the chance that mapping the generated archive at the designated base
+            // succeeds, to test Klass pointer encoding at that weird location. We do this by sizing heap + class space
+            // small, and by switching off compressed oops.
+            // On the second run, we don't do this but instead go with default parameters. This is more of a test of
+            // CDS' ability to recover if mapping at runtime fails.
+            for (String testEntry : testTable) {
+                String filename = "SharedBaseAddress-base" + testEntry + "-run" + run + ".jsa";
+                System.out.println("sharedBaseAddress = " + testEntry);
+                CDSOptions opts = (new CDSOptions())
+                        .setArchiveName(filename)
+                        .addPrefix("-XX:SharedBaseAddress=" + testEntry)
+                        .addPrefix("-Xlog:cds=debug")
+                        .addPrefix("-Xlog:cds+reloc=debug")
+                        .addPrefix("-Xlog:nmt=debug")
+                        .addPrefix("-Xlog:os=debug")
+                        .addPrefix("-Xlog:gc+metaspace")
+                        .addPrefix("-XX:NativeMemoryTracking=detail");
 
-            CDSTestUtils.createArchiveAndCheck(opts);
-            OutputAnalyzer out = CDSTestUtils.runWithArchiveAndCheck(opts);
-            if (testEntry.equals("0")) {
-              out.shouldContain("Archive(s) were created with -XX:SharedBaseAddress=0. Always map at os-selected address.")
-                 .shouldContain("Try to map archive(s) at an alternative address")
-                 .shouldNotMatch(failedPattern);
+                if (run == 0) {
+                    opts.addPrefix("-Xmx128m")
+                        .addPrefix("-XX:CompressedClassSpaceSize=32m")
+                        .addPrefix("-XX:-UseCompressedOops");
+                }
+                CDSTestUtils.createArchiveAndCheck(opts);
+                OutputAnalyzer out = CDSTestUtils.runWithArchiveAndCheck(opts);
+                if (testEntry.equals("0")) {
+                    out.shouldContain("Archive(s) were created with -XX:SharedBaseAddress=0. Always map at os-selected address.")
+                            .shouldContain("Try to map archive(s) at an alternative address")
+                            .shouldNotMatch(failedPattern);
+                }
             }
         }
     }


### PR DESCRIPTION
Hi,

may I please have a review for this aarch64-specific fix? Details see JBS issue and code comment.

I manually tested that this fix works. Patch includes a repro case.

Cheers, Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265705](https://bugs.openjdk.java.net/browse/JDK-8265705): aarch64: KlassDecodeMovk mode broken


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**) ⚠️ Review applies to 16246025a3600ba76e2ea11d518c37c585b99845
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Nick Gasson](https://openjdk.java.net/census#ngasson) (@nick-arm - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3968/head:pull/3968` \
`$ git checkout pull/3968`

Update a local copy of the PR: \
`$ git checkout pull/3968` \
`$ git pull https://git.openjdk.java.net/jdk pull/3968/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3968`

View PR using the GUI difftool: \
`$ git pr show -t 3968`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3968.diff">https://git.openjdk.java.net/jdk/pull/3968.diff</a>

</details>
