### PR TITLE
8267351: runtime/cds/SharedBaseAddress.java fails on x86_32 due to Unrecognized VM option 'UseCompressedOops'

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/SharedBaseAddress.java
+++ b/test/hotspot/jtreg/runtime/cds/SharedBaseAddress.java
@@ -23,7 +23,7 @@
 
 /**
  * @test SharedBaseAddress
- * @bug 8265705
+ * @bug 8265705 8267351
  * @summary Test variety of values for SharedBaseAddress, making sure
  *          VM handles normal values as well as edge values w/o a crash.
  * @requires vm.cds

--- a/test/hotspot/jtreg/runtime/cds/SharedBaseAddress.java
+++ b/test/hotspot/jtreg/runtime/cds/SharedBaseAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@
 
 import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.cds.CDSOptions;
+import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 
 public class SharedBaseAddress {
@@ -78,7 +79,7 @@ public class SharedBaseAddress {
                         .addPrefix("-Xlog:gc+metaspace")
                         .addPrefix("-XX:NativeMemoryTracking=detail");
 
-                if (run == 0) {
+                if (run == 0 && Platform.is64bit()) {
                     opts.addPrefix("-Xmx128m")
                         .addPrefix("-XX:CompressedClassSpaceSize=32m")
                         .addPrefix("-XX:-UseCompressedOops");


### PR DESCRIPTION
Hi all,

Please review the small fix which fixes the failure on x86_32.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267351](https://bugs.openjdk.java.net/browse/JDK-8267351): runtime/cds/SharedBaseAddress.java fails on x86_32 due to Unrecognized VM option 'UseCompressedOops'


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 4cce86be1e01c30a389f004c673cd4220fc007ba
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**) ⚠️ Review applies to 4cce86be1e01c30a389f004c673cd4220fc007ba


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4104/head:pull/4104` \
`$ git checkout pull/4104`

Update a local copy of the PR: \
`$ git checkout pull/4104` \
`$ git pull https://git.openjdk.java.net/jdk pull/4104/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4104`

View PR using the GUI difftool: \
`$ git pr show -t 4104`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4104.diff">https://git.openjdk.java.net/jdk/pull/4104.diff</a>

</details>
