### PR TITLE
8267531: [x86] Assembler::andb(Address,Register) encoding is incorrect

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -1471,7 +1471,7 @@ void Assembler::vaesenclast(XMMRegister dst, XMMRegister nds, XMMRegister src, i
 
 void Assembler::andb(Address dst, Register src) {
   InstructionMark im(this);
-  prefix(dst, src);
+  prefix(dst, src, true);
   emit_int8(0x20);
   emit_operand(src, dst);
 }


### PR DESCRIPTION
See the bug report to see the way we arrived here. I looked through the [breakage changeset](https://github.com/openjdk/jdk/commit/de784312c340b4a4f4c4d11854bfbe9e9e826ea3), and I think that is the only "*b" case that is missing.

Attention @JohnTortugo.

Additional testing:
 - [x] Failing fuzzer test (now passes)
 - [x] Linux x86_64 fastdebug `tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267531](https://bugs.openjdk.java.net/browse/JDK-8267531): [x86] Assembler::andb(Address,Register) encoding is incorrect


### Reviewers
 * [Azeem Jiva](https://openjdk.java.net/census#azeemj) (@AzeemJiva - Author)
 * @JohnTortugo (no known github.com user name / role)
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4145/head:pull/4145` \
`$ git checkout pull/4145`

Update a local copy of the PR: \
`$ git checkout pull/4145` \
`$ git pull https://git.openjdk.java.net/jdk pull/4145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4145`

View PR using the GUI difftool: \
`$ git pr show -t 4145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4145.diff">https://git.openjdk.java.net/jdk/pull/4145.diff</a>

</details>
