### PR TITLE
8256304: should MonitorUsedDeflationThreshold be experimental or diagnostic

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -711,7 +711,7 @@ const intx ObjectAlignmentInBytes = 8;
           "at one time (minimum is 1024).")                      \
           range(1024, max_jint)                                             \
                                                                             \
-  product(intx, MonitorUsedDeflationThreshold, 90, EXPERIMENTAL,            \
+  product(intx, MonitorUsedDeflationThreshold, 90, DIAGNOSTIC,              \
           "Percentage of used monitors before triggering deflation (0 is "  \
           "off). The check is performed on GuaranteedSafepointInterval "    \
           "or AsyncDeflationInterval.")                                     \

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -519,7 +519,7 @@ int ObjectMonitor::TryLock(JavaThread* current) {
 // Contending threads that see that condition know to retry their operation.
 //
 bool ObjectMonitor::deflate_monitor() {
-  if (is_busy() != 0) {
+  if (is_busy()) {
     // Easy checks are first - the ObjectMonitor is busy so no deflation.
     return false;
   }

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -236,7 +236,7 @@ class ObjectMonitor : public CHeapObj<mtInternal> {
   volatile markWord* header_addr();
   void               set_header(markWord hdr);
 
-  intptr_t is_busy() const {
+  bool is_busy() const {
     // TODO-FIXME: assert _owner == null implies _recursions = 0
     intptr_t ret_code = _waiters | intptr_t(_cxq) | intptr_t(_EntryList);
     if (contentions() > 0) {
@@ -245,7 +245,7 @@ class ObjectMonitor : public CHeapObj<mtInternal> {
     if (!owner_is_DEFLATER_MARKER()) {
       ret_code |= intptr_t(owner_raw());
     }
-    return ret_code;
+    return ret_code != 0;
   }
   const char* is_busy_to_string(stringStream* ss);
 

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1771,9 +1771,9 @@ void ObjectSynchronizer::log_in_use_monitor_details(outputStream* out) {
       const markWord mark = mid->header();
       ResourceMark rm;
       out->print(INTPTR_FORMAT "  %d%d%d  " INTPTR_FORMAT "  %s", p2i(mid),
-                 mid->is_busy() != 0, mark.hash() != 0, mid->owner() != NULL,
+                 mid->is_busy(), mark.hash() != 0, mid->owner() != NULL,
                  p2i(obj), obj == NULL ? "" : obj->klass()->external_name());
-      if (mid->is_busy() != 0) {
+      if (mid->is_busy()) {
         out->print(" (%s)", mid->is_busy_to_string(&ss));
         ss.reset();
       }


### PR DESCRIPTION
A pair of trivial fixes for a couple of ObjectMonitor cleanups.

Tested with Mach5 Tier[1-3].

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8256304](https://bugs.openjdk.java.net/browse/JDK-8256304): should MonitorUsedDeflationThreshold be experimental or diagnostic
 * [JDK-8256301](https://bugs.openjdk.java.net/browse/JDK-8256301): ObjectMonitor::is_busy() should return bool


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Patricio Chilano Mateo](https://openjdk.java.net/census#pchilanomate) (@pchilano - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4137/head:pull/4137` \
`$ git checkout pull/4137`

Update a local copy of the PR: \
`$ git checkout pull/4137` \
`$ git pull https://git.openjdk.java.net/jdk pull/4137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4137`

View PR using the GUI difftool: \
`$ git pr show -t 4137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4137.diff">https://git.openjdk.java.net/jdk/pull/4137.diff</a>

</details>
