### PR TITLE
JDK-8267219: Javadoc method summary breaks when {@inheritDoc} from an empty parent

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Table.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Table.java
@@ -327,8 +327,8 @@ public class Table extends Content {
             HtmlStyle cellStyle = (columnStyles == null || colIndex > columnStyles.size())
                     ? null
                     : columnStyles.get(colIndex);
-            // Replace empty content with HtmlTree.EMPTY to make sure the cell isn't dropped
-            HtmlTree cell = HtmlTree.DIV(cellStyle, !c.isEmpty() ? c : HtmlTree.EMPTY);
+            // Replace invalid content with HtmlTree.EMPTY to make sure the cell isn't dropped
+            HtmlTree cell = HtmlTree.DIV(cellStyle, c.isValid() ? c : HtmlTree.EMPTY);
             if (rowStyle != null) {
                 cell.addStyle(rowStyle);
             }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/ContentBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/ContentBuilder.java
@@ -93,6 +93,15 @@ public class ContentBuilder extends Content {
     }
 
     @Override
+    public boolean isValid() {
+        for (Content content: contents) {
+            if (content.isValid())
+                return true;
+        }
+        return false;
+    }
+
+    @Override
     public int charCount() {
         int n = 0;
         for (Content c : contents)

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/ContentBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/ContentBuilder.java
@@ -92,6 +92,14 @@ public class ContentBuilder extends Content {
         return true;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @implSpec
+     * A content builder is valid if any of its content is; thus, it is
+     * valid to be added to an HtmlTree, which checks the validity of
+     * each content in this builder.
+     */
     @Override
     public boolean isValid() {
         for (Content content: contents) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/Content.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/Content.java
@@ -107,7 +107,8 @@ public abstract class Content {
     public abstract boolean isEmpty();
 
     /**
-     * Returns true if the content is valid.
+     * Returns true if the content is valid. This allows filtering during
+     * {@link #add(Content) addition}.
      *
      * @return true if the content is valid else return false
      */

--- a/test/langtools/jdk/javadoc/doclet/testEmptyInheritDoc/TestEmptyInheritDoc.java
+++ b/test/langtools/jdk/javadoc/doclet/testEmptyInheritDoc/TestEmptyInheritDoc.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug      8267219
+ * @summary  The method summary's description cell should not be removed when
+ *           it only has inline tags that don't produce any output
+ * @library  /tools/lib ../../lib
+ * @modules  jdk.javadoc/jdk.javadoc.internal.tool
+ * @build    javadoc.tester.*
+ * @run main TestEmptyInheritDoc
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
+
+public class TestEmptyInheritDoc extends JavadocTester {
+
+    public static void main(String... args) throws Exception {
+        TestEmptyInheritDoc tester = new TestEmptyInheritDoc();
+        tester.runTests();
+    }
+
+    ToolBox tb = new ToolBox();
+    Path src;
+
+    TestEmptyInheritDoc() throws Exception {
+        src = Files.createDirectories(Paths.get("src"));
+        tb.writeJavaFiles(src,
+                """
+                    package pkg;
+
+                    public class First {
+                        public void act() {}
+                    }
+                    """,
+                """
+                    package pkg;
+
+                    public class Second extends First {
+                        /**
+                         * {@inheritDoc}
+                         */
+                        public void act() {}
+                        public void bark() {}
+                    }
+                    """);
+    }
+
+    @Test
+    public void run() {
+        javadoc("-d", "out-empty-inheritdoc",
+                "-sourcepath", src.toString(),
+                "pkg");
+        checkExit(Exit.OK);
+
+        checkOutput("pkg/Second.html", true,
+                """
+                   <div class="col-second even-row-color method-summary-table \
+                   method-summary-table-tab2 method-summary-table-tab4"><code>\
+                   <a href="#act()" class="member-name-link">act</a>()</code></div>
+                   <div class="col-last even-row-color method-summary-table \
+                   method-summary-table-tab2 method-summary-table-tab4"></div>""");
+    }
+}


### PR DESCRIPTION
This change fixes when a method body has only inline tags that produce no output, the method summary will get eaten.

This change allows `{@inheritDoc}` from empty parents to go through the code path used by `-nocomment` and properly generate tables.

All `jtreg:test/langtools/jdk/javadoc/doclet` tests pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267219](https://bugs.openjdk.java.net/browse/JDK-8267219): Javadoc method summary breaks when {@inheritDoc} from an empty parent


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.java.net/census#hannesw) (@hns - **Reviewer**) ⚠️ Review applies to 6e4435cd0544bc066c876cb98e0162eecb40ba57


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4066/head:pull/4066` \
`$ git checkout pull/4066`

Update a local copy of the PR: \
`$ git checkout pull/4066` \
`$ git pull https://git.openjdk.java.net/jdk pull/4066/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4066`

View PR using the GUI difftool: \
`$ git pr show -t 4066`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4066.diff">https://git.openjdk.java.net/jdk/pull/4066.diff</a>

</details>
