### PR TITLE
JDK-8263438: Unused method AbstractMemberWriter.isInherited

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
@@ -295,20 +295,6 @@ public abstract class AbstractMemberWriter implements MemberSummaryWriter, Membe
     }
 
     /**
-     * Returns {@code true} if the given element is inherited
-     * by the class that is being documented.
-     *
-     * @param ped the element being checked
-     *
-     * @return {@code true} if inherited
-     */
-    protected boolean isInherited(Element ped){
-        return (!utils.isPrivate(ped) &&
-                (!utils.isPackagePrivate(ped) ||
-                    ped.getEnclosingElement().equals(ped.getEnclosingElement())));
-    }
-
-    /**
      * Adds use information to the documentation tree.
      *
      * @param members     list of program elements for which the use information will be added


### PR DESCRIPTION
Trivial change to remove unused method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263438](https://bugs.openjdk.java.net/browse/JDK-8263438): Unused method AbstractMemberWriter.isInherited


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4049/head:pull/4049` \
`$ git checkout pull/4049`

Update a local copy of the PR: \
`$ git checkout pull/4049` \
`$ git pull https://git.openjdk.java.net/jdk pull/4049/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4049`

View PR using the GUI difftool: \
`$ git pr show -t 4049`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4049.diff">https://git.openjdk.java.net/jdk/pull/4049.diff</a>

</details>
