### PR TITLE
8267357: build breaks with -Werror option on micro benchmark added for JDK-8256973

### DIFF
--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskQueryOperationsBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskQueryOperationsBenchmark.java
@@ -38,16 +38,15 @@ public class MaskQueryOperationsBenchmark {
     @Param({"1","2","3"})
     int inputs;
 
-    VectorSpecies bspecies;
-    VectorSpecies sspecies;
-    VectorSpecies ispecies;
-    VectorSpecies lspecies;
-    VectorMask    bmask;
-    VectorMask    smask;
-    VectorMask    imask;
-    VectorMask    lmask;
-    boolean []    mask_arr;
-
+    VectorSpecies<Byte> bspecies;
+    VectorSpecies<Short> sspecies;
+    VectorSpecies<Integer> ispecies;
+    VectorSpecies<Long> lspecies;
+    VectorMask<Byte> bmask;
+    VectorMask<Short> smask;
+    VectorMask<Integer> imask;
+    VectorMask<Long> lmask;
+    boolean [] mask_arr;
 
     static final boolean [] mask_avg_case = {
        false, false, false, true, false, false, false, false,


### PR DESCRIPTION
Relevant declarations modified and tested with -Werror, no longer see unchecked conversion warnings.

Kindly review and approve.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267357](https://bugs.openjdk.java.net/browse/JDK-8267357): build breaks with -Werror option on micro benchmark added for JDK-8256973


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4108/head:pull/4108` \
`$ git checkout pull/4108`

Update a local copy of the PR: \
`$ git checkout pull/4108` \
`$ git pull https://git.openjdk.java.net/jdk pull/4108/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4108`

View PR using the GUI difftool: \
`$ git pr show -t 4108`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4108.diff">https://git.openjdk.java.net/jdk/pull/4108.diff</a>

</details>
