### PR TITLE
8267570: The comment of the class JavacParser is not appropriate

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -62,11 +62,12 @@ import static com.sun.tools.javac.resources.CompilerProperties.Fragments.Implici
 import static com.sun.tools.javac.resources.CompilerProperties.Fragments.VarAndExplicitNotAllowed;
 import static com.sun.tools.javac.resources.CompilerProperties.Fragments.VarAndImplicitNotAllowed;
 
-/** The parser maps a token sequence into an abstract syntax
- *  tree. It operates by recursive descent, with code derived
- *  systematically from an LL(1) grammar. For efficiency reasons, an
- *  operator precedence scheme is used for parsing binary operation
- *  expressions.
+/**
+ * The parser maps a token sequence into an abstract syntax tree.
+ * The current javac parser is a hand-written recursive-descent parser.
+ * It implements the grammar described in the Java Language Specification.
+ * For efficiency reasons, an operator precedence scheme is used
+ * for parsing binary operation expressions.
  *
  *  <p><b>This is NOT part of any supported API.
  *  If you write code that depends on this, you do so at your own risk.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -64,8 +64,8 @@ import static com.sun.tools.javac.resources.CompilerProperties.Fragments.VarAndI
 
 /**
  * The parser maps a token sequence into an abstract syntax tree.
- * The current javac parser is a hand-written recursive-descent parser.
- * It implements the grammar described in the Java Language Specification.
+ * The parser is a hand-written recursive-descent parser that
+ * implements the grammar described in the Java Language Specification.
  * For efficiency reasons, an operator precedence scheme is used
  * for parsing binary operation expressions.
  *


### PR DESCRIPTION
Hi all,

The following comment of the class JavacParser is not appropriate.

```
It operates by recursive descent, with code derived
systematically from an LL(1) grammar.
```

From the source code, the current javac parser looks like a LL(K) parser instead of LL(1).
This patch revises the comment so that developers won't be confused by it.

Thank you for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267570](https://bugs.openjdk.java.net/browse/JDK-8267570): The comment of the class JavacParser is not appropriate


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4153/head:pull/4153` \
`$ git checkout pull/4153`

Update a local copy of the PR: \
`$ git checkout pull/4153` \
`$ git pull https://git.openjdk.java.net/jdk pull/4153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4153`

View PR using the GUI difftool: \
`$ git pr show -t 4153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4153.diff">https://git.openjdk.java.net/jdk/pull/4153.diff</a>

</details>
