### PR TITLE
8266073: Regression ~2% in Derby after 8261804

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1580,7 +1580,7 @@ void G1ConcurrentMark::weak_refs_work(bool clear_all_soft_refs) {
 
     // Parallel processing task executor.
     G1CMRefProcTaskExecutor par_task_executor(_g1h, this,
-                                             _g1h->workers(), active_workers);
+                                              _g1h->workers(), active_workers);
     AbstractRefProcTaskExecutor* executor = (rp->processing_is_mt() ? &par_task_executor : NULL);
 
     ReferenceProcessorPhaseTimes pt(_gc_timer_cm, rp->max_num_queues());

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1565,14 +1565,8 @@ void G1ConcurrentMark::weak_refs_work(bool clear_all_soft_refs) {
     // is not multi-threaded we use the current (VMThread) thread,
     // otherwise we use the work gang from the G1CollectedHeap and
     // we utilize all the worker threads we can.
-    bool processing_is_mt = rp->processing_is_mt();
-    uint active_workers = (processing_is_mt ? _g1h->workers()->active_workers() : 1U);
+    uint active_workers = (ParallelRefProcEnabled ? _g1h->workers()->active_workers() : 1U);
     active_workers = clamp(active_workers, 1u, _max_num_tasks);
-
-    // Parallel processing task executor.
-    G1CMRefProcTaskExecutor par_task_executor(_g1h, this,
-                                              _g1h->workers(), active_workers);
-    AbstractRefProcTaskExecutor* executor = (processing_is_mt ? &par_task_executor : NULL);
 
     // Set the concurrency level. The phase was already set prior to
     // executing the remark task.
@@ -1583,6 +1577,11 @@ void G1ConcurrentMark::weak_refs_work(bool clear_all_soft_refs) {
     // the number of active workers.  This is OK as long as the discovered
     // Reference lists are balanced (see balance_all_queues() and balance_queues()).
     rp->set_active_mt_degree(active_workers);
+
+    // Parallel processing task executor.
+    G1CMRefProcTaskExecutor par_task_executor(_g1h, this,
+                                             _g1h->workers(), active_workers);
+    AbstractRefProcTaskExecutor* executor = (rp->processing_is_mt() ? &par_task_executor : NULL);
 
     ReferenceProcessorPhaseTimes pt(_gc_timer_cm, rp->max_num_queues());
 

--- a/src/hotspot/share/gc/g1/g1FullGCReferenceProcessorExecutor.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCReferenceProcessorExecutor.cpp
@@ -37,15 +37,11 @@ G1FullGCReferenceProcessingExecutor::G1FullGCReferenceProcessingExecutor(G1FullC
     _collector(collector),
     _reference_processor(collector->reference_processor()),
     _old_mt_degree(_reference_processor->num_queues()) {
-  if (_reference_processor->processing_is_mt()) {
-    _reference_processor->set_active_mt_degree(_collector->workers());
-  }
+  _reference_processor->set_active_mt_degree(_collector->workers());
 }
 
 G1FullGCReferenceProcessingExecutor::~G1FullGCReferenceProcessingExecutor() {
-  if (_reference_processor->processing_is_mt()) {
-    _reference_processor->set_active_mt_degree(_old_mt_degree);
-  }
+  _reference_processor->set_active_mt_degree(_old_mt_degree);
 }
 
 G1FullGCReferenceProcessingExecutor::G1RefProcTaskProxy::G1RefProcTaskProxy(ProcessTask& proc_task,

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -2125,9 +2125,8 @@ void PSParallelCompact::marking_phase(ParCompactionManager* cm,
     ReferenceProcessorStats stats;
     ReferenceProcessorPhaseTimes pt(&_gc_timer, ref_processor()->max_num_queues());
 
+    ref_processor()->set_active_mt_degree(active_gc_threads);
     if (ref_processor()->processing_is_mt()) {
-      ref_processor()->set_active_mt_degree(active_gc_threads);
-
       RefProcTaskExecutor task_executor;
       stats = ref_processor()->process_discovered_references(
         is_alive_closure(), &mark_and_push_closure, &follow_stack_closure,

--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -1373,7 +1373,7 @@ RefProcMTDegreeAdjuster::RefProcMTDegreeAdjuster(ReferenceProcessor* rp,
                                                  size_t ref_count):
     _rp(rp),
     _saved_num_queues(_rp->num_queues()) {
-  if (!_rp->processing_is_mt() || !_rp->adjust_no_of_processing_threads() || (ReferencesPerThread == 0)) {
+  if (!_rp->adjust_no_of_processing_threads() || (ReferencesPerThread == 0)) {
     return;
   }
 


### PR DESCRIPTION
My change in 8261804 made processing_is_mt() to always be false when _active_mt_degree is one. This is better because we then need not to execute on another thread. However, at a few places we do not change the _active_mt_degree if processing_is_mt() is false. We could then be stuck at 1 thread. I now change the code to always change the mt degree. 

Derby does no longer regress for g1, and tier 1 passes. I am running tier 1-3 at the moment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266073](https://bugs.openjdk.java.net/browse/JDK-8266073): Regression ~2% in Derby after 8261804


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Committer) ⚠️ Review applies to c8bf51f9323326e2155f8a10348afbabebae2cfd
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3972/head:pull/3972` \
`$ git checkout pull/3972`

Update a local copy of the PR: \
`$ git checkout pull/3972` \
`$ git pull https://git.openjdk.java.net/jdk pull/3972/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3972`

View PR using the GUI difftool: \
`$ git pr show -t 3972`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3972.diff">https://git.openjdk.java.net/jdk/pull/3972.diff</a>

</details>
