### PR TITLE
8266932: Make "title" attribute global

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/HtmlTag.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/HtmlTag.java
@@ -448,10 +448,10 @@ public enum HtmlTag {
         ARIA_MULTISELECTABLE,
         ARIA_OWNS,
         ARIA_POSINSET,
-        ARIA_SETSIZE,
         ARIA_READONLY,
         ARIA_REQUIRED,
         ARIA_SELECTED,
+        ARIA_SETSIZE,
         ARIA_SORT,
         AXIS,
         BACKGROUND,
@@ -504,6 +504,7 @@ public enum HtmlTag {
         SUMMARY,
         TARGET,
         TEXT,
+        TITLE,
         TYPE,
         VALIGN,
         VALUE,
@@ -577,6 +578,7 @@ public enum HtmlTag {
         attrs.put(Attr.ID, AttrKind.OK);
         attrs.put(Attr.STYLE, AttrKind.OK);
         attrs.put(Attr.ROLE, AttrKind.OK);
+        attrs.put(Attr.TITLE, AttrKind.OK);
         // for now, assume that all ARIA attributes are allowed on all tags.
         attrs.put(Attr.ARIA_ACTIVEDESCENDANT, AttrKind.OK);
         attrs.put(Attr.ARIA_CONTROLS, AttrKind.OK);


### PR DESCRIPTION
This adds `title` as an allowed attribute for all current and future HTML elements modelled by HtmlTag (as per https://html.spec.whatwg.org/multipage/dom.html#global-attributes). Currently, the `title` attribute (not to be confused with the `<title>` element) is not specified as a possible attribute for any of the HTML elements modelled by `HtmlTag`.

This came up when I was teasing out bugs in HTML attribute parsing by doclint. It came as a surprise that `<abbr title="foo">bar</abbr>` yielded `error: unknown attribute: title`.

The change is tiny and, hopefully, future-proof.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8266932](https://bugs.openjdk.java.net/browse/JDK-8266932): Make "title" attribute global


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3987/head:pull/3987` \
`$ git checkout pull/3987`

Update a local copy of the PR: \
`$ git checkout pull/3987` \
`$ git pull https://git.openjdk.java.net/jdk pull/3987/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3987`

View PR using the GUI difftool: \
`$ git pr show -t 3987`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3987.diff">https://git.openjdk.java.net/jdk/pull/3987.diff</a>

</details>
