### PR TITLE
JDK-8263684: Avoid wrapping into BufferedWriter twice

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/ElementListWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/ElementListWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/ElementListWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/ElementListWriter.java
@@ -74,7 +74,9 @@ public class ElementListWriter {
     }
 
     protected void generateElementListFile(DocletEnvironment docEnv) throws DocFileIOException {
-        try (BufferedWriter out = new BufferedWriter(file.openWriter())) {
+        try (Writer fileWriter = file.openWriter();
+             BufferedWriter out = (fileWriter instanceof BufferedWriter b) ? b
+                     : new BufferedWriter(file.openWriter())) {
             if (configuration.showModules) {
                 for (ModuleElement mdle : configuration.modulePackages.keySet()) {
                     if (!(options.noDeprecated() && utils.isDeprecated(mdle))) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/ElementListWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/ElementListWriter.java
@@ -76,7 +76,7 @@ public class ElementListWriter {
     protected void generateElementListFile(DocletEnvironment docEnv) throws DocFileIOException {
         try (Writer fileWriter = file.openWriter();
              BufferedWriter out = (fileWriter instanceof BufferedWriter b) ? b
-                     : new BufferedWriter(file.openWriter())) {
+                     : new BufferedWriter(fileWriter)) {
             if (configuration.showModules) {
                 for (ModuleElement mdle : configuration.modulePackages.keySet()) {
                     if (!(options.noDeprecated() && utils.isDeprecated(mdle))) {


### PR DESCRIPTION
Please review a trivial fix to avoid creating an unnecessary `BufferedWriter`.

`noreg-trivial` (or `noreg-cleanup` : take your pick). Either way, no test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263684](https://bugs.openjdk.java.net/browse/JDK-8263684): Avoid wrapping into BufferedWriter twice


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**) ⚠️ Review applies to 11be026fa0a19f9c19458166467143298a97b8f6


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4080/head:pull/4080` \
`$ git checkout pull/4080`

Update a local copy of the PR: \
`$ git checkout pull/4080` \
`$ git pull https://git.openjdk.java.net/jdk pull/4080/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4080`

View PR using the GUI difftool: \
`$ git pr show -t 4080`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4080.diff">https://git.openjdk.java.net/jdk/pull/4080.diff</a>

</details>
