### PR TITLE
TimerTaskable

### DIFF
--- a/src/java.base/share/classes/java/util/TimerTaskable.java
+++ b/src/java.base/share/classes/java/util/TimerTaskable.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 1999, 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.*;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A task that can be scheduled for one-time or repeated execution by a
+ * {@link Timer}.
+ *
+ * <p>
+ * A timer task is <em>not</em> reusable. Once a task has been scheduled for
+ * execution on a {@code Timer} or cancelled, subsequent attempts to schedule it
+ * for execution will throw {@code IllegalStateException}.
+ *
+ * @author Josh Bloch
+ * @since 1.3
+ */
+
+public interface TimerTaskable extends Runnable {
+  /**
+   * This object is used to control access to the TimerTask internals.
+   */
+  Object lock = new Object();
+
+  /**
+   * This task has not yet been scheduled.
+   */
+  int VIRGIN      = 0;
+
+  /**
+   * This task is scheduled for execution.  If it is a non-repeating task,
+   * it has not yet been executed.
+   */
+  int SCHEDULED   = 1;
+
+  /**
+   * This non-repeating task has already executed (or is currently
+   * executing) and has not been cancelled.
+   */
+  int EXECUTED    = 2;
+
+  /**
+   * This task has been cancelled (with a call to TimerTask.cancel).
+   */
+  int CANCELLED   = 3;
+
+  /**
+   * The state of this task, chosen from the constants belo
+   */
+  AtomicInteger state = new AtomicInteger(VIRGIN);
+
+  /**
+   * Next execution time for this task in the format returned by
+   * System.currentTimeMillis, assuming this task is scheduled for execution. For
+   * repeating tasks, this field is updated prior to each task execution.
+   */
+  long nextExecutionTime = 0;
+
+  /**
+   * Period in milliseconds for repeating tasks. A positive value indicates
+   * fixed-rate execution. A negative value indicates fixed-delay execution. A
+   * value of 0 indicates a non-repeating task.
+   */
+  long period = 0;
+
+  /**
+   * The action to be performed by this timer task.
+   */
+  public void run();
+
+  /**
+   * Cancels this timer task. If the task has been scheduled for one-time
+   * execution and has not yet run, or has not yet been scheduled, it will never
+   * run. If the task has been scheduled for repeated execution, it will never run
+   * again. (If the task is running when this call occurs, the task will run to
+   * completion, but will never run again.)
+   *
+   * <p>
+   * Note that calling this method from within the {@code run} method of a
+   * repeating timer task absolutely guarantees that the timer task will not run
+   * again.
+   *
+   * <p>
+   * This method may be called repeatedly; the second and subsequent calls have no
+   * effect.
+   *
+   * @return true if this task is scheduled for one-time execution and has not yet
+   *         run, or this task is scheduled for repeated execution. Returns false
+   *         if the task was scheduled for one-time execution and has already run,
+   *         or if the task was never scheduled, or if the task was already
+   *         cancelled. (Loosely speaking, this method returns {@code true} if it
+   *         prevents one or more scheduled executions from taking place.)
+   */
+  public default boolean cancel() {
+    synchronized (lock) {
+      boolean result = (state.get()==SCHEDULED);
+      state.set(CANCELLED);
+      return result;
+    }
+  }
+
+  /**
+   * Returns the <i>scheduled</i> execution time of the most recent <i>actual</i>
+   * execution of this task. (If this method is invoked while task execution is in
+   * progress, the return value is the scheduled execution time of the ongoing
+   * task execution.)
+   *
+   * <p>
+   * This method is typically invoked from within a task's run method, to
+   * determine whether the current execution of the task is sufficiently timely to
+   * warrant performing the scheduled activity:
+   * 
+   * <pre>
+   * {@code
+   *   public void run() {
+   *       if (System.currentTimeMillis() - scheduledExecutionTime() >=
+   *           MAX_TARDINESS)
+   *               return;  // Too late; skip this execution.
+   *       // Perform the task
+   *   }
+   * }
+   * </pre>
+   * 
+   * This method is typically <i>not</i> used in conjunction with <i>fixed-delay
+   * execution</i> repeating tasks, as their scheduled execution times are allowed
+   * to drift over time, and so are not terribly significant.
+   *
+   * @return the time at which the most recent execution of this task was
+   *         scheduled to occur, in the format returned by Date.getTime(). The
+   *         return value is undefined if the task has yet to commence its first
+   *         execution.
+   * @see Date#getTime()
+   */
+  public default long scheduledExecutionTime() {
+    synchronized(lock) {
+      return (period < 0 ? nextExecutionTime + period
+                         : nextExecutionTime - period);
+    }
+  }
+}


### PR DESCRIPTION
Functional Java 8 Interface that runs like abstract class TimerTask

---
I am looking for a way to define an instance field for state, so any instance or lambda won't share the same failing behavior.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4041/head:pull/4041` \
`$ git checkout pull/4041`

Update a local copy of the PR: \
`$ git checkout pull/4041` \
`$ git pull https://git.openjdk.java.net/jdk pull/4041/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4041`

View PR using the GUI difftool: \
`$ git pr show -t 4041`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4041.diff">https://git.openjdk.java.net/jdk/pull/4041.diff</a>

</details>
