### PR TITLE
8267396: Avoid recording "pc" in unhandled oops detector for better performance

### DIFF
--- a/src/hotspot/share/oops/oopsHierarchy.cpp
+++ b/src/hotspot/share/oops/oopsHierarchy.cpp
@@ -36,8 +36,7 @@ void oop::register_oop() {
   // This gets expensive, which is why checking unhandled oops is on a switch.
   Thread* t = Thread::current_or_null();
   if (t != NULL && t->is_Java_thread()) {
-     frame fr = os::current_frame();
-     t->unhandled_oops()->register_unhandled_oop(this, fr.pc());
+     t->unhandled_oops()->register_unhandled_oop(this);
   }
 }
 

--- a/src/hotspot/share/runtime/unhandledOops.cpp
+++ b/src/hotspot/share/runtime/unhandledOops.cpp
@@ -57,7 +57,7 @@ void UnhandledOops::dump_oops(UnhandledOops *list) {
 // You don't want to turn it on in compiled code here.
 static Thread* unhandled_oop_print = NULL;
 
-void UnhandledOops::register_unhandled_oop(oop* op, address pc) {
+void UnhandledOops::register_unhandled_oop(oop* op) {
   if (!_thread->is_in_live_stack((address)op)) {
     return;
   }
@@ -67,7 +67,7 @@ void UnhandledOops::register_unhandled_oop(oop* op, address pc) {
     for (int i=0; i < _level; i++) tty->print(" ");
     tty->print_cr("r " INTPTR_FORMAT, p2i(op));
   }
-  UnhandledOopEntry entry(op, pc);
+  UnhandledOopEntry entry(op);
   _oop_list->push(entry);
 }
 
@@ -120,8 +120,7 @@ void UnhandledOops::clear_unhandled_oops() {
     // in the unhandled oop generator.
     if (!_thread->is_in_live_stack((address)entry._oop_ptr)) {
       tty->print_cr("oop_ptr is " INTPTR_FORMAT, p2i(entry._oop_ptr));
-      tty->print_cr("thread is " INTPTR_FORMAT " from pc " INTPTR_FORMAT,
-                     p2i(_thread), p2i(entry._pc));
+      tty->print_cr("thread is " INTPTR_FORMAT, p2i(_thread));
       assert(false, "heap is corrupted by the unhandled oop detector");
     }
     // Set unhandled oops to a pattern that will crash distinctively

--- a/src/hotspot/share/runtime/unhandledOops.hpp
+++ b/src/hotspot/share/runtime/unhandledOops.hpp
@@ -53,12 +53,11 @@ class UnhandledOopEntry : public CHeapObj<mtThread> {
  private:
   oop* _oop_ptr;
   bool _ok_for_gc;
-  address _pc;
  public:
   oop* oop_ptr() { return _oop_ptr; }
-  UnhandledOopEntry() : _oop_ptr(NULL), _ok_for_gc(false), _pc(NULL) {}
-  UnhandledOopEntry(oop* op, address pc) :
-                        _oop_ptr(op),   _ok_for_gc(false), _pc(pc) {}
+  UnhandledOopEntry() : _oop_ptr(NULL), _ok_for_gc(false) {}
+  UnhandledOopEntry(oop* op) :
+                        _oop_ptr(op),   _ok_for_gc(false) {}
 };
 
 
@@ -75,7 +74,7 @@ class UnhandledOops : public CHeapObj<mtThread> {
 
  public:
   static void dump_oops(UnhandledOops* list);
-  void register_unhandled_oop(oop* op, address pc);
+  void register_unhandled_oop(oop* op);
   void unregister_unhandled_oop(oop* op);
 };
 


### PR DESCRIPTION
See the rationale in the bug.

Additional testing:
 - [x] Known slow test with `-XX:+CheckUnhandledOops`
 - [x] tier1 with `-XX:+CheckUnhandledOops`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267396](https://bugs.openjdk.java.net/browse/JDK-8267396): Avoid recording "pc" in unhandled oops detector for better performance


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4114/head:pull/4114` \
`$ git checkout pull/4114`

Update a local copy of the PR: \
`$ git checkout pull/4114` \
`$ git pull https://git.openjdk.java.net/jdk pull/4114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4114`

View PR using the GUI difftool: \
`$ git pr show -t 4114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4114.diff">https://git.openjdk.java.net/jdk/pull/4114.diff</a>

</details>
