### PR TITLE
8266520: Revert to OpenGL as the default 2D rendering pipeline for macOS

### DIFF
--- a/src/java.desktop/macosx/classes/sun/java2d/MacOSFlags.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/MacOSFlags.java
@@ -90,16 +90,13 @@ public class MacOSFlags {
                     PropertyState metalState = getBooleanProp("sun.java2d.metal", PropertyState.UNSPECIFIED);
 
                     // Handle invalid combinations to use the default rendering pipeline
-                    // Current default rendering pipeline is Metal
-                    // (The default can be changed to OpenGL in future just by toggling two states in this if condition block)
-                    // ---------------------------------------------------------------------
-                    // TODO : Revert default rendering pipeline to OpenGL
-                    // ---------------------------------------------------------------------
+                    // Current default rendering pipeline is OpenGL
+                    // (The default can be changed to Metal in future just by toggling two states in this if condition block)
                     if ((oglState == PropertyState.UNSPECIFIED && metalState == PropertyState.UNSPECIFIED) ||
                         (oglState == PropertyState.DISABLED && metalState == PropertyState.DISABLED) ||
                         (oglState == PropertyState.ENABLED && metalState == PropertyState.ENABLED)) {
-                        metalState = PropertyState.ENABLED; // Enable default pipeline
-                        oglState = PropertyState.DISABLED; // Disable non-default pipeline
+                        oglState = PropertyState.ENABLED; // Enable default pipeline
+                        metalState = PropertyState.DISABLED; // Disable non-default pipeline
                     }
 
                     if (metalState == PropertyState.UNSPECIFIED) {


### PR DESCRIPTION
This PR reverts to OpenGL as the default Java2D rendering pipeline for macOS.

Note : from JBS description :
In JDK 17 build 19 under bug id [JDK-8265304](https://bugs.openjdk.java.net/browse/JDK-8265304) we switched to Metal as the default rendering pipeline with the plan that it would be reverted to OpenGL after 4 builds.