### PR TITLE
8263614: javac allows local variables to be accessed from a static context

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -1503,18 +1503,9 @@ public class Resolve {
             }
             if (sym.exists()) {
                 if (staticOnly &&
-                   (sym.flags() & STATIC) == 0 &&
-                    sym.kind == VAR &&
-                        // if it is a field
-                        (sym.owner.kind == TYP ||
-                        // or it is a local variable but it is not declared inside of the static local type
-                        // then error
-                        allowRecords &&
-                        (sym.owner.kind == MTH) &&
-                        env1 != env &&
-                        !isInnerClassOfMethod(sym.owner, env.tree.hasTag(CLASSDEF) ?
-                                ((JCClassDecl)env.tree).sym :
-                                env.enclClass.sym)))
+                        sym.kind == VAR &&
+                        sym.owner.kind == TYP &&
+                        (sym.flags() & STATIC) == 0)
                     return new StaticError(sym);
                 else
                     return sym;
@@ -2316,35 +2307,20 @@ public class Resolve {
         return bestSoFar;
     }
 
-    Symbol findTypeVar(Env<AttrContext> currentEnv, Env<AttrContext> originalEnv, Name name, boolean staticOnly) {
-        for (Symbol sym : currentEnv.info.scope.getSymbolsByName(name)) {
+    Symbol findTypeVar(Env<AttrContext> env, Name name, boolean staticOnly) {
+        for (Symbol sym : env.info.scope.getSymbolsByName(name)) {
             if (sym.kind == TYP) {
-                if (staticOnly &&
-                    sym.type.hasTag(TYPEVAR) &&
-                    ((sym.owner.kind == TYP) ||
-                    // are we trying to access a TypeVar defined in a method from a local static type: interface, enum or record?
-                    allowRecords &&
-                    (sym.owner.kind == MTH &&
-                    currentEnv != originalEnv &&
-                        (!isInnerClassOfMethod(sym.owner, originalEnv.tree.hasTag(CLASSDEF) ?
-                        ((JCClassDecl)originalEnv.tree).sym :
-                        originalEnv.enclClass.sym) ||
-                        originalEnv.info.staticLevel > currentEnv.info.staticLevel)
-                    ))) {
+                if (sym.type.hasTag(TYPEVAR) &&
+                        (staticOnly || (isStatic(env) && sym.owner.kind == TYP)))
+                    // if staticOnly is set, it means that we have recursed through a static declaration,
+                    // so type variable symbols should not be accessible. If staticOnly is unset, but
+                    // we are in a static declaration (field or method), we should not allow type-variables
+                    // defined in the enclosing class to "leak" into this context.
                     return new StaticError(sym);
-                }
                 return sym;
             }
         }
         return typeNotFound;
-    }
-
-    boolean isInnerClassOfMethod(Symbol msym, Symbol csym) {
-        while (csym.owner != msym) {
-            if (csym.isStatic()) return false;
-            csym = csym.owner.enclClass();
-        }
-        return (csym.owner == msym && !csym.isStatic());
     }
 
     /** Find an unqualified type symbol.
@@ -2358,9 +2334,9 @@ public class Resolve {
         Symbol sym;
         boolean staticOnly = false;
         for (Env<AttrContext> env1 = env; env1.outer != null; env1 = env1.outer) {
-            if (isStatic(env1)) staticOnly = true;
             // First, look for a type variable and the first member type
-            final Symbol tyvar = findTypeVar(env1, env, name, staticOnly);
+            final Symbol tyvar = findTypeVar(env1, name, staticOnly);
+            if (isStatic(env1)) staticOnly = true;
             sym = findImmediateMemberType(env1, env1.enclClass.sym.type,
                                           name, env1.enclClass.sym);
 

--- a/test/langtools/tools/javac/records/RecordCompilationTests.java
+++ b/test/langtools/tools/javac/records/RecordCompilationTests.java
@@ -747,8 +747,20 @@ public class RecordCompilationTests extends CompilationTestCase {
                 """,
                 """
                 record R() {
+                    void test(U u) {}
+                }
+                """,
+                """
+                record R() {
                     void test1() {
                         class X { void test2(T t) {} }
+                    }
+                }
+                """,
+                """
+                record R() {
+                    void test1() {
+                        class X { void test2(U u) {} }
                     }
                 }
                 """,
@@ -802,11 +814,23 @@ public class RecordCompilationTests extends CompilationTestCase {
                 """,
                 """
                 interface I {
+                    default void test(U u) {}
+                }
+                """,
+                """
+                interface I {
                     default void test1() {
                         class X { void test2(T t) {} }
                     }
                 }
                 """,
+                """
+                interface I {
+                    default void test1() {
+                        class X { void test2(U u) {} }
+                    }
+                }
+                """,
 
                 """
                 enum E {
@@ -865,8 +889,22 @@ public class RecordCompilationTests extends CompilationTestCase {
                 """
                 enum E {
                     A;
+                    void test(U u) {}
+                }
+                """,
+                """
+                enum E {
+                    A;
                     void test1() {
                         class X { void test2(T t) {} }
+                    }
+                }
+                """,
+                """
+                enum E {
+                    A;
+                    void test1() {
+                        class X { void test2(U u) {} }
                     }
                 }
                 """,
@@ -920,8 +958,20 @@ public class RecordCompilationTests extends CompilationTestCase {
                 """,
                 """
                 static class SC {
+                    void test(U u) {}
+                }
+                """,
+                """
+                static class SC {
                     void test1() {
                         class X { void test2(T t) {} }
+                    }
+                }
+                """,
+                """
+                static class SC {
+                    void test1() {
+                        class X { void test2(U u) {} }
                     }
                 }
                 """
@@ -965,6 +1015,30 @@ public class RecordCompilationTests extends CompilationTestCase {
                 }
                 """
         );
+
+        // but still non-static declarations can't be accessed from a static method inside a local class
+        for (String s : List.of(
+                "System.out.println(localVar)",
+                "System.out.println(param)",
+                "System.out.println(field)",
+                "T t",
+                "U u"
+        )) {
+            assertFail("compiler.err.non-static.cant.be.ref",
+                    """
+                    class C<T> {
+                        int field = 0;
+                        <U> void foo(int param) {
+                            int localVar = 1;
+                            class Local {
+                                static void m() {
+                                    #S;
+                                }
+                            }
+                        }
+                    }
+                    """.replaceFirst("#S", s));
+        }
     }
 
     public void testReturnInCanonical_Compact() {


### PR DESCRIPTION
javac breaks with NPE if compiles this code:

```
public class LocalClasses {
    public static void main(String[] args) {
        int i = 5;
        class Local {
            static void m() {
                System.out.println("Value of i = " + i);
            }
        }
        Local.m();
    }
} 
```

actually the compiler should issue a compiling error as local variable `i` is being accessed from a static context. Please review this fix to address this issue. Some notes:

`com.sun.tools.javac.comp.AttrContext.staticLevel` keeps a the number of nested static contexts but this calculation doesn't consider static type declarations. This is because static declaration doesn't introduce a static context. But if they have a static modifier, even if implicit as it is for local records, then this affects what variables, type variables, etc are accessible from the body of the static type declaration. For this reason I have used an `adjusted` static level that takes static type declarations into account.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263614](https://bugs.openjdk.java.net/browse/JDK-8263614): javac allows local variables to be accessed from a static context


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4004/head:pull/4004` \
`$ git checkout pull/4004`

Update a local copy of the PR: \
`$ git checkout pull/4004` \
`$ git pull https://git.openjdk.java.net/jdk pull/4004/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4004`

View PR using the GUI difftool: \
`$ git pr show -t 4004`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4004.diff">https://git.openjdk.java.net/jdk/pull/4004.diff</a>

</details>
