### PR TITLE
8265431: Add -fno-delete-null-pointer-checks to clang builds

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -737,6 +737,15 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
     $1_TOOLCHAIN_CFLAGS="${$1_GCC6_CFLAGS}"
 
     $1_WARNING_CFLAGS_JVM="-Wno-format-zero-length -Wtype-limits -Wuninitialized"
+  elif test "x$TOOLCHAIN_TYPE" = xclang; then
+    NO_DELETE_NULL_POINTER_CHECKS_CFLAG="-fno-delete-null-pointer-checks"
+    FLAGS_COMPILER_CHECK_ARGUMENTS(ARGUMENT: [$NO_DELETE_NULL_POINTER_CHECKS_CFLAG],
+        PREFIX: $3,
+        IF_FALSE: [
+            NO_DELETE_NULL_POINTER_CHECKS_CFLAG=
+        ]
+    )
+    $1_TOOLCHAIN_CFLAGS="${NO_DELETE_NULL_POINTER_CHECKS_CFLAG}"
   fi
 
   if test "x$TOOLCHAIN_TYPE" = xmicrosoft && test "x$ENABLE_REPRODUCIBLE_BUILD" = xtrue; then


### PR DESCRIPTION
This commit adds the `-fno-delete-null-pointer-checks` compiler option to clang builds, which is going to become necessary starting from clang version 12.0.0 (see the [bug report](https://bugs.openjdk.java.net/browse/JDK-8265431) for more info).

Verified on Linux (with both gcc and clang toolchains) and MacOS (with only the clang toolchain) by
- Running configure with `--with-toolchain-type=clang`; the following appears in the configure output:
```
...
checking if BUILD_CC supports "-fno-delete-null-pointer-checks"... yes
checking if BUILD_CXX supports "-fno-delete-null-pointer-checks"... yes
checking if both BUILD_CC and BUILD_CXX support "-fno-delete-null-pointer-checks"... yes
...
* Toolchain:      clang (clang/LLVM)
* C Compiler:     Version 10.0.0 (at /usr/bin/clang)
* C++ Compiler:   Version 10.0.0 (at /usr/bin/clang++)
```
- Successfully building `make images`. The option is actually passed down to the compiler:
```
$ grep fno-delete-null-pointer-checks .../jdk/build/linux-x86_64-server-release/hotspot/variant-server/libjvm/objs/*cmdline | wc -l 
1069
```
-  Running `make run-test-tier1` on Linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265431](https://bugs.openjdk.java.net/browse/JDK-8265431): Add -fno-delete-null-pointer-checks to clang builds


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4166/head:pull/4166` \
`$ git checkout pull/4166`

Update a local copy of the PR: \
`$ git checkout pull/4166` \
`$ git pull https://git.openjdk.java.net/jdk pull/4166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4166`

View PR using the GUI difftool: \
`$ git pr show -t 4166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4166.diff">https://git.openjdk.java.net/jdk/pull/4166.diff</a>

</details>
