### PR TITLE
JDK-8266651: Convert Table method parameters from String to Content

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllClassesIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllClassesIndexWriter.java
@@ -115,14 +115,14 @@ public class AllClassesIndexWriter extends HtmlDocletWriter {
                 .setHeader(new TableHeader(contents.classLabel, contents.descriptionLabel))
                 .setColumnStyles(HtmlStyle.colFirst, HtmlStyle.colLast)
                 .setId(HtmlIds.ALL_CLASSES_TABLE)
-                .setDefaultTab(contents.allClassesAndInterfacesLabel.toString())
-                .addTab(contents.interfaces.toString(), utils::isInterface)
-                .addTab(contents.classes.toString(), e -> utils.isOrdinaryClass((TypeElement)e))
-                .addTab(contents.enums.toString(), utils::isEnum)
-                .addTab(contents.records.toString(), e -> utils.isRecord((TypeElement)e))
-                .addTab(contents.exceptions.toString(), e -> utils.isException((TypeElement)e))
-                .addTab(contents.errors.toString(), e -> utils.isError((TypeElement)e))
-                .addTab(contents.annotationTypes.toString(), utils::isAnnotationType);
+                .setDefaultTab(contents.allClassesAndInterfacesLabel)
+                .addTab(contents.interfaces, utils::isInterface)
+                .addTab(contents.classes, e -> utils.isOrdinaryClass((TypeElement)e))
+                .addTab(contents.enums, utils::isEnum)
+                .addTab(contents.records, e -> utils.isRecord((TypeElement)e))
+                .addTab(contents.exceptions, e -> utils.isException((TypeElement)e))
+                .addTab(contents.errors, e -> utils.isError((TypeElement)e))
+                .addTab(contents.annotationTypes, utils::isAnnotationType);
         for (Character unicode : indexBuilder.getFirstCharacters()) {
             for (IndexItem indexItem : indexBuilder.getItems(unicode)) {
                 TypeElement typeElement = (TypeElement) indexItem.getElement();

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriterImpl.java
@@ -201,14 +201,14 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
                 .setHeader(getSummaryTableHeader(typeElement))
                 .setColumnStyles(HtmlStyle.colFirst, HtmlStyle.colSecond, HtmlStyle.colLast)
                 .setId(HtmlIds.METHOD_SUMMARY_TABLE)
-                .setDefaultTab(resources.getText("doclet.All_Methods"))
-                .addTab(resources.getText("doclet.Static_Methods"), utils::isStatic)
-                .addTab(resources.getText("doclet.Instance_Methods"), e -> !utils.isStatic(e))
-                .addTab(resources.getText("doclet.Abstract_Methods"), utils::isAbstract)
-                .addTab(resources.getText("doclet.Concrete_Methods"),
+                .setDefaultTab(contents.getContent("doclet.All_Methods"))
+                .addTab(contents.getContent("doclet.Static_Methods"), utils::isStatic)
+                .addTab(contents.getContent("doclet.Instance_Methods"), e -> !utils.isStatic(e))
+                .addTab(contents.getContent("doclet.Abstract_Methods"), utils::isAbstract)
+                .addTab(contents.getContent("doclet.Concrete_Methods"),
                         e -> !utils.isAbstract(e) && !utils.isInterface(e.getEnclosingElement()))
-                .addTab(resources.getText("doclet.Default_Methods"), utils::isDefault)
-                .addTab(resources.getText("doclet.Deprecated_Methods"),
+                .addTab(contents.getContent("doclet.Default_Methods"), utils::isDefault)
+                .addTab(contents.getContent("doclet.Deprecated_Methods"),
                         e -> utils.isDeprecated(e) || utils.isDeprecated(typeElement));
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleIndexWriter.java
@@ -93,13 +93,13 @@ public class ModuleIndexWriter extends AbstractOverviewIndexWriter {
                     .setHeader(tableHeader)
                     .setColumnStyles(HtmlStyle.colFirst, HtmlStyle.colLast)
                     .setId(HtmlIds.ALL_MODULES_TABLE)
-                    .setDefaultTab(resources.getText("doclet.All_Modules"));
+                    .setDefaultTab(contents.getContent("doclet.All_Modules"));
 
             // add the tabs in command-line order
             for (String groupName : configuration.group.getGroupList()) {
                 Set<ModuleElement> groupModules = groupModuleMap.get(groupName);
                 if (groupModules != null) {
-                    table.addTab(groupName, groupModules::contains);
+                    table.addTab(Text.of(groupName), groupModules::contains);
                 }
             }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriterImpl.java
@@ -551,10 +551,10 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
     public void addPackageSummary(HtmlTree li) {
         Table table = new Table(HtmlStyle.summaryTable)
                 .setId(HtmlIds.PACKAGE_SUMMARY_TABLE)
-                .setDefaultTab(resources.getText("doclet.All_Packages"))
-                .addTab(resources.getText("doclet.Exported_Packages_Summary"), this::isExported)
-                .addTab(resources.getText("doclet.Opened_Packages_Summary"), this::isOpened)
-                .addTab(resources.getText("doclet.Concealed_Packages_Summary"), this::isConcealed);
+                .setDefaultTab(contents.getContent("doclet.All_Packages"))
+                .addTab(contents.getContent("doclet.Exported_Packages_Summary"), this::isExported)
+                .addTab(contents.getContent("doclet.Opened_Packages_Summary"), this::isOpened)
+                .addTab(contents.getContent("doclet.Concealed_Packages_Summary"), this::isConcealed);
 
         // Determine whether to show the "Exported To" and "Opened To" columns,
         // based on whether such columns would provide "useful" info.
@@ -648,9 +648,9 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
 
     private Content getPackageExportOpensTo(Set<ModuleElement> modules) {
         if (modules == null) {
-            return Text.of(resources.getText("doclet.None"));
+            return contents.getContent("doclet.None");
         } else if (modules.isEmpty()) {
-            return Text.of(resources.getText("doclet.All_Modules"));
+            return contents.getContent("doclet.All_Modules");
         } else {
             Content list = new ContentBuilder();
             for (ModuleElement m : modules) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageIndexWriter.java
@@ -31,6 +31,7 @@ import javax.lang.model.element.PackageElement;
 
 import jdk.javadoc.internal.doclets.formats.html.markup.ContentBuilder;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlStyle;
+import jdk.javadoc.internal.doclets.formats.html.markup.Text;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 import jdk.javadoc.internal.doclets.toolkit.util.DocFileIOException;
 import jdk.javadoc.internal.doclets.toolkit.util.DocPath;
@@ -93,13 +94,13 @@ public class PackageIndexWriter extends AbstractOverviewIndexWriter {
                     .setHeader(getPackageTableHeader())
                     .setColumnStyles(HtmlStyle.colFirst, HtmlStyle.colLast)
                     .setId(HtmlIds.ALL_PACKAGES_TABLE)
-                    .setDefaultTab(resources.getText("doclet.All_Packages"));
+                    .setDefaultTab(contents.getContent("doclet.All_Packages"));
 
             // add the tabs in command-line order
             for (String groupName : configuration.group.getGroupList()) {
                 Set<PackageElement> groupPackages = groupPackageMap.get(groupName);
                 if (groupPackages != null) {
-                    table.addTab(groupName, groupPackages::contains);
+                    table.addTab(Text.of(groupName), groupPackages::contains);
                 }
             }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
@@ -252,14 +252,14 @@ public class PackageWriterImpl extends HtmlDocletWriter
                 .setHeader(new TableHeader(contents.classLabel, contents.descriptionLabel))
                 .setColumnStyles(HtmlStyle.colFirst, HtmlStyle.colLast)
                 .setId(HtmlIds.CLASS_SUMMARY)
-                .setDefaultTab(contents.allClassesAndInterfacesLabel.toString())
-                .addTab(contents.interfaces.toString(), utils::isInterface)
-                .addTab(contents.classes.toString(), e -> utils.isOrdinaryClass((TypeElement)e))
-                .addTab(contents.enums.toString(), utils::isEnum)
-                .addTab(contents.records.toString(), e -> utils.isRecord((TypeElement)e))
-                .addTab(contents.exceptions.toString(), e -> utils.isException((TypeElement)e))
-                .addTab(contents.errors.toString(), e -> utils.isError((TypeElement)e))
-                .addTab(contents.annotationTypes.toString(), utils::isAnnotationType);
+                .setDefaultTab(contents.allClassesAndInterfacesLabel)
+                .addTab(contents.interfaces, utils::isInterface)
+                .addTab(contents.classes, e -> utils.isOrdinaryClass((TypeElement)e))
+                .addTab(contents.enums, utils::isEnum)
+                .addTab(contents.records, e -> utils.isRecord((TypeElement)e))
+                .addTab(contents.exceptions, e -> utils.isException((TypeElement)e))
+                .addTab(contents.errors, e -> utils.isError((TypeElement)e))
+                .addTab(contents.annotationTypes, utils::isAnnotationType);
         for (TypeElement typeElement : allClasses) {
             if (typeElement != null && utils.isCoreClass(typeElement)) {
                 Content classLink = getLink(new HtmlLinkInfo(

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Table.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Table.java
@@ -43,7 +43,6 @@ import jdk.javadoc.internal.doclets.formats.html.markup.HtmlAttr;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlId;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlStyle;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlTree;
-import jdk.javadoc.internal.doclets.formats.html.markup.Text;
 import jdk.javadoc.internal.doclets.formats.html.markup.TagName;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 
@@ -77,9 +76,9 @@ import jdk.javadoc.internal.doclets.toolkit.Content;
 public class Table extends Content {
     private final HtmlStyle tableStyle;
     private Content caption;
-    private Map<String, Predicate<Element>> tabMap;
-    private String defaultTab;
-    private Set<String> tabs;
+    private Map<Content, Predicate<Element>> tabMap;
+    private Content defaultTab;
+    private Set<Content> tabs;
     private HtmlStyle tabListStyle = HtmlStyle.tableTabs;
     private HtmlStyle activeTabStyle = HtmlStyle.activeTableTab;
     private HtmlStyle tabStyle = HtmlStyle.tableTab;
@@ -118,28 +117,28 @@ public class Table extends Content {
      * predicate for the tab, and an element associated with each row.
      * Tabs will appear left-to-right in the order they are added.
      *
-     * @param name      the name of the tab
+     * @param label     the tab label
      * @param predicate the predicate
      * @return this object
      */
-    public Table addTab(String name, Predicate<Element> predicate) {
+    public Table addTab(Content label, Predicate<Element> predicate) {
         if (tabMap == null) {
             tabMap = new LinkedHashMap<>();     // preserves order that tabs are added
             tabs = new HashSet<>();             // order not significant
         }
-        tabMap.put(name, predicate);
+        tabMap.put(label, predicate);
         return this;
     }
 
     /**
-     * Sets the name for the default tab, which displays all the rows in the table.
+     * Sets the label for the default tab, which displays all the rows in the table.
      * This tab will appear first in the left-to-right list of displayed tabs.
      *
-     * @param name the name
+     * @param label the default tab label
      * @return this object
      */
-    public Table setDefaultTab(String name) {
-        defaultTab = name;
+    public Table setDefaultTab(Content label) {
+        defaultTab = label;
         return this;
     }
 
@@ -266,7 +265,7 @@ public class Table extends Content {
      * If tabs have been added to the table, the specified element will be used
      * to determine whether the row should be displayed when any particular tab
      * is selected, using the predicate specified when the tab was
-     * {@link #addTab(String,Predicate) added}.
+     * {@link #addTab(Content, Predicate) added}.
      *
      * @param element the element
      * @param contents the contents for the row
@@ -285,7 +284,7 @@ public class Table extends Content {
      * If tabs have been added to the table, the specified element will be used
      * to determine whether the row should be displayed when any particular tab
      * is selected, using the predicate specified when the tab was
-     * {@link #addTab(String,Predicate) added}.
+     * {@link #addTab(Content, Predicate) added}.
      *
      * @param element the element
      * @param contents the contents for the row
@@ -312,11 +311,11 @@ public class Table extends Content {
             // The values are used to determine the cells to make visible when a tab is selected.
             tabClasses.add(id.name());
             int tabIndex = 1;
-            for (Map.Entry<String, Predicate<Element>> e : tabMap.entrySet()) {
-                String name = e.getKey();
+            for (Map.Entry<Content, Predicate<Element>> e : tabMap.entrySet()) {
+                Content label = e.getKey();
                 Predicate<Element> predicate = e.getValue();
                 if (predicate.test(element)) {
-                    tabs.add(name);
+                    tabs.add(label);
                     tabClasses.add(HtmlIds.forTab(id, tabIndex).name());
                 }
                 tabIndex++;
@@ -380,8 +379,7 @@ public class Table extends Content {
             if (tabMap == null) {
                 main.add(caption);
             } else {
-                String tabName = tabs.iterator().next();
-                main.add(getCaption(Text.of(tabName)));
+                main.add(getCaption(tabs.iterator().next()));
             }
             table.add(getTableBody());
             main.add(table);
@@ -393,10 +391,10 @@ public class Table extends Content {
             int tabIndex = 0;
             tablist.add(createTab(HtmlIds.forTab(id, tabIndex), activeTabStyle, true, defaultTab));
             table.put(HtmlAttr.ARIA_LABELLEDBY, HtmlIds.forTab(id, tabIndex).name());
-            for (String tabName : tabMap.keySet()) {
+            for (Content tabLabel : tabMap.keySet()) {
                 tabIndex++;
-                if (tabs.contains(tabName)) {
-                    HtmlTree tab = createTab(HtmlIds.forTab(id, tabIndex), tabStyle, false, tabName);
+                if (tabs.contains(tabLabel)) {
+                    HtmlTree tab = createTab(HtmlIds.forTab(id, tabIndex), tabStyle, false, tabLabel);
                     tablist.add(tab);
                 }
             }
@@ -414,7 +412,7 @@ public class Table extends Content {
         return main;
     }
 
-    private HtmlTree createTab(HtmlId tabId, HtmlStyle style, boolean defaultTab, String tabName) {
+    private HtmlTree createTab(HtmlId tabId, HtmlStyle style, boolean defaultTab, Content tabLabel) {
         HtmlTree tab = new HtmlTree(TagName.BUTTON)
                 .setId(tabId)
                 .put(HtmlAttr.ROLE, "tab")
@@ -425,7 +423,7 @@ public class Table extends Content {
                 .put(HtmlAttr.ONCLICK, "show('" + id.name() + "', '" + (defaultTab ? id : tabId).name()
                         + "', " + columnStyles.size() + ")")
                 .setStyle(style);
-        tab.add(tabName);
+        tab.add(tabLabel);
         return tab;
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
@@ -67,7 +67,6 @@ import jdk.javadoc.internal.doclets.toolkit.util.CommentHelper;
 import jdk.javadoc.internal.doclets.toolkit.util.DocLink;
 import jdk.javadoc.internal.doclets.toolkit.util.DocPath;
 import jdk.javadoc.internal.doclets.toolkit.util.DocPaths;
-import jdk.javadoc.internal.doclets.toolkit.util.DocletConstants;
 import jdk.javadoc.internal.doclets.toolkit.util.IndexItem;
 import jdk.javadoc.internal.doclets.toolkit.util.Utils;
 
@@ -329,7 +328,7 @@ public class TagletWriterImpl extends TagletWriter {
                     utils.getSimpleName(holder);
             DocLink link = constantsPath.fragment(whichConstant);
             links.add(htmlWriter.links.createLink(link,
-                    Text.of(resources.getText("doclet.Constants_Summary"))));
+                    contents.getContent("doclet.Constants_Summary")));
         }
         if (utils.isClass(holder) && utils.isSerializable((TypeElement)holder)) {
             //Automatically add link to serialized form page for serializable classes.
@@ -338,7 +337,7 @@ public class TagletWriterImpl extends TagletWriter {
                 DocPath serialPath = htmlWriter.pathToRoot.resolve(DocPaths.SERIALIZED_FORM);
                 DocLink link = serialPath.fragment(utils.getFullyQualifiedName(holder));
                 links.add(htmlWriter.links.createLink(link,
-                        Text.of(resources.getText("doclet.Serialized_Form"))));
+                        contents.getContent("doclet.Serialized_Form")));
             }
         }
         if (links.isEmpty()) {


### PR DESCRIPTION
This changes the parameter type for the tab label from `String` to `Content` in the `formats.html.Table` `addTab` and `setDefaultTab` methods. The change is straightforward because the tab name was converted to `Content` anyway, and all resources are readily available in `Content` form. 

I briefly considered overriding the `hashCode` and `equals` methods in `Text` to be depend on content instead of object identity, but decided against it. This would just cover up bugs where we generate the same content twice. (In the process I made sure we currently don't have any such cases where a `Text` instance is compared to another one with the same string content.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266651](https://bugs.openjdk.java.net/browse/JDK-8266651): Convert Table method parameters from String to Content


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3994/head:pull/3994` \
`$ git checkout pull/3994`

Update a local copy of the PR: \
`$ git checkout pull/3994` \
`$ git pull https://git.openjdk.java.net/jdk pull/3994/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3994`

View PR using the GUI difftool: \
`$ git pr show -t 3994`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3994.diff">https://git.openjdk.java.net/jdk/pull/3994.diff</a>

</details>
