### PR TITLE
 8267553: Extra JavaThread assignment in ClassLoader::create_class_path_entry()

### DIFF
--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -722,18 +722,17 @@ ClassPathEntry* ClassLoader::create_class_path_entry(JavaThread* current,
                                                      const char *path, const struct stat* st,
                                                      bool is_boot_append,
                                                      bool from_class_path_attr) {
-  JavaThread* thread = current->as_Java_thread();
   ClassPathEntry* new_entry = NULL;
   if ((st->st_mode & S_IFMT) == S_IFREG) {
-    ResourceMark rm(thread);
+    ResourceMark rm(current);
     // Regular file, should be a zip file
     // Canonicalized filename
-    const char* canonical_path = get_canonical_path(path, thread);
+    const char* canonical_path = get_canonical_path(path, current);
     if (canonical_path == NULL) {
       return NULL;
     }
     char* error_msg = NULL;
-    jzfile* zip = open_zip_file(canonical_path, &error_msg, thread);
+    jzfile* zip = open_zip_file(canonical_path, &error_msg, current);
     if (zip != NULL && error_msg == NULL) {
       new_entry = new ClassPathZipEntry(zip, path, is_boot_append, from_class_path_attr);
     } else {


### PR DESCRIPTION
This is a trivial cleanup that was missed when "JDK-8252685 APIs that require JavaThread should take JavaThread arguments " was merged and integrated.

Thanks to @calvinccheung for spotting this.

Testing: tiers 1-3 (in progress)

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267553](https://bugs.openjdk.java.net/browse/JDK-8267553): Extra JavaThread assignment in ClassLoader::create_class_path_entry()


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4160/head:pull/4160` \
`$ git checkout pull/4160`

Update a local copy of the PR: \
`$ git checkout pull/4160` \
`$ git pull https://git.openjdk.java.net/jdk pull/4160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4160`

View PR using the GUI difftool: \
`$ git pr show -t 4160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4160.diff">https://git.openjdk.java.net/jdk/pull/4160.diff</a>

</details>
