### PR TITLE
8224158: assertion related to NPE at DynamicCallSiteDesc::withArgs should be reworded

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/DynamicCallSiteDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/DynamicCallSiteDesc.java
@@ -156,7 +156,7 @@ public class DynamicCallSiteDesc {
      *                      to the bootstrap, that would appear in the
      *                      {@code BootstrapMethods} attribute
      * @return the nominal descriptor
-     * @throws NullPointerException if any parameter is null
+     * @throws NullPointerException if the argument or its contents are {@code null}
      */
     public DynamicCallSiteDesc withArgs(ConstantDesc... bootstrapArgs) {
         return new DynamicCallSiteDesc(bootstrapMethod, invocationName, invocationType, bootstrapArgs);


### PR DESCRIPTION
This is a very small patch that is just rewording the spec for DynamicCallSiteDesc::withArgs. Basically adding that NPE can also be thrown if the content of the argument is `null`

TIA for the review

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8224158](https://bugs.openjdk.java.net/browse/JDK-8224158): assertion related to NPE at DynamicCallSiteDesc::withArgs should be reworded


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4067/head:pull/4067` \
`$ git checkout pull/4067`

Update a local copy of the PR: \
`$ git checkout pull/4067` \
`$ git pull https://git.openjdk.java.net/jdk pull/4067/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4067`

View PR using the GUI difftool: \
`$ git pr show -t 4067`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4067.diff">https://git.openjdk.java.net/jdk/pull/4067.diff</a>

</details>
