### PR TITLE
8267584: The java.security.krb5.realm system property only needs to be defined once

### DIFF
--- a/src/java.security.jgss/share/classes/javax/security/auth/kerberos/KerberosPrincipal.java
+++ b/src/java.security.jgss/share/classes/javax/security/auth/kerberos/KerberosPrincipal.java
@@ -106,7 +106,7 @@ public final class KerberosPrincipal
      *
      * <p>If the input name does not contain a realm, the default realm
      * is used. The default realm can be specified either in a Kerberos
-     * configuration file or via the {@systemProperty java.security.krb5.realm}
+     * configuration file or via the {@code java.security.krb5.realm}
      * system property. For more information, see the
      * {@extLink security_guide_jgss_tutorial Kerberos Requirements}.
      *
@@ -155,7 +155,7 @@ public final class KerberosPrincipal
      *
      * <p>If the input name does not contain a realm, the default realm
      * is used. The default realm can be specified either in a Kerberos
-     * configuration file or via the {@systemProperty java.security.krb5.realm}
+     * configuration file or via the {@code java.security.krb5.realm}
      * system property. For more information, see the
      * {@extLink security_guide_jgss_tutorial Kerberos Requirements}.
      *


### PR DESCRIPTION
A system property only needs to be put in a `{@systemProperty}` tag where it's first defined. For this one, it's https://github.com/openjdk/jdk/blob/cf21c5ef116c136f09ac5be0d68f02553d0c7a70/src/java.security.jgss/share/classes/javax/security/auth/kerberos/package-info.java#L41.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267584](https://bugs.openjdk.java.net/browse/JDK-8267584): The java.security.krb5.realm system property only needs to be defined once


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4159/head:pull/4159` \
`$ git checkout pull/4159`

Update a local copy of the PR: \
`$ git checkout pull/4159` \
`$ git pull https://git.openjdk.java.net/jdk pull/4159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4159`

View PR using the GUI difftool: \
`$ git pr show -t 4159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4159.diff">https://git.openjdk.java.net/jdk/pull/4159.diff</a>

</details>
