### PR TITLE
8153490:Cannot setBytes() if incoming buffer's length is bigger than number of elements we want to insert.

### DIFF
--- a/src/java.sql.rowset/share/classes/javax/sql/rowset/serial/SerialClob.java
+++ b/src/java.sql.rowset/share/classes/javax/sql/rowset/serial/SerialClob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -368,15 +368,12 @@ public class SerialClob implements Clob, Serializable, Cloneable {
      * @param pos the position at which to start writing to the <code>CLOB</code>
      *         value that this <code>SerialClob</code> object represents; the first
      *         position is <code>1</code>; must not be less than <code>1</code> nor
-     *         greater than the length of this <code>SerialClob</code> object
+     *         greater than the length+1 of this {@code SerialClob} object
      * @param str the string to be written to the <code>CLOB</code>
      *        value that this <code>SerialClob</code> object represents
      * @return the number of characters written
      * @throws SerialException if there is an error accessing the
-     *     <code>CLOB</code> value; if an invalid position is set; if an
-     *     invalid offset value is set; if number of bytes to be written
-     *     is greater than the <code>SerialClob</code> length; or the combined
-     *     values of the length and offset is greater than the Clob buffer;
+     *     {@code CLOB} value; if an invalid position is set;
      * if the {@code free} method had been previously called on this object
      */
     public int setString(long pos, String str) throws SerialException {
@@ -391,7 +388,7 @@ public class SerialClob implements Clob, Serializable, Cloneable {
      * @param pos the position at which to start writing to the <code>CLOB</code>
      *         value that this <code>SerialClob</code> object represents; the first
      *         position is <code>1</code>; must not be less than <code>1</code> nor
-     *         greater than the length of this <code>SerialClob</code> object
+     *         greater than the length+1 of this {@code SerialClob} object
      * @param str the string to be written to the <code>CLOB</code>
      *        value that this <code>Clob</code> object represents
      * @param offset the offset into <code>str</code> to start reading
@@ -400,42 +397,45 @@ public class SerialClob implements Clob, Serializable, Cloneable {
      * @return the number of characters written
      * @throws SerialException if there is an error accessing the
      *     <code>CLOB</code> value; if an invalid position is set; if an
-     *     invalid offset value is set; if number of bytes to be written
-     *     is greater than the <code>SerialClob</code> length; or the combined
-     *     values of the length and offset is greater than the Clob buffer;
+     *     invalid offset value is set; or the combined values of the
+     *     {@code length} and {@code offset} is greater than the length of
+     *     {@code str};
      * if the {@code free} method had been previously called on this object
      */
     public int setString(long pos, String str, int offset, int length)
         throws SerialException {
         isValid();
-        String temp = str.substring(offset);
-        char cPattern[] = temp.toCharArray();
-
         if (offset < 0 || offset > str.length()) {
-            throw new SerialException("Invalid offset in byte array set");
+            throw new SerialException("Invalid offset in String object set");
         }
 
-        if (pos < 1 || pos > this.length()) {
+        if (pos < 1 || pos > len + 1) {
             throw new SerialException("Invalid position in Clob object set");
         }
 
-        if ((long)(length) > origLen) {
-            throw new SerialException("Buffer is not sufficient to hold the value");
-        }
-
         if ((length + offset) > str.length()) {
-            // need check to ensure length + offset !> bytes.length
+            // need check to ensure length + offset !> str.length
             throw new SerialException("Invalid OffSet. Cannot have combined offset " +
-                " and length that is greater that the Blob buffer");
+                " and length that is greater than the length of str");
         }
 
-        int i = 0;
-        pos--;  //values in the array are at position one less
-        while ( i < length || (offset + i +1) < (str.length() - offset ) ) {
-            this.buf[(int)pos + i ] = cPattern[offset + i ];
-            i++;
+        if (pos - 1 + length > Integer.MAX_VALUE) {
+            throw new SerialException("Invalid length. Cannot have combined pos " +
+                    "and length that is greater than Integer.MAX_VALUE");
         }
-        return i;
+
+        pos--;  //values in the array are at position one less
+        if (pos + length > len) {
+            len = pos + length;
+            char[] newbuf = new char[(int)len];
+            System.arraycopy(buf, 0, newbuf, 0, (int)pos);
+            buf = newbuf;
+        }
+
+        String temp = str.substring(offset, offset + length);
+        char cPattern[] = temp.toCharArray();
+        System.arraycopy(cPattern, 0, buf, (int)pos, length);
+        return length;
     }
 
     /**

--- a/test/jdk/javax/sql/testng/test/rowset/serial/SerialBlobTests.java
+++ b/test/jdk/javax/sql/testng/test/rowset/serial/SerialBlobTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -395,5 +395,57 @@ public class SerialBlobTests extends BaseTest {
         SerialBlob sb = new SerialBlob(new StubBlob());
         long pos = sb.position(pattern, 2);
         assertEquals(pos, expectedPos);
+    }
+
+    /*
+     * Validate that setBytes will properly write a set of bytes to the
+     * specified location in the SerialBlob and the correct count is returned
+     * for bytes written (writePos - 1 + diff.length > sb.length() &&
+     * writePos - 1 + bytesToWrite <= sb.length())
+     */
+    @Test
+    public void test31() throws Exception {
+        int writePos = 5;
+        int bytesToWrite = 1;
+        byte[] diff = new byte[]{7, 8, 9};
+        byte[] expected = new byte[]{1, 2, 3, 4, 7};
+        SerialBlob sb = new SerialBlob(bytes);
+        int written = sb.setBytes(writePos, diff, 0, bytesToWrite);
+        assertEquals(written, bytesToWrite);
+        assertEquals(sb.getBytes(1, (int) sb.length()), expected);
+    }
+
+    /*
+     * Validate that setBytes will properly write a set of bytes to the
+     * specified location in the SerialBlob and the correct count is returned
+     * for bytes written (writePos - 1 + bytesToWrite > sb.length())
+     */
+    @Test
+    public void test32() throws Exception {
+        int writePos = 5;
+        int bytesToWrite = 2;
+        byte[] diff = new byte[]{7, 8, 9, 0};
+        byte[] expected = new byte[]{1, 2, 3, 4, 8, 9};
+        SerialBlob sb = new SerialBlob(bytes);
+        int written = sb.setBytes(writePos, diff, 1, bytesToWrite);
+        assertEquals(written, bytesToWrite);
+        assertEquals(sb.getBytes(1, (int) sb.length()), expected);
+    }
+
+    /*
+     * Validate that setBytes will properly write a set of bytes to the
+     * specified location in the SerialBlob and the correct count is returned
+     * for bytes written (writePos == sb.length() + 1)
+     */
+    @Test
+    public void test33() throws Exception {
+        int writePos = 6;
+        int bytesToWrite = 3;
+        byte[] diff = new byte[]{7, 8, 9, 0};
+        byte[] expected = new byte[]{1, 2, 3, 4, 5, 8, 9, 0};
+        SerialBlob sb = new SerialBlob(bytes);
+        int written = sb.setBytes(writePos, diff, 1, bytesToWrite);
+        assertEquals(written, bytesToWrite);
+        assertEquals(sb.getBytes(1, (int) sb.length()), expected);
     }
 }

--- a/test/jdk/javax/sql/testng/test/rowset/serial/SerialClobTests.java
+++ b/test/jdk/javax/sql/testng/test/rowset/serial/SerialClobTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -407,18 +407,21 @@ public class SerialClobTests extends BaseTest {
 
     /*
      * Check that setString() updates the appropriate characters in the
-     * SerialClob
+     * SerialClob (writePos - 1 + val1.length() - offset > sc.length() &&
+     * writePos - 1 + expectedWritten <= sc.length())
      */
-    @Test(enabled = false)
+    @Test
     public void test32() throws Exception {
+        int writePos = 10;
+        int offset = 7;
         int expectedWritten = 9;
         String val = "Hi, I am Catwoman!!!!!!";
         String val1 = "Hahaha the Joker, who are you?!";
-        String expected = "Hi, I am the Joker!";
+        String expected = "Hi, I am the Joker!!!!!";
         SerialClob sc = new SerialClob(val.toCharArray());
-        int written = sc.setString(10, val1, 8, expectedWritten+1);
+        int written = sc.setString(writePos, val1, offset, expectedWritten);
         assertEquals(written, expectedWritten);
-
+        assertEquals(sc.getSubString(1, (int) sc.length()), expected);
     }
 
     /*
@@ -495,5 +498,53 @@ public class SerialClobTests extends BaseTest {
         SerialClob sc = new SerialClob(chars);
         SerialClob sc2 = serializeDeserializeObject(sc);
         assertTrue(sc.equals(sc2), "SerialClobs not equal");
+    }
+
+    /*
+     * Check calling setString() with offset > val1.length() throws a
+     * SerialException
+     */
+    @Test(expectedExceptions = SerialException.class)
+    public void test39() throws Exception {
+        String val1 = "hello";
+        int offset = val1.length() + 1;
+        SerialClob sc = new SerialClob(chars);
+        sc.setString(1, val1, offset, 0);
+    }
+
+    /*
+     * Check that setString() updates the appropriate characters in the
+     * SerialClob (writePos - 1 + expectedWritten > sc.length())
+     */
+    @Test
+    public void test40() throws Exception {
+        int writePos = 13;
+        int offset = 7;
+        int expectedWritten = 24;
+        String val = "Hello, I am Bruce Wayne";
+        String val1 = "Hahaha the Joker, who are you?!";
+        String expected = "Hello, I am the Joker, who are you?!";
+        SerialClob sc = new SerialClob(val.toCharArray());
+        int written = sc.setString(writePos, val1, offset, expectedWritten);
+        assertEquals(written, expectedWritten);
+        assertEquals(sc.getSubString(1, (int) sc.length()), expected);
+    }
+
+    /*
+     * Check that setString() updates the appropriate characters in the
+     * SerialClob (writePos == sc.length() + 1)
+     */
+    @Test
+    public void test41() throws Exception {
+        int writePos = 10;
+        int offset = 7;
+        int expectedWritten = 10;
+        String val = "Hi, I am ";
+        String val1 = "Hahaha the Joker!";
+        String expected = "Hi, I am the Joker!";
+        SerialClob sc = new SerialClob(val.toCharArray());
+        int written = sc.setString(writePos, val1, offset, expectedWritten);
+        assertEquals(written, expectedWritten);
+        assertEquals(sc.getSubString(1, (int) sc.length()), expected);
     }
 }


### PR DESCRIPTION
Fix `SerialBlob.setBytes(long pos, byte[] bytes, int offset, int length)` in the following cases:

1. `pos - 1 + bytes.length - offset > this.length() && pos - 1 + length <= this.length()`
   The original implementation throws `ArrayIndexOutOfBoundsException` but this case should end successfully.
   (test31)

2. `pos - 1 + length > this.length()`
   The original implementation throws `ArrayIndexOutOfBoundsException` but this case should end successfully. *1
   (test32)

3. `pos == this.length() + 1`
   The original implementation throws `SerialException` but this case should end successfully. *2
   (test33)

Additionally, fix `SerialClob.setString(long pos, String str, int offset, int length)` in the following cases:

1. `offset > str.length()`
   The original implementaion throws `StringIndexOutOfBoundsException` but this case should throw `SerialException`.
   (test39)

2. `pos - 1 + str.length() - offset > this.length() && pos - 1 + length <= this.length()`
   The original implementation throws `ArrayIndexOutOfBoundsException` but this case should end successfully.
   (test32)

3. `pos - 1 + length > this.length()`
   The original implementaion throws `SerialException` but this case should end successfully. *3
   (test40)

4. `pos == this.length() + 1`
   The original implementaion throws `SerialException` but this case should end successfully. *4
   (test41)

The javadoc has also been modified according to the above.

*1 The documentation of `Blob.setBytes()` says, "If the end of the Blob value is reached while writing the array of bytes, then the length of the Blob value will be increased to accommodate the extra bytes."

*2 The documentation of `Blob.setBytes()` says, "If the value specified for pos is greater than the length+1 of the BLOB value then the behavior is undefined."
   So, it should work correctly when pos == length+1 of the BLOB value.

*3 The documentation of `Clob.setString()` says, "If the end of the Clob value is eached while writing the given string, then the length of the Clob value will be increased to accommodate the extra characters."

*4 The documentation of `Clob.setString()` says, "If the value specified for pos is greater than the length+1 of the CLOB value then the behavior is undefined."
   So, it should work correctly when pos == length+1 of the CLOB value.