### PR TITLE
JDK-8267138: Stray suffix when starting gtests via GTestWrapper.java

### DIFF
--- a/test/hotspot/jtreg/gtest/GTestWrapper.java
+++ b/test/hotspot/jtreg/gtest/GTestWrapper.java
@@ -83,7 +83,7 @@ public class GTestWrapper {
         command.add("-jdk");
         command.add(Utils.TEST_JDK);
         command.add("--gtest_output=xml:" + resultFile);
-        command.add("--gtest_catch_exceptions=0" + resultFile);
+        command.add("--gtest_catch_exceptions=0");
         for (String a : args) {
             command.add(a);
         }


### PR DESCRIPTION
For JDK-8185734: "[Windows] Structured Exception Catcher missing around gtest execution", I specified that `--gtest_catch_exceptions=0` should be specified when starting the gtestlauncher from within the gtest jtreg wrappers. The intent was to leave signal handling to the VM - needed is this for windows 32-bit where fault handling happens via stack-based SEH, and gtestrunner's own SEH handler would intercept exceptions bubbling up from faults in test coding. For more details, please see the description of JDK-8185734.

However turned out I added a typo. It did not prevent the option from working, but should be fixed nevertheless.

This is really really trivial. Thanks for reviewing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267138](https://bugs.openjdk.java.net/browse/JDK-8267138): Stray suffix when starting gtests via GTestWrapper.java


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4025/head:pull/4025` \
`$ git checkout pull/4025`

Update a local copy of the PR: \
`$ git checkout pull/4025` \
`$ git pull https://git.openjdk.java.net/jdk pull/4025/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4025`

View PR using the GUI difftool: \
`$ git pr show -t 4025`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4025.diff">https://git.openjdk.java.net/jdk/pull/4025.diff</a>

</details>
