### PR TITLE
8267361: JavaTokenizer reads octal numbers mistakenly

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavaTokenizer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavaTokenizer.java
@@ -640,6 +640,13 @@ public class JavaTokenizer extends UnicodeReader {
                     break;
                 }
             }
+            // If it is not a floating point literal,
+            // the octal number should be rescanned correctly.
+            if (radix == 8) {
+                sb.setLength(0);
+                reset(pos);
+                scanDigits(pos, 8);
+            }
 
             if (acceptOneOf('l', 'L')) {
                 tk = TokenKind.LONGLITERAL;

--- a/test/langtools/tools/javac/lexer/OctalNumberTest.java
+++ b/test/langtools/tools/javac/lexer/OctalNumberTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8267361
+ * @summary JavaTokenizer reads octal numbers mistakenly
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main OctalNumberTest
+ */
+
+import java.util.Arrays;
+import java.util.List;
+
+import toolbox.JavacTask;
+import toolbox.ToolBox;
+import toolbox.TestRunner;
+import toolbox.Task;
+
+public class OctalNumberTest extends TestRunner {
+    ToolBox tb;
+
+    OctalNumberTest() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    public static void main(String[] args) throws Exception {
+        var t = new OctalNumberTest();
+        t.runTests();
+    }
+
+    @Test
+    public void testOctalNumber() throws Exception {
+        String code = """
+                class Digit {
+                    int a = 023; // normal
+                    int b = 089;
+                    int c = 02389;
+                    int d = 028a;
+                    int e = 02a8;
+                }""";
+        List<String> output = new JavacTask(tb)
+                .sources(code)
+                .options("-XDrawDiagnostics")
+                .run(Task.Expect.FAIL)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+        List<String> expected = Arrays.asList(
+                "Digit.java:3:14: compiler.err.expected: ';'",
+                "Digit.java:4:16: compiler.err.expected: ';'",
+                "Digit.java:5:15: compiler.err.expected: ';'",
+                "Digit.java:5:17: compiler.err.expected: token.identifier",
+                "Digit.java:6:15: compiler.err.expected: ';'",
+                "Digit.java:6:17: compiler.err.expected: token.identifier",
+                "6 errors");
+        tb.checkEqual(expected, output);
+    }
+}


### PR DESCRIPTION
Hi all,

When compiling the following code about the wrong octal number:

```
class Digit {
        int n = 079;
}
```

The javac would output the following error message:

```
Digit.java:2: error: integer number too large
        int n = 079;
                ^
1 error
```

This error message is unclear and not silimar to other wrong numbers.
Considering the following code about the wrong binary, hexadecimal and floating point numbers:

```
class Digit {
        double a = 9.f2;
        int n = 0b123;
        int n = 0x12r3;
}
```

The javac would output the silimar error message: `error: ';' expected`. The whole information is shown below.

```
Digit.java:2: error: ';' expected
        double a = 9.f2;
                      ^
Digit.java:3: error: ';' expected
        int n = 0b123;
                   ^
Digit.java:4: error: ';' expected
        int n = 0x12r3;
                    ^
Digit.java:4: error: <identifier> expected
        int n = 0x12r3;
                      ^
4 errors
```

Because the lexer(JavaTokenizer) incorrectly reads `079` as a token.
Then the parser(JavacParser) would throw the NumberFormatException when using the method Convert#string2int.
So the javac would output `integer number too large`.

The token  `079` is a wrong octal number token. And this is a issue of the lexer, but it is caught by the parser so that the unrelated error message is generated.

This patch fixes it and adds a corresponding test case.
Thank you for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267361](https://bugs.openjdk.java.net/browse/JDK-8267361): JavaTokenizer reads octal numbers mistakenly


### Reviewers
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4111/head:pull/4111` \
`$ git checkout pull/4111`

Update a local copy of the PR: \
`$ git checkout pull/4111` \
`$ git pull https://git.openjdk.java.net/jdk pull/4111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4111`

View PR using the GUI difftool: \
`$ git pr show -t 4111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4111.diff">https://git.openjdk.java.net/jdk/pull/4111.diff</a>

</details>
