### PR TITLE
8267209: Child threads should defer logging to after child-parent handshake

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -552,9 +552,6 @@ static void *thread_native_entry(Thread *thread) {
 
   osthread->set_thread_id(os::Bsd::gettid());
 
-  log_info(os, thread)("Thread is alive (tid: " UINTX_FORMAT ", pthread id: " UINTX_FORMAT ").",
-    os::current_thread_id(), (uintx) pthread_self());
-
 #ifdef __APPLE__
   // Store unique OS X thread id used by SA
   osthread->set_unique_thread_id();
@@ -586,6 +583,9 @@ static void *thread_native_entry(Thread *thread) {
       sync->wait_without_safepoint_check();
     }
   }
+
+  log_info(os, thread)("Thread is alive (tid: " UINTX_FORMAT ", pthread id: " UINTX_FORMAT ").",
+    os::current_thread_id(), (uintx) pthread_self());
 
   // call one more level start routine
   thread->call_run();

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -684,9 +684,6 @@ static void *thread_native_entry(Thread *thread) {
 
   osthread->set_thread_id(os::current_thread_id());
 
-  log_info(os, thread)("Thread is alive (tid: " UINTX_FORMAT ", pthread id: " UINTX_FORMAT ").",
-    os::current_thread_id(), (uintx) pthread_self());
-
   if (UseNUMA) {
     int lgrp_id = os::numa_get_group_id();
     if (lgrp_id != -1) {
@@ -712,6 +709,9 @@ static void *thread_native_entry(Thread *thread) {
       sync->wait_without_safepoint_check();
     }
   }
+
+  log_info(os, thread)("Thread is alive (tid: " UINTX_FORMAT ", pthread id: " UINTX_FORMAT ").",
+    os::current_thread_id(), (uintx) pthread_self());
 
   assert(osthread->pthread_id() != 0, "pthread_id was not set as expected");
 


### PR DESCRIPTION
Hi,

May I have reviews for this very simple change (triggered by this ML discussion [1]):

On Linux and BSD, we have a handshake between creator thread and newborn thread. Creator thread waits until the newborn is alive and reports back via a monitor handshake.

The newborn should avoid doing anything unnecessary before reporting back to the creator. But we added logging there, whose performance impact can be anything. We should defer logging to after that handshake.

I ran OPs [1] test on my machine and with logging to a very fast ssd enabled:

```
thomas@starfish:/shared/projects/openjdk$ ./jdk-jdk/output-release/images-stock/jdk/bin/java -Xlog:os+thread:t1.log -cp ./test/repros/repros8/target/repros8-1.0.jar de.stuefe.repros.WaishonTest
Duration: 5191
```

with this patch test time drops by about 19%:

```
thomas@starfish:/shared/projects/openjdk$ ./jdk-jdk/output-release/images-stock/jdk/bin/java -Xlog:os+thread:t1.log -cp ./test/repros/repros8/target/repros8-1.0.jar de.stuefe.repros.WaishonTest
Duration: 4228
```

No perceptible difference with logging disabled, as it should be.

---

(Side note: We don't do this handshake on AIX and Windows. Instead, there, we create the thread in suspended state and resume it later. Would be nice to get rid of that handshake for Linux too.)

[1] https://mail.openjdk.java.net/pipermail/discuss/2021-May/005807.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267209](https://bugs.openjdk.java.net/browse/JDK-8267209): Child threads should defer logging to after child-parent handshake


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4042/head:pull/4042` \
`$ git checkout pull/4042`

Update a local copy of the PR: \
`$ git checkout pull/4042` \
`$ git pull https://git.openjdk.java.net/jdk pull/4042/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4042`

View PR using the GUI difftool: \
`$ git pr show -t 4042`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4042.diff">https://git.openjdk.java.net/jdk/pull/4042.diff</a>

</details>
