### PR TITLE
8252476: as_Worker_thread() doesn't check what it intends

### DIFF
--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -40,6 +40,7 @@
 #include "oops/oop.inline.hpp"
 #include "runtime/java.hpp"
 #include "runtime/nonJavaThread.hpp"
+#include "runtime/thread.inline.hpp"
 
 ReferencePolicy* ReferenceProcessor::_always_clear_soft_ref_policy = NULL;
 ReferencePolicy* ReferenceProcessor::_default_soft_ref_policy      = NULL;

--- a/src/hotspot/share/runtime/nonJavaThread.hpp
+++ b/src/hotspot/share/runtime/nonJavaThread.hpp
@@ -106,11 +106,6 @@ class WorkerThread: public NamedThread {
   WorkerThread() : _id(0)               { }
   virtual bool is_Worker_thread() const { return true; }
 
-  virtual WorkerThread* as_Worker_thread() const {
-    assert(is_Worker_thread(), "Dubious cast to WorkerThread*?");
-    return (WorkerThread*) this;
-  }
-
   void set_id(uint work_id)             { _id = work_id; }
   uint id() const                       { return _id; }
 };

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -455,6 +455,13 @@ Thread::~Thread() {
   CHECK_UNHANDLED_OOPS_ONLY(if (CheckUnhandledOops) delete unhandled_oops();)
 }
 
+// Cast to worker thread
+// Not in hpp/inline.hpp, because WorkerThread is defined in its own header.
+const WorkerThread* Thread::as_Worker_thread() const {
+  assert(is_Worker_thread(), "incorrect cast to const WorkerThread");
+  return static_cast<const WorkerThread*>(this);
+}
+
 #ifdef ASSERT
 // A JavaThread is considered dangling if it not handshake-safe with respect to
 // the current thread, it is not on a ThreadsList, or not at safepoint.

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -455,13 +455,6 @@ Thread::~Thread() {
   CHECK_UNHANDLED_OOPS_ONLY(if (CheckUnhandledOops) delete unhandled_oops();)
 }
 
-// Cast to worker thread
-// Not in hpp/inline.hpp, because WorkerThread is defined in its own header.
-const WorkerThread* Thread::as_Worker_thread() const {
-  assert(is_Worker_thread(), "incorrect cast to const WorkerThread");
-  return static_cast<const WorkerThread*>(this);
-}
-
 #ifdef ASSERT
 // A JavaThread is considered dangling if it not handshake-safe with respect to
 // the current thread, it is not on a ThreadsList, or not at safepoint.

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1590,7 +1590,7 @@ inline JavaThread* JavaThread::current() {
 }
 
 inline WorkerThread* Thread::as_Worker_thread() const {
-  assert(is_Worker_thread(), "Dubious cast to WorkerThread*?");
+  assert(is_Worker_thread(), "incorrect cast to WorkerThread");
   return (WorkerThread*)this;
 }
 

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -355,7 +355,7 @@ class Thread: public ThreadShadow {
   virtual bool is_active_Java_thread() const         { return false; }
 
   // Casts
-  const WorkerThread* as_Worker_thread() const;
+  inline const WorkerThread* as_Worker_thread() const;
   inline JavaThread* as_Java_thread();
   inline const JavaThread* as_Java_thread() const;
 

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -355,7 +355,7 @@ class Thread: public ThreadShadow {
   virtual bool is_active_Java_thread() const         { return false; }
 
   // Casts
-  virtual WorkerThread* as_Worker_thread() const     { return NULL; }
+  WorkerThread* as_Worker_thread() const;
   inline JavaThread* as_Java_thread();
   inline const JavaThread* as_Java_thread() const;
 
@@ -1587,6 +1587,11 @@ public:
 // Inline implementation of JavaThread::current
 inline JavaThread* JavaThread::current() {
   return Thread::current()->as_Java_thread();
+}
+
+inline WorkerThread* Thread::as_Worker_thread() const {
+  assert(is_Worker_thread(), "Dubious cast to WorkerThread*?");
+  return (WorkerThread*)this;
 }
 
 inline JavaThread* Thread::as_Java_thread() {

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -355,7 +355,7 @@ class Thread: public ThreadShadow {
   virtual bool is_active_Java_thread() const         { return false; }
 
   // Casts
-  WorkerThread* as_Worker_thread() const;
+  const WorkerThread* as_Worker_thread() const;
   inline JavaThread* as_Java_thread();
   inline const JavaThread* as_Java_thread() const;
 
@@ -1587,11 +1587,6 @@ public:
 // Inline implementation of JavaThread::current
 inline JavaThread* JavaThread::current() {
   return Thread::current()->as_Java_thread();
-}
-
-inline WorkerThread* Thread::as_Worker_thread() const {
-  assert(is_Worker_thread(), "incorrect cast to WorkerThread");
-  return (WorkerThread*)this;
 }
 
 inline JavaThread* Thread::as_Java_thread() {

--- a/src/hotspot/share/runtime/thread.inline.hpp
+++ b/src/hotspot/share/runtime/thread.inline.hpp
@@ -31,6 +31,7 @@
 #include "runtime/orderAccess.hpp"
 #include "runtime/safepoint.hpp"
 #include "runtime/thread.hpp"
+#include "runtime/nonJavaThread.hpp"
 
 #if defined(__APPLE__) && defined(AARCH64)
 #include "runtime/os.hpp"
@@ -62,6 +63,11 @@ inline ThreadsList* Thread::get_threads_hazard_ptr() const {
 
 inline void Thread::set_threads_hazard_ptr(ThreadsList* new_list) {
   Atomic::release_store_fence(&_threads_hazard_ptr, new_list);
+}
+
+inline const WorkerThread* Thread::as_Worker_thread() const {
+  assert(is_Worker_thread(), "incorrect cast to const WorkerThread");
+  return static_cast<const WorkerThread*>(this);
 }
 
 #if defined(__APPLE__) && defined(AARCH64)


### PR DESCRIPTION
Convert `as_Worker_thread` to non-virtual, like other `as_*_thread` methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252476](https://bugs.openjdk.java.net/browse/JDK-8252476): as_Worker_thread() doesn't check what it intends


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Contributors
 * David Holmes `<dholmes@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4167/head:pull/4167` \
`$ git checkout pull/4167`

Update a local copy of the PR: \
`$ git checkout pull/4167` \
`$ git pull https://git.openjdk.java.net/jdk pull/4167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4167`

View PR using the GUI difftool: \
`$ git pr show -t 4167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4167.diff">https://git.openjdk.java.net/jdk/pull/4167.diff</a>

</details>
