### PR TITLE
8249395: (macos) jpackage tests timeout on MacPro5_1 systems

### DIFF
--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacDmgBundler.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacDmgBundler.java
@@ -325,7 +325,7 @@ public class MacDmgBundler extends MacBaseInstallerBundler {
                 "-fs", "HFS+",
                 "-format", "UDRW");
         try {
-            IOUtils.exec(pb);
+            IOUtils.exec(pb, false, null, true, Executor.INFINITE_TIMEOUT);
         } catch (IOException ex) {
             Log.verbose(ex); // Log exception
 
@@ -346,7 +346,7 @@ public class MacDmgBundler extends MacBaseInstallerBundler {
                 "-volname", APP_NAME.fetchFrom(params),
                 "-ov", protoDMG.toAbsolutePath().toString(),
                 "-fs", "HFS+");
-            IOUtils.exec(pb);
+            IOUtils.exec(pb, false, null, true, Executor.INFINITE_TIMEOUT);
         }
 
         // mount temp image
@@ -463,7 +463,7 @@ public class MacDmgBundler extends MacBaseInstallerBundler {
                                 "-force",
                                 hdiUtilVerbosityFlag,
                                 mountedRoot.toAbsolutePath().toString());
-                        IOUtils.exec(pb);
+                        IOUtils.exec(pb, false, null, true, Executor.INFINITE_TIMEOUT);
                     }
                 }
             }
@@ -495,7 +495,7 @@ public class MacDmgBundler extends MacBaseInstallerBundler {
                         hdiUtilVerbosityFlag,
                         "-format", "UDZO",
                         "-o", finalDMG.toAbsolutePath().toString());
-                IOUtils.exec(pb);
+                IOUtils.exec(pb, false, null, true, Executor.INFINITE_TIMEOUT);
             } finally {
                 Files.deleteIfExists(protoDMG2);
             }


### PR DESCRIPTION
Looks like it is similar to JDK-8236282, except for "hdiutil create". Based on call stack from failed test we launched "hdiutil create" and were waiting for it to terminate while reading output from it. However, based on process dump from machine which reproduced this issue, hdiutil no longer runs and existed long time ago. Fixed in same way as JDK-8236282 by writing output to file and then reading it back when process terminates.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8249395](https://bugs.openjdk.java.net/browse/JDK-8249395): (macos) jpackage tests timeout on MacPro5_1 systems


### Reviewers
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4021/head:pull/4021` \
`$ git checkout pull/4021`

Update a local copy of the PR: \
`$ git checkout pull/4021` \
`$ git pull https://git.openjdk.java.net/jdk pull/4021/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4021`

View PR using the GUI difftool: \
`$ git pr show -t 4021`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4021.diff">https://git.openjdk.java.net/jdk/pull/4021.diff</a>

</details>
