### PR TITLE
8266291: (jrtfs) Calling Files.exists may break the JRT filesystem

### DIFF
--- a/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
@@ -468,6 +468,20 @@ public final class ImageReader implements AutoCloseable {
 
         Node handleResource(String name) {
             Node n = null;
+            if (!name.startsWith("/modules/")) {
+                return null;
+            }
+            // Make sure that the thing that following "/modules/" is a module name.
+            // This will rule out paths that start as "/modules/modules/".
+            int moduleEndIndex = name.indexOf('/', "/modules/".length());
+            if (moduleEndIndex == -1) {
+                return null;
+            }
+            ImageLocation moduleLoc = findLocation(name.substring(0, moduleEndIndex));
+            if (moduleLoc == null || moduleLoc.getModuleOffset() == 0) {
+                return null;
+            }
+
             String locationPath = name.substring("/modules".length());
             ImageLocation resourceLoc = findLocation(locationPath);
             if (resourceLoc != null) {

--- a/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
@@ -472,7 +472,6 @@ public final class ImageReader implements AutoCloseable {
                 return null;
             }
             // Make sure that the thing that follows "/modules/" is a module name.
-            // This will rule out paths that start as "/modules/modules/".
             int moduleEndIndex = name.indexOf('/', "/modules/".length());
             if (moduleEndIndex == -1) {
                 return null;

--- a/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
@@ -471,7 +471,7 @@ public final class ImageReader implements AutoCloseable {
             if (!name.startsWith("/modules/")) {
                 return null;
             }
-            // Make sure that the thing that following "/modules/" is a module name.
+            // Make sure that the thing that follows "/modules/" is a module name.
             // This will rule out paths that start as "/modules/modules/".
             int moduleEndIndex = name.indexOf('/', "/modules/".length());
             if (moduleEndIndex == -1) {

--- a/test/jdk/jdk/internal/jrtfs/Basic.java
+++ b/test/jdk/jdk/internal/jrtfs/Basic.java
@@ -244,22 +244,30 @@ public class Basic {
         }
     }
 
-    @DataProvider(name = "topLevelPkgDirs")
-    private Object[][] topLevelPkgDirs() {
+    @DataProvider(name = "topLevelNonExistingDirs")
+    private Object[][] topLevelNonExistingDirs() {
         return new Object[][] {
             { "/java/lang" },
             { "java/lang"  },
             { "/java/util" },
             { "java/util"  },
+            { "/modules/modules"  },
+            { "/modules/modules/"  },
+            { "/modules/modules/java.base"  },
+            { "/modules/modules/java.base/"  },
+            { "/modules/modules/java.base/java/lang/Object.class"  },
+            { "/modules/modules/javax.scripting"  },
+            { "/modules/modules/javax.scripting/"  },
+            { "/modules/modules/javax.scripting/javax/script/ScriptEngine.class"  },
         };
     }
 
-    @Test(dataProvider = "topLevelPkgDirs")
+    @Test(dataProvider = "topLevelNonExistingDirs")
     public void testNotExists(String path) throws Exception {
         FileSystem fs = FileSystems.getFileSystem(URI.create("jrt:/"));
         Path dir = fs.getPath(path);
 
-        // package directories should not be there at top level
+        // these directories should not be there at top level
         assertTrue(Files.notExists(dir));
     }
 
@@ -755,6 +763,16 @@ public class Basic {
         Path classFile = fs.getPath(path);
 
         assertTrue(Files.size(classFile) > 0L);
+    }
+
+    // @bug 8266291: (jrtfs) Calling Files.exists may break the JRT filesystem
+    @Test
+    public void fileExistsCallBreaksFileSystem() throws Exception {
+        Path p = FileSystems.getFileSystem(URI.create("jrt:/")).getPath("modules");
+        boolean wasDirectory = Files.isDirectory(p);
+        Path m = p.resolve("modules");
+        Files.exists(m);
+        assertTrue(wasDirectory == Files.isDirectory(p));
     }
 }
 

--- a/test/jdk/jdk/internal/jrtfs/Basic.java
+++ b/test/jdk/jdk/internal/jrtfs/Basic.java
@@ -267,7 +267,7 @@ public class Basic {
         FileSystem fs = FileSystems.getFileSystem(URI.create("jrt:/"));
         Path dir = fs.getPath(path);
 
-        // these directories should not be there at top level
+        // These directories should not be there at top level
         assertTrue(Files.notExists(dir));
     }
 


### PR DESCRIPTION
Problematic paths that start with /modules/modules prefix are handled properly

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266291](https://bugs.openjdk.java.net/browse/JDK-8266291): (jrtfs) Calling Files.exists may break the JRT filesystem


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to ba288d936b83052cfc300c87bb0633e5bad3bad4
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to ba288d936b83052cfc300c87bb0633e5bad3bad4


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4022/head:pull/4022` \
`$ git checkout pull/4022`

Update a local copy of the PR: \
`$ git checkout pull/4022` \
`$ git pull https://git.openjdk.java.net/jdk pull/4022/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4022`

View PR using the GUI difftool: \
`$ git pr show -t 4022`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4022.diff">https://git.openjdk.java.net/jdk/pull/4022.diff</a>

</details>
