### PR TITLE
8263385: IGV: Graph is not opened in the window that has focus.

### DIFF
--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/GraphViewerImplementation.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/GraphViewerImplementation.java
@@ -27,6 +27,9 @@ import com.sun.hotspot.igv.data.InputGraph;
 import com.sun.hotspot.igv.data.services.GraphViewer;
 import com.sun.hotspot.igv.graph.Diagram;
 import com.sun.hotspot.igv.settings.Settings;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.openide.windows.Mode;
 import org.openide.windows.TopComponent;
 import org.openide.windows.WindowManager;
@@ -45,7 +48,10 @@ public class GraphViewerImplementation implements GraphViewer {
         if (!clone) {
             WindowManager manager = WindowManager.getDefault();
             for (Mode m : manager.getModes()) {
-                for (TopComponent t : manager.getOpenedTopComponents(m)) {
+                List<TopComponent> l = new ArrayList<>();
+                l.add(m.getSelectedTopComponent());
+                l.addAll(Arrays.asList(manager.getOpenedTopComponents(m)));
+                for (TopComponent t : l) {
                     if (t instanceof EditorTopComponent) {
                         EditorTopComponent etc = (EditorTopComponent) t;
                         if (etc.getModel().getGroup().getGraphs().contains(graph)) {


### PR DESCRIPTION
This pull request enables IGV opens a graph in the window that is focused.

At the moment IGV opens a graph in the window that has the graph and is found first. So in this pull request I used preferentially the active EditorTopComponent.

I tested the following scenarios manually:

1. Open a graph, open clone, then open another graph (as described in the bug report). It replaces the clone graph with the last opened graph.
2. Open a graph, open clone, swap tabs by dragging the clone graph, then open another graph. It replaces the clone graph with the last opened graph.
3. Open a graph, open clone, change the focus from the clone graph to the first graph, then open another graph. It replaces the first graph with the last opened graph.
4. Open a graph, open clone, open the same graph xml file from the toolbar, open a graph in the second folder, then open a graph in the first folder. It replaces the leftmost graph that was opened the first with the last opened graph.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263385](https://bugs.openjdk.java.net/browse/JDK-8263385): IGV: Graph is not opened in the window that has focus.


### Reviewers
 * [Richard Reingruber](https://openjdk.java.net/census#rrich) (@reinrich - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4078/head:pull/4078` \
`$ git checkout pull/4078`

Update a local copy of the PR: \
`$ git checkout pull/4078` \
`$ git pull https://git.openjdk.java.net/jdk pull/4078/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4078`

View PR using the GUI difftool: \
`$ git pr show -t 4078`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4078.diff">https://git.openjdk.java.net/jdk/pull/4078.diff</a>

</details>
