### PR TITLE
8267237: ARM32: bad AD file in matcher.cpp after 8266810

### DIFF
--- a/src/hotspot/cpu/arm/matcher_arm.hpp
+++ b/src/hotspot/cpu/arm/matcher_arm.hpp
@@ -139,7 +139,7 @@
   // true means we have fast l2f convers
   // false means that conversion is done by runtime call
   static constexpr bool convL2FSupported(void) {
-      return true;
+      return false;
   }
 
 #endif // CPU_ARM_MATCHER_ARM_HPP


### PR DESCRIPTION
It appears that [JDK-8266810](https://bugs.openjdk.java.net/browse/JDK-8266810) introduced regression into aarch32. Many JTreg tests are failing with:
```
#  Internal Error (/var/jnode/openjdk-build-ws/workspace/openjdk-build/jdk/jdk-arm-linux-gnueabihf/jdk/src/hotspot/share/opto/matcher.cpp:1670), pid=15030, tid=15047
#  assert(false) failed: bad AD file
```

Testing: hotspot tier1 on ARMv7-A / linux

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267237](https://bugs.openjdk.java.net/browse/JDK-8267237): ARM32: bad AD file in matcher.cpp after 8266810


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4053/head:pull/4053` \
`$ git checkout pull/4053`

Update a local copy of the PR: \
`$ git checkout pull/4053` \
`$ git pull https://git.openjdk.java.net/jdk pull/4053/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4053`

View PR using the GUI difftool: \
`$ git pr show -t 4053`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4053.diff">https://git.openjdk.java.net/jdk/pull/4053.diff</a>

</details>
