### PR TITLE
JDK-8265362 java/net/Socket/UdpSocket.java fails with "java.net.BindException: Address already in use" (macos-aarch64)

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -608,7 +608,6 @@ java/net/MulticastSocket/SetGetNetworkInterfaceTest.java        8219083 windows-
 
 java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
 
-java/net/Socket/UdpSocket.java                                  8265362 macosx-aarch64
 
 java/net/httpclient/websocket/PendingBinaryPongClose.java       8265367 macosx-aarch64
 java/net/httpclient/websocket/PendingBinaryPingClose.java       8265367 macosx-aarch64

--- a/test/jdk/java/net/Socket/UdpSocket.java
+++ b/test/jdk/java/net/Socket/UdpSocket.java
@@ -37,9 +37,10 @@ import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
 import java.security.Permission;
 import java.util.Arrays;
-import java.util.ArrayList;
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.net.SocketException;
+import java.net.BindException;
 
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
@@ -133,8 +134,21 @@ public class UdpSocket {
         }
     }
 
+
     private Socket newUdpSocket() throws IOException {
-        return new Socket(InetAddress.getLoopbackAddress(), 8000, false);
+        Socket newUdpSocket = null;
+
+        try {
+            newUdpSocket = new Socket(InetAddress.getLoopbackAddress(), 8000, false);
+        } catch (SocketException soEx) {
+            if (soEx instanceof BindException) {
+                System.out.println("BindException caught retry Socket creation");
+                newUdpSocket = new Socket(InetAddress.getLoopbackAddress(), 8000, false);
+            } else {
+                throw soEx;
+            }
+        }
+        return newUdpSocket;
     }
 
     private void closeAll(Deque<Socket> sockets) throws IOException {

--- a/test/jdk/java/net/Socket/UdpSocket.java
+++ b/test/jdk/java/net/Socket/UdpSocket.java
@@ -39,7 +39,6 @@ import java.security.Permission;
 import java.util.Arrays;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.net.SocketException;
 import java.net.BindException;
 
 import org.testng.annotations.Test;
@@ -60,7 +59,6 @@ public class UdpSocket {
 
             int port = ((InetSocketAddress) dc.getLocalAddress()).getPort();
             try (Socket s = new Socket(loopback, port, false)) {
-
                 // send datagram with socket output stream
                 byte[] array1 = MESSAGE.getBytes("UTF-8");
                 s.getOutputStream().write(array1);
@@ -140,13 +138,9 @@ public class UdpSocket {
 
         try {
             newUdpSocket = new Socket(InetAddress.getLoopbackAddress(), 8000, false);
-        } catch (SocketException soEx) {
-            if (soEx instanceof BindException) {
-                System.out.println("BindException caught retry Socket creation");
-                newUdpSocket = new Socket(InetAddress.getLoopbackAddress(), 8000, false);
-            } else {
-                throw soEx;
-            }
+        } catch (BindException biEx) {
+            System.out.println("BindException caught retry Socket creation");
+            newUdpSocket = new Socket(InetAddress.getLoopbackAddress(), 8000, false);
         }
         return newUdpSocket;
     }

--- a/test/jdk/java/net/Socket/UdpSocket.java
+++ b/test/jdk/java/net/Socket/UdpSocket.java
@@ -134,15 +134,15 @@ public class UdpSocket {
 
 
     private Socket newUdpSocket() throws IOException {
-        Socket newUdpSocket = null;
+        Socket s = null;
 
         try {
-            newUdpSocket = new Socket(InetAddress.getLoopbackAddress(), 8000, false);
-        } catch (BindException biEx) {
+            s = new Socket(InetAddress.getLoopbackAddress(), 8000, false);
+        } catch (BindException unexpected) {
             System.out.println("BindException caught retry Socket creation");
-            newUdpSocket = new Socket(InetAddress.getLoopbackAddress(), 8000, false);
+            s = new Socket(InetAddress.getLoopbackAddress(), 8000, false);
         }
-        return newUdpSocket;
+        return s;
     }
 
     private void closeAll(Deque<Socket> sockets) throws IOException {


### PR DESCRIPTION
The test java/net/Socket/UdpSocket.java has been seen to fail with a BindException, in the testMaxSockets test, on a regular basis on macOS-aarch64 platform. testMaxSockets tests the maximum number of UDP Sockets that may be created as defined by a system property sun.net.maxDatagramSockets. It invokes the Socket constructor Socket(InetAddress host, int port, boolean stream) with stream set to false to create a UDP Socket. This instantiation is a compound operation, consisting of the creation of a socket, the explicit binding of wildcard address and ephemeral port, and a connect to the socket end point specified in the constructor parameters.  Analysis has shown that during the test that the OS intermittently allocates the same ephemeral port multiple times during the bind system call, such that two separate sockets end up bound to the same port. Then on the connect invocation a BindException is thrown for the second socket. This has been determined to be a transient condition during heavy loads and where a significant number of ephemeral ports are being allocated.

As this is deemed an OS issues, and in order to increase test stability, it has been found that for the BindException condition a retry of the Socket creation mitigates the issues and tests the max creation property.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265362](https://bugs.openjdk.java.net/browse/JDK-8265362): java/net/Socket/UdpSocket.java fails with "java.net.BindException: Address already in use" (macos-aarch64)


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to 1f05203e9a5acfdf08b7edae4fef79e09bee9a94
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4103/head:pull/4103` \
`$ git checkout pull/4103`

Update a local copy of the PR: \
`$ git checkout pull/4103` \
`$ git pull https://git.openjdk.java.net/jdk pull/4103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4103`

View PR using the GUI difftool: \
`$ git pr show -t 4103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4103.diff">https://git.openjdk.java.net/jdk/pull/4103.diff</a>

</details>
