### PR TITLE
8267304: Bump global JTReg memory limit to 768m

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -258,8 +258,6 @@ langtools_JTREG_PROBLEM_LIST += $(TOPDIR)/test/langtools/ProblemList.txt
 hotspot_JTREG_PROBLEM_LIST += $(TOPDIR)/test/hotspot/jtreg/ProblemList.txt
 lib-test_JTREG_PROBLEM_LIST += $(TOPDIR)/test/lib-test/ProblemList.txt
 
-langtools_JTREG_MAX_MEM := 768m
-
 ################################################################################
 # Parse test selection
 #
@@ -722,7 +720,7 @@ define SetupRunJtregTestBody
   # Convert JTREG_foo into $1_JTREG_foo with a suitable value.
   $$(eval $$(call SetJtregValue,$1,JTREG_TEST_MODE,agentvm))
   $$(eval $$(call SetJtregValue,$1,JTREG_ASSERT,true))
-  $$(eval $$(call SetJtregValue,$1,JTREG_MAX_MEM,512m))
+  $$(eval $$(call SetJtregValue,$1,JTREG_MAX_MEM,768m))
   $$(eval $$(call SetJtregValue,$1,JTREG_NATIVEPATH))
   $$(eval $$(call SetJtregValue,$1,JTREG_BASIC_OPTIONS))
   $$(eval $$(call SetJtregValue,$1,JTREG_PROBLEM_LIST))


### PR DESCRIPTION
See the rationale in the RFE.

Additional testing:
 - [x] Linux x86_64 fastdebug `java/time/format/TestZoneTextPrinterParser.java` with aggressive GC options
 - [x] Linux x86_64 fastdebug `jdk:tier1`
 - [x] Linux x86_64 fastdebug `tier1`
 - [x] Linux x86_64 fastdebug `tier2`
 - [x] Linux x86_32 fastdebug `tier1`
 - [x] Linux x86_32 fastdebug `tier2`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267304](https://bugs.openjdk.java.net/browse/JDK-8267304): Bump global JTReg memory limit to 768m


### Reviewers
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - Committer)
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4087/head:pull/4087` \
`$ git checkout pull/4087`

Update a local copy of the PR: \
`$ git checkout pull/4087` \
`$ git pull https://git.openjdk.java.net/jdk pull/4087/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4087`

View PR using the GUI difftool: \
`$ git pr show -t 4087`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4087.diff">https://git.openjdk.java.net/jdk/pull/4087.diff</a>

</details>
