### PR TITLE
8267133: jdk/jfr/event/gc/collection/TestG1ParallelPhases.java fails with Not expected phases: RestorePreservedMarks, RemoveSelfForwardingPtr: expected true, was false

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -836,7 +836,6 @@ jdk/jfr/event/compiler/TestCodeSweeper.java                     8225209    gener
 jdk/jfr/event/os/TestThreadContextSwitches.java                 8247776 windows-all
 jdk/jfr/startupargs/TestStartName.java                          8214685 windows-x64
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
-jdk/jfr/event/gc/collection/TestG1ParallelPhases.java           8267133 generic-all
 
 ############################################################################
 

--- a/test/jdk/jdk/jfr/event/gc/collection/TestG1ParallelPhases.java
+++ b/test/jdk/jdk/jfr/event/gc/collection/TestG1ParallelPhases.java
@@ -123,6 +123,10 @@ public class TestG1ParallelPhases {
         // Some GC phases may or may not occur depending on environment. Filter them out
         // since we can not reliably guarantee that they occur (or not).
         Set<String> optPhases = of(
+            // The following two phases only occur on evacuation failure.
+            "RemoveSelfForwardingPtr",
+            "RestorePreservedMarks",
+
             "OptScanHR",
             "OptMergeRS",
             "OptCodeRoots",

--- a/test/jdk/jdk/jfr/event/gc/collection/TestG1ParallelPhases.java
+++ b/test/jdk/jdk/jfr/event/gc/collection/TestG1ParallelPhases.java
@@ -104,8 +104,6 @@ public class TestG1ParallelPhases {
             "CodeRoots",
             "ObjCopy",
             "Termination",
-            "StringDedupQueueFixup",
-            "StringDedupTableFixup",
             "RedirtyCards",
             "RecalculateUsed",
             "ResetHotCardCache",


### PR DESCRIPTION
`RestorePreservedMarks`, and `RemoveSelfForwardingPtr` are conditionally emitted (only on evac failure). Updating the test to exclude these events in the assert.

```
double G1GCPhaseTimes::print_post_evacuate_collection_set() const {
  ...
  debug_phase(_gc_par_phases[RecalculateUsed], 1);
  if (G1CollectedHeap::heap()->evacuation_failed()) {
    debug_phase(_gc_par_phases[RemoveSelfForwardingPtr], 1);
  }

  debug_time("Post Evacuate Cleanup 2", _cur_post_evacuate_cleanup_2_time_ms);
  if (G1CollectedHeap::heap()->evacuation_failed()) {
    debug_phase(_gc_par_phases[RecalculateUsed], 1);
    debug_phase(_gc_par_phases[RestorePreservedMarks], 1);
  }
  ...
}
```

Tested: manually set a smaller heap size to see the test fail, but pass with the PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8267133](https://bugs.openjdk.java.net/browse/JDK-8267133): jdk/jfr/event/gc/collection/TestG1ParallelPhases.java fails with Not expected phases: RestorePreservedMarks, RemoveSelfForwardingPtr: expected true, was false
 * [JDK-8267218](https://bugs.openjdk.java.net/browse/JDK-8267218): jdk/jfr/event/gc/collection/TestG1ParallelPhases.java fails with Not found phases\: StringDedupQueueFixup, StringDedupTableFixup


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer)


### Contributors
 * Thomas Schatzl `<tschatzl@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4056/head:pull/4056` \
`$ git checkout pull/4056`

Update a local copy of the PR: \
`$ git checkout pull/4056` \
`$ git pull https://git.openjdk.java.net/jdk pull/4056/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4056`

View PR using the GUI difftool: \
`$ git pr show -t 4056`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4056.diff">https://git.openjdk.java.net/jdk/pull/4056.diff</a>

</details>
