### PR TITLE
 8267480: Explicitly problemlist all runtime/os/TestTracePageSizes.java tests on linux-aarch64 to reduce noise

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -92,7 +92,12 @@ gc/epsilon/TestClasses.java 8267348 linux-x64
 runtime/cds/appcds/jigsaw/modulepath/ModulePathAndCP_JFR.java 8253437 windows-x64
 runtime/cds/DeterministicDump.java 8253495 generic-all
 runtime/jni/terminatedThread/TestTerminatedThread.java 8219652 aix-ppc64
-runtime/os/TestTracePageSizes.java 8267460 linux-aarch64
+runtime/os/TestTracePageSizes.java#no-options 8267460 linux-aarch64
+runtime/os/TestTracePageSizes.java#explicit-large-page-size 8267460 linux-aarch64
+runtime/os/TestTracePageSizes.java#compiler-options 8267460 linux-aarch64
+runtime/os/TestTracePageSizes.java#with-G1 8267460 linux-aarch64
+runtime/os/TestTracePageSizes.java#with-Parallel 8267460 linux-aarch64
+runtime/os/TestTracePageSizes.java#with-Serial 8267460 linux-aarch64
 
 #############################################################################
 


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that explicitly problemlists all subtests of runtime/os/TestTracePageSizes.java to reduce noise in CI.

Reasons are that JDK-8267463 failed to do anything: using just the test name was supposed to catch-all tests, but that did not work at all. Further we are seeing other tests failing as well, so the suggestion in this test is to problemlist all 6 subtests.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267480](https://bugs.openjdk.java.net/browse/JDK-8267480): Explicitly problemlist all runtime/os/TestTracePageSizes.java tests on linux-aarch64 to reduce noise


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4129/head:pull/4129` \
`$ git checkout pull/4129`

Update a local copy of the PR: \
`$ git checkout pull/4129` \
`$ git pull https://git.openjdk.java.net/jdk pull/4129/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4129`

View PR using the GUI difftool: \
`$ git pr show -t 4129`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4129.diff">https://git.openjdk.java.net/jdk/pull/4129.diff</a>

</details>
