### PR TITLE
JDK-8267041: javac crash when creating lambda with capture inside a switch expression

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -1353,7 +1353,7 @@ public class LambdaToMethod extends TreeTranslator {
         public void visitIdent(JCIdent tree) {
             if (context() != null && lambdaIdentSymbolFilter(tree.sym)) {
                 if (tree.sym.kind == VAR &&
-                        tree.sym.owner.kind == MTH &&
+                        (tree.sym.owner.kind == MTH || tree.sym.owner.kind == VAR) &&
                         tree.type.constValue() == null) {
                     TranslationContext<?> localContext = context();
                     while (localContext != null) {
@@ -1566,7 +1566,7 @@ public class LambdaToMethod extends TreeTranslator {
 
             List<Frame> prevStack = frameStack;
             try {
-                if (tree.sym.owner.kind == MTH) {
+                if (tree.sym.owner.kind == MTH || tree.sym.owner.kind == VAR) {
                     frameStack.head.addLocal(tree.sym);
                 }
                 frameStack = frameStack.prepend(new Frame(tree));

--- a/test/langtools/tools/javac/switchexpr/ExpressionSwitchLambdaCapture.java
+++ b/test/langtools/tools/javac/switchexpr/ExpressionSwitchLambdaCapture.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8267041
+ * @summary Verify local variables are captured properly for switch expressions used in field initializers
+ * @compile ExpressionSwitchLambdaCapture.java
+ * @run main ExpressionSwitchLambdaCapture
+ */
+public class ExpressionSwitchLambdaCapture {
+
+    private static final Func<Object> func1 = switch (0) {
+        case 0 -> {
+            Object o = null;
+            yield () -> o;
+        }
+        case 1 -> {
+            Object o = null;
+            yield new Func<>() {
+                @Override
+                public Object func() {
+                    return o;
+                }
+            };
+        }
+        default -> null;
+    };
+    private final Func<Object> func2 = switch (0) {
+        case 0 -> {
+            Object o = null;
+            yield () -> o;
+        }
+        case 1 -> {
+            Object o = null;
+            yield new Func<>() {
+                @Override
+                public Object func() {
+                    return o;
+                }
+            };
+        }
+        default -> null;
+    };
+    private static final Func<Func<Object>> func3 = () -> switch (0) {
+        case 0 -> {
+            Object o = null;
+            yield () -> o;
+        }
+        case 1 -> {
+            Object o = null;
+            yield new Func<>() {
+                @Override
+                public Object func() {
+                    return o;
+                }
+            };
+        }
+        default -> null;
+    };
+    private final Func<Func<Object>> func4 = () -> switch (0) {
+        case 0 -> {
+            Object o = null;
+            yield () -> o;
+        }
+        case 1 -> {
+            Object o = null;
+            yield new Func<>() {
+                @Override
+                public Object func() {
+                    return o;
+                }
+            };
+        }
+        default -> null;
+    };
+
+    private final Func<Object> func5 = switch (0) {
+        case 0 -> {
+            Object o = null;
+            Func f = () -> o;
+            yield f;
+        }
+        case 1 -> {
+            Object o = null;
+            yield new Func<>() {
+                @Override
+                public Object func() {
+                    return o;
+                }
+            };
+        }
+        default -> null;
+    };
+
+    public static void main(String... args) {
+        new ExpressionSwitchLambdaCapture();
+    }
+}
+
+interface Func<T> {
+    T func();
+}


### PR DESCRIPTION
Variables declared inside switch expressions used as initializers to fields have the field as their owner. We need to make sure they are captured by `LambdaToMethod` - there were a few places where the checks were missing, leading to a crash later during code generation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8267041](https://bugs.openjdk.java.net/browse/JDK-8267041): javac crash when creating lambda with capture inside a switch expression


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4012/head:pull/4012` \
`$ git checkout pull/4012`

Update a local copy of the PR: \
`$ git checkout pull/4012` \
`$ git pull https://git.openjdk.java.net/jdk pull/4012/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4012`

View PR using the GUI difftool: \
`$ git pr show -t 4012`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4012.diff">https://git.openjdk.java.net/jdk/pull/4012.diff</a>

</details>
