### PR TITLE
8267047: Put serviceability/sa/TestJmapCoreMetaspace.java back on ZGC problem list due to JDK-8267045

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -40,4 +40,5 @@ serviceability/sa/ClhsdbSymbol.java                           8220624   generic-
 serviceability/sa/TestHeapDumpForInvokeDynamic.java           8220624   generic-all
 serviceability/sa/TestHeapDumpForLargeArray.java              8220624   generic-all
 serviceability/sa/TestJmapCore.java                           8220624   generic-all
+serviceability/sa/TestJmapCoreMetaspace.java                  8267045   generic-all
 vmTestbase/jit/escape/AdaptiveBlocking/AdaptiveBlocking001/AdaptiveBlocking001.java 8260303 windows-x64


### PR DESCRIPTION
[JDK-8267045](https://bugs.openjdk.java.net/browse/JDK)-8267045 removed this test from the ZGC problem list, but it still fails, so it needs to be re-added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267047](https://bugs.openjdk.java.net/browse/JDK-8267047): Put serviceability/sa/TestJmapCoreMetaspace.java back on ZGC problem list due to  JDK-8267045


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4002/head:pull/4002` \
`$ git checkout pull/4002`

Update a local copy of the PR: \
`$ git checkout pull/4002` \
`$ git pull https://git.openjdk.java.net/jdk pull/4002/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4002`

View PR using the GUI difftool: \
`$ git pr show -t 4002`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4002.diff">https://git.openjdk.java.net/jdk/pull/4002.diff</a>

</details>
