### PR TITLE
8266400: importkeystore fails to a password less pkcs12 keystore

### DIFF
--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -2429,8 +2429,15 @@ public final class Main {
             newPass = destKeyPass;
             pp = new PasswordProtection(destKeyPass);
         } else if (objs.snd != null) {
-            newPass = P12KEYSTORE.equalsIgnoreCase(storetype) ?
-                    storePass : objs.snd;
+            if (P12KEYSTORE.equalsIgnoreCase(storetype)) {
+                if (isPasswordlessKeyStore) {
+                    newPass = objs.snd;
+                } else {
+                    newPass = storePass;
+                }
+            } else {
+                newPass = objs.snd;
+            }
             pp = new PasswordProtection(newPass);
         }
 
@@ -2442,7 +2449,7 @@ public final class Main {
             keyStore.setEntry(newAlias, entry, pp);
             // Place the check so that only successful imports are blocked.
             // For example, we don't block a failed SecretEntry import.
-            if (P12KEYSTORE.equalsIgnoreCase(storetype)) {
+            if (P12KEYSTORE.equalsIgnoreCase(storetype) && !isPasswordlessKeyStore) {
                 if (newPass != null && !Arrays.equals(newPass, storePass)) {
                     throw new Exception(rb.getString(
                             "The.destination.pkcs12.keystore.has.different.storepass.and.keypass.Please.retry.with.destkeypass.specified."));

--- a/test/jdk/sun/security/tools/keytool/ImportToPwordlessPK12.java
+++ b/test/jdk/sun/security/tools/keytool/ImportToPwordlessPK12.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8266400
+ * @summary Test importkeystore to a password less PKCS12 keystore
+ * @library /test/lib
+ */
+
+import jdk.test.lib.SecurityTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class ImportToPwordlessPK12 {
+
+    static OutputAnalyzer kt(String cmd, String ks) throws Exception {
+        return SecurityTools.keytool("-storepass changeit " + cmd +
+                " -keystore " + ks);
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        kt("-genkeypair -keyalg EC -alias testcert -dname CN=EE " +
+                "-storetype jks -keypass pass123 ", "ks.jks");
+
+        /*
+         * Test by setting the responses for source keystore password and
+         * key password for alias
+         */
+        SecurityTools.setResponse("changeit", "pass123");
+        SecurityTools.keytool("-importkeystore -srckeystore ks.jks " +
+                "-destkeystore ks.p12 " +
+                "-J-Dkeystore.pkcs12.macAlgorithm=NONE " +
+                "-J-Dkeystore.pkcs12.certProtectionAlgorithm=NONE")
+                .shouldHaveExitValue(0);
+
+        SecurityTools.keytool("-list -keystore ks.p12 -debug")
+                .shouldContain("Keystore type: PKCS12")
+                .shouldContain("keystore contains 1 entry")
+                .shouldNotContain("Enter keystore password:")
+                .shouldHaveExitValue(0);
+
+        kt("-genkeypair -keyalg EC -alias testcert -dname CN=EE " +
+                "-storetype jks -keypass pass123 ", "ks1.jks");
+
+        // Test with all of options specified on command line
+        SecurityTools.keytool("-importkeystore -srckeystore ks1.jks " +
+                "-destkeystore ks1.p12 " +
+                "-srcstorepass changeit " +
+                "-srcalias testcert " +
+                "-srckeypass pass123 " +
+                "-J-Dkeystore.pkcs12.macAlgorithm=NONE " +
+                "-J-Dkeystore.pkcs12.certProtectionAlgorithm=NONE")
+                .shouldHaveExitValue(0);
+
+        SecurityTools.keytool("-list -keystore ks1.p12 -debug")
+                .shouldContain("Keystore type: PKCS12")
+                .shouldContain("keystore contains 1 entry")
+                .shouldNotContain("Enter keystore password:")
+                .shouldHaveExitValue(0);
+    }
+}


### PR DESCRIPTION
Please review the fix to address keytool -importkeystore failure when importing to a password-less PKCS12 keystore.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266400](https://bugs.openjdk.java.net/browse/JDK-8266400): importkeystore fails to a password less pkcs12 keystore


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4119/head:pull/4119` \
`$ git checkout pull/4119`

Update a local copy of the PR: \
`$ git checkout pull/4119` \
`$ git pull https://git.openjdk.java.net/jdk pull/4119/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4119`

View PR using the GUI difftool: \
`$ git pr show -t 4119`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4119.diff">https://git.openjdk.java.net/jdk/pull/4119.diff</a>

</details>
