### PR TITLE
8267117: sun/hotspot/whitebox/CPUInfoTest.java fails on Ice Lake

### DIFF
--- a/test/lib-test/sun/hotspot/whitebox/CPUInfoTest.java
+++ b/test/lib-test/sun/hotspot/whitebox/CPUInfoTest.java
@@ -62,7 +62,7 @@ public class CPUInfoTest {
                     "avx512bw",     "avx512vl",         "sha",               "fma",
                     "vzeroupper",   "avx512_vpopcntdq", "avx512_vpclmulqdq", "avx512_vaes",
                     "avx512_vnni",  "clflush",          "clflushopt",        "clwb",
-                    "avx512_vmbi2", "avx512_vmbi",      "hv"
+                    "avx512_vbmi2", "avx512_vbmi",      "hv"
                     );
             // @formatter:on
             // Checkstyle: resume


### PR DESCRIPTION
Fix a typo in the test.

Testing:
- [x] failing test on Ice Lake host

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267117](https://bugs.openjdk.java.net/browse/JDK-8267117): sun/hotspot/whitebox/CPUInfoTest.java fails on Ice Lake


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4017/head:pull/4017` \
`$ git checkout pull/4017`

Update a local copy of the PR: \
`$ git checkout pull/4017` \
`$ git pull https://git.openjdk.java.net/jdk pull/4017/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4017`

View PR using the GUI difftool: \
`$ git pr show -t 4017`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4017.diff">https://git.openjdk.java.net/jdk/pull/4017.diff</a>

</details>
