### PR TITLE
8267112: JVMCI compiler modules should be kept upgradable

### DIFF
--- a/make/common/Modules.gmk
+++ b/make/common/Modules.gmk
@@ -62,11 +62,9 @@ endif
 # Filter out jvmci specific modules if jvmci is disabled
 ifeq ($(INCLUDE_JVMCI), false)
   MODULES_FILTER += jdk.internal.vm.ci
+  MODULES_FILTER += jdk.internal.vm.compiler
+  MODULES_FILTER += jdk.internal.vm.compiler.management
 endif
-
-# Filter out Graal specific modules
-MODULES_FILTER += jdk.internal.vm.compiler
-MODULES_FILTER += jdk.internal.vm.compiler.management
 
 # jpackage is only on windows, macosx, and linux
 ifeq ($(call isTargetOs, windows macosx linux), false)

--- a/make/conf/module-loader-map.conf
+++ b/make/conf/module-loader-map.conf
@@ -61,6 +61,8 @@ BOOT_MODULES= \
 # should carefully be considered if it should be upgradeable or not.
 UPGRADEABLE_PLATFORM_MODULES= \
     java.compiler \
+    jdk.internal.vm.compiler \
+    jdk.internal.vm.compiler.management \
     #
 
 PLATFORM_MODULES= \

