### PR TITLE
8267229: Split runtime/Metaspace/elastic test configurations for better scalability

### DIFF
--- a/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT1.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT1.java
@@ -86,7 +86,7 @@
  *
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  *
- * @run main/othervm/timeout=400 
+ * @run main/othervm/timeout=400
  *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *      -XX:VerifyMetaspaceInterval=10
  *      -XX:MetaspaceReclaimPolicy=aggressive

--- a/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT1.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT1.java
@@ -41,7 +41,7 @@
  */
 
 /*
- * @test id=debug
+ * @test id=debug-default
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -51,15 +51,68 @@
  *
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  *
- * @run main/othervm/timeout=400 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI  -XX:VerifyMetaspaceInterval=10                                        TestMetaspaceAllocationMT1
- * @run main/othervm/timeout=400 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI  -XX:VerifyMetaspaceInterval=10  -XX:MetaspaceReclaimPolicy=none       TestMetaspaceAllocationMT1
- * @run main/othervm/timeout=400 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI  -XX:VerifyMetaspaceInterval=10  -XX:MetaspaceReclaimPolicy=aggressive TestMetaspaceAllocationMT1
- * @run main/othervm/timeout=400 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI  -XX:VerifyMetaspaceInterval=10  -XX:+MetaspaceGuardAllocations        TestMetaspaceAllocationMT1
- *
+ * @run main/othervm/timeout=400
+ *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      -XX:VerifyMetaspaceInterval=10
+ *      TestMetaspaceAllocationMT1
  */
 
 /*
- * @test id=ndebug
+ * @test id=debug-none
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @build sun.hotspot.WhiteBox
+ * @key randomness
+ * @requires (vm.debug == true)
+ *
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ *
+ * @run main/othervm/timeout=400
+ *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      -XX:VerifyMetaspaceInterval=10
+ *      -XX:MetaspaceReclaimPolicy=none
+ *      TestMetaspaceAllocationMT1
+ */
+
+/*
+ * @test id=debug-aggressive
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @build sun.hotspot.WhiteBox
+ * @key randomness
+ * @requires (vm.debug == true)
+ *
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ *
+ * @run main/othervm/timeout=400 
+ *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      -XX:VerifyMetaspaceInterval=10
+ *      -XX:MetaspaceReclaimPolicy=aggressive
+ *      TestMetaspaceAllocationMT1
+ */
+
+/*
+ * @test id=debug-guard
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @build sun.hotspot.WhiteBox
+ * @key randomness
+ * @requires (vm.debug == true)
+ *
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ *
+ * @run main/othervm/timeout=400
+ *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      -XX:VerifyMetaspaceInterval=10
+ *      -XX:+MetaspaceGuardAllocations
+ *      TestMetaspaceAllocationMT1
+ */
+
+/*
+ * @test id=ndebug-default
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -69,9 +122,43 @@
  *
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  *
- * @run main/othervm/timeout=400 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI                                        TestMetaspaceAllocationMT1
- * @run main/othervm/timeout=400 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI  -XX:MetaspaceReclaimPolicy=none       TestMetaspaceAllocationMT1
- * @run main/othervm/timeout=400 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI  -XX:MetaspaceReclaimPolicy=aggressive TestMetaspaceAllocationMT1
+ * @run main/othervm/timeout=400
+ *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      TestMetaspaceAllocationMT1
+ */
+
+/*
+ * @test id=ndebug-none
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @build sun.hotspot.WhiteBox
+ * @key randomness
+ * @requires (vm.debug == false)
+ *
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ *
+ * @run main/othervm/timeout=400
+ *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      -XX:MetaspaceReclaimPolicy=none
+ *      TestMetaspaceAllocationMT1
+ */
+
+/*
+ * @test id=ndebug-aggressive
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @build sun.hotspot.WhiteBox
+ * @key randomness
+ * @requires (vm.debug == false)
+ *
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ *
+ * @run main/othervm/timeout=400
+ *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      -XX:MetaspaceReclaimPolicy=aggressive
+ *      TestMetaspaceAllocationMT1
  */
 
 public class TestMetaspaceAllocationMT1 {

--- a/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT2.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT2.java
@@ -41,7 +41,7 @@
  */
 
 /*
- * @test id=debug
+ * @test id=debug-default
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -51,15 +51,68 @@
  *
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  *
- * @run main/othervm/timeout=400 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI  -XX:VerifyMetaspaceInterval=10                                        TestMetaspaceAllocationMT2
- * @run main/othervm/timeout=400 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI  -XX:VerifyMetaspaceInterval=10  -XX:MetaspaceReclaimPolicy=none       TestMetaspaceAllocationMT2
- * @run main/othervm/timeout=400 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI  -XX:VerifyMetaspaceInterval=10  -XX:MetaspaceReclaimPolicy=aggressive TestMetaspaceAllocationMT2
- * @run main/othervm/timeout=400 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI  -XX:VerifyMetaspaceInterval=10  -XX:+MetaspaceGuardAllocations        TestMetaspaceAllocationMT2
- *
+ * @run main/othervm/timeout=400
+ *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      -XX:VerifyMetaspaceInterval=10
+ *      TestMetaspaceAllocationMT2
  */
 
 /*
- * @test id=ndebug
+ * @test id=debug-none
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @build sun.hotspot.WhiteBox
+ * @key randomness
+ * @requires (vm.debug == true)
+ *
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ *
+ * @run main/othervm/timeout=400
+ *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      -XX:VerifyMetaspaceInterval=10
+ *      -XX:MetaspaceReclaimPolicy=none
+ *      TestMetaspaceAllocationMT2
+ */
+
+/*
+ * @test id=debug-aggressive
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @build sun.hotspot.WhiteBox
+ * @key randomness
+ * @requires (vm.debug == true)
+ *
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ *
+ * @run main/othervm/timeout=400
+ *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      -XX:VerifyMetaspaceInterval=10
+ *      -XX:MetaspaceReclaimPolicy=aggressive
+ *      TestMetaspaceAllocationMT2
+ */
+
+/*
+ * @test id=debug-guard
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @build sun.hotspot.WhiteBox
+ * @key randomness
+ * @requires (vm.debug == true)
+ *
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ *
+ * @run main/othervm/timeout=400
+ *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      -XX:VerifyMetaspaceInterval=10
+ *      -XX:+MetaspaceGuardAllocations
+ *      TestMetaspaceAllocationMT2
+ */
+
+/*
+ * @test id=ndebug-default
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -69,9 +122,43 @@
  *
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  *
- * @run main/othervm/timeout=400 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI                                        TestMetaspaceAllocationMT2
- * @run main/othervm/timeout=400 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI  -XX:MetaspaceReclaimPolicy=none       TestMetaspaceAllocationMT2
- * @run main/othervm/timeout=400 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI  -XX:MetaspaceReclaimPolicy=aggressive TestMetaspaceAllocationMT2
+ * @run main/othervm/timeout=400 
+ *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      TestMetaspaceAllocationMT2
+ */
+
+/*
+ * @test id=ndebug-none
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @build sun.hotspot.WhiteBox
+ * @key randomness
+ * @requires (vm.debug == false)
+ *
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ *
+ * @run main/othervm/timeout=400
+ *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      -XX:MetaspaceReclaimPolicy=none
+ *      TestMetaspaceAllocationMT2
+ */
+
+/*
+ * @test id=ndebug-aggressive
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @build sun.hotspot.WhiteBox
+ * @key randomness
+ * @requires (vm.debug == false)
+ *
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ *
+ * @run main/othervm/timeout=400
+ *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      -XX:MetaspaceReclaimPolicy=aggressive
+ *      TestMetaspaceAllocationMT2
  */
 
 public class TestMetaspaceAllocationMT2 {

--- a/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT2.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT2.java
@@ -122,7 +122,7 @@
  *
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  *
- * @run main/othervm/timeout=400 
+ * @run main/othervm/timeout=400
  *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *      TestMetaspaceAllocationMT2
  */


### PR DESCRIPTION
JDK-8251158 added runtime/Metaspace/elastic tests that run in hotspot:tier1. Unfortunately, those tests are quite long, and they contribute to long tail in hotspot:tier1 on larger machines. We can split the test by configuration for better scalability.

Attention @tstuefe.

Additional testing:
  - [x] affected tests on Linux x86_64, fastdebug/release
  - [x] hotspot:tier1 on Linux x86_64, fastdebug

Times before:

```
# runtime/Metaspace/elastic

real	3m49.412s
user	9m27.347s
sys	0m30.982s

# hotspot:tier1

real	9m26.916s
user	273m45.575s
sys	24m49.788s
```

Times after:

```
# runtime/Metaspace/elastic

real	1m14.261s
user	9m51.823s
sys	0m31.092s

# hotspot:tier1

real	7m7.153s
user	268m49.231s
sys	25m53.377s
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267229](https://bugs.openjdk.java.net/browse/JDK-8267229): Split runtime/Metaspace/elastic test configurations for better scalability


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4047/head:pull/4047` \
`$ git checkout pull/4047`

Update a local copy of the PR: \
`$ git checkout pull/4047` \
`$ git pull https://git.openjdk.java.net/jdk pull/4047/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4047`

View PR using the GUI difftool: \
`$ git pr show -t 4047`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4047.diff">https://git.openjdk.java.net/jdk/pull/4047.diff</a>

</details>
