### PR TITLE
8267612; Declare package-private VarHandle.AccessMode/AccessType counts

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
@@ -45,7 +45,7 @@ import java.util.function.BiFunction;
 /* package */ class IndirectVarHandle extends VarHandle {
 
     @Stable
-    private final MethodHandle[] handleMap = new MethodHandle[AccessMode.values().length];
+    private final MethodHandle[] handleMap = new MethodHandle[AccessMode.COUNT];
     private final VarHandle directTarget; // cache, for performance reasons
     private final VarHandle target;
     private final BiFunction<AccessMode, MethodHandle, MethodHandle> handleFactory;

--- a/src/java.base/share/classes/java/lang/invoke/Invokers.java
+++ b/src/java.base/share/classes/java/lang/invoke/Invokers.java
@@ -55,8 +55,8 @@ class Invokers {
             INV_GENERIC        =  1,  // MethodHandles.invoker (generic invocation)
             INV_BASIC          =  2,  // MethodHandles.basicInvoker
             VH_INV_EXACT       =  3,  // MethodHandles.varHandleExactInvoker
-            VH_INV_GENERIC     =  VH_INV_EXACT   + VarHandle.AccessMode.values().length,  // MethodHandles.varHandleInvoker
-            INV_LIMIT          =  VH_INV_GENERIC + VarHandle.AccessMode.values().length;
+            VH_INV_GENERIC     =  VH_INV_EXACT   + VarHandle.AccessMode.COUNT,  // MethodHandles.varHandleInvoker
+            INV_LIMIT          =  VH_INV_GENERIC + VarHandle.AccessMode.COUNT;
 
     /** Compute and cache information common to all collecting adapters
      *  that implement members of the erasure-family of the given erased type.

--- a/src/java.base/share/classes/java/lang/invoke/VarForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarForm.java
@@ -49,8 +49,8 @@ final class VarForm {
     final @Stable MemberName[] memberName_table;
 
     VarForm(Class<?> implClass, Class<?> receiver, Class<?> value, Class<?>... intermediate) {
-        this.methodType_table = new MethodType[VarHandle.AccessType.values().length];
-        this.memberName_table = new MemberName[VarHandle.AccessMode.values().length];
+        this.methodType_table = new MethodType[VarHandle.AccessType.COUNT];
+        this.memberName_table = new MemberName[VarHandle.AccessMode.COUNT];
         this.implClass = implClass;
         if (receiver == null) {
             initMethodTypes(value, intermediate);
@@ -64,7 +64,7 @@ final class VarForm {
 
     // Used by IndirectVarHandle
     VarForm(Class<?> value, Class<?>[] coordinates) {
-        this.methodType_table = new MethodType[VarHandle.AccessType.values().length];
+        this.methodType_table = new MethodType[VarHandle.AccessType.COUNT];
         this.memberName_table = null;
         this.implClass = null;
         initMethodTypes(value, coordinates);

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -1636,7 +1636,7 @@ public abstract class VarHandle implements Constable {
         COMPARE_AND_EXCHANGE(Object.class),
         GET_AND_UPDATE(Object.class);
 
-        static final int COUNT = 5;
+        static final int COUNT = GET_AND_UPDATE.ordinal() + 1;
         static {
             assert (COUNT == values().length);
         }
@@ -1894,7 +1894,7 @@ public abstract class VarHandle implements Constable {
         GET_AND_BITWISE_XOR_ACQUIRE("getAndBitwiseXorAcquire", AccessType.GET_AND_UPDATE),
         ;
 
-        static final int COUNT = 31;
+        static final int COUNT = GET_AND_BITWISE_XOR_ACQUIRE.ordinal() + 1;
         static {
             assert (COUNT == values().length);
         }

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -1636,6 +1636,10 @@ public abstract class VarHandle implements Constable {
         COMPARE_AND_EXCHANGE(Object.class),
         GET_AND_UPDATE(Object.class);
 
+        static final int COUNT = 5;
+        static {
+            assert (COUNT == values().length);
+        }
         final Class<?> returnType;
         final boolean isMonomorphicInReturnType;
 
@@ -1890,6 +1894,10 @@ public abstract class VarHandle implements Constable {
         GET_AND_BITWISE_XOR_ACQUIRE("getAndBitwiseXorAcquire", AccessType.GET_AND_UPDATE),
         ;
 
+        static final int COUNT = 31;
+        static {
+            assert (COUNT == values().length);
+        }
         final String methodName;
         final AccessType at;
 
@@ -2112,12 +2120,10 @@ public abstract class VarHandle implements Constable {
 
     static class TypesAndInvokers {
         final @Stable
-        MethodType[] methodType_table =
-                new MethodType[VarHandle.AccessType.values().length];
+        MethodType[] methodType_table = new MethodType[VarHandle.AccessType.COUNT];
 
         final @Stable
-        MethodHandle[] methodHandle_table =
-                new MethodHandle[AccessMode.values().length];
+        MethodHandle[] methodHandle_table = new MethodHandle[AccessMode.COUNT];
     }
 
     @ForceInline


### PR DESCRIPTION
Slightly reduce VarHandle startup overhead by introducing package-private COUNT constants for two enums

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267612](https://bugs.openjdk.java.net/browse/JDK-8267612): Declare package-private VarHandle.AccessMode/AccessType counts


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4164/head:pull/4164` \
`$ git checkout pull/4164`

Update a local copy of the PR: \
`$ git checkout pull/4164` \
`$ git pull https://git.openjdk.java.net/jdk pull/4164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4164`

View PR using the GUI difftool: \
`$ git pr show -t 4164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4164.diff">https://git.openjdk.java.net/jdk/pull/4164.diff</a>

</details>
