### PR TITLE
8266962: Add arch supporting check for "Op_VectorLoadConst" before creating the node

### DIFF
--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -352,6 +352,9 @@ bool LibraryCallKit::inline_vector_shuffle_iota() {
   if (!arch_supports_vector(Op_AndV, num_elem, elem_bt, VecMaskNotUsed)) {
     return false;
   }
+  if (!arch_supports_vector(Op_VectorLoadConst, num_elem, elem_bt, VecMaskNotUsed)) {
+    return false;
+  }
   if (!arch_supports_vector(Op_VectorBlend, num_elem, elem_bt, VecMaskUseLoad)) {
     return false;
   }


### PR DESCRIPTION
When creating the vector shuffle, the `"VectorLoadConstNode"` will be created to get an initial index vector. Before creating it, the compiler should check whether the current platform supports this opcode in case the jvm crashes with `"bad ad file"`. The compiler should finish the intrinsification and go back to the default java implementation if the backend doesn't support it.

Tested tier1 and jdk::tier3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266962](https://bugs.openjdk.java.net/browse/JDK-8266962): Add arch supporting check for "Op_VectorLoadConst" before creating the node


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4023/head:pull/4023` \
`$ git checkout pull/4023`

Update a local copy of the PR: \
`$ git checkout pull/4023` \
`$ git pull https://git.openjdk.java.net/jdk pull/4023/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4023`

View PR using the GUI difftool: \
`$ git pr show -t 4023`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4023.diff">https://git.openjdk.java.net/jdk/pull/4023.diff</a>

</details>
