### PR TITLE
8267151: C2: Don't create dummy Opaque1Node for outmost unswitched IfNode

### DIFF
--- a/src/hotspot/share/opto/loopUnswitch.cpp
+++ b/src/hotspot/share/opto/loopUnswitch.cpp
@@ -147,7 +147,9 @@ void PhaseIdealLoop::do_unswitching(IdealLoopTree *loop, Node_List &old_new) {
     head->as_CountedLoop()->set_normal_loop();
   }
 
-  ProjNode* proj_true = create_slow_version_of_loop(loop, old_new, unswitch_iff->Opcode(), CloneIncludesStripMined);
+  IfNode* invar_iff = create_slow_version_of_loop(loop, old_new, unswitch_iff, CloneIncludesStripMined);
+  ProjNode* proj_true = invar_iff->proj_out(1);
+  ProjNode* proj_false = invar_iff->proj_out(0);
 
 #ifdef ASSERT
   assert(proj_true->is_IfTrue(), "must be true projection");
@@ -183,20 +185,10 @@ void PhaseIdealLoop::do_unswitching(IdealLoopTree *loop, Node_List &old_new) {
   head->set_unswitch_count(nct);
   head_clone->set_unswitch_count(nct);
 
-  // Add test to new "if" outside of loop
-  IfNode* invar_iff   = proj_true->in(0)->as_If();
-  Node* invar_iff_c   = invar_iff->in(0);
-  BoolNode* bol       = unswitch_iff->in(1)->as_Bool();
-  invar_iff->set_req(1, bol);
-  invar_iff->_prob    = unswitch_iff->_prob;
-
-  ProjNode* proj_false = invar_iff->proj_out(0)->as_Proj();
-
   // Hoist invariant casts out of each loop to the appropriate
   // control projection.
 
   Node_List worklist;
-
   for (DUIterator_Fast imax, i = unswitch_iff->fast_outs(imax); i < imax; i++) {
     ProjNode* proj= unswitch_iff->fast_out(i)->as_Proj();
     // Copy to a worklist for easier manipulation
@@ -249,10 +241,10 @@ void PhaseIdealLoop::do_unswitching(IdealLoopTree *loop, Node_List &old_new) {
 //-------------------------create_slow_version_of_loop------------------------
 // Create a slow version of the loop by cloning the loop
 // and inserting an if to select fast-slow versions.
-// Return control projection of the entry to the fast version.
-ProjNode* PhaseIdealLoop::create_slow_version_of_loop(IdealLoopTree *loop,
+// Return the inserted if.
+IfNode* PhaseIdealLoop::create_slow_version_of_loop(IdealLoopTree *loop,
                                                       Node_List &old_new,
-                                                      int opcode,
+                                                      IfNode* unswitch_iff,
                                                       CloneLoopMode mode) {
   LoopNode* head  = loop->_head->as_Loop();
   bool counted_loop = head->is_CountedLoop();
@@ -262,14 +254,10 @@ ProjNode* PhaseIdealLoop::create_slow_version_of_loop(IdealLoopTree *loop,
 
   head->verify_strip_mined(1);
 
-  Node *cont      = _igvn.intcon(1);
-  set_ctrl(cont, C->root());
-  Node* opq       = new Opaque1Node(C, cont);
-  register_node(opq, outer_loop, entry, dom_depth(entry));
-  Node *bol       = new Conv2BNode(opq);
-  register_node(bol, outer_loop, entry, dom_depth(entry));
-  IfNode* iff = (opcode == Op_RangeCheck) ? new RangeCheckNode(entry, bol, PROB_MAX, COUNT_UNKNOWN) :
-    new IfNode(entry, bol, PROB_MAX, COUNT_UNKNOWN);
+  // Add test to new "if" outside of loop
+  Node *bol   = unswitch_iff->in(1)->as_Bool();
+  IfNode* iff = (unswitch_iff->Opcode() == Op_RangeCheck) ? new RangeCheckNode(entry, bol, unswitch_iff->_prob, unswitch_iff->_fcnt) :
+    new IfNode(entry, bol, unswitch_iff->_prob, unswitch_iff->_fcnt);
   register_node(iff, outer_loop, entry, dom_depth(entry));
   ProjNode* iffast = new IfTrueNode(iff);
   register_node(iffast, outer_loop, iff, dom_depth(iff));
@@ -296,7 +284,7 @@ ProjNode* PhaseIdealLoop::create_slow_version_of_loop(IdealLoopTree *loop,
 
   recompute_dom_depth();
 
-  return iffast;
+  return iff;
 }
 
 LoopNode* PhaseIdealLoop::create_reserve_version_of_loop(IdealLoopTree *loop, CountedLoopReserveKit* lk) {

--- a/src/hotspot/share/opto/loopUnswitch.cpp
+++ b/src/hotspot/share/opto/loopUnswitch.cpp
@@ -247,7 +247,6 @@ IfNode* PhaseIdealLoop::create_slow_version_of_loop(IdealLoopTree *loop,
                                                       IfNode* unswitch_iff,
                                                       CloneLoopMode mode) {
   LoopNode* head  = loop->_head->as_Loop();
-  bool counted_loop = head->is_CountedLoop();
   Node*     entry = head->skip_strip_mined()->in(LoopNode::EntryControl);
   _igvn.rehash_node_delayed(entry);
   IdealLoopTree* outer_loop = loop->_parent;
@@ -290,7 +289,6 @@ IfNode* PhaseIdealLoop::create_slow_version_of_loop(IdealLoopTree *loop,
 LoopNode* PhaseIdealLoop::create_reserve_version_of_loop(IdealLoopTree *loop, CountedLoopReserveKit* lk) {
   Node_List old_new;
   LoopNode* head  = loop->_head->as_Loop();
-  bool counted_loop = head->is_CountedLoop();
   Node*     entry = head->skip_strip_mined()->in(LoopNode::EntryControl);
   _igvn.rehash_node_delayed(entry);
   IdealLoopTree* outer_loop = head->is_strip_mined() ? loop->_parent->_parent : loop->_parent;

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1345,9 +1345,10 @@ public:
 
   // Create a slow version of the loop by cloning the loop
   // and inserting an if to select fast-slow versions.
-  ProjNode* create_slow_version_of_loop(IdealLoopTree *loop,
+  // Return the inserted if.
+  IfNode* create_slow_version_of_loop(IdealLoopTree *loop,
                                         Node_List &old_new,
-                                        int opcode,
+                                        IfNode* unswitch_iff,
                                         CloneLoopMode mode);
 
   // Clone a loop and return the clone head (clone_loop_head).


### PR DESCRIPTION
In create_slow_version_of_loop(), C2 creates the outmost unswitched IfNode(i.e. **if(xx)**{ for{} }else{ for{} }) with a dummy opaque bool node as its condition input.

https://github.com/openjdk/jdk/blob/cd1c17c0a6416a8d16cf2035f3e97dba95b6b8af/src/hotspot/share/opto/loopUnswitch.cpp#L265-L271

After that, it sets the _prob(missing _fcnt?) of the outmost unswitched IfNode in do_unswitching().

https://github.com/openjdk/jdk/blob/cd1c17c0a6416a8d16cf2035f3e97dba95b6b8af/src/hotspot/share/opto/loopUnswitch.cpp#L186-L191

I think we can merge these two steps into a single step, that is, create the outmost unswitched IfNode meanwhile setting its condition input, _prob and _fcnt w/ creating the dummy opaque bool node.

Testing:
- hotspot/jtreg/compiler(slowdebug)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267151](https://bugs.openjdk.java.net/browse/JDK-8267151): C2: Don't create dummy Opaque1Node for outmost unswitched IfNode


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4079/head:pull/4079` \
`$ git checkout pull/4079`

Update a local copy of the PR: \
`$ git checkout pull/4079` \
`$ git pull https://git.openjdk.java.net/jdk pull/4079/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4079`

View PR using the GUI difftool: \
`$ git pr show -t 4079`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4079.diff">https://git.openjdk.java.net/jdk/pull/4079.diff</a>

</details>
