### PR TITLE
8267089: Use typedef KVHashtable for ID2KlassTable

### DIFF
--- a/src/hotspot/share/cds/classListParser.cpp
+++ b/src/hotspot/share/cds/classListParser.cpp
@@ -54,7 +54,7 @@
 volatile Thread* ClassListParser::_parsing_thread = NULL;
 ClassListParser* ClassListParser::_instance = NULL;
 
-ClassListParser::ClassListParser(const char* file) {
+ClassListParser::ClassListParser(const char* file) : _id2klass_table(INITIAL_TABLE_SIZE) {
   _classlist_file = file;
   _file = NULL;
   // Use os::open() because neither fopen() nor os::fopen()

--- a/src/hotspot/share/cds/classListParser.hpp
+++ b/src/hotspot/share/cds/classListParser.hpp
@@ -35,11 +35,6 @@
 
 class Thread;
 
-class ID2KlassTable : public KVHashtable<int, InstanceKlass*, mtInternal> {
-public:
-  ID2KlassTable() : KVHashtable<int, InstanceKlass*, mtInternal>(1987) {}
-};
-
 class CDSIndyInfo {
   GrowableArray<const char*>* _items;
 public:
@@ -71,6 +66,8 @@ public:
 };
 
 class ClassListParser : public StackObj {
+  typedef KVHashtable<int, InstanceKlass*, mtInternal> ID2KlassTable;
+
   enum {
     _unspecified      = -999,
 
@@ -83,6 +80,7 @@ class ClassListParser : public StackObj {
     _line_buf_size        = _max_allowed_line_len + _line_buf_extra
   };
 
+  static const int INITIAL_TABLE_SIZE = 1987;
   static volatile Thread* _parsing_thread; // the thread that created _instance
   static ClassListParser* _instance; // the singleton.
   const char* _classlist_file;

--- a/src/hotspot/share/cds/classListParser.hpp
+++ b/src/hotspot/share/cds/classListParser.hpp
@@ -106,7 +106,7 @@ class ClassListParser : public StackObj {
   bool parse_int_option(const char* option_name, int* value);
   bool parse_uint_option(const char* option_name, int* value);
   InstanceKlass* load_class_from_source(Symbol* class_name, TRAPS);
-  ID2KlassTable *table() {
+  ID2KlassTable* table() {
     return &_id2klass_table;
   }
   InstanceKlass* lookup_class_by_id(int id);


### PR DESCRIPTION
While backporting some stuff to jdk11, I noticed main functionalities of ID2KlassTable have been removed afterJDK-8213587, it seems that we can use a simple typedef KVHashtable instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267089](https://bugs.openjdk.java.net/browse/JDK-8267089): Use typedef KVHashtable for ID2KlassTable


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4007/head:pull/4007` \
`$ git checkout pull/4007`

Update a local copy of the PR: \
`$ git checkout pull/4007` \
`$ git pull https://git.openjdk.java.net/jdk pull/4007/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4007`

View PR using the GUI difftool: \
`$ git pr show -t 4007`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4007.diff">https://git.openjdk.java.net/jdk/pull/4007.diff</a>

</details>
