### PR TITLE
8264408: test_oopStorage no longer needs to disable some tests on WIN32

### DIFF
--- a/test/hotspot/gtest/gc/shared/test_oopStorage.cpp
+++ b/test/hotspot/gtest/gc/shared/test_oopStorage.cpp
@@ -41,13 +41,6 @@
 #include "utilities/quickSort.hpp"
 #include "unittest.hpp"
 
-// --- FIXME: Disable some tests on 32bit Windows, because SafeFetch
-//     (which is used by allocation_status) doesn't currently provide
-//     protection in the context where gtests are run; see JDK-8185734.
-#ifdef _WIN32
-#define DISABLE_GARBAGE_ALLOCATION_STATUS_TESTS
-#endif
-
 // Access storage internals.
 class OopStorage::TestAccess : public AllStatic {
 public:
@@ -1056,9 +1049,7 @@ TEST_VM_F(OopStorageTestWithAllocation, allocation_status) {
 
   EXPECT_EQ(OopStorage::ALLOCATED_ENTRY, _storage.allocation_status(retained));
   EXPECT_EQ(OopStorage::UNALLOCATED_ENTRY, _storage.allocation_status(released));
-#ifndef DISABLE_GARBAGE_ALLOCATION_STATUS_TESTS
   EXPECT_EQ(OopStorage::INVALID_ENTRY, _storage.allocation_status(garbage));
-#endif
 
   for (size_t i = 0; i < _max_entries; ++i) {
     if ((_entries[i] != retained) && (_entries[i] != released)) {
@@ -1072,10 +1063,8 @@ TEST_VM_F(OopStorageTestWithAllocation, allocation_status) {
     while (_storage.delete_empty_blocks()) {}
   }
   EXPECT_EQ(OopStorage::ALLOCATED_ENTRY, _storage.allocation_status(retained));
-#ifndef DISABLE_GARBAGE_ALLOCATION_STATUS_TESTS
   EXPECT_EQ(OopStorage::INVALID_ENTRY, _storage.allocation_status(released));
   EXPECT_EQ(OopStorage::INVALID_ENTRY, _storage.allocation_status(garbage));
-#endif // DISABLE_GARBAGE_ALLOCATION_STATUS_TESTS
 }
 
 TEST_VM_F(OopStorageTest, usage_info) {


### PR DESCRIPTION
The gtest gc/shared/test_oopStorage.cpp disables some tests on 32bit Windows because they use SafeFetch, which couldn't be used in the context where these tests were run. JDK-8185734 tracked the problem of using SafeFetch in gtests, and has since been fixed. So the OopStorage tests no longer need to be disabled.

Removing the test suppression involves removing the macro DISABLE_GARBAGE_ALLOCATION_STATUS_TEST and the #ifndef uses of it from test_oopStorage.cpp.

Note that the condition for defining that macro was botched, so that it applied to all Windows platforms, not just 32bit Windows. So the relevant tests haven't been executed on any version of Windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264408](https://bugs.openjdk.java.net/browse/JDK-8264408): test_oopStorage no longer needs to disable some tests on WIN32


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4026/head:pull/4026` \
`$ git checkout pull/4026`

Update a local copy of the PR: \
`$ git checkout pull/4026` \
`$ git pull https://git.openjdk.java.net/jdk pull/4026/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4026`

View PR using the GUI difftool: \
`$ git pr show -t 4026`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4026.diff">https://git.openjdk.java.net/jdk/pull/4026.diff</a>

</details>
