### PR TITLE
8260360: IGV: Short name of combined nodes is hidden by background color

### DIFF
--- a/src/utils/IdealGraphVisualizer/Filter/src/main/java/com/sun/hotspot/igv/filter/CombineFilter.java
+++ b/src/utils/IdealGraphVisualizer/Filter/src/main/java/com/sun/hotspot/igv/filter/CombineFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,6 +85,7 @@ public class CombineFilter extends AbstractFilter {
                         } else {
                             assert slot != null;
                             slot.setText(f.getProperties().get("dump_spec"));
+                            slot.setColor(f.getColor());
                             if (f.getProperties().get("short_name") != null) {
                                 slot.setShortName(f.getProperties().get("short_name"));
                             } else {
@@ -139,6 +140,7 @@ public class CombineFilter extends AbstractFilter {
                                     }
                                 } else {
                                     slot.setText(succ.getProperties().get("dump_spec"));
+                                    slot.setColor(succ.getColor());
                                     if (succ.getProperties().get("short_name") != null) {
                                         slot.setShortName(succ.getProperties().get("short_name"));
                                     } else {


### PR DESCRIPTION
This pull request enables the short name of combined nodes readable. 

At present those node are painted out with black because their OutputSlot color is null. So this pull request sets the original color to the OutputSlot.

I tested the following scenario manually:

- Open a graph, then enable "Simplify graph" (as described in the bug report). The result is the following images. There are two graphs. One is black and white only graph, the other is colored graph.

<img width="540" alt="スクリーンショット 2021-05-18 16 25 03" src="https://user-images.githubusercontent.com/60008/118609442-b36bf780-b7f5-11eb-86a4-109b4f11b857.png">
<img width="540" alt="スクリーンショット 2021-05-18 16 25 33" src="https://user-images.githubusercontent.com/60008/118609451-b666e800-b7f5-11eb-85e0-1e3604109a8a.png">


