### PR TITLE
8240997: Remove more "hack" word in security codes

### DIFF
--- a/src/java.base/share/classes/sun/security/rsa/RSAPSSSignature.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAPSSSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -368,7 +368,7 @@ public class RSAPSSSignature extends SignatureSpi {
         try {
             ensureInit();
         } catch (SignatureException se) {
-            // hack for working around API bug
+            // workaround for API bug
             throw new RuntimeException(se.getMessage());
         }
         this.md.update(b);

--- a/src/java.base/share/classes/sun/security/ssl/SSLTransport.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLTransport.java
@@ -110,7 +110,7 @@ interface SSLTransport {
             plaintexts =
                     context.inputRecord.decode(srcs, srcsOffset, srcsLength);
         } catch (UnsupportedOperationException unsoe) {         // SSLv2Hello
-            // Hack code to deliver SSLv2 error message for SSL/TLS connections.
+            // Code to deliver SSLv2 error message for SSL/TLS connections.
             if (!context.sslContext.isDTLS()) {
                 context.outputRecord.encodeV2NoCipher();
                 if (SSLLogger.isOn && SSLLogger.isOn("ssl")) {

--- a/src/java.base/share/classes/sun/security/util/CurveDB.java
+++ b/src/java.base/share/classes/sun/security/util/CurveDB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,7 +80,7 @@ public class CurveDB {
             return (NamedCurve)params;
         }
 
-        // This is a hack to allow SunJSSE to work with 3rd party crypto
+        // This code allows SunJSSE to work with 3rd party crypto
         // providers for ECC and not just SunPKCS11.
         // This can go away once we decide how to expose curve names in the
         // public API.

--- a/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CSignature.java
+++ b/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -584,14 +584,14 @@ abstract class CSignature extends SignatureSpi {
             try {
                 ensureInit();
             } catch (SignatureException se) {
-                // hack for working around API bug
+                // workaround for API bug
                 throw new RuntimeException(se.getMessage());
             }
             if (fallbackSignature != null) {
                 try {
                     fallbackSignature.update(input);
                 } catch (SignatureException se) {
-                    // hack for working around API bug
+                    // workaround for API bug
                     throw new RuntimeException(se.getMessage());
                 }
             } else {


### PR DESCRIPTION
This change is part of a larger  code cleanup effort and removes the term "hack" out of several files in the jdk.
JBS: [](https://bugs.openjdk.java.net/browse/JDK-8240997 )

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8240997](https://bugs.openjdk.java.net/browse/JDK-8240997): Remove more "hack" word in security codes


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4148/head:pull/4148` \
`$ git checkout pull/4148`

Update a local copy of the PR: \
`$ git checkout pull/4148` \
`$ git pull https://git.openjdk.java.net/jdk pull/4148/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4148`

View PR using the GUI difftool: \
`$ git pr show -t 4148`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4148.diff">https://git.openjdk.java.net/jdk/pull/4148.diff</a>

</details>
