### PR TITLE
8261354: SIGSEGV at MethodIteratorHost

### DIFF
--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
@@ -865,10 +865,9 @@ class MethodIteratorHost {
       const InstanceKlass* ik = InstanceKlass::cast(klass);
       while (ik != NULL) {
         const int len = ik->methods()->length();
-        Filter filter(ik->previous_versions() != NULL ? len : 0);
         for (int i = 0; i < len; ++i) {
           MethodPtr method = ik->methods()->at(i);
-          if (_method_flag_predicate(method) && filter(i)) {
+          if (_method_flag_predicate(method)) {
             _method_cb(method);
           }
         }

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
@@ -863,9 +863,9 @@ class MethodIteratorHost {
   bool operator()(KlassPtr klass) {
     if (_method_used_predicate(klass)) {
       const InstanceKlass* ik = InstanceKlass::cast(klass);
-      const int len = ik->methods()->length();
-      Filter filter(ik->previous_versions() != NULL ? len : 0);
       while (ik != NULL) {
+        const int len = ik->methods()->length();
+        Filter filter(ik->previous_versions() != NULL ? len : 0);
         for (int i = 0; i < len; ++i) {
           MethodPtr method = ik->methods()->at(i);
           if (_method_flag_predicate(method) && filter(i)) {


### PR DESCRIPTION
The `MethodIteratorHost` will iterate over previous versions of redefined classes but the number of methods in that class is retrieved only for the current version. 
Since the previous versions may theoretically, and before JDK 15 also practically, contain fewer methods than the current version (hotspot did support adding `private static` methods during retransformation) this can lead to SIGSEGV when the iterator tries accessing out-of-range method element.

Although for after JDK 15 it is not possible to have differing number of methods between multiple versions of a retransformed class it feels right not to rely on the implementation detail and re-retrieve the number of methods per each class version.

All jdk_jfr tests are passing on Linux x64 and MacOS x64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261354](https://bugs.openjdk.java.net/browse/JDK-8261354): SIGSEGV at MethodIteratorHost


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**) ⚠️ Review applies to 96ddee5b8f51ff0a81632b6744ed284522899980


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4143/head:pull/4143` \
`$ git checkout pull/4143`

Update a local copy of the PR: \
`$ git checkout pull/4143` \
`$ git pull https://git.openjdk.java.net/jdk pull/4143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4143`

View PR using the GUI difftool: \
`$ git pr show -t 4143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4143.diff">https://git.openjdk.java.net/jdk/pull/4143.diff</a>

</details>
