### PR TITLE
8267404: vmTestbase/vm/mlvm/anonloader/stress/oome/metaspace/Test.java failed with OutOfMemoryError

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -154,7 +154,6 @@ vmTestbase/vm/mlvm/meth/stress/jdi/breakpointInCompiledCode/Test.java 8257761 ge
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2none_a/TestDescription.java 8013267 generic-all
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manyDiff_b/TestDescription.java 8013267 generic-all
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manySame_b/TestDescription.java 8013267 generic-all
-vmTestbase/vm/mlvm/anonloader/stress/oome/metaspace/Test.java 8267404 linux-aarch64
 
 vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn001/forceEarlyReturn001.java 7199837 generic-all
 

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/anonloader/stress/oome/metaspace/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/anonloader/stress/oome/metaspace/Test.java
@@ -42,7 +42,7 @@ public class Test {
 
     public static void main(String[] args) throws Exception {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-            "-Xshare:off", "-XX:MaxMetaspaceSize=100k", "-version");
+            "-Xshare:off", "-XX:MaxMetaspaceSize=512k", "-version");
 
         OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
 

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/anonloader/stress/oome/metaspace/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/anonloader/stress/oome/metaspace/Test.java
@@ -24,69 +24,38 @@
 
 /*
  * @test
- * @modules java.base/jdk.internal.misc
  *
  * @summary converted from VM Testbase vm/mlvm/anonloader/stress/oome/metaspace.
  * VM Testbase keywords: [feature_mlvm, nonconcurrent]
  *
- * @library /vmTestbase
- *          /test/lib
+ * @library /test/lib
  *
- * @comment build test class and indify classes
- * @build vm.mlvm.anonloader.stress.oome.metaspace.Test
- * @run driver vm.mlvm.share.IndifiedClassesBuilder
- *
- * @run main/othervm -Xmx1g -XX:-UseGCOverheadLimit -XX:MetaspaceSize=10m -XX:MaxMetaspaceSize=20m vm.mlvm.anonloader.stress.oome.metaspace.Test
+ * @run driver vm.mlvm.anonloader.stress.oome.metaspace.Test
  */
 
 package vm.mlvm.anonloader.stress.oome.metaspace;
 
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodHandles.Lookup;
-import java.util.List;
-import java.io.IOException;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
-import vm.mlvm.anonloader.share.AnonkTestee01;
-import vm.mlvm.share.MlvmOOMTest;
-import vm.mlvm.share.MlvmTestExecutor;
-import vm.mlvm.share.Env;
-import vm.share.FileUtils;
+public class Test {
 
-/**
- * This test loads classes using defineHiddenClass and stores them,
- * expecting Metaspace OOME.
- *
- */
-public class Test extends MlvmOOMTest {
-    @Override
-    protected void checkOOME(OutOfMemoryError oome) {
-        String message = oome.getMessage();
-        if (!"Metaspace".equals(message) && !"Compressed class space".equals(message)) {
-            throw new RuntimeException("TEST FAIL : wrong OOME", oome);
+    public static void main(String[] args) throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            "-Xshare:off", "-XX:MaxMetaspaceSize=100k", "-version");
+
+        OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
+
+        analyzer.shouldNotHaveExitValue(0);
+
+        if (!analyzer.getStdout().contains("OutOfMemoryError")) {
+            throw new RuntimeException("TEST FAIL : no OOME");
+        }
+
+        if (!analyzer.getStdout().contains("Metaspace") &&
+            !analyzer.getStdout().contains("Compressed class space")) {
+            throw new RuntimeException("TEST FAIL : wrong OOME");
         }
     }
 
-    @Override
-    protected void eatMemory(List<Object> list) {
-        byte[] classBytes = null;
-        try {
-            classBytes = FileUtils.readClass(AnonkTestee01.class.getName());
-        } catch (IOException e) {
-            Env.throwAsUncheckedException(e);
-        }
-        try {
-            while (true) {
-                Lookup lookup = MethodHandles.lookup();
-                Lookup ank_lookup = MethodHandles.privateLookupIn(AnonkTestee01.class, lookup);
-                Class<?> c = ank_lookup.defineHiddenClass(classBytes, true).lookupClass();
-                list.add(c.newInstance());
-             }
-         } catch (InstantiationException | IllegalAccessException e) {
-             Env.throwAsUncheckedException(e);
-         }
-    }
-
-    public static void main(String[] args) {
-        MlvmTestExecutor.launch(args);
-    }
 }

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/anonloader/stress/oome/metaspace/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/anonloader/stress/oome/metaspace/Test.java
@@ -36,7 +36,7 @@
  * @build vm.mlvm.anonloader.stress.oome.metaspace.Test
  * @run driver vm.mlvm.share.IndifiedClassesBuilder
  *
- * @run main/othervm -Xmx256m -XX:-UseGCOverheadLimit -XX:MaxMetaspaceSize=8m vm.mlvm.anonloader.stress.oome.metaspace.Test
+ * @run main/othervm -Xmx1g -XX:-UseGCOverheadLimit -XX:MetaspaceSize=10m -XX:MaxMetaspaceSize=20m vm.mlvm.anonloader.stress.oome.metaspace.Test
  */
 
 package vm.mlvm.anonloader.stress.oome.metaspace;


### PR DESCRIPTION
Hi all,

vmTestbase/vm/mlvm/anonloader/stress/oome/metaspace/Test.java OOMEs on Oracle's aarch64 platforms.
The reason is that both -Xmx and -XX:MetaspaceSize are not enough.

From the original JBS decription of JDK-8267404, the VM OOMEs before the expected OOME in metaspace happened showing that -Xmx256m is not enough.

Then, @dcubed-ojdk helped me test with -Xmx512, which still OOMEs.
However, the expected OOME in metaspace was caught this time.
But a second uncaught OOME in metaspace happened soon, which means -XX:MetaspaceSize=8m is not enough.

So both -Xmx and -XX:MetaspaceSize should be increased.
The fix just:
  - Revert changes about mataspace size setting
  - Increase -Xmx from 256m to 1g

-Xmx512m may be OK on Oracle's aarch64 machines, but to make it safer, -Xmx1g is preferred.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267404](https://bugs.openjdk.java.net/browse/JDK-8267404): vmTestbase/vm/mlvm/anonloader/stress/oome/metaspace/Test.java failed with OutOfMemoryError


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to 877910769d15cdbc00e92e6d416b7638fe874713


### Contributors
 * xiangyuan `<xiangyuan@tencent.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4140/head:pull/4140` \
`$ git checkout pull/4140`

Update a local copy of the PR: \
`$ git checkout pull/4140` \
`$ git pull https://git.openjdk.java.net/jdk pull/4140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4140`

View PR using the GUI difftool: \
`$ git pr show -t 4140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4140.diff">https://git.openjdk.java.net/jdk/pull/4140.diff</a>

</details>
