### PR TITLE
8267332: Fix Xor value() 

### DIFF
--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -920,7 +920,7 @@ const Type* XorINode::Value(PhaseGVN* phase) const {
   if (in1->eqv_uncast(in2)) {
     return add_id();
   }
-  return AddNode::Value(phase);
+  return t1->meet(t2);
 }
 
 //------------------------------add_ring---------------------------------------
@@ -970,7 +970,7 @@ const Type* XorLNode::Value(PhaseGVN* phase) const {
   if (in1->eqv_uncast(in2)) {
     return add_id();
   }
-  return AddNode::Value(phase);
+  return t1->meet(t2);
 }
 
 Node* MaxNode::build_min_max(Node* a, Node* b, bool is_max, bool is_unsigned, const Type* t, PhaseGVN& gvn) {


### PR DESCRIPTION
This PR fixes the XorI and XorL value() methods to less conservative versions.

The bound of a Xor of two values v1, v2 is lo:min(v1.lo,v2.lo) and high:(max(v1.hi,v2.hi)). This is the join of the two possible sets of values, or in C2 type system lingo - the meet of the constraints.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8267332](https://bugs.openjdk.java.net/browse/JDK-8267332): Fix Xor value()


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4123/head:pull/4123` \
`$ git checkout pull/4123`

Update a local copy of the PR: \
`$ git checkout pull/4123` \
`$ git pull https://git.openjdk.java.net/jdk pull/4123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4123`

View PR using the GUI difftool: \
`$ git pr show -t 4123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4123.diff">https://git.openjdk.java.net/jdk/pull/4123.diff</a>

</details>
