### PR TITLE
8267086: Fix ArrayIndexOutOfBoundsException in DerIndefLenConverter

### DIFF
--- a/src/java.base/share/classes/sun/security/util/DerIndefLenConverter.java
+++ b/src/java.base/share/classes/sun/security/util/DerIndefLenConverter.java
@@ -340,6 +340,10 @@ class DerIndefLenConverter {
                 return null;
             }
             parseValue(len);
+            if (dataPos < 0 || dataPos > dataSize) {
+                // parseValue can overflow dataPos or exceed dataSize.
+                return null;
+            }
             if (unresolved == 0) {
                 unused = dataSize - dataPos;
                 dataSize = dataPos;


### PR DESCRIPTION
`sun.security.util.DerIndefLenConverter#convertBytes` does not perform sufficient checks after calling `#parseValue`, which can overflow `dataPos` or make it exceed `dataSize`. This can lead to an `ArrayIndexOutOfBoundsException`.

The fix is to ensure `dataPos` is in the valid range `[0,dataSize]` after the call to `parseValue`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * ⚠️ Failed to retrieve information on issue `8267086`.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4058/head:pull/4058` \
`$ git checkout pull/4058`

Update a local copy of the PR: \
`$ git checkout pull/4058` \
`$ git pull https://git.openjdk.java.net/jdk pull/4058/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4058`

View PR using the GUI difftool: \
`$ git pr show -t 4058`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4058.diff">https://git.openjdk.java.net/jdk/pull/4058.diff</a>

</details>
