### PR TITLE
8267311: vmTestbase/gc/gctests/StringInternGC/StringInternGC.java eventually OOMEs

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/StringInternGC/StringInternGC.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/StringInternGC/StringInternGC.java
@@ -47,7 +47,7 @@ import nsk.share.gc.*;
  */
 public class StringInternGC extends ThreadedGCTest {
         private int maxLength = 1000; // Maximum number of characters to add per operation.
-        private int maxTotalLength = 128 * 1024; // Random total maximum length of the string.
+        private int maxTotalLength = 128 * 1024; // Total maximum length of the string until a new StringBuffer will be allocated.
 
         private class StringGenerator implements Runnable {
                 private StringBuffer sb = new StringBuffer();

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/StringInternGC/StringInternGC.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/StringInternGC/StringInternGC.java
@@ -31,7 +31,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xmx1g gc.gctests.StringInternGC.StringInternGC
+ * @run main/othervm gc.gctests.StringInternGC.StringInternGC
  */
 
 package gc.gctests.StringInternGC;
@@ -46,13 +46,17 @@ import nsk.share.gc.*;
  * String pool should not overflow.
  */
 public class StringInternGC extends ThreadedGCTest {
-        private int maxLength = 1000;
+        private int maxLength = 1000; // Maximum length to add per operation.
+        private int maxTotalLength = 128 * 1024; // Random total maximum length of the string.
 
         private class StringGenerator implements Runnable {
                 private StringBuffer sb = new StringBuffer();
 
                 private String generateString() {
                         int length = LocalRandom.nextInt(maxLength);
+                        if (sb.length() > maxTotalLength) {
+                                sb = new StringBuffer();
+                        }
                         for (int i = 0; i < length; ++i)
                                 sb.append((char) LocalRandom.nextInt(Integer.MAX_VALUE));
                         return sb.toString();

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/StringInternGC/StringInternGC.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/StringInternGC/StringInternGC.java
@@ -59,12 +59,6 @@ public class StringInternGC extends ThreadedGCTest {
                                 sb = new StringBuffer();
                         }
 
-                        long currentTime = System.currentTimeMillis();
-                        if (currentTime - lastTime > 5000) { // Cause a full gc every 5s.
-                                lastTime = currentTime;
-                                System.gc();
-                        }
-
                         for (int i = 0; i < length; ++i)
                                 sb.append((char) LocalRandom.nextInt(Integer.MAX_VALUE));
                         return sb.toString();
@@ -72,6 +66,12 @@ public class StringInternGC extends ThreadedGCTest {
 
 
                 public void run() {
+                        long currentTime = System.currentTimeMillis();
+                        if (currentTime - lastTime > 5000) { // Cause a full gc every 5s.
+                                lastTime = currentTime;
+                                System.gc();
+                        }
+
                         generateString().intern();
                 }
         }

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/StringInternGC/StringInternGC.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/StringInternGC/StringInternGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm gc.gctests.StringInternGC.StringInternGC
+ * @run main/othervm -Xmx1g gc.gctests.StringInternGC.StringInternGC
  */
 
 package gc.gctests.StringInternGC;

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/StringInternGC/StringInternGC.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/StringInternGC/StringInternGC.java
@@ -46,7 +46,7 @@ import nsk.share.gc.*;
  * String pool should not overflow.
  */
 public class StringInternGC extends ThreadedGCTest {
-        private int maxLength = 1000; // Maximum length to add per operation.
+        private int maxLength = 1000; // Maximum number of characters to add per operation.
         private int maxTotalLength = 128 * 1024; // Random total maximum length of the string.
 
         private class StringGenerator implements Runnable {

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/StringInternGC/StringInternGC.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/StringInternGC/StringInternGC.java
@@ -31,7 +31,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm gc.gctests.StringInternGC.StringInternGC
+ * @run main/othervm -XX:+ExplicitGCInvokesConcurrent gc.gctests.StringInternGC.StringInternGC
  */
 
 package gc.gctests.StringInternGC;
@@ -48,6 +48,7 @@ import nsk.share.gc.*;
 public class StringInternGC extends ThreadedGCTest {
         private int maxLength = 1000; // Maximum number of characters to add per operation.
         private int maxTotalLength = 128 * 1024; // Total maximum length of the string until a new StringBuffer will be allocated.
+        private long lastTime = System.currentTimeMillis();
 
         private class StringGenerator implements Runnable {
                 private StringBuffer sb = new StringBuffer();
@@ -57,6 +58,13 @@ public class StringInternGC extends ThreadedGCTest {
                         if (sb.length() > maxTotalLength) {
                                 sb = new StringBuffer();
                         }
+
+                        long currentTime = System.currentTimeMillis();
+                        if (currentTime - lastTime > 5000) { // Cause a full gc every 5s.
+                                lastTime = currentTime;
+                                System.gc();
+                        }
+
                         for (int i = 0; i < length; ++i)
                                 sb.append((char) LocalRandom.nextInt(Integer.MAX_VALUE));
                         return sb.toString();


### PR DESCRIPTION
Hi all,

vmTestbase/gc/gctests/StringInternGC/StringInternGC.java fails with release VM on our many-core machines due to `-XX:MaxRAMPercentage=0`.
This is because `-XX:MaxRAMPercentage=0` will be 0 if JTREG_JOBS > 25 [1].

Reproduce:
 - make test TEST="vmTestbase/gc/gctests/StringInternGC/StringInternGC.java" JTREG="JOBS=26" CONF=server-release

`-Xmx1g` is added to make it more robust.
Note: we still see failure with `-Xmx512m`.

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk/blob/master/make/RunTests.gmk#L741

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267311](https://bugs.openjdk.java.net/browse/JDK-8267311): vmTestbase/gc/gctests/StringInternGC/StringInternGC.java eventually OOMEs


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Contributors
 * Thomas Schatzl `<tschatzl@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4086/head:pull/4086` \
`$ git checkout pull/4086`

Update a local copy of the PR: \
`$ git checkout pull/4086` \
`$ git pull https://git.openjdk.java.net/jdk pull/4086/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4086`

View PR using the GUI difftool: \
`$ git pr show -t 4086`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4086.diff">https://git.openjdk.java.net/jdk/pull/4086.diff</a>

</details>
