### PR TITLE
JDK-8267236: Versioned platform link in TestMemberSummary.java

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testMemberSummary/TestMemberSummary.java
+++ b/test/langtools/jdk/javadoc/doclet/testMemberSummary/TestMemberSummary.java
@@ -46,7 +46,7 @@ public class TestMemberSummary extends JavadocTester {
     @Test
     public void test() {
         javadoc("-d", "out",
-                "-private",
+                "-private", "--no-platform-links",
                 "-sourcepath", testSrc,
                 "pkg","pkg2");
         checkExit(Exit.OK);
@@ -85,7 +85,7 @@ public class TestMemberSummary extends JavadocTester {
     @Test
     public void testSummaries() {
         javadoc("-d", "out-summaries",
-                "-private",
+                "-private", "--no-platform-links",
                 "-sourcepath", testSrc,
                 "pkg3");
         checkExit(Exit.OK);
@@ -150,7 +150,7 @@ public class TestMemberSummary extends JavadocTester {
                     <div class="table-header col-first">Modifier and Type</div>
                     <div class="table-header col-second">Optional Element</div>
                     <div class="table-header col-last">Description</div>
-                    <div class="col-first even-row-color"><code><a href="https://download.java.net/java/early_access/jdk17/docs/api/java.base/java/lang/String.html" title="class or interface in java.lang" class="external-link">String</a></code></div>
+                    <div class="col-first even-row-color"><code>java.lang.String</code></div>
                     <div class="col-second even-row-color"><code><a href="#s()" class="member-name-link">s</a></code></div>
                     <div class="col-last even-row-color">&nbsp;</div>
                     </div>


### PR DESCRIPTION
Simple change to disable platform links in TestMemberSummary.java tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267236](https://bugs.openjdk.java.net/browse/JDK-8267236): Versioned platform link in TestMemberSummary.java


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4051/head:pull/4051` \
`$ git checkout pull/4051`

Update a local copy of the PR: \
`$ git checkout pull/4051` \
`$ git pull https://git.openjdk.java.net/jdk pull/4051/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4051`

View PR using the GUI difftool: \
`$ git pr show -t 4051`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4051.diff">https://git.openjdk.java.net/jdk/pull/4051.diff</a>

</details>
