### PR TITLE
8267633: Clarify documentation of (Doc)TreeScanner

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/source/util/DocTreeScanner.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/DocTreeScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,13 +40,13 @@ import com.sun.source.doctree.*;
  * <ul>
  * <li>If the node being visited has no children, the result will be {@code null}.
  * <li>If the node being visited has one child, the result will be the
- * result of calling {@code scan} on that child. The child may be a simple node
+ * result of calling {@code scan} with that child. The child may be a simple node
  * or itself a list of nodes.
  * <li> If the node being visited has more than one child, the result will
- * be determined by calling {@code scan} each child in turn, and then combining the
+ * be determined by calling {@code scan} with each child in turn, and then combining the
  * result of each scan after the first with the cumulative result
  * so far, as determined by the {@link #reduce} method. Each child may be either
- * a simple node of a list of nodes. The default behavior of the {@code reduce}
+ * a simple node or a list of nodes. The default behavior of the {@code reduce}
  * method is such that the result of the visitXYZ method will be the result of
  * the last child scanned.
  * </ul>

--- a/src/jdk.compiler/share/classes/com/sun/source/util/DocTreeScanner.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/DocTreeScanner.java
@@ -42,7 +42,7 @@ import com.sun.source.doctree.*;
  * <li>If the node being visited has one child, the result will be the
  * result of calling {@code scan} with that child. The child may be a simple node
  * or itself a list of nodes.
- * <li> If the node being visited has more than one child, the result will
+ * <li>If the node being visited has more than one child, the result will
  * be determined by calling {@code scan} with each child in turn, and then combining the
  * result of each scan after the first with the cumulative result
  * so far, as determined by the {@link #reduce} method. Each child may be either

--- a/src/jdk.compiler/share/classes/com/sun/source/util/TreePath.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/TreePath.java
@@ -33,7 +33,7 @@ import com.sun.source.tree.*;
 
 /**
  * A path of tree nodes, typically used to represent the sequence of ancestor
- * nodes of a tree node up to the top-level {@link CompilationUnitTree} node.
+ * nodes of a tree node up to the top-level {@code CompilationUnitTree} node.
  *
  * @author Jonathan Gibbons
  * @since 1.6

--- a/src/jdk.compiler/share/classes/com/sun/source/util/TreePath.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/TreePath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import com.sun.source.tree.*;
 
 /**
  * A path of tree nodes, typically used to represent the sequence of ancestor
- * nodes of a tree node up to the top level CompilationUnitTree node.
+ * nodes of a tree node up to the top-level {@link CompilationUnitTree} node.
  *
  * @author Jonathan Gibbons
  * @since 1.6

--- a/src/jdk.compiler/share/classes/com/sun/source/util/TreeScanner.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/TreeScanner.java
@@ -41,7 +41,7 @@ import com.sun.source.tree.*;
  * <li>If the node being visited has one child, the result will be the
  * result of calling {@code scan} with that child. The child may be a simple node
  * or itself a list of nodes.
- * <li> If the node being visited has more than one child, the result will
+ * <li>If the node being visited has more than one child, the result will
  * be determined by calling {@code scan} with each child in turn, and then combining the
  * result of each scan after the first with the cumulative result
  * so far, as determined by the {@link #reduce} method. Each child may be either

--- a/src/jdk.compiler/share/classes/com/sun/source/util/TreeScanner.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/TreeScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,13 +39,13 @@ import com.sun.source.tree.*;
  * <ul>
  * <li>If the node being visited has no children, the result will be {@code null}.
  * <li>If the node being visited has one child, the result will be the
- * result of calling {@code scan} on that child. The child may be a simple node
+ * result of calling {@code scan} with that child. The child may be a simple node
  * or itself a list of nodes.
  * <li> If the node being visited has more than one child, the result will
- * be determined by calling {@code scan} each child in turn, and then combining the
+ * be determined by calling {@code scan} with each child in turn, and then combining the
  * result of each scan after the first with the cumulative result
  * so far, as determined by the {@link #reduce} method. Each child may be either
- * a simple node of a list of nodes. The default behavior of the {@code reduce}
+ * a simple node or a list of nodes. The default behavior of the {@code reduce}
  * method is such that the result of the visitXYZ method will be the result of
  * the last child scanned.
  * </ul>


### PR DESCRIPTION
When a method is said to be called "on an object", this means that the object is a receiver. When a method is said to be called "with an object", this means that the object is a parameter.

To scan an instance of (Doc)Tree, the "scan" method is called on the instance of (Doc)TreeScanner with that instance of (Doc)Tree.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267633](https://bugs.openjdk.java.net/browse/JDK-8267633): Clarify documentation of (Doc)TreeScanner


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to 9f5ba18456ff44672c6b55a613a7d751cc929cbd


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4174/head:pull/4174` \
`$ git checkout pull/4174`

Update a local copy of the PR: \
`$ git checkout pull/4174` \
`$ git pull https://git.openjdk.java.net/jdk pull/4174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4174`

View PR using the GUI difftool: \
`$ git pr show -t 4174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4174.diff">https://git.openjdk.java.net/jdk/pull/4174.diff</a>

</details>
