### PR TITLE
8260331: javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java failed with "ERROR: icon and imageIcon not same."

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -877,7 +877,6 @@ java/awt/event/MouseEvent/SpuriousExitEnter/SpuriousExitEnter.java 8254841 macos
 java/awt/Focus/AppletInitialFocusTest/AppletInitialFocusTest1.java 8256289 windows-x64
 java/awt/FullScreen/TranslucentWindow/TranslucentWindow.java 8258103 linux-all
 java/awt/Focus/FrameMinimizeTest/FrameMinimizeTest.java 8016266 linux-x64
-javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java 8260331 linux-x64
 
 
 ############################################################################

--- a/test/jdk/javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java
+++ b/test/jdk/javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java
@@ -194,9 +194,11 @@ public class JInternalFrameIconTest {
         Rectangle rect = internalFrame.getBounds();
         Rectangle captureRect = new Rectangle(
                 point.x + internalFrame.getInsets().left,
-                point.y,
-                rect.width,
-                internalFrame.getInsets().top);
+                point.y + internalFrame.getInsets().top,
+                titleImageIcon.getIconWidth(),
+                titleImageIcon.getIconHeight());
+
+        System.out.println("imageicon captureRect " + captureRect);
         imageIconImage
                 = robot.createScreenCapture(captureRect);
     }
@@ -206,9 +208,11 @@ public class JInternalFrameIconTest {
         Rectangle rect = internalFrame.getBounds();
         Rectangle captureRect = new Rectangle(
                 point.x + internalFrame.getInsets().left,
-                point.y,
-                rect.width,
-                internalFrame.getInsets().top);
+                point.y + internalFrame.getInsets().top,
+                titleIcon.getIconWidth(),
+                titleIcon.getIconHeight());
+
+        System.out.println("icon captureRect " + captureRect);
         iconImage
                 = robot.createScreenCapture(captureRect);
     }


### PR DESCRIPTION
This testcase has failed intermittently in CI testing citing icon and ImageIcon images are not same.
It's been observed that the rectangle been passed to Robot.createScreenCapture was incorrect to compare the icon images but is passing because the images were not different (but the images itself was incorrect) so not reliable.

When it fails, it is seen that the icon and imageicon images captured, with height of the screenCapture which is the value of the topinset of internalFrame, is wrong and differ in some pixels at the end
`icon captureRect java.awt.Rectangle[x=715,y=366,width=500,height=5]`
The failed images look like (where one can see that there is some difference at the end of line)
icon image
![iconImage-fail](https://user-images.githubusercontent.com/43534309/118223456-f5680700-b49e-11eb-9d9e-937f8bf96fa3.png)
image icon
![imageicon-fail](https://user-images.githubusercontent.com/43534309/118223479-01ec5f80-b49f-11eb-9f5e-f5da704f71ba.png)

which is not compring the icon images actually.

Rectified screenrect to correctly compare the icons. After the fix, the images being compared are these
icon image
![iconImage-success](https://user-images.githubusercontent.com/43534309/118223532-27796900-b49f-11eb-8bfc-63a9ed7e97f8.png)
imageicon
![imageicon-success](https://user-images.githubusercontent.com/43534309/118223544-2c3e1d00-b49f-11eb-8af9-ef3a22a4f8c9.png)

Several iterations of the modified test execution is green on all platforms. Link in JBS.
I have also verified the modified test fails without 8146321 fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260331](https://bugs.openjdk.java.net/browse/JDK-8260331): javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java failed with "ERROR: icon and imageIcon not same."


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4048/head:pull/4048` \
`$ git checkout pull/4048`

Update a local copy of the PR: \
`$ git checkout pull/4048` \
`$ git pull https://git.openjdk.java.net/jdk pull/4048/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4048`

View PR using the GUI difftool: \
`$ git pr show -t 4048`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4048.diff">https://git.openjdk.java.net/jdk/pull/4048.diff</a>

</details>
