### PR TITLE
8263382: java/util/logging/ParentLoggersTest.java failed with "checkLoggers: getLoggerNames() returned unexpected loggers"

### DIFF
--- a/test/jdk/java/util/logging/ParentLoggersTest.java
+++ b/test/jdk/java/util/logging/ParentLoggersTest.java
@@ -29,7 +29,7 @@
  * @author  ss45998
  *
  * @build ParentLoggersTest
- * @run main ParentLoggersTest
+ * @run main/othervm ParentLoggersTest
  */
 
 /*


### PR DESCRIPTION
ParentLoggersTest.java has been (rarely) seen failing with "checkLoggers: getLoggerNames() returned unexpected loggers"
The suspicion is that there might be some possible interaction with other tests running in the same VM. This test causes the LogManager to reparse its configuration and should therefore run in its own VM.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263382](https://bugs.openjdk.java.net/browse/JDK-8263382): java/util/logging/ParentLoggersTest.java failed with "checkLoggers: getLoggerNames() returned unexpected loggers"


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/3997/head:pull/3997` \
`$ git checkout pull/3997`

Update a local copy of the PR: \
`$ git checkout pull/3997` \
`$ git pull https://git.openjdk.java.net/jdk pull/3997/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3997`

View PR using the GUI difftool: \
`$ git pr show -t 3997`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/3997.diff">https://git.openjdk.java.net/jdk/pull/3997.diff</a>

</details>
