### PR TITLE
8267376: C2: Deduce the result bound of ModXNode

### DIFF
--- a/src/hotspot/share/opto/divnode.cpp
+++ b/src/hotspot/share/opto/divnode.cpp
@@ -999,7 +999,7 @@ const Type* ModINode::Value(PhaseGVN* phase) const {
       // x and y are both constant!
       return TypeInt::make(i1->get_con() % i2->get_con());
     }
-    // Otherwise, the bound can be deduced given that divisor is a known constant 
+    // Otherwise, the bound can be deduced given that divisor is a known constant
     // x % -y  ==> [0, y - 1]
     // x % y   ==> [0, y - 1]
     // -x % y  ==> [-y + 1, 0]
@@ -1176,7 +1176,7 @@ const Type* ModLNode::Value(PhaseGVN* phase) const {
       // x and y are both constant!
       return TypeLong::make(i1->get_con() % i2->get_con());
     }
-    // Otherwise, the bound can be deduced given that divisor is a known constant 
+    // Otherwise, the bound can be deduced given that divisor is a known constant
     // x % -y  ==> [0, y - 1]
     // x % y   ==> [0, y - 1]
     // -x % y  ==> [-y + 1, 0]


### PR DESCRIPTION
if the divisor is a constant and not equal to 0, it's possible to deduce the final bound of ModXNode given that the following rules:
```
       x % -y ==> [0, y - 1]
       x % y ==> [0, y - 1]
       -x % y ==> [-y + 1, 0]
       -x % -y ==> [-y + 1, 0]
```

FYI: The original purpose of this patch is to eliminate array access range check(e.g. `arr[val%5]`) which discussed in https://github.com/openjdk/jdk/pull/4083#issuecomment-846971247, because ModXNode would be transformed to other nodes during IGVN, RangeCheckNode is still generated when accessing array element. Regardless of eliminating array access range check, it's still reasonable to deduce the bound of % operation if the divisor is known constant.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8267376](https://bugs.openjdk.java.net/browse/JDK-8267376): C2: Deduce the result bound of ModXNode


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4179/head:pull/4179` \
`$ git checkout pull/4179`

Update a local copy of the PR: \
`$ git checkout pull/4179` \
`$ git pull https://git.openjdk.java.net/jdk pull/4179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4179`

View PR using the GUI difftool: \
`$ git pr show -t 4179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4179.diff">https://git.openjdk.java.net/jdk/pull/4179.diff</a>

</details>
