### PR TITLE
8208747: [a11y] [macos] In Optionpane Demo, inside ComponentDialog Example, unable to navigate to all items, with VO on

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
@@ -896,6 +896,14 @@ static NSObject *sAttributeNamesLOCK = nil;
     return NO;
 }
 
+- (NSInteger)accessibilityIndex {
+    int index = 0;
+    if (fParent != NULL) {
+        index = [fParent accessibilityIndexOfChild:self];
+    }
+    return index;
+}
+
 /*
  * The java/lang/Number concrete class could be for any of the Java primitive
  * numerical types or some other subclass.


### PR DESCRIPTION
Added accessibilityIndex function that correctly returns the index of a
child in parent container

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8208747](https://bugs.openjdk.java.net/browse/JDK-8208747): [a11y] [macos] In Optionpane Demo, inside ComponentDialog Example, unable to navigate to all items, with VO on


### Reviewers
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4084/head:pull/4084` \
`$ git checkout pull/4084`

Update a local copy of the PR: \
`$ git checkout pull/4084` \
`$ git pull https://git.openjdk.java.net/jdk pull/4084/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4084`

View PR using the GUI difftool: \
`$ git pr show -t 4084`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4084.diff">https://git.openjdk.java.net/jdk/pull/4084.diff</a>

</details>
