### PR TITLE
8267119: switch expressions lack support for deferred type-checking

### DIFF
--- a/test/langtools/tools/javac/switchexpr/ExpressionSwitch-old.out
+++ b/test/langtools/tools/javac/switchexpr/ExpressionSwitch-old.out
@@ -1,4 +1,4 @@
-ExpressionSwitch.java:40:16: compiler.err.feature.not.supported.in.source.plural: (compiler.misc.feature.switch.expressions), 9, 14
-ExpressionSwitch.java:41:20: compiler.err.feature.not.supported.in.source.plural: (compiler.misc.feature.switch.rules), 9, 14
-ExpressionSwitch.java:93:31: compiler.err.feature.not.supported.in.source.plural: (compiler.misc.feature.multiple.case.labels), 9, 14
+ExpressionSwitch.java:41:16: compiler.err.feature.not.supported.in.source.plural: (compiler.misc.feature.switch.expressions), 9, 14
+ExpressionSwitch.java:42:20: compiler.err.feature.not.supported.in.source.plural: (compiler.misc.feature.switch.rules), 9, 14
+ExpressionSwitch.java:94:31: compiler.err.feature.not.supported.in.source.plural: (compiler.misc.feature.multiple.case.labels), 9, 14
 3 errors

--- a/test/langtools/tools/javac/switchexpr/ExpressionSwitch.java
+++ b/test/langtools/tools/javac/switchexpr/ExpressionSwitch.java
@@ -1,6 +1,6 @@
 /*
  * @test /nodynamiccopyright/
- * @bug 8206986 8222169 8224031 8240964
+ * @bug 8206986 8222169 8224031 8240964 8267119
  * @summary Check expression switch works.
  * @compile/fail/ref=ExpressionSwitch-old.out -source 9 -Xlint:-options -XDrawDiagnostics ExpressionSwitch.java
  * @compile ExpressionSwitch.java
@@ -34,6 +34,7 @@ public class ExpressionSwitch {
         assertEquals(convert2(""), -1);
         localClass(T.A);
         assertEquals(castSwitchExpressions(T.A), "A");
+        testTypeInference(true, 0);
     }
 
     private String print(T t) {
@@ -144,6 +145,17 @@ public class ExpressionSwitch {
         };
     }
 
+    private void testTypeInference(boolean b, int i) {
+        m(s -> s.length(), String.class);
+        m(b ? s -> s.length() : s -> s.length(), String.class);
+        m(switch (i) {
+            case 0 -> s -> s.length();
+            default -> s -> s.length();
+        }, String.class);
+    }
+
+    <Z> void m(Consumer<Z> c, Class<Z> cl) {}
+
     private void check(T t, String expected) {
         String result = print(t);
         assertEquals(result, expected);
@@ -161,5 +173,9 @@ public class ExpressionSwitch {
     void t() {
         Runnable r = () -> {};
         r.run();
+    }
+
+    interface Consumer<Z> {
+        public void consume(Z z);
     }
 }


### PR DESCRIPTION
Similarly to lambdas with block body looking at expression in return statements, we need `CheckStuckPolicy` to look at all `yield` values in a switch expression, to determine the types correctly, as pointed out in the bugreport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267119](https://bugs.openjdk.java.net/browse/JDK-8267119): switch expressions lack support for deferred type-checking


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4054/head:pull/4054` \
`$ git checkout pull/4054`

Update a local copy of the PR: \
`$ git checkout pull/4054` \
`$ git pull https://git.openjdk.java.net/jdk pull/4054/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4054`

View PR using the GUI difftool: \
`$ git pr show -t 4054`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4054.diff">https://git.openjdk.java.net/jdk/pull/4054.diff</a>

</details>
