### PR TITLE
8266421: Deadlock in Sound System

### DIFF
--- a/src/java.desktop/share/classes/com/sun/media/sound/AbstractDataLine.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/AbstractDataLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -295,13 +295,7 @@ abstract class AbstractDataLine extends AbstractLine implements DataLine {
         //boolean sendEvents = false;
         //long position = getLongFramePosition();
 
-        synchronized (this) {
-
-            if (this.active != active) {
-                this.active = active;
-                //sendEvents = true;
-            }
-        }
+        this.active = active;
 
         // $$kk: 11.19.99: take ACTIVE / INACTIVE / EOM events out;
         // putting them in is technically an API change.
@@ -324,12 +318,9 @@ abstract class AbstractDataLine extends AbstractLine implements DataLine {
         boolean sendEvents = false;
         long position = getLongFramePosition();
 
-        synchronized (this) {
-
-            if (this.started != started) {
-                this.started = started;
-                sendEvents = true;
-            }
+        if (this.started != started) {
+            this.started = started;
+            sendEvents = true;
         }
 
         if (sendEvents) {

--- a/src/java.desktop/share/classes/com/sun/media/sound/AbstractLine.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/AbstractLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -159,11 +159,9 @@ abstract class AbstractLine implements Line {
         boolean sendEvents = false;
         long position = getLongFramePosition();
 
-        synchronized (this) {
-            if (this.open != open) {
-                this.open = open;
-                sendEvents = true;
-            }
+        if (this.open != open) {
+            this.open = open;
+            sendEvents = true;
         }
 
         if (sendEvents) {

--- a/src/java.desktop/share/classes/com/sun/media/sound/DirectAudioDevice.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/DirectAudioDevice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1192,7 +1192,7 @@ final class DirectAudioDevice extends AbstractMixer {
         }
 
         @Override
-        public synchronized void setMicrosecondPosition(long microseconds) {
+        public void setMicrosecondPosition(long microseconds) {
             long frames = Toolkit.micros2frames(getFormat(), microseconds);
             setFramePosition((int) frames);
         }

--- a/test/jdk/javax/sound/sampled/Clip/SetPositionHang.java
+++ b/test/jdk/javax/sound/sampled/Clip/SetPositionHang.java
@@ -72,7 +72,7 @@ public final class SetPositionHang implements Runnable {
             t3.join();
             t4.join();
             t5.join();
-        } catch (LineUnavailableException | IllegalArgumentException e) {
+        } catch (LineUnavailableException | IllegalArgumentException ignored) {
             // the test is not applicable
         }
     }

--- a/test/jdk/javax/sound/sampled/Clip/SetPositionHang.java
+++ b/test/jdk/javax/sound/sampled/Clip/SetPositionHang.java
@@ -80,8 +80,8 @@ public final class SetPositionHang implements Runnable {
     public void run() {
         System.out.println("Thread " + thread + " Start");
         for (int i = 0; i < 100; i++) {
-            System.out.println("Thread " + thread + " Play "
-                                       + System.currentTimeMillis() % 100000);
+//            System.out.println("Thread " + thread + " Play " +
+//                               System.currentTimeMillis() % 100000);
             playSound();
             try {
                 Thread.sleep(i);
@@ -92,7 +92,7 @@ public final class SetPositionHang implements Runnable {
         System.out.println("Thread " + thread + " Finish");
     }
 
-    void playSound() {
+    private void playSound() {
         if (clip.isRunning()) {
             clip.stop();
         }

--- a/test/jdk/javax/sound/sampled/Clip/SetPositionHang.java
+++ b/test/jdk/javax/sound/sampled/Clip/SetPositionHang.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.Clip;
+import javax.sound.sampled.LineUnavailableException;
+
+/**
+ * @test
+ * @bug 8266421
+ * @summary Tests that Clip.setFramePosition/setMicrosecondPosition do not hang.
+ */
+public final class SetPositionHang implements Runnable {
+
+    private static volatile boolean testFramePosition;
+    private final Clip clip;
+    private final String thread;
+
+    private SetPositionHang(String thread, Clip clip) {
+        this.thread = thread;
+        this.clip = clip;
+    }
+
+    public static void main(String[] args) throws Exception {
+        testFramePosition = false;
+        test();
+        testFramePosition = true;
+        test();
+    }
+
+    private static void test() throws InterruptedException {
+        try (Clip clip = AudioSystem.getClip()) {
+            // prepare audio data
+            int frameCount = 441000; // lets say 10 seconds
+            AudioFormat format = new AudioFormat(44100.0f, 16, 2, true, false);
+            byte[] bytes = new byte[frameCount * format.getFrameSize()];
+
+            clip.open(format, bytes, 0, frameCount);
+            Thread t1 = new Thread(new SetPositionHang("1", clip));
+            Thread t2 = new Thread(new SetPositionHang("2", clip));
+            Thread t3 = new Thread(new SetPositionHang("3", clip));
+            Thread t4 = new Thread(new SetPositionHang("4", clip));
+            Thread t5 = new Thread(new SetPositionHang("5", clip));
+            t1.start();
+            t2.start();
+            t3.start();
+            t4.start();
+            t5.start();
+            t1.join();
+            t2.join();
+            t3.join();
+            t4.join();
+            t5.join();
+        } catch (LineUnavailableException | IllegalArgumentException e) {
+            // the test is not applicable
+        }
+    }
+
+    public void run() {
+        System.out.println("Thread " + thread + " Start");
+        for (int i = 0; i < 100; i++) {
+            System.out.println("Thread " + thread + " Play "
+                                       + System.currentTimeMillis() % 100000);
+            playSound();
+            try {
+                Thread.sleep(i);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        System.out.println("Thread " + thread + " Finish");
+    }
+
+    void playSound() {
+        if (clip.isRunning()) {
+            clip.stop();
+        }
+        if (testFramePosition) {
+            clip.setFramePosition(0);
+        } else {
+            clip.setMicrosecondPosition(0);
+        }
+        clip.start();
+    }
+}


### PR DESCRIPTION
In the fix for JDK-8207150 I have updated the synchronization of some code paths under one "lock", before that code was synchronized only on some threads and missing on others. Old review:
http://mail.openjdk.java.net/pipermail/sound-dev/2018-August/000650.html

That fix introduced this order of locks: "lock"->"synchronized(this)", I have checked other places and did not found where we use the opposite order. Unfortunately, one such place exists in the private subclass DirectClip.

I have checked both usages of synchronized which caused deadlock:
 - In the DirectClip class the method setMicrosecondPosition is marked as "synchronized" but it is unclear why. This method is implemented as a call to another public method setFramePosition which is not "synchronized" and use some internal synchronization. So I have removed this keyword.
 - In a few places we have the code like this:
```
        boolean sendEvents = false;
        synchronized (this) {
            if (this.started != started) {
                this.started = started;
                sendEvents = true;
            }
	}
        if (sendEvents) {.....
```
I doubt that this type of synchronization may help something - the fields are volatile and we use sendEvents flag after synchronisation block, so I removed it as well. Any thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266421](https://bugs.openjdk.java.net/browse/JDK-8266421): Deadlock in Sound System


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4141/head:pull/4141` \
`$ git checkout pull/4141`

Update a local copy of the PR: \
`$ git checkout pull/4141` \
`$ git pull https://git.openjdk.java.net/jdk pull/4141/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4141`

View PR using the GUI difftool: \
`$ git pr show -t 4141`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4141.diff">https://git.openjdk.java.net/jdk/pull/4141.diff</a>

</details>
