### PR TITLE
8267246: -XX:MaxRAMPercentage=0 is unreasonable for jtreg tests on many-core machines

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -738,7 +738,7 @@ define SetupRunJtregTestBody
 
   # Make sure MaxRAMPercentage is high enough to not cause OOM or swapping since
   # we may end up with a lot of JVM's
-  $1_JTREG_MAX_RAM_PERCENTAGE := $$(shell $$(EXPR) 1 + 25 / $$($1_JTREG_JOBS))
+  $1_JTREG_MAX_RAM_PERCENTAGE := $$(shell $(AWK) 'BEGIN { print 25 / $$($1_JTREG_JOBS); }')
 
   JTREG_TIMEOUT_FACTOR ?= 4
 

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -738,7 +738,7 @@ define SetupRunJtregTestBody
 
   # Make sure MaxRAMPercentage is high enough to not cause OOM or swapping since
   # we may end up with a lot of JVM's
-  $1_JTREG_MAX_RAM_PERCENTAGE := $$(shell $$(EXPR) 25 / $$($1_JTREG_JOBS))
+  $1_JTREG_MAX_RAM_PERCENTAGE := $$(shell $$(EXPR) 1 + 25 / $$($1_JTREG_JOBS))
 
   JTREG_TIMEOUT_FACTOR ?= 4
 


### PR DESCRIPTION
Hi all,

vmTestbase/vm/mlvm/anonloader/stress/oome/metaspace/Test.java fails on our many-core machines due to `-XX:MaxRAMPercentage=0`.
This is because `MaxRAMPercentage` will be always 0 if JTREG_JOBS > 25 [1].

It can be reproduced by: `make test TEST="vmTestbase/vm/mlvm/anonloader/stress/oome/metaspace/Test.java" JTREG="JOBS=26"` on almost all machines.

Setting `-XX:MaxRAMPercentage=0` on many-core machines seems unreasonable.
It would be better to fix it.

Thanks.
Best regards,
Jie


[1] https://github.com/openjdk/jdk/blob/master/make/RunTests.gmk#L741

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267246](https://bugs.openjdk.java.net/browse/JDK-8267246): -XX:MaxRAMPercentage=0 is unreasonable for jtreg tests on many-core machines


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4062/head:pull/4062` \
`$ git checkout pull/4062`

Update a local copy of the PR: \
`$ git checkout pull/4062` \
`$ git pull https://git.openjdk.java.net/jdk pull/4062/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4062`

View PR using the GUI difftool: \
`$ git pr show -t 4062`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4062.diff">https://git.openjdk.java.net/jdk/pull/4062.diff</a>

</details>
