### PR TITLE
8267350: Archived old interface extends interface with default method causes crash

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2370,7 +2370,11 @@ void InstanceKlass::metaspace_pointers_do(MetaspaceClosure* it) {
   it->push(&_local_interfaces);
   it->push(&_transitive_interfaces);
   it->push(&_method_ordering);
-  it->push(&_default_vtable_indices);
+  if (!is_rewritten()) {
+    it->push(&_default_vtable_indices, MetaspaceClosure::_writable);
+  } else {
+    it->push(&_default_vtable_indices);
+  }
   it->push(&_fields);
 
   if (itable_length() > 0) {

--- a/test/hotspot/jtreg/runtime/cds/appcds/OldInfExtendsInfDefMeth.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/OldInfExtendsInfDefMeth.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+/*
+ * @test
+ * @bug 8267350
+ * @summary CDS support of old classes with major version < JDK_6 (50) for static archive.
+ *          Test an old interface extends another interface which has a default method.
+ * @requires vm.cds
+ * @library /test/lib
+ * @compile test-classes/InfDefMeth.java
+ * @compile test-classes/OldInfDefMeth.jasm
+ * @compile test-classes/OldInfDefMethImpl.java
+ * @compile test-classes/OldInfDefMethApp.java
+ * @run driver OldInfExtendsInfDefMeth
+ */
+
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class OldInfExtendsInfDefMeth {
+    public static void main(String[] args) throws Exception {
+        String mainClass = "OldInfDefMethApp";
+        String namePrefix = "oldinfdefmeth";
+        String appClasses[] = TestCommon.list("InfDefMeth", "OldInfDefMeth", "OldInfDefMethImpl", mainClass);
+        JarBuilder.build(namePrefix, appClasses);
+        String appJar = TestCommon.getTestJar(namePrefix + ".jar");
+
+        boolean dynamicMode = CDSTestUtils.DYNAMIC_DUMP;
+
+        // create archive with class list
+        OutputAnalyzer output = TestCommon.dump(appJar, appClasses, "-Xlog:class+load,cds=debug,verification=trace");
+        TestCommon.checkExecReturn(output, 0,
+                                   dynamicMode ? true : false,
+                                   "Pre JDK 6 class not supported by CDS: 49.0 OldInfDefMeth");
+
+        // run with archive
+        TestCommon.run(
+            "-cp", appJar,
+            "-Xlog:class+load,cds=debug,verification=trace",
+            mainClass)
+          .assertNormalExit(out -> {
+              out.shouldContain("Verifying class OldInfDefMeth with old format")
+                 .shouldContain("Verifying class OldInfDefMethImpl with new format");
+              if (!dynamicMode) {
+                  out.shouldContain("InfDefMeth source: shared objects file")
+                     .shouldContain("OldInfDefMeth source: shared objects file")
+                     .shouldContain("OldInfDefMethImpl source: shared objects file");
+              } else {
+                  // InfDefMeth has version >=50 so it should be loaded from the
+                  // dynamic archive.
+                  out.shouldContain("InfDefMeth source: shared objects file (top)")
+                  // Old classes were already linked before dynamic dump happened,
+                  // so they couldn't be archived.
+                     .shouldMatch(".class.load.*OldInfDefMeth source:.*oldinfdefmeth.jar")
+                     .shouldMatch(".class.load.*OldInfDefMethImpl source:.*oldinfdefmeth.jar");
+              }
+          });
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/InfDefMeth.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/InfDefMeth.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+public interface InfDefMeth {
+    default public int size() { return 0;};
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/OldInfDefMeth.jasm
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/OldInfDefMeth.jasm
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+public interface  OldInfDefMeth
+	implements InfDefMeth
+	version 49:0
+{
+  public abstract Method SayHello:"()Ljava/lang/String;";
+
+} // end Class OldInfDefMeth

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/OldInfDefMethApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/OldInfDefMethApp.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+public class OldInfDefMethApp {
+    public static void main(String args[]) {
+        OldInfDefMethImpl o = new OldInfDefMethImpl();
+        System.out.println(o.SayHello());
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/OldInfDefMethImpl.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/OldInfDefMethImpl.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+public class OldInfDefMethImpl implements OldInfDefMeth {
+    public String SayHello() { return "Hello from OldInfDefMethImpl"; }
+}


### PR DESCRIPTION
During CDS dumping, an old class/interface won't be linked/rewritten. If an old interface extends an interface which contains a default method, the `_default_vtable_indices` will be updated during runtime. This small path is to make the `_default_vtable_indices` r/w during dump time for a class which hasn't been rewritten during dump time.

Testing:

- [x] mach5 tiers 1 - 4 (including the new test)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267350](https://bugs.openjdk.java.net/browse/JDK-8267350): Archived old interface extends interface with default method causes crash


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4132/head:pull/4132` \
`$ git checkout pull/4132`

Update a local copy of the PR: \
`$ git checkout pull/4132` \
`$ git pull https://git.openjdk.java.net/jdk pull/4132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4132`

View PR using the GUI difftool: \
`$ git pr show -t 4132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4132.diff">https://git.openjdk.java.net/jdk/pull/4132.diff</a>

</details>
