### PR TITLE
8266404: Fatal error report generated with -XX:+CrashOnOutOfMemoryError should not contain suggestion to submit a bug report

### DIFF
--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -289,13 +289,13 @@ void report_vm_status_error(const char* file, int line, const char* error_msg,
 }
 
 // Declaration for ATTRIBUTE_PRINTF application.
-void report_fatal_impl(VMErrorType error_type, const char* file, int line,
+static void report_fatal_impl(VMErrorType error_type, const char* file, int line,
                        const char* detail_fmt, va_list detail_args)
   ATTRIBUTE_PRINTF(4,0);
 
 // Definition
-void report_fatal_impl(VMErrorType error_type, const char* file, int line,
-                       const char* detail_fmt, va_list detail_args) {
+static void report_fatal_impl(VMErrorType error_type, const char* file, int line,
+                              const char* detail_fmt, va_list detail_args) {
   if (Debugging || error_is_suppressed(file, line)) return;
   void* context = NULL;
 #ifdef CAN_SHOW_REGISTERS_ON_ASSERT

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -288,15 +288,10 @@ void report_vm_status_error(const char* file, int line, const char* error_msg,
   report_vm_error(file, line, error_msg, "error %s(%d), %s", os::errno_name(status), status, detail);
 }
 
-// Declaration for ATTRIBUTE_PRINTF application.
-static void report_fatal_impl(VMErrorType error_type, const char* file, int line,
-                       const char* detail_fmt, va_list detail_args)
-  ATTRIBUTE_PRINTF(4,0);
-
-// Definition
-static void report_fatal_impl(VMErrorType error_type, const char* file, int line,
-                              const char* detail_fmt, va_list detail_args) {
+void report_fatal(VMErrorType error_type, const char* file, int line, const char* detail_fmt, ...) {
   if (Debugging || error_is_suppressed(file, line)) return;
+  va_list detail_args;
+  va_start(detail_args, detail_fmt);
   void* context = NULL;
 #ifdef CAN_SHOW_REGISTERS_ON_ASSERT
   if (g_assertion_context != NULL && os::current_thread_id() == g_asserting_thread) {
@@ -309,19 +304,6 @@ static void report_fatal_impl(VMErrorType error_type, const char* file, int line
   VMError::report_and_die(error_type, "fatal error", detail_fmt, detail_args,
                           Thread::current_or_null(), NULL, NULL, context,
                           file, line, 0);
-}
-
-void report_fatal(const char* file, int line, const char* detail_fmt, ...) {
-  va_list detail_args;
-  va_start(detail_args, detail_fmt);
-  report_fatal_impl(INTERNAL_ERROR, file, line, detail_fmt, detail_args);
-  va_end(detail_args);
-}
-
-void report_fatal(VMErrorType error_type, const char* file, int line, const char* detail_fmt, ...) {
-  va_list detail_args;
-  va_start(detail_args, detail_fmt);
-  report_fatal_impl(error_type, file, line, detail_fmt, detail_args);
   va_end(detail_args);
 }
 

--- a/src/hotspot/share/utilities/debug.hpp
+++ b/src/hotspot/share/utilities/debug.hpp
@@ -150,7 +150,8 @@ enum VMErrorType {
   INTERNAL_ERROR   = 0xe0000000,
   OOM_MALLOC_ERROR = 0xe0000001,
   OOM_MMAP_ERROR   = 0xe0000002,
-  OOM_MPROTECT_ERROR = 0xe0000003
+  OOM_MPROTECT_ERROR = 0xe0000003,
+  OOM_JAVA_HEAP_FATAL = 0xe000004
 };
 
 // Set to suppress secondary error reporting.
@@ -164,6 +165,7 @@ void report_vm_error(const char* file, int line, const char* error_msg,
 void report_vm_status_error(const char* file, int line, const char* error_msg,
                             int status, const char* detail);
 void report_fatal(const char* file, int line, const char* detail_fmt, ...) ATTRIBUTE_PRINTF(3, 4);
+void report_fatal(VMErrorType error_type, const char* file, int line, const char* detail_fmt, ...) ATTRIBUTE_PRINTF(4, 5);
 void report_vm_out_of_memory(const char* file, int line, size_t size, VMErrorType vm_err_type,
                              const char* detail_fmt, ...) ATTRIBUTE_PRINTF(5, 6);
 void report_should_not_call(const char* file, int line);

--- a/src/hotspot/share/utilities/debug.hpp
+++ b/src/hotspot/share/utilities/debug.hpp
@@ -151,7 +151,7 @@ enum VMErrorType {
   OOM_MALLOC_ERROR = 0xe0000001,
   OOM_MMAP_ERROR   = 0xe0000002,
   OOM_MPROTECT_ERROR = 0xe0000003,
-  OOM_JAVA_HEAP_FATAL = 0xe000004
+  OOM_JAVA_HEAP_FATAL = 0xe0000004
 };
 
 // Set to suppress secondary error reporting.

--- a/src/hotspot/share/utilities/debug.hpp
+++ b/src/hotspot/share/utilities/debug.hpp
@@ -106,7 +106,7 @@ do {                                                                            
 #define fatal(...)                                                                \
 do {                                                                              \
   TOUCH_ASSERT_POISON;                                                            \
-  report_fatal(__FILE__, __LINE__, __VA_ARGS__);                                  \
+  report_fatal(INTERNAL_ERROR, __FILE__, __LINE__, __VA_ARGS__);                  \
   BREAKPOINT;                                                                     \
 } while (0)
 
@@ -164,7 +164,6 @@ void report_vm_error(const char* file, int line, const char* error_msg,
                      const char* detail_fmt, ...) ATTRIBUTE_PRINTF(4, 5);
 void report_vm_status_error(const char* file, int line, const char* error_msg,
                             int status, const char* detail);
-void report_fatal(const char* file, int line, const char* detail_fmt, ...) ATTRIBUTE_PRINTF(3, 4);
 void report_fatal(VMErrorType error_type, const char* file, int line, const char* detail_fmt, ...) ATTRIBUTE_PRINTF(4, 5);
 void report_vm_out_of_memory(const char* file, int line, size_t size, VMErrorType vm_err_type,
                              const char* detail_fmt, ...) ATTRIBUTE_PRINTF(5, 6);

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -636,7 +636,7 @@ void VMError::report(outputStream* st, bool _verbose) {
 
   STEP("printing bug submit message")
 
-     if (should_report_bug(_id) && _verbose) {
+     if (should_submit_bug_report(_id) && _verbose) {
        print_bug_submit_message(st, _thread);
      }
 
@@ -1584,7 +1584,7 @@ void VMError::report_and_die(int id, const char* message, const char* detail_fmt
     }
   }
 
-  static bool skip_bug_url = !should_report_bug(_id);
+  static bool skip_bug_url = !should_submit_bug_report(_id);
   if (!skip_bug_url) {
     skip_bug_url = true;
 

--- a/src/hotspot/share/utilities/vmError.hpp
+++ b/src/hotspot/share/utilities/vmError.hpp
@@ -109,6 +109,10 @@ class VMError : public AllStatic {
     return (id != OOM_MALLOC_ERROR) && (id != OOM_MMAP_ERROR);
   }
 
+  static bool should_submit_bug_report(unsigned int id) {
+    return should_report_bug(id) && (id != OOM_JAVA_HEAP_FATAL);
+  }
+
   // Write a hint to the stream in case siginfo relates to a segv/bus error
   // and the offending address points into CDS store.
   static void check_failing_cds_access(outputStream* st, const void* siginfo);


### PR DESCRIPTION
A simple fix to add a new VMErrorType (OOM_JAVA_HEAP_FATAL) to indicate we've requested a Java OOM error to be fatal. A new overload of report_fatal is provided to allow this to be passed through.

VMError has an existing notion of "should_report_bug" but that encompasses more than just printing the bug submission URL, so I added a new specific check for that.

Checked hs_err files before and after with the fix, from the CrashOnOutOfMemoryError test.

Tested tiers 1-3 for good measure.

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266404](https://bugs.openjdk.java.net/browse/JDK-8266404): Fatal error report generated with -XX:+CrashOnOutOfMemoryError should not contain suggestion to submit a bug report


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to 147b5cf10be7c3bd2a5b8d6fd4185ba596fef4e8
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to 147b5cf10be7c3bd2a5b8d6fd4185ba596fef4e8
 * [Gerard Ziemski](https://openjdk.java.net/census#gziemski) (@gerard-ziemski - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4006/head:pull/4006` \
`$ git checkout pull/4006`

Update a local copy of the PR: \
`$ git checkout pull/4006` \
`$ git pull https://git.openjdk.java.net/jdk pull/4006/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4006`

View PR using the GUI difftool: \
`$ git pr show -t 4006`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4006.diff">https://git.openjdk.java.net/jdk/pull/4006.diff</a>

</details>
