### PR TITLE
8267338: [JVMCI] revive JVMCI API removed by JDK-8243287

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/ResolvedJavaType.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/ResolvedJavaType.java
@@ -137,6 +137,14 @@ public interface ResolvedJavaType extends JavaType, ModifiersProvider, Annotated
     boolean isAssignableFrom(ResolvedJavaType other);
 
     /**
+     * Returns {@code null} since support for VM anonymous class was removed by JDK-8243287.
+     * This method is preserved for JVMCI backwards compatibility.
+     */
+    default ResolvedJavaType getHostClass() {
+        return null;
+    }
+
+    /**
      * Returns true if this type is exactly the type {@link java.lang.Object}.
      */
     default boolean isJavaLangObject() {

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/ResolvedJavaType.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/ResolvedJavaType.java
@@ -140,6 +140,7 @@ public interface ResolvedJavaType extends JavaType, ModifiersProvider, Annotated
      * Returns {@code null} since support for VM anonymous class was removed by JDK-8243287.
      * This method is preserved for JVMCI backwards compatibility.
      */
+    @Deprecated
     default ResolvedJavaType getHostClass() {
         return null;
     }

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java
@@ -1116,6 +1116,7 @@ public class TestResolvedJavaType extends TypeUniverse {
         "isLinked",
         "getJavaClass",
         "getObjectHub",
+        "getHostClass",
         "hasFinalizableSubclass",
         "hasFinalizer",
         "isLocal",


### PR DESCRIPTION
This PR revives ResolvedJavaType.getHostClass to preserve JVMCI compatibility. The revived method just returns `null`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267338](https://bugs.openjdk.java.net/browse/JDK-8267338): [JVMCI] revive JVMCI API removed by JDK-8243287


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to 5bffb99ae302fd5a8808c9404948791787680ed1
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4099/head:pull/4099` \
`$ git checkout pull/4099`

Update a local copy of the PR: \
`$ git checkout pull/4099` \
`$ git pull https://git.openjdk.java.net/jdk pull/4099/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4099`

View PR using the GUI difftool: \
`$ git pr show -t 4099`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4099.diff">https://git.openjdk.java.net/jdk/pull/4099.diff</a>

</details>
