### PR TITLE
JDK-8266748: Move modifiers code to Signatures.java

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriterImpl.java
@@ -85,8 +85,6 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
                      "java.lang.constant.ConstantDesc",
                      "java.io.Serializable");
 
-    private static final Set<String> previewModifiers = Collections.emptySet();
-
     protected final TypeElement typeElement;
 
     protected final ClassTree classtree;
@@ -197,28 +195,9 @@ public class ClassWriterImpl extends SubWriterHolderWriter implements ClassWrite
     }
 
     @Override
-    public void addClassSignature(String modifiers, Content classInfoTree) {
-        ContentBuilder mods = new ContentBuilder();
-        String sep = null;
-        for (String modifiersPart : modifiers.split(" ")) {
-            if (sep != null) {
-                mods.add(sep);
-            }
-            if (previewModifiers.contains(modifiersPart)) {
-                mods.add(modifiersPart);
-                mods.add(HtmlTree.SUP(links.createLink(htmlIds.forPreviewSection(typeElement),
-                                                       contents.previewMark)));
-            } else {
-                mods.add(modifiersPart);
-            }
-            sep = " ";
-        }
-        if (modifiers.endsWith(" ")) {
-            mods.add(" ");
-        }
+    public void addClassSignature(Content classInfoTree) {
         classInfoTree.add(new HtmlTree(TagName.HR));
         classInfoTree.add(new Signatures.TypeSignature(typeElement, this)
-                .setModifiers(mods)
                 .toContent());
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Signatures.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Signatures.java
@@ -131,7 +131,7 @@ public class Signatures {
 
             HtmlTree nameSpan = new HtmlTree(TagName.SPAN).setStyle(HtmlStyle.elementName);
             Content className = Text.of(utils.getSimpleName(typeElement));
-            if (writer.options.linkSource()) {
+            if (configuration.getOptions().linkSource()) {
                 writer.addSrcLink(typeElement, className, nameSpan);
             } else {
                 nameSpan.addStyle(HtmlStyle.typeNameLabel).add(className);
@@ -207,7 +207,7 @@ public class Signatures {
                     permitsSpan.add(link);
                 }
                 if (linkablePermits.size() < permits.size()) {
-                    Content c = Text.of(writer.resources.getText("doclet.not.exhaustive"));
+                    Content c = Text.of(configuration.getDocResources().getText("doclet.not.exhaustive"));
                     permitsSpan.add(" ");
                     permitsSpan.add(HtmlTree.SPAN(HtmlStyle.permitsNote, c));
                 }
@@ -245,8 +245,8 @@ public class Signatures {
                  content.add(modifier);
                  if (previewModifiers.contains(modifier)) {
                      content.add(HtmlTree.SUP(writer.links.createLink(
-                             writer.htmlIds.forPreviewSection(typeElement),
-                             writer.contents.previewMark)));
+                             configuration.htmlIds.forPreviewSection(typeElement),
+                             configuration.contents.previewMark)));
                  }
                  sep = " ";
              }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Signatures.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Signatures.java
@@ -113,7 +113,7 @@ public class Signatures {
              this.writer = writer;
              this.utils = writer.utils;
              this.configuration = writer.configuration;
-             this.modifiers = markPreviewModifiers(getModifiers(typeElement));
+             this.modifiers = markPreviewModifiers(getModifiers());
          }
 
         public TypeSignature setModifiers(Content modifiers) {
@@ -254,8 +254,8 @@ public class Signatures {
              return content;
         }
 
-        private static List<String> getModifiers(Element e) {
-            SortedSet<Modifier> modifiers = new TreeSet<>(e.getModifiers());
+        private List<String> getModifiers() {
+            SortedSet<Modifier> modifiers = new TreeSet<>(typeElement.getModifiers());
             modifiers.remove(NATIVE);
             modifiers.remove(STRICTFP);
             modifiers.remove(SYNCHRONIZED);
@@ -338,7 +338,7 @@ public class Signatures {
                     return list;
                 }
 
-            }.visit(e, modifiers);
+            }.visit(typeElement, modifiers);
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Signatures.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Signatures.java
@@ -37,20 +37,29 @@ import jdk.javadoc.internal.doclets.toolkit.util.DocletConstants;
 import jdk.javadoc.internal.doclets.toolkit.util.Utils;
 
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.ModuleElement;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.RecordComponentElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementKindVisitor14;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import static javax.lang.model.element.Modifier.ABSTRACT;
+import static javax.lang.model.element.Modifier.FINAL;
 import static javax.lang.model.element.Modifier.NATIVE;
+import static javax.lang.model.element.Modifier.PRIVATE;
+import static javax.lang.model.element.Modifier.PROTECTED;
 import static javax.lang.model.element.Modifier.PUBLIC;
+import static javax.lang.model.element.Modifier.STATIC;
 import static javax.lang.model.element.Modifier.STRICTFP;
 import static javax.lang.model.element.Modifier.SYNCHRONIZED;
 
@@ -92,17 +101,20 @@ public class Signatures {
     static class TypeSignature {
 
         private final TypeElement typeElement;
-        private final ClassWriterImpl classWriter;
+        private final HtmlDocletWriter writer;
         private final Utils utils;
         private final HtmlConfiguration configuration;
         private Content modifiers;
 
-        TypeSignature(TypeElement typeElement, ClassWriterImpl classWriter) {
-            this.typeElement = typeElement;
-            this.classWriter = classWriter;
-            this.utils = classWriter.utils;
-            this.configuration = classWriter.configuration;
-        }
+        private static final Set<String> previewModifiers = Collections.emptySet();
+
+         TypeSignature(TypeElement typeElement, HtmlDocletWriter writer) {
+             this.typeElement = typeElement;
+             this.writer = writer;
+             this.utils = writer.utils;
+             this.configuration = writer.configuration;
+             this.modifiers = markPreviewModifiers(getModifiers(typeElement));
+         }
 
         public TypeSignature setModifiers(Content modifiers) {
             this.modifiers = modifiers;
@@ -111,7 +123,7 @@ public class Signatures {
 
         public Content toContent() {
             Content content = new ContentBuilder();
-            Content annotationInfo = classWriter.getAnnotationInfo(typeElement, true);
+            Content annotationInfo = writer.getAnnotationInfo(typeElement, true);
             if (!annotationInfo.isEmpty()) {
                 content.add(HtmlTree.SPAN(HtmlStyle.annotations, annotationInfo));
             }
@@ -119,8 +131,8 @@ public class Signatures {
 
             HtmlTree nameSpan = new HtmlTree(TagName.SPAN).setStyle(HtmlStyle.elementName);
             Content className = Text.of(utils.getSimpleName(typeElement));
-            if (classWriter.options.linkSource()) {
-                classWriter.addSrcLink(typeElement, className, nameSpan);
+            if (writer.options.linkSource()) {
+                writer.addSrcLink(typeElement, className, nameSpan);
             } else {
                 nameSpan.addStyle(HtmlStyle.typeNameLabel).add(className);
             }
@@ -128,7 +140,7 @@ public class Signatures {
                     HtmlLinkInfo.Kind.CLASS_SIGNATURE, typeElement);
             //Let's not link to ourselves in the signature.
             linkInfo.linkToSelf = false;
-            nameSpan.add(classWriter.getTypeParameterLinks(linkInfo));
+            nameSpan.add(writer.getTypeParameterLinks(linkInfo));
             content.add(nameSpan);
 
             if (utils.isRecord(typeElement)) {
@@ -142,7 +154,7 @@ public class Signatures {
                     if (superclass != null) {
                         content.add(DocletConstants.NL);
                         extendsImplements.add("extends ");
-                        Content link = classWriter.getLink(new HtmlLinkInfo(configuration,
+                        Content link = writer.getLink(new HtmlLinkInfo(configuration,
                                 HtmlLinkInfo.Kind.CLASS_SIGNATURE_PARENT_NAME,
                                 superclass));
                         extendsImplements.add(link);
@@ -163,7 +175,7 @@ public class Signatures {
                         } else {
                             extendsImplements.add(", ");
                         }
-                        Content link = classWriter.getLink(new HtmlLinkInfo(configuration,
+                        Content link = writer.getLink(new HtmlLinkInfo(configuration,
                                 HtmlLinkInfo.Kind.CLASS_SIGNATURE_PARENT_NAME,
                                 type));
                         extendsImplements.add(link);
@@ -189,13 +201,13 @@ public class Signatures {
                     } else {
                         permitsSpan.add(", ");
                     }
-                    Content link = classWriter.getLink(new HtmlLinkInfo(configuration,
+                    Content link = writer.getLink(new HtmlLinkInfo(configuration,
                             HtmlLinkInfo.Kind.PERMITTED_SUBCLASSES,
                             type));
                     permitsSpan.add(link);
                 }
                 if (linkablePermits.size() < permits.size()) {
-                    Content c = Text.of(classWriter.resources.getText("doclet.not.exhaustive"));
+                    Content c = Text.of(writer.resources.getText("doclet.not.exhaustive"));
                     permitsSpan.add(" ");
                     permitsSpan.add(HtmlTree.SPAN(HtmlStyle.permitsNote, c));
                 }
@@ -210,9 +222,9 @@ public class Signatures {
             String sep = "";
             for (RecordComponentElement e : typeElement.getRecordComponents()) {
                 content.add(sep);
-                classWriter.getAnnotations(e.getAnnotationMirrors(), false)
+                writer.getAnnotations(e.getAnnotationMirrors(), false)
                         .forEach(a -> { content.add(a).add(" "); });
-                Content link = classWriter.getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.RECORD_COMPONENT,
+                Content link = writer.getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.RECORD_COMPONENT,
                         e.asType()));
                 content.add(link);
                 content.add(Entity.NO_BREAK_SPACE);
@@ -221,6 +233,112 @@ public class Signatures {
             }
             content.add(")");
             return content;
+        }
+
+        private Content markPreviewModifiers(List<String> modifiers) {
+             Content content = new ContentBuilder();
+             String sep = null;
+             for (String modifier : modifiers) {
+                 if (sep != null) {
+                    content.add(sep);
+                 }
+                 content.add(modifier);
+                 if (previewModifiers.contains(modifier)) {
+                     content.add(HtmlTree.SUP(writer.links.createLink(
+                             writer.htmlIds.forPreviewSection(typeElement),
+                             writer.contents.previewMark)));
+                 }
+                 sep = " ";
+             }
+             content.add(" ");
+             return content;
+        }
+
+        private static List<String> getModifiers(Element e) {
+            SortedSet<Modifier> modifiers = new TreeSet<>(e.getModifiers());
+            modifiers.remove(NATIVE);
+            modifiers.remove(STRICTFP);
+            modifiers.remove(SYNCHRONIZED);
+
+            return new ElementKindVisitor14<List<String>, SortedSet<Modifier>>() {
+                final List<String> list = new ArrayList<>();
+
+                void addVisibilityModifier(Set<Modifier> modifiers) {
+                    if (modifiers.contains(PUBLIC)) {
+                        list.add("public");
+                    } else if (modifiers.contains(PROTECTED)) {
+                        list.add("protected");
+                    } else if (modifiers.contains(PRIVATE)) {
+                        list.add("private");
+                    }
+                }
+
+                void addStatic(Set<Modifier> modifiers) {
+                    if (modifiers.contains(STATIC)) {
+                        list.add("static");
+                    }
+                }
+
+                void addSealed(TypeElement e) {
+                    if (e.getModifiers().contains(Modifier.SEALED)) {
+                        list.add("sealed");
+                    } else if (e.getModifiers().contains(Modifier.NON_SEALED)) {
+                        list.add("non-sealed");
+                    }
+                }
+
+                void addModifiers(Set<Modifier> modifiers) {
+                    modifiers.stream()
+                            .map(Modifier::toString)
+                            .forEachOrdered(list::add);
+                }
+
+                @Override
+                public List<String> visitTypeAsInterface(TypeElement e, SortedSet<Modifier> mods) {
+                    addVisibilityModifier(mods);
+                    addStatic(mods);
+                    addSealed(e);
+                    list.add("interface");
+                    return list;
+                }
+
+                @Override
+                public List<String> visitTypeAsEnum(TypeElement e, SortedSet<Modifier> mods) {
+                    addVisibilityModifier(mods);
+                    addStatic(mods);
+                    list.add("enum");
+                    return list;
+                }
+
+                @Override
+                public List<String> visitTypeAsAnnotationType(TypeElement e, SortedSet<Modifier> mods) {
+                    addVisibilityModifier(mods);
+                    addStatic(mods);
+                    list.add("@interface");
+                    return list;
+                }
+
+                @Override
+                public List<String> visitTypeAsRecord(TypeElement e, SortedSet<Modifier> mods) {
+                    mods.remove(FINAL); // suppress the implicit `final`
+                    return visitTypeAsClass(e, mods);
+                }
+
+                @Override
+                public List<String> visitTypeAsClass(TypeElement e, SortedSet<Modifier> mods) {
+                    addModifiers(mods);
+                    String keyword = e.getKind() == ElementKind.RECORD ? "record" : "class";
+                    list.add(keyword);
+                    return list;
+                }
+
+                @Override
+                protected List<String> defaultAction(Element e, SortedSet<Modifier> mods) {
+                    addModifiers(mods);
+                    return list;
+                }
+
+            }.visit(e, modifiers);
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/ClassWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/ClassWriter.java
@@ -145,10 +145,9 @@ public interface ClassWriter {
     /**
      * Add the signature of the current class content tree.
      *
-     * @param modifiers the modifiers for the signature
      * @param classInfoTree the class content tree to which the signature will be added
      */
-    void addClassSignature(String modifiers, Content classInfoTree);
+    void addClassSignature(Content classInfoTree);
 
     /**
      * Build the class description.

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/ClassBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/ClassBuilder.java
@@ -295,7 +295,7 @@ public class ClassBuilder extends AbstractBuilder {
      * @param classInfoTree the content tree to which the documentation will be added
      */
     protected void buildClassSignature(Content classInfoTree) {
-        writer.addClassSignature(utils.modifiersToString(typeElement, true), classInfoTree);
+        writer.addClassSignature(classInfoTree);
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -34,7 +34,6 @@ import java.text.ParseException;
 import java.text.RuleBasedCollator;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
@@ -81,7 +80,6 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
 import javax.lang.model.type.WildcardType;
 import javax.lang.model.util.ElementFilter;
-import javax.lang.model.util.ElementKindVisitor14;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.SimpleAnnotationValueVisitor14;
 import javax.lang.model.util.SimpleElementVisitor14;
@@ -126,7 +124,6 @@ import jdk.javadoc.internal.doclets.toolkit.taglets.Taglet;
 import jdk.javadoc.internal.tool.DocEnvImpl;
 
 import static javax.lang.model.element.ElementKind.*;
-import static javax.lang.model.element.Modifier.*;
 import static javax.lang.model.type.TypeKind.*;
 
 import static com.sun.source.doctree.DocTree.Kind.*;
@@ -488,104 +485,6 @@ public class Utils {
 
     public boolean definesSerializableFields(TypeElement aclass) {
         return configuration.workArounds.definesSerializableFields( aclass);
-    }
-
-    public String modifiersToString(Element e, boolean trailingSpace) {
-        SortedSet<Modifier> modifiers = new TreeSet<>(e.getModifiers());
-        modifiers.remove(NATIVE);
-        modifiers.remove(STRICTFP);
-        modifiers.remove(SYNCHRONIZED);
-
-        return new ElementKindVisitor14<String, SortedSet<Modifier>>() {
-            final StringBuilder sb = new StringBuilder();
-
-            void addVisibilityModifier(Set<Modifier> modifiers) {
-                if (modifiers.contains(PUBLIC)) {
-                    append("public");
-                } else if (modifiers.contains(PROTECTED)) {
-                    append("protected");
-                } else if (modifiers.contains(PRIVATE)) {
-                    append("private");
-                }
-            }
-
-            void addStatic(Set<Modifier> modifiers) {
-                if (modifiers.contains(STATIC)) {
-                    append("static");
-                }
-            }
-
-            void addSealed(TypeElement e) {
-                if (e.getModifiers().contains(Modifier.SEALED)) {
-                    append("sealed");
-                } else if (e.getModifiers().contains(Modifier.NON_SEALED)) {
-                    append("non-sealed");
-                }
-            }
-
-            void addModifiers(Set<Modifier> modifiers) {
-                modifiers.stream()
-                        .map(Modifier::toString)
-                        .forEachOrdered(this::append);
-            }
-
-            void append(String s) {
-                if (sb.length() > 0) {
-                    sb.append(" ");
-                }
-                sb.append(s);
-            }
-
-            String finalString(String s) {
-                append(s);
-                if (trailingSpace) {
-                    sb.append(" ");
-                }
-                return sb.toString();
-            }
-
-            @Override
-            public String visitTypeAsInterface(TypeElement e, SortedSet<Modifier> mods) {
-                addVisibilityModifier(mods);
-                addStatic(mods);
-                addSealed(e);
-                return finalString("interface");
-            }
-
-            @Override
-            public String visitTypeAsEnum(TypeElement e, SortedSet<Modifier> mods) {
-                addVisibilityModifier(mods);
-                addStatic(mods);
-                return finalString("enum");
-            }
-
-            @Override
-            public String visitTypeAsAnnotationType(TypeElement e, SortedSet<Modifier> mods) {
-                addVisibilityModifier(mods);
-                addStatic(mods);
-                return finalString("@interface");
-            }
-
-            @Override
-            public String visitTypeAsRecord(TypeElement e, SortedSet<Modifier> mods) {
-                mods.remove(FINAL); // suppress the implicit `final`
-                return visitTypeAsClass(e, mods);
-            }
-
-            @Override
-            public String visitTypeAsClass(TypeElement e, SortedSet<Modifier> mods) {
-                addModifiers(mods);
-                String keyword = e.getKind() == ElementKind.RECORD ? "record" : "class";
-                return finalString(keyword);
-            }
-
-            @Override
-            protected String defaultAction(Element e, SortedSet<Modifier> mods) {
-                addModifiers(mods);
-                return sb.toString().trim();
-            }
-
-        }.visit(e, modifiers);
     }
 
     public boolean isFunctionalInterface(AnnotationMirror amirror) {


### PR DESCRIPTION
This change consolidates the code to generate type signature modifiers into `Signatures.TypeSignature`. 

Although this mostly consists of moving the code from `ClassWriterImpl` and `Utils` to `Signatures`, I also avoided the need to split the modifiers string when processing preview modifiers by returning a `List<String>` instead of a `String` in what used to be `Utils.modifiersToString` and is now `TypeSignature.getModifiers`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266748](https://bugs.openjdk.java.net/browse/JDK-8266748): Move modifiers code to Signatures.java


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4142/head:pull/4142` \
`$ git checkout pull/4142`

Update a local copy of the PR: \
`$ git checkout pull/4142` \
`$ git pull https://git.openjdk.java.net/jdk pull/4142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4142`

View PR using the GUI difftool: \
`$ git pr show -t 4142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4142.diff">https://git.openjdk.java.net/jdk/pull/4142.diff</a>

</details>
