### PR TITLE
JDK-8266892: avoid maybe-uninitialized gcc warnings on linux s390x

### DIFF
--- a/src/hotspot/cpu/s390/assembler_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/assembler_s390.inline.hpp
@@ -1387,6 +1387,7 @@ inline unsigned int Assembler::get_instruction(unsigned char *pc, unsigned long 
       // The length as returned from instr_len() can only be 2, 4, or 6 bytes.
       // Having a default clause makes the compiler happy.
       ShouldNotReachHere();
+      *instr = 0L; // This assignment is there to make gcc8 happy.
       break;
   }
   return len;


### PR DESCRIPTION
In the linux s390x hs code there are a few "maybe-uninitialized" gcc warnings with gcc 8 (those warning class is disabled currently in jdk17 but enabled e.g. in jdk11).  It would be good to fix them anyway which is done by this small change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266892](https://bugs.openjdk.java.net/browse/JDK-8266892): avoid maybe-uninitialized gcc warnings on linux s390x


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.java.net/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3970/head:pull/3970` \
`$ git checkout pull/3970`

Update a local copy of the PR: \
`$ git checkout pull/3970` \
`$ git pull https://git.openjdk.java.net/jdk pull/3970/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3970`

View PR using the GUI difftool: \
`$ git pr show -t 3970`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3970.diff">https://git.openjdk.java.net/jdk/pull/3970.diff</a>

</details>
