### PR TITLE
8267614: Outline VarHandleGuards exact behavior checks

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -40,6 +40,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import jdk.internal.util.Preconditions;
+import jdk.internal.vm.annotation.DontInline;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 import jdk.internal.vm.annotation.Stable;
@@ -2026,6 +2027,19 @@ public abstract class VarHandle implements Constable {
      */
     public final MethodType accessModeType(AccessMode accessMode) {
         return accessModeType(accessMode.at.ordinal());
+    }
+
+    @ForceInline
+    final void checkExactAccessMode(VarHandle.AccessDescriptor ad) {
+        if (exact && accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
+            throwWrongMethodTypeException(ad);
+        }
+    }
+
+    @DontInline
+    private final void throwWrongMethodTypeException(VarHandle.AccessDescriptor ad) {
+        throw new WrongMethodTypeException("expected " + accessModeType(ad.type) + " but found "
+                + ad.symbolicMethodTypeExact);
     }
 
     @ForceInline

--- a/src/java.base/share/classes/java/lang/invoke/VarHandleGuards.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandleGuards.java
@@ -34,10 +34,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final Object guard_L_L(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             Object r = MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
             return ad.returnType.cast(r);
@@ -51,10 +48,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LL_V(VarHandle handle, Object arg0, Object arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -69,10 +63,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LLL_Z(VarHandle handle, Object arg0, Object arg1, Object arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -85,10 +76,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final Object guard_LLL_L(VarHandle handle, Object arg0, Object arg1, Object arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             Object r = MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
             return ad.returnType.cast(r);
@@ -102,10 +90,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final Object guard_LL_L(VarHandle handle, Object arg0, Object arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             Object r = MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
             return ad.returnType.cast(r);
@@ -119,10 +104,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_L_I(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
@@ -135,10 +117,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LI_V(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -153,10 +132,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LII_Z(VarHandle handle, Object arg0, int arg1, int arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -169,10 +145,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_LII_I(VarHandle handle, Object arg0, int arg1, int arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -185,10 +158,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_LI_I(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -201,10 +171,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_L_J(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
@@ -217,10 +184,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LJ_V(VarHandle handle, Object arg0, long arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -235,10 +199,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LJJ_Z(VarHandle handle, Object arg0, long arg1, long arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -251,10 +212,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_LJJ_J(VarHandle handle, Object arg0, long arg1, long arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -267,10 +225,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_LJ_J(VarHandle handle, Object arg0, long arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -283,10 +238,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard_L_F(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
@@ -299,10 +251,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LF_V(VarHandle handle, Object arg0, float arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -317,10 +266,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LFF_Z(VarHandle handle, Object arg0, float arg1, float arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -333,10 +279,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard_LFF_F(VarHandle handle, Object arg0, float arg1, float arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -349,10 +292,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard_LF_F(VarHandle handle, Object arg0, float arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -365,10 +305,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard_L_D(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
@@ -381,10 +318,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LD_V(VarHandle handle, Object arg0, double arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -399,10 +333,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LDD_Z(VarHandle handle, Object arg0, double arg1, double arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -415,10 +346,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard_LDD_D(VarHandle handle, Object arg0, double arg1, double arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -431,10 +359,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard_LD_D(VarHandle handle, Object arg0, double arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -447,10 +372,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final Object guard__L(VarHandle handle, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             Object r = MethodHandle.linkToStatic(handle, handle.vform.getMemberName(ad.mode));
             return ad.returnType.cast(r);
@@ -464,10 +386,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_L_V(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -482,10 +401,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LL_Z(VarHandle handle, Object arg0, Object arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -498,10 +414,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard__I(VarHandle handle, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, handle.vform.getMemberName(ad.mode));
         } else {
@@ -514,10 +427,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_I_V(VarHandle handle, int arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -532,10 +442,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_II_Z(VarHandle handle, int arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -548,10 +455,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_II_I(VarHandle handle, int arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -564,10 +468,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_I_I(VarHandle handle, int arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
@@ -580,10 +481,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard__J(VarHandle handle, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, handle.vform.getMemberName(ad.mode));
         } else {
@@ -596,10 +494,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_J_V(VarHandle handle, long arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -614,10 +509,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_JJ_Z(VarHandle handle, long arg0, long arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -630,10 +522,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_JJ_J(VarHandle handle, long arg0, long arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -646,10 +535,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_J_J(VarHandle handle, long arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
@@ -662,10 +548,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard__F(VarHandle handle, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, handle.vform.getMemberName(ad.mode));
         } else {
@@ -678,10 +561,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_F_V(VarHandle handle, float arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -696,10 +576,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_FF_Z(VarHandle handle, float arg0, float arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -712,10 +589,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard_FF_F(VarHandle handle, float arg0, float arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -728,10 +602,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard_F_F(VarHandle handle, float arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
@@ -744,10 +615,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard__D(VarHandle handle, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, handle.vform.getMemberName(ad.mode));
         } else {
@@ -760,10 +628,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_D_V(VarHandle handle, double arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -778,10 +643,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_DD_Z(VarHandle handle, double arg0, double arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -794,10 +656,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard_DD_D(VarHandle handle, double arg0, double arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -810,10 +669,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard_D_D(VarHandle handle, double arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
@@ -826,10 +682,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final Object guard_LI_L(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             Object r = MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
             return ad.returnType.cast(r);
@@ -843,10 +696,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LIL_V(VarHandle handle, Object arg0, int arg1, Object arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -861,10 +711,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LILL_Z(VarHandle handle, Object arg0, int arg1, Object arg2, Object arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
@@ -877,10 +724,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final Object guard_LILL_L(VarHandle handle, Object arg0, int arg1, Object arg2, Object arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             Object r = MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
             return ad.returnType.cast(r);
@@ -894,10 +738,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final Object guard_LIL_L(VarHandle handle, Object arg0, int arg1, Object arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             Object r = MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
             return ad.returnType.cast(r);
@@ -911,10 +752,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LII_V(VarHandle handle, Object arg0, int arg1, int arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -929,10 +767,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LIII_Z(VarHandle handle, Object arg0, int arg1, int arg2, int arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
@@ -945,10 +780,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_LIII_I(VarHandle handle, Object arg0, int arg1, int arg2, int arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
@@ -961,10 +793,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_LI_J(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -977,10 +806,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LIJ_V(VarHandle handle, Object arg0, int arg1, long arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -995,10 +821,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LIJJ_Z(VarHandle handle, Object arg0, int arg1, long arg2, long arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
@@ -1011,10 +834,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_LIJJ_J(VarHandle handle, Object arg0, int arg1, long arg2, long arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
@@ -1027,10 +847,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_LIJ_J(VarHandle handle, Object arg0, int arg1, long arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -1043,10 +860,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard_LI_F(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -1059,10 +873,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LIF_V(VarHandle handle, Object arg0, int arg1, float arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -1077,10 +888,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LIFF_Z(VarHandle handle, Object arg0, int arg1, float arg2, float arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
@@ -1093,10 +901,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard_LIFF_F(VarHandle handle, Object arg0, int arg1, float arg2, float arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
@@ -1109,10 +914,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard_LIF_F(VarHandle handle, Object arg0, int arg1, float arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -1125,10 +927,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard_LI_D(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -1141,10 +940,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LID_V(VarHandle handle, Object arg0, int arg1, double arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -1159,10 +955,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LIDD_Z(VarHandle handle, Object arg0, int arg1, double arg2, double arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
@@ -1175,10 +968,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard_LIDD_D(VarHandle handle, Object arg0, int arg1, double arg2, double arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
@@ -1191,10 +981,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard_LID_D(VarHandle handle, Object arg0, int arg1, double arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -1207,10 +994,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_LJ_I(VarHandle handle, Object arg0, long arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -1223,10 +1007,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LJI_V(VarHandle handle, Object arg0, long arg1, int arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -1241,10 +1022,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LJII_Z(VarHandle handle, Object arg0, long arg1, int arg2, int arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
@@ -1257,10 +1035,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_LJII_I(VarHandle handle, Object arg0, long arg1, int arg2, int arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
@@ -1273,10 +1048,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_LJI_I(VarHandle handle, Object arg0, long arg1, int arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -1289,10 +1061,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LJJ_V(VarHandle handle, Object arg0, long arg1, long arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -1307,10 +1076,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LJJJ_Z(VarHandle handle, Object arg0, long arg1, long arg2, long arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
@@ -1323,10 +1089,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_LJJJ_J(VarHandle handle, Object arg0, long arg1, long arg2, long arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-                    + ad.symbolicMethodTypeExact);
-        }
+        handle.checkExactAccessMode(ad);
         if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -686,10 +686,7 @@ final class VarHandles {
 //                @LambdaForm.Compiled
 //                @Hidden
 //                static final <METHOD> throws Throwable {
-//                    if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-//                        throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-//                                + ad.symbolicMethodTypeExact);
-//                    }
+//                    handle.checkExactAccessMode(ad);
 //                    if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
 //                        <RESULT_ERASED>MethodHandle.linkToStatic(<LINK_TO_STATIC_ARGS>);<RETURN_ERASED>
 //                    } else {
@@ -704,10 +701,7 @@ final class VarHandles {
 //                @LambdaForm.Compiled
 //                @Hidden
 //                static final <METHOD> throws Throwable {
-//                    if (handle.hasInvokeExactBehavior() && handle.accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-//                        throw new WrongMethodTypeException("expected " + handle.accessModeType(ad.type) + " but found "
-//                                + ad.symbolicMethodTypeExact);
-//                    }
+//                    handle.checkExactAccessMode(ad);
 //                    if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
 //                        MethodHandle.linkToStatic(<LINK_TO_STATIC_ARGS>);
 //                    } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {


### PR DESCRIPTION
Extract some common behavior checks from the generated VarHandleGuards code to a package-private VarHandle method. This reduces the code size (-5.2kb lib/modules) and slightly improves startup, while being performance neutral on microbenchmarks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267614](https://bugs.openjdk.java.net/browse/JDK-8267614): Outline VarHandleGuards exact behavior checks


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4165/head:pull/4165` \
`$ git checkout pull/4165`

Update a local copy of the PR: \
`$ git checkout pull/4165` \
`$ git pull https://git.openjdk.java.net/jdk pull/4165/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4165`

View PR using the GUI difftool: \
`$ git pr show -t 4165`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4165.diff">https://git.openjdk.java.net/jdk/pull/4165.diff</a>

</details>
