### PR TITLE
8266923: [JVMCI] expose StackOverflow::_stack_overflow_limit to JVMCI

### DIFF
--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -173,6 +173,7 @@
   nonstatic_field(JavaThread,                  _threadObj,                                    OopHandle)                             \
   nonstatic_field(JavaThread,                  _anchor,                                       JavaFrameAnchor)                       \
   nonstatic_field(JavaThread,                  _vm_result,                                    oop)                                   \
+  nonstatic_field(JavaThread,                  _stack_overflow_state._stack_overflow_limit,   address)                               \
   volatile_nonstatic_field(JavaThread,         _exception_oop,                                oop)                                   \
   volatile_nonstatic_field(JavaThread,         _exception_pc,                                 address)                               \
   volatile_nonstatic_field(JavaThread,         _is_method_handle_return,                      int)                                   \


### PR DESCRIPTION
This PR exposes the `StackOverflow::_stack_overflow_limit` field to JVMCI Java code for use in Graal.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266923](https://bugs.openjdk.java.net/browse/JDK-8266923): [JVMCI] expose StackOverflow::_stack_overflow_limit to JVMCI


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3982/head:pull/3982` \
`$ git checkout pull/3982`

Update a local copy of the PR: \
`$ git checkout pull/3982` \
`$ git pull https://git.openjdk.java.net/jdk pull/3982/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3982`

View PR using the GUI difftool: \
`$ git pr show -t 3982`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3982.diff">https://git.openjdk.java.net/jdk/pull/3982.diff</a>

</details>
