### PR TITLE
8267066: New NSAccessibility peers should return they roles and subroles directly

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ButtonAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ButtonAccessibility.h
@@ -31,6 +31,7 @@
 @interface ButtonAccessibility : CommonComponentAccessibility <NSAccessibilityButton> {
 
 };
-- (nullable NSString *)accessibilityLabel;
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
+- (NSString * _Nullable)accessibilityLabel;
 - (BOOL)accessibilityPerformPress;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ButtonAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ButtonAccessibility.m
@@ -29,7 +29,12 @@
  * Implementation of the accessibility peer for the pushbutton role
  */
 @implementation ButtonAccessibility
-- (nullable NSString *)accessibilityLabel
+- (NSAccessibilityRole _Nonnull)accessibilityRole
+{
+    return NSAccessibilityButtonRole;
+}
+
+- (NSString * _Nullable)accessibilityLabel
 {
     return [self accessibilityTitleAttribute];
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CheckboxAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CheckboxAccessibility.h
@@ -28,5 +28,6 @@
 @interface CheckboxAccessibility : ButtonAccessibility <NSAccessibilityCheckBox> {
 
 };
-- (id)accessibilityValue;
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
+- (id _Nonnull)accessibilityValue;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CheckboxAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CheckboxAccessibility.m
@@ -31,8 +31,12 @@
  * Implementation of the accessibility peer for the checkbox role
  */
 @implementation CheckboxAccessibility
+- (NSAccessibilityRole _Nonnull)accessibilityRole
+{
+    return NSAccessibilityCheckBoxRole;
+}
 
-- (id) accessibilityValue
+- (id _Nonnull) accessibilityValue
 {
     AWT_ASSERT_APPKIT_THREAD;
     return [self accessibilityValueAttribute];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.h
@@ -41,7 +41,7 @@
 + (void) initializeRolesMap;
 + (JavaComponentAccessibility * _Nullable) getComponentAccessibility:(NSString * _Nonnull)role;
 - (NSRect)accessibilityFrame;
-- (nullable id)accessibilityParent;
+- (id _Nullable)accessibilityParent;
 - (BOOL)performAccessibleAction:(int)index;
 - (BOOL)isAccessibilityElement;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -164,7 +164,7 @@ static jobject sAccessibilityClass = NULL;
     return NSMakeRect(point.x, point.y, size.width, size.height);
 }
 
-- (nullable id)accessibilityParent
+- (id _Nullable)accessibilityParent
 {
     return [self accessibilityParentAttribute];
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonTextAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonTextAccessibility.h
@@ -34,9 +34,9 @@
 @interface CommonTextAccessibility : CommonComponentAccessibility {
 
 }
-- (nullable NSString *)accessibilityValueAttribute;
+- (NSString * _Nullable)accessibilityValueAttribute;
 - (NSRange)accessibilityVisibleCharacterRangeAttribute;
-- (nullable NSString *)accessibilityStringForRangeAttribute:(NSRange)parameter;
+- (NSString * _Nullable)accessibilityStringForRangeAttribute:(NSRange)parameter;
 @end
 
 #endif

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/GroupAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/GroupAccessibility.h
@@ -31,6 +31,6 @@
 @interface GroupAccessibility : CommonComponentAccessibility <NSAccessibilityGroup> {
 
 };
-
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
 - (NSArray * _Nullable)accessibilityChildren;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/GroupAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/GroupAccessibility.m
@@ -32,6 +32,10 @@
  * classes reflecting the logic of the class.
  */
 @implementation GroupAccessibility
+- (NSAccessibilityRole _Nonnull)accessibilityRole
+{
+    return NSAccessibilityGroupRole;
+}
 
 /*
  * Return all non-ignored children.

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ImageAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ImageAccessibility.h
@@ -31,5 +31,6 @@
 @interface ImageAccessibility : CommonComponentAccessibility <NSAccessibilityImage> {
 
 };
-- (nullable NSString *)accessibilityLabel;
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
+- (NSString * _Nullable)accessibilityLabel;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ImageAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ImageAccessibility.m
@@ -29,7 +29,12 @@
  * Implementation of the accessibility peer for the icon role
  */
 @implementation ImageAccessibility
-- (nullable NSString *)accessibilityLabel
+- (NSAccessibilityRole _Nonnull)accessibilityRole
+{
+    return NSAccessibilityImageRole;
+}
+
+- (NSString * _Nullable)accessibilityLabel
 {
     return [self accessibilityTitleAttribute];
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/RadiobuttonAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/RadiobuttonAccessibility.h
@@ -28,5 +28,6 @@
 @interface RadiobuttonAccessibility : ButtonAccessibility <NSAccessibilityRadioButton> {
 
 };
-- (id)accessibilityValue;
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
+- (id _Nonnull)accessibilityValue;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/RadiobuttonAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/RadiobuttonAccessibility.m
@@ -31,8 +31,12 @@
  * Implementation of the accessibility peer for the radiobutton role
  */
 @implementation RadiobuttonAccessibility
+- (NSAccessibilityRole _Nonnull)accessibilityRole
+{
+    return NSAccessibilityRadioButtonRole;
+}
 
-- (id) accessibilityValue
+- (id _Nonnull) accessibilityValue
 {
     AWT_ASSERT_APPKIT_THREAD;
     return [self accessibilityValueAttribute];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollAreaAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollAreaAccessibility.h
@@ -31,7 +31,7 @@
 @interface ScrollAreaAccessibility : CommonComponentAccessibility {
 
 };
-- (NSString * _Nonnull)accessibilityRole;
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
 - (NSArray * _Nullable)accessibilityContents;
 - (id _Nullable)accessibilityHorizontalScrollBar;
 - (id _Nullable)accessibilityVerticalScrollBar;

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollAreaAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollAreaAccessibility.m
@@ -83,9 +83,9 @@
     return nil;
 }
 
-- (NSString * _Nonnull)accessibilityRole
+- (NSAccessibilityRole _Nonnull)accessibilityRole
 {
-    return [self accessibilityRoleAttribute];
+    return NSAccessibilityScrollAreaRole;
 }
 
 - (NSArray * _Nullable)accessibilityContents

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollBarAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollBarAccessibility.h
@@ -31,6 +31,6 @@
 @interface ScrollBarAccessibility : CommonComponentAccessibility {
 
 };
-- (NSString * _Nonnull)accessibilityRole;
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
 - (NSAccessibilityOrientation) accessibilityOrientation;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollBarAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollBarAccessibility.m
@@ -32,9 +32,9 @@
  */
 @implementation ScrollBarAccessibility
 
-- (NSString * _Nonnull)accessibilityRole
+- (NSAccessibilityRole _Nonnull)accessibilityRole
 {
-    return [self accessibilityRoleAttribute];
+    return NSAccessibilityScrollBarRole;
 }
 
 - (NSAccessibilityOrientation) accessibilityOrientation

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SliderAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SliderAccessibility.h
@@ -31,9 +31,9 @@
 @interface SliderAccessibility : CommonComponentAccessibility <NSAccessibilitySlider> {
 
 };
-
-- (nullable NSString *)accessibilityLabel;
-- (nullable id)accessibilityValue;
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
+- (NSString * _Nullable)accessibilityLabel;
+- (id _Nullable)accessibilityValue;
 - (BOOL)accessibilityPerformDecrement;
 - (BOOL)accessibilityPerformIncrement;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SliderAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SliderAccessibility.m
@@ -32,12 +32,17 @@
  * Implementation of the accessibility peer for the slider role
  */
 @implementation SliderAccessibility
-- (nullable NSString *)accessibilityLabel
+- (NSAccessibilityRole _Nonnull)accessibilityRole
+{
+    return NSAccessibilitySliderRole;
+}
+
+- (NSString * _Nullable)accessibilityLabel
 {
     return [self accessibilityTitleAttribute];
 }
 
-- (nullable id)accessibilityValue
+- (id _Nullable)accessibilityValue
 {
     return [self accessibilityValueAttribute];
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SpinboxAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SpinboxAccessibility.h
@@ -31,9 +31,9 @@
 @interface SpinboxAccessibility : CommonComponentAccessibility <NSAccessibilityStepper> {
 
 };
-
-- (nullable NSString *)accessibilityLabel;
-- (nullable id)accessibilityValue;
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
+- (NSString * _Nullable)accessibilityLabel;
+- (id _Nullable)accessibilityValue;
 - (BOOL)accessibilityPerformDecrement;
 - (BOOL)accessibilityPerformIncrement;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SpinboxAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SpinboxAccessibility.m
@@ -32,12 +32,17 @@
  * Implementation of the accessibility peer for the spinner role
  */
 @implementation SpinboxAccessibility
-- (nullable NSString *)accessibilityLabel
+- (NSAccessibilityRole _Nonnull)accessibilityRole
+{
+    return NSAccessibilityIncrementorRole;
+}
+
+- (NSString * _Nullable)accessibilityLabel
 {
     return [self accessibilityTitleAttribute];
 }
 
-- (nullable id)accessibilityValue
+- (id _Nullable)accessibilityValue
 {
     return [self accessibilityValueAttribute];
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.h
@@ -35,8 +35,8 @@
 
 };
 - (NSAccessibilityRole _Nonnull)accessibilityRole;
-- (nullable NSString *)accessibilityAttributedStringForRange:(NSRange)range;
-- (nullable NSString *)accessibilityValue;
+- (NSString * _Nullable)accessibilityAttributedStringForRange:(NSRange)range;
+- (NSString * _Nullable)accessibilityValue;
 - (NSRange)accessibilityVisibleCharacterRange;
 @end
 #endif

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.h
@@ -34,6 +34,7 @@
 @interface StaticTextAccessibility : CommonTextAccessibility<NSAccessibilityStaticText> {
 
 };
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
 - (nullable NSString *)accessibilityAttributedStringForRange:(NSRange)range;
 - (nullable NSString *)accessibilityValue;
 - (NSRange)accessibilityVisibleCharacterRange;

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.m
@@ -27,12 +27,17 @@
 
 @implementation StaticTextAccessibility
 
-- (nullable NSString *)accessibilityAttributedStringForRange:(NSRange)range
+- (NSAccessibilityRole _Nonnull)accessibilityRole
+{
+    return NSAccessibilityStaticTextRole;
+}
+
+- (NSString * _Nullable)accessibilityAttributedStringForRange:(NSRange)range
 {
     return [self accessibilityStringForRangeAttribute:range];
 }
 
-- (nullable NSString *)accessibilityValue
+- (NSString * _Nullable)accessibilityValue
 {
     return [self accessibilityValueAttribute];
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ToolbarAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ToolbarAccessibility.h
@@ -31,5 +31,5 @@
 @interface ToolbarAccessibility : CommonComponentAccessibility {
 
 };
-- (NSString * _Nonnull)accessibilityRole;
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ToolbarAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ToolbarAccessibility.m
@@ -30,8 +30,8 @@
  */
 @implementation ToolbarAccessibility
 
-- (NSString * _Nonnull)accessibilityRole
+- (NSAccessibilityRole _Nonnull)accessibilityRole
 {
-    return [self accessibilityRoleAttribute];
+    return NSAccessibilityToolbarRole;
 }
 @end


### PR DESCRIPTION
Made all implementing classes return their roles directly.
Change nullability attributes to the singular style across new classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267066](https://bugs.openjdk.java.net/browse/JDK-8267066): New NSAccessibility peers should return they roles and subroles directly


### Reviewers
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4162/head:pull/4162` \
`$ git checkout pull/4162`

Update a local copy of the PR: \
`$ git checkout pull/4162` \
`$ git pull https://git.openjdk.java.net/jdk pull/4162/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4162`

View PR using the GUI difftool: \
`$ git pr show -t 4162`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4162.diff">https://git.openjdk.java.net/jdk/pull/4162.diff</a>

</details>
