### PR TITLE
8267544:  (test) rmi test NonLocalSkeleton fails if network has multiple adapters with the same address

### DIFF
--- a/test/jdk/java/rmi/registry/nonLocalRegistry/NonLocalSkeletonTest.java
+++ b/test/jdk/java/rmi/registry/nonLocalRegistry/NonLocalSkeletonTest.java
@@ -37,6 +37,7 @@ import java.rmi.server.ObjID;
 import java.rmi.server.RemoteObjectInvocationHandler;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Arrays;
 import java.util.Set;
 
 
@@ -85,8 +86,8 @@ public class NonLocalSkeletonTest {
 
         // Check if running the test on a local system; it only applies to remote
         String myHostName = InetAddress.getLocalHost().getHostName();
-        Set<InetAddress> myAddrs = Set.of(InetAddress.getAllByName(myHostName));
-        Set<InetAddress> hostAddrs = Set.of(InetAddress.getAllByName(host));
+        Set<InetAddress> myAddrs = Set.copyOf(Arrays.asList(InetAddress.getAllByName(myHostName)));
+        Set<InetAddress> hostAddrs = Set.copyOf(Arrays.asList(InetAddress.getAllByName(host)));
         boolean isLocal = (hostAddrs.stream().anyMatch(i -> myAddrs.contains(i))
                 || hostAddrs.stream().anyMatch(h -> h.isLoopbackAddress()));
 


### PR DESCRIPTION
Correct test code that creates a set of unique hostnames from an array of non-unique hostname.
Was using Set.of that throws if the elements are not unique.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267544](https://bugs.openjdk.java.net/browse/JDK-8267544): (test) rmi test NonLocalSkeleton fails if network has multiple adapters with the same address


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4151/head:pull/4151` \
`$ git checkout pull/4151`

Update a local copy of the PR: \
`$ git checkout pull/4151` \
`$ git pull https://git.openjdk.java.net/jdk pull/4151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4151`

View PR using the GUI difftool: \
`$ git pr show -t 4151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4151.diff">https://git.openjdk.java.net/jdk/pull/4151.diff</a>

</details>
