### PR TITLE
8267339: Temporarily disable os.release_multi_mappings_vm on macOS x64

### DIFF
--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -412,7 +412,11 @@ struct NUMASwitcher {
 #endif
 
 #ifndef _AIX // JDK-8257041
-TEST_VM(os, release_multi_mappings) {
+#if defined(__APPLE__) && !defined(AARCH64) // JDK-8267339
+  TEST_VM(os, DISABLED_release_multi_mappings) {
+#else
+  TEST_VM(os, release_multi_mappings) {
+#endif
   // Test that we can release an area created with multiple reservation calls
   const size_t stripe_len = 4 * M;
   const int num_stripes = 4;


### PR DESCRIPTION
After adding the fix for https://bugs.openjdk.java.net/browse/JDK-8262952 #3865 on macOS aarch64, things broke on macOS x64. For my initial analysis please see https://bugs.openjdk.java.net/browse/JDK-8267339

The real fix for this issue is tracked by JDK-8267339, however, here we need a quick workaround to get the build fixed, so this is a temporary workaround where we disable the test in question until we have the real fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267339](https://bugs.openjdk.java.net/browse/JDK-8267339): Temporarily disable os.release_multi_mappings_vm on macOS x64


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4100/head:pull/4100` \
`$ git checkout pull/4100`

Update a local copy of the PR: \
`$ git checkout pull/4100` \
`$ git pull https://git.openjdk.java.net/jdk pull/4100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4100`

View PR using the GUI difftool: \
`$ git pr show -t 4100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4100.diff">https://git.openjdk.java.net/jdk/pull/4100.diff</a>

</details>
