### PR TITLE
JDK-8266281: Assign Symbols to the package selector expression

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Enter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Enter.java
@@ -326,6 +326,7 @@ public class Enter extends JCTree.Visitor {
             JCPackageDecl pd = tree.getPackage();
             if (pd != null) {
                 tree.packge = pd.packge = syms.enterPackage(tree.modle, TreeInfo.fullName(pd.pid));
+                setPackageSymbols.scan(pd);
                 if (   pd.annotations.nonEmpty()
                     || pkginfoOpt == PkgInfo.ALWAYS
                     || tree.docComments != null) {
@@ -389,6 +390,31 @@ public class Enter extends JCTree.Visitor {
         log.useSource(prev);
         result = null;
     }
+        //where:
+        //set package Symbols to the package expression:
+        private final TreeScanner setPackageSymbols = new TreeScanner() {
+            Symbol currentPackage;
+
+            @Override
+            public void visitIdent(JCIdent tree) {
+                tree.sym = currentPackage;
+                tree.type = currentPackage.type;
+            }
+
+            @Override
+            public void visitSelect(JCFieldAccess tree) {
+                tree.sym = currentPackage;
+                tree.type = currentPackage.type;
+                currentPackage = currentPackage.owner;
+                super.visitSelect(tree);
+            }
+
+            @Override
+            public void visitPackageDef(JCPackageDecl tree) {
+                currentPackage = tree.packge;
+                scan(tree.pid);
+            }
+        };
 
     @Override
     public void visitClassDef(JCClassDecl tree) {

--- a/test/langtools/tools/javac/api/TestGetElementReference.java
+++ b/test/langtools/tools/javac/api/TestGetElementReference.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8012929 8243074
+ * @bug 8012929 8243074 8266281
  * @summary Trees.getElement should work not only for declaration trees, but also for use-trees
  * @modules jdk.compiler
  * @build TestGetElementReference

--- a/test/langtools/tools/javac/api/TestGetElementReferenceData.java
+++ b/test/langtools/tools/javac/api/TestGetElementReferenceData.java
@@ -21,10 +21,10 @@
  * questions.
  */
 
-package test;
-/*getElement:PACKAGE:test*/
+package test/*getElement:PACKAGE:test*/.nested/*getElement:PACKAGE:test.nested*/;
+/*getElement:PACKAGE:test.nested*/
 import java.lang.annotation.*;
-import static test.TestGetElementReferenceData.Sub.*;
+import static test.nested.TestGetElementReferenceData.Sub.*;
 
 public class TestGetElementReferenceData {
 
@@ -33,8 +33,8 @@ public class TestGetElementReferenceData {
         sb/*getElement:LOCAL_VARIABLE:sb*/.append/*getElement:METHOD:java.lang.StringBuilder.append(int)*/(0);
         sb.reverse( /*getElement:METHOD:java.lang.StringBuilder.reverse()*/);
         java.util.List< /*getElement:INTERFACE:java.util.List*/ String> l;
-        utility/*getElement:METHOD:test.TestGetElementReferenceData.Base.utility()*/();
-        target(TestGetElementReferenceData :: test/*getElement:METHOD:test.TestGetElementReferenceData.test()*/);
+        utility/*getElement:METHOD:test.nested.TestGetElementReferenceData.Base.utility()*/();
+        target(TestGetElementReferenceData :: test/*getElement:METHOD:test.nested.TestGetElementReferenceData.test()*/);
         Object/*getElement:CLASS:java.lang.Object*/ o = null;
         if (o/*getElement:LOCAL_VARIABLE:o*/ instanceof String/*getElement:CLASS:java.lang.String*/ str/*getElement:BINDING_VARIABLE:str*/) ;
     }
@@ -42,7 +42,7 @@ public class TestGetElementReferenceData {
     public static class Base {
         public static void utility() {}
     }
-    public static class Sub extends @TypeAnnotation( /*getElement:ANNOTATION_TYPE:test.TestGetElementReferenceData.TypeAnnotation*/) Base {
+    public static class Sub extends @TypeAnnotation( /*getElement:ANNOTATION_TYPE:test.nested.TestGetElementReferenceData.TypeAnnotation*/) Base {
     }
    @Deprecated( /*getElement:ANNOTATION_TYPE:java.lang.Deprecated*/)
     public static class TypeParam<TT/*getElement:TYPE_PARAMETER:TT*/> {

--- a/test/langtools/tools/javac/api/lambdaErrorRecovery/TestGetTypeMirrorReference.java
+++ b/test/langtools/tools/javac/api/lambdaErrorRecovery/TestGetTypeMirrorReference.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8240658
+ * @bug 8240658 8266281
  * @summary Verify that broken method invocations with lambdas get type inference done
  * @modules jdk.compiler
  * @compile --enable-preview -source ${jdk.version} TestGetTypeMirrorReference.java

--- a/test/langtools/tools/javac/api/lambdaErrorRecovery/TestGetTypeMirrorReferenceData.java
+++ b/test/langtools/tools/javac/api/lambdaErrorRecovery/TestGetTypeMirrorReferenceData.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-package test;
+package test/*getTypeMirror:PACKAGE:test*/;
 
 public class TestGetTypeMirrorReferenceData {
 


### PR DESCRIPTION
The proposal in this patch is that package names in the package clause would be attributed with the appropriate PackageSymbols. So when using Trees.getElement on an AST node of some part of the package name, a sensible PackageSymbol would be returned.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266281](https://bugs.openjdk.java.net/browse/JDK-8266281): Assign Symbols to the package selector expression


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3977/head:pull/3977` \
`$ git checkout pull/3977`

Update a local copy of the PR: \
`$ git checkout pull/3977` \
`$ git pull https://git.openjdk.java.net/jdk pull/3977/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3977`

View PR using the GUI difftool: \
`$ git pr show -t 3977`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3977.diff">https://git.openjdk.java.net/jdk/pull/3977.diff</a>

</details>
