### PR TITLE
JDK-8267394: Do not rely on object identity for empty valid Content instance

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DeprecatedListWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DeprecatedListWriter.java
@@ -29,8 +29,8 @@ import com.sun.source.doctree.DeprecatedTree;
 import java.util.List;
 
 import javax.lang.model.element.Element;
-import jdk.javadoc.internal.doclets.formats.html.markup.HtmlTree;
 import jdk.javadoc.internal.doclets.formats.html.Navigation.PageMode;
+import jdk.javadoc.internal.doclets.formats.html.markup.Text;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 import jdk.javadoc.internal.doclets.toolkit.util.DeprecatedAPIListBuilder;
 import jdk.javadoc.internal.doclets.toolkit.util.DocFileIOException;
@@ -96,7 +96,7 @@ public class DeprecatedListWriter extends SummaryListWriter<DeprecatedAPIListBui
         if (!tags.isEmpty()) {
             addInlineDeprecatedComment(e, tags.get(0), desc);
         } else {
-            desc.add(HtmlTree.EMPTY);
+            desc.add(Text.VALID_EMPTY);
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Navigation.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Navigation.java
@@ -38,9 +38,9 @@ import jdk.javadoc.internal.doclets.formats.html.markup.ContentBuilder;
 import jdk.javadoc.internal.doclets.formats.html.markup.Entity;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlAttr;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlStyle;
-import jdk.javadoc.internal.doclets.formats.html.markup.TagName;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlTree;
 import jdk.javadoc.internal.doclets.formats.html.markup.Links;
+import jdk.javadoc.internal.doclets.formats.html.markup.TagName;
 import jdk.javadoc.internal.doclets.formats.html.markup.Text;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 import jdk.javadoc.internal.doclets.toolkit.util.DocFile;
@@ -620,7 +620,7 @@ public class Navigation {
         tree.add(subDiv);
 
         tree.add(MarkerComments.END_OF_TOP_NAVBAR);
-        tree.add(HtmlTree.SPAN(HtmlStyle.skipNav, HtmlTree.EMPTY)
+        tree.add(HtmlTree.SPAN(HtmlStyle.skipNav, Text.VALID_EMPTY)
                 .setId(HtmlIds.SKIP_NAVBAR_TOP));
 
         return tree;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
@@ -302,7 +302,7 @@ public class PackageWriterImpl extends HtmlDocletWriter
 
             for (PackageElement pkg : packages) {
                 Content packageLink = getPackageLink(pkg, Text.of(pkg.getQualifiedName()));
-                Content moduleLink = HtmlTree.EMPTY;
+                Content moduleLink = Text.VALID_EMPTY;
                 if (showModules) {
                     ModuleElement module = (ModuleElement) pkg.getEnclosingElement();
                     if (module != null && !module.isUnnamed()) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PreviewListWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PreviewListWriter.java
@@ -31,8 +31,8 @@ import javax.lang.model.element.Element;
 
 import com.sun.source.doctree.DocTree;
 
-import jdk.javadoc.internal.doclets.formats.html.markup.HtmlTree;
 import jdk.javadoc.internal.doclets.formats.html.Navigation.PageMode;
+import jdk.javadoc.internal.doclets.formats.html.markup.Text;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 import jdk.javadoc.internal.doclets.toolkit.util.DocFileIOException;
 import jdk.javadoc.internal.doclets.toolkit.util.DocPath;
@@ -86,7 +86,7 @@ public class PreviewListWriter extends SummaryListWriter<PreviewAPIListBuilder> 
         if (!tags.isEmpty()) {
             addPreviewComment(e, tags, desc);
         } else {
-            desc.add(HtmlTree.EMPTY);
+            desc.add(Text.VALID_EMPTY);
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Table.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Table.java
@@ -44,6 +44,7 @@ import jdk.javadoc.internal.doclets.formats.html.markup.HtmlId;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlStyle;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlTree;
 import jdk.javadoc.internal.doclets.formats.html.markup.TagName;
+import jdk.javadoc.internal.doclets.formats.html.markup.Text;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 
 /**
@@ -327,7 +328,7 @@ public class Table extends Content {
                     ? null
                     : columnStyles.get(colIndex);
             // Replace invalid content with HtmlTree.EMPTY to make sure the cell isn't dropped
-            HtmlTree cell = HtmlTree.DIV(cellStyle, c.isValid() ? c : HtmlTree.EMPTY);
+            HtmlTree cell = HtmlTree.DIV(cellStyle, c.isValid() ? c : Text.VALID_EMPTY);
             if (rowStyle != null) {
                 cell.addStyle(rowStyle);
             }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/BodyContents.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/BodyContents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,7 +96,7 @@ public class BodyContents extends Content {
 
         HtmlTree flexContent = HtmlTree.DIV(HtmlStyle.flexContent)
                 .add(HtmlTree.MAIN().add(mainContents))
-                .add(footer == null ? HtmlTree.EMPTY : footer);
+                .add(footer == null ? Text.VALID_EMPTY : footer);
 
         return HtmlTree.DIV(HtmlStyle.flexBox)
                 .add(flexHeader)

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlTree.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlTree.java
@@ -85,12 +85,6 @@ public class HtmlTree extends Content {
     private List<Content> content = List.of();
 
     /**
-     * A sentinel value to explicitly indicate empty content.
-     * The '==' identity of this object is significant.
-     */
-    public static final Content EMPTY = Text.of("");
-
-    /**
      * Creates an {@code HTMLTree} object representing an HTML element
      * with the given name.
      *
@@ -177,8 +171,8 @@ public class HtmlTree extends Content {
         if (content instanceof ContentBuilder) {
             ((ContentBuilder) content).contents.forEach(this::add);
         }
-        else if (content == HtmlTree.EMPTY || content.isValid()) {
-            // quietly avoid adding empty or invalid nodes (except EMPTY)
+        else if (content.isValid()) {
+            // quietly avoid adding invalid nodes
             if (this.content.isEmpty())
                 this.content = new ArrayList<>();
             this.content.add(content);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Text.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Text.java
@@ -42,7 +42,22 @@ import jdk.javadoc.internal.doclets.toolkit.util.DocletConstants;
 public class Text extends Content {
     private final String string;
 
+    /**
+     * An empty {@code Text} instance. Like most other empty content, this is
+     * considered invalid and silently ignored when added to a content tree.
+     */
     public static final Text EMPTY = Text.of("");
+
+    /**
+     * An empty yet valid {@code Text} instance. This is useful for building
+     * valid content trees without adding actual content.
+     */
+    public static final Text VALID_EMPTY = new Text("") {
+        @Override
+        public boolean isValid() {
+            return true;
+        }
+    };
 
     /**
      * Creates a new object containing immutable text.


### PR DESCRIPTION
This is a simple cleanup to replace the sentinel `HtmlTree.EMPTY` text constant with an instance that achieves the same by overriding `isValid()`. I think this is the nicer solution, and it allows us to remove the special case identity check in `HtmlTree.add(Content)`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8267394](https://bugs.openjdk.java.net/browse/JDK-8267394): Do not rely on object identity for empty valid Content instance


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4130/head:pull/4130` \
`$ git checkout pull/4130`

Update a local copy of the PR: \
`$ git checkout pull/4130` \
`$ git pull https://git.openjdk.java.net/jdk pull/4130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4130`

View PR using the GUI difftool: \
`$ git pr show -t 4130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4130.diff">https://git.openjdk.java.net/jdk/pull/4130.diff</a>

</details>
