### PR TITLE
8267190: Optimize Vector API test operations

### DIFF
--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -1382,9 +1382,10 @@ bool LibraryCallKit::inline_vector_convert() {
     return false; // should be primitive type
   }
   BasicType elem_bt_to = elem_type_to->basic_type();
-  if (is_mask && elem_bt_from != elem_bt_to) {
-    return false; // type mismatch
+  if (is_mask && (type2aelembytes(elem_bt_from) != type2aelembytes(elem_bt_to))) {
+    return false; // elem size mismatch
   }
+
   int num_elem_from = vlen_from->get_con();
   int num_elem_to = vlen_to->get_con();
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
@@ -599,10 +599,15 @@ final class Byte128Vector extends ByteVector {
             return (Byte128Vector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -624,6 +629,24 @@ final class Byte128Vector extends ByteVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    Byte128Mask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
@@ -606,19 +606,18 @@ final class Byte128Vector extends ByteVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new Byte128Vector.Byte128Mask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new Short128Vector.Short128Mask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new Int128Vector.Int128Mask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new Long128Vector.Long128Mask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new Float128Vector.Float128Mask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new Double128Vector.Double128Mask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new Byte128Vector.Byte128Mask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new Short128Vector.Short128Mask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new Int128Vector.Int128Mask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new Long128Vector.Long128Mask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new Float128Vector.Float128Mask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new Double128Vector.Double128Mask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
@@ -600,35 +600,25 @@ final class Byte128Vector extends ByteVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new Byte128Vector.Byte128Mask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new Short128Vector.Short128Mask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new Int128Vector.Int128Mask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new Long128Vector.Long128Mask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new Float128Vector.Float128Mask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new Double128Vector.Double128Mask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new Byte128Vector.Byte128Mask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new Short128Vector.Short128Mask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new Int128Vector.Int128Mask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new Long128Vector.Long128Mask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new Float128Vector.Float128Mask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new Double128Vector.Double128Mask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -644,9 +634,9 @@ final class Byte128Vector extends ByteVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    Byte128Mask::defaultMaskReinterpret);
+                    Byte128Mask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
@@ -632,35 +632,25 @@ final class Byte256Vector extends ByteVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new Byte256Vector.Byte256Mask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new Short256Vector.Short256Mask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new Int256Vector.Int256Mask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new Long256Vector.Long256Mask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new Float256Vector.Float256Mask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new Double256Vector.Double256Mask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new Byte256Vector.Byte256Mask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new Short256Vector.Short256Mask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new Int256Vector.Int256Mask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new Long256Vector.Long256Mask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new Float256Vector.Float256Mask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new Double256Vector.Double256Mask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -676,9 +666,9 @@ final class Byte256Vector extends ByteVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    Byte256Mask::defaultMaskReinterpret);
+                    Byte256Mask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
@@ -638,19 +638,18 @@ final class Byte256Vector extends ByteVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new Byte256Vector.Byte256Mask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new Short256Vector.Short256Mask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new Int256Vector.Int256Mask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new Long256Vector.Long256Mask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new Float256Vector.Float256Mask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new Double256Vector.Double256Mask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new Byte256Vector.Byte256Mask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new Short256Vector.Short256Mask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new Int256Vector.Int256Mask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new Long256Vector.Long256Mask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new Float256Vector.Float256Mask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new Double256Vector.Double256Mask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
@@ -631,10 +631,15 @@ final class Byte256Vector extends ByteVector {
             return (Byte256Vector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -656,6 +661,24 @@ final class Byte256Vector extends ByteVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    Byte256Mask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
@@ -702,19 +702,18 @@ final class Byte512Vector extends ByteVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new Byte512Vector.Byte512Mask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new Short512Vector.Short512Mask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new Int512Vector.Int512Mask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new Long512Vector.Long512Mask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new Float512Vector.Float512Mask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new Double512Vector.Double512Mask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new Byte512Vector.Byte512Mask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new Short512Vector.Short512Mask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new Int512Vector.Int512Mask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new Long512Vector.Long512Mask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new Float512Vector.Float512Mask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new Double512Vector.Double512Mask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
@@ -695,10 +695,15 @@ final class Byte512Vector extends ByteVector {
             return (Byte512Vector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -720,6 +725,24 @@ final class Byte512Vector extends ByteVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    Byte512Mask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
@@ -696,35 +696,25 @@ final class Byte512Vector extends ByteVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new Byte512Vector.Byte512Mask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new Short512Vector.Short512Mask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new Int512Vector.Int512Mask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new Long512Vector.Long512Mask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new Float512Vector.Float512Mask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new Double512Vector.Double512Mask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new Byte512Vector.Byte512Mask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new Short512Vector.Short512Mask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new Int512Vector.Int512Mask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new Long512Vector.Long512Mask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new Float512Vector.Float512Mask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new Double512Vector.Double512Mask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -740,9 +730,9 @@ final class Byte512Vector extends ByteVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    Byte512Mask::defaultMaskReinterpret);
+                    Byte512Mask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
@@ -583,10 +583,15 @@ final class Byte64Vector extends ByteVector {
             return (Byte64Vector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -608,6 +613,24 @@ final class Byte64Vector extends ByteVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    Byte64Mask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
@@ -590,19 +590,18 @@ final class Byte64Vector extends ByteVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new Byte64Vector.Byte64Mask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new Short64Vector.Short64Mask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new Int64Vector.Int64Mask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new Long64Vector.Long64Mask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new Float64Vector.Float64Mask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new Double64Vector.Double64Mask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new Byte64Vector.Byte64Mask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new Short64Vector.Short64Mask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new Int64Vector.Int64Mask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new Long64Vector.Long64Mask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new Float64Vector.Float64Mask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new Double64Vector.Double64Mask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
@@ -584,35 +584,25 @@ final class Byte64Vector extends ByteVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new Byte64Vector.Byte64Mask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new Short64Vector.Short64Mask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new Int64Vector.Int64Mask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new Long64Vector.Long64Mask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new Float64Vector.Float64Mask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new Double64Vector.Double64Mask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new Byte64Vector.Byte64Mask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new Short64Vector.Short64Mask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new Int64Vector.Int64Mask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new Long64Vector.Long64Mask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new Float64Vector.Float64Mask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new Double64Vector.Double64Mask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -628,9 +618,9 @@ final class Byte64Vector extends ByteVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    Byte64Mask::defaultMaskReinterpret);
+                    Byte64Mask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
@@ -576,19 +576,18 @@ final class ByteMaxVector extends ByteVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new ByteMaxVector.ByteMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new ShortMaxVector.ShortMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new IntMaxVector.IntMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new LongMaxVector.LongMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new FloatMaxVector.FloatMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new DoubleMaxVector.DoubleMaxMask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new ByteMaxVector.ByteMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new ShortMaxVector.ShortMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new IntMaxVector.IntMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new LongMaxVector.LongMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new FloatMaxVector.FloatMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new DoubleMaxVector.DoubleMaxMask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
@@ -569,10 +569,15 @@ final class ByteMaxVector extends ByteVector {
             return (ByteMaxVector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -594,6 +599,24 @@ final class ByteMaxVector extends ByteVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    ByteMaxMask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
@@ -570,35 +570,25 @@ final class ByteMaxVector extends ByteVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new ByteMaxVector.ByteMaxMask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new ShortMaxVector.ShortMaxMask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new IntMaxVector.IntMaxMask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new LongMaxVector.LongMaxMask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new FloatMaxVector.FloatMaxMask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new DoubleMaxVector.DoubleMaxMask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new ByteMaxVector.ByteMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new ShortMaxVector.ShortMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new IntMaxVector.IntMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new LongMaxVector.LongMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new FloatMaxVector.FloatMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new DoubleMaxVector.DoubleMaxMask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -614,9 +604,9 @@ final class ByteMaxVector extends ByteVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    ByteMaxMask::defaultMaskReinterpret);
+                    ByteMaxMask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
@@ -567,10 +567,15 @@ final class Double128Vector extends DoubleVector {
             return (Double128Vector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -592,6 +597,24 @@ final class Double128Vector extends DoubleVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    Double128Mask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
@@ -568,35 +568,25 @@ final class Double128Vector extends DoubleVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new Byte128Vector.Byte128Mask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new Short128Vector.Short128Mask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new Int128Vector.Int128Mask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new Long128Vector.Long128Mask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new Float128Vector.Float128Mask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new Double128Vector.Double128Mask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new Byte128Vector.Byte128Mask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new Short128Vector.Short128Mask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new Int128Vector.Int128Mask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new Long128Vector.Long128Mask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new Float128Vector.Float128Mask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new Double128Vector.Double128Mask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -612,9 +602,9 @@ final class Double128Vector extends DoubleVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    Double128Mask::defaultMaskReinterpret);
+                    Double128Mask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
@@ -574,19 +574,18 @@ final class Double128Vector extends DoubleVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new Byte128Vector.Byte128Mask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new Short128Vector.Short128Mask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new Int128Vector.Int128Mask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new Long128Vector.Long128Mask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new Float128Vector.Float128Mask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new Double128Vector.Double128Mask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new Byte128Vector.Byte128Mask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new Short128Vector.Short128Mask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new Int128Vector.Int128Mask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new Long128Vector.Long128Mask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new Float128Vector.Float128Mask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new Double128Vector.Double128Mask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
@@ -578,19 +578,18 @@ final class Double256Vector extends DoubleVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new Byte256Vector.Byte256Mask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new Short256Vector.Short256Mask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new Int256Vector.Int256Mask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new Long256Vector.Long256Mask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new Float256Vector.Float256Mask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new Double256Vector.Double256Mask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new Byte256Vector.Byte256Mask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new Short256Vector.Short256Mask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new Int256Vector.Int256Mask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new Long256Vector.Long256Mask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new Float256Vector.Float256Mask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new Double256Vector.Double256Mask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
@@ -571,10 +571,15 @@ final class Double256Vector extends DoubleVector {
             return (Double256Vector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -596,6 +601,24 @@ final class Double256Vector extends DoubleVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    Double256Mask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
@@ -572,35 +572,25 @@ final class Double256Vector extends DoubleVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new Byte256Vector.Byte256Mask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new Short256Vector.Short256Mask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new Int256Vector.Int256Mask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new Long256Vector.Long256Mask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new Float256Vector.Float256Mask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new Double256Vector.Double256Mask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new Byte256Vector.Byte256Mask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new Short256Vector.Short256Mask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new Int256Vector.Int256Mask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new Long256Vector.Long256Mask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new Float256Vector.Float256Mask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new Double256Vector.Double256Mask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -616,9 +606,9 @@ final class Double256Vector extends DoubleVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    Double256Mask::defaultMaskReinterpret);
+                    Double256Mask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
@@ -579,10 +579,15 @@ final class Double512Vector extends DoubleVector {
             return (Double512Vector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -604,6 +609,24 @@ final class Double512Vector extends DoubleVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    Double512Mask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
@@ -586,19 +586,18 @@ final class Double512Vector extends DoubleVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new Byte512Vector.Byte512Mask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new Short512Vector.Short512Mask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new Int512Vector.Int512Mask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new Long512Vector.Long512Mask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new Float512Vector.Float512Mask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new Double512Vector.Double512Mask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new Byte512Vector.Byte512Mask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new Short512Vector.Short512Mask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new Int512Vector.Int512Mask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new Long512Vector.Long512Mask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new Float512Vector.Float512Mask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new Double512Vector.Double512Mask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
@@ -580,35 +580,25 @@ final class Double512Vector extends DoubleVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new Byte512Vector.Byte512Mask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new Short512Vector.Short512Mask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new Int512Vector.Int512Mask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new Long512Vector.Long512Mask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new Float512Vector.Float512Mask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new Double512Vector.Double512Mask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new Byte512Vector.Byte512Mask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new Short512Vector.Short512Mask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new Int512Vector.Int512Mask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new Long512Vector.Long512Mask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new Float512Vector.Float512Mask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new Double512Vector.Double512Mask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -624,9 +614,9 @@ final class Double512Vector extends DoubleVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    Double512Mask::defaultMaskReinterpret);
+                    Double512Mask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
@@ -565,10 +565,15 @@ final class Double64Vector extends DoubleVector {
             return (Double64Vector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -590,6 +595,24 @@ final class Double64Vector extends DoubleVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    Double64Mask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
@@ -572,19 +572,18 @@ final class Double64Vector extends DoubleVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new Byte64Vector.Byte64Mask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new Short64Vector.Short64Mask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new Int64Vector.Int64Mask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new Long64Vector.Long64Mask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new Float64Vector.Float64Mask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new Double64Vector.Double64Mask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new Byte64Vector.Byte64Mask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new Short64Vector.Short64Mask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new Int64Vector.Int64Mask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new Long64Vector.Long64Mask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new Float64Vector.Float64Mask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new Double64Vector.Double64Mask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
@@ -566,35 +566,25 @@ final class Double64Vector extends DoubleVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new Byte64Vector.Byte64Mask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new Short64Vector.Short64Mask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new Int64Vector.Int64Mask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new Long64Vector.Long64Mask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new Float64Vector.Float64Mask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new Double64Vector.Double64Mask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new Byte64Vector.Byte64Mask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new Short64Vector.Short64Mask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new Int64Vector.Int64Mask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new Long64Vector.Long64Mask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new Float64Vector.Float64Mask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new Double64Vector.Double64Mask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -610,9 +600,9 @@ final class Double64Vector extends DoubleVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    Double64Mask::defaultMaskReinterpret);
+                    Double64Mask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
@@ -571,19 +571,18 @@ final class DoubleMaxVector extends DoubleVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new ByteMaxVector.ByteMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new ShortMaxVector.ShortMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new IntMaxVector.IntMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new LongMaxVector.LongMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new FloatMaxVector.FloatMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new DoubleMaxVector.DoubleMaxMask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new ByteMaxVector.ByteMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new ShortMaxVector.ShortMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new IntMaxVector.IntMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new LongMaxVector.LongMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new FloatMaxVector.FloatMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new DoubleMaxVector.DoubleMaxMask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
@@ -564,10 +564,15 @@ final class DoubleMaxVector extends DoubleVector {
             return (DoubleMaxVector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -589,6 +594,24 @@ final class DoubleMaxVector extends DoubleVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    DoubleMaxMask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
@@ -565,35 +565,25 @@ final class DoubleMaxVector extends DoubleVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new ByteMaxVector.ByteMaxMask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new ShortMaxVector.ShortMaxMask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new IntMaxVector.IntMaxMask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new LongMaxVector.LongMaxMask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new FloatMaxVector.FloatMaxMask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new DoubleMaxVector.DoubleMaxMask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new ByteMaxVector.ByteMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new ShortMaxVector.ShortMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new IntMaxVector.IntMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new LongMaxVector.LongMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new FloatMaxVector.FloatMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new DoubleMaxVector.DoubleMaxMask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -609,9 +599,9 @@ final class DoubleMaxVector extends DoubleVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    DoubleMaxMask::defaultMaskReinterpret);
+                    DoubleMaxMask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
@@ -572,35 +572,25 @@ final class Float128Vector extends FloatVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new Byte128Vector.Byte128Mask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new Short128Vector.Short128Mask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new Int128Vector.Int128Mask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new Long128Vector.Long128Mask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new Float128Vector.Float128Mask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new Double128Vector.Double128Mask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new Byte128Vector.Byte128Mask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new Short128Vector.Short128Mask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new Int128Vector.Int128Mask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new Long128Vector.Long128Mask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new Float128Vector.Float128Mask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new Double128Vector.Double128Mask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -616,9 +606,9 @@ final class Float128Vector extends FloatVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    Float128Mask::defaultMaskReinterpret);
+                    Float128Mask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
@@ -571,10 +571,15 @@ final class Float128Vector extends FloatVector {
             return (Float128Vector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -596,6 +601,24 @@ final class Float128Vector extends FloatVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    Float128Mask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
@@ -578,19 +578,18 @@ final class Float128Vector extends FloatVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new Byte128Vector.Byte128Mask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new Short128Vector.Short128Mask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new Int128Vector.Int128Mask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new Long128Vector.Long128Mask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new Float128Vector.Float128Mask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new Double128Vector.Double128Mask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new Byte128Vector.Byte128Mask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new Short128Vector.Short128Mask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new Int128Vector.Int128Mask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new Long128Vector.Long128Mask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new Float128Vector.Float128Mask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new Double128Vector.Double128Mask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
@@ -580,35 +580,25 @@ final class Float256Vector extends FloatVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new Byte256Vector.Byte256Mask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new Short256Vector.Short256Mask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new Int256Vector.Int256Mask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new Long256Vector.Long256Mask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new Float256Vector.Float256Mask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new Double256Vector.Double256Mask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new Byte256Vector.Byte256Mask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new Short256Vector.Short256Mask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new Int256Vector.Int256Mask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new Long256Vector.Long256Mask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new Float256Vector.Float256Mask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new Double256Vector.Double256Mask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -624,9 +614,9 @@ final class Float256Vector extends FloatVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    Float256Mask::defaultMaskReinterpret);
+                    Float256Mask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
@@ -579,10 +579,15 @@ final class Float256Vector extends FloatVector {
             return (Float256Vector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -604,6 +609,24 @@ final class Float256Vector extends FloatVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    Float256Mask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
@@ -586,19 +586,18 @@ final class Float256Vector extends FloatVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new Byte256Vector.Byte256Mask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new Short256Vector.Short256Mask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new Int256Vector.Int256Mask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new Long256Vector.Long256Mask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new Float256Vector.Float256Mask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new Double256Vector.Double256Mask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new Byte256Vector.Byte256Mask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new Short256Vector.Short256Mask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new Int256Vector.Int256Mask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new Long256Vector.Long256Mask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new Float256Vector.Float256Mask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new Double256Vector.Double256Mask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
@@ -596,35 +596,25 @@ final class Float512Vector extends FloatVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new Byte512Vector.Byte512Mask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new Short512Vector.Short512Mask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new Int512Vector.Int512Mask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new Long512Vector.Long512Mask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new Float512Vector.Float512Mask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new Double512Vector.Double512Mask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new Byte512Vector.Byte512Mask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new Short512Vector.Short512Mask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new Int512Vector.Int512Mask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new Long512Vector.Long512Mask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new Float512Vector.Float512Mask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new Double512Vector.Double512Mask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -640,9 +630,9 @@ final class Float512Vector extends FloatVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    Float512Mask::defaultMaskReinterpret);
+                    Float512Mask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
@@ -602,19 +602,18 @@ final class Float512Vector extends FloatVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new Byte512Vector.Byte512Mask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new Short512Vector.Short512Mask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new Int512Vector.Int512Mask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new Long512Vector.Long512Mask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new Float512Vector.Float512Mask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new Double512Vector.Double512Mask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new Byte512Vector.Byte512Mask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new Short512Vector.Short512Mask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new Int512Vector.Int512Mask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new Long512Vector.Long512Mask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new Float512Vector.Float512Mask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new Double512Vector.Double512Mask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
@@ -595,10 +595,15 @@ final class Float512Vector extends FloatVector {
             return (Float512Vector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -620,6 +625,24 @@ final class Float512Vector extends FloatVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    Float512Mask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
@@ -574,19 +574,18 @@ final class Float64Vector extends FloatVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new Byte64Vector.Byte64Mask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new Short64Vector.Short64Mask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new Int64Vector.Int64Mask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new Long64Vector.Long64Mask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new Float64Vector.Float64Mask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new Double64Vector.Double64Mask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new Byte64Vector.Byte64Mask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new Short64Vector.Short64Mask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new Int64Vector.Int64Mask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new Long64Vector.Long64Mask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new Float64Vector.Float64Mask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new Double64Vector.Double64Mask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
@@ -568,35 +568,25 @@ final class Float64Vector extends FloatVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new Byte64Vector.Byte64Mask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new Short64Vector.Short64Mask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new Int64Vector.Int64Mask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new Long64Vector.Long64Mask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new Float64Vector.Float64Mask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new Double64Vector.Double64Mask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new Byte64Vector.Byte64Mask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new Short64Vector.Short64Mask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new Int64Vector.Int64Mask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new Long64Vector.Long64Mask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new Float64Vector.Float64Mask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new Double64Vector.Double64Mask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -612,9 +602,9 @@ final class Float64Vector extends FloatVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    Float64Mask::defaultMaskReinterpret);
+                    Float64Mask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
@@ -567,10 +567,15 @@ final class Float64Vector extends FloatVector {
             return (Float64Vector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -592,6 +597,24 @@ final class Float64Vector extends FloatVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    Float64Mask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
@@ -564,10 +564,15 @@ final class FloatMaxVector extends FloatVector {
             return (FloatMaxVector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -589,6 +594,24 @@ final class FloatMaxVector extends FloatVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    FloatMaxMask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
@@ -565,35 +565,25 @@ final class FloatMaxVector extends FloatVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new ByteMaxVector.ByteMaxMask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new ShortMaxVector.ShortMaxMask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new IntMaxVector.IntMaxMask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new LongMaxVector.LongMaxMask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new FloatMaxVector.FloatMaxMask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new DoubleMaxVector.DoubleMaxMask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new ByteMaxVector.ByteMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new ShortMaxVector.ShortMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new IntMaxVector.IntMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new LongMaxVector.LongMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new FloatMaxVector.FloatMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new DoubleMaxVector.DoubleMaxMask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -609,9 +599,9 @@ final class FloatMaxVector extends FloatVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    FloatMaxMask::defaultMaskReinterpret);
+                    FloatMaxMask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
@@ -571,19 +571,18 @@ final class FloatMaxVector extends FloatVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new ByteMaxVector.ByteMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new ShortMaxVector.ShortMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new IntMaxVector.IntMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new LongMaxVector.LongMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new FloatMaxVector.FloatMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new DoubleMaxVector.DoubleMaxMask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new ByteMaxVector.ByteMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new ShortMaxVector.ShortMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new IntMaxVector.IntMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new LongMaxVector.LongMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new FloatMaxVector.FloatMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new DoubleMaxVector.DoubleMaxMask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
@@ -575,10 +575,15 @@ final class Int128Vector extends IntVector {
             return (Int128Vector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -600,6 +605,24 @@ final class Int128Vector extends IntVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    Int128Mask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
@@ -582,19 +582,18 @@ final class Int128Vector extends IntVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new Byte128Vector.Byte128Mask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new Short128Vector.Short128Mask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new Int128Vector.Int128Mask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new Long128Vector.Long128Mask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new Float128Vector.Float128Mask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new Double128Vector.Double128Mask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new Byte128Vector.Byte128Mask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new Short128Vector.Short128Mask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new Int128Vector.Int128Mask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new Long128Vector.Long128Mask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new Float128Vector.Float128Mask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new Double128Vector.Double128Mask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
@@ -576,35 +576,25 @@ final class Int128Vector extends IntVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new Byte128Vector.Byte128Mask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new Short128Vector.Short128Mask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new Int128Vector.Int128Mask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new Long128Vector.Long128Mask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new Float128Vector.Float128Mask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new Double128Vector.Double128Mask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new Byte128Vector.Byte128Mask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new Short128Vector.Short128Mask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new Int128Vector.Int128Mask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new Long128Vector.Long128Mask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new Float128Vector.Float128Mask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new Double128Vector.Double128Mask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -620,9 +610,9 @@ final class Int128Vector extends IntVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    Int128Mask::defaultMaskReinterpret);
+                    Int128Mask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
@@ -590,19 +590,18 @@ final class Int256Vector extends IntVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new Byte256Vector.Byte256Mask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new Short256Vector.Short256Mask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new Int256Vector.Int256Mask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new Long256Vector.Long256Mask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new Float256Vector.Float256Mask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new Double256Vector.Double256Mask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new Byte256Vector.Byte256Mask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new Short256Vector.Short256Mask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new Int256Vector.Int256Mask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new Long256Vector.Long256Mask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new Float256Vector.Float256Mask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new Double256Vector.Double256Mask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
@@ -583,10 +583,15 @@ final class Int256Vector extends IntVector {
             return (Int256Vector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -608,6 +613,24 @@ final class Int256Vector extends IntVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    Int256Mask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
@@ -584,35 +584,25 @@ final class Int256Vector extends IntVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new Byte256Vector.Byte256Mask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new Short256Vector.Short256Mask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new Int256Vector.Int256Mask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new Long256Vector.Long256Mask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new Float256Vector.Float256Mask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new Double256Vector.Double256Mask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new Byte256Vector.Byte256Mask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new Short256Vector.Short256Mask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new Int256Vector.Int256Mask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new Long256Vector.Long256Mask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new Float256Vector.Float256Mask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new Double256Vector.Double256Mask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -628,9 +618,9 @@ final class Int256Vector extends IntVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    Int256Mask::defaultMaskReinterpret);
+                    Int256Mask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
@@ -606,19 +606,18 @@ final class Int512Vector extends IntVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new Byte512Vector.Byte512Mask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new Short512Vector.Short512Mask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new Int512Vector.Int512Mask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new Long512Vector.Long512Mask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new Float512Vector.Float512Mask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new Double512Vector.Double512Mask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new Byte512Vector.Byte512Mask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new Short512Vector.Short512Mask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new Int512Vector.Int512Mask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new Long512Vector.Long512Mask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new Float512Vector.Float512Mask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new Double512Vector.Double512Mask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
@@ -600,35 +600,25 @@ final class Int512Vector extends IntVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new Byte512Vector.Byte512Mask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new Short512Vector.Short512Mask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new Int512Vector.Int512Mask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new Long512Vector.Long512Mask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new Float512Vector.Float512Mask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new Double512Vector.Double512Mask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new Byte512Vector.Byte512Mask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new Short512Vector.Short512Mask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new Int512Vector.Int512Mask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new Long512Vector.Long512Mask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new Float512Vector.Float512Mask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new Double512Vector.Double512Mask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -644,9 +634,9 @@ final class Int512Vector extends IntVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    Int512Mask::defaultMaskReinterpret);
+                    Int512Mask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
@@ -599,10 +599,15 @@ final class Int512Vector extends IntVector {
             return (Int512Vector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -624,6 +629,24 @@ final class Int512Vector extends IntVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    Int512Mask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
@@ -572,35 +572,25 @@ final class Int64Vector extends IntVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new Byte64Vector.Byte64Mask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new Short64Vector.Short64Mask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new Int64Vector.Int64Mask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new Long64Vector.Long64Mask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new Float64Vector.Float64Mask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new Double64Vector.Double64Mask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new Byte64Vector.Byte64Mask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new Short64Vector.Short64Mask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new Int64Vector.Int64Mask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new Long64Vector.Long64Mask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new Float64Vector.Float64Mask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new Double64Vector.Double64Mask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -616,9 +606,9 @@ final class Int64Vector extends IntVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    Int64Mask::defaultMaskReinterpret);
+                    Int64Mask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
@@ -578,19 +578,18 @@ final class Int64Vector extends IntVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new Byte64Vector.Byte64Mask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new Short64Vector.Short64Mask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new Int64Vector.Int64Mask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new Long64Vector.Long64Mask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new Float64Vector.Float64Mask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new Double64Vector.Double64Mask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new Byte64Vector.Byte64Mask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new Short64Vector.Short64Mask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new Int64Vector.Int64Mask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new Long64Vector.Long64Mask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new Float64Vector.Float64Mask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new Double64Vector.Double64Mask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
@@ -569,10 +569,15 @@ final class IntMaxVector extends IntVector {
             return (IntMaxVector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -594,6 +599,24 @@ final class IntMaxVector extends IntVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    IntMaxMask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
@@ -576,19 +576,18 @@ final class IntMaxVector extends IntVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new ByteMaxVector.ByteMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new ShortMaxVector.ShortMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new IntMaxVector.IntMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new LongMaxVector.LongMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new FloatMaxVector.FloatMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new DoubleMaxVector.DoubleMaxMask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new ByteMaxVector.ByteMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new ShortMaxVector.ShortMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new IntMaxVector.IntMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new LongMaxVector.LongMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new FloatMaxVector.FloatMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new DoubleMaxVector.DoubleMaxMask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
@@ -570,35 +570,25 @@ final class IntMaxVector extends IntVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new ByteMaxVector.ByteMaxMask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new ShortMaxVector.ShortMaxMask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new IntMaxVector.IntMaxMask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new LongMaxVector.LongMaxMask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new FloatMaxVector.FloatMaxMask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new DoubleMaxVector.DoubleMaxMask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new ByteMaxVector.ByteMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new ShortMaxVector.ShortMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new IntMaxVector.IntMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new LongMaxVector.LongMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new FloatMaxVector.FloatMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new DoubleMaxVector.DoubleMaxMask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -614,9 +604,9 @@ final class IntMaxVector extends IntVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    IntMaxMask::defaultMaskReinterpret);
+                    IntMaxMask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
@@ -562,35 +562,25 @@ final class Long128Vector extends LongVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new Byte128Vector.Byte128Mask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new Short128Vector.Short128Mask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new Int128Vector.Int128Mask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new Long128Vector.Long128Mask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new Float128Vector.Float128Mask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new Double128Vector.Double128Mask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new Byte128Vector.Byte128Mask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new Short128Vector.Short128Mask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new Int128Vector.Int128Mask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new Long128Vector.Long128Mask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new Float128Vector.Float128Mask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new Double128Vector.Double128Mask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -606,9 +596,9 @@ final class Long128Vector extends LongVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    Long128Mask::defaultMaskReinterpret);
+                    Long128Mask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
@@ -561,10 +561,15 @@ final class Long128Vector extends LongVector {
             return (Long128Vector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -586,6 +591,24 @@ final class Long128Vector extends LongVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    Long128Mask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
@@ -568,19 +568,18 @@ final class Long128Vector extends LongVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new Byte128Vector.Byte128Mask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new Short128Vector.Short128Mask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new Int128Vector.Int128Mask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new Long128Vector.Long128Mask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new Float128Vector.Float128Mask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new Double128Vector.Double128Mask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new Byte128Vector.Byte128Mask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new Short128Vector.Short128Mask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new Int128Vector.Int128Mask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new Long128Vector.Long128Mask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new Float128Vector.Float128Mask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new Double128Vector.Double128Mask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
@@ -572,19 +572,18 @@ final class Long256Vector extends LongVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new Byte256Vector.Byte256Mask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new Short256Vector.Short256Mask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new Int256Vector.Int256Mask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new Long256Vector.Long256Mask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new Float256Vector.Float256Mask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new Double256Vector.Double256Mask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new Byte256Vector.Byte256Mask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new Short256Vector.Short256Mask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new Int256Vector.Int256Mask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new Long256Vector.Long256Mask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new Float256Vector.Float256Mask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new Double256Vector.Double256Mask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
@@ -565,10 +565,15 @@ final class Long256Vector extends LongVector {
             return (Long256Vector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -590,6 +595,24 @@ final class Long256Vector extends LongVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    Long256Mask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
@@ -566,35 +566,25 @@ final class Long256Vector extends LongVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new Byte256Vector.Byte256Mask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new Short256Vector.Short256Mask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new Int256Vector.Int256Mask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new Long256Vector.Long256Mask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new Float256Vector.Float256Mask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new Double256Vector.Double256Mask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new Byte256Vector.Byte256Mask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new Short256Vector.Short256Mask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new Int256Vector.Int256Mask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new Long256Vector.Long256Mask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new Float256Vector.Float256Mask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new Double256Vector.Double256Mask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -610,9 +600,9 @@ final class Long256Vector extends LongVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    Long256Mask::defaultMaskReinterpret);
+                    Long256Mask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
@@ -580,19 +580,18 @@ final class Long512Vector extends LongVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new Byte512Vector.Byte512Mask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new Short512Vector.Short512Mask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new Int512Vector.Int512Mask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new Long512Vector.Long512Mask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new Float512Vector.Float512Mask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new Double512Vector.Double512Mask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new Byte512Vector.Byte512Mask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new Short512Vector.Short512Mask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new Int512Vector.Int512Mask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new Long512Vector.Long512Mask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new Float512Vector.Float512Mask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new Double512Vector.Double512Mask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
@@ -574,35 +574,25 @@ final class Long512Vector extends LongVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new Byte512Vector.Byte512Mask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new Short512Vector.Short512Mask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new Int512Vector.Int512Mask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new Long512Vector.Long512Mask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new Float512Vector.Float512Mask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new Double512Vector.Double512Mask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new Byte512Vector.Byte512Mask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new Short512Vector.Short512Mask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new Int512Vector.Int512Mask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new Long512Vector.Long512Mask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new Float512Vector.Float512Mask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new Double512Vector.Double512Mask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -618,9 +608,9 @@ final class Long512Vector extends LongVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    Long512Mask::defaultMaskReinterpret);
+                    Long512Mask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
@@ -560,35 +560,25 @@ final class Long64Vector extends LongVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new Byte64Vector.Byte64Mask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new Short64Vector.Short64Mask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new Int64Vector.Int64Mask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new Long64Vector.Long64Mask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new Float64Vector.Float64Mask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new Double64Vector.Double64Mask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new Byte64Vector.Byte64Mask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new Short64Vector.Short64Mask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new Int64Vector.Int64Mask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new Long64Vector.Long64Mask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new Float64Vector.Float64Mask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new Double64Vector.Double64Mask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -604,9 +594,9 @@ final class Long64Vector extends LongVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    Long64Mask::defaultMaskReinterpret);
+                    Long64Mask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
@@ -559,10 +559,15 @@ final class Long64Vector extends LongVector {
             return (Long64Vector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -584,6 +589,24 @@ final class Long64Vector extends LongVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    Long64Mask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
@@ -566,19 +566,18 @@ final class Long64Vector extends LongVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new Byte64Vector.Byte64Mask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new Short64Vector.Short64Mask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new Int64Vector.Int64Mask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new Long64Vector.Long64Mask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new Float64Vector.Float64Mask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new Double64Vector.Double64Mask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new Byte64Vector.Byte64Mask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new Short64Vector.Short64Mask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new Int64Vector.Int64Mask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new Long64Vector.Long64Mask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new Float64Vector.Float64Mask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new Double64Vector.Double64Mask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
@@ -566,19 +566,18 @@ final class LongMaxVector extends LongVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new ByteMaxVector.ByteMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new ShortMaxVector.ShortMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new IntMaxVector.IntMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new LongMaxVector.LongMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new FloatMaxVector.FloatMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new DoubleMaxVector.DoubleMaxMask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new ByteMaxVector.ByteMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new ShortMaxVector.ShortMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new IntMaxVector.IntMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new LongMaxVector.LongMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new FloatMaxVector.FloatMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new DoubleMaxVector.DoubleMaxMask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
@@ -560,35 +560,25 @@ final class LongMaxVector extends LongVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new ByteMaxVector.ByteMaxMask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new ShortMaxVector.ShortMaxMask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new IntMaxVector.IntMaxMask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new LongMaxVector.LongMaxMask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new FloatMaxVector.FloatMaxMask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new DoubleMaxVector.DoubleMaxMask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new ByteMaxVector.ByteMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new ShortMaxVector.ShortMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new IntMaxVector.IntMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new LongMaxVector.LongMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new FloatMaxVector.FloatMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new DoubleMaxVector.DoubleMaxMask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -604,9 +594,9 @@ final class LongMaxVector extends LongVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    LongMaxMask::defaultMaskReinterpret);
+                    LongMaxMask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
@@ -559,10 +559,15 @@ final class LongMaxVector extends LongVector {
             return (LongMaxVector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -584,6 +589,24 @@ final class LongMaxVector extends LongVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    LongMaxMask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
@@ -583,10 +583,15 @@ final class Short128Vector extends ShortVector {
             return (Short128Vector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -608,6 +613,24 @@ final class Short128Vector extends ShortVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    Short128Mask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
@@ -590,19 +590,18 @@ final class Short128Vector extends ShortVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new Byte128Vector.Byte128Mask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new Short128Vector.Short128Mask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new Int128Vector.Int128Mask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new Long128Vector.Long128Mask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new Float128Vector.Float128Mask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new Double128Vector.Double128Mask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new Byte128Vector.Byte128Mask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new Short128Vector.Short128Mask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new Int128Vector.Int128Mask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new Long128Vector.Long128Mask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new Float128Vector.Float128Mask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new Double128Vector.Double128Mask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
@@ -584,35 +584,25 @@ final class Short128Vector extends ShortVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new Byte128Vector.Byte128Mask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new Short128Vector.Short128Mask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new Int128Vector.Int128Mask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new Long128Vector.Long128Mask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new Float128Vector.Float128Mask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new Double128Vector.Double128Mask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new Byte128Vector.Byte128Mask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new Short128Vector.Short128Mask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new Int128Vector.Int128Mask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new Long128Vector.Long128Mask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new Float128Vector.Float128Mask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new Double128Vector.Double128Mask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -628,9 +618,9 @@ final class Short128Vector extends ShortVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    Short128Mask::defaultMaskReinterpret);
+                    Short128Mask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
@@ -599,10 +599,15 @@ final class Short256Vector extends ShortVector {
             return (Short256Vector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -624,6 +629,24 @@ final class Short256Vector extends ShortVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    Short256Mask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
@@ -600,35 +600,25 @@ final class Short256Vector extends ShortVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new Byte256Vector.Byte256Mask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new Short256Vector.Short256Mask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new Int256Vector.Int256Mask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new Long256Vector.Long256Mask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new Float256Vector.Float256Mask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new Double256Vector.Double256Mask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new Byte256Vector.Byte256Mask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new Short256Vector.Short256Mask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new Int256Vector.Int256Mask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new Long256Vector.Long256Mask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new Float256Vector.Float256Mask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new Double256Vector.Double256Mask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -644,9 +634,9 @@ final class Short256Vector extends ShortVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    Short256Mask::defaultMaskReinterpret);
+                    Short256Mask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
@@ -606,19 +606,18 @@ final class Short256Vector extends ShortVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new Byte256Vector.Byte256Mask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new Short256Vector.Short256Mask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new Int256Vector.Int256Mask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new Long256Vector.Long256Mask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new Float256Vector.Float256Mask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new Double256Vector.Double256Mask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new Byte256Vector.Byte256Mask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new Short256Vector.Short256Mask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new Int256Vector.Int256Mask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new Long256Vector.Long256Mask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new Float256Vector.Float256Mask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new Double256Vector.Double256Mask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
@@ -638,19 +638,18 @@ final class Short512Vector extends ShortVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new Byte512Vector.Byte512Mask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new Short512Vector.Short512Mask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new Int512Vector.Int512Mask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new Long512Vector.Long512Mask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new Float512Vector.Float512Mask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new Double512Vector.Double512Mask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new Byte512Vector.Byte512Mask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new Short512Vector.Short512Mask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new Int512Vector.Int512Mask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new Long512Vector.Long512Mask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new Float512Vector.Float512Mask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new Double512Vector.Double512Mask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
@@ -631,10 +631,15 @@ final class Short512Vector extends ShortVector {
             return (Short512Vector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -656,6 +661,24 @@ final class Short512Vector extends ShortVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    Short512Mask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
@@ -632,35 +632,25 @@ final class Short512Vector extends ShortVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new Byte512Vector.Byte512Mask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new Short512Vector.Short512Mask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new Int512Vector.Int512Mask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new Long512Vector.Long512Mask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new Float512Vector.Float512Mask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new Double512Vector.Double512Mask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new Byte512Vector.Byte512Mask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new Short512Vector.Short512Mask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new Int512Vector.Int512Mask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new Long512Vector.Long512Mask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new Float512Vector.Float512Mask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new Double512Vector.Double512Mask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -676,9 +666,9 @@ final class Short512Vector extends ShortVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    Short512Mask::defaultMaskReinterpret);
+                    Short512Mask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
@@ -576,35 +576,25 @@ final class Short64Vector extends ShortVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new Byte64Vector.Byte64Mask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new Short64Vector.Short64Mask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new Int64Vector.Int64Mask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new Long64Vector.Long64Mask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new Float64Vector.Float64Mask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new Double64Vector.Double64Mask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new Byte64Vector.Byte64Mask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new Short64Vector.Short64Mask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new Int64Vector.Int64Mask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new Long64Vector.Long64Mask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new Float64Vector.Float64Mask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new Double64Vector.Double64Mask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -620,9 +610,9 @@ final class Short64Vector extends ShortVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    Short64Mask::defaultMaskReinterpret);
+                    Short64Mask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
@@ -582,19 +582,18 @@ final class Short64Vector extends ShortVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new Byte64Vector.Byte64Mask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new Short64Vector.Short64Mask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new Int64Vector.Int64Mask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new Long64Vector.Long64Mask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new Float64Vector.Float64Mask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new Double64Vector.Double64Mask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new Byte64Vector.Byte64Mask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new Short64Vector.Short64Mask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new Int64Vector.Int64Mask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new Long64Vector.Long64Mask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new Float64Vector.Float64Mask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new Double64Vector.Double64Mask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
@@ -575,10 +575,15 @@ final class Short64Vector extends ShortVector {
             return (Short64Vector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -600,6 +605,24 @@ final class Short64Vector extends ShortVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    Short64Mask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
@@ -576,19 +576,18 @@ final class ShortMaxVector extends ShortVector {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new ByteMaxVector.ByteMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new ShortMaxVector.ShortMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new IntMaxVector.IntMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new LongMaxVector.LongMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new FloatMaxVector.FloatMaxMask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new DoubleMaxVector.DoubleMaxMask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new ByteMaxVector.ByteMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new ShortMaxVector.ShortMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new IntMaxVector.IntMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new LongMaxVector.LongMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new FloatMaxVector.FloatMaxMask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new DoubleMaxVector.DoubleMaxMask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
@@ -569,10 +569,15 @@ final class ShortMaxVector extends ShortVector {
             return (ShortMaxVector) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -594,6 +599,24 @@ final class ShortMaxVector extends ShortVector {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    ShortMaxMask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
@@ -570,35 +570,25 @@ final class ShortMaxVector extends ShortVector {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new ByteMaxVector.ByteMaxMask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new ShortMaxVector.ShortMaxMask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new IntMaxVector.IntMaxMask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new LongMaxVector.LongMaxMask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new FloatMaxVector.FloatMaxMask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new DoubleMaxVector.DoubleMaxMask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new ByteMaxVector.ByteMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new ShortMaxVector.ShortMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new IntMaxVector.IntMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new LongMaxVector.LongMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new FloatMaxVector.FloatMaxMask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new DoubleMaxVector.DoubleMaxMask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -614,9 +604,9 @@ final class ShortMaxVector extends ShortVector {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    ShortMaxMask::defaultMaskReinterpret);
+                    ShortMaxMask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
@@ -849,19 +849,18 @@ final class $vectortype$ extends $abstractvectortype$ {
         @ForceInline
         private final <E>
         VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            assert(length() == dsp.laneCount());
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            return (
-                switch (dsp.laneType.switchKey) {
-                    case LaneType.SK_BYTE   -> new Byte$bits$Vector.Byte$bits$Mask(maskArray).check(dsp);
-                    case LaneType.SK_SHORT  -> new Short$bits$Vector.Short$bits$Mask(maskArray).check(dsp);
-                    case LaneType.SK_INT    -> new Int$bits$Vector.Int$bits$Mask(maskArray).check(dsp);
-                    case LaneType.SK_LONG   -> new Long$bits$Vector.Long$bits$Mask(maskArray).check(dsp);
-                    case LaneType.SK_FLOAT  -> new Float$bits$Vector.Float$bits$Mask(maskArray).check(dsp);
-                    case LaneType.SK_DOUBLE -> new Double$bits$Vector.Double$bits$Mask(maskArray).check(dsp);
-                    default                 -> throw new AssertionError(dsp);
-                }
-            );
+            return switch (dsp.laneType.switchKey) {
+                     case LaneType.SK_BYTE   -> new Byte$bits$Vector.Byte$bits$Mask(maskArray).check(dsp);
+                     case LaneType.SK_SHORT  -> new Short$bits$Vector.Short$bits$Mask(maskArray).check(dsp);
+                     case LaneType.SK_INT    -> new Int$bits$Vector.Int$bits$Mask(maskArray).check(dsp);
+                     case LaneType.SK_LONG   -> new Long$bits$Vector.Long$bits$Mask(maskArray).check(dsp);
+                     case LaneType.SK_FLOAT  -> new Float$bits$Vector.Float$bits$Mask(maskArray).check(dsp);
+                     case LaneType.SK_DOUBLE -> new Double$bits$Vector.Double$bits$Mask(maskArray).check(dsp);
+                     default                 -> throw new AssertionError(dsp);
+            };
         }
 
         @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
@@ -843,35 +843,25 @@ final class $vectortype$ extends $abstractvectortype$ {
         }
 
         /**
-         * Helper function for all sorts of lane-wise conversions.
+         * Helper function for lane-wise mask conversions.
          * This function kicks in after intrinsic failure.
          */
-        /*package-private*/
         @ForceInline
-        final <E>
-        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
             boolean[] maskArray = toArray();
             // enum-switches don't optimize properly JDK-8161245
-            switch (species.laneType.switchKey) {
-            case LaneType.SK_BYTE:
-                return new Byte$bits$Vector.Byte$bits$Mask(maskArray).check(species);
-            case LaneType.SK_SHORT:
-                return new Short$bits$Vector.Short$bits$Mask(maskArray).check(species);
-            case LaneType.SK_INT:
-                return new Int$bits$Vector.Int$bits$Mask(maskArray).check(species);
-            case LaneType.SK_LONG:
-                return new Long$bits$Vector.Long$bits$Mask(maskArray).check(species);
-            case LaneType.SK_FLOAT:
-                return new Float$bits$Vector.Float$bits$Mask(maskArray).check(species);
-            case LaneType.SK_DOUBLE:
-                return new Double$bits$Vector.Double$bits$Mask(maskArray).check(species);
-            }
-
-            // Should not reach here.
-            throw new AssertionError(species);
+            return (
+                switch (dsp.laneType.switchKey) {
+                    case LaneType.SK_BYTE   -> new Byte$bits$Vector.Byte$bits$Mask(maskArray).check(dsp);
+                    case LaneType.SK_SHORT  -> new Short$bits$Vector.Short$bits$Mask(maskArray).check(dsp);
+                    case LaneType.SK_INT    -> new Int$bits$Vector.Int$bits$Mask(maskArray).check(dsp);
+                    case LaneType.SK_LONG   -> new Long$bits$Vector.Long$bits$Mask(maskArray).check(dsp);
+                    case LaneType.SK_FLOAT  -> new Float$bits$Vector.Float$bits$Mask(maskArray).check(dsp);
+                    case LaneType.SK_DOUBLE -> new Double$bits$Vector.Double$bits$Mask(maskArray).check(dsp);
+                    default                 -> throw new AssertionError(dsp);
+                }
+            );
         }
 
         @Override
@@ -887,9 +877,9 @@ final class $vectortype$ extends $abstractvectortype$ {
                     this.getClass(), ETYPE, VLENGTH,
                     dmtype, dtype, VLENGTH,
                     this, species,
-                    $Type$$bits$Mask::defaultMaskReinterpret);
+                    $Type$$bits$Mask::defaultMaskCast);
             }
-            return this.defaultMaskReinterpret(species);
+            return this.defaultMaskCast(species);
         }
 
         // Unary operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
@@ -842,10 +842,15 @@ final class $vectortype$ extends $abstractvectortype$ {
             return ($vectortype$) super.toVectorTemplate();  // specialize
         }
 
-        @Override
+        /**
+         * Helper function for all sorts of lane-wise conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        /*package-private*/
         @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> s) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) s;
+        final <E>
+        VectorMask<E> defaultMaskReinterpret(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
             if (length() != species.laneCount())
                 throw new IllegalArgumentException("VectorMask length and species length differ");
             boolean[] maskArray = toArray();
@@ -867,6 +872,24 @@ final class $vectortype$ extends $abstractvectortype$ {
 
             // Should not reach here.
             throw new AssertionError(species);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            if (VSIZE == species.vectorBitSize()) {
+                Class<?> dtype = species.elementType();
+                Class<?> dmtype = species.maskType();
+                return VectorSupport.convert(VectorSupport.VECTOR_OP_REINTERPRET,
+                    this.getClass(), ETYPE, VLENGTH,
+                    dmtype, dtype, VLENGTH,
+                    this, species,
+                    $Type$$bits$Mask::defaultMaskReinterpret);
+            }
+            return this.defaultMaskReinterpret(species);
         }
 
         // Unary operations


### PR DESCRIPTION
Vector API test operations (IS_DEFAULT, IS_FINITE, IS_INFINITE, IS_NAN and IS_NEGATIVE) are computed in three steps:
1) reinterpreting the floating point vectors as integral vectors (int/long)
2) perform the test in integer domain to get a int/long mask
3) reinterpret the int/long mask as float/double mask
Step 3) currently is very slow. It can be optimized by modifying the Java code to utilize the existing reinterpret intrinsic.

For the VectorTestPerf attached to the JBS for JDK-8267190, the performance improves as follows:

Base:
Benchmark (size) Mode Cnt Score Error Units
VectorTestPerf.IS_DEFAULT 1024 thrpt 5 223.156 ± 90.452 ops/ms
VectorTestPerf.IS_FINITE 1024 thrpt 5 223.841 ± 91.685 ops/ms
VectorTestPerf.IS_INFINITE 1024 thrpt 5 224.561 ± 83.890 ops/ms
VectorTestPerf.IS_NAN 1024 thrpt 5 223.777 ± 70.629 ops/ms
VectorTestPerf.IS_NEGATIVE 1024 thrpt 5 218.392 ± 79.806 ops/ms

With patch:
Benchmark (size) Mode Cnt Score Error Units
VectorTestPerf.IS_DEFAULT 1024 thrpt 5 8812.357 ± 40.477 ops/ms
VectorTestPerf.IS_FINITE 1024 thrpt 5 7425.739 ± 296.622 ops/ms
VectorTestPerf.IS_INFINITE 1024 thrpt 5 8932.730 ± 269.988 ops/ms
VectorTestPerf.IS_NAN 1024 thrpt 5 8574.872 ± 498.649 ops/ms
VectorTestPerf.IS_NEGATIVE 1024 thrpt 5 8838.400 ± 11.849 ops/ms

Best Regards,
Sandhya

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267190](https://bugs.openjdk.java.net/browse/JDK-8267190): Optimize Vector API test operations


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to b506fc45739f9a85586b3426b3cd4acf03b02383
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to bb0d400030bdefd98194af7d002d934dcba64d11


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4039/head:pull/4039` \
`$ git checkout pull/4039`

Update a local copy of the PR: \
`$ git checkout pull/4039` \
`$ git pull https://git.openjdk.java.net/jdk pull/4039/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4039`

View PR using the GUI difftool: \
`$ git pr show -t 4039`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4039.diff">https://git.openjdk.java.net/jdk/pull/4039.diff</a>

</details>
