### PR TITLE
JDK-8264181: javadoc tool Incorrect error message about malformed link

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
@@ -458,7 +458,8 @@ public class DocCommentParser {
             nextChar();
         }
 
-        if (depth != 0)
+        // depth < 0 will be caught and reported by ReferenceParser#parse
+        if (depth > 0)
             throw new ParseException("dc.unterminated.signature");
 
         String sig = newString(pos, bp);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -3215,7 +3215,7 @@ compiler.err.dc.gt.expected=\
     ''>'' expected
 
 compiler.err.dc.ref.bad.parens=\
-    '')'' missing in reference
+    unexpected parenthesis
 
 compiler.err.dc.ref.syntax.error=\
     syntax error in reference

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -3215,7 +3215,7 @@ compiler.err.dc.gt.expected=\
     ''>'' expected
 
 compiler.err.dc.ref.bad.parens=\
-    unexpected parenthesis
+    unexpected text after parenthesis
 
 compiler.err.dc.ref.syntax.error=\
     syntax error in reference

--- a/test/langtools/tools/javac/diags/examples/RefBadParens1.java
+++ b/test/langtools/tools/javac/diags/examples/RefBadParens1.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.err.dc.ref.bad.parens
+// key: compiler.note.note
+// key: compiler.note.proc.messager
+// run: backdoor
+// options: -processor DocCommentProcessor -proc:only
+
+/** @see #m(int)) */
+class RefBadParens1 { }
+

--- a/test/langtools/tools/javac/diags/examples/RefUnexpectedInput1.java
+++ b/test/langtools/tools/javac/diags/examples/RefUnexpectedInput1.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.err.dc.ref.unexpected.input
+// key: compiler.note.note
+// key: compiler.note.proc.messager
+// run: backdoor
+// options: -processor DocCommentProcessor -proc:only
+
+/** @see RefUnexpectedInput1<Object>> */
+class RefUnexpectedInput1<T> { }
+

--- a/test/langtools/tools/javac/diags/examples/UnterminatedSignature1.java
+++ b/test/langtools/tools/javac/diags/examples/UnterminatedSignature1.java
@@ -21,12 +21,12 @@
  * questions.
  */
 
-// key: compiler.err.dc.ref.bad.parens
+// key: compiler.err.dc.unterminated.signature
 // key: compiler.note.note
 // key: compiler.note.proc.messager
 // run: backdoor
 // options: -processor DocCommentProcessor -proc:only
 
-/** @see #m(int)x */
-class RefBadParens1 { }
+/** @see java.util.Set<String */
+class UnterminatedSignature1 { }
 


### PR DESCRIPTION
The primary problem was that key `compiler.err.dc.ref.bad.parens` had the wrong message "')' missing in reference". That error message is not used when the right parenthesis is missing, but when it occurs before the end of the signature. The missing parenthesis case is caught earlier by the parens balancing code in `DocCommentParser#reference` and uses message `compiler.err.dc.unterminated.signature` ("unterminated signature").

I changed the message for `compiler.err.dc.ref.bad.parens` to "unexpected parenthesis". 

A secondary problem was that `DocCommentParser#reference` also threw "unterminated signature" when there were too many closing angle brackets or parentheses. These cases are now passed through in`DocCommentParser#reference` so that `ReferenceParser#parse` can throw a more appropriate error ("unexpected parenthesis" or "unexpected input"). 

Here's a list of what references now cause what error messages:

 - `#foo(int`     `unterminated signature`
 - `#foo((int))`   `unexpected parenthesis`
 - `#foo(int))`   `unexpected parenthesis`
 - `#foo(int)x`   `unexpected parenthesis`
 - `F<T`        `unterminated signature`
 - `F<T>>`    `unexpected input`

I added two new tests for the cases with too many closing brackets/parens that used to fail with "unterminated signature".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264181](https://bugs.openjdk.java.net/browse/JDK-8264181): javadoc tool Incorrect error message about malformed link


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4068/head:pull/4068` \
`$ git checkout pull/4068`

Update a local copy of the PR: \
`$ git checkout pull/4068` \
`$ git pull https://git.openjdk.java.net/jdk pull/4068/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4068`

View PR using the GUI difftool: \
`$ git pr show -t 4068`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4068.diff">https://git.openjdk.java.net/jdk/pull/4068.diff</a>

</details>
