### PR TITLE
8195129: System.load() fails to load from unicode paths

### DIFF
--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3353,29 +3353,25 @@ JVM_END
 
 // Library support ///////////////////////////////////////////////////////////////////////////
 
-JVM_ENTRY_NO_ENV(void*, JVM_LoadLibrary(const char* name))
+JVM_ENTRY_NO_ENV(void*, JVM_LoadLibrary(const char* utf8_name))
   //%note jvm_ct
   char ebuf[1024];
   void *load_result;
   {
     ThreadToNativeFromVM ttnfvm(thread);
-    load_result = os::dll_load(name, ebuf, sizeof ebuf);
+    load_result = os::dll_load(utf8_name, ebuf, sizeof ebuf);
   }
   if (load_result == NULL) {
     char msg[1024];
-    jio_snprintf(msg, sizeof msg, "%s: %s", name, ebuf);
-    // Since 'ebuf' may contain a string encoded using
-    // platform encoding scheme, we need to pass
-    // Exceptions::unsafe_to_utf8 to the new_exception method
-    // as the last argument. See bug 6367357.
+    jio_snprintf(msg, sizeof msg, "%s: %s", utf8_name, ebuf);
     Handle h_exception =
       Exceptions::new_exception(thread,
                                 vmSymbols::java_lang_UnsatisfiedLinkError(),
-                                msg, Exceptions::unsafe_to_utf8);
+                                msg);
 
     THROW_HANDLE_0(h_exception);
   }
-  log_info(library)("Loaded library %s, handle " INTPTR_FORMAT, name, p2i(load_result));
+  log_info(library)("Loaded library %s, handle " INTPTR_FORMAT, utf8_name, p2i(load_result));
   return load_result;
 JVM_END
 

--- a/src/hotspot/share/utilities/globalDefinitions_visCPP.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_visCPP.hpp
@@ -112,6 +112,7 @@ inline int g_isfinite(jdouble f)                 { return _finite(f); }
 
 // Visual Studio 2005 deprecates POSIX names - use ISO C++ names instead
 #define open _open
+#define wopen _wopen
 #define close _close
 #define read  _read
 #define write _write

--- a/src/java.base/share/native/libjava/NativeLibraries.c
+++ b/src/java.base/share/native/libjava/NativeLibraries.c
@@ -123,14 +123,9 @@ Java_jdk_internal_loader_NativeLibraries_load
     if (!initIDs(env))
         return JNI_FALSE;
 
