### PR TITLE
8267180: Typo in copyright header  for HashesTest

### DIFF
--- a/test/jdk/tools/jmod/hashes/HashesTest.java
+++ b/test/jdk/tools/jmod/hashes/HashesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2015, 2021, Oracle and/or its affiliates. All rig reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Please review this fix for a typo in the copyright header in HashTest which the jdk-tier1 does not catch

Best
Lance

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267180](https://bugs.openjdk.java.net/browse/JDK-8267180): Typo in copyright header  for HashesTest


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4034/head:pull/4034` \
`$ git checkout pull/4034`

Update a local copy of the PR: \
`$ git checkout pull/4034` \
`$ git pull https://git.openjdk.java.net/jdk pull/4034/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4034`

View PR using the GUI difftool: \
`$ git pr show -t 4034`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4034.diff">https://git.openjdk.java.net/jdk/pull/4034.diff</a>

</details>
