### PR TITLE
8267580: The method JavacParser#peekToken is wrong when the first parameter is not zero

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -309,8 +309,8 @@ public class JavacParser implements Parser {
 
     @SuppressWarnings("unchecked")
     protected boolean peekToken(int lookahead, Predicate<TokenKind>... kinds) {
-        for (; lookahead < kinds.length ; lookahead++) {
-            if (!kinds[lookahead].test(S.token(lookahead + 1).kind)) {
+        for (Predicate<TokenKind> kind : kinds) {
+            if (!kind.test(S.token(++lookahead).kind)) {
                 return false;
             }
         }


### PR DESCRIPTION
Hi all,

The method `JavacParser#peekToken(int lookahead, Predicate<TokenKind>... kinds)` succeeds only when the first parameter `lookahead` is zero. If the `lookahead` is not zero, it is wrong and returns unexpected result.

The parameter `kinds` should not be dereferenced by `lookahead` and should be always started at zero.

But currently, the method `JavacParser#peekToken(int lookahead, Predicate<TokenKind>... kinds)` has not been used so that this issue doesn't effect the parser.

An alternative way:  remove the following methods, because they are not used.
```
    protected boolean peekToken(Predicate<TokenKind>... kinds)
    protected boolean peekToken(int lookahead, Predicate<TokenKind>... kinds) 
```

To test this patch, we can comment out the following methods  and  run the tests locally.
Note: some methods may need to add `@SuppressWarnings("unchecked")`.
```
    protected boolean peekToken(Predicate<TokenKind> tk1, Predicate<TokenKind> tk2, Predicate<TokenKind> tk3) {
        return peekToken(0, tk1, tk2, tk3);
    }

    protected boolean peekToken(int lookahead, Predicate<TokenKind> tk1, Predicate<TokenKind> tk2, Predicate<TokenKind> tk3) {
        return tk1.test(S.token(lookahead + 1).kind) &&
                tk2.test(S.token(lookahead + 2).kind) &&
                tk3.test(S.token(lookahead + 3).kind);
    }
```

Thanks for your review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267580](https://bugs.openjdk.java.net/browse/JDK-8267580): The method JavacParser#peekToken is wrong when the first parameter is not zero


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4158/head:pull/4158` \
`$ git checkout pull/4158`

Update a local copy of the PR: \
`$ git checkout pull/4158` \
`$ git pull https://git.openjdk.java.net/jdk pull/4158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4158`

View PR using the GUI difftool: \
`$ git pr show -t 4158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4158.diff">https://git.openjdk.java.net/jdk/pull/4158.diff</a>

</details>
