### PR TITLE
8267355: Adjust the parameters of the method UnicodeReader#digit

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavaTokenizer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavaTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -485,7 +485,7 @@ public class JavaTokenizer extends UnicodeReader {
             }
 
             next();
-        } while (digit(pos, digitRadix) >= 0 || is('_'));
+        } while (digit(digitRadix) >= 0 || is('_'));
 
         if (leadingUnderscorePos != NOT_FOUND) {
             lexError(leadingUnderscorePos, Errors.IllegalUnderscore);
@@ -505,7 +505,7 @@ public class JavaTokenizer extends UnicodeReader {
             acceptOneOfThenPut('+', '-');
             skipIllegalUnderscores();
 
-            if (digit(pos, 10) >= 0) {
+            if (digit(10) >= 0) {
                 scanDigits(pos, 10);
             } else {
                 lexError(pos, Errors.MalformedFpLit);
@@ -532,7 +532,7 @@ public class JavaTokenizer extends UnicodeReader {
     private void scanFraction(int pos) {
         skipIllegalUnderscores();
 
-        if (digit(pos, 10) >= 0) {
+        if (digit(10) >= 0) {
             scanDigits(pos, 10);
         }
 
@@ -543,7 +543,7 @@ public class JavaTokenizer extends UnicodeReader {
             acceptOneOfThenPut('+', '-');
             skipIllegalUnderscores();
 
-            if (digit(pos, 10) >= 0) {
+            if (digit(10) >= 0) {
                 scanDigits(pos, 10);
                 return;
             }
@@ -581,7 +581,7 @@ public class JavaTokenizer extends UnicodeReader {
         putThenNext();
         skipIllegalUnderscores();
 
-        if (digit(pos, 16) >= 0) {
+        if (digit(16) >= 0) {
             seendigit = true;
             scanDigits(pos, 16);
         }
@@ -612,7 +612,7 @@ public class JavaTokenizer extends UnicodeReader {
         // for octal, allow base-10 digit in case it's a float literal
         this.radix = radix;
         int digitRadix = (radix == 8 ? 10 : radix);
-        int firstDigit = digit(pos, Math.max(10, digitRadix));
+        int firstDigit = digit(Math.max(10, digitRadix));
         boolean seendigit = firstDigit >= 0;
         boolean seenValidDigit = firstDigit >= 0 && firstDigit < digitRadix;
 
@@ -838,7 +838,7 @@ public class JavaTokenizer extends UnicodeReader {
                             int savePos = position();
                             skip('_');
 
-                            if (digit(pos, 10) < 0) {
+                            if (digit(10) < 0) {
                                 lexError(savePos, Errors.IllegalUnderscore);
                             }
                         }
@@ -862,7 +862,7 @@ public class JavaTokenizer extends UnicodeReader {
 
                         if (accept('.')) {
                             lexError(savePos, Errors.IllegalDot);
-                        } else if (digit(pos, 10) >= 0) {
+                        } else if (digit(10) >= 0) {
                             put('.');
                             scanFractionAndSuffix(pos); // (Spec. 3.10)
                         } else {
@@ -1004,7 +1004,7 @@ public class JavaTokenizer extends UnicodeReader {
 
                         if (isJavaIdentifierStart) {
                             scanIdent();
-                        } else if (digit(pos, 10) >= 0) {
+                        } else if (digit(10) >= 0) {
                             scanNumber(pos, 10);
                         } else if (is((char)EOI) || !isAvailable()) {
                             tk = TokenKind.EOF;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/UnicodeReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/UnicodeReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -496,12 +496,11 @@ public class UnicodeReader {
      * Convert an ASCII digit from its base (8, 10, or 16) to its value. Does not
      * advance character.
      *
-     * @param pos         starting position.
      * @param digitRadix  base of number being converted.
      *
      * @return value of digit.
      */
-    protected int digit(int pos, int digitRadix) {
+    protected int digit(int digitRadix) {
         int result;
 
         // Just an ASCII digit.


### PR DESCRIPTION
Hi all,

This patch removes the parameter `int pos` of the method `UnicodeReader#digit`. Several places which use the method `UnicodeReader#digit` are adjusted, too.

Thank you for taking the time to review.

---

A related issue for comments.

After merging this patch, the methods `JavaTokenizer#scanLitChar` and `JavaTokenizer#scanDigits` also have the unused parameters `int pos`. It seems that they could be removed, too.
But I consider that the methods `scan***` of the class  `JavaTokenizer` have a context which may look ahead or back. So their parameters `int pos` may be used in the future. Maybe it is good to remain them.

What's your opionion? Any idea is appreciated.

---

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8267355](https://bugs.openjdk.java.net/browse/JDK-8267355): Adjust the parameters of the method UnicodeReader#digit


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4106/head:pull/4106` \
`$ git checkout pull/4106`

Update a local copy of the PR: \
`$ git checkout pull/4106` \
`$ git pull https://git.openjdk.java.net/jdk pull/4106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4106`

View PR using the GUI difftool: \
`$ git pr show -t 4106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4106.diff">https://git.openjdk.java.net/jdk/pull/4106.diff</a>

</details>
