### PR TITLE
8267463: Problemlist runtime/os/TestTracePageSizes.java on linux-aarch64 to reduce noise

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -92,6 +92,7 @@ gc/epsilon/TestClasses.java 8267348 linux-x64
 runtime/cds/appcds/jigsaw/modulepath/ModulePathAndCP_JFR.java 8253437 windows-x64
 runtime/cds/DeterministicDump.java 8253495 generic-all
 runtime/jni/terminatedThread/TestTerminatedThread.java 8219652 aix-ppc64
+runtime/os/TestTracePageSizes.java 8267460 linux-aarch64
 
 #############################################################################
 


### PR DESCRIPTION
Hi,

  can I have reviews for this trivial(?) problemlisting of a test?

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267463](https://bugs.openjdk.java.net/browse/JDK-8267463): Problemlist runtime/os/TestTracePageSizes.java on linux-aarch64 to reduce noise


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4125/head:pull/4125` \
`$ git checkout pull/4125`

Update a local copy of the PR: \
`$ git checkout pull/4125` \
`$ git pull https://git.openjdk.java.net/jdk pull/4125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4125`

View PR using the GUI difftool: \
`$ git pr show -t 4125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4125.diff">https://git.openjdk.java.net/jdk/pull/4125.diff</a>

</details>
