### PR TITLE
8266835: Add a --validate option to the jar tool

### DIFF
--- a/src/jdk.jartool/share/classes/sun/tools/jar/GNUStyleOptions.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/GNUStyleOptions.java
@@ -58,14 +58,14 @@ class GNUStyleOptions {
             // Main operations
             new Option(false, OptionType.MAIN_OPERATION, "--create", "-c") {
                 void process(Main tool, String opt, String arg) throws BadArgs {
-                    if (tool.iflag || tool.tflag || tool.uflag || tool.xflag || tool.dflag)
+                    if (tool.iflag || tool.tflag || tool.uflag || tool.xflag || tool.dflag || tool.validate)
                         throw new BadArgs("error.multiple.main.operations").showUsage(true);
                     tool.cflag = true;
                 }
             },
             new Option(true, OptionType.MAIN_OPERATION, "--generate-index", "-i") {
                 void process(Main tool, String opt, String arg) throws BadArgs {
-                    if (tool.cflag || tool.tflag || tool.uflag || tool.xflag || tool.dflag)
+                    if (tool.cflag || tool.tflag || tool.uflag || tool.xflag || tool.dflag || tool.validate)
                         throw new BadArgs("error.multiple.main.operations").showUsage(true);
                     tool.iflag = true;
                     tool.rootjar = arg;
@@ -73,30 +73,37 @@ class GNUStyleOptions {
             },
             new Option(false, OptionType.MAIN_OPERATION, "--list", "-t") {
                 void process(Main tool, String opt, String arg) throws BadArgs {
-                    if (tool.cflag || tool.iflag || tool.uflag || tool.xflag || tool.dflag)
+                    if (tool.cflag || tool.iflag || tool.uflag || tool.xflag || tool.dflag || tool.validate)
                         throw new BadArgs("error.multiple.main.operations").showUsage(true);
                     tool.tflag = true;
                 }
             },
             new Option(false, OptionType.MAIN_OPERATION, "--update", "-u") {
                 void process(Main tool, String opt, String arg) throws BadArgs {
-                    if (tool.cflag || tool.iflag || tool.tflag || tool.xflag || tool.dflag)
+                    if (tool.cflag || tool.iflag || tool.tflag || tool.xflag || tool.dflag || tool.validate)
                         throw new BadArgs("error.multiple.main.operations").showUsage(true);
                     tool.uflag = true;
                 }
             },
             new Option(false, OptionType.MAIN_OPERATION, "--extract", "-x") {
                 void process(Main tool, String opt, String arg) throws BadArgs {
-                    if (tool.cflag || tool.iflag  || tool.tflag || tool.uflag || tool.dflag)
+                    if (tool.cflag || tool.iflag  || tool.tflag || tool.uflag || tool.dflag || tool.validate)
                         throw new BadArgs("error.multiple.main.operations").showUsage(true);
                     tool.xflag = true;
                 }
             },
             new Option(false, OptionType.MAIN_OPERATION, "--describe-module", "-d") {
                 void process(Main tool, String opt, String arg) throws BadArgs {
-                    if (tool.cflag || tool.iflag  || tool.tflag || tool.uflag || tool.xflag)
+                    if (tool.cflag || tool.iflag  || tool.tflag || tool.uflag || tool.xflag || tool.validate)
                         throw new BadArgs("error.multiple.main.operations").showUsage(true);
                     tool.dflag = true;
+                }
+            },
+            new Option(false, OptionType.MAIN_OPERATION, "--validate") {
+                void process(Main tool, String opt, String arg) throws BadArgs {
+                    if (tool.cflag || tool.iflag  || tool.tflag || tool.uflag || tool.xflag || tool.dflag)
+                        throw new BadArgs("error.multiple.main.operations").showUsage(true);
+                    tool.validate = true;
                 }
             },
 

--- a/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
@@ -236,9 +236,10 @@ main.help.opt.main.extract=\
 main.help.opt.main.describe-module=\
 \  -d, --describe-module      Print the module descriptor, or automatic module name
 main.help.opt.main.validate=\
-\      --validate             Validate a jar. This process will validate that the API\n\
-\                             exported by a multi-release jar is consistent across all\n\
-\                             different release versions.
+\      --validate             Validate the contents of the jar archive. This option\n\
+\                             will validate that the API exported by a multi-release\n\
+\                             jar archive is consistent across all different release\n\
+\                             versions.
 main.help.opt.any=\
 \ Operation modifiers valid in any mode:\n\
 \n\

--- a/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
@@ -236,7 +236,9 @@ main.help.opt.main.extract=\
 main.help.opt.main.describe-module=\
 \  -d, --describe-module      Print the module descriptor, or automatic module name
 main.help.opt.main.validate=\
-\      --validate             Validate a jar
+\      --validate             Validate a jar. This process will validate that the API\n\
+\                             exported by a multi-release jar is consistent across all\n\
+\                             different release versions.
 main.help.opt.any=\
 \ Operation modifiers valid in any mode:\n\
 \n\

--- a/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
@@ -236,7 +236,7 @@ main.help.opt.main.extract=\
 main.help.opt.main.describe-module=\
 \  -d, --describe-module      Print the module descriptor, or automatic module name
 main.help.opt.main.validate=\
-\  --validate                 Validate a jar
+\      --validate             Validate a jar
 main.help.opt.any=\
 \ Operation modifiers valid in any mode:\n\
 \n\

--- a/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
@@ -235,6 +235,8 @@ main.help.opt.main.extract=\
 \  -x, --extract              Extract named (or all) files from the archive
 main.help.opt.main.describe-module=\
 \  -d, --describe-module      Print the module descriptor, or automatic module name
+main.help.opt.main.validate=\
+\      --validate             Validate a multi-release jar
 main.help.opt.any=\
 \ Operation modifiers valid in any mode:\n\
 \n\

--- a/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
@@ -36,7 +36,7 @@ error.missing.arg=\
 error.bad.file.arg=\
      Error parsing file arguments
 error.bad.option=\
-        One of options -{ctxuid} must be specified.
+        One of options -{ctxuid} or --validate must be specified.
 error.bad.cflag=\
         'c' flag requires manifest or input files to be specified!
 error.bad.uflag=\

--- a/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
@@ -236,7 +236,7 @@ main.help.opt.main.extract=\
 main.help.opt.main.describe-module=\
 \  -d, --describe-module      Print the module descriptor, or automatic module name
 main.help.opt.main.validate=\
-\      --validate             Validate a multi-release jar
+\  --validate                 Validate a jar
 main.help.opt.any=\
 \ Operation modifiers valid in any mode:\n\
 \n\

--- a/test/jdk/tools/jar/multiRelease/ApiValidatorTest.java
+++ b/test/jdk/tools/jar/multiRelease/ApiValidatorTest.java
@@ -46,22 +46,15 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
-import java.net.URI;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
-import java.nio.file.FileVisitResult;
-import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Map;
-import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
-import java.util.zip.ZipOutputStream;
 
 public class ApiValidatorTest extends MRTestBase {
 

--- a/test/jdk/tools/jar/multiRelease/ApiValidatorTest.java
+++ b/test/jdk/tools/jar/multiRelease/ApiValidatorTest.java
@@ -44,12 +44,24 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Map;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import java.util.zip.ZipOutputStream;
 
 public class ApiValidatorTest extends MRTestBase {
 
@@ -85,13 +97,19 @@ public class ApiValidatorTest extends MRTestBase {
                 "-C", classes.resolve("base").toString(), ".",
                 "--release", "10", "-C", classes.resolve("v10").toString(),
                 ".");
-        if (isAcceptable) {
-            result.shouldHaveExitValue(SUCCESS)
-                  .shouldBeEmptyIgnoreVMWarnings();
-        } else {
-            result.shouldNotHaveExitValue(SUCCESS)
-                    .shouldContain("contains a class with different api from earlier version");
-        }
+
+        String failureMessage = "contains a class with different api from earlier version";
+        checkResult(result, isAcceptable, failureMessage);
+        if (isAcceptable) result.shouldBeEmptyIgnoreVMWarnings();
+
+
+        Path malformed = root.resolve("zip").resolve("test.jar");
+        zip(malformed,
+            Map.entry("", classes.resolve("base")),
+            Map.entry("META-INF/versions/10", classes.resolve("v10")));
+
+        result = validateJar(malformed.toString(), isAcceptable, failureMessage);
+        if (isAcceptable) result.shouldBeEmptyIgnoreVMWarnings();
     }
 
     @DataProvider
@@ -127,11 +145,20 @@ public class ApiValidatorTest extends MRTestBase {
         compileTemplate(classes.resolve("base"), base);
         compileTemplate(classes.resolve("v10"), v10);
 
+        String failureMessage = "contains a class with different api from earlier version";
+
         String jarfile = root.resolve("test.jar").toString();
         jar("cf", jarfile, "-C", classes.resolve("base").toString(), ".",
                 "--release", "10", "-C", classes.resolve("v10").toString(), ".")
                 .shouldNotHaveExitValue(SUCCESS)
-                .shouldContain("contains a class with different api from earlier version");
+                .shouldContain(failureMessage);
+
+        Path malformed = root.resolve("zip").resolve("test.jar");
+        zip(malformed,
+            Map.entry("", classes.resolve("base")),
+            Map.entry("META-INF/versions/10", classes.resolve("v10")));
+
+        validateJar(malformed.toString(), false, failureMessage);
     }
 
     @DataProvider
@@ -163,14 +190,17 @@ public class ApiValidatorTest extends MRTestBase {
         jar("cf", jarfile, "-C", classes.resolve("base").toString(), ".",
                 "--release", "10", "-C", classes.resolve("v10").toString(), ".")
                 .shouldHaveExitValue(SUCCESS);
+        validateJar(jarfile);
         // add release
         jar("uf", jarfile,
                 "--release", "11", "-C", classes.resolve("v10").toString(), ".")
                 .shouldHaveExitValue(SUCCESS);
+        validateJar(jarfile);
         // replace release
         jar("uf", jarfile,
                 "--release", "11", "-C", classes.resolve("v10").toString(), ".")
                 .shouldHaveExitValue(SUCCESS);
+        validateJar(jarfile);
     }
 
     @DataProvider
@@ -201,20 +231,31 @@ public class ApiValidatorTest extends MRTestBase {
         compileModule(classes.resolve("base"), "module A { }");
         compileModule(classes.resolve("v10"), "module B { }");
 
+        String failureMessage = "incorrect name";
+
         String jarfile = root.resolve("test.jar").toString();
         jar("cf", jarfile, "-C", classes.resolve("base").toString(), ".",
                 "--release", "10", "-C", classes.resolve("v10").toString(), ".")
                 .shouldNotHaveExitValue(SUCCESS)
-                .shouldContain("incorrect name");
+                .shouldContain(failureMessage);
+
+        Path malformed = root.resolve("zip").resolve("test.jar");
+        zip(malformed,
+            Map.entry("", classes.resolve("base")),
+            Map.entry("META-INF/versions/10", classes.resolve("v10")));
+
+        validateJar(malformed.toString(), false, failureMessage);
 
         // update module-info release
         jar("cf", jarfile, "-C", classes.resolve("base").toString(), ".",
                 "--release", "10", "-C", classes.resolve("base").toString(), ".")
                 .shouldHaveExitValue(SUCCESS);
+        validateJar(jarfile);
+
         jar("uf", jarfile,
                 "--release", "10", "-C", classes.resolve("v10").toString(), ".")
                 .shouldNotHaveExitValue(SUCCESS)
-                .shouldContain("incorrect name");
+                .shouldContain(failureMessage);
     }
 
     //    @Test @ignore 8173370
@@ -233,6 +274,7 @@ public class ApiValidatorTest extends MRTestBase {
         jar("cf", jarfile, "-C", classes.resolve("base").toString(), ".",
                 "--release", "10", "-C", classes.resolve("base").toString(), ".")
                 .shouldHaveExitValue(SUCCESS);
+        validateJar(jarfile);
         jar("uf", jarfile,
                 "--release", "10", "-C", classes.resolve("v10").toString(), ".")
                 .shouldNotHaveExitValue(SUCCESS)
@@ -378,12 +420,14 @@ public class ApiValidatorTest extends MRTestBase {
         OutputAnalyzer output = jar("cf", jarfile,
                 "-C", classes.resolve("base").toString(), ".",
                 "--release", "10", "-C", classes.resolve("v10").toString(), ".");
-        if (expectSuccess) {
-            output.shouldHaveExitValue(SUCCESS);
-        } else {
-            output.shouldNotHaveExitValue(SUCCESS)
-                    .shouldContain(expectedMessage);
-        }
+        checkResult(output, expectSuccess, expectedMessage);
+
+        Path malformed = root.resolve("zip").resolve("test.jar");
+        zip(malformed,
+            Map.entry("", classes.resolve("base")),
+            Map.entry("META-INF/versions/10", classes.resolve("v10")));
+
+        validateJar(malformed.toString(), expectSuccess, expectedMessage);
     }
 
     private void compileModule(Path classes, String moduleSource,
@@ -416,5 +460,53 @@ public class ApiValidatorTest extends MRTestBase {
         }
 
         javac(classes, sourceFiles);
+    }
+
+    @SafeVarargs
+    private void zip(Path file, Map.Entry<String, Path>... copies) throws IOException {
+        Files.createDirectories(file.getParent());
+        Files.deleteIfExists(file);
+        try (FileSystem zipfs = FileSystems.newFileSystem(file, Map.of("create", "true"))) {
+            for (var entry : copies) {
+                Path dstDir = zipfs.getPath(entry.getKey());
+                Path srcDir = entry.getValue();
+
+                Files.createDirectories(dstDir);
+
+                try (Stream<Path> stream = Files.walk(srcDir)) {
+                    stream.filter(Files::isRegularFile).forEach(srcFile -> {
+                        try {
+                            Path relativePath = srcDir.relativize(srcFile);
+                            Path dst = dstDir.resolve(relativePath.toString());
+                            Path dstParent = dst.getParent();
+                            if (dstParent != null)
+                                Files.createDirectories(dstParent);
+                            Files.copy(srcFile, dst);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    private static OutputAnalyzer checkResult(OutputAnalyzer result, boolean isAcceptable, String failureMessage) {
+        if (isAcceptable) {
+            result.shouldHaveExitValue(SUCCESS);
+        } else {
+            result.shouldNotHaveExitValue(SUCCESS)
+                    .shouldContain(failureMessage);
+        }
+
+        return result;
+    }
+
+    private OutputAnalyzer validateJar(String jarFile) throws Throwable {
+        return validateJar(jarFile, true, "");
+    }
+
+    private OutputAnalyzer validateJar(String jarFile, boolean shouldSucceed, String failureMessage) throws Throwable {
+        return checkResult(jar("--validate", "--file", jarFile), shouldSucceed, failureMessage);
     }
 }


### PR DESCRIPTION
This patch adds a `--validate` option to the jar tool which can be used to validate a jar file that might be malformed. For instance, if a jar is a multi-release jar, it is malformed if different versions expose different APIs.

The implementation is straight forward since there already exists validation logic that is run when creating or updating a jar. This patch just exposes that logic directly under a new command line flag.

I've enhanced the existing ApiValidatorTest to also create malformed jars using the zip file APIs (the jar tool does not output malformed jars) and run them through `jar --validate`.

Note that while the jdk's jar tool does not output malformed jars, third-party archiving tools might, or the jar could have been manually edited.

Some prior discussion here: https://mail.openjdk.java.net/pipermail/core-libs-dev/2021-May/077420.html

Testing: running jdk/tools/jar test suite locally, tier 1-3 (in progress), manual testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266835](https://bugs.openjdk.java.net/browse/JDK-8266835): Add a --validate option to the jar tool


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to c4cfe847797994be019eea6ac1d6d7cdc4c48dc4


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3971/head:pull/3971` \
`$ git checkout pull/3971`

Update a local copy of the PR: \
`$ git checkout pull/3971` \
`$ git pull https://git.openjdk.java.net/jdk pull/3971/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3971`

View PR using the GUI difftool: \
`$ git pr show -t 3971`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3971.diff">https://git.openjdk.java.net/jdk/pull/3971.diff</a>

</details>
