### PR TITLE
8266783: java\lang\reflect\Proxy\DefaultMethods.java fails with jtreg 6

### DIFF
--- a/test/jdk/java/lang/reflect/Proxy/DefaultMethods.java
+++ b/test/jdk/java/lang/reflect/Proxy/DefaultMethods.java
@@ -333,17 +333,17 @@ public class DefaultMethods {
     @DataProvider(name = "illegalArguments")
     private Object[][] illegalArguments() {
         return new Object[][] {
-            new Object[] {},
-            new Object[] { 100 },
-            new Object[] { 100, "foo", 100 },
-            new Object[] { 100L, "foo" },
-            new Object[] { "foo", 100},
-            new Object[] { null, "foo" }
+            new Object[] { new Object[0]},
+            new Object[] { new Object[] { 100 }},
+            new Object[] { new Object[] { 100, "foo", 100 }},
+            new Object[] { new Object[] { 100L, "foo" }},
+            new Object[] { new Object[] { "foo", 100 }},
+            new Object[] { new Object[] { null, "foo" }}
         };
     }
 
     @Test(dataProvider = "illegalArguments", expectedExceptions = {IllegalArgumentException.class})
-    public void testIllegalArgument(Object... args) throws Throwable {
+    public void testIllegalArgument(Object[] args) throws Throwable {
         ClassLoader loader = DefaultMethods.class.getClassLoader();
         I4 proxy = (I4)Proxy.newProxyInstance(loader, new Class<?>[]{I4.class}, HANDLER);
         Method m = I4.class.getMethod("mix", int.class, String.class);


### PR DESCRIPTION
Data provider with varargs does not work on TestNG 7.4.0.   Fix the test to create an object array instead of varargs to workaround this issue.