### PR TITLE
8267235: [macos_aarch64] InterpreterRuntime::throw_pending_exception messing up LR results in crash

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -681,9 +681,7 @@ void MacroAssembler::call_VM_base(Register oop_result,
   // lr could be poisoned with PAC signature during throw_pending_exception
   // if it was tail-call optimized by compiler, since lr is not callee-saved
   // reload it with proper value
-  ldr(lr, Address(rthread,
-                            JavaThread::frame_anchor_offset()
-                            + JavaFrameAnchor::last_Java_pc_offset()));
+  adr(lr, l);
 
   // reset last Java frame
   // Only interpreter should have to clear fp

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -678,6 +678,13 @@ void MacroAssembler::call_VM_base(Register oop_result,
   // do the call, remove parameters
   MacroAssembler::call_VM_leaf_base(entry_point, number_of_arguments, &l);
 
+  // lr could be poisoned with PAC signature during throw_pending_exception
+  // if it was tail-call optimized by compiler, since lr is not callee-saved
+  // reload it with proper value
+  ldr(lr, Address(rthread,
+                            JavaThread::frame_anchor_offset()
+                            + JavaFrameAnchor::last_Java_pc_offset()));
+
   // reset last Java frame
   // Only interpreter should have to clear fp
   reset_last_Java_frame(true);


### PR DESCRIPTION
Please review this patch for call_VM_Base routine.
it's expected there the LR is callee-saved register, but it's not on aarch64.
when InterpreterRuntime::throw_pending_exception is tail-call optimized,
the last subroutine before return is pthread_jit_write_protect_np which pac-sign LR.
It can only be reproduced in macos 11.4beta (just run J2Ddemo ) but in fact affects every aarch64 build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267235](https://bugs.openjdk.java.net/browse/JDK-8267235): [macos_aarch64] InterpreterRuntime::throw_pending_exception messing up LR results in crash


### Reviewers
 * [Anton Kozlov](https://openjdk.java.net/census#akozlov) (@AntonKozlov - Committer) ⚠️ Review applies to 5b7c4cec5611652dc744c5b5696cb3c01bc714b8
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4115/head:pull/4115` \
`$ git checkout pull/4115`

Update a local copy of the PR: \
`$ git checkout pull/4115` \
`$ git pull https://git.openjdk.java.net/jdk pull/4115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4115`

View PR using the GUI difftool: \
`$ git pr show -t 4115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4115.diff">https://git.openjdk.java.net/jdk/pull/4115.diff</a>

</details>
