### PR TITLE
8266822: Rename MetaspaceShared::is_old_class to has_old_class_version

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -389,7 +389,7 @@ static void rewrite_nofast_bytecode(const methodHandle& method) {
 void MetaspaceShared::rewrite_nofast_bytecodes_and_calculate_fingerprints(Thread* thread, InstanceKlass* ik) {
   for (int i = 0; i < ik->methods()->length(); i++) {
     methodHandle m(thread, ik->methods()->at(i));
-    if (!is_old_class(ik)) {
+    if (!has_old_class_version(ik)) {
       rewrite_nofast_bytecode(m);
     }
     Fingerprinter fp(m);
@@ -574,21 +574,25 @@ public:
   ClassLoaderData* cld_at(int index) { return _loaded_cld.at(index); }
 };
 
-// Check if a class or its super class/interface is old.
-bool MetaspaceShared::is_old_class(InstanceKlass* ik) {
+// Check if a class or its super class/interface has a version older than 50.
+// CDS will not perform verification of old classes during dump time because
+// without changing the old verifier, the verification constraint cannot be
+// retrieved during dump time.
+// Verification of archived old classes will be performed during run time.
+bool MetaspaceShared::has_old_class_version(InstanceKlass* ik) {
   if (ik == NULL) {
     return false;
   }
   if (ik->major_version() < 50 /*JAVA_6_VERSION*/) {
     return true;
   }
-  if (is_old_class(ik->java_super())) {
+  if (has_old_class_version(ik->java_super())) {
     return true;
   }
   Array<InstanceKlass*>* interfaces = ik->local_interfaces();
   int len = interfaces->length();
   for (int i = 0; i < len; i++) {
-    if (is_old_class(interfaces->at(i))) {
+    if (has_old_class_version(interfaces->at(i))) {
       return true;
     }
   }
@@ -598,7 +602,7 @@ bool MetaspaceShared::is_old_class(InstanceKlass* ik) {
 bool MetaspaceShared::linking_required(InstanceKlass* ik) {
   // For static CDS dump, do not link old classes.
   // For dynamic CDS dump, only link classes loaded by the builtin class loaders.
-  return DumpSharedSpaces ? !MetaspaceShared::is_old_class(ik) : !ik->is_shared_unregistered_class();
+  return DumpSharedSpaces ? !MetaspaceShared::has_old_class_version(ik) : !ik->is_shared_unregistered_class();
 }
 
 bool MetaspaceShared::link_class_for_cds(InstanceKlass* ik, TRAPS) {
@@ -778,7 +782,7 @@ bool MetaspaceShared::try_link_class(Thread* current, InstanceKlass* ik) {
   ExceptionMark em(current);
   Thread* THREAD = current; // For exception macros.
   Arguments::assert_is_dumping_archive();
-  if (ik->is_loaded() && !ik->is_linked() && !MetaspaceShared::is_old_class(ik) &&
+  if (ik->is_loaded() && !ik->is_linked() && !MetaspaceShared::has_old_class_version(ik) &&
       !SystemDictionaryShared::has_class_failed_verification(ik)) {
     bool saved = BytecodeVerificationLocal;
     if (ik->is_shared_unregistered_class() && ik->class_loader() == NULL) {

--- a/src/hotspot/share/cds/metaspaceShared.hpp
+++ b/src/hotspot/share/cds/metaspaceShared.hpp
@@ -137,7 +137,7 @@ public:
   static void link_and_cleanup_shared_classes(TRAPS) NOT_CDS_RETURN;
   static bool link_class_for_cds(InstanceKlass* ik, TRAPS) NOT_CDS_RETURN_(false);
   static bool linking_required(InstanceKlass* ik) NOT_CDS_RETURN_(false);
-  static bool is_old_class(InstanceKlass* ik) NOT_CDS_RETURN_(false);
+  static bool has_old_class_version(InstanceKlass* ik) NOT_CDS_RETURN_(false);
 
 #if INCLUDE_CDS
   // Alignment for the 2 core CDS regions (RW/RO) only.

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -1382,7 +1382,7 @@ bool SystemDictionaryShared::should_be_excluded(InstanceKlass* k) {
       warn_excluded(k, "Failed verification");
       return true;
     } else {
-      if (!MetaspaceShared::is_old_class(k)) {
+      if (!MetaspaceShared::has_old_class_version(k)) {
         warn_excluded(k, "Not linked");
         return true;
       }
@@ -1397,7 +1397,7 @@ bool SystemDictionaryShared::should_be_excluded(InstanceKlass* k) {
     return true;
   }
 
-  if (MetaspaceShared::is_old_class(k) && k->is_linked()) {
+  if (MetaspaceShared::has_old_class_version(k) && k->is_linked()) {
     warn_excluded(k, "Old class has been linked");
     return true;
   }

--- a/src/hotspot/share/interpreter/rewriter.cpp
+++ b/src/hotspot/share/interpreter/rewriter.cpp
@@ -571,7 +571,7 @@ void Rewriter::rewrite(InstanceKlass* klass, TRAPS) {
 #if INCLUDE_CDS
   if (klass->is_shared()) {
     assert(!klass->is_rewritten(), "rewritten shared classes cannot be rewritten again");
-    assert(MetaspaceShared::is_old_class(klass), "only shared old classes aren't rewritten");
+    assert(MetaspaceShared::has_old_class_version(klass), "only shared old classes aren't rewritten");
   }
 #endif // INCLUDE_CDS
   ResourceMark rm(THREAD);

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2429,7 +2429,7 @@ void InstanceKlass::metaspace_pointers_do(MetaspaceClosure* it) {
 
 void InstanceKlass::remove_unshareable_info() {
 
-  if (MetaspaceShared::is_old_class(this)) {
+  if (MetaspaceShared::has_old_class_version(this)) {
     // Set the old class bit.
     set_is_shared_old_klass();
   }

--- a/src/hotspot/share/oops/klassVtable.cpp
+++ b/src/hotspot/share/oops/klassVtable.cpp
@@ -1094,8 +1094,8 @@ void itableMethodEntry::initialize(InstanceKlass* klass, Method* m) {
 #ifdef ASSERT
   if (MetaspaceShared::is_in_shared_metaspace((void*)&_method) &&
      !MetaspaceShared::remapped_readwrite() &&
-     !MetaspaceShared::is_old_class(m->method_holder()) &&
-     !MetaspaceShared::is_old_class(klass)) {
+     !MetaspaceShared::has_old_class_version(m->method_holder()) &&
+     !MetaspaceShared::has_old_class_version(klass)) {
     // At runtime initialize_itable is rerun as part of link_class_impl()
     // for a shared class loaded by the non-boot loader.
     // The dumptime itable method entry should be the same as the runtime entry.


### PR DESCRIPTION
Please review this simple patch for renaming the function from `MetaspaceShared::is_old_class` to `MetaspaceShared::has_old_class_version`. Also added some comment to the function.

Tests:
- [x] tier1, 2