### PR TITLE
8266807: Windows os_windows-gtest broken for UseLargePages

### DIFF
--- a/test/hotspot/gtest/runtime/test_os_windows.cpp
+++ b/test/hotspot/gtest/runtime/test_os_windows.cpp
@@ -90,7 +90,7 @@ void TestReserveMemorySpecial_test() {
   const size_t alignment = os::large_page_size() * 2;
   const size_t new_large_size = alignment * 4;
   char* aligned_request = os::reserve_memory_special(new_large_size, alignment, os::large_page_size(), NULL, false);
-  EXPECT_TRUE(aligned_request != NULL) << "Should not fail this reservation if the first two were ok.";
+  EXPECT_TRUE(aligned_request != NULL) << "Unexpected reservation failure, can’t verify correct alignment";
   EXPECT_TRUE(is_aligned(aligned_request, alignment)) << "Returned address must be aligned";
   MemoryReleaser m3(aligned_request, new_large_size);
 }

--- a/test/hotspot/gtest/runtime/test_os_windows.cpp
+++ b/test/hotspot/gtest/runtime/test_os_windows.cpp
@@ -70,7 +70,6 @@ void TestReserveMemorySpecial_test() {
   char* result = os::reserve_memory_special(large_allocation_size, os::large_page_size(), os::large_page_size(), NULL, false);
   if (result == NULL) {
       // failed to allocate memory, skipping the test
-      log_info(test)("Skipping Windows large page test since first large page allocation failed");
       return;
   }
   MemoryReleaser m1(result, large_allocation_size);

--- a/test/hotspot/gtest/runtime/test_os_windows.cpp
+++ b/test/hotspot/gtest/runtime/test_os_windows.cpp
@@ -83,7 +83,8 @@ void TestReserveMemorySpecial_test() {
   // Instead try reserving after the first reservation.
   expected_location = result + large_allocation_size;
   actual_location = os::reserve_memory_special(expected_allocation_size, os::large_page_size(), os::large_page_size(), expected_location, false);
-  EXPECT_TRUE(actual_location == NULL || actual_location == expected_location) << "Reservation must either fail or be at requested location";
+  EXPECT_TRUE(actual_location != NULL) << "Unexpected reservation failure, can’t verify correct location";
+  EXPECT_TRUE(actual_location == expected_location) << "Reservation must be at requested location";
   MemoryReleaser m2(actual_location, os::large_page_size());
 
   // Now try to do a reservation with a larger alignment.

--- a/test/hotspot/gtest/runtime/test_os_windows.cpp
+++ b/test/hotspot/gtest/runtime/test_os_windows.cpp
@@ -25,6 +25,7 @@
 
 #ifdef _WINDOWS
 
+#include "logging/log.hpp"
 #include "runtime/os.hpp"
 #include "runtime/flags/flagSetting.hpp"
 #include "runtime/globals_extension.hpp"
@@ -38,7 +39,9 @@ namespace {
    public:
     MemoryReleaser(char* ptr, size_t size) : _ptr(ptr), _size(size) { }
     ~MemoryReleaser() {
-      os::release_memory_special(_ptr, _size);
+      if (_ptr != NULL) {
+        os::release_memory_special(_ptr, _size);
+      }
     }
   };
 }
@@ -65,25 +68,32 @@ void TestReserveMemorySpecial_test() {
 
   const size_t large_allocation_size = os::large_page_size() * 4;
   char* result = os::reserve_memory_special(large_allocation_size, os::large_page_size(), os::large_page_size(), NULL, false);
-  if (result != NULL) {
+  if (result == NULL) {
       // failed to allocate memory, skipping the test
+      log_info(test)("Skipping Windows large page test since first large page allocation failed");
       return;
   }
-  MemoryReleaser mr(result, large_allocation_size);
+  MemoryReleaser m1(result, large_allocation_size);
 
-  // allocate another page within the recently allocated memory area which seems to be a good location. At least
-  // we managed to get it once.
+  // Reserve another page within the recently allocated memory area. This should fail
   const size_t expected_allocation_size = os::large_page_size();
   char* expected_location = result + os::large_page_size();
   char* actual_location = os::reserve_memory_special(expected_allocation_size, os::large_page_size(), os::large_page_size(), expected_location, false);
-  if (actual_location != NULL) {
-      // failed to allocate memory, skipping the test
-      return;
-  }
-  MemoryReleaser mr2(actual_location, expected_allocation_size);
+  EXPECT_TRUE(actual_location == NULL) << "Should not be allowed to reserve within present reservation";
 
-  EXPECT_EQ(expected_location, actual_location)
-        << "Failed to allocate memory at requested location " << expected_location << " of size " << expected_allocation_size;
+  // Instead try reserving after the first reservation.
+  expected_location = result + large_allocation_size;
+  actual_location = os::reserve_memory_special(expected_allocation_size, os::large_page_size(), os::large_page_size(), expected_location, false);
+  EXPECT_TRUE(actual_location == NULL || actual_location == expected_location) << "Reservation must either fail or be at requested location";
+  MemoryReleaser m2(actual_location, os::large_page_size());
+
+  // Now try to do a reservation with a larger alignment.
+  const size_t alignment = os::large_page_size() * 2;
+  const size_t new_large_size = alignment * 4;
+  char* aligned_request = os::reserve_memory_special(new_large_size, alignment, os::large_page_size(), NULL, false);
+  EXPECT_TRUE(aligned_request != NULL) << "Should not fail this reservation if the first two were ok.";
+  EXPECT_TRUE(is_aligned(aligned_request, alignment)) << "Returned address must be aligned";
+  MemoryReleaser m3(aligned_request, new_large_size);
 }
 
 // The types of path modifications we randomly apply to a path. They should not change the file designated by the path.


### PR DESCRIPTION
Please review this change to fix the large page testing on Windows.

**Summary**
The comparisons in the test check for reservations `!= NULL` and consider that a failed reservation, that is incorrect. This leads to the test never really doing anything. When `UseLargePages` is false, the test is skipped and when true and the user is configured with lock permissions (needed to use large pages), the test is skipped after the first allocation (since it is wrongly seen as a failure).

When a user doesn't have permissions to lock memory, the JVM will turn off large pages so this will be the same as running with `-UseLargePages`. 

The test has been changed to skip testing if the first large page reservation fail, similar to what was intended before. After that the rest of the reservations are expected to pass, apart from the reservation trying to reserve in an already existing reservation.

**Testing**
Manual testing on a Windows host with and without large pages enabled. Also tested through mach5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266807](https://bugs.openjdk.java.net/browse/JDK-8266807): Windows os_windows-gtest broken for UseLargePages


### Reviewers
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer) ⚠️ Review applies to bc86a6fad5f30d3dd2769cdc305a82281903b3f6
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Committer)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4090/head:pull/4090` \
`$ git checkout pull/4090`

Update a local copy of the PR: \
`$ git checkout pull/4090` \
`$ git pull https://git.openjdk.java.net/jdk pull/4090/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4090`

View PR using the GUI difftool: \
`$ git pr show -t 4090`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4090.diff">https://git.openjdk.java.net/jdk/pull/4090.diff</a>

</details>