--- a/src/jdk.internal.vm.ci/share/classes/module-info.java
+++ b/src/jdk.internal.vm.ci/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,12 +27,6 @@ module jdk.internal.vm.ci {
     exports jdk.vm.ci.services to
         jdk.internal.vm.compiler,
         jdk.internal.vm.compiler.management;
-    exports jdk.vm.ci.runtime to
-        jdk.internal.vm.compiler,
-        jdk.internal.vm.compiler.management;
-    exports jdk.vm.ci.meta to jdk.internal.vm.compiler;
-    exports jdk.vm.ci.code to jdk.internal.vm.compiler;
-    exports jdk.vm.ci.hotspot to jdk.internal.vm.compiler;
 
     uses jdk.vm.ci.services.JVMCIServiceLocator;
     uses jdk.vm.ci.hotspot.HotSpotJVMCIBackendFactory;

--- a/src/jdk.internal.vm.compiler.management/share/classes/module-info.java
+++ b/src/jdk.internal.vm.compiler.management/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,15 +24,18 @@
  */
 
 /**
- * Registers Graal Compiler specific management interfaces for the JVM.
+ * Registers JVMCI compiler specific management interfaces for the JVM.
+ *
+ * This is an empty and upgradeable module that is a placeholder for an
+ * external implementation of a JVMCI compiler. It must be upgradeable so
+ * that it can be replaced when jlinking a new JDK image without failing
+ * the hash check for the qualified exports in jdk.internal.vm.ci's
+ * module descriptor.
  *
  * @moduleGraph
  * @since 10
  */
 module jdk.internal.vm.compiler.management {
-    requires java.management;
-    requires jdk.management;
     requires jdk.internal.vm.ci;
-    requires jdk.internal.vm.compiler;
 }
 

--- a/src/jdk.internal.vm.compiler/share/classes/module-info.java
+++ b/src/jdk.internal.vm.compiler/share/classes/module-info.java
@@ -23,35 +23,19 @@
  * questions.
  */
 
+/**
+  * JVMCI compiler implementation for the JVM.
+  *
+  * This is an empty and upgradeable module that is a placeholder for an
+  * external implementation of a JVMCI compiler. It must be upgradeable so
+  * that it can be replaced when jlinking a new JDK image without failing
+  * the hash check for the qualified exports in jdk.internal.vm.ci's
+  * module descriptor.
+  *
+  * @moduleGraph
+  * @since 9
+  */
+
 module jdk.internal.vm.compiler {
-    requires java.instrument;
-    requires java.management;
     requires jdk.internal.vm.ci;
-    requires jdk.management;
-    requires jdk.unsupported;   // sun.misc.Unsafe is used
-
-    uses org.graalvm.compiler.code.DisassemblerProvider;
-    uses org.graalvm.compiler.core.match.MatchStatementSet;
-    uses org.graalvm.compiler.debug.DebugHandlersFactory;
-    uses org.graalvm.compiler.debug.TTYStreamProvider;
-    uses org.graalvm.compiler.hotspot.CompilerConfigurationFactory;
-    uses org.graalvm.compiler.hotspot.HotSpotBackendFactory;
-    uses org.graalvm.compiler.hotspot.HotSpotCodeCacheListener;
-    uses org.graalvm.compiler.hotspot.HotSpotGraalManagementRegistration;
-    uses org.graalvm.compiler.nodes.graphbuilderconf.GeneratedPluginFactory;
-    uses org.graalvm.compiler.phases.common.jmx.HotSpotMBeanOperationProvider;
-    uses org.graalvm.compiler.serviceprovider.JMXService;
-
-    exports jdk.internal.vm.compiler.collections        to jdk.internal.vm.compiler.management;
-    exports org.graalvm.compiler.core.common            to
-        jdk.internal.vm.compiler.management;
-    exports org.graalvm.compiler.debug                  to
-        jdk.internal.vm.compiler.management;
-    exports org.graalvm.compiler.hotspot                to
-        jdk.internal.vm.compiler.management;
-    exports org.graalvm.compiler.options                to
-        jdk.internal.vm.compiler.management;
-    exports org.graalvm.compiler.phases.common.jmx      to jdk.internal.vm.compiler.management;
-    exports org.graalvm.compiler.serviceprovider        to
-        jdk.internal.vm.compiler.management;
 }

--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/IsCompilableTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/IsCompilableTest.java
@@ -24,7 +24,7 @@
 /**
  * @test
  * @bug 8136421
- * @requires vm.jvmci & vm.compMode == "Xmixed"
+ * @requires vm.graal.enabled & vm.compMode == "Xmixed"
  * @library /test/lib /
  * @library ../common/patches
  * @modules jdk.internal.vm.compiler

--- a/test/jdk/java/lang/Class/getDeclaredField/FieldSetAccessibleTest.java
+++ b/test/jdk/java/lang/Class/getDeclaredField/FieldSetAccessibleTest.java
@@ -286,7 +286,11 @@ public class FieldSetAccessibleTest {
          * Filter deployment modules
          */
         static Set<String> systemModules() {
-            Set<String> mods = Set.of("javafx.deploy", "jdk.deploy", "jdk.plugin", "jdk.javaws");
+            Set<String> mods = Set.of("javafx.deploy", "jdk.deploy", "jdk.plugin", "jdk.javaws",
+                // All JVMCI packages other than jdk.vm.ci.services are dynamically
+                // exported to jdk.internal.vm.compiler
+                "jdk.internal.vm.compiler"
+            );
             return ModuleFinder.ofSystem().findAll().stream()
                                .map(mref -> mref.descriptor().name())
                                .filter(mn -> !mods.contains(mn))

--- a/test/jdk/jdk/modules/etc/UpgradeableModules.java
+++ b/test/jdk/jdk/modules/etc/UpgradeableModules.java
@@ -43,7 +43,10 @@ import java.util.stream.Collectors;
 
 public class UpgradeableModules {
     private static final List<String> UPGRADEABLE_MODULES =
-        List.of("java.compiler");
+        List.of("java.compiler",
+                "jdk.internal.vm.compiler",
+                "jdk.internal.vm.compiler.management");
+
 
     public static void main(String... args) {
         Set<String> hashedModules = hashedModules();

--- a/test/jdk/tools/jimage/VerifyJimage.java
+++ b/test/jdk/tools/jimage/VerifyJimage.java
@@ -196,7 +196,11 @@ public class VerifyJimage {
     }
 
     private static Set<String> EXCLUDED_MODULES =
-        Set.of("javafx.deploy", "jdk.deploy", "jdk.plugin", "jdk.javaws");
+        Set.of("javafx.deploy", "jdk.deploy", "jdk.plugin", "jdk.javaws",
+            // All JVMCI packages other than jdk.vm.ci.services are dynamically
+            // exported to jdk.internal.vm.compiler
+            "jdk.internal.vm.compiler"
+        );
 
     private boolean accept(String entry) {
         int index = entry.indexOf('/', 1);


### PR DESCRIPTION
[JDK-8264806](https://bugs.openjdk.java.net/browse/JDK-8264806) changes removed sources and also removed JVMCI compiler from list of upgradable modules. JVMCI compiler modules should be upgradable in JDK to work with GraalVM. 

Make these modules upgradable again and empty by leaving only reference to JVMCI (jdk.internal.vm.ci) module. It does not restore sources - only `module-info.java` files are kept.

Note, we continue discussion about [JDK-8265091](https://bugs.openjdk.java.net/browse/JDK-8265091): "Use Module API to export JVMCI packages at runtime" to see if we can remove these `module-info.java` files.

Changes were proposed by @dougxc after testing [JDK-8264806](https://bugs.openjdk.java.net/browse/JDK-8264806) changes with GraalVM.
I restored related code in some tests for them to pass.

Testing: full tier1-tier3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267112](https://bugs.openjdk.java.net/browse/JDK-8267112): JVMCI compiler modules should be kept upgradable


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * dnsimon - Committer ⚠️ Added manually

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4014/head:pull/4014` \
`$ git checkout pull/4014`

Update a local copy of the PR: \
`$ git checkout pull/4014` \
`$ git pull https://git.openjdk.java.net/jdk pull/4014/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4014`

View PR using the GUI difftool: \
`$ git pr show -t 4014`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4014.diff">https://git.openjdk.java.net/jdk/pull/4014.diff</a>

</details>
