### PR TITLE
8267307: Introduce new client property for XAWT: xawt.mwm_decor_title

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11/XDecoratedPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XDecoratedPeer.java
@@ -1324,7 +1324,7 @@ abstract class XDecoratedPeer extends XWindowPeer {
     public final Optional<Boolean> getMWMDecorTitleProperty() {
         Optional<Boolean> res = Optional.empty();
 
-        if (target instanceof javax.swing.RootPaneContainer) {
+        if (SunToolkit.isInstanceOf(target, "javax.swing.RootPaneContainer")) {
             javax.swing.JRootPane rootpane = ((javax.swing.RootPaneContainer) target).getRootPane();
             Object prop = rootpane.getClientProperty(MWM_DECOR_TITLE_PROPERTY_NAME);
             if (prop != null) {

--- a/src/java.desktop/unix/classes/sun/awt/X11/XDecoratedPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XDecoratedPeer.java
@@ -32,6 +32,7 @@ import java.awt.event.WindowEvent;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import sun.awt.IconInfo;
 import sun.util.logging.PlatformLogger;
@@ -340,7 +341,19 @@ abstract class XDecoratedPeer extends XWindowPeer {
             || ev.get_atom() == XWM.XA_NET_FRAME_EXTENTS.getAtom())
         {
             if (XWM.getWMID() != XWM.UNITY_COMPIZ_WM) {
-                getWMSetInsets(XAtom.get(ev.get_atom()));
+                if (getMWMDecorTitleProperty().isPresent()) {
+                    // Insets might have changed "in-flight" if that property
+                    // is present, so we need to get the actual values of
+                    // insets from the WM and propagate them through all the
+                    // proper channels.
+                    wm_set_insets = null;
+                    Insets in = getWMSetInsets(XAtom.get(ev.get_atom()));
+                    if (in != null && !in.equals(dimensions.getInsets())) {
+                        handleCorrectInsets(in);
+                    }
+                } else {
+                    getWMSetInsets(XAtom.get(ev.get_atom()));
+                }
             } else {
                 if (!isReparented()) {
                     return;
@@ -1304,5 +1317,25 @@ abstract class XDecoratedPeer extends XWindowPeer {
             }
         }
         super.handleWindowFocusOut(oppositeWindow, serial);
+    }
+
+    public static final String MWM_DECOR_TITLE_PROPERTY_NAME = "xawt.mwm_decor_title";
+
+    public final Optional<Boolean> getMWMDecorTitleProperty() {
+        Optional<Boolean> res = Optional.empty();
+
+        if (target instanceof javax.swing.RootPaneContainer) {
+            javax.swing.JRootPane rootpane = ((javax.swing.RootPaneContainer) target).getRootPane();
+            Object prop = rootpane.getClientProperty(MWM_DECOR_TITLE_PROPERTY_NAME);
+            if (prop != null) {
+                res = Optional.of(Boolean.parseBoolean(prop.toString()));
+            }
+        }
+
+        return res;
+    }
+
+    public final boolean getWindowTitleVisible() {
+        return getMWMDecorTitleProperty().orElse(true);
     }
 }

--- a/src/java.desktop/unix/classes/sun/awt/X11/XFramePeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XFramePeer.java
@@ -34,6 +34,7 @@ import java.awt.Insets;
 import java.awt.MenuBar;
 import java.awt.Rectangle;
 import java.awt.peer.FramePeer;
+import sun.awt.SunToolkit;
 import sun.util.logging.PlatformLogger;
 import sun.awt.AWTAccessor;
 
@@ -81,7 +82,7 @@ class XFramePeer extends XDecoratedPeer implements FramePeer {
     }
 
     private void registerWindowDecorationChangeListener() {
-        if (target instanceof javax.swing.RootPaneContainer) {
+        if (SunToolkit.isInstanceOf(target, "javax.swing.RootPaneContainer")) { // avoid unnecessary class loading
             javax.swing.JRootPane rootpane = ((javax.swing.RootPaneContainer) target).getRootPane();
             rootpane.addPropertyChangeListener(MWM_DECOR_TITLE_PROPERTY_NAME, e -> winAttr.decorations = getWindowDecorationBits() );
         }

--- a/src/java.desktop/unix/classes/sun/awt/X11/XFramePeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XFramePeer.java
@@ -66,11 +66,7 @@ class XFramePeer extends XDecoratedPeer implements FramePeer {
         state = 0;
         undecorated = Boolean.valueOf(target.isUndecorated());
         winAttr.nativeDecor = !target.isUndecorated();
-        if (winAttr.nativeDecor) {
-            winAttr.decorations = XWindowAttributesData.AWT_DECOR_ALL;
-        } else {
-            winAttr.decorations = XWindowAttributesData.AWT_DECOR_NONE;
-        }
+        winAttr.decorations = getWindowDecorationBits();
         winAttr.functions = MWMConstants.MWM_FUNC_ALL;
         winAttr.isResizable = true; // target.isResizable();
         winAttr.title = target.getTitle();
@@ -80,6 +76,38 @@ class XFramePeer extends XDecoratedPeer implements FramePeer {
                      Integer.valueOf(winAttr.decorations), Boolean.valueOf(winAttr.initialResizability),
                      Boolean.valueOf(!winAttr.nativeDecor), Integer.valueOf(winAttr.initialState));
         }
+
+        registerWindowDecorationChangeListener();
+    }
+
+    private void registerWindowDecorationChangeListener() {
+        if (target instanceof javax.swing.RootPaneContainer) {
+            javax.swing.JRootPane rootpane = ((javax.swing.RootPaneContainer) target).getRootPane();
+            rootpane.addPropertyChangeListener(MWM_DECOR_TITLE_PROPERTY_NAME, e -> winAttr.decorations = getWindowDecorationBits() );
+        }
+    }
+
+    private int getWindowDecorationBits() {
+        int decorations = XWindowAttributesData.AWT_DECOR_NONE;
+        final Frame target = (Frame)(this.target);
+        final boolean useNativeDecor = !target.isUndecorated();
+        if (useNativeDecor) {
+            decorations = XWindowAttributesData.AWT_DECOR_ALL;
+
+            if (!getWindowTitleVisible()) {
+                // NB: the window must be [re-]mapped to make this change effective. Also, window insets will probably
+                // change and that'll be caught by one of the subsequent property change events in XDecoratedPeer
+                // (not necessarily the very next event, though).
+                decorations = XWindowAttributesData.AWT_DECOR_BORDER;
+            }
+
+            if (log.isLoggable(PlatformLogger.Level.FINE)) {
+                log.fine("Frame''s initial decorations affected by the client property {0}={1}",
+                         MWM_DECOR_TITLE_PROPERTY_NAME, getMWMDecorTitleProperty());
+            }
+        }
+
+        return decorations;
     }
 
     void postInit(XCreateWindowParams params) {

--- a/test/jdk/java/awt/Window/WindowTitleVisibleTest/WindowTitleVisibleTestLinuxGnome.java
+++ b/test/jdk/java/awt/Window/WindowTitleVisibleTest/WindowTitleVisibleTestLinuxGnome.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, JetBrains s.r.o.. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @key headful
+ * @summary Verifies the client property xawt.mwm_decor_title for Linux.
+ *          Note: the test requires GNOME Shell window manager and will automatically
+ *          pass with any other WM.
+ * @requires (os.family == "linux")
+ * @run main WindowTitleVisibleTestLinuxGnome
+ */
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import javax.swing.*;
+import java.nio.charset.StandardCharsets;
+import java.io.File;
+import javax.imageio.*;
+
+public class WindowTitleVisibleTestLinuxGnome
+{
+    private static WindowTitleVisibleTestLinuxGnome theTest;
+
+    private Robot robot;
+
+    private JFrame frame;
+    private JRootPane rootPane;
+
+    private Rectangle titleBarBounds;
+    private BufferedImage titleBarImageVisible;
+    private BufferedImage titleBarImageNotVisible;
+
+    private int DELAY = 1000;
+
+    public WindowTitleVisibleTestLinuxGnome() {
+        try {
+            robot = new Robot();
+        } catch (AWTException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public void performTest() {
+        constructAndShowFrame();
+
+        robot.delay(DELAY);
+
+        Insets insets = frame.getInsets();
+        Rectangle bounds = frame.getBounds();
+        titleBarBounds = new Rectangle(bounds.x, bounds.y, bounds.width, insets.top);
+        captureTitleBarVisible();
+
+        robot.delay(DELAY);
+
+        hideTitleBar();
+
+        robot.delay(DELAY);
+
+        captureTitleBarNotVisible();
+
+        if (imagesEqual(titleBarImageVisible, titleBarImageNotVisible)) {
+            throw new RuntimeException("Test failed: title bars shown and hidden are the same.");
+        }
+
+        runSwing(() -> frame.dispose());
+
+        frame = null;
+        rootPane = null;
+    }
+
+    private static boolean imagesEqual(BufferedImage img1, BufferedImage img2) {
+        for (int px = 0; px < img1.getWidth(); px++) {
+            for (int py = 0; py < img1.getHeight(); py++) {
+                int rgb1 = img1.getRGB(px, py);
+                int rgb2 = img2.getRGB(px, py);
+                if (rgb1 != rgb2) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private void captureTitleBarNotVisible() {
+        runSwing( () -> {
+            titleBarImageNotVisible = robot.createScreenCapture(titleBarBounds);
+        });
+    }
+
+    private void hideTitleBar() {
+        runSwing( () -> {
+            rootPane.putClientProperty("xawt.mwm_decor_title", false);
+            frame.setVisible(false);
+            frame.setVisible(true);
+        });
+    }
+
+    private void captureTitleBarVisible() {
+        runSwing( () -> {
+            titleBarImageVisible = robot.createScreenCapture(titleBarBounds);
+        });
+    }
+
+    private void constructAndShowFrame() {
+        runSwing(() -> {
+            frame = new JFrame("IIIIIIIIIIIIIIII");
+            frame.setBounds(100, 100, 300, 150);
+            rootPane = frame.getRootPane();
+            rootPane.putClientProperty("xawt.mwm_decor_title", true);
+            JComponent contentPane = (JComponent) frame.getContentPane();
+            JPanel comp = new JPanel();
+            contentPane.add(comp);
+            comp.setBackground(Color.RED);
+            frame.setVisible(true);
+        });
+    }
+
+    public void dispose() {
+        if (frame != null) {
+            frame.dispose();
+            frame = null;
+        }
+    }
+
+    private static void runSwing(Runnable r) {
+        try {
+            SwingUtilities.invokeAndWait(r);
+        } catch (InterruptedException e) {
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String getWindowManagerID() {
+        String WMID = null;
+        try {
+            Process p = new ProcessBuilder("xprop", "-root", "_NET_SUPPORTING_WM_CHECK").start();
+            System.out.println( new String(p.getErrorStream().readAllBytes(), StandardCharsets.UTF_8) );
+            String stdout = new String(p.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            final String windowID = stdout.substring(stdout.lastIndexOf(" ")).strip();
+
+            p = new ProcessBuilder("xprop", "-id", windowID, "_NET_WM_NAME").start();
+            System.out.println( new String(p.getErrorStream().readAllBytes(), StandardCharsets.UTF_8) );
+            stdout = new String(p.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            WMID = stdout.substring(stdout.lastIndexOf("=")).strip();
+            System.out.println("WM name: " + WMID);
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return WMID;
+    }
+
+    public static void main(String[] args) {
+        final String WMID = getWindowManagerID();
+        if (WMID == null) {
+            System.out.println("Failed to determine Window Manager. The test will not run and is considered passed.");
+            return;
+        } else if (!WMID.toLowerCase().contains("gnome")) {
+            System.out.println("Window Manager " + WMID + " is not supported, only GNOME is. The test will not run and is considered passed.");
+            return;
+        }
+
+        try {
+            runSwing(() -> theTest = new WindowTitleVisibleTestLinuxGnome());
+            theTest.performTest();
+        } finally {
+            if (theTest != null) {
+                runSwing(() -> theTest.dispose());
+            }
+        }
+    }
+}
+

--- a/test/jdk/java/awt/Window/WindowTitleVisibleTest/WindowTitleVisibleTestLinuxGnome.java
+++ b/test/jdk/java/awt/Window/WindowTitleVisibleTest/WindowTitleVisibleTestLinuxGnome.java
@@ -107,9 +107,7 @@ public class WindowTitleVisibleTestLinuxGnome
     }
 
     private void captureTitleBarNotVisible() {
-        runSwing( () -> {
-            titleBarImageNotVisible = robot.createScreenCapture(titleBarBounds);
-        });
+        titleBarImageNotVisible = robot.createScreenCapture(titleBarBounds);
     }
 
     private void hideTitleBar() {
@@ -121,9 +119,7 @@ public class WindowTitleVisibleTestLinuxGnome
     }
 
     private void captureTitleBarVisible() {
-        runSwing( () -> {
-            titleBarImageVisible = robot.createScreenCapture(titleBarBounds);
-        });
+        titleBarImageVisible = robot.createScreenCapture(titleBarBounds);
     }
 
     private void constructAndShowFrame() {


### PR DESCRIPTION
This commit introduces a new client property xawt.mwm_decor_title implementing JDK-8267307. The property can be set prior to showing a window or after the window has been displayed, in which case the window will have to be hidden/shown (re-mapped) for the property to take effect.

The general idea is to provide control over the "decorations" part of the X11 window property called _MOTIF_WM_HINTS. Those "decoration" bits are set to 1 (XWindowAttributesData.AWT_DECOR_ALL) to show all the decorations or 0 (XWindowAttributesData.AWT_DECOR_NONE) to ask the window manager (WM) not to decorate with anything, even borders or resize handles. With xawt.mwm_decor_title property set to "true", this commit adds the ability to set the bits to 2 (XWindowAttributesData.AWT_DECOR_BORDER), which some WMs take as "decorate with only a border", thus effectively removing the window's title bar, but still leaving the resize capability.

This feature was tested and works correctly on "vanilla" Ubuntu 20.04 with the "GNOME Shell" window manager. It was also tested with Xfwm4 and KDE, where it did not have any effect; these two WMs have limited respected for the "decorations" bits of the _MOTIF_WM_HINTS window property.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267307](https://bugs.openjdk.java.net/browse/JDK-8267307): Introduce new client property for XAWT: xawt.mwm_decor_title


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**) ⚠️ Review applies to da9fbfd800f4bc8fc26ac7fa3909a64991d07a80
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4113/head:pull/4113` \
`$ git checkout pull/4113`

Update a local copy of the PR: \
`$ git checkout pull/4113` \
`$ git pull https://git.openjdk.java.net/jdk pull/4113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4113`

View PR using the GUI difftool: \
`$ git pr show -t 4113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4113.diff">https://git.openjdk.java.net/jdk/pull/4113.diff</a>

</details>
