### PR TITLE
8191441: (Process) add Readers and Writer access to java.lang.Process streams

### DIFF
--- a/src/java.base/share/classes/java/lang/Process.java
+++ b/src/java.base/share/classes/java/lang/Process.java
@@ -227,14 +227,14 @@ public abstract class Process {
      * sequences are replaced with the charset's default replacement.
      * The {@code BufferedReader} reads and buffers characters from the InputStreamReader.
      *
+     * <p>The first call to this method creates the {@link BufferedReader BufferedReader},
+     * if called again with the same {@code charset} the same {@code BufferedReader} is returned.
+     * It is an error to call this method again with a different {@code charset}.
+     *
      * <p>If the standard output of the process has been redirected using
      * {@link ProcessBuilder#redirectOutput(Redirect) ProcessBuilder.redirectOutput}
      * then the {@code InputStreamReader} will be reading from a
      * <a href="ProcessBuilder.html#redirect-output">null input stream</a>.
-     *
-     * <p>The first call to this method creates the {@link BufferedReader BufferedReader},
-     * if called again with the same {@code charset} the same {@code BufferedReader} is returned.
-     * It is an error to call this method again with a different {@code charset}.
      *
      * <p>Otherwise, if the standard error of the process has been redirected using
      * {@link ProcessBuilder#redirectErrorStream(boolean)
@@ -378,7 +378,7 @@ public abstract class Process {
      *
      * <p>If the standard input of the process has been redirected using
      * {@link ProcessBuilder#redirectInput(Redirect)
-     * ProcessBuilder.redirectInput} then this method will return a
+     * ProcessBuilder.redirectInput} then the {@code OutputStreamWriter} writes to a
      * <a href="ProcessBuilder.html#redirect-input">null output stream</a>.
      *
      * @apiNote

--- a/src/java.base/share/classes/java/lang/Process.java
+++ b/src/java.base/share/classes/java/lang/Process.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -259,17 +259,15 @@ public abstract class Process {
     }
 
     /**
-     * Returns a {@code PrintWriter} connected to the normal input of the process.
-     * PrintWriter prints formatted representations of objects to a text-output stream.
-     * PrintWriter does not throw exceptions; instead, exceptional situations set
-     * an internal flag that can be tested via the {@link PrintWriter#checkError} method.
+     * Returns a {@code BufferedWriter} connected to the normal input of the process the native encoding.
+     * Writes text to a character-output stream, buffering characters so as to provide
+     * for the efficient writing of single characters, arrays, and strings.
      *
-     * <p>Characters written to the writer are converted to bytes using the
-     * {@link Charset} named by the {@systemProperty native.encoding} system property
+     * <p>Characters written encoded to bytes using {@link OutputStreamWriter}
+     * and the {@link Charset} named by the {@systemProperty native.encoding} system property
      * piped into the standard input of the process represented by this {@code Process} object.
      * If the {@code Charset} is not supported, the {@link Charset#defaultCharset()} is used.
-     * Call the {@link PrintWriter#flush()} method to flush buffered output
-     * to the process.
+     * Call the {@link BufferedWriter#flush()} method to flush buffered output to the process.
      *
      * <p>If the standard input of the process has been redirected using
      * {@link ProcessBuilder#redirectInput(Redirect)
@@ -277,32 +275,31 @@ public abstract class Process {
      * <a href="ProcessBuilder.html#redirect-input">null output writer</a>.
      *
      * @apiNote
+     * A {@linkplain BufferedWriter} writes characters, arrays of characters, and strings.
+     * Wrapping the {@link BufferedWriter} with a {@link PrintWriter} provides
+     * efficient buffering and formatting of primitives and objects as well as support
+     * for auto-flush on line endings.
+     * <p>
      * Use {@link #getOutputStream} and {@link #outputWriter} with extreme care.
-     * Output to the PrintWriter may be held in the buffer until
-     * {@linkplain PrintWriter#flush flush} is called.
+     * Output to the BufferedWriter may be held in the buffer until
+     * {@linkplain BufferedWriter#flush flush} is called.
      *
-     * @param autoFlush if {@code true} the {@code println}, {@code printf}, or {@code format}
-     *                  methods will flush the output buffer
-     * @return a PrintWriter to the standard input of the process using the charset
+     * @return a BufferedWriter to the standard input of the process using the charset
      *          for the {@code native.encoding} system property
      */
-    public PrintWriter outputWriter(boolean autoFlush) {
-        return new PrintWriter(getOutputStream(), autoFlush, CharsetHolder.nativeCharset());
+    public BufferedWriter outputWriter() {
+        return outputWriter(CharsetHolder.nativeCharset());
     }
 
     /**
-     * Returns a {@code PrintWriter} connected to the normal input of the process using a Charset.
-     * PrintWriter prints formatted representations of objects to a text-output stream.
-     * PrintWriter does not throw exceptions; instead, exceptional situations set
-     * an internal flag that can be tested via the {@link PrintWriter#checkError} method.
+     * Returns a {@code BufferedWriter} connected to the normal input of the process using a Charset.
+     * Writes text to a character-output stream, buffering characters so as to provide
+     * for the efficient writing of single characters, arrays, and strings.
      *
-     * <p>Characters written to the writer are converted to bytes using the
-     * {@link Charset} named by the {@systemProperty native.encoding} system property
+     * <p>Characters written by the writer are encoded to bytes using {@link OutputStreamWriter}
+     * and the {@link Charset}
      * piped into the standard input of the process represented by this {@code Process} object.
-     * If the {@code Charset} for the {@code native.encoding} is not supported,
-     * the {@link Charset#defaultCharset()} is used.
-     * Call the {@link PrintWriter#flush()} method to flush buffered output
-     * to the process.
+     * Call the {@link BufferedWriter#flush()} method to flush buffered output to the process.
      *
      * <p>If the standard input of the process has been redirected using
      * {@link ProcessBuilder#redirectInput(Redirect)
@@ -310,17 +307,20 @@ public abstract class Process {
      * <a href="ProcessBuilder.html#redirect-input">null output writer</a>.
      *
      * @apiNote
+     * A {@linkplain BufferedWriter} writes characters, arrays of characters, and strings.
+     * Wrapping the {@link BufferedWriter} with a {@link PrintWriter} provides
+     * efficient buffering and formatting of primitives and objects as well as support
+     * for auto-flush on line endings.
+     * <p>
      * Use {@link #getOutputStream} and {@link #outputWriter} with extreme care.
-     * Output to the PrintWriter may be held in the buffer until
-     * {@linkplain PrintWriter#flush flush} is called.
+     * Output to the BufferedWriter may be held in the buffer until
+     * {@linkplain BufferedWriter#flush flush} is called.
      *
-     * @param autoFlush if {@code true} the {@code println}, {@code printf}, or {@code format}
-     *                  methods will flush the output buffer
-     * @param charset the {@code Charset} to convert characters to bytes
-     * @return a PrintWriter to the standard input of the process using the {@code charset}
+     * @param charset the {@code Charset} to encode characters to bytes
+     * @return a BufferedWriter to the standard input of the process using the {@code charset}
      */
-    public PrintWriter outputWriter(boolean autoFlush, Charset charset) {
-        return new PrintWriter(getOutputStream(), autoFlush, charset);
+    public BufferedWriter outputWriter(Charset charset) {
+        return new BufferedWriter(new OutputStreamWriter(getOutputStream(), charset));
     }
 
     /**
@@ -769,8 +769,6 @@ public abstract class Process {
 
         /**
          * {@return Charset for the native encoding or {@link Charset#defaultCharset()}
-         *
-         * @return the Charset for the native encoding or {@link Charset#defaultCharset()}
          */
         static Charset nativeCharset() {
             return nativeCharset;

--- a/src/java.base/share/classes/java/lang/Process.java
+++ b/src/java.base/share/classes/java/lang/Process.java
@@ -62,7 +62,7 @@ import java.util.stream.Stream;
  * {@link #getInputStream()}, and
  * {@link #getErrorStream()}.
  * The I/O streams of characters and lines can be written and read using the methods
- * {@link #outputWriter(boolean)}, {@link #outputWriter(boolean, Charset)}},
+ * {@link #outputWriter()}, {@link #outputWriter(Charset)}},
  * {@link #inputReader()}, {@link #inputReader(Charset)},
  * {@link #errorReader()}, and {@link #errorReader(Charset)}.
  * The parent process uses these streams to feed input to and get output
@@ -170,38 +170,51 @@ public abstract class Process {
     public abstract InputStream getErrorStream();
 
     /**
-     * Returns a {@link BufferedReader BufferedReader} connected to the standard output of the process.
-     * The {@code BufferedReader} can be used to read characters, lines, or stream lines of the standard output.
-     * The reader decodes the standard output of this process using the
-     * {@link Charset} named by the {@systemProperty native.encoding} system property.
-     * If the {@code Charset} is not supported, the {@link Charset#defaultCharset()} is used.
+     * Returns a {@link BufferedReader BufferedReader} connected to the standard
+     * output of the process. The {@link Charset} for the native encoding is used
+     * to read characters, lines, or stream lines from standard output.
      *
-     * @return a {@link BufferedReader BufferedReader} using the {@code native.encoding} if supported,
-     *          otherwise, the {@link Charset#defaultCharset()}
+     * <p>This method delegates to {@link #inputReader(Charset)} using the
+     * {@link Charset} named by the {@systemProperty native.encoding}
+     * system property or the {@link Charset#defaultCharset()} if the
+     * {@code native.encoding} is not supported.
+     *
+     * @return a {@link BufferedReader BufferedReader} using the
+     *          {@code native.encoding} if supported, otherwise, the
+     *          {@link Charset#defaultCharset()}
+     * @since 17
      */
     public BufferedReader inputReader() {
-        return new BufferedReader(new InputStreamReader(getInputStream(), CharsetHolder.nativeCharset()));
+        return inputReader(CharsetHolder.nativeCharset());
     }
 
     /**
-     * Returns a {@link BufferedReader BufferedReader} connected to the standard output
-     * of the process using a Charset.
-     * The {@code BufferedReader} can be used to read characters, lines, or stream lines of the standard output.
-     * The reader decodes the standard output of this process using the {@code charset}.
+     * Returns a {@link BufferedReader BufferedReader} connected to the
+     * standard output of this process using a Charset.
+     * The {@code BufferedReader} can be used to read characters, lines,
+     * or stream lines of the standard output.
+     *
+     * <p>Characters are read by an InputStreamReader that reads and decodes bytes
+     * from this process {@link #getInputStream()}. Bytes are decoded to characters
+     * using the {@code charset}; malformed-input and unmappable-character
+     * sequences are replaced with the charset's default replacement.
+     * The BufferedReader reads and buffers characters from the InputStreamReader.
      *
      * <p>If the standard output of the process has been redirected using
      * {@link ProcessBuilder#redirectOutput(Redirect) ProcessBuilder.redirectOutput}
-     * then this method will return a
-     * <a href="ProcessBuilder.html#redirect-output">null input reader</a>.
+     * then the {@code InputStreamReader} will be reading from a
+     * <a href="ProcessBuilder.html#redirect-output">null input stream</a>.
      *
      * <p>Otherwise, if the standard error of the process has been redirected using
-     * {@link ProcessBuilder#redirectErrorStream(boolean) ProcessBuilder.redirectErrorStream}
-     * then the input stream returned by this method will receive the
-     * merged standard output and the standard error of the process.
+     * {@link ProcessBuilder#redirectErrorStream(boolean)
+     * ProcessBuilder.redirectErrorStream} then the input reader returned by
+     * this method will receive the merged standard output and the standard error
+     * of the process.
      *
      * @apiNote
-     * Using both {@link #getInputStream} and {@link #inputReader} has unpredictable behavior
-     * since the buffered reader reads ahead from the input stream.
+     * Using both {@link #getInputStream} and {@link #inputReader} has
+     * unpredictable behavior since the buffered reader reads ahead from the
+     * input stream.
      *
      * @implNote
      * This is equivalent to:
@@ -209,41 +222,56 @@ public abstract class Process {
      *     return new BufferedReader(new InputStreamReader(getInputStream(), charset));
      * }
      *
-     * @param charset the {@code Charset} used to convert bytes to characters, not null
+     * @param charset the {@code Charset} used to decode bytes to characters, not null
      * @return a BufferedReader for the standard output of the process using the {@code charset}
+     * @throws NullPointerException if the {@code charset} is {@code null}
+     * @since 17
      */
     public BufferedReader inputReader(Charset charset) {
         return new BufferedReader(new InputStreamReader(getInputStream(), charset));
     }
 
     /**
-     * Returns a {@link BufferedReader BufferedReader} connected to the standard error of the process.
-     * The {@code BufferedReader} can be used to read characters, lines, or stream lines of the error output.
-     * The reader decodes the standard error of this process using the
-     * {@link Charset} named by the {@systemProperty native.encoding} system property.
-     * If the {@code Charset} is not supported, the {@link Charset#defaultCharset()} is used.
+     * Returns a {@link BufferedReader BufferedReader} connected to the standard
+     * error of the process. The {@link Charset} for the native encoding is used
+     * to read characters, lines, or stream lines from standard error.
      *
-     * @return a {@link BufferedReader BufferedReader} using the {@code native.encoding} if supported,
-     *          otherwise, the {@link Charset#defaultCharset()}
+     * <p>This method delegates to {@link #errorReader(Charset)} using the
+     * {@link Charset} named by the {@systemProperty native.encoding}
+     * system property or the {@link Charset#defaultCharset()} if the
+     * {@code native.encoding} is not supported.
+     *
+     * @return a {@link BufferedReader BufferedReader} using the
+     *          {@code native.encoding} if supported, otherwise, the
+     *          {@link Charset#defaultCharset()}
+     * @since 17
      */
     public BufferedReader errorReader() {
-        return new BufferedReader(new InputStreamReader(getErrorStream(), CharsetHolder.nativeCharset()));
+        return errorReader(CharsetHolder.nativeCharset());
     }
 
     /**
-     * Returns a {@link BufferedReader BufferedReader} connected to the standard error of the process using a Charset.
-     * The {@code BufferedReader} can be used to read characters, lines, or stream lines of the error output.
-     * The reader decodes the standard error of this process using the {@code charset}.
+     * Returns a {@link BufferedReader BufferedReader} connected to the
+     * standard error of this process using a Charset.
+     * The {@code BufferedReader} can be used to read characters, lines,
+     * or stream lines of the standard error.
+     *
+     * <p>Characters are read by an InputStreamReader that reads and decodes bytes
+     * from this process {@link #getErrorStream()}. Bytes are decoded to characters
+     * using the {@code charset}; malformed-input and unmappable-character
+     * sequences are replaced with the charset's default replacement.
+     * The BufferedReader reads and buffers characters from the InputStreamReader.
      *
      * <p>If the standard error of the process has been redirected using
      * {@link ProcessBuilder#redirectError(Redirect) ProcessBuilder.redirectError} or
      * {@link ProcessBuilder#redirectErrorStream(boolean) ProcessBuilder.redirectErrorStream}
-     * then this method will return a
-     * <a href="ProcessBuilder.html#redirect-output">null input reader</a>.
+     * then the {@code InputStreamReader} will be reading from a
+     * <a href="ProcessBuilder.html#redirect-output">null input stream</a>.
      *
      * @apiNote
-     * Using both {@link #getErrorStream} and {@link #errorReader} has unpredictable behavior
-     * since the buffered reader reads ahead from the input stream.
+     * Using both {@link #getErrorStream} and {@link #errorReader} has
+     * unpredictable behavior since the buffered reader reads ahead from the
+     * error stream.
      *
      * @implNote
      * This is equivalent to:
@@ -251,8 +279,10 @@ public abstract class Process {
      *     return new BufferedReader(new InputStreamReader(getErrorStream(), charset));
      * }
      *
-     * @param charset the {@code Charset} used to convert bytes to characters, not null
+     * @param charset the {@code Charset} used to decode bytes to characters, not null
      * @return a BufferedReader for the standard error of the process using the {@code charset}
+     * @throws NullPointerException if the {@code charset} is {@code null}
+     * @since 17
      */
     public BufferedReader errorReader(Charset charset) {
         return new BufferedReader(new InputStreamReader(getErrorStream(), charset));
@@ -286,6 +316,7 @@ public abstract class Process {
      *
      * @return a BufferedWriter to the standard input of the process using the charset
      *          for the {@code native.encoding} system property
+     * @since 17
      */
     public BufferedWriter outputWriter() {
         return outputWriter(CharsetHolder.nativeCharset());
@@ -316,8 +347,10 @@ public abstract class Process {
      * Output to the BufferedWriter may be held in the buffer until
      * {@linkplain BufferedWriter#flush flush} is called.
      *
-     * @param charset the {@code Charset} to encode characters to bytes
+     * @param charset the {@code Charset} to encode characters to bytes, not null
      * @return a BufferedWriter to the standard input of the process using the {@code charset}
+     * @throws NullPointerException if the {@code charset} is {@code null}
+     * @since 17
      */
     public BufferedWriter outputWriter(Charset charset) {
         return new BufferedWriter(new OutputStreamWriter(getOutputStream(), charset));

--- a/src/java.base/share/classes/java/lang/Process.java
+++ b/src/java.base/share/classes/java/lang/Process.java
@@ -395,7 +395,7 @@ public abstract class Process {
      * @param charset the {@code Charset} to encode characters to bytes
      * @return a {@code BufferedWriter} to the standard input of the process using the {@code charset}
      * @throws NullPointerException if the {@code charset} is {@code null}
-     * @throws IllegalArgumentException if called more than once with different charset arguments
+     * @throws IllegalStateException if called more than once with different charset arguments
      * @since 17
      */
     public final BufferedWriter outputWriter(Charset charset) {
@@ -406,7 +406,7 @@ public abstract class Process {
                 outputWriter = new BufferedWriter(new OutputStreamWriter(getOutputStream(), charset));
             } else {
                 if (!outputCharset.equals(charset))
-                    throw new IllegalArgumentException("BufferedWriter was created with charset: " + outputCharset);
+                    throw new IllegalStateException("BufferedWriter was created with charset: " + outputCharset);
             }
             return outputWriter;
         }

--- a/test/jdk/java/io/Serializable/serialFilter/SerialFilterTest.java
+++ b/test/jdk/java/io/Serializable/serialFilter/SerialFilterTest.java
@@ -52,8 +52,8 @@ import org.testng.annotations.DataProvider;
 /* @test
  * @bug 8234836
  * @build SerialFilterTest
- * @run testng/othervm  -Djdk.serialFilterTrace SerialFilterTest
- * @run testng/othervm  -Djdk.serialSetFilterAfterRead=true -Djdk.serialFilterTrace SerialFilterTest
+ * @run testng/othervm  SerialFilterTest
+ * @run testng/othervm  -Djdk.serialSetFilterAfterRead=true SerialFilterTest
  *
  * @summary Test ObjectInputFilters
  */

--- a/test/jdk/java/io/Serializable/serialFilter/SerialFilterTest.java
+++ b/test/jdk/java/io/Serializable/serialFilter/SerialFilterTest.java
@@ -52,8 +52,8 @@ import org.testng.annotations.DataProvider;
 /* @test
  * @bug 8234836
  * @build SerialFilterTest
- * @run testng/othervm  SerialFilterTest
- * @run testng/othervm  -Djdk.serialSetFilterAfterRead=true SerialFilterTest
+ * @run testng/othervm  -Djdk.serialFilterTrace SerialFilterTest
+ * @run testng/othervm  -Djdk.serialSetFilterAfterRead=true -Djdk.serialFilterTrace SerialFilterTest
  *
  * @summary Test ObjectInputFilters
  */

--- a/test/jdk/java/lang/ProcessBuilder/ReaderWriterTest.java
+++ b/test/jdk/java/lang/ProcessBuilder/ReaderWriterTest.java
@@ -271,8 +271,8 @@ public class ReaderWriterTest {
             var writer = p.outputWriter(cs);
             writer = p.outputWriter(cs);        // try again with same
             writer = p.outputWriter(otherCharset);  // this should throw
-            Assert.fail("Process.outputWriter(otherCharset) did not throw IllegalArgumentException");
-        } catch (IllegalArgumentException ile) {
+            Assert.fail("Process.outputWriter(otherCharset) did not throw IllegalStateException");
+        } catch (IllegalStateException ile) {
             // expected, ignore
             System.out.println(ile);
         }
@@ -280,8 +280,8 @@ public class ReaderWriterTest {
             var reader = p.inputReader(cs);
             reader = p.inputReader(cs);             // try again with same
             reader = p.inputReader(otherCharset);   // this should throw
-            Assert.fail("Process.inputReader(otherCharset) did not throw IllegalArgumentException");
-        } catch (IllegalArgumentException ile) {
+            Assert.fail("Process.inputReader(otherCharset) did not throw IllegalStateException");
+        } catch (IllegalStateException ile) {
             // expected, ignore
             System.out.println(ile);
         }
@@ -289,8 +289,8 @@ public class ReaderWriterTest {
             var reader = p.errorReader(cs);
             reader = p.errorReader(cs);             // try again with same
             reader = p.errorReader(otherCharset);   // this should throw
-            Assert.fail("Process.errorReader(otherCharset) did not throw IllegalArgumentException");
-        } catch (IllegalArgumentException ile) {
+            Assert.fail("Process.errorReader(otherCharset) did not throw IllegalStateException");
+        } catch (IllegalStateException ile) {
             // expected, ignore
             System.out.println(ile);
         }

--- a/test/jdk/java/lang/ProcessBuilder/ReaderWriterTest.java
+++ b/test/jdk/java/lang/ProcessBuilder/ReaderWriterTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import static org.testng.Assert.*;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import jdk.test.lib.process.ProcessTools;
+
+import jdk.test.lib.hexdump.HexPrinter;
+import jdk.test.lib.hexdump.HexPrinter.Formatters;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Locale;
+
+/*
+ * @test
+ * @library /test/lib
+ * @build jdk.test.lib.process.ProcessTools jdk.test.lib.hexdump.HexPrinter
+ * @run testng ReaderWriterTest
+ */
+
+@Test
+public class ReaderWriterTest {
+
+    static final String ASCII = "ASCII: \u0000_A-Z_a-Z_\u007C_\u007D_\u007E_\u007F_;";
+    static final String ISO_8859_1 = " Symbols: \u00AB_\u00BB_\u00fc_\u00fd_\u00fe_\u00ff;";
+    static final String FRACTIONS = " Fractions: \u00bc_\u00bd_\u00be_\u00bf;";
+
+    public static final String TESTCHARS = "OneWay: " + ASCII + ISO_8859_1 + FRACTIONS;
+    public static final String ROUND_TRIP_TESTCHARS = "RoundTrip: " + ASCII + ISO_8859_1 + FRACTIONS;
+
+    @DataProvider(name="CharsetCases")
+    static Object[][] charsetCases() {
+        return new Object[][] {
+                {"UTF-8"},
+                {"ISO8859-1"},
+                {"US-ASCII"},
+        };
+    }
+
+    /**
+     * Test the defaults case of native.encoding.  No extra command line flags or switches.
+     */
+    @Test
+    void testCaseNativeEncoding() throws IOException {
+        String nativeEncoding = System.getProperty("native.encoding");
+        Charset cs = Charset.forName(nativeEncoding);
+        System.out.println("Native.encoding Charset: " + cs);
+
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("ReaderWriterTest$ChildWithCharset");
+        Process p = pb.start();
+        writeTestChars(p.outputWriter(true));
+        checkReader(p.inputReader(), cs, "Out");
+        checkReader(p.errorReader(), cs, "Err");
+        try {
+            int exitValue = p.waitFor();
+            if (exitValue != 0)
+                System.out.println("exitValue: " + exitValue);
+        } catch (InterruptedException ie) {
+            Assert.fail("waitFor interrupted");
+        }
+    }
+
+    /**
+     * Write the test characters to the child using the Process.outputWriter.
+     * @param writer the Writer
+     * @throws IOException if an I/O error occurs
+     */
+    private static void writeTestChars(Writer writer) throws IOException {
+        // Write the test data to the child
+        try (writer) {
+            writer.append(ROUND_TRIP_TESTCHARS);
+            writer.append(System.lineSeparator());
+        }
+    }
+
+    /**
+     *
+     * @param nativeEncoding
+     */
+    @Test(dataProvider = "CharsetCases", enabled = true)
+    void testCase(String nativeEncoding) throws IOException {
+        String osName = System.getProperty("os.name").toLowerCase(Locale.ROOT);
+
+        Charset cs = Charset.forName(nativeEncoding);
+        System.out.println("Charset: " + cs);
+        String cleanCSName = cleanCharsetName(cs);
+
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-Dsun.stdout.encoding=" + cleanCSName,     // Encode in the child using the charset
+                "-Dsun.stderr.encoding=" + cleanCSName,
+                "ReaderWriterTest$ChildWithCharset");
+        var env = pb.environment();
+        env.put("LANG", "en_US." + cleanCSName);
+
+        Process p = pb.start();
+        // Write the test data to the child
+        writeTestChars(p.outputWriter(true, cs));
+        checkReader(p.inputReader(cs), cs, "Out");
+        checkReader(p.errorReader(cs), cs, "Err");
+        try {
+            int exitValue = p.waitFor();
+            if (exitValue != 0)
+                System.out.println("exitValue: " + exitValue);
+        } catch (InterruptedException ie) {
+
+        }
+    }
+
+    private static void checkReader(BufferedReader reader, Charset cs, String label) throws IOException {
+        try (BufferedReader in = reader) {
+            String prefix = "    " + label + ": ";
+            String firstline = in.readLine();
+            System.out.append(prefix).println(firstline);
+            String secondline = in.readLine();
+            System.out.append(prefix).println(secondline);
+            for (String line = in.readLine(); line != null; line = in.readLine()) {
+                System.out.append(prefix).append(line);
+                System.out.println();
+            }
+            ByteBuffer bb = cs.encode(TESTCHARS);
+            String reencoded = cs.decode(bb).toString();
+            if (!firstline.equals(reencoded))
+                diffStrings(firstline, reencoded);
+            assertEquals(firstline, reencoded, label + " Test Chars");
+
+            bb = cs.encode(ROUND_TRIP_TESTCHARS);
+            reencoded = cs.decode(bb).toString();
+            if (!secondline.equals(reencoded))
+                diffStrings(secondline, reencoded);
+            assertEquals(secondline, reencoded, label + " Round Trip Test Chars");
+        }
+    }
+
+    /**
+     * A cleaned up Charset name that is suitable for Linux LANG environment variable.
+     * If there are two '-'s the first one is removed.
+     * @param cs a Charset
+     * @return the cleanedup Charset name
+     */
+    private static String cleanCharsetName(Charset cs) {
+        String name = cs.name();
+        int ndx = name.indexOf('-');
+        if (ndx >= 0 && name.indexOf('-', ndx + 1) >= 0) {
+            name = name.substring(0, ndx) + name.substring(ndx + 1);
+        }
+        return name;
+    }
+
+    private static void diffStrings(String actual, String expected) {
+        if (actual.equals(expected))
+            return;
+        int lenDiff = expected.length() - actual.length();
+        if (lenDiff != 0)
+            System.out.println("String lengths:  " + actual.length() + " != " + expected.length());
+        int first;  // find first mismatched character
+        for (first = 0; first < Math.min(actual.length(), expected.length()); first++) {
+            if (actual.charAt(first) != expected.charAt(first))
+                break;
+        }
+        int last;
+        for (last = actual.length() - 1; last >= 0 && (last + lenDiff) >= 0; last--) {
+            if (actual.charAt(last) != expected.charAt(last + lenDiff))
+                break;      // last mismatched character
+        }
+        System.out.printf("actual vs expected[%3d]: 0x%04x != 0x%04x%n", first, (int)actual.charAt(first), (int)expected.charAt(first));
+        System.out.printf("actual vs expected[%3d]: 0x%04x != 0x%04x%n", last, (int)actual.charAt(last), (int)expected.charAt(last));
+        System.out.printf("actual  [%3d-%3d]: %s%n", first, last, actual.substring(first, last+1));
+        System.out.printf("expected[%3d-%3d]: %s%n", first, last, expected.substring(first, last + lenDiff + 1));
+    }
+
+    static class ChildWithCharset {
+        public static void main(String[] args) {
+            String nativeEncoding = System.getProperty("native.encoding");
+            System.out.println(TESTCHARS);
+            byte[] bytes = null;
+            try {
+                bytes = System.in.readAllBytes();
+                System.out.write(bytes);    // echo bytes back to parent on stdout
+            } catch (IOException ioe) {
+                ioe.printStackTrace();      // Seen by the parent
+            }
+            System.out.println("native.encoding: " + nativeEncoding);
+            System.out.println("sun.stdout.encoding: " + System.getProperty("sun.stdout.encoding"));
+            System.out.println("LANG: " + System.getenv().get("LANG"));
+
+            System.err.println(TESTCHARS);
+            try {
+                System.err.write(bytes);    // echo bytes back to parent on stderr
+            } catch (IOException ioe) {
+                ioe.printStackTrace();      // Seen by the parent
+            }
+            System.err.println("native.encoding: " + nativeEncoding);
+            System.err.println("sun.stderr.encoding: " + System.getProperty("sun.stderr.encoding"));
+        }
+    }
+}


### PR DESCRIPTION
Methods are added to java.lang.Process to read and write characters and lines from and to a spawned Process.
The Charset used to encode and decode characters to bytes can be specified or use the
operating system native encoding as is available from the "native.encoding" system property.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8191441](https://bugs.openjdk.java.net/browse/JDK-8191441): (Process) add Readers and Writer access to java.lang.Process streams


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4134/head:pull/4134` \
`$ git checkout pull/4134`

Update a local copy of the PR: \
`$ git checkout pull/4134` \
`$ git pull https://git.openjdk.java.net/jdk pull/4134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4134`

View PR using the GUI difftool: \
`$ git pr show -t 4134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4134.diff">https://git.openjdk.java.net/jdk/pull/4134.diff</a>

</details>
