### PR TITLE
8267056: tools/jpackage/share/RuntimePackageTest.java fails with NoSuchFileException

### DIFF
--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacPkgBundler.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacPkgBundler.java
@@ -393,8 +393,8 @@ public class MacPkgBundler extends MacBaseInstallerBundler {
         // Not needed for runtime installer and it might break runtime installer
         // if parent does not have any other files
         if (!StandardBundlerParam.isRuntimeInstaller(params)) {
-            Path[] list = Files.list(rootDir).toArray(Path[]::new);
-            if (list != null) { // Should not happend
+            try (var fileList = Files.list(rootDir)) {
+                Path[] list = fileList.toArray(Path[]::new);
                 // We should only have app image and/or .DS_Store
                 if (list.length == 1) {
                     return rootDir.toString();

--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacPkgBundler.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacPkgBundler.java
@@ -390,16 +390,20 @@ public class MacPkgBundler extends MacBaseInstallerBundler {
         Path rootDir = appLocation.getParent() == null ?
                 Path.of(".") : appLocation.getParent();
 
-        Path[] list = Files.list(rootDir).toArray(Path[]::new);
-        if (list != null) { // Should not happend
-            // We should only have app image and/or .DS_Store
-            if (list.length == 1) {
-                return rootDir.toString();
-            } else if (list.length == 2) {
-                // Check case with app image and .DS_Store
-                if (list[0].toString().toLowerCase().endsWith(".ds_store") ||
-                    list[1].toString().toLowerCase().endsWith(".ds_store")) {
-                    return rootDir.toString(); // Only app image and .DS_Store
+        // Not needed for runtime installer and it might break runtime installer
+        // if parent does not have any other files
+        if (!StandardBundlerParam.isRuntimeInstaller(params)) {
+            Path[] list = Files.list(rootDir).toArray(Path[]::new);
+            if (list != null) { // Should not happend
+                // We should only have app image and/or .DS_Store
+                if (list.length == 1) {
+                    return rootDir.toString();
+                } else if (list.length == 2) {
+                    // Check case with app image and .DS_Store
+                    if (list[0].toString().toLowerCase().endsWith(".ds_store") ||
+                        list[1].toString().toLowerCase().endsWith(".ds_store")) {
+                        return rootDir.toString(); // Only app image and .DS_Store
+                    }
                 }
             }
         }

--- a/test/jdk/tools/jpackage/share/RuntimePackageTest.java
+++ b/test/jdk/tools/jpackage/share/RuntimePackageTest.java
@@ -151,6 +151,7 @@ public class RuntimePackageTest {
             final Path prefsDir = Path.of(".systemPrefs");
             return files.map(root::relativize)
                     .filter(x -> !x.startsWith(prefsDir))
+                    .filter(x -> !x.endsWith(".DS_Store"))
                     .collect(Collectors.toSet());
         }
     }


### PR DESCRIPTION
For debug build on macOS, runtime which used for test fill be located in /path/jdk-17/fastdebug and /path/jdk-17 will not contain any other files except fastdebug and in this case our check to decide if we need to copy app or runtime will return /path/jdk-17 which is not correct. Fixed by skipping this check for runtime and only using it for app. Also, added ignoring .DS_Store to test which is needed if user used Finder to look inside runtime folder which will cause .DS_Store to be created and will cause test to fail, since this file is not being packaged.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267056](https://bugs.openjdk.java.net/browse/JDK-8267056): tools/jpackage/share/RuntimePackageTest.java fails with NoSuchFileException


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4120/head:pull/4120` \
`$ git checkout pull/4120`

Update a local copy of the PR: \
`$ git checkout pull/4120` \
`$ git pull https://git.openjdk.java.net/jdk pull/4120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4120`

View PR using the GUI difftool: \
`$ git pr show -t 4120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4120.diff">https://git.openjdk.java.net/jdk/pull/4120.diff</a>

</details>
