### PR TITLE
8233380: CHT: Node allocation and freeing

### DIFF
--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -122,11 +122,11 @@ class StringTableConfig : public StackObj {
     return 0;
   }
   // We use default allocation/deallocation but counted
-  static void* allocate_node(size_t size, Value const& value) {
+  static void* allocate_node(void* context, size_t size, Value const& value) {
     StringTable::item_added();
     return AllocateHeap(size, mtSymbol);
   }
-  static void free_node(void* memory, Value const& value) {
+  static void free_node(void* context, void* memory, Value const& value) {
     value.release(StringTable::_oop_storage);
     FreeHeap(memory);
     StringTable::item_removed();

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -132,11 +132,11 @@ public:
     }
   }
   // We use default allocation/deallocation but counted
-  static void* allocate_node(size_t size, Value const& value) {
+  static void* allocate_node(void* context, size_t size, Value const& value) {
     SymbolTable::item_added();
     return AllocateHeap(size, mtSymbol);
   }
-  static void free_node(void* memory, Value const& value) {
+  static void free_node(void* context, void* memory, Value const& value) {
     // We get here because #1 some threads lost a race to insert a newly created Symbol
     // or #2 we're cleaning up unused symbol.
     // If #1, then the symbol can be either permanent,

--- a/src/hotspot/share/prims/resolvedMethodTable.cpp
+++ b/src/hotspot/share/prims/resolvedMethodTable.cpp
@@ -79,11 +79,11 @@ class ResolvedMethodTableConfig : public AllStatic {
   }
 
   // We use default allocation/deallocation but counted
-  static void* allocate_node(size_t size, Value const& value) {
+  static void* allocate_node(void* context, size_t size, Value const& value) {
     ResolvedMethodTable::item_added();
     return AllocateHeap(size, mtClass);
   }
-  static void free_node(void* memory, Value const& value) {
+  static void free_node(void* context, void* memory, Value const& value) {
     value.release(ResolvedMethodTable::_oop_storage);
     FreeHeap(memory);
     ResolvedMethodTable::item_removed();

--- a/src/hotspot/share/services/threadIdTable.cpp
+++ b/src/hotspot/share/services/threadIdTable.cpp
@@ -69,11 +69,11 @@ class ThreadIdTableConfig : public AllStatic {
       jlong tid = value->tid();
       return primitive_hash(tid);
     }
-    static void* allocate_node(size_t size, Value const& value) {
+    static void* allocate_node(void* context, size_t size, Value const& value) {
       ThreadIdTable::item_added();
       return AllocateHeap(size, mtInternal);
     }
-    static void free_node(void* memory, Value const& value) {
+    static void free_node(void* context, void* memory, Value const& value) {
       delete value;
       FreeHeap(memory);
       ThreadIdTable::item_removed();


### PR DESCRIPTION
Hi all,

Please review this change to pass an allocator ("context") instance to the CHT at initialization instead of relying on the static configuration. The allocator instance is passed down to the allocate/free_node methods making it easier to use Arena-style allocators in the CHT.

Testing: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8233380](https://bugs.openjdk.java.net/browse/JDK-8233380): CHT: Node allocation and freeing


### Reviewers
 * [Robbin Ehn](https://openjdk.java.net/census#rehn) (@robehn - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4081/head:pull/4081` \
`$ git checkout pull/4081`

Update a local copy of the PR: \
`$ git checkout pull/4081` \
`$ git pull https://git.openjdk.java.net/jdk pull/4081/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4081`

View PR using the GUI difftool: \
`$ git pr show -t 4081`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4081.diff">https://git.openjdk.java.net/jdk/pull/4081.diff</a>

</details>
