### PR TITLE
8263242: serviceability/sa/ClhsdbFindPC.java cannot find MaxJNILocalCapacity with ASLR

### DIFF
--- a/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.c
@@ -187,8 +187,9 @@ static bool fill_addr_info(lib_info* lib) {
   lib->exec_end = (uintptr_t)-1L;
   for (ph = phbuf, cnt = 0; cnt < ehdr.e_phnum; cnt++, ph++) {
     if (ph->p_type == PT_LOAD) {
-      uintptr_t aligned_start = align_down(lib->base + ph->p_vaddr, ph->p_align);
-      uintptr_t aligned_end = align_up(aligned_start + ph->p_filesz, ph->p_align);
+      uintptr_t unaligned_start = lib->base + ph->p_vaddr;
+      uintptr_t aligned_start = align_down(unaligned_start, ph->p_align);
+      uintptr_t aligned_end = align_up(unaligned_start + ph->p_memsz, ph->p_align);
       if ((lib->end == (uintptr_t)-1L) || (lib->end < aligned_end)) {
         lib->end = aligned_end;
       }
@@ -540,4 +541,3 @@ ps_lgetregs(struct ps_prochandle *ph, lwpid_t lid, prgregset_t gregset) {
   print_debug("ps_lgetfpregs not implemented\n");
   return PS_OK;
 }
-


### PR DESCRIPTION
The issue is that SA thought the library was smaller than it actually was, so SA refused to map an address to a symbol if the address was beyond what SA thought was the end of the library's memory range. However, the converse, mapping a symbol to an address, still worked even if the resulting address was thought to be out of range. This is because there was no range checking done in this case. Thus you could look up the address of a symbol, but then mapping the address back to a symbol might fail.

The root of the problem was using p_filesz instead of p_memsz when determining the size of a library segment, and there was also a rounding error once p_memsz was used, so it took a bit of extra logic to get the size computation just right. This comment in CR describes it best:

https://bugs.openjdk.java.net/browse/JDK-8263242?focusedCommentId=14408953&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14408953

There are also a bunch of p_filesz references in ps_core.c that should probably be p_memsz. However, I did some printfs and found the values to always be the same within core files, so decided not to risk making this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263242](https://bugs.openjdk.java.net/browse/JDK-8263242): serviceability/sa/ClhsdbFindPC.java cannot find MaxJNILocalCapacity with ASLR


### Reviewers
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer)
 * [Yasumasa Suenaga](https://openjdk.java.net/census#ysuenaga) (@YaSuenag - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4075/head:pull/4075` \
`$ git checkout pull/4075`

Update a local copy of the PR: \
`$ git checkout pull/4075` \
`$ git pull https://git.openjdk.java.net/jdk pull/4075/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4075`

View PR using the GUI difftool: \
`$ git pr show -t 4075`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4075.diff">https://git.openjdk.java.net/jdk/pull/4075.diff</a>

</details>
