### PR TITLE
8191786: Thread-SMR hash table size should be dynamic

### DIFF
--- a/src/hotspot/share/runtime/threadSMR.cpp
+++ b/src/hotspot/share/runtime/threadSMR.cpp
@@ -193,17 +193,7 @@ class ThreadScanHashtable : public CHeapObj<mtThread> {
   }
 
   int _table_size;
-  // Note: I want this to be mtThread, but that causes linkage errors:
-  //
-  //   Undefined symbols for architecture x86_64:
-  //   "BasicHashtable<(MEMFLAGS)2>::free_buckets()", referenced from:
-  //   ThreadsSMRSupport::free_list(ThreadsList*) in threadSMR.o
-  //   ThreadsSMRSupport::is_a_protected_JavaThread(JavaThread*) in threadSMR.o
-  //   "BasicHashtable<(MEMFLAGS)2>::new_entry(unsigned int)", referenced from:
-  //   KVHashtable<void*, bool, (MEMFLAGS)2, &(unsigned int primitive_hash<void*>(void* const&)), &(bool primitive_equals<void*>(void* const&, void* const&))>::add_if_absent(void*, bool, bool*) in threadSMR.o
-  //
-  // so I'm using mtInternal instead.
-  KVHashtable<void *, bool, mtInternal, &ThreadScanHashtable::ptr_hash,
+  KVHashtable<void *, bool, mtThread, &ThreadScanHashtable::ptr_hash,
                             &ThreadScanHashtable::ptr_equals> _ptrs;
 
  public:

--- a/src/hotspot/share/runtime/threadSMR.cpp
+++ b/src/hotspot/share/runtime/threadSMR.cpp
@@ -36,9 +36,9 @@
 #include "services/threadService.hpp"
 #include "utilities/copy.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "utilities/hashtable.inline.hpp"
 #include "utilities/ostream.hpp"
 #include "utilities/powerOfTwo.hpp"
-#include "utilities/resourceHash.hpp"
 #include "utilities/vmError.hpp"
 
 // The '_cnt', '_max' and '_times" fields are enabled via
@@ -193,29 +193,36 @@ class ThreadScanHashtable : public CHeapObj<mtThread> {
   }
 
   int _table_size;
-  // ResourceHashtable SIZE is specified at compile time so our
-  // dynamic _table_size is unused for now; 1031 is the first prime
-  // after 1024.
-  typedef ResourceHashtable<void *, int, &ThreadScanHashtable::ptr_hash,
-                            &ThreadScanHashtable::ptr_equals, 1031,
-                            ResourceObj::C_HEAP, mtThread> PtrTable;
-  PtrTable * _ptrs;
+  // Note: I want this to be mtThread, but that causes linkage errors:
+  //
+  //   Undefined symbols for architecture x86_64:
+  //   "BasicHashtable<(MEMFLAGS)2>::free_buckets()", referenced from:
+  //   ThreadsSMRSupport::free_list(ThreadsList*) in threadSMR.o
+  //   ThreadsSMRSupport::is_a_protected_JavaThread(JavaThread*) in threadSMR.o
+  //   "BasicHashtable<(MEMFLAGS)2>::new_entry(unsigned int)", referenced from:
+  //   KVHashtable<void*, bool, (MEMFLAGS)2, &(unsigned int primitive_hash<void*>(void* const&)), &(bool primitive_equals<void*>(void* const&, void* const&))>::add_if_absent(void*, bool, bool*) in threadSMR.o
+  //
+  // so I'm using mtInternal instead.
+  KVHashtable<void *, bool, mtInternal, &ThreadScanHashtable::ptr_hash,
+                            &ThreadScanHashtable::ptr_equals> _ptrs;
 
  public:
-  // ResourceHashtable is passed to various functions and populated in
-  // different places so we allocate it using C_HEAP to make it immune
-  // from any ResourceMarks that happen to be in the code paths.
-  ThreadScanHashtable(int table_size) : _table_size(table_size), _ptrs(new (ResourceObj::C_HEAP, mtThread) PtrTable()) {}
-
-  ~ThreadScanHashtable() { delete _ptrs; }
-
-  bool has_entry(void *pointer) {
-    int *val_ptr = _ptrs->get(pointer);
-    return val_ptr != NULL && *val_ptr == 1;
+  ThreadScanHashtable(int table_size) : _table_size(table_size), _ptrs(table_size) {
+      log_trace(thread, smr)("tid=" UINTX_FORMAT ": allocate ThreadScanHashtable(%d) at " INTPTR_FORMAT, os::current_thread_id(), _table_size, p2i(this));
   }
 
-  void add_entry(void *pointer) {
-    _ptrs->put(pointer, 1);
+  ~ThreadScanHashtable() {
+      log_trace(thread, smr)("tid=" UINTX_FORMAT ": deallocate ThreadScanHashtable(%d) at " INTPTR_FORMAT, os::current_thread_id(), _table_size, p2i(this));
+  }
+
+  bool add_if_absent(void* pointer) {
+    bool created;
+    _ptrs.add_if_absent(pointer, true, &created);
+    return created;
+  }
+
+  bool has_entry(void* pointer) {
+    return (_ptrs.lookup(pointer) != NULL);
   }
 };
 
@@ -232,12 +239,10 @@ class AddThreadHazardPointerThreadClosure : public ThreadClosure {
   AddThreadHazardPointerThreadClosure(ThreadScanHashtable *table) : _table(table) {}
 
   virtual void do_thread(Thread *thread) {
-    if (!_table->has_entry((void*)thread)) {
-      // The same JavaThread might be on more than one ThreadsList or
-      // more than one thread might be using the same ThreadsList. In
-      // either case, we only need a single entry for a JavaThread.
-      _table->add_entry((void*)thread);
-    }
+    // The same JavaThread might be on more than one ThreadsList or
+    // more than one thread might be using the same ThreadsList. In
+    // either case, we only need a single entry for a JavaThread.
+    (void)_table->add_if_absent((void*)thread);
   }
 };
 
@@ -326,9 +331,7 @@ class ScanHazardPtrGatherThreadsListClosure : public ThreadClosure {
     // published), then the only side effect is that we might keep a
     // to-be-deleted ThreadsList alive a little longer.
     hazard_ptr = Thread::untag_hazard_ptr(hazard_ptr);
-    if (!_table->has_entry((void*)hazard_ptr)) {
-      _table->add_entry((void*)hazard_ptr);
-    }
+    (void)_table->add_if_absent((void*)hazard_ptr);
   }
 };
 
