### PR TITLE
8266310: deadlock between System.loadLibrary and JNI FindClass loading another class

### DIFF
--- a/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
+++ b/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
@@ -475,13 +475,15 @@ public final class NativeLibraries {
         private int counter = 0;
 
         public void increment() {
-            if (++counter < 0) // overflow
+            if (counter == Integer.MAX_VALUE) {
+                // prevent overflow
                 throw new Error("Maximum lock count exceeded");
+            }
+            ++counter;
         }
 
         public void decrement() {
-            if (--counter < 0) // underflow
-                throw new Error("Lock count is below zero");
+            --counter;
         }
 
         public int getCounter() {
@@ -494,13 +496,13 @@ public final class NativeLibraries {
             new ConcurrentHashMap<>();
 
     private static void acquireNativeLibraryLock(String libraryName) {
-        nativeLibraryLockMap.compute(libraryName, (name, lock) -> {
-            if (lock == null) {
-                lock = new CountedLock();
+        nativeLibraryLockMap.compute(libraryName, (name, currentLock) -> {
+            if (currentLock == null) {
+                currentLock = new CountedLock();
             }
             // safe as compute lambda is executed atomically
-            lock.increment();
-            return lock;
+            currentLock.increment();
+            return currentLock;
         }).lock();
     }
 

--- a/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/Class1.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/Class1.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.File;
+
+/*
+ * Class1 loads a native library that calls ClassLoader.findClass in JNI_OnLoad.
+ * Class1 runs concurrently with another thread that opens a signed jar file.
+ */
+class Class1 {
+    static {
+        System.loadLibrary("loadLibraryDeadlock");
+        System.out.println("Signed jar loaded from native library.");
+    }
+}

--- a/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/LoadLibraryDeadlock.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/LoadLibraryDeadlock.java
@@ -32,7 +32,6 @@
  * called from Class1, then acquiring ZipFile during the search for a class
  * triggered from JNI.
  */
-import java.security.*;
 import java.lang.*;
 
 public class LoadLibraryDeadlock {

--- a/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/LoadLibraryDeadlock.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/LoadLibraryDeadlock.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * LoadLibraryDeadlock class triggers the deadlock between the two
+ * lock objects - ZipFile object and ClassLoader.loadedLibraryNames hashmap.
+ * Thread #2 loads a signed jar which leads to acquiring the lock objects in
+ * natural order (ZipFile then HashMap) - loading a signed jar may involve
+ * Providers initialization. Providers may load native libraries.
+ * Thread #1 acquires the locks in reverse order, first entering loadLibrary
+ * called from Class1, then acquiring ZipFile during the search for a class
+ * triggered from JNI.
+ */
+import java.security.*;
+import java.lang.*;
+
+public class LoadLibraryDeadlock {
+
+    public static void main(String[] args) {
+        Thread t1 = new Thread() {
+            public void run() {
+                try {
+                    // an instance of unsigned class that loads a native library
+                    Class c1 = Class.forName("Class1");
+                    Object o = c1.newInstance();
+                } catch (ClassNotFoundException |
+                         InstantiationException |
+                         IllegalAccessException ignore) {
+                    System.out.println("Class Class1 not found.");
+                }
+            }
+        };
+        Thread t2 = new Thread() {
+            public void run() {
+                try {
+                    // load a class from a signed jar, which locks the JarFile
+                    Class c2 = Class.forName("p.Class2");
+                    System.out.println("Signed jar loaded.");
+                } catch (ClassNotFoundException ignore) {
+                    System.out.println("Class Class2 not found.");
+                }
+            }
+        };
+        t2.start();
+        t1.start();
+        try {
+            t1.join();
+            t2.join();
+        } catch (InterruptedException ignore) {
+        }
+    }
+}

--- a/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/LoadLibraryDeadlock.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/LoadLibraryDeadlock.java
@@ -45,8 +45,9 @@ public class LoadLibraryDeadlock {
                     Object o = c1.newInstance();
                 } catch (ClassNotFoundException |
                          InstantiationException |
-                         IllegalAccessException ignore) {
+                         IllegalAccessException e) {
                     System.out.println("Class Class1 not found.");
+                    throw new RuntimeException(e);
                 }
             }
         };
@@ -56,8 +57,9 @@ public class LoadLibraryDeadlock {
                     // load a class from a signed jar, which locks the JarFile
                     Class c2 = Class.forName("p.Class2");
                     System.out.println("Signed jar loaded.");
-                } catch (ClassNotFoundException ignore) {
+                } catch (ClassNotFoundException e) {
                     System.out.println("Class Class2 not found.");
+                    throw new RuntimeException(e);
                 }
             }
         };

--- a/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/LoadLibraryDeadlock.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/LoadLibraryDeadlock.java
@@ -41,7 +41,7 @@ public class LoadLibraryDeadlock {
             public void run() {
                 try {
                     // an instance of unsigned class that loads a native library
-                    Class c1 = Class.forName("Class1");
+                    Class<?> c1 = Class.forName("Class1");
                     Object o = c1.newInstance();
                 } catch (ClassNotFoundException |
                          InstantiationException |
@@ -55,7 +55,7 @@ public class LoadLibraryDeadlock {
             public void run() {
                 try {
                     // load a class from a signed jar, which locks the JarFile
-                    Class c2 = Class.forName("p.Class2");
+                    Class<?> c2 = Class.forName("p.Class2");
                     System.out.println("Signed jar loaded.");
                 } catch (ClassNotFoundException e) {
                     System.out.println("Class Class2 not found.");

--- a/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/TestLoadLibraryDeadlock.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/TestLoadLibraryDeadlock.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8266310
+ * @summary deadlock while loading the JNI code
+ * @library /test/lib
+ * @build LoadLibraryDeadlock Class1 p.Class2
+ * @run main/othervm/native -Xcheck:jni TestLoadLibraryDeadlock
+ */
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.JDKToolFinder;
+import jdk.test.lib.process.*;
+
+import java.lang.ProcessBuilder;
+import java.lang.Process;
+import java.io.*;
+import java.util.*;
+import java.util.concurrent.*;
+import java.nio.charset.StandardCharsets;
+
+public class TestLoadLibraryDeadlock {
+
+    private static final String KEYSTORE = "keystore.jks";
+    private static final String STOREPASS = "changeit";
+    private static final String KEYPASS = "changeit";
+    private static final String ALIAS = "test";
+    private static final String DNAME = "CN=test";
+    private static final String VALIDITY = "366";
+
+    private static String testClassPath = System.getProperty("test.classes");
+    private static String testLibraryPath = System.getProperty("test.nativepath");
+    private static String classPathSeparator = System.getProperty("path.separator");
+
+    private static OutputAnalyzer runCommand(File workingDirectory, String... commands) throws Throwable {
+        ProcessBuilder pb = new ProcessBuilder(commands);
+        pb.directory(workingDirectory);
+        System.out.println("COMMAND: " + String.join(" ", commands));
+        return ProcessTools.executeProcess(pb);
+    }
+
+    private static OutputAnalyzer runCommandInTestClassPath(String... commands) throws Throwable {
+        return runCommand(new File(testClassPath), commands);
+    }
+
+    private static OutputAnalyzer genKey() throws Throwable {
+        runCommandInTestClassPath("rm", "-f", KEYSTORE);
+        String keytool = JDKToolFinder.getJDKTool("keytool");
+        return runCommandInTestClassPath(keytool,
+                "-storepass", STOREPASS,
+                "-keypass", KEYPASS,
+                "-keystore", KEYSTORE,
+                "-keyalg", "rsa", "-keysize", "2048",
+                "-genkeypair",
+                "-alias", ALIAS,
+                "-dname", DNAME,
+                "-validity", VALIDITY
+        );
+    }
+
+    private static OutputAnalyzer createJar(String outputJar, String... classes) throws Throwable {
+        String jar = JDKToolFinder.getJDKTool("jar");
+        List<String> commands = new ArrayList<String>();
+        Collections.addAll(commands, jar, "cvf", outputJar);
+        Collections.addAll(commands, classes);
+        return runCommandInTestClassPath(commands.toArray(new String[0]));
+    }
+
+    private static OutputAnalyzer signJar(String jarToSign) throws Throwable {
+        String jarsigner = JDKToolFinder.getJDKTool("jarsigner");
+        return runCommandInTestClassPath(jarsigner,
+                "-keystore", KEYSTORE,
+                "-storepass", STOREPASS,
+                jarToSign, ALIAS
+        );
+    }
+
+    private static Process runJavaCommand(String... command) throws Throwable {
+        String java = JDKToolFinder.getJDKTool("java");
+        List<String> commands = new ArrayList<String>();
+        Collections.addAll(commands, java);
+        Collections.addAll(commands, command);
+        System.out.println("COMMAND: " + String.join(" ", commands));
+        return new ProcessBuilder(commands.toArray(new String[0]))
+                .redirectErrorStream(true)
+                .directory(new File(testClassPath))
+                .start();
+    }
+
+    private static OutputAnalyzer jcmd(long pid, String command) throws Throwable {
+        String jcmd = JDKToolFinder.getJDKTool("jcmd");
+        return runCommandInTestClassPath(jcmd,
+                String.valueOf(pid),
+                command
+        );
+    }
+
+    private static String readAvailable(final InputStream is) throws Throwable {
+        final List<String> list = Collections.synchronizedList(new ArrayList<String>());
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        Future<String> future = executor.submit(new Callable<String>() {
+            public String call() {
+                String result = new String();
+                BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+                try {
+                    while(true) {
+                        String s = reader.readLine();
+                        if (s.length() > 0) {
+                            list.add(s);
+                            result += s + "\n";
+                        }
+                    }
+                } catch (IOException ignore) {}
+                return result;
+            }
+        });
+        try {
+            return future.get(1000, TimeUnit.MILLISECONDS);
+        } catch (Exception ignoreAll) {
+            future.cancel(true);
+            return String.join("\n", list);
+        }
+    }
+
+    public static void main(String[] args) throws Throwable {
+        genKey()
+                .shouldHaveExitValue(0);
+
+        runCommandInTestClassPath("rm", "-f", "*.jar")
+                .shouldHaveExitValue(0);
+
+        createJar("a.jar",
+                "LoadLibraryDeadlock.class",
+                "LoadLibraryDeadlock$1.class",
+                "LoadLibraryDeadlock$2.class")
+                .shouldHaveExitValue(0);
+
+        createJar("b.jar",
+                "Class1.class")
+                .shouldHaveExitValue(0);
+
+        createJar("c.jar",
+                "p/Class2.class")
+                .shouldHaveExitValue(0);
+
+        signJar("c.jar")
+                .shouldHaveExitValue(0);
+
+        // load trigger class
+        Process process = runJavaCommand("-cp",
+                "a.jar" + classPathSeparator +
+                "b.jar" + classPathSeparator +
+                "c.jar",
+                "-Djava.library.path=" + testLibraryPath,
+                "LoadLibraryDeadlock");
+
+        // wait for a while to grab some output
+        process.waitFor(5, TimeUnit.SECONDS);
+
+        // dump available output
+        String output = readAvailable(process.getInputStream());
+        OutputAnalyzer outputAnalyzer = new OutputAnalyzer(output);
+        outputAnalyzer
+                .asLines().stream()
+                .forEach(s -> System.out.println(s));
+
+        // if the process is still running, get the thread dump
+        OutputAnalyzer outputAnalyzerJcmd = jcmd(process.pid(), "Thread.print");
+        outputAnalyzerJcmd
+                .asLines().stream()
+                .forEach(s -> System.out.println(s));
+
+        Asserts.assertTrue(outputAnalyzerJcmd
+                .asLines().stream()
+                .filter(s -> s.contains("Java-level deadlock"))
+                .count() == 0,
+                "Found a deadlock.");
+
+        // if no deadlock, make sure all components have been loaded
+        Asserts.assertTrue(outputAnalyzer
+                .asLines().stream()
+                .filter(s -> s.contains("Class Class1 not found."))
+                .count() == 0,
+                "Unable to load class. Class1 not found.");
+
+        Asserts.assertTrue(outputAnalyzer
+                .asLines().stream()
+                .filter(s -> s.contains("Class Class2 not found."))
+                .count() == 0,
+                "Unable to load class. Class2 not found.");
+
+        Asserts.assertTrue(outputAnalyzer
+                .asLines().stream()
+                .filter(s -> s.contains("Native library loaded."))
+                .count() > 0,
+                "Unable to load native library.");
+
+        Asserts.assertTrue(outputAnalyzer
+                .asLines().stream()
+                .filter(s -> s.contains("Signed jar loaded."))
+                .count() > 0,
+                "Unable to load signed jar.");
+
+        Asserts.assertTrue(outputAnalyzer
+                .asLines().stream()
+                .filter(s -> s.contains("Signed jar loaded from native library."))
+                .count() > 0,
+                "Unable to load signed jar from native library.");
+
+        if (!process.waitFor(5, TimeUnit.SECONDS)) {
+            // if process is still frozen, fail the test even though
+            // the "deadlock" text hasn't been found
+            process.destroyForcibly();
+            Asserts.assertTrue(process.waitFor() == 0,
+                    "Process frozen.");
+        }
+    }
+}

--- a/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/libloadLibraryDeadlock.c
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/libloadLibraryDeadlock.c
@@ -26,8 +26,8 @@
 #include "jni.h"
 
 /*
- * JNI library that loads an arbitrary class from a (signed) jar.
- * This triggers the search in jars, and the lock in ZipFile is being acquired
+ * Native library that loads an arbitrary class from a (signed) jar.
+ * This triggers the search in jars, and the lock in ZipFile is acquired
  * as a result.
  */
 JNIEXPORT jint JNICALL

--- a/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/libloadLibraryDeadlock.c
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/libloadLibraryDeadlock.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <stdio.h>
+#include "jni.h"
+
+/*
+ * JNI library that loads an arbitrary class from a (signed) jar.
+ * This triggers the search in jars, and the lock in ZipFile is being acquired
+ * as a result.
+ */
+JNIEXPORT jint JNICALL
+JNI_OnLoad(JavaVM *vm, void *reserved)
+{
+    JNIEnv *env;
+    jclass cl;
+
+    printf("Native library loaded.\n");
+    fflush(stdout);
+
+    if ((*vm)->GetEnv(vm, (void**) &env, JNI_VERSION_1_2) != JNI_OK) {
+        return JNI_EVERSION; /* JNI version not supported */
+    }
+
+    // find any class which triggers the search in jars
+    cl = (*env)->FindClass(env, "p/Class2");
+
+    return JNI_VERSION_1_2;
+}

--- a/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/p/Class2.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/p/Class2.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * Class2 is loaded from Thread #2 that checks jar signature and from
+ * Thread #1 that loads a native library.
+ */
+package p;
+
+class Class2 {}

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
@@ -69,7 +69,7 @@ public class LoadLibraryUnload {
             }
         }
     }
-    
+
     private static class LoadLibraryFromClass implements Runnable {
         Object object;
         Method method;

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
@@ -126,7 +126,7 @@ public class LoadLibraryUnload {
             t.join();
         }
 
-        // expect all errors to be UnsatisfiedLinkError 
+        // expect all errors to be UnsatisfiedLinkError
         boolean allAreUnsatisfiedLinkError = exceptions
                 .stream()
                 .map(e -> e instanceof UnsatisfiedLinkError)

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * LoadLibraryUnload class calls ClassLoader.loadedLibrary from multiple threads
+ */
+/*
+ * @test
+ * @bug 8266310
+ * @summary deadlock while loading the JNI code
+ * @library /test/lib
+ * @build LoadLibraryUnload p.Class1
+ * @run main/othervm/native -Xcheck:jni LoadLibraryUnload
+ */
+import jdk.test.lib.Asserts;
+import java.lang.*;
+import java.lang.reflect.*;
+import java.lang.ref.WeakReference;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import p.Class1;
+
+public class LoadLibraryUnload {
+
+    private static class TestLoader extends URLClassLoader {
+        public TestLoader() throws Exception {
+            super(new URL[] { Path.of(System.getProperty("test.classes")).toUri().toURL() });
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            synchronized (getClassLoadingLock(name)) {
+                Class clazz = findLoadedClass(name);
+                if (clazz == null) {
+                    try {
+                        clazz = findClass(name);
+                    } catch (ClassNotFoundException ignore) {
+                    }
+                    if (clazz == null) {
+                        clazz = super.loadClass(name);
+                    }
+                }
+                return clazz;
+            }
+        }
+    }
+    
+    private static class LoadLibraryFromClass implements Runnable {
+        Object object;
+        Method method;
+
+        public LoadLibraryFromClass(Class<?> fromClass) {
+            try {
+                this.object = fromClass.newInstance();
+                this.method = fromClass.getDeclaredMethod("loadLibrary");
+            } catch (Exception error) {
+                throw new Error(error);
+            }
+        }
+
+        @Override
+        public void run() {
+            try {
+                method.invoke(object);
+            } catch (Exception error) {
+                throw new Error(error);
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        URLClassLoader loader = new TestLoader();
+        Class<?> class1 = loader.loadClass("p.Class1");
+        List<Thread> threads = new ArrayList<>();
+
+        for (int i = 0 ; i < 10 ; i++) {
+            threads.add(new Thread(new LoadLibraryFromClass(class1)));
+        }
+        threads.forEach( t -> {
+            t.start();
+        });
+
+        // wait for all threads to finish
+        for (Thread t : threads) {
+            t.join();
+        }
+        WeakReference<Class> wClass = new WeakReference<>(class1);
+
+        // release strong refs
+        class1 = null;
+        loader = null;
+        threads = null;
+        waitForUnload(wClass);
+        Asserts.assertTrue(wClass.get() == null, "Class1 hasn't been GC'ed");
+    }
+
+    private static void waitForUnload(WeakReference<Class> wClass)
+            throws InterruptedException {
+        for (int i = 0; i < 100 && wClass.get() != null; ++i) {
+            System.gc();
+            Thread.sleep(1);
+        }
+    }
+}

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
@@ -64,7 +64,7 @@ public class LoadLibraryUnload {
         @Override
         public Class<?> loadClass(String name) throws ClassNotFoundException {
             synchronized (getClassLoadingLock(name)) {
-                Class clazz = findLoadedClass(name);
+                Class<?> clazz = findLoadedClass(name);
                 if (clazz == null) {
                     try {
                         clazz = findClass(name);
@@ -146,7 +146,7 @@ public class LoadLibraryUnload {
         Asserts.assertTrue(allAreUnsatisfiedLinkError,
                 "All errors have to be UnsatisfiedLinkError");
 
-        WeakReference<Class> wClass = new WeakReference<>(clazz);
+        WeakReference<Class<?>> wClass = new WeakReference<>(clazz);
 
         // release strong refs
         clazz = null;

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnloadTest.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnloadTest.java
@@ -86,16 +86,16 @@ public class LoadLibraryUnloadTest {
         dump(outputAnalyzer);
 
         Asserts.assertTrue(
-                countLines(outputAnalyzer, "Native library loaded from Class1.") > 1,
-                "Unable to load Class1.");
+                countLines(outputAnalyzer, "Native library loaded from Class1.") == 2,
+                "Native library expected to be loaded in 2 threads.");
 
         long refCount = countLines(outputAnalyzer, "Native library loaded.");
 
-        Asserts.assertTrue(
-                refCount > 0,
-                "Failed to load native library.");
+        Asserts.assertTrue(refCount > 0, "Failed to load native library.");
 
         System.out.println("Native library loaded in " + refCount + " threads");
+
+        Asserts.assertTrue(refCount == 1, "Native library is loaded more than once.");
 
         Asserts.assertTrue(
                 countLines(outputAnalyzer, "Native library unloaded.") == refCount,

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnloadTest.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnloadTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * LoadLibraryUnloadTest ensures all objects (NativeLibrary) are deallocated
+ * when loaded in concurrent mode.
+ */
+/*
+ * @test
+ * @bug 8266310
+ * @summary deadlock while loading the JNI code
+ * @library /test/lib
+ * @build LoadLibraryUnload p.Class1
+ * @run main/othervm/native -Xcheck:jni LoadLibraryUnloadTest
+ */
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.JDKToolFinder;
+import jdk.test.lib.process.*;
+
+import java.lang.ProcessBuilder;
+import java.lang.Process;
+import java.io.File;
+import java.util.*;
+
+public class LoadLibraryUnloadTest {
+
+    private static String testClassPath = System.getProperty("test.classes");
+    private static String testLibraryPath = System.getProperty("test.nativepath");
+    private static String classPathSeparator = System.getProperty("path.separator");
+
+    private static Process runJavaCommand(String... command) throws Throwable {
+        String java = JDKToolFinder.getJDKTool("java");
+        List<String> commands = new ArrayList<>();
+        Collections.addAll(commands, java);
+        Collections.addAll(commands, command);
+        System.out.println("COMMAND: " + String.join(" ", commands));
+        return new ProcessBuilder(commands.toArray(new String[0]))
+                .redirectErrorStream(true)
+                .directory(new File(testClassPath))
+                .start();
+    }
+
+    private final static long countLines(OutputAnalyzer output, String string) {
+        return output.asLines()
+                     .stream()
+                     .filter(s -> s.contains(string))
+                     .count();
+    }
+
+    private final static void dump(OutputAnalyzer output) {
+        output.asLines()
+              .stream()
+              .forEach(s -> System.out.println(s));
+    }
+
+    public static void main(String[] args) throws Throwable {
+
+        Process process = runJavaCommand(
+                "-Dtest.classes=" + testClassPath,
+                "-Djava.library.path=" + testLibraryPath,
+                "LoadLibraryUnload");
+
+        OutputAnalyzer outputAnalyzer = new OutputAnalyzer(process);
+        dump(outputAnalyzer);
+
+        Asserts.assertTrue(
+                countLines(outputAnalyzer, "Native library loaded from Class1.") > 1,
+                "Unable to load Class1.");
+
+        long refCount = countLines(outputAnalyzer, "Native library loaded.");
+
+        Asserts.assertTrue(
+                refCount > 0,
+                "Failed to load native library.");
+
+        System.out.println("Native library loaded in " + refCount + " threads");
+
+        Asserts.assertTrue(
+                countLines(outputAnalyzer, "Native library unloaded.") == refCount,
+                "Failed to unload native library");
+    }
+}

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnloadTest.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnloadTest.java
@@ -29,7 +29,9 @@
 /*
  * @test
  * @bug 8266310
- * @summary deadlock while loading the JNI code
+ * @summary Checks that JNI_OnLoad is invoked only once when multiple threads
+ *          call System.loadLibrary concurrently, and JNI_OnUnload is invoked
+ *          when the native library is loaded from a custom class loader.
  * @library /test/lib
  * @build LoadLibraryUnload p.Class1
  * @run main/othervm/native -Xcheck:jni LoadLibraryUnloadTest

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/libloadLibraryUnload.c
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/libloadLibraryUnload.c
@@ -22,13 +22,28 @@
  * questions.
  */
 
-/*
- * Class1 loads a native library that calls ClassLoader.findClass in JNI_OnLoad.
- * Class1 runs concurrently with another thread that opens a signed jar file.
- */
-class Class1 {
-    static {
-        System.loadLibrary("loadLibraryDeadlock");
-        System.out.println("Signed jar loaded from native library.");
+#include <stdio.h>
+#include "jni.h"
+
+JNIEXPORT jint JNICALL
+JNI_OnLoad(JavaVM *vm, void *reserved)
+{
+    JNIEnv *env;
+
+    printf("Native library loaded.\n");
+    fflush(stdout);
+
+    if ((*vm)->GetEnv(vm, (void**) &env, JNI_VERSION_1_2) != JNI_OK) {
+        return JNI_EVERSION; /* JNI version not supported */
     }
+
+    return JNI_VERSION_1_2;
 }
+
+JNIEXPORT void JNICALL
+JNI_OnUnload(JavaVM *vm, void *reserved) {
+
+    printf("Native library unloaded.\n");
+    fflush(stdout);
+}
+

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/p/Class1.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/p/Class1.java
@@ -23,12 +23,21 @@
  */
 
 /*
- * Class1 loads a native library that calls ClassLoader.findClass in JNI_OnLoad.
- * Class1 runs concurrently with another thread that opens a signed jar file.
+ * Class1 loads a native library.
  */
-class Class1 {
-    static {
-        System.loadLibrary("loadLibraryDeadlock");
-        System.out.println("Signed jar loaded from native library.");
+package p;
+
+public class Class1 {
+
+    public Class1() {
+    }
+
+    // method called from java threads
+    public void loadLibrary() throws Exception {
+        try {
+            System.loadLibrary("loadLibraryUnload");
+            System.out.println("Native library loaded from Class1.");
+        } catch (Exception ignore) {
+        }
     }
 }

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/p/Class1.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/p/Class1.java
@@ -34,10 +34,7 @@ public class Class1 {
 
     // method called from java threads
     public void loadLibrary() throws Exception {
-        try {
-            System.loadLibrary("loadLibraryUnload");
-            System.out.println("Native library loaded from Class1.");
-        } catch (Exception ignore) {
-        }
+        System.loadLibrary("loadLibraryUnload");
+        System.out.println("Native library loaded from Class1.");
     }
 }


### PR DESCRIPTION
Please review this PR which fixes the deadlock in ClassLoader between the two lock objects - a lock object associated with the class being loaded, and the ClassLoader.loadedLibraryNames hash map, locked during the native library load operation.

Problem being fixed:

The initial reproducer demonstrated a deadlock between the JarFile/ZipFile and the hash map. That deadlock exists even when the ZipFile/JarFile lock is removed because there's another lock object in the class loader, associated with the name of the class being loaded. Such objects are stored in ClassLoader.parallelLockMap. The deadlock occurs when JNI_OnLoad() loads exactly the same class, whose signature is being verified in another thread.

Proposed fix:

The proposed patch suggests to get rid of locking loadedLibraryNames hash map and synchronize on each entry name, as it's done with class names in see ClassLoader.getClassLoadingLock(name) method.

The patch introduces nativeLibraryLockMap which holds the lock objects for each library name, and the getNativeLibraryLock() private method is used to lazily initialize the corresponding lock object. nativeLibraryContext was changed to ThreadLocal, so that in any concurrent thread it would have a NativeLibrary object on top of the stack, that's being currently loaded/unloaded in that thread. nativeLibraryLockMap accumulates the names of all native libraries loaded - in line with class loading code, it is not explicitly cleared.

Testing:  jtreg and jck testing with no regressions. A new regression test was developed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266310](https://bugs.openjdk.java.net/browse/JDK-8266310): deadlock between System.loadLibrary and JNI FindClass loading another class


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 85005d57246f3449d67228c8bf06689704e4721d
 * [Peter Levart](https://openjdk.java.net/census#plevart) (@plevart - **Reviewer**) ⚠️ Review applies to 85005d57246f3449d67228c8bf06689704e4721d
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**) ⚠️ Review applies to 85005d57246f3449d67228c8bf06689704e4721d
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3976/head:pull/3976` \
`$ git checkout pull/3976`

Update a local copy of the PR: \
`$ git checkout pull/3976` \
`$ git pull https://git.openjdk.java.net/jdk pull/3976/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3976`

View PR using the GUI difftool: \
`$ git pr show -t 3976`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3976.diff">https://git.openjdk.java.net/jdk/pull/3976.diff</a>

</details>
