### PR TITLE
JDK-8267136: jtreg gtest runner should not require flagless-ness

### DIFF
--- a/test/hotspot/jtreg/gtest/GTestWrapper.java
+++ b/test/hotspot/jtreg/gtest/GTestWrapper.java
@@ -26,7 +26,6 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.xml
- * @requires vm.flagless
  * @run main/native GTestWrapper
  */
 

--- a/test/hotspot/jtreg/gtest/LargePageGtests.java
+++ b/test/hotspot/jtreg/gtest/LargePageGtests.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2020, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,6 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.xml
- * @requires vm.flagless
  * @run main/native GTestWrapper --gtest_filter=os* -XX:-PrintWarnings -XX:+UseLargePages
  */
 
@@ -52,7 +51,6 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.xml
- * @requires vm.flagless
  * @run main/native GTestWrapper --gtest_filter=os* -XX:-PrintWarnings -XX:+UseLargePages -XX:LargePageSizeInBytes=1G
  */
 
@@ -62,6 +60,5 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.xml
- * @requires vm.flagless
  * @run main/native GTestWrapper --gtest_filter=os* -XX:-PrintWarnings -XX:+UseLargePages -XX:+UseSHM
  */

--- a/test/hotspot/jtreg/gtest/MetaspaceGtests.java
+++ b/test/hotspot/jtreg/gtest/MetaspaceGtests.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2020, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,6 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.xml
- * @requires vm.flagless
  * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:MetaspaceReclaimPolicy=none -XX:+UnlockDiagnosticVMOptions -XX:VerifyMetaspaceInterval=3
  */
 
@@ -46,7 +45,6 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.xml
- * @requires vm.flagless
  * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:MetaspaceReclaimPolicy=none
  */
 
@@ -60,7 +58,6 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.xml
- * @requires vm.flagless
  * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:MetaspaceReclaimPolicy=aggressive -XX:+UnlockDiagnosticVMOptions -XX:VerifyMetaspaceInterval=3
  */
 
@@ -70,7 +67,6 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.xml
- * @requires vm.flagless
  * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:MetaspaceReclaimPolicy=aggressive
  */
 
@@ -83,7 +79,6 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.xml
- * @requires vm.flagless
  * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:+UnlockDiagnosticVMOptions -XX:VerifyMetaspaceInterval=3 -XX:+MetaspaceGuardAllocations
  */
 
@@ -96,6 +91,5 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.xml
- * @requires vm.flagless
  * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:MetaspaceReclaimPolicy=balanced -XX:-UseCompressedClassPointers
  */

--- a/test/hotspot/jtreg/gtest/MetaspaceUtilsGtests.java
+++ b/test/hotspot/jtreg/gtest/MetaspaceUtilsGtests.java
@@ -35,6 +35,5 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.xml
- * @requires vm.flagless
  * @run main/native GTestWrapper --gtest_filter=MetaspaceUtils* -XX:-UseCompressedClassPointers
  */


### PR DESCRIPTION
There is no reason to require flagless-ness when running gtests.

Its completely pointless since any arguments go down to GTestWrapper.java, which just starts the gtest runner in a child process, only passing *explicitly specified* vm arguments down. This does not include -vmoptions arguments.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8267136](https://bugs.openjdk.java.net/browse/JDK-8267136): jtreg gtest runner should not require flagless-ness


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4024/head:pull/4024` \
`$ git checkout pull/4024`

Update a local copy of the PR: \
`$ git checkout pull/4024` \
`$ git pull https://git.openjdk.java.net/jdk pull/4024/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4024`

View PR using the GUI difftool: \
`$ git pr show -t 4024`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4024.diff">https://git.openjdk.java.net/jdk/pull/4024.diff</a>

</details>