@@ -847,6 +850,14 @@ bool ThreadsSMRSupport::delete_notify() {
   return (Atomic::load_acquire(&_delete_notify) != 0);
 }
 
+// Hash table size should be first power of two higher than twice the
+// length of the ThreadsList
+static int hash_table_size() {
+  ThreadsList* threads = ThreadsSMRSupport::get_java_thread_list();
+  int hash_table_size = MIN2((int)threads->length(), 32) << 1;
+  return round_up_power_of_2(hash_table_size);
+}
+
 // Safely free a ThreadsList after a Threads::add() or Threads::remove().
 // The specified ThreadsList may not get deleted during this call if it
 // is still in-use (referenced by a hazard ptr). Other ThreadsLists
@@ -870,12 +881,8 @@ void ThreadsSMRSupport::free_list(ThreadsList* threads) {
     }
   }
 
-  // Hash table size should be first power of two higher than twice the length of the ThreadsList
-  int hash_table_size = MIN2((int)get_java_thread_list()->length(), 32) << 1;
-  hash_table_size = round_up_power_of_2(hash_table_size);
-
   // Gather a hash table of the current hazard ptrs:
-  ThreadScanHashtable *scan_table = new ThreadScanHashtable(hash_table_size);
+  ThreadScanHashtable *scan_table = new ThreadScanHashtable(hash_table_size());
   ScanHazardPtrGatherThreadsListClosure scan_cl(scan_table);
   threads_do(&scan_cl);
   OrderAccess::acquire(); // Must order reads of hazard ptr before reads of
@@ -929,14 +936,9 @@ void ThreadsSMRSupport::free_list(ThreadsList* threads) {
 bool ThreadsSMRSupport::is_a_protected_JavaThread(JavaThread *thread) {
   assert_locked_or_safepoint(Threads_lock);
 
-  // Hash table size should be first power of two higher than twice
-  // the length of the Threads list.
-  int hash_table_size = MIN2((int)get_java_thread_list()->length(), 32) << 1;
-  hash_table_size = round_up_power_of_2(hash_table_size);
-
   // Gather a hash table of the JavaThreads indirectly referenced by
   // hazard ptrs.
-  ThreadScanHashtable *scan_table = new ThreadScanHashtable(hash_table_size);
+  ThreadScanHashtable *scan_table = new ThreadScanHashtable(hash_table_size());
   ScanHazardPtrGatherProtectedThreadsClosure scan_cl(scan_table);
   threads_do(&scan_cl);
   OrderAccess::acquire(); // Must order reads of hazard ptr before reads of

--- a/src/hotspot/share/utilities/hashtable.cpp
+++ b/src/hotspot/share/utilities/hashtable.cpp
@@ -279,7 +279,6 @@ template class BasicHashtable<mtModule>;
 template class BasicHashtable<mtCompiler>;
 template class BasicHashtable<mtTracing>;
 template class BasicHashtable<mtServiceability>;
-template class BasicHashtable<mtThread>;
 
 template void BasicHashtable<mtClass>::verify_table<DictionaryEntry>(char const*);
 template void BasicHashtable<mtModule>::verify_table<ModuleEntry>(char const*);

--- a/src/hotspot/share/utilities/hashtable.cpp
+++ b/src/hotspot/share/utilities/hashtable.cpp
@@ -279,6 +279,7 @@ template class BasicHashtable<mtModule>;
 template class BasicHashtable<mtCompiler>;
 template class BasicHashtable<mtTracing>;
 template class BasicHashtable<mtServiceability>;
+template class BasicHashtable<mtThread>;
 
 template void BasicHashtable<mtClass>::verify_table<DictionaryEntry>(char const*);
 template void BasicHashtable<mtModule>::verify_table<ModuleEntry>(char const*);


### PR DESCRIPTION
Small change to switch Thread-SMR's hash table from ResourceHashtable to KVHashtable
so that a variable sized hash table is used instead of a fixed size hash table (1031 elements).
Also refactor common hash table size calculation code into static hash_table_size()
function and call it from both places.

Test with Mach5 Tier[1-7] testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8191786](https://bugs.openjdk.java.net/browse/JDK-8191786): Thread-SMR hash table size should be dynamic


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Robbin Ehn](https://openjdk.java.net/census#rehn) (@robehn - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4168/head:pull/4168` \
`$ git checkout pull/4168`

Update a local copy of the PR: \
`$ git checkout pull/4168` \
`$ git pull https://git.openjdk.java.net/jdk pull/4168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4168`

View PR using the GUI difftool: \
`$ git pr show -t 4168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4168.diff">https://git.openjdk.java.net/jdk/pull/4168.diff</a>

</details>
