### PR TITLE
8267611: Print more info when pointer_delta assert fails

### DIFF
--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -152,10 +152,6 @@ class oopDesc;
 #define UINTX_FORMAT_W(width) "%" #width PRIuPTR
 
 // Convert pointer to intptr_t, for use in printing pointers.
-inline intptr_t p2i(const void* p) {
-  return (intptr_t) p;
-}
-
 inline intptr_t p2i(const volatile void* p) {
   return (intptr_t) p;
 }

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -151,6 +151,15 @@ class oopDesc;
 #define INTX_FORMAT_W(width)  "%" #width PRIdPTR
 #define UINTX_FORMAT_W(width) "%" #width PRIuPTR
 
+// Convert pointer to intptr_t, for use in printing pointers.
+inline intptr_t p2i(const void* p) {
+  return (intptr_t) p;
+}
+
+inline intptr_t p2i(const volatile void* p) {
+  return (intptr_t) p;
+}
+
 //----------------------------------------------------------------------------------------------------
 // Constants
 
@@ -416,7 +425,7 @@ inline address_word  castable_address(void* x)                { return address_w
 inline size_t pointer_delta(const volatile void* left,
                             const volatile void* right,
                             size_t element_size) {
-  assert(left >= right, "avoid underflow");
+  assert(left >= right, "avoid underflow - left: " PTR_FORMAT " right: " PTR_FORMAT, p2i(left), p2i(right));
   return (((uintptr_t) left) - ((uintptr_t) right)) / element_size;
 }
 
@@ -1087,11 +1096,6 @@ inline int extract_high_short_from_int(jint x) {
 
 inline int build_int_from_shorts( jushort low, jushort high ) {
   return ((int)((unsigned int)high << 16) | (unsigned int)low);
-}
-
-// Convert pointer to intptr_t, for use in printing pointers.
-inline intptr_t p2i(const void * p) {
-  return (intptr_t) p;
 }
 
 // swap a & b


### PR DESCRIPTION
We've seen a few new failures with the new pointer_delta assert. It would be nice if the assert printed the 'left' and 'right' pointer values.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267611](https://bugs.openjdk.java.net/browse/JDK-8267611): Print more info when pointer_delta assert fails


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to b2b3b649a7819b44823eff119682eadc9cd1cec4
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**) ⚠️ Review applies to b2b3b649a7819b44823eff119682eadc9cd1cec4
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to b2b3b649a7819b44823eff119682eadc9cd1cec4
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4163/head:pull/4163` \
`$ git checkout pull/4163`

Update a local copy of the PR: \
`$ git checkout pull/4163` \
`$ git pull https://git.openjdk.java.net/jdk pull/4163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4163`

View PR using the GUI difftool: \
`$ git pr show -t 4163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4163.diff">https://git.openjdk.java.net/jdk/pull/4163.diff</a>

</details>
