### PR TITLE
8266904: Use function pointer typedefs in OopOopIterateDispatch

### DIFF
--- a/src/hotspot/share/memory/iterator.inline.hpp
+++ b/src/hotspot/share/memory/iterator.inline.hpp
@@ -206,6 +206,8 @@ void Devirtualizer::do_cld(OopClosureType* closure, ClassLoaderData* cld) {
 template <typename OopClosureType>
 class OopOopIterateDispatch : public AllStatic {
 private:
+  typedef void (*FunctionType)(OopClosureType*, oop, Klass*);
+
   class Table {
   private:
     template <typename KlassType, typename T>
@@ -242,7 +244,7 @@ private:
     }
 
   public:
-    void (*_function[KLASS_ID_COUNT])(OopClosureType*, oop, Klass*);
+    FunctionType _function[KLASS_ID_COUNT];
 
     Table(){
       set_init_function<InstanceKlass>();
@@ -257,7 +259,7 @@ private:
   static Table _table;
 public:
 
-  static void (*function(Klass* klass))(OopClosureType*, oop, Klass*) {
+  static FunctionType function(Klass* klass) {
     return _table._function[klass->id()];
   }
 };
@@ -269,6 +271,8 @@ typename OopOopIterateDispatch<OopClosureType>::Table OopOopIterateDispatch<OopC
 template <typename OopClosureType>
 class OopOopIterateBoundedDispatch {
 private:
+  typedef void (*FunctionType)(OopClosureType*, oop, Klass*, MemRegion);
+
   class Table {
   private:
     template <typename KlassType, typename T>
@@ -302,7 +306,7 @@ private:
     }
 
   public:
-    void (*_function[KLASS_ID_COUNT])(OopClosureType*, oop, Klass*, MemRegion);
+    FunctionType _function[KLASS_ID_COUNT];
 
     Table(){
       set_init_function<InstanceKlass>();
@@ -317,7 +321,7 @@ private:
   static Table _table;
 public:
 
-  static void (*function(Klass* klass))(OopClosureType*, oop, Klass*, MemRegion) {
+  static FunctionType function(Klass* klass) {
     return _table._function[klass->id()];
   }
 };
@@ -329,6 +333,8 @@ typename OopOopIterateBoundedDispatch<OopClosureType>::Table OopOopIterateBounde
 template <typename OopClosureType>
 class OopOopIterateBackwardsDispatch {
 private:
+  typedef void (*FunctionType)(OopClosureType*, oop, Klass*);
+
   class Table {
   private:
     template <typename KlassType, typename T>
@@ -362,7 +368,7 @@ private:
     }
 
   public:
-    void (*_function[KLASS_ID_COUNT])(OopClosureType*, oop, Klass*);
+    FunctionType _function[KLASS_ID_COUNT];
 
     Table(){
       set_init_function<InstanceKlass>();
@@ -377,7 +383,7 @@ private:
   static Table _table;
 public:
 
-  static void (*function(Klass* klass))(OopClosureType*, oop, Klass*) {
+  static FunctionType function(Klass* klass) {
     return _table._function[klass->id()];
   }
 };


### PR DESCRIPTION
The way our OopIterateClosures are devirtualized is quite complex. I think we can lower the complexity a tiny bit by using a function pointer typedef.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266904](https://bugs.openjdk.java.net/browse/JDK-8266904): Use function pointer typedefs in OopOopIterateDispatch


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3986/head:pull/3986` \
`$ git checkout pull/3986`

Update a local copy of the PR: \
`$ git checkout pull/3986` \
`$ git pull https://git.openjdk.java.net/jdk pull/3986/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3986`

View PR using the GUI difftool: \
`$ git pr show -t 3986`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3986.diff">https://git.openjdk.java.net/jdk/pull/3986.diff</a>

</details>
