### PR TITLE
JDK-8266942: gtest/GTestWrapper.java os.iso8601_time_vm failed

### DIFF
--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -782,28 +782,29 @@ TEST_VM(os, iso8601_time) {
   buffer[os::iso8601_timestamp_size] = 'X'; // canary
   const char* result = NULL;
   // YYYY-MM-DDThh:mm:ss.mmm+zzzz
-  const char* const pattern = "dddd-dd-dd.dd:dd:dd.ddd+dddd";
+  const char* const pattern_utc = "dddd-dd-dd.dd:dd:dd.ddd.0000";
+  const char* const pattern_local = "dddd-dd-dd.dd:dd:dd.ddd.dddd";
 
   result = os::iso8601_time(buffer, sizeof(buffer), true);
   tty->print_cr("%s", result);
   EXPECT_EQ(result, buffer);
-  EXPECT_TRUE(very_simple_string_matcher(pattern, result));
+  EXPECT_TRUE(very_simple_string_matcher(pattern_utc, result));
 
   result = os::iso8601_time(buffer, sizeof(buffer), false);
   tty->print_cr("%s", result);
   EXPECT_EQ(result, buffer);
-  EXPECT_TRUE(very_simple_string_matcher(pattern, result));
+  EXPECT_TRUE(very_simple_string_matcher(pattern_local, result));
 
   // Test with explicit timestamps
   result = os::iso8601_time(0, buffer, sizeof(buffer), true);
   tty->print_cr("%s", result);
   EXPECT_EQ(result, buffer);
-  EXPECT_TRUE(very_simple_string_matcher("1970-01-01.00:00:00.000+dddd", result));
+  EXPECT_TRUE(very_simple_string_matcher("1970-01-01.00:00:00.000+0000", result));
 
   result = os::iso8601_time(17, buffer, sizeof(buffer), true);
   tty->print_cr("%s", result);
   EXPECT_EQ(result, buffer);
-  EXPECT_TRUE(very_simple_string_matcher("1970-01-01.00:00:00.017+dddd", result));
+  EXPECT_TRUE(very_simple_string_matcher("1970-01-01.00:00:00.017+0000", result));
 
   // Canary should still be intact
   EXPECT_EQ(buffer[os::iso8601_timestamp_size], 'X');


### PR DESCRIPTION
My test only worked on half the globe, since the timezone stamp comparison was wrong (always compared for '+').

Fixed that. Also made the UTC-variant-tests more strict by requiring the timezone delta to be 0000.

Tested manually with various time zones.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266942](https://bugs.openjdk.java.net/browse/JDK-8266942): gtest/GTestWrapper.java os.iso8601_time_vm failed


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4013/head:pull/4013` \
`$ git checkout pull/4013`

Update a local copy of the PR: \
`$ git checkout pull/4013` \
`$ git pull https://git.openjdk.java.net/jdk pull/4013/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4013`

View PR using the GUI difftool: \
`$ git pr show -t 4013`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4013.diff">https://git.openjdk.java.net/jdk/pull/4013.diff</a>

</details>
