### PR TITLE
8267403: tools/jpackage/share/FileAssociationsTest.java#id0 failed with "Error: Bundler "Mac PKG Package" (pkg) failed to produce a package"

### DIFF
--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacPkgBundler.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacPkgBundler.java
@@ -451,7 +451,7 @@ public class MacPkgBundler extends MacBaseInstallerBundler {
                     "--analyze",
                     cpl.toAbsolutePath().toString());
 
-            IOUtils.exec(pb);
+            IOUtils.exec(pb, false, null, true, Executor.INFINITE_TIMEOUT);
 
             patchCPLFile(cpl);
 
@@ -467,7 +467,7 @@ public class MacPkgBundler extends MacBaseInstallerBundler {
                         "--identifier",
                          MAC_CF_BUNDLE_IDENTIFIER.fetchFrom(params),
                         appPKG.toAbsolutePath().toString());
-                IOUtils.exec(pb);
+                IOUtils.exec(pb, false, null, true, Executor.INFINITE_TIMEOUT);
             } else {
                 preparePackageScripts(params);
                 pb = new ProcessBuilder("/usr/bin/pkgbuild",
@@ -483,7 +483,7 @@ public class MacPkgBundler extends MacBaseInstallerBundler {
                         "--identifier",
                          MAC_CF_BUNDLE_IDENTIFIER.fetchFrom(params),
                         appPKG.toAbsolutePath().toString());
-                IOUtils.exec(pb);
+                IOUtils.exec(pb, false, null, true, Executor.INFINITE_TIMEOUT);
             }
 
             // build final package
@@ -541,7 +541,7 @@ public class MacPkgBundler extends MacBaseInstallerBundler {
             commandLine.add(finalPKG.toAbsolutePath().toString());
 
             pb = new ProcessBuilder(commandLine);
-            IOUtils.exec(pb);
+            IOUtils.exec(pb, false, null, true, Executor.INFINITE_TIMEOUT);
 
             return finalPKG;
         } catch (Exception ignored) {

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Executor.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Executor.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public final class Executor {
@@ -182,7 +181,7 @@ public final class Executor {
                 code = p.waitFor();
             }
             if (!quietCommand) {
-                Log.verbose(pb.command(), getOutput(), code);
+                Log.verbose(pb.command(), getOutput(), code, IOUtils.getPID(p));
             }
             return code;
         } catch (InterruptedException ex) {

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/IOUtils.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/IOUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -243,7 +243,7 @@ public class IOUtils {
         t.start();
 
         int ret = p.waitFor();
-        Log.verbose(pb.command(), list, ret);
+        Log.verbose(pb.command(), list, ret, IOUtils.getPID(p));
 
         result.clear();
         result.addAll(list);
@@ -333,6 +333,17 @@ public class IOUtils {
             throw iae;
         }
         return filename;
+    }
+
+    public static long getPID(Process p) {
+        try {
+            return p.pid();
+        } catch (UnsupportedOperationException ex) {
+            Log.verbose(ex); // Just log exception and ignore it. This method
+                             // is used for verbose output, so not a problem
+                             // if unsupported.
+            return -1;
+        }
     }
 
     private static class PrettyPrintHandler implements InvocationHandler {

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/JLinkBundlerHelper.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/JLinkBundlerHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -192,7 +192,7 @@ final class JLinkBundlerHelper {
         String jlinkOut = writer.toString();
 
         args.add(0, "jlink");
-        Log.verbose(args, List.of(jlinkOut), retVal);
+        Log.verbose(args, List.of(jlinkOut), retVal, -1);
 
 
         if (retVal != 0) {

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Log.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Log.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,9 +106,13 @@ public class Log {
         }
 
         public void verbose(List<String> strings,
-                List<String> output, int returnCode) {
+                List<String> output, int returnCode, long pid) {
             if (verbose) {
-                StringBuffer sb = new StringBuffer("Command:\n   ");
+                StringBuffer sb = new StringBuffer();
+                sb.append("Command [PID: ");
+                sb.append(pid);
+                sb.append("]:\n   ");
+
                 for (String s : strings) {
                     sb.append(" " + s);
                 }
@@ -174,7 +178,8 @@ public class Log {
        instance.get().verbose(t);
     }
 
-    public static void verbose(List<String> strings, List<String> out, int ret) {
-       instance.get().verbose(strings, out, ret);
+    public static void verbose(List<String> strings, List<String> out,
+            int ret, long pid) {
+       instance.get().verbose(strings, out, ret, pid);
     }
 }


### PR DESCRIPTION
Looks like another issue similar to hdiutil (JDK-8249395) when process is gone, but we still waiting for it. I was not able to reproduce this issue by running test or pkgbuild separately and conclusion was made based on logs. Fixed in same way as hdiutil issue. Also, I added logging PID for external commands to simplify log analysis. Log will have multiple hdiutil and/or pkgbuild processes, since we running multiple tests in parallel and matching external process to test failure requires looking at command line for particular process, so PID should simplify this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267403](https://bugs.openjdk.java.net/browse/JDK-8267403): tools/jpackage/share/FileAssociationsTest.java#id0 failed with "Error: Bundler "Mac PKG Package" (pkg) failed to produce a package"


### Reviewers
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4139/head:pull/4139` \
`$ git checkout pull/4139`

Update a local copy of the PR: \
`$ git checkout pull/4139` \
`$ git pull https://git.openjdk.java.net/jdk pull/4139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4139`

View PR using the GUI difftool: \
`$ git pr show -t 4139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4139.diff">https://git.openjdk.java.net/jdk/pull/4139.diff</a>

</details>
