### PR TITLE
8230486: G1BarrierSetAssembler::g1_write_barrier_post unnecessarily pushes/pops new_val

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/g1/g1BarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/g1/g1BarrierSetAssembler_aarch64.cpp
@@ -254,7 +254,7 @@ void G1BarrierSetAssembler::g1_write_barrier_post(MacroAssembler* masm,
 
   __ bind(runtime);
   // save the live input values
-  RegSet saved = RegSet::of(store_addr, new_val);
+  RegSet saved = RegSet::of(store_addr);
   __ push(saved, sp);
   __ call_VM_leaf(CAST_FROM_FN_PTR(address, G1BarrierSetRuntime::write_ref_field_post_entry), card_addr, thread);
   __ pop(saved, sp);

--- a/src/hotspot/cpu/x86/gc/g1/g1BarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/g1/g1BarrierSetAssembler_x86.cpp
@@ -329,7 +329,6 @@ void G1BarrierSetAssembler::g1_write_barrier_post(MacroAssembler* masm,
   __ bind(runtime);
   // save the live input values
   __ push(store_addr);
-  __ push(new_val);
 #ifdef _LP64
   __ call_VM_leaf(CAST_FROM_FN_PTR(address, G1BarrierSetRuntime::write_ref_field_post_entry), card_addr, r15_thread);
 #else
@@ -337,7 +336,6 @@ void G1BarrierSetAssembler::g1_write_barrier_post(MacroAssembler* masm,
   __ call_VM_leaf(CAST_FROM_FN_PTR(address, G1BarrierSetRuntime::write_ref_field_post_entry), card_addr, thread);
   __ pop(thread);
 #endif
-  __ pop(new_val);
   __ pop(store_addr);
 
   __ bind(done);


### PR DESCRIPTION
Removes the unnecessary push/pop instruction.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8230486](https://bugs.openjdk.java.net/browse/JDK-8230486): G1BarrierSetAssembler::g1_write_barrier_post unnecessarily pushes/pops new_val


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4063/head:pull/4063` \
`$ git checkout pull/4063`

Update a local copy of the PR: \
`$ git checkout pull/4063` \
`$ git pull https://git.openjdk.java.net/jdk pull/4063/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4063`

View PR using the GUI difftool: \
`$ git pr show -t 4063`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4063.diff">https://git.openjdk.java.net/jdk/pull/4063.diff</a>

</details>
