### PR TITLE
8264561: javap get NegativeArraySizeException on bad instruction

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Instruction.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Instruction.java
@@ -285,6 +285,8 @@ public class Instruction {
                         int default_ = getInt(pad);
                         int low = getInt(pad + 4);
                         int high = getInt(pad + 8);
+                        if (low > high)
+                            throw new IllegalStateException();
                         int[] values = new int[high - low + 1];
                         for (int i = 0; i < values.length; i++)
                             values[i] = getInt(pad + 12 + 4 * i);
@@ -295,6 +297,8 @@ public class Instruction {
                         int pad = align(pc + 1) - pc;
                         int default_ = getInt(pad);
                         int npairs = getInt(pad + 4);
+                        if (npairs < 0)
+                            throw new IllegalStateException();
                         int[] matches = new int[npairs];
                         int[] offsets = new int[npairs];
                         for (int i = 0; i < npairs; i++) {

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/CodeWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/CodeWriter.java
@@ -106,7 +106,7 @@ public class CodeWriter extends BasicWriter {
                 for (InstructionDetailWriter w: detailWriters)
                     w.writeDetails(instr);
                 writeInstr(instr);
-            } catch (ArrayIndexOutOfBoundsException e) {
+            } catch (ArrayIndexOutOfBoundsException | IllegalStateException e) {
                 println(report("error at or after byte " + instr.getPC()));
                 break;
             }


### PR DESCRIPTION
Actual javap implementation reacts on corrupted TABLESWITCH or LOOKUPSWITCH bytecode instructions resulting to negative array allocation with NegativeArraySizeException, which is reported to user with stack trace and as serious internal error.

The fix in c.s.t.classfile.Instruction is checking for negative array size of corrupted TABLESWITCH or LOOKUPSWITCH bytecode and throwing j.l.IllegalStateException instead of the NegativeArraySizeException.
 
Another part of the fix in c.s.t.javap.CodeWriter is catching j.l.IllegalStateException and reporting it as error in the analyzed bytecode, instead of passing it up and causing serious internal javap error.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264561](https://bugs.openjdk.java.net/browse/JDK-8264561): javap get NegativeArraySizeException on bad instruction


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4061/head:pull/4061` \
`$ git checkout pull/4061`

Update a local copy of the PR: \
`$ git checkout pull/4061` \
`$ git pull https://git.openjdk.java.net/jdk pull/4061/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4061`

View PR using the GUI difftool: \
`$ git pr show -t 4061`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4061.diff">https://git.openjdk.java.net/jdk/pull/4061.diff</a>

</details>
