### PR TITLE
JDK-8267371: Concurrent gtests take too long

### DIFF
--- a/test/hotspot/gtest/concurrentTestRunner.inline.hpp
+++ b/test/hotspot/gtest/concurrentTestRunner.inline.hpp
@@ -64,7 +64,7 @@ public:
   // runnableArg - what to run
   // nrOfThreadsArg - how many threads to use concurrently
   // testDurationMillisArg - duration for each test run
-  ConcurrentTestRunner(TestRunnable* const runnableArg, int nrOfThreadsArg, long testDurationMillisArg = 5000) :
+  ConcurrentTestRunner(TestRunnable* const runnableArg, int nrOfThreadsArg, long testDurationMillisArg) :
     unitTestRunnable(runnableArg),
     nrOfThreads(nrOfThreadsArg),
     testDurationMillis(testDurationMillisArg) {}

--- a/test/hotspot/gtest/concurrentTestRunner.inline.hpp
+++ b/test/hotspot/gtest/concurrentTestRunner.inline.hpp
@@ -64,7 +64,7 @@ public:
   // runnableArg - what to run
   // nrOfThreadsArg - how many threads to use concurrently
   // testDurationMillisArg - duration for each test run
-  ConcurrentTestRunner(TestRunnable* const runnableArg, int nrOfThreadsArg, long testDurationMillisArg) :
+  ConcurrentTestRunner(TestRunnable* const runnableArg, int nrOfThreadsArg, long testDurationMillisArg = 5000) :
     unitTestRunnable(runnableArg),
     nrOfThreads(nrOfThreadsArg),
     testDurationMillis(testDurationMillisArg) {}

--- a/test/hotspot/gtest/memory/test_virtualspace.cpp
+++ b/test/hotspot/gtest/memory/test_virtualspace.cpp
@@ -664,7 +664,7 @@ public:
 
 TEST_VM(VirtualSpace, os_reserve_space_concurrent) {
   ReservedSpaceRunnable runnable;
-  ConcurrentTestRunner testRunner(&runnable, 30, 15000);
+  ConcurrentTestRunner testRunner(&runnable, 30);
   testRunner.run();
 }
 
@@ -677,6 +677,6 @@ public:
 
 TEST_VM(VirtualSpace, os_virtual_space_concurrent) {
   VirtualSpaceRunnable runnable;
-  ConcurrentTestRunner testRunner(&runnable, 30, 15000);
+  ConcurrentTestRunner testRunner(&runnable, 30);
   testRunner.run();
 }

--- a/test/hotspot/gtest/memory/test_virtualspace.cpp
+++ b/test/hotspot/gtest/memory/test_virtualspace.cpp
@@ -664,7 +664,7 @@ public:
 
 TEST_VM(VirtualSpace, os_reserve_space_concurrent) {
   ReservedSpaceRunnable runnable;
-  ConcurrentTestRunner testRunner(&runnable, 30);
+  ConcurrentTestRunner testRunner(&runnable, 5, 3000);
   testRunner.run();
 }
 
@@ -677,6 +677,6 @@ public:
 
 TEST_VM(VirtualSpace, os_virtual_space_concurrent) {
   VirtualSpaceRunnable runnable;
-  ConcurrentTestRunner testRunner(&runnable, 30);
+  ConcurrentTestRunner testRunner(&runnable, 5, 3000);
   testRunner.run();
 }

--- a/test/hotspot/gtest/runtime/test_os_linux.cpp
+++ b/test/hotspot/gtest/runtime/test_os_linux.cpp
@@ -416,7 +416,7 @@ public:
 
 TEST_VM(os_linux, reserve_memory_special_concurrent) {
   ReserveMemorySpecialRunnable runnable;
-  ConcurrentTestRunner testRunner(&runnable, 30, 15000);
+  ConcurrentTestRunner testRunner(&runnable, 30);
   testRunner.run();
 }
 

--- a/test/hotspot/gtest/runtime/test_os_linux.cpp
+++ b/test/hotspot/gtest/runtime/test_os_linux.cpp
@@ -415,9 +415,11 @@ public:
 };
 
 TEST_VM(os_linux, reserve_memory_special_concurrent) {
-  ReserveMemorySpecialRunnable runnable;
-  ConcurrentTestRunner testRunner(&runnable, 30);
-  testRunner.run();
+  if (UseLargePages) {
+    ReserveMemorySpecialRunnable runnable;
+    ConcurrentTestRunner testRunner(&runnable, 5, 3000);
+    testRunner.run();
+  }
 }
 
 #endif


### PR DESCRIPTION
More than half of the total runtime of the gtests is currently used by just three tests:

- VirtualSpace.os_reserve_space_concurrent_vm
- VirtualSpace.os_virtual_space_concurrent_vm
- os_linux.reserve_memory_special_concurrent_vm

These tests do concurrent tests with 30 threads, with a timeout of 15 seconds each.

Since we run the gtests with several configurations (see hotspot/jtreg/gtests) these numbers multiply, which hurts especially when run as part of tier1. I think we can safely reduce the timeouts, still have good test coverage and recover some of the gtest runtime.

---

The patch reduces the timeout to 5 seconds, which reduces the time for one gtest by 30 seconds from 80 seconds down to 50 seconds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267371](https://bugs.openjdk.java.net/browse/JDK-8267371): Concurrent gtests take too long


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Gerard Ziemski](https://openjdk.java.net/census#gziemski) (@gerard-ziemski - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4110/head:pull/4110` \
`$ git checkout pull/4110`

Update a local copy of the PR: \
`$ git checkout pull/4110` \
`$ git pull https://git.openjdk.java.net/jdk pull/4110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4110`

View PR using the GUI difftool: \
`$ git pr show -t 4110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4110.diff">https://git.openjdk.java.net/jdk/pull/4110.diff</a>

</details>
