### PR TITLE
8267317: Remove DeferredTypeCompleter

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ArgumentAttr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ArgumentAttr.java
@@ -36,7 +36,6 @@ import com.sun.tools.javac.comp.Check.CheckContext;
 import com.sun.tools.javac.comp.DeferredAttr.AttrMode;
 import com.sun.tools.javac.comp.DeferredAttr.DeferredAttrContext;
 import com.sun.tools.javac.comp.DeferredAttr.DeferredType;
-import com.sun.tools.javac.comp.DeferredAttr.DeferredTypeCompleter;
 import com.sun.tools.javac.comp.DeferredAttr.LambdaReturnScanner;
 import com.sun.tools.javac.comp.DeferredAttr.SwitchExpressionScanner;
 import com.sun.tools.javac.comp.Infer.PartiallyInferredMethodType;
@@ -55,7 +54,6 @@ import com.sun.tools.javac.tree.JCTree.JCReturn;
 import com.sun.tools.javac.tree.JCTree.JCSwitchExpression;
 import com.sun.tools.javac.tree.TreeCopier;
 import com.sun.tools.javac.tree.TreeInfo;
-import com.sun.tools.javac.util.Assert;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.DiagnosticSource;
 import com.sun.tools.javac.util.JCDiagnostic;
@@ -336,7 +334,7 @@ public class ArgumentAttr extends JCTree.Visitor {
      * perform an overload check without the need of calling back to Attr. This extra information
      * is typically stored in the form of a speculative tree.
      */
-    abstract class ArgumentType<T extends JCExpression> extends DeferredType implements DeferredTypeCompleter {
+    abstract class ArgumentType<T extends JCExpression> extends DeferredType {
 
         /** The speculative tree carrying type information. */
         T speculativeTree;
@@ -351,24 +349,18 @@ public class ArgumentAttr extends JCTree.Visitor {
         }
 
         @Override
-        final DeferredTypeCompleter completer() {
-            return this;
-        }
-
-        @Override
-        public final Type complete(DeferredType dt, ResultInfo resultInfo, DeferredAttrContext deferredAttrContext) {
-            Assert.check(dt == this);
+        public final Type complete(ResultInfo resultInfo, DeferredAttrContext deferredAttrContext) {
             if (deferredAttrContext.mode == AttrMode.SPECULATIVE) {
                 Type t = (resultInfo.pt == Type.recoveryType) ?
-                        deferredAttr.basicCompleter.complete(dt, resultInfo, deferredAttrContext) :
+                        super.complete(resultInfo, deferredAttrContext) :
                         overloadCheck(resultInfo, deferredAttrContext);
                 speculativeTypes.put(resultInfo, t);
                 return t;
             } else {
                 if (!env.info.attributionMode.isSpeculative) {
-                    argumentTypeCache.remove(new UniquePos(dt.tree));
+                    argumentTypeCache.remove(new UniquePos(tree));
                 }
-                return deferredAttr.basicCompleter.complete(dt, resultInfo, deferredAttrContext);
+                return super.complete(resultInfo, deferredAttrContext);
             }
         }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/DeferredAttr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/DeferredAttr.java
@@ -306,8 +306,21 @@ public class DeferredAttr extends JCTree.Visitor {
             return e != null ? e.speculativeTree : stuckTree;
         }
 
-        DeferredTypeCompleter completer() {
-            return basicCompleter;
+        public Type complete(ResultInfo resultInfo, DeferredAttrContext deferredAttrContext) {
+            switch (deferredAttrContext.mode) {
+                case SPECULATIVE:
+                    //Note: if a symbol is imported twice we might do two identical
+                    //speculative rounds...
+                    Assert.check(mode == null || mode == AttrMode.SPECULATIVE);
+                    JCTree speculativeTree = attribSpeculative(tree, env, resultInfo);
+                    speculativeCache.put(speculativeTree, resultInfo);
+                    return speculativeTree.type;
+                case CHECK:
+                    Assert.check(mode != null);
+                    return attr.attribTree(tree, env, resultInfo);
+            }
+            Assert.error();
+            return null;
         }
 
         /**
@@ -327,65 +340,29 @@ public class DeferredAttr extends JCTree.Visitor {
             } else {
                 deferredStuckPolicy = new CheckStuckPolicy(resultInfo, this);
             }
-            return check(resultInfo, deferredStuckPolicy, completer());
+            return check(resultInfo, deferredStuckPolicy);
         }
 
-        private Type check(ResultInfo resultInfo, DeferredStuckPolicy deferredStuckPolicy,
-                DeferredTypeCompleter deferredTypeCompleter) {
+        private Type check(ResultInfo resultInfo, DeferredStuckPolicy deferredStuckPolicy) {
             DeferredAttrContext deferredAttrContext =
                     resultInfo.checkContext.deferredAttrContext();
             Assert.check(deferredAttrContext != emptyDeferredAttrContext);
             if (deferredStuckPolicy.isStuck()) {
-                notPertinentToApplicability.add(deferredAttrContext.msym);
                 deferredAttrContext.addDeferredAttrNode(this, resultInfo, deferredStuckPolicy);
+                if (deferredAttrContext.mode == AttrMode.SPECULATIVE) {
+                    notPertinentToApplicability.add(deferredAttrContext.msym);
+                    mode = AttrMode.SPECULATIVE;
+                }
                 return Type.noType;
             } else {
                 try {
-                    return deferredTypeCompleter.complete(this, resultInfo, deferredAttrContext);
+                    return complete(resultInfo, deferredAttrContext);
                 } finally {
                     mode = deferredAttrContext.mode;
                 }
             }
         }
     }
-
-    /**
-     * A completer for deferred types. Defines an entry point for type-checking
-     * a deferred type.
-     */
-    interface DeferredTypeCompleter {
-        /**
-         * Entry point for type-checking a deferred type. Depending on the
-         * circumstances, type-checking could amount to full attribution
-         * or partial structural check (aka potential applicability).
-         */
-        Type complete(DeferredType dt, ResultInfo resultInfo, DeferredAttrContext deferredAttrContext);
-    }
-
-
-    /**
-     * A basic completer for deferred types. This completer type-checks a deferred type
-     * using attribution; depending on the attribution mode, this could be either standard
-     * or speculative attribution.
-     */
-    DeferredTypeCompleter basicCompleter = new DeferredTypeCompleter() {
-        public Type complete(DeferredType dt, ResultInfo resultInfo, DeferredAttrContext deferredAttrContext) {
-            switch (deferredAttrContext.mode) {
-                case SPECULATIVE:
-                    //Note: if a symbol is imported twice we might do two identical
-                    //speculative rounds...
-                    Assert.check(dt.mode == null || dt.mode == AttrMode.SPECULATIVE);
-                    JCTree speculativeTree = attribSpeculative(dt.tree, dt.env, resultInfo);
-                    dt.speculativeCache.put(speculativeTree, resultInfo);
-                    return speculativeTree.type;
-                case CHECK:
-                    Assert.check(dt.mode != null);
-                    return attr.attribTree(dt.tree, dt.env, resultInfo);
-            }
-            Assert.error();
-            return null;
-        }
-    };
 
     /**
      * Policy for detecting stuck expressions. Different criteria might cause
@@ -781,7 +758,8 @@ public class DeferredAttr extends JCTree.Visitor {
             switch (deferredAttrContext.mode) {
                 case SPECULATIVE:
                     if (deferredStuckPolicy.isStuck()) {
-                        dt.check(resultInfo, dummyStuckPolicy, new StructuralStuckChecker());
+                        new StructuralStuckChecker().check(dt, resultInfo, deferredAttrContext);
+                        dt.mode = deferredAttrContext.mode;
                         return true;
                     } else {
                         Assert.error("Cannot get here");
@@ -813,7 +791,7 @@ public class DeferredAttr extends JCTree.Visitor {
                                 "attribution shouldn't be happening here");
                         ResultInfo instResultInfo =
                                 resultInfo.dup(deferredAttrContext.inferenceContext.asInstType(resultInfo.pt));
-                        dt.check(instResultInfo, dummyStuckPolicy, basicCompleter);
+                        dt.check(instResultInfo, dummyStuckPolicy);
                         return true;
                     }
                 default:
@@ -824,19 +802,18 @@ public class DeferredAttr extends JCTree.Visitor {
         /**
          * Structural checker for stuck expressions
          */
-        class StructuralStuckChecker extends TreeScanner implements DeferredTypeCompleter {
+        class StructuralStuckChecker extends TreeScanner {
 
             ResultInfo resultInfo;
             InferenceContext inferenceContext;
             Env<AttrContext> env;
 
-            public Type complete(DeferredType dt, ResultInfo resultInfo, DeferredAttrContext deferredAttrContext) {
+            public void check(DeferredType dt, ResultInfo resultInfo, DeferredAttrContext deferredAttrContext) {
                 this.resultInfo = resultInfo;
                 this.inferenceContext = deferredAttrContext.inferenceContext;
                 this.env = dt.env;
                 dt.tree.accept(this);
                 dt.speculativeCache.put(stuckTree, resultInfo);
-                return Type.noType;
             }
 
             @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/DeferredAttr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/DeferredAttr.java
@@ -759,7 +759,6 @@ public class DeferredAttr extends JCTree.Visitor {
                 case SPECULATIVE:
                     if (deferredStuckPolicy.isStuck()) {
                         new StructuralStuckChecker().check(dt, resultInfo, deferredAttrContext);
-                        dt.mode = deferredAttrContext.mode;
                         return true;
                     } else {
                         Assert.error("Cannot get here");


### PR DESCRIPTION
This pathc removes DeferredTypeCompleter, which seems like a dubious abstraction. In its place there is now a `complete` method on `DeferredType` which is overridden by `ArgumentType`. The only problematic usage is from `StructuralStuckChecker`, but after inspecting the code I realized that the only side effect this code expected from calling `DeferredType::check` was to set the deferred type mode to `SPECULATIVE`, which we can easily do inline.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267317](https://bugs.openjdk.java.net/browse/JDK-8267317): Remove DeferredTypeCompleter


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4091/head:pull/4091` \
`$ git checkout pull/4091`

Update a local copy of the PR: \
`$ git checkout pull/4091` \
`$ git pull https://git.openjdk.java.net/jdk pull/4091/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4091`

View PR using the GUI difftool: \
`$ git pr show -t 4091`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4091.diff">https://git.openjdk.java.net/jdk/pull/4091.diff</a>

</details>
