### PR TITLE
8267543: Post JEP 411 refactoring: security

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/JceKeyStore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/JceKeyStore.java
@@ -683,7 +683,6 @@ public final class JceKeyStore extends KeyStoreSpi {
      * @exception CertificateException if any of the certificates in the
      * keystore could not be loaded
      */
-    @SuppressWarnings("removal")
     public void engineLoad(InputStream stream, char[] password)
         throws IOException, NoSuchAlgorithmException, CertificateException
     {
@@ -838,7 +837,8 @@ public final class JceKeyStore extends KeyStoreSpi {
                             ois = new ObjectInputStream(dis);
                             final ObjectInputStream ois2 = ois;
                             // Set a deserialization checker
-                            AccessController.doPrivileged(
+                            @SuppressWarnings("removal")
+                            var dummy = AccessController.doPrivileged(
                                 (PrivilegedAction<Void>)() -> {
                                     ois2.setObjectInputFilter(
                                         new DeserializationChecker(fullLength));

--- a/src/java.base/share/classes/java/security/KeyStore.java
+++ b/src/java.base/share/classes/java/security/KeyStore.java
@@ -987,10 +987,9 @@ public class KeyStore {
      * if no such property exists.
      * @see java.security.Security security properties
      */
-    @SuppressWarnings("removal")
     public static final String getDefaultType() {
-        String kstype;
-        kstype = AccessController.doPrivileged(new PrivilegedAction<>() {
+        @SuppressWarnings("removal")
+        String kstype = AccessController.doPrivileged(new PrivilegedAction<>() {
             public String run() {
                 return Security.getProperty(KEYSTORE_TYPE);
             }
@@ -1957,7 +1956,6 @@ public class KeyStore {
          *   of either PasswordProtection or CallbackHandlerProtection; or
          *   if file does not exist or does not refer to a normal file
          */
-        @SuppressWarnings("removal")
         public static Builder newInstance(String type, Provider provider,
                 File file, ProtectionParameter protection) {
             if ((type == null) || (file == null) || (protection == null)) {
@@ -1974,8 +1972,9 @@ public class KeyStore {
                     ("File does not exist or it does not refer " +
                      "to a normal file: " + file);
             }
-            return new FileBuilder(type, provider, file, protection,
-                AccessController.getContext());
+            @SuppressWarnings("removal")
+            var acc = AccessController.getContext();
+            return new FileBuilder(type, provider, file, protection, acc);
         }
 
         /**

--- a/src/java.base/share/classes/java/security/Security.java
+++ b/src/java.base/share/classes/java/security/Security.java
@@ -51,7 +51,6 @@ import sun.security.jca.*;
  * @since 1.1
  */
 
-@SuppressWarnings("removal")
 public final class Security {
 
     /* Are we debugging? -- for developers */
@@ -72,7 +71,8 @@ public final class Security {
         // things in initialize that might require privs.
         // (the FileInputStream call and the File.exists call,
         // the securityPropFile call, etc)
-        AccessController.doPrivileged(new PrivilegedAction<>() {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged(new PrivilegedAction<>() {
             public Void run() {
                 initialize();
                 return null;
@@ -761,6 +761,7 @@ public final class Security {
      * @see java.security.SecurityPermission
      */
     public static String getProperty(String key) {
+        @SuppressWarnings("removal")
         SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
             sm.checkPermission(new SecurityPermission("getProperty."+
@@ -828,6 +829,7 @@ public final class Security {
     }
 
     private static void check(String directive) {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
             security.checkSecurityAccess(directive);
@@ -835,6 +837,7 @@ public final class Security {
     }
 
     private static void checkInsertProvider(String name) {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
             try {

--- a/src/java.base/share/classes/javax/crypto/ProviderVerifier.java
+++ b/src/java.base/share/classes/javax/crypto/ProviderVerifier.java
@@ -83,7 +83,6 @@ final class ProviderVerifier {
      * In OpenJDK, we just need to examine the "cryptoperms" file to see
      * if any permissions were bundled together with this jar file.
      */
-    @SuppressWarnings("removal")
     void verify() throws IOException {
 
         // Short-circuit.  If we weren't asked to save any, we're done.
@@ -102,7 +101,8 @@ final class ProviderVerifier {
 
             // Get a link to the Jarfile to search.
             try {
-                jf = AccessController.doPrivileged(
+                @SuppressWarnings("removal")
+                var tmp = AccessController.doPrivileged(
                          new PrivilegedExceptionAction<JarFile>() {
                              public JarFile run() throws Exception {
                                  JarURLConnection conn =
@@ -113,6 +113,7 @@ final class ProviderVerifier {
                                  return conn.getJarFile();
                              }
                          });
+                jf = tmp;
             } catch (java.security.PrivilegedActionException pae) {
                 throw new SecurityException("Cannot load " + url.toString(),
                     pae.getCause());

--- a/src/java.base/share/classes/sun/security/jca/ProviderConfig.java
+++ b/src/java.base/share/classes/sun/security/jca/ProviderConfig.java
@@ -160,7 +160,7 @@ final class ProviderConfig {
     /**
      * Get the provider object. Loads the provider if it is not already loaded.
      */
-    @SuppressWarnings({"removal","deprecation"})
+    @SuppressWarnings("deprecation")
     Provider getProvider() {
         // volatile variable load
         Provider p = provider;
@@ -188,7 +188,8 @@ final class ProviderConfig {
                 p = new sun.security.ssl.SunJSSE();
             } else if (provName.equals("Apple") || provName.equals("apple.security.AppleProvider")) {
                 // need to use reflection since this class only exists on MacOsx
-                p = AccessController.doPrivileged(new PrivilegedAction<Provider>() {
+                @SuppressWarnings("removal")
+                var tmp = AccessController.doPrivileged(new PrivilegedAction<Provider>() {
                     public Provider run() {
                         try {
                             Class<?> c = Class.forName("apple.security.AppleProvider");
@@ -208,6 +209,7 @@ final class ProviderConfig {
                         }
                     }
                 });
+                p = tmp;
             } else {
                 if (isLoading) {
                     // because this method is synchronized, this can only

--- a/src/java.base/share/classes/sun/security/provider/MD4.java
+++ b/src/java.base/share/classes/sun/security/provider/MD4.java
@@ -43,7 +43,6 @@ import static sun.security.util.SecurityConstants.PROVIDER_VER;
  *
  * @author      Andreas Sterbenz
  */
-@SuppressWarnings("removal")
 public final class MD4 extends DigestBase {
 
     // state of this object
@@ -71,7 +70,8 @@ public final class MD4 extends DigestBase {
             @java.io.Serial
             private static final long serialVersionUID = -8850464997518327965L;
         };
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged(new PrivilegedAction<Void>() {
             public Void run() {
                 md4Provider.put("MessageDigest.MD4", "sun.security.provider.MD4");
                 return null;

--- a/src/java.base/share/classes/sun/security/provider/SunEntries.java
+++ b/src/java.base/share/classes/sun/security/provider/SunEntries.java
@@ -81,7 +81,6 @@ import static sun.security.util.SecurityProviderConstants.getAliases;
  * - JavaLoginConfig is the default file-based LoginModule Configuration type.
  */
 
-@SuppressWarnings("removal")
 public final class SunEntries {
 
     // the default algo used by SecureRandom class for new SecureRandom() calls
@@ -325,10 +324,8 @@ public final class SunEntries {
     static final String URL_DEV_RANDOM = "file:/dev/random";
     static final String URL_DEV_URANDOM = "file:/dev/urandom";
 
-    private static final String seedSource;
-
-    static {
-        seedSource = AccessController.doPrivileged(
+    @SuppressWarnings("removal")
+    private static final String seedSource = AccessController.doPrivileged(
                 new PrivilegedAction<String>() {
 
             @Override
@@ -345,6 +342,7 @@ public final class SunEntries {
             }
         });
 
+    static {
         DEF_SECURE_RANDOM_ALGO  = (NativePRNG.isAvailable() &&
             (seedSource.equals(URL_DEV_URANDOM) ||
              seedSource.equals(URL_DEV_RANDOM)) ?

--- a/src/java.base/share/classes/sun/security/ssl/SSLEngineImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLEngineImpl.java
@@ -1195,7 +1195,6 @@ final class SSLEngineImpl extends SSLEngine implements SSLTransport {
             this.engine = engineInstance;
         }
 
-        @SuppressWarnings("removal")
         @Override
         public void run() {
             engine.engineLock.lock();
@@ -1206,7 +1205,8 @@ final class SSLEngineImpl extends SSLEngine implements SSLTransport {
                 }
 
                 try {
-                    AccessController.doPrivileged(
+                    @SuppressWarnings("removal")
+                    var dummy = AccessController.doPrivileged(
                             new DelegatedAction(hc), engine.conContext.acc);
                 } catch (PrivilegedActionException pae) {
                     // Get the handshake context again in case the

--- a/src/java.base/share/classes/sun/security/util/AnchorCertificates.java
+++ b/src/java.base/share/classes/sun/security/util/AnchorCertificates.java
@@ -43,7 +43,6 @@ import sun.security.x509.X509CertImpl;
  * The purpose of this class is to determine the trust anchor certificates is in
  * the cacerts file.  This is used for PKIX CertPath checking.
  */
-@SuppressWarnings("removal")
 public class AnchorCertificates {
 
     private static final Debug debug = Debug.getInstance("certpath");
@@ -52,7 +51,8 @@ public class AnchorCertificates {
     private static Set<X500Principal> certIssuers = Collections.emptySet();
 
     static  {
-        AccessController.doPrivileged(new PrivilegedAction<>() {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged(new PrivilegedAction<>() {
             @Override
             public Void run() {
                 File f = new File(FilePaths.cacerts());

--- a/src/java.base/share/classes/sun/security/util/KeyStoreDelegator.java
+++ b/src/java.base/share/classes/sun/security/util/KeyStoreDelegator.java
@@ -55,7 +55,6 @@ public class KeyStoreDelegator extends KeyStoreSpi {
     private KeyStoreSpi keystore; // the delegate
     private boolean compatModeEnabled = true;
 
-    @SuppressWarnings("removal")
     public KeyStoreDelegator(
         String primaryType,
         Class<? extends KeyStoreSpi> primaryKeyStore,
@@ -63,9 +62,10 @@ public class KeyStoreDelegator extends KeyStoreSpi {
         Class<? extends KeyStoreSpi> secondaryKeyStore) {
 
         // Check whether compatibility mode has been disabled
-        compatModeEnabled = "true".equalsIgnoreCase(
-            AccessController.doPrivileged((PrivilegedAction<String>) () ->
-                Security.getProperty(KEYSTORE_TYPE_COMPAT)));
+        @SuppressWarnings("removal")
+        var prop = AccessController.doPrivileged((PrivilegedAction<String>) () ->
+                        Security.getProperty(KEYSTORE_TYPE_COMPAT));
+        compatModeEnabled = "true".equalsIgnoreCase(prop);
 
         if (compatModeEnabled) {
             this.primaryType = primaryType;

--- a/src/java.base/share/classes/sun/security/util/UntrustedCertificates.java
+++ b/src/java.base/share/classes/sun/security/util/UntrustedCertificates.java
@@ -42,7 +42,6 @@ import sun.security.x509.X509CertImpl;
  * <b>Attention</b>: This check is NOT meant to replace the standard PKI-defined
  * validation check, neither is it used as an alternative to CRL.
  */
-@SuppressWarnings("removal")
 public final class UntrustedCertificates {
 
     private static final Debug debug = Debug.getInstance("certpath");
@@ -52,7 +51,8 @@ public final class UntrustedCertificates {
     private static final String algorithm;
 
     static {
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged(new PrivilegedAction<Void>() {
             @Override
             public Void run() {
                 File f = new File(StaticProperty.javaHome(),

--- a/src/java.management/share/classes/com/sun/jmx/remote/security/JMXPluggableAuthenticator.java
+++ b/src/java.management/share/classes/com/sun/jmx/remote/security/JMXPluggableAuthenticator.java
@@ -85,7 +85,6 @@ public final class JMXPluggableAuthenticator implements JMXAuthenticator {
      * @exception SecurityException if the authentication mechanism cannot be
      *            initialized.
      */
-    @SuppressWarnings("removal")
     public JMXPluggableAuthenticator(Map<?, ?> env) {
 
         String loginConfigName = null;
@@ -107,6 +106,7 @@ public final class JMXPluggableAuthenticator implements JMXAuthenticator {
 
             } else {
                 // use the default JAAS login configuration (file-based)
+                @SuppressWarnings("removal")
                 SecurityManager sm = System.getSecurityManager();
                 if (sm != null) {
                     sm.checkPermission(
@@ -117,7 +117,8 @@ public final class JMXPluggableAuthenticator implements JMXAuthenticator {
                 final String pf = passwordFile;
                 final String hashPass = hashPasswords;
                 try {
-                    loginContext = AccessController.doPrivileged(
+                    @SuppressWarnings("removal")
+                    var tmp = AccessController.doPrivileged(
                         new PrivilegedExceptionAction<LoginContext>() {
                             public LoginContext run() throws LoginException {
                                 return new LoginContext(
@@ -127,6 +128,7 @@ public final class JMXPluggableAuthenticator implements JMXAuthenticator {
                                                 new FileLoginConfig(pf, hashPass));
                             }
                         });
+                    loginContext = tmp;
                 } catch (PrivilegedActionException pae) {
                     throw (LoginException) pae.getException();
                 }
@@ -156,7 +158,6 @@ public final class JMXPluggableAuthenticator implements JMXAuthenticator {
      * @exception SecurityException if the server cannot authenticate the user
      * with the provided credentials.
      */
-    @SuppressWarnings("removal")
     public Subject authenticate(Object credentials) {
         // Verify that credentials is of type String[].
         //
@@ -193,7 +194,8 @@ public final class JMXPluggableAuthenticator implements JMXAuthenticator {
         try {
             loginContext.login();
             final Subject subject = loginContext.getSubject();
-            AccessController.doPrivileged(new PrivilegedAction<Void>() {
+            @SuppressWarnings("removal")
+            var dummy = AccessController.doPrivileged(new PrivilegedAction<Void>() {
                     public Void run() {
                         subject.setReadOnly();
                         return null;

--- a/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5Context.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5Context.java
@@ -592,7 +592,6 @@ class Krb5Context implements GSSContextSpi {
      *    to send the token to its peer for processing.
      * @exception GSSException
      */
-    @SuppressWarnings("removal")
     public final byte[] initSecContext(InputStream is, int mechTokenSize)
         throws GSSException {
 
@@ -642,6 +641,7 @@ class Krb5Context implements GSSContextSpi {
                      * for this service in the Subject and reuse it
                      */
 
+                    @SuppressWarnings("removal")
                     final AccessControlContext acc =
                         AccessController.getContext();
 
@@ -649,7 +649,8 @@ class Krb5Context implements GSSContextSpi {
                         KerberosTicket kerbTicket = null;
                         try {
                            // get service ticket from caller's subject
-                           kerbTicket = AccessController.doPrivileged(
+                           @SuppressWarnings("removal")
+                           var tmp = AccessController.doPrivileged(
                                 new PrivilegedExceptionAction<KerberosTicket>() {
                                 public KerberosTicket run() throws Exception {
                                     // XXX to be cleaned
@@ -667,6 +668,7 @@ class Krb5Context implements GSSContextSpi {
                                         peerName.getKrb5PrincipalName().getName(),
                                         acc);
                                 }});
+                            kerbTicket = tmp;
                         } catch (PrivilegedActionException e) {
                             if (DEBUG) {
                                 System.out.println("Attempt to obtain service"
@@ -706,6 +708,7 @@ class Krb5Context implements GSSContextSpi {
                                     tgt);
                         }
                         if (GSSUtil.useSubjectCredsOnly(caller)) {
+                            @SuppressWarnings("removal")
                             final Subject subject =
                                 AccessController.doPrivileged(
                                 new java.security.PrivilegedAction<Subject>() {
@@ -724,7 +727,8 @@ class Krb5Context implements GSSContextSpi {
                                  */
                                 final KerberosTicket kt =
                                         Krb5Util.credsToTicket(serviceCreds);
-                                AccessController.doPrivileged (
+                                @SuppressWarnings("removal")
+                                var dummy = AccessController.doPrivileged (
                                     new java.security.PrivilegedAction<Void>() {
                                       public Void run() {
                                         subject.getPrivateCredentials().add(kt);

--- a/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/SunNativeProvider.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/SunNativeProvider.java
@@ -43,7 +43,6 @@ import static sun.security.util.SecurityConstants.PROVIDER_VER;
  * @author Yu-Ching Valerie Peng
  */
 
-@SuppressWarnings("removal")
 public final class SunNativeProvider extends Provider {
 
     private static final long serialVersionUID = -238911724858694204L;
@@ -52,8 +51,6 @@ public final class SunNativeProvider extends Provider {
     private static final String INFO = "Sun Native GSS provider";
     private static final String MF_CLASS =
         "sun.security.jgss.wrapper.NativeGSSFactory";
-    private static final HashMap<String, String> MECH_MAP;
-    static final Provider INSTANCE;
     static boolean DEBUG;
     static void debug(String message) {
         if (DEBUG) {
@@ -64,8 +61,8 @@ public final class SunNativeProvider extends Provider {
         }
     }
 
-    static {
-        MECH_MAP =
+    @SuppressWarnings("removal")
+    private static final HashMap<String, String> MECH_MAP =
             AccessController.doPrivileged(
                 new PrivilegedAction<>() {
                     public HashMap<String, String> run() {
@@ -124,10 +121,11 @@ public final class SunNativeProvider extends Provider {
                         return null;
                     }
                 });
-        // initialize INSTANCE after MECH_MAP is constructed
-        INSTANCE = new SunNativeProvider();
-    }
 
+    // initialize INSTANCE after MECH_MAP is constructed
+    static final Provider INSTANCE = new SunNativeProvider();
+
+    @SuppressWarnings("removal")
     public SunNativeProvider() {
         /* We are the Sun NativeGSS provider */
         super(NAME, PROVIDER_VER, INFO);

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/ccache/FileCredentialsCache.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/ccache/FileCredentialsCache.java
@@ -455,15 +455,14 @@ public class FileCredentialsCache extends CredentialsCache
      * 4. <user.home>/krb5cc (if can't get <user.name>)
      */
 
-    @SuppressWarnings("removal")
     public static String getDefaultCacheName() {
 
         String stdCacheNameComponent = "krb5cc";
-        String name;
 
         // The env var can start with TYPE:, we only support FILE: here.
         // http://docs.oracle.com/cd/E19082-01/819-2252/6n4i8rtr3/index.html
-        name = java.security.AccessController.doPrivileged(
+        @SuppressWarnings("removal")
+        String name = java.security.AccessController.doPrivileged(
                 new java.security.PrivilegedAction<String>() {
             @Override
             public String run() {

--- a/src/java.smartcardio/unix/classes/sun/security/smartcardio/PlatformPCSC.java
+++ b/src/java.smartcardio/unix/classes/sun/security/smartcardio/PlatformPCSC.java
@@ -40,12 +40,9 @@ import sun.security.util.Debug;
  * @since   1.6
  * @author  Andreas Sterbenz
  */
-@SuppressWarnings("removal")
 class PlatformPCSC {
 
     static final Debug debug = Debug.getInstance("pcsc");
-
-    static final Throwable initException;
 
     private final static String PROP_NAME = "sun.security.smartcardio.library";
 
@@ -57,23 +54,23 @@ class PlatformPCSC {
         // empty
     }
 
-    static {
-        initException = AccessController.doPrivileged(new PrivilegedAction<Throwable>() {
-            public Throwable run() {
-                try {
-                    System.loadLibrary("j2pcsc");
-                    String library = getLibraryName();
-                    if (debug != null) {
-                        debug.println("Using PC/SC library: " + library);
-                    }
-                    initialize(library);
-                    return null;
-                } catch (Throwable e) {
-                    return e;
+    @SuppressWarnings("removal")
+    static final Throwable initException
+            = AccessController.doPrivileged(new PrivilegedAction<Throwable>() {
+        public Throwable run() {
+            try {
+                System.loadLibrary("j2pcsc");
+                String library = getLibraryName();
+                if (debug != null) {
+                    debug.println("Using PC/SC library: " + library);
                 }
+                initialize(library);
+                return null;
+            } catch (Throwable e) {
+                return e;
             }
-        });
-    }
+        }
+    });
 
     // expand $LIBISA to the system specific directory name for libraries
     private static String expand(String lib) {

--- a/src/java.xml.crypto/share/classes/com/sun/org/slf4j/internal/Logger.java
+++ b/src/java.xml.crypto/share/classes/com/sun/org/slf4j/internal/Logger.java
@@ -29,7 +29,6 @@ import java.security.PrivilegedAction;
 import java.util.logging.Level;
 
 // Bridge to java.util.logging.
-@SuppressWarnings("removal")
 public class Logger {
 
     /**
@@ -39,13 +38,11 @@ public class Logger {
      * public debug()/warn()/error()/trace() methods in this class --
      * to find the caller.
      */
-    private static final StackWalker WALKER;
-    static {
-        final PrivilegedAction<StackWalker> action =
-                () -> StackWalker.getInstance(StackWalker.Option
-                        .RETAIN_CLASS_REFERENCE);
-        WALKER = AccessController.doPrivileged(action);
-    }
+    @SuppressWarnings("removal")
+    private static final StackWalker WALKER = AccessController.doPrivileged(
+            (PrivilegedAction<StackWalker>)
+            () -> StackWalker.getInstance(
+                    StackWalker.Option.RETAIN_CLASS_REFERENCE));
 
     private final java.util.logging.Logger impl;
 

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -1012,7 +1012,6 @@ public final class SunPKCS11 extends AuthProvider {
     // test if a token is present and initialize this provider for it if so.
     // does nothing if no token is found
     // called from constructor and by poller
-    @SuppressWarnings("removal")
     private void initToken(CK_SLOT_INFO slotInfo) throws PKCS11Exception {
         if (slotInfo == null) {
             slotInfo = p11.C_GetSlotInfo(slotID);
@@ -1104,7 +1103,8 @@ public final class SunPKCS11 extends AuthProvider {
         }
 
         // register algorithms in provider
-        AccessController.doPrivileged(new PrivilegedAction<Object>() {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged(new PrivilegedAction<Object>() {
             public Object run() {
                 for (Map.Entry<Descriptor,Integer> entry
                         : supportedAlgs.entrySet()) {

--- a/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/SunMSCAPI.java
+++ b/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/SunMSCAPI.java
@@ -43,7 +43,6 @@ import static sun.security.util.SecurityProviderConstants.getAliases;
  * @since 1.6
  */
 
-@SuppressWarnings("removal")
 public final class SunMSCAPI extends Provider {
 
     private static final long serialVersionUID = 8622598936488630849L; //TODO
@@ -51,7 +50,8 @@ public final class SunMSCAPI extends Provider {
     private static final String INFO = "Sun's Microsoft Crypto API provider";
 
     static {
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged(new PrivilegedAction<Void>() {
             public Void run() {
                 System.loadLibrary("sunmscapi");
                 return null;
@@ -144,6 +144,7 @@ public final class SunMSCAPI extends Provider {
         }
     }
 
+    @SuppressWarnings("removal")
     public SunMSCAPI() {
         super("SunMSCAPI", PROVIDER_VER, INFO);
 


### PR DESCRIPTION
For all modified files in #4073 having "security", "crypto", or "ssl" in their names. Codes are refactored to bring a `@SuppressWarning` annotation nearer to the deprecated API usage and also shrink the size of its target.

I'll add a copyright year update commit before integration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267543](https://bugs.openjdk.java.net/browse/JDK-8267543): Post JEP 411 refactoring: security


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**) ⚠️ Review applies to 176f44e841600e029764b81e5148e8df41f85205


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4172/head:pull/4172` \
`$ git checkout pull/4172`

Update a local copy of the PR: \
`$ git checkout pull/4172` \
`$ git pull https://git.openjdk.java.net/jdk pull/4172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4172`

View PR using the GUI difftool: \
`$ git pr show -t 4172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4172.diff">https://git.openjdk.java.net/jdk/pull/4172.diff</a>

</details>
