### PR TITLE
8248843: java in source-file mode suggests javac-only options

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/Main.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/Main.java
@@ -348,6 +348,7 @@ public class Main {
 
         // add implicit options
         javacOpts.add("-proc:none");
+        javacOpts.add("-Xdiags:verbose");
 
         return javacOpts;
     }


### PR DESCRIPTION
`java` in source-file mode (see JEP 330) displays compiler notes suggesting `recompile with -Xdiags:verbose to get full output`. According JEP 330 these advanced `javac` optionns are not allowed. The goal with JEP 330 was to support developers that are at the early stages of learning Java, so options such as `-Xdiags:verbose` are out of their scope.

This patch prevents displaying `Note: Some messages have been simplified; recompile with -Xdiags:verbose to get full output` suggestion in `java` source-file mode by implicitly enabling `-Xdiags:verbose` in com.sun.tool.javac.launcher.Main for all invocations.

Beside avoiding prohibited `javac` option suggestion notes this patch has positive effect of more verbose compilation diagnostic. Higher diagnostic verbosity is appreciated by users learning Java on single-source programs in `java` source-file mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248843](https://bugs.openjdk.java.net/browse/JDK-8248843): java in source-file mode suggests javac-only options


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4094/head:pull/4094` \
`$ git checkout pull/4094`

Update a local copy of the PR: \
`$ git checkout pull/4094` \
`$ git pull https://git.openjdk.java.net/jdk pull/4094/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4094`

View PR using the GUI difftool: \
`$ git pr show -t 4094`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4094.diff">https://git.openjdk.java.net/jdk/pull/4094.diff</a>

</details>
