### PR TITLE
JDK-8267481: Make sure table row has correct number of cells

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Table.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Table.java
@@ -295,6 +295,9 @@ public class Table extends Content {
         if (tabMap != null && element == null) {
             throw new NullPointerException();
         }
+        if (contents.size() != columnStyles.size()) {
+            throw new IllegalArgumentException("row content size does not match number of columns");
+        }
 
         Content row = new ContentBuilder();
 
@@ -323,9 +326,7 @@ public class Table extends Content {
         }
         int colIndex = 0;
         for (Content c : contents) {
-            HtmlStyle cellStyle = (columnStyles == null || colIndex > columnStyles.size())
-                    ? null
-                    : columnStyles.get(colIndex);
+            HtmlStyle cellStyle = columnStyles.get(colIndex);
             // Replace invalid content with HtmlTree.EMPTY to make sure the cell isn't dropped
             HtmlTree cell = HtmlTree.DIV(cellStyle, c.isValid() ? c : HtmlTree.EMPTY);
             if (rowStyle != null) {


### PR DESCRIPTION
This is a trivial change to throw a NPE or IllegalArgumentException if the number of cells passed to `addRow` does not match the number of column styles. (The non-nullness of `columnStyles` is already implied by other Table methods such as `toContent()`.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267481](https://bugs.openjdk.java.net/browse/JDK-8267481): Make sure table row has correct number of cells


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4131/head:pull/4131` \
`$ git checkout pull/4131`

Update a local copy of the PR: \
`$ git checkout pull/4131` \
`$ git pull https://git.openjdk.java.net/jdk pull/4131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4131`

View PR using the GUI difftool: \
`$ git pr show -t 4131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4131.diff">https://git.openjdk.java.net/jdk/pull/4131.diff</a>

</details>