-    const int utf8_len    = (*env)->GetStringUTFLength(env, name);
-    const int chars_count = (*env)->GetStringLength(env, name);
-    char * utf8_name = malloc(utf8_len + 1);
-    if (utf8_name == NULL) {
-      JNU_ThrowOutOfMemoryError(env, NULL);
-      return JNI_FALSE;
-    }
-    (*env)->GetStringUTFRegion(env, name, 0, chars_count, utf8_name);
+    const char * utf8_name = GetStringUTF8Chars(env, name);
+    if (utf8_name == NULL)
+            return JNI_FALSE;
     handle = isBuiltin ? procHandle : JVM_LoadLibrary(utf8_name);
     if (isJNI) {
         if (handle) {
@@ -183,7 +178,7 @@ Java_jdk_internal_loader_NativeLibraries_load
     loaded = JNI_TRUE;
 
  done:
-    free(utf8_name);
+    ReleaseStringUTF8Chars(env, name, utf8_name);
     return loaded;
 }
 

--- a/src/java.base/share/native/libjava/jni_util.h
+++ b/src/java.base/share/native/libjava/jni_util.h
@@ -96,6 +96,13 @@ JNU_ThrowIOExceptionWithLastError(JNIEnv *env, const char *defaultDetail);
 JNIEXPORT const char *
 GetStringPlatformChars(JNIEnv *env, jstring jstr, jboolean *isCopy);
 
+/* Convert the Java string to UTF-8 (not "modified UTF-8") */
+JNIEXPORT const char *
+GetStringUTF8Chars(JNIEnv *env, jstring jstr);
+
+JNIEXPORT void
+ReleaseStringUTF8Chars(JNIEnv* env, jstring jstr, const char *str);
+
 JNIEXPORT jstring JNICALL
 JNU_NewStringPlatform(JNIEnv *env, const char *str);
 

--- a/test/hotspot/jtreg/runtime/jni/loadLibraryUnicode/LoadLibraryUnicode.java
+++ b/test/hotspot/jtreg/runtime/jni/loadLibraryUnicode/LoadLibraryUnicode.java
@@ -33,7 +33,8 @@ public class LoadLibraryUnicode {
 
     static native int giveANumber();
 
-    private static final String NON_LATIN_PATH_NAME = "ka-\u1889-omega-\u03c9";
+    // Use non-Latin characters from basic (\u1889) and supplementary (\uD844\uDDD9) Unicode planes
+    private static final String NON_LATIN_PATH_NAME = "ka-\u1889-supp-\uD844\uDDD9";
 
     private static String toPlatformLibraryName(String name) {
         return (Platform.isWindows() ? "" : "lib") + name + "." + Platform.sharedLibraryExt();

--- a/test/hotspot/jtreg/runtime/jni/loadLibraryUnicode/LoadLibraryUnicode.java
+++ b/test/hotspot/jtreg/runtime/jni/loadLibraryUnicode/LoadLibraryUnicode.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, JetBrains s.r.o.. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import jdk.test.lib.Platform;
+import jdk.test.lib.Asserts;
+
+public class LoadLibraryUnicode {
+
+    static native int giveANumber();
+
+    private static final String NON_LATIN_PATH_NAME = "ka-\u1889-omega-\u03c9";
+
+    public static void verifySystemLoad() throws Exception {
+        String osDependentLibraryFileName = null;
+        if (Platform.isLinux()) {
+            osDependentLibraryFileName = "libLoadLibraryUnicode.so";
+        } else if (Platform.isOSX()) {
+            osDependentLibraryFileName = "libLoadLibraryUnicode.dylib";
+        } else if (Platform.isWindows()) {
+            osDependentLibraryFileName = "LoadLibraryUnicode.dll";
+        } else {
+            throw new Error("Unsupported OS");
+        }
+
+        String testNativePath = LoadLibraryUnicodeTest.getSystemProperty("test.nativepath");
+        Path origLibraryPath = Paths.get(testNativePath).resolve(osDependentLibraryFileName);
+
+        Path currentDirPath = Paths.get(".").toAbsolutePath();
+        Path newLibraryPath = currentDirPath.resolve(NON_LATIN_PATH_NAME);
+        Files.createDirectory(newLibraryPath);
+        newLibraryPath = newLibraryPath.resolve(osDependentLibraryFileName);
+
+        System.out.println(String.format("Copying '%s' to '%s'", origLibraryPath, newLibraryPath));
+        Files.copy(origLibraryPath, newLibraryPath);
+
+        System.out.println(String.format("Loading '%s'", newLibraryPath));
+        System.load(newLibraryPath.toString());
+
+        final int retval = giveANumber();
+        Asserts.assertEquals(retval, 42);
+    }
+
+    public static void verifyExceptionMessage() throws Exception {
+        Path currentDirPath = Paths.get(".").toAbsolutePath();
+        Path newLibraryPath = currentDirPath.resolve(NON_LATIN_PATH_NAME).resolve("non-existent-library");
+
+        System.out.println(String.format("Loading '%s'", newLibraryPath));
+        try {
+            System.load(newLibraryPath.toString());
+        } catch(UnsatisfiedLinkError e) {
+            // The name of the library may have been corrupted by encoding/decoding it improperly.
+            // Verify that it is still the same.
+            Asserts.assertTrue(e.getMessage().contains(NON_LATIN_PATH_NAME));
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        verifySystemLoad();
+        verifyExceptionMessage();
+    }
+}

--- a/test/hotspot/jtreg/runtime/jni/loadLibraryUnicode/LoadLibraryUnicode.java
+++ b/test/hotspot/jtreg/runtime/jni/loadLibraryUnicode/LoadLibraryUnicode.java
@@ -35,17 +35,12 @@ public class LoadLibraryUnicode {
 
     private static final String NON_LATIN_PATH_NAME = "ka-\u1889-omega-\u03c9";
 
+    private static String toPlatformLibraryName(String name) {
+        return (Platform.isWindows() ? "" : "lib") + name + "." + Platform.sharedLibraryExt();
+    }
+
     public static void verifySystemLoad() throws Exception {
-        String osDependentLibraryFileName = null;
-        if (Platform.isLinux()) {
-            osDependentLibraryFileName = "libLoadLibraryUnicode.so";
-        } else if (Platform.isOSX()) {
-            osDependentLibraryFileName = "libLoadLibraryUnicode.dylib";
-        } else if (Platform.isWindows()) {
-            osDependentLibraryFileName = "LoadLibraryUnicode.dll";
-        } else {
-            throw new Error("Unsupported OS");
-        }
+        final String osDependentLibraryFileName = toPlatformLibraryName("LoadLibraryUnicode");
 
         String testNativePath = LoadLibraryUnicodeTest.getSystemProperty("test.nativepath");
         Path origLibraryPath = Paths.get(testNativePath).resolve(osDependentLibraryFileName);

--- a/test/hotspot/jtreg/runtime/jni/loadLibraryUnicode/LoadLibraryUnicodeTest.java
+++ b/test/hotspot/jtreg/runtime/jni/loadLibraryUnicode/LoadLibraryUnicodeTest.java
@@ -26,7 +26,7 @@
  * @bug 8195129
  * @summary regression test for 8195129,
  *          verifies the ability to System.load() from a location containing non-Latin characters
- * @requires (os.family == "windows") | (os.family == "mac") | (os.family == "linux")
+ * @requires (os.family == "windows")
  * @library /test/lib
  * @build LoadLibraryUnicode
  * @run main/native LoadLibraryUnicodeTest
@@ -37,11 +37,6 @@ import jdk.test.lib.process.ProcessTools;
 public class LoadLibraryUnicodeTest {
 
     public static void main(String args[]) throws Exception {
-        if (!java.nio.charset.Charset.isSupported("UTF-8")) {
-            System.out.println("Test requires UTF-8 support; will not run and is considered passed.");
-            return;
-        }
-
         String nativePathSetting = "-Dtest.nativepath=" + getSystemProperty("test.nativepath");
         ProcessBuilder pb = ProcessTools.createTestJvm(nativePathSetting, LoadLibraryUnicode.class.getName());
         pb.environment().put("LC_ALL", "en_US.UTF-8");

--- a/test/hotspot/jtreg/runtime/jni/loadLibraryUnicode/LoadLibraryUnicodeTest.java
+++ b/test/hotspot/jtreg/runtime/jni/loadLibraryUnicode/LoadLibraryUnicodeTest.java
@@ -37,6 +37,11 @@ import jdk.test.lib.process.ProcessTools;
 public class LoadLibraryUnicodeTest {
 
     public static void main(String args[]) throws Exception {
+        if (!java.nio.charset.Charset.isSupported("UTF-8")) {
+            System.out.println("Test requires UTF-8 support; will not run and is considered passed.");
+            return;
+        }
+
         String nativePathSetting = "-Dtest.nativepath=" + getSystemProperty("test.nativepath");
         ProcessBuilder pb = ProcessTools.createTestJvm(nativePathSetting, LoadLibraryUnicode.class.getName());
         pb.environment().put("LC_ALL", "en_US.UTF-8");

--- a/test/hotspot/jtreg/runtime/jni/loadLibraryUnicode/LoadLibraryUnicodeTest.java
+++ b/test/hotspot/jtreg/runtime/jni/loadLibraryUnicode/LoadLibraryUnicodeTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, JetBrains s.r.o.. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8195129
+ * @summary regression test for 8195129,
+ *          verifies the ability to System.load() from a location containing non-Latin characters
+ * @requires (os.family == "windows") | (os.family == "mac") | (os.family == "linux")
+ * @library /test/lib
+ * @build LoadLibraryUnicode
+ * @run main/native LoadLibraryUnicodeTest
+ */
+
+import jdk.test.lib.process.ProcessTools;
+
+public class LoadLibraryUnicodeTest {
+
+    public static void main(String args[]) throws Exception {
+        String nativePathSetting = "-Dtest.nativepath=" + getSystemProperty("test.nativepath");
+        ProcessBuilder pb = ProcessTools.createTestJvm(nativePathSetting, LoadLibraryUnicode.class.getName());
+        pb.environment().put("LC_ALL", "en_US.UTF-8");
+        ProcessTools.executeProcess(pb)
+                    .outputTo(System.out)
+                    .errorTo(System.err)
+                    .shouldHaveExitValue(0);
+    }
+
+    // Utility method to retrieve and validate system properties
+    public static String getSystemProperty(String propertyName) throws Error {
+        String systemProperty = System.getProperty(propertyName, "").trim();
+        System.out.println(propertyName + " = " + systemProperty);
+        if (systemProperty.isEmpty()) {
+            throw new Error("TESTBUG: property " + propertyName + " is empty");
+        }
+        return systemProperty;
+    }
+}

--- a/test/hotspot/jtreg/runtime/jni/loadLibraryUnicode/libLoadLibraryUnicode.c
+++ b/test/hotspot/jtreg/runtime/jni/loadLibraryUnicode/libLoadLibraryUnicode.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, JetBrains s.r.o.. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+#include <jni.h>
+
+JNIEXPORT jint JNICALL
+Java_LoadLibraryUnicode_giveANumber(JNIEnv *env) {
+    return 42;
+}


### PR DESCRIPTION
Character strings within JVM are produced and consumed in several formats. Strings come from/to Java in the UTF8 format and POSIX APIs (like fprintf() or dlopen()) consume strings also in UTF8. On Windows, however, the situation is far less simple: some new(er) APIs expect UTF16 (wide-character strings), some older APIs can only work with strings in a "platform" format, where not all UTF8 characters can be represented; which ones can depends on the current "code page".

This commit switches the Windows version of native library loading code to using the new UTF16 API `LoadLibraryW()` and attempts to streamline the use of various string formats in the surrounding code. 

Namely, exception messages are made to consume strings explicitly in the UTF8 format, while logging functions (that end up using legacy Windows API) are made to consume "platform" strings in most cases. One exception is `JVM_LoadLibrary()` logging where the UTF8 name of the library is logged, which can, of course, be fixed, but was considered not worth the additional code (NB: this isn't a new bug).

The test runs in a separate JVM in order to make NIO happy about non-ASCII characters in the file name; tests are executed with LC_ALL=C and that doesn't let NIO work with non-ASCII file names even on Linux or MacOS.

Tested by running `test/hotspot/jtreg:tier1` on Linux and `jtreg:test/hotspot/jtreg/runtime` on Windows 10. The new test (`   jtreg:test/hotspot/jtreg/runtime/jni/loadLibraryUnicode`) was explicitly ran on those platforms as well.

Results from Linux:
```
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/hotspot/jtreg:tier1                     1784  1784     0     0   
==============================
TEST SUCCESS
```
```
Building target 'run-test-only' in configuration 'linux-x86_64-server-release'
Test selection 'jtreg:test/hotspot/jtreg/runtime/jni/loadLibraryUnicode', will run:
* jtreg:test/hotspot/jtreg/runtime/jni/loadLibraryUnicode

Running test 'jtreg:test/hotspot/jtreg/runtime/jni/loadLibraryUnicode'
Passed: runtime/jni/loadLibraryUnicode/LoadLibraryUnicodeTest.java
Test results: passed: 1
```

Results from Windows 10:
```
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR
   jtreg:test/hotspot/jtreg/runtime                    746   746     0     0
==============================
TEST SUCCESS
Finished building target 'run-test-only' in configuration 'windows-x86_64-server-fastdebug'
```
```
Building target 'run-test-only' in configuration 'windows-x86_64-server-fastdebug'
Test selection 'test/hotspot/jtreg/runtime/jni/loadLibraryUnicode', will run:
* jtreg:test/hotspot/jtreg/runtime/jni/loadLibraryUnicode

Running test 'jtreg:test/hotspot/jtreg/runtime/jni/loadLibraryUnicode'
Passed: runtime/jni/loadLibraryUnicode/LoadLibraryUnicodeTest.java
Test results: passed: 1
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8195129](https://bugs.openjdk.java.net/browse/JDK-8195129): System.load() fails to load from unicode paths


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4169/head:pull/4169` \
`$ git checkout pull/4169`

Update a local copy of the PR: \
`$ git checkout pull/4169` \
`$ git pull https://git.openjdk.java.net/jdk pull/4169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4169`

View PR using the GUI difftool: \
`$ git pr show -t 4169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4169.diff">https://git.openjdk.java.net/jdk/pull/4169.diff</a>

</details>
