### PR TITLE
8266528: Optimize C2 VerifyIterativeGVN execution time

### DIFF
--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -2212,22 +2212,16 @@ void Node::verify_edges(Unique_Node_List &visited) {
 }
 
 // Verify all nodes if verify_depth is negative
-void Node::verify(Node* n, int verify_depth) {
+void Node::verify(int verify_depth, VectorSet& visited, Node_List& worklist) {
   assert(verify_depth != 0, "depth should not be 0");
-  ResourceMark rm;
-  VectorSet old_space;
-  VectorSet new_space;
-  Node_List worklist;
-  worklist.push(n);
   Compile* C = Compile::current();
-  uint last_index_on_current_depth = 0;
+  uint last_index_on_current_depth = worklist.size() - 1;
   verify_depth--; // Visiting the first node on depth 1
   // Only add nodes to worklist if verify_depth is negative (visit all nodes) or greater than 0
   bool add_to_worklist = verify_depth != 0;
 
-
   for (uint list_index = 0; list_index < worklist.size(); list_index++) {
-    n = worklist[list_index];
+    Node* n = worklist[list_index];
 
     if (n->is_Con() && n->bottom_type() == Type::TOP) {
       if (C->cached_top_node() == NULL) {
@@ -2236,17 +2230,27 @@ void Node::verify(Node* n, int verify_depth) {
       assert(C->cached_top_node() == n, "TOP node must be unique");
     }
 
-    for (uint i = 0; i < n->len(); i++) {
-      Node* x = n->in(i);
+    uint in_len = n->len();
+    for (uint i = 0; i < in_len; i++) {
+      Node* x = n->_in[i];
       if (!x || x->is_top()) {
         continue;
       }
 
       // Verify my input has a def-use edge to me
       // Count use-def edges from n to x
-      int cnt = 0;
-      for (uint j = 0; j < n->len(); j++) {
-        if (n->in(j) == x) {
+      int cnt = 1;
+      for (uint j = 0; j < i; j++) {
+        if (n->_in[j] == x) {
+          cnt++;
+          break;
+        }
+      }
+      if (cnt == 2) {
+        continue;
+      }
+      for (uint j = i + 1; j < in_len; j++) {
+        if (n->_in[j] == x) {
           cnt++;
         }
       }
@@ -2260,11 +2264,7 @@ void Node::verify(Node* n, int verify_depth) {
       }
       assert(cnt == 0, "mismatched def-use edge counts");
 
-      // Contained in new_space or old_space?
-      VectorSet* v = C->node_arena()->contains(x) ? &new_space : &old_space;
-      // Check for visited in the proper space. Numberings are not unique
-      // across spaces so we need a separate VectorSet for each space.
-      if (add_to_worklist && !v->test_set(x->_idx)) {
+      if (add_to_worklist && !visited.test_set(x->_idx)) {
         worklist.push(x);
       }
     }

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -2247,6 +2247,7 @@ void Node::verify(int verify_depth, VectorSet& visited, Node_List& worklist) {
         }
       }
       if (cnt == 2) {
+        // x is already checked as n's previous input, skip its duplicated def-use count checking
         continue;
       }
       for (uint j = i + 1; j < in_len; j++) {

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1202,7 +1202,7 @@ public:
   void collect_nodes_out_all_ctrl_boundary(GrowableArray<Node*> *ns) const;
 
   void verify_edges(Unique_Node_List &visited); // Verify bi-directional edges
-  static void verify(Node* n, int verify_depth);
+  static void verify(int verify_depth, VectorSet& visited, Node_List& worklist);
 
   // This call defines a class-unique string used to identify class instances
   virtual const char *Name() const;

--- a/test/hotspot/jtreg/compiler/debug/TraceIterativeGVN.java
+++ b/test/hotspot/jtreg/compiler/debug/TraceIterativeGVN.java
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @requires vm.debug == true & vm.flavor == "server"
+ * @requires vm.debug == true & vm.compiler2.enabled
  * @run main/othervm -Xbatch -XX:-TieredCompilation
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+TraceIterativeGVN
  *                   compiler.debug.TraceIterativeGVN

--- a/test/hotspot/jtreg/compiler/debug/TraceIterativeGVN.java
+++ b/test/hotspot/jtreg/compiler/debug/TraceIterativeGVN.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +24,7 @@
 
 /*
  * @test
- *
+ * @requires vm.debug == true & vm.flavor == "server"
  * @run main/othervm -Xbatch -XX:-TieredCompilation
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+TraceIterativeGVN
  *                   compiler.debug.TraceIterativeGVN


### PR DESCRIPTION
Please help review this enhancement for VerifyIterativeGVN, reduce about 3x - 200x executime time when VerifyIterativeGVN is on.

In simple test "-Xcomp -XX:+VerifyIterativeGVN -XX:-TieredCompilation -version", time reduced from 8.67s to 2.4s.
In extreme case hotspot/test/jtreg/compiler/escapeAnalysis/Test6689060.java, time reduced from 20000s to 95s.

Test with "-Xbatch -XX:+VerifyIterativeGVN -XX:-TieredCompilation", tier1/2/3 with fastdebug and no regression.

1. Remove node_arena()->contains checking for verifing  nodes.  _verify_window  is reset before every PhaseIterGVN::optimize. Searching from root or nodes in _verify_window  will not meet nodes whose _idx is not  unique (PhaseIterGVN::optimize is not triggered in the middle of PhaseRenumberLive ).  Assertion every node is in current node_arena() in Node::verify, passes tier1/2/3 checks (with -Xbatch -XX:+VerifyIterativeGVN -XX:-TieredCompilation), no assertion failure happens.

2. Combine verification for nodes in _verify_window into one worklist and skipping redundant nodes in _verify_window.

3. Optimize duplicate checking for same input nodes, skipping if current input index is not its first occurence.

4. Optimize field access: Replace "n->in(j)" with "n->_in[j]", same with outcnt calucation for input node x.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266528](https://bugs.openjdk.java.net/browse/JDK-8266528): Optimize C2 VerifyIterativeGVN execution time


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 9635c9b98a5ec179a366180506e2619d4e48a926
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4045/head:pull/4045` \
`$ git checkout pull/4045`

Update a local copy of the PR: \
`$ git checkout pull/4045` \
`$ git pull https://git.openjdk.java.net/jdk pull/4045/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4045`

View PR using the GUI difftool: \
`$ git pr show -t 4045`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4045.diff">https://git.openjdk.java.net/jdk/pull/4045.diff</a>

</details>
