### PR TITLE
8267212: test/jdk/java/util/Collections/FindSubList.java intermittent crash with "no reachable node should have no use"

### DIFF
--- a/src/hotspot/share/opto/intrinsicnode.cpp
+++ b/src/hotspot/share/opto/intrinsicnode.cpp
@@ -47,7 +47,7 @@ Node* StrIntrinsicNode::Ideal(PhaseGVN* phase, bool can_reshape) {
     uint alias_idx = phase->C->get_alias_index(adr_type());
     mem = mem->is_MergeMem() ? mem->as_MergeMem()->memory_at(alias_idx) : mem;
     if (mem != in(MemNode::Memory)) {
-      set_req(MemNode::Memory, mem);
+      set_req_X(MemNode::Memory, mem, phase);
       return this;
     }
   }

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1754,7 +1754,7 @@ Node *LoadNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     // try to optimize our memory input
     Node* opt_mem = MemNode::optimize_memory_chain(mem, addr_t, this, phase);
     if (opt_mem != mem) {
-      set_req(MemNode::Memory, opt_mem);
+      set_req_X(MemNode::Memory, opt_mem, phase);
       if (phase->type( opt_mem ) == Type::TOP) return NULL;
       return this;
     }
@@ -1829,7 +1829,7 @@ Node *LoadNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     // just return a prior value, which is done by Identity calls.
     if (can_see_stored_value(prev_mem, phase)) {
       // Make ready for step (d):
-      set_req(MemNode::Memory, prev_mem);
+      set_req_X(MemNode::Memory, prev_mem, phase);
       return this;
     }
   }


### PR DESCRIPTION
… crash with "no reachable node should have no use"

Please help reivew this fix.

StrIntrinsicNode::Ideal uses Node::set_req to replace memory input, old memory input might have 0 use, but not added into PhaseGVN worklist. Using set_req_X to ensure add 0 out old memory input node into PhaseGVN worklist.

Find other two similar problemtic code in LoadNode::Ideal.

Tier1/2/3 pass with release/fastdebug build.
test/jdk/java/util/Collections/FindSubList.java doesn't fail in 100 runs (before fix 2/3 failure in 10 runs).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267212](https://bugs.openjdk.java.net/browse/JDK-8267212): test/jdk/java/util/Collections/FindSubList.java intermittent crash with "no reachable node should have no use"


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4055/head:pull/4055` \
`$ git checkout pull/4055`

Update a local copy of the PR: \
`$ git checkout pull/4055` \
`$ git pull https://git.openjdk.java.net/jdk pull/4055/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4055`

View PR using the GUI difftool: \
`$ git pr show -t 4055`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4055.diff">https://git.openjdk.java.net/jdk/pull/4055.diff</a>

</details>
