### PR TITLE
JDK-8266918: merge_stack in check_code.c add NULL check

### DIFF
--- a/src/java.base/share/native/libverify/check_code.c
+++ b/src/java.base/share/native/libverify/check_code.c
@@ -3244,7 +3244,7 @@ merge_stack(context_type *context, unsigned int from_inumber,
         jboolean change = JNI_FALSE;
         for (old = stack, new = new_stack; old != NULL;
                    old = old->next, new = new->next) {
-            if (!isAssignableTo(context, new->item, old->item)) {
+            if (new != NULL && !isAssignableTo(context, new->item, old->item)) {
                 change = JNI_TRUE;
                 break;
             }

--- a/src/java.base/share/native/libverify/check_code.c
+++ b/src/java.base/share/native/libverify/check_code.c
@@ -3244,7 +3244,8 @@ merge_stack(context_type *context, unsigned int from_inumber,
         jboolean change = JNI_FALSE;
         for (old = stack, new = new_stack; old != NULL;
                    old = old->next, new = new->next) {
-            if (new != NULL && !isAssignableTo(context, new->item, old->item)) {
+            assert(new != NULL);
+            if (!isAssignableTo(context, new->item, old->item)) {
                 change = JNI_TRUE;
                 break;
             }


### PR DESCRIPTION
Hello, please review this small Sonar finding.
Sonar reports a potential NULL pointer dereference here :
https://sonarcloud.io/project/issues?id=shipilev_jdk&languages=c&open=AXck8CPLBBG2CXpcnh_z&resolved=false&severities=MAJOR&types=BUG
"Access to field 'item' results in a dereference of a null pointer (loaded from variable 'new')"
It would be better to add a check .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266918](https://bugs.openjdk.java.net/browse/JDK-8266918): merge_stack in check_code.c add NULL check


### Reviewers
 * [Ralf Schmelter](https://openjdk.java.net/census#rschmelter) (@schmelter-sap - Committer)
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3979/head:pull/3979` \
`$ git checkout pull/3979`

Update a local copy of the PR: \
`$ git checkout pull/3979` \
`$ git pull https://git.openjdk.java.net/jdk pull/3979/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3979`

View PR using the GUI difftool: \
`$ git pr show -t 3979`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3979.diff">https://git.openjdk.java.net/jdk/pull/3979.diff</a>

</details>
