### PR TITLE
8267651: runtime/handshake/HandshakeTimeoutTest.java times out when dumping core

### DIFF
--- a/test/hotspot/jtreg/runtime/handshake/HandshakeTimeoutTest.java
+++ b/test/hotspot/jtreg/runtime/handshake/HandshakeTimeoutTest.java
@@ -30,6 +30,7 @@ import sun.hotspot.WhiteBox;
 
 /*
  * @test HandshakeTimeoutTest
+ * @bug 8262454 8267651
  * @summary Test handshake timeout.
  * @requires vm.debug
  * @library /testlibrary /test/lib
@@ -61,6 +62,7 @@ public class HandshakeTimeoutTest {
                     "-XX:CICompilerCount=2",
                     "-XX:+UnlockExperimentalVMOptions",
                     "-XX:HandshakeTimeout=50",
+                    "-XX:-CreateCoredumpOnCrash",
                     useJVMCICompilerStr,
                     "HandshakeTimeoutTest$Test");
 


### PR DESCRIPTION
Please review this trivial test fix to add -XX:-CreateCoredumpOnCrash to the exec'd VM that we expect to crash with SIGILL. If the core dump is generated it can take a long time on macos and cause the whole test to timeout.

Testing: ran 50x on macos-x64, plus local linux-x64

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267651](https://bugs.openjdk.java.net/browse/JDK-8267651): runtime/handshake/HandshakeTimeoutTest.java times out when dumping core


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4177/head:pull/4177` \
`$ git checkout pull/4177`

Update a local copy of the PR: \
`$ git checkout pull/4177` \
`$ git pull https://git.openjdk.java.net/jdk pull/4177/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4177`

View PR using the GUI difftool: \
`$ git pr show -t 4177`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4177.diff">https://git.openjdk.java.net/jdk/pull/4177.diff</a>

</details>
