### PR TITLE
8231031: runtime/ReservedStack/ReservedStackTest.java fails after jsr166 refresh

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -91,7 +91,6 @@ gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java 8241293 macosx-x64
 runtime/cds/appcds/jigsaw/modulepath/ModulePathAndCP_JFR.java 8253437 windows-x64
 runtime/cds/DeterministicDump.java 8253495 generic-all
 runtime/jni/terminatedThread/TestTerminatedThread.java 8219652 aix-ppc64
-runtime/ReservedStack/ReservedStackTest.java 8231031 generic-all
 
 #############################################################################
 

--- a/test/hotspot/jtreg/runtime/ReservedStack/ReservedStackTest.java
+++ b/test/hotspot/jtreg/runtime/ReservedStack/ReservedStackTest.java
@@ -29,12 +29,16 @@
  * @modules java.base/jdk.internal.misc
  * @modules java.base/jdk.internal.vm.annotation
  *
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:MaxInlineLevel=2 -XX:C1MaxInlineLevel=2 -XX:CompileCommand=exclude,java/util/concurrent/locks/AbstractOwnableSynchronizer.setExclusiveOwnerThread ReservedStackTest
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:CompileCommand=DontInline,java/util/concurrent/locks/ReentrantLock.lock -XX:CompileCommand=exclude,java/util/concurrent/locks/AbstractOwnableSynchronizer.setExclusiveOwnerThread ReservedStackTest
  */
 
 /* The exclusion of java.util.concurrent.locks.AbstractOwnableSynchronizer.setExclusiveOwnerThread()
  * from the compilable methods is required to ensure that the test will be able
  * to trigger a StackOverflowError on the right method.
+ *
+ * The DontInline directive for ReentrantLock.lock() ensures that lockAndcall
+ * is not considered as being annotated by ReservedStackAccess by virtue of
+ * it inlining such a method.
  */
 
 


### PR DESCRIPTION
Please see the bug report for detailed description of the issue. The simple fix for the test is to disable inlining of the lock() method (something which I think the existing MaxInlineLevel flags were trying to achieve but didn't).

Testing:
 - before fix I ran the test 50x on linux-x64, macos-x64 and macos-aarch64 product and fastdebug -> 300 failures
 - after: 300 successes
 - I also ran the fixed version 50x across all platforms using the test flags from tiers 1 through 8 (total of 1408 test runs) with zero failures or crashes. 

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8231031](https://bugs.openjdk.java.net/browse/JDK-8231031): runtime/ReservedStack/ReservedStackTest.java fails after jsr166 refresh


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3989/head:pull/3989` \
`$ git checkout pull/3989`

Update a local copy of the PR: \
`$ git checkout pull/3989` \
`$ git pull https://git.openjdk.java.net/jdk pull/3989/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3989`

View PR using the GUI difftool: \
`$ git pr show -t 3989`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3989.diff">https://git.openjdk.java.net/jdk/pull/3989.diff</a>

</details>
