### PR TITLE
8267213: cpuinfo_segv is incorrectly triaged as execution protection violation on x86_32

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2458,9 +2458,7 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
       //
       // 15 bytes seems to be a (very) safe value for max instruction size.
       bool pc_is_near_addr = false;
-      if (addr <= pc) {
-        pc_is_near_addr = pointer_delta((void*) pc, (void*) addr, sizeof(char)) < 15;
-      } else {
+      if (addr >= pc) {
         pc_is_near_addr = pointer_delta((void*) addr, (void*) pc, sizeof(char)) < 15;
       }
 

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2457,11 +2457,8 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
       // different - we still want to unguard the 2nd page in this case.
       //
       // 15 bytes seems to be a (very) safe value for max instruction size.
-      bool pc_is_near_addr = false;
-      if (addr >= pc) {
-        pc_is_near_addr = pointer_delta((void*) addr, (void*) pc, sizeof(char)) < 15;
-      }
-
+      bool pc_is_near_addr = (addr >= pc) &&
+        (pointer_delta((void*) addr, (void*) pc, sizeof(char)) < 15);
       bool instr_spans_page_boundary =
         (align_down((intptr_t) pc ^ (intptr_t) addr,
                          (intptr_t) page_size) > 0);

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2457,8 +2457,13 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
       // different - we still want to unguard the 2nd page in this case.
       //
       // 15 bytes seems to be a (very) safe value for max instruction size.
-      bool pc_is_near_addr =
-        (pointer_delta((void*) addr, (void*) pc, sizeof(char)) < 15);
+      bool pc_is_near_addr = false;
+      if (addr <= pc) {
+        pc_is_near_addr = pointer_delta((void*) pc, (void*) addr, sizeof(char)) < 15;
+      } else {
+        pc_is_near_addr = pointer_delta((void*) addr, (void*) pc, sizeof(char)) < 15;
+      }
+
       bool instr_spans_page_boundary =
         (align_down((intptr_t) pc ^ (intptr_t) addr,
                          (intptr_t) page_size) > 0);

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2457,7 +2457,7 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
       // different - we still want to unguard the 2nd page in this case.
       //
       // 15 bytes seems to be a (very) safe value for max instruction size.
-      bool pc_is_near_addr = (addr >= pc) &&
+      bool pc_is_near_addr =
         (pointer_delta((void*) addr, (void*) pc, sizeof(char)) < 15);
       bool instr_spans_page_boundary =
         (align_down((intptr_t) pc ^ (intptr_t) addr,

--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -551,6 +551,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
   // the si_code for this condition may change in the future.
   // Furthermore, a false-positive should be harmless.
   if (UnguardOnExecutionViolation > 0 &&
+      stub == NULL &&
       (sig == SIGSEGV || sig == SIGBUS) &&
       uc->context_trapno == trap_page_fault) {
     int page_size = os::vm_page_size();
@@ -564,7 +565,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
     // different - we still want to unguard the 2nd page in this case.
     //
     // 15 bytes seems to be a (very) safe value for max instruction size.
-    bool pc_is_near_addr = (addr >= pc) &&
+    bool pc_is_near_addr =
       (pointer_delta((void*) addr, (void*) pc, sizeof(char)) < 15);
     bool instr_spans_page_boundary =
       (align_down((intptr_t) pc ^ (intptr_t) addr,

--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -564,11 +564,8 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
     // different - we still want to unguard the 2nd page in this case.
     //
     // 15 bytes seems to be a (very) safe value for max instruction size.
-    bool pc_is_near_addr = false;
-    if (addr >= pc) {
-      pc_is_near_addr = pointer_delta((void*) addr, (void*) pc, sizeof(char)) < 15;
-    }
-
+    bool pc_is_near_addr = (addr >= pc) &&
+      (pointer_delta((void*) addr, (void*) pc, sizeof(char)) < 15);
     bool instr_spans_page_boundary =
       (align_down((intptr_t) pc ^ (intptr_t) addr,
                        (intptr_t) page_size) > 0);

--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -564,8 +564,13 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
     // different - we still want to unguard the 2nd page in this case.
     //
     // 15 bytes seems to be a (very) safe value for max instruction size.
-    bool pc_is_near_addr =
-      (pointer_delta((void*) addr, (void*) pc, sizeof(char)) < 15);
+    bool pc_is_near_addr = false;
+    if (addr <= pc) {
+      pc_is_near_addr = pointer_delta((void*) pc, (void*) addr, sizeof(char)) < 15;
+    } else {
+      pc_is_near_addr = pointer_delta((void*) addr, (void*) pc, sizeof(char)) < 15;
+    }
+
     bool instr_spans_page_boundary =
       (align_down((intptr_t) pc ^ (intptr_t) addr,
                        (intptr_t) page_size) > 0);

--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -565,9 +565,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
     //
     // 15 bytes seems to be a (very) safe value for max instruction size.
     bool pc_is_near_addr = false;
-    if (addr <= pc) {
-      pc_is_near_addr = pointer_delta((void*) pc, (void*) addr, sizeof(char)) < 15;
-    } else {
+    if (addr >= pc) {
       pc_is_near_addr = pointer_delta((void*) addr, (void*) pc, sizeof(char)) < 15;
     }
 

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -356,8 +356,13 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
     // different - we still want to unguard the 2nd page in this case.
     //
     // 15 bytes seems to be a (very) safe value for max instruction size.
-    bool pc_is_near_addr =
-      (pointer_delta((void*) addr, (void*) pc, sizeof(char)) < 15);
+    bool pc_is_near_addr = false;
+    if (addr <= pc) {
+      pc_is_near_addr = pointer_delta((void*) pc, (void*) addr, sizeof(char)) < 15;
+    } else {
+      pc_is_near_addr = pointer_delta((void*) addr, (void*) pc, sizeof(char)) < 15;
+    }
+
     bool instr_spans_page_boundary =
       (align_down((intptr_t) pc ^ (intptr_t) addr,
                        (intptr_t) page_size) > 0);

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -357,9 +357,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
     //
     // 15 bytes seems to be a (very) safe value for max instruction size.
     bool pc_is_near_addr = false;
-    if (addr <= pc) {
-      pc_is_near_addr = pointer_delta((void*) pc, (void*) addr, sizeof(char)) < 15;
-    } else {
+    if (addr >= pc) {
       pc_is_near_addr = pointer_delta((void*) addr, (void*) pc, sizeof(char)) < 15;
     }
 

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -343,6 +343,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
   // the si_code for this condition may change in the future.
   // Furthermore, a false-positive should be harmless.
   if (UnguardOnExecutionViolation > 0 &&
+      stub == NULL &&
       (sig == SIGSEGV || sig == SIGBUS) &&
       uc->uc_mcontext.gregs[REG_TRAPNO] == trap_page_fault) {
     int page_size = os::vm_page_size();
@@ -356,7 +357,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
     // different - we still want to unguard the 2nd page in this case.
     //
     // 15 bytes seems to be a (very) safe value for max instruction size.
-    bool pc_is_near_addr = (addr >= pc) &&
+    bool pc_is_near_addr =
       (pointer_delta((void*) addr, (void*) pc, sizeof(char)) < 15);
     bool instr_spans_page_boundary =
       (align_down((intptr_t) pc ^ (intptr_t) addr,

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -356,11 +356,8 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
     // different - we still want to unguard the 2nd page in this case.
     //
     // 15 bytes seems to be a (very) safe value for max instruction size.
-    bool pc_is_near_addr = false;
-    if (addr >= pc) {
-      pc_is_near_addr = pointer_delta((void*) addr, (void*) pc, sizeof(char)) < 15;
-    }
-
+    bool pc_is_near_addr = (addr >= pc) &&
+      (pointer_delta((void*) addr, (void*) pc, sizeof(char)) < 15);
     bool instr_spans_page_boundary =
       (align_down((intptr_t) pc ^ (intptr_t) addr,
                        (intptr_t) page_size) > 0);


### PR DESCRIPTION
Hi all,

This is a follow-up of JDK-8260046.
And it can be reproduced by `java -XX:UnguardOnExecutionViolation=1` on x86_32.
Let's fix it

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267213](https://bugs.openjdk.java.net/browse/JDK-8267213): cpuinfo_segv is incorrectly triaged as execution protection violation on x86_32


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4044/head:pull/4044` \
`$ git checkout pull/4044`

Update a local copy of the PR: \
`$ git checkout pull/4044` \
`$ git pull https://git.openjdk.java.net/jdk pull/4044/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4044`

View PR using the GUI difftool: \
`$ git pr show -t 4044`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4044.diff">https://git.openjdk.java.net/jdk/pull/4044.diff</a>

</details>
