### PR TITLE
8267079: Support async handshakes that can be executed by a remote thread

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -2051,7 +2051,7 @@ WB_ENTRY(jint, WB_HandshakeWalkStack(JNIEnv* env, jobject wb, jobject thread_han
 WB_END
 
 WB_ENTRY(void, WB_AsyncHandshakeWalkStack(JNIEnv* env, jobject wb, jobject thread_handle))
-  class TraceSelfClosure : public AsyncHandshakeClosure {
+  class TraceSelfClosure : public SelfExecutedHandshakeClosure {
     JavaThread* _self;
     void do_thread(Thread* th) {
       assert(th->is_Java_thread(), "sanity");
@@ -2066,13 +2066,13 @@ WB_ENTRY(void, WB_AsyncHandshakeWalkStack(JNIEnv* env, jobject wb, jobject threa
     }
 
   public:
-    TraceSelfClosure(JavaThread* self_target) : AsyncHandshakeClosure("WB_TraceSelf"), _self(self_target) {}
+    TraceSelfClosure(JavaThread* self_target) : SelfExecutedHandshakeClosure("WB_TraceSelf"), _self(self_target) {}
   };
   oop thread_oop = JNIHandles::resolve(thread_handle);
   if (thread_oop != NULL) {
     JavaThread* target = java_lang_Thread::thread(thread_oop);
     TraceSelfClosure* tsc = new TraceSelfClosure(target);
-    Handshake::execute(tsc, target);
+    Handshake::enqueue(tsc, target);
   }
 WB_END
 

--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -77,7 +77,7 @@ class HandshakeOperation : public CHeapObj<mtThread> {
   int32_t pending_threads()        { return Atomic::load(&_pending_threads); }
   const char* name()               { return _handshake_cl->name(); }
   bool is_async()                  { return _handshake_cl->is_async(); }
-  bool remote_executable()         { return _handshake_cl->remote_executable(); }
+  bool self_executed()             { return _handshake_cl->self_executed(); }
 };
 
 class AsyncHandshakeOperation : public HandshakeOperation {
@@ -440,20 +440,20 @@ HandshakeOperation* HandshakeState::pop_for_self() {
   return _queue.pop();
 };
 
-static bool remote_executable_queue_filter(HandshakeOperation* op) {
-  return op->remote_executable();
+static bool non_self_queue_filter(HandshakeOperation* op) {
+  return !op->self_executed();
 }
 
-bool HandshakeState::has_remote_executable_operation() {
+bool HandshakeState::have_non_self_executable_operation() {
   assert(_handshakee != Thread::current(), "Must not be called by self");
   assert(_lock.owned_by_self(), "Lock must be held");
-  return _queue.contains(remote_executable_queue_filter);
+  return _queue.contains(non_self_queue_filter);
 }
 
 HandshakeOperation* HandshakeState::pop() {
   assert(_handshakee != Thread::current(), "Must not be called by self");
   assert(_lock.owned_by_self(), "Lock must be held");
-  return _queue.pop(remote_executable_queue_filter);
+  return _queue.pop(non_self_queue_filter);
 };
 
 bool HandshakeState::process_by_self() {
@@ -533,7 +533,7 @@ bool HandshakeState::claim_handshake() {
   // If all handshake operations for the handshakee are finished and someone
   // just adds an operation we may see it here. But if the handshakee is not
   // armed yet it is not safe to proceed.
-  if (has_remote_executable_operation()) {
+  if (have_non_self_executable_operation()) {
     if (SafepointMechanism::local_poll_armed(_handshakee)) {
       return true;
     }
@@ -590,9 +590,13 @@ HandshakeState::ProcessResult HandshakeState::try_process(HandshakeOperation* ma
       op->do_handshake(_handshakee);
       _active_handshaker = NULL;
 
+      if (op->is_async()) {
+        delete op;
+      }
+
       executed++;
     }
-  } while (has_remote_executable_operation());
+  } while (have_non_self_executable_operation());
 
   _lock.unlock();
 

--- a/src/hotspot/share/runtime/handshake.hpp
+++ b/src/hotspot/share/runtime/handshake.hpp
@@ -48,7 +48,7 @@ class HandshakeClosure : public ThreadClosure, public CHeapObj<mtThread> {
   virtual ~HandshakeClosure()                      {}
   const char* name() const                         { return _name; }
   virtual bool is_async()                          { return false; }
-  virtual bool remote_executable()                 { return true; }
+  virtual bool self_executed()                     { return false; }
   virtual void do_thread(Thread* thread) = 0;
 };
 
@@ -65,7 +65,7 @@ class SelfExecutedHandshakeClosure : public AsyncHandshakeClosure {
  public:
   SelfExecutedHandshakeClosure(const char* name) : AsyncHandshakeClosure(name) {}
   virtual ~SelfExecutedHandshakeClosure() {}
-  virtual bool remote_executable() { return false; }
+  virtual bool self_executed()            { return true; }
 };
 
 class Handshake : public AllStatic {
@@ -109,7 +109,7 @@ class HandshakeState {
   // state so a safepoint may be in-progress.)
   bool process_self_inner();
 
-  bool has_remote_executable_operation();
+  bool have_non_self_executable_operation();
   HandshakeOperation* pop_for_self();
   HandshakeOperation* pop();
 


### PR DESCRIPTION
Hi all,

Can I have reviews for this small refactoring change? It resolves a pending concern from [JDK-8238761](https://bugs.openjdk.java.net/browse/JDK-8238761), clarifies the code and allows more use case of async handshakes. See [JDK-8267079](https://bugs.openjdk.java.net/browse/JDK-8267079) for detailed description.

-Man

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8267079](https://bugs.openjdk.java.net/browse/JDK-8267079): Support async handshakes that can be executed by a remote thread


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4005/head:pull/4005` \
`$ git checkout pull/4005`

Update a local copy of the PR: \
`$ git checkout pull/4005` \
`$ git pull https://git.openjdk.java.net/jdk pull/4005/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4005`

View PR using the GUI difftool: \
`$ git pr show -t 4005`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4005.diff">https://git.openjdk.java.net/jdk/pull/4005.diff</a>

</details>
