### PR TITLE
8266937: Remove Compile::reshape_address

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -2753,10 +2753,6 @@ bool Matcher::pd_clone_address_expressions(AddPNode* m, Matcher::MStack& mstack,
   return false;
 }
 
-void Compile::reshape_address(AddPNode* addp) {
-}
-
-
 #define MOV_VOLATILE(REG, BASE, INDEX, SCALE, DISP, SCRATCH, INSN)      \
   C2_MacroAssembler _masm(&cbuf);                                       \
   {                                                                     \

--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -1123,9 +1123,6 @@ bool Matcher::pd_clone_address_expressions(AddPNode* m, Matcher::MStack& mstack,
   return clone_base_plus_offset_address(m, mstack, address_visited);
 }
 
-void Compile::reshape_address(AddPNode* addp) {
-}
-
 bool Matcher::narrow_oop_use_complex_address() {
   NOT_LP64(ShouldNotCallThis());
   assert(UseCompressedOops, "only for compressed oops code");

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -1005,9 +1005,6 @@ bool Matcher::pd_clone_address_expressions(AddPNode* m, Matcher::MStack& mstack,
   return clone_base_plus_offset_address(m, mstack, address_visited);
 }
 
-void Compile::reshape_address(AddPNode* addp) {
-}
-
 // Optimize load-acquire.
 //
 // Check if acquire is unnecessary due to following operation that does

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -1799,9 +1799,6 @@ bool Matcher::pd_clone_address_expressions(AddPNode* m, Matcher::MStack& mstack,
   return clone_base_plus_offset_address(m, mstack, address_visited);
 }
 
-void Compile::reshape_address(AddPNode* addp) {
-}
-
 %} // source
 
 //----------ENCODING BLOCK-----------------------------------------------------

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -2177,9 +2177,6 @@ bool Matcher::pd_clone_address_expressions(AddPNode* m, Matcher::MStack& mstack,
   return false;
 }
 
-void Compile::reshape_address(AddPNode* addp) {
-}
-
 static inline Assembler::ComparisonPredicate booltest_pred_to_comparison_pred(int bt) {
   switch (bt) {
     case BoolTest::eq: return Assembler::eq;

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -3129,8 +3129,6 @@ void Compile::final_graph_reshaping_main_switch(Node* n, Final_Reshape_Counts& f
       }
     }
 #endif
-    // platform dependent reshaping of the address expression
-    reshape_address(n->as_AddP());
     break;
   }
 

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -480,8 +480,6 @@ class Compile : public Phase {
 
   PhaseOutput*          _output;
 
-  void reshape_address(AddPNode* n);
-
  public:
   // Accessors
 


### PR DESCRIPTION
This method was introduced for aarch64 only in JDK-8154826 but the implementation was intentionally removed by JDK-8204348

The declarations and empty methods were left behind on all platforms, though.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266937](https://bugs.openjdk.java.net/browse/JDK-8266937): Remove Compile::reshape_address


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3988/head:pull/3988` \
`$ git checkout pull/3988`

Update a local copy of the PR: \
`$ git checkout pull/3988` \
`$ git pull https://git.openjdk.java.net/jdk pull/3988/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3988`

View PR using the GUI difftool: \
`$ git pr show -t 3988`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3988.diff">https://git.openjdk.java.net/jdk/pull/3988.diff</a>

</details>
