### PR TITLE
8267043: IntelliJ project doesn't handle generated sources correctly

### DIFF
--- a/make/ide/idea/jdk/template/misc.xml
+++ b/make/ide/idea/jdk/template/misc.xml
@@ -12,7 +12,7 @@
       <target file="file://###ROOT_DIR###/make/ide/idea/jdk/build.xml" name="images" />
     </ant>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_9" assert-keyword="true" jdk-15="true">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_16" assert-keyword="true" jdk-15="true">
     <output url="file://###BUILD_DIR###/idea" />
   </component>
 </project>

--- a/make/ide/idea/jdk/template/misc.xml
+++ b/make/ide/idea/jdk/template/misc.xml
@@ -13,6 +13,6 @@
     </ant>
   </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_9" assert-keyword="true" jdk-15="true">
-    <output url="file://###BUILD_DIR###" />
+    <output url="file://###BUILD_DIR###/idea" />
   </component>
 </project>


### PR DESCRIPTION
Since generated sources are placed in the build folder, and since the build folder is indicated by the IntelliJ project settings as "project output", IntelliJ indexing blissfully ignores all the classes which are generated during the build.
This simple patch fixes that, by simply pointing the project output to a non-existing folder inside the build path (called `idea`).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267043](https://bugs.openjdk.java.net/browse/JDK-8267043): IntelliJ project doesn't handle generated sources correctly


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4000/head:pull/4000` \
`$ git checkout pull/4000`

Update a local copy of the PR: \
`$ git checkout pull/4000` \
`$ git pull https://git.openjdk.java.net/jdk pull/4000/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4000`

View PR using the GUI difftool: \
`$ git pr show -t 4000`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4000.diff">https://git.openjdk.java.net/jdk/pull/4000.diff</a>

</details>
