### PR TITLE
8267468: Rename refill waster counters in ThreadLocalAllocBuffer

### DIFF
--- a/src/hotspot/share/gc/shared/threadLocalAllocBuffer.cpp
+++ b/src/hotspot/share/gc/shared/threadLocalAllocBuffer.cpp
@@ -51,7 +51,7 @@ ThreadLocalAllocBuffer::ThreadLocalAllocBuffer() :
   _allocated_before_last_gc(0),
   _bytes_since_last_sample_point(0),
   _number_of_refills(0),
-  _slow_refill_waste(0),
+  _refill_waste(0),
   _gc_waste(0),
   _slow_allocations(0),
   _allocated_size(0),
@@ -104,9 +104,9 @@ void ThreadLocalAllocBuffer::accumulate_and_reset_statistics(ThreadLocalAllocSta
     stats->update_fast_allocations(_number_of_refills,
                                    _allocated_size,
                                    _gc_waste,
-                                   _slow_refill_waste);
+                                   _refill_waste);
   } else {
-    assert(_number_of_refills == 0 && _slow_refill_waste == 0 && _gc_waste == 0,
+    assert(_number_of_refills == 0 && _refill_waste == 0 && _gc_waste == 0,
            "tlab stats == 0");
   }
 
@@ -147,7 +147,7 @@ void ThreadLocalAllocBuffer::retire(ThreadLocalAllocStats* stats) {
 }
 
 void ThreadLocalAllocBuffer::retire_before_allocation() {
-  _slow_refill_waste += (unsigned int)remaining();
+  _refill_waste += (unsigned int)remaining();
   retire();
 }
 
@@ -173,7 +173,7 @@ void ThreadLocalAllocBuffer::resize() {
 
 void ThreadLocalAllocBuffer::reset_statistics() {
   _number_of_refills = 0;
-  _slow_refill_waste = 0;
+  _refill_waste      = 0;
   _gc_waste          = 0;
   _slow_allocations  = 0;
   _allocated_size    = 0;
@@ -292,7 +292,7 @@ void ThreadLocalAllocBuffer::print_stats(const char* tag) {
   }
 
   Thread* thrd = thread();
-  size_t waste = _gc_waste + _slow_refill_waste;
+  size_t waste = _gc_waste + _refill_waste;
   double waste_percent = percent_of(waste, _allocated_size);
   size_t tlab_used  = Universe::heap()->tlab_used(thrd);
   log.trace("TLAB: %s thread: " INTPTR_FORMAT " [id: %2d]"
@@ -307,7 +307,7 @@ void ThreadLocalAllocBuffer::print_stats(const char* tag) {
             _allocation_fraction.average() * tlab_used / K,
             _number_of_refills, waste_percent,
             _gc_waste * HeapWordSize,
-            _slow_refill_waste * HeapWordSize);
+            _refill_waste * HeapWordSize);
 }
 
 void ThreadLocalAllocBuffer::set_sample_end(bool reset_byte_accumulation) {
@@ -395,15 +395,15 @@ unsigned int ThreadLocalAllocStats::allocating_threads_avg() {
 void ThreadLocalAllocStats::update_fast_allocations(unsigned int refills,
                                        size_t allocations,
                                        size_t gc_waste,
-                                       size_t slow_refill_waste) {
+                                       size_t refill_waste) {
   _allocating_threads      += 1;
   _total_refills           += refills;
   _max_refills              = MAX2(_max_refills, refills);
   _total_allocations       += allocations;
   _total_gc_waste          += gc_waste;
   _max_gc_waste             = MAX2(_max_gc_waste, gc_waste);
-  _total_slow_refill_waste += slow_refill_waste;
-  _max_slow_refill_waste    = MAX2(_max_slow_refill_waste, slow_refill_waste);
+  _total_slow_refill_waste += refill_waste;
+  _max_slow_refill_waste    = MAX2(_max_slow_refill_waste, refill_waste);
 }
 
 void ThreadLocalAllocStats::update_slow_allocations(unsigned int allocations) {

--- a/src/hotspot/share/gc/shared/threadLocalAllocBuffer.hpp
+++ b/src/hotspot/share/gc/shared/threadLocalAllocBuffer.hpp
@@ -63,7 +63,7 @@ private:
   static unsigned _target_refills;                    // expected number of refills between GCs
 
   unsigned  _number_of_refills;
-  unsigned  _slow_refill_waste;
+  unsigned  _refill_waste;
   unsigned  _gc_waste;
   unsigned  _slow_allocations;
   size_t    _allocated_size;
@@ -221,7 +221,7 @@ public:
   void update_fast_allocations(unsigned int refills,
                                size_t allocations,
                                size_t gc_waste,
-                               size_t slow_refill_waste);
+                               size_t refill_waste);
   void update_slow_allocations(unsigned int allocations);
   void update(const ThreadLocalAllocStats& other);
 

--- a/src/hotspot/share/gc/shared/threadLocalAllocBuffer.hpp
+++ b/src/hotspot/share/gc/shared/threadLocalAllocBuffer.hpp
@@ -194,8 +194,8 @@ private:
   static PerfVariable* _perf_total_allocations;
   static PerfVariable* _perf_total_gc_waste;
   static PerfVariable* _perf_max_gc_waste;
-  static PerfVariable* _perf_total_slow_refill_waste;
-  static PerfVariable* _perf_max_slow_refill_waste;
+  static PerfVariable* _perf_total_refill_waste;
+  static PerfVariable* _perf_max_refill_waste;
   static PerfVariable* _perf_total_slow_allocations;
   static PerfVariable* _perf_max_slow_allocations;
 
@@ -207,8 +207,8 @@ private:
   size_t       _total_allocations;
   size_t       _total_gc_waste;
   size_t       _max_gc_waste;
-  size_t       _total_slow_refill_waste;
-  size_t       _max_slow_refill_waste;
+  size_t       _total_refill_waste;
+  size_t       _max_refill_waste;
   unsigned int _total_slow_allocations;
   unsigned int _max_slow_allocations;
 

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -408,7 +408,7 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
      static_field(ThreadLocalAllocBuffer,      _reserve_for_allocation_prefetch,              int)                                   \
      static_field(ThreadLocalAllocBuffer,      _target_refills,                               unsigned)                              \
   nonstatic_field(ThreadLocalAllocBuffer,      _number_of_refills,                            unsigned)                              \
-  nonstatic_field(ThreadLocalAllocBuffer,      _slow_refill_waste,                            unsigned)                              \
+  nonstatic_field(ThreadLocalAllocBuffer,      _refill_waste,                                 unsigned)                              \
   nonstatic_field(ThreadLocalAllocBuffer,      _gc_waste,                                     unsigned)                              \
   nonstatic_field(ThreadLocalAllocBuffer,      _slow_allocations,                             unsigned)                              \
   nonstatic_field(VirtualSpace,                _low_boundary,                                 char*)                                 \

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/resources/aliasmap
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/resources/aliasmap
@@ -198,7 +198,7 @@ alias sun.cls.unloadedBytes                       // 1.5.0 b39
 
 // sun.gc
 alias sun.gc.cause                                // 1.5.0 b39
-        hotspot.gc.cause                          // 1.4.2_02 
+        hotspot.gc.cause                          // 1.4.2_02
 
 // sun.gc.collector.0
 alias sun.gc.collector.0.invocations              // 1.5.0 b39
@@ -401,7 +401,7 @@ alias sun.gc.generation.2.spaces                  // 1.5.0 b39
 
 // sun.gc
 alias sun.gc.lastCause                            // 1.5.0 b39
-        hotspot.gc.last_cause                     // 1.4.2_02 
+        hotspot.gc.last_cause                     // 1.4.2_02
 
 // sun.gc.policy
 alias sun.gc.policy.avgBaseFootprint              // 1.5.0 b39
@@ -535,11 +535,13 @@ alias sun.gc.tlab.maxGcWaste                      // 1.5.0 b39
 	hotspot.gc.tlab.maxgcwaste                // 1.5.0 b21
 alias sun.gc.tlab.maxSlowAlloc                    // 1.5.0 b39
 	hotspot.gc.tlab.maxslowalloc              // 1.5.0 b21
-alias sun.gc.tlab.maxSlowWaste                    // 1.5.0 b39
+alias sun.gc.tlab.maxRefillWaste                  // 17
+	sun.gc.tlab.maxSlowWaste                  // 1.5.0 b39
 	hotspot.gc.tlab.maxslowwaste              // 1.5.0 b21
 alias sun.gc.tlab.slowAlloc                       // 1.5.0 b39
 	hotspot.gc.tlab.slowalloc                 // 1.5.0 b21
-alias sun.gc.tlab.slowWaste                       // 1.5.0 b39
+alias sun.gc.tlab.refillWaste                     // 17
+	sun.gc.tlab.slowWaste                     // 1.5.0 b39
 	hotspot.gc.tlab.slowwaste                 // 1.5.0 b21
 
 // sun.os


### PR DESCRIPTION
Followup of https://bugs.openjdk.java.net/browse/JDK-8234532 (https://github.com/openjdk/jdk/pull/3756), dropping the "slow" segment in various counter names.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267468](https://bugs.openjdk.java.net/browse/JDK-8267468): Rename refill waster counters in ThreadLocalAllocBuffer


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4146/head:pull/4146` \
`$ git checkout pull/4146`

Update a local copy of the PR: \
`$ git checkout pull/4146` \
`$ git pull https://git.openjdk.java.net/jdk pull/4146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4146`

View PR using the GUI difftool: \
`$ git pr show -t 4146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4146.diff">https://git.openjdk.java.net/jdk/pull/4146.diff</a>

</details>
