### PR TITLE
8266480: Implicit null check optimization does not update control of hoisted memory operation

### DIFF
--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -412,7 +412,8 @@ void PhaseCFG::implicit_null_check(Block* block, Node *proj, Node *val, int allo
 
   // Move the control dependence if it is pinned to not-null block.
   // Don't change it in other cases: NULL or dominating control.
-  if (best->in(0) == not_null_block->head()) {
+  Node* ctrl = best->in(0);
+  if (get_block_for_node(ctrl) == not_null_block) {
     // Set it to control edge of null check.
     best->set_req(0, proj->in(0)->in(0));
   }

--- a/test/hotspot/jtreg/compiler/c2/TestImplicitNullCheckDominance.java
+++ b/test/hotspot/jtreg/compiler/c2/TestImplicitNullCheckDominance.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2;
+
+/**
+ * @test
+ * @bug 8266480
+ * @summary Check correct re-wiring of control edge when hoisting a memory
+ *          operation for an implicit null check.
+ * @run main/othervm -Xbatch
+ *                   compiler.c2.TestImplicitNullCheckDominance
+ */
+public class TestImplicitNullCheckDominance {
+
+    double dFld;
+    int iFld;
+
+    static void test1(TestImplicitNullCheckDominance t, double d) {
+        for (int i = 0; i < 100; i++) {
+            t.dFld = d % 42;
+            t.iFld = 43;
+        }
+    }
+
+    static void test2(TestImplicitNullCheckDominance t) {
+        for (int i = 0; i < 10; i++) {
+            for (int j = 0; j < 100; j++) {
+               t.dFld %= 42;
+               t.iFld = 43;
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        TestImplicitNullCheckDominance t = new TestImplicitNullCheckDominance();
+        for (int i = 0; i < 50_000; ++i) {
+            test1(t, i);
+            test2(t);
+        }
+    }
+}


### PR DESCRIPTION
C2 replaces explicit null checks by hoisting a nearby memory operation to the null check and using it as implicit null check. In some cases, control of that memory operation is not updated correctly, leading to assert failures during `PhaseCFG::verify()` because a use is no longer dominated by its definition.

After matching, the graph looks like this:

<img src="https://user-images.githubusercontent.com/5312595/118652773-346fc280-b7e7-11eb-828a-eddb72b81d6e.png" width=50% height=50%>

`64 testP_reg` is an explicit null check and `78 loadD`, `73 storeD` and `77 storeImmI` are candidates for an implicit null check because they are operating on the same oop. `PhaseCFG::implicit_null_check` decides to hoist the `77 storeImmI` from the `not_null_block` B12 to the null check in B11/B13:

<img src="https://user-images.githubusercontent.com/5312595/118652778-36d21c80-b7e7-11eb-88d0-1c2c117a9450.png" width=50% height=50%>

Now the problem is that control of `77 storeImmI` was not updated and still points into the non-dominating block B15. The following code is supposed to fix this:
https://github.com/openjdk/jdk/blob/9d168e25d1e2e8b662dc7aa6cda7516c423cef7d/src/hotspot/share/opto/lcm.cpp#L413-L418

However, it does not trigger because control is not the `not_null_block->head()` but `59 MachProj` which is the control projection from `60 CallLeafDirect` emitted by a `drem`. The fix is to simply check `get_block_for_node(ctrl)` instead.

This is an old issue that was only caught by the assert recently introduced by [JDK-8263227](https://bugs.openjdk.java.net/browse/JDK-8263227).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266480](https://bugs.openjdk.java.net/browse/JDK-8266480): Implicit null check optimization does not update control of hoisted memory operation


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4093/head:pull/4093` \
`$ git checkout pull/4093`

Update a local copy of the PR: \
`$ git checkout pull/4093` \
`$ git pull https://git.openjdk.java.net/jdk pull/4093/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4093`

View PR using the GUI difftool: \
`$ git pr show -t 4093`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4093.diff">https://git.openjdk.java.net/jdk/pull/4093.diff</a>

</details>
