### PR TITLE
8266891: Provide a switch to force the class space to a specific location

### DIFF
--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -686,6 +686,9 @@ void Metaspace::global_initialize() {
 #if INCLUDE_CDS
   // case (a)
   if (UseSharedSpaces) {
+    if (!FLAG_IS_DEFAULT(CompressedClassSpaceBaseAddress)) {
+      log_warning(metaspace)("CDS active - ignoring CompressedClassSpaceBaseAddress.");
+    }
     MetaspaceShared::initialize_runtime_shared_and_meta_spaces();
     // If any of the archived space fails to map, UseSharedSpaces
     // is reset to false.
@@ -701,23 +704,49 @@ void Metaspace::global_initialize() {
   if (using_class_space() && !class_space_is_initialized()) {
     assert(!UseSharedSpaces, "CDS archive is not mapped at this point");
 
-    // case (b)
+    // case (b) (No CDS)
     ReservedSpace rs;
-
-    // If UseCompressedOops=1 and the java heap has been placed in coops-friendly
-    //  territory, i.e. its base is under 32G, then we attempt to place ccs
-    //  right above the java heap.
-    // Otherwise the lower 32G are still free. We try to place ccs at the lowest
-    // allowed mapping address.
-    address base = (UseCompressedOops && (uint64_t)CompressedOops::base() < OopEncodingHeapMax) ?
-                   CompressedOops::end() : (address)HeapBaseMinAddress;
-    base = align_up(base, Metaspace::reserve_alignment());
-
     const size_t size = align_up(CompressedClassSpaceSize, Metaspace::reserve_alignment());
-    if (base != NULL) {
-      if (CompressedKlassPointers::is_valid_base(base)) {
-        rs = ReservedSpace(size, Metaspace::reserve_alignment(),
-                           os::vm_page_size(), (char*)base);
+    address base = NULL;
+
+    // If CompressedClassSpaceBaseAddress is set, we attempt to force-map class space to
+    // the given address. This is a debug-only feature aiding tests. Due to the ASLR lottery
+    // this may fail, in which case the VM will exit after printing an appropiate message.
+    // Tests using this switch should cope with that.
+    if (!FLAG_IS_DEFAULT(CompressedClassSpaceBaseAddress) && CompressedClassSpaceBaseAddress != 0) {
+      base = (address)CompressedClassSpaceBaseAddress;
+      if (!is_aligned(base, Metaspace::reserve_alignment())) {
+        vm_exit_during_initialization(
+            err_msg("CompressedClassSpaceBaseAddress=" PTR_FORMAT " invalid "
+                    "(must be aligned to " SIZE_FORMAT_HEX ").",
+                    CompressedClassSpaceBaseAddress, Metaspace::reserve_alignment()));
+      }
+      rs = ReservedSpace(size, Metaspace::reserve_alignment(),
+                         os::vm_page_size() /* large */, (char*)base);
+      if (rs.is_reserved()) {
+        log_info(metaspace)("Sucessfully forced class space address to " PTR_FORMAT, p2i(base));
+      } else {
+        vm_exit_during_initialization(
+            err_msg("CompressedClassSpaceBaseAddress=" PTR_FORMAT " given, but reserving class space failed.",
+                CompressedClassSpaceBaseAddress));
+      }
+    }
+
+    if (!rs.is_reserved()) {
+      // If UseCompressedOops=1 and the java heap has been placed in coops-friendly
+      //  territory, i.e. its base is under 32G, then we attempt to place ccs
+      //  right above the java heap.
+      // Otherwise the lower 32G are still free. We try to place ccs at the lowest
+      // allowed mapping address.
+      base = (UseCompressedOops && (uint64_t)CompressedOops::base() < OopEncodingHeapMax) ?
+              CompressedOops::end() : (address)HeapBaseMinAddress;
+      base = align_up(base, Metaspace::reserve_alignment());
+
+      if (base != NULL) {
+        if (CompressedKlassPointers::is_valid_base(base)) {
+          rs = ReservedSpace(size, Metaspace::reserve_alignment(),
+                             os::vm_page_size(), (char*)base);
+        }
       }
     }
 

--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -713,7 +713,7 @@ void Metaspace::global_initialize() {
     // the given address. This is a debug-only feature aiding tests. Due to the ASLR lottery
     // this may fail, in which case the VM will exit after printing an appropiate message.
     // Tests using this switch should cope with that.
-    if (!FLAG_IS_DEFAULT(CompressedClassSpaceBaseAddress) && CompressedClassSpaceBaseAddress != 0) {
+    if (CompressedClassSpaceBaseAddress != 0) {
       base = (address)CompressedClassSpaceBaseAddress;
       if (!is_aligned(base, Metaspace::reserve_alignment())) {
         vm_exit_during_initialization(

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1462,6 +1462,10 @@ const intx ObjectAlignmentInBytes = 8;
           "class pointers are used")                                        \
           range(1*M, 3*G)                                                   \
                                                                             \
+  develop(size_t, CompressedClassSpaceBaseAddress, 0,                       \
+          "Force the class space to be allocated at this address or "       \
+          "fails VM initialization (requires -Xshare=off.")                 \
+                                                                            \
   product(ccstr, MetaspaceReclaimPolicy, "balanced",                        \
           "options: balanced, aggressive, none")                            \
                                                                             \


### PR DESCRIPTION
To test compressed Klass pointer encoding and other metaspace interna, it would be nice to be able to force location of the class space to a specific location. This would help with analysis of problems like JDK-8261552 or JDK-8265705 - errors in Klass* encoding/decoding which managed to stay unnoticed for an astonishingly long time.

For simplicity, it would be sufficient to only have this ability if CDS is disabled (Xshare=off), since CCS allocation is tied to CDS location otherwise and that would be more diffictult to disentangle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266891](https://bugs.openjdk.java.net/browse/JDK-8266891): Provide a switch to force the class space to a specific location


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to 532a7287ac234e0dbb9cf007461e5be5854f3b24
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3969/head:pull/3969` \
`$ git checkout pull/3969`

Update a local copy of the PR: \
`$ git checkout pull/3969` \
`$ git pull https://git.openjdk.java.net/jdk pull/3969/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3969`

View PR using the GUI difftool: \
`$ git pr show -t 3969`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3969.diff">https://git.openjdk.java.net/jdk/pull/3969.diff</a>

</details>
