### PR TITLE
8255674: SSLEngine class description is missing "case" in switch statement

### DIFF
--- a/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -224,7 +224,7 @@ import java.util.function.BiFunction;
  * <pre>{@code
  *   SSLEngineResult r = engine.unwrap(src, dst);
  *   switch (r.getStatus()) {
- *   BUFFER_OVERFLOW:
+ *   case BUFFER_OVERFLOW:
  *       // Could attempt to drain the dst buffer of any already obtained
  *       // data, but we'll just increase it to the size needed.
  *       int appSize = engine.getSession().getApplicationBufferSize();
@@ -234,7 +234,7 @@ import java.util.function.BiFunction;
  *       dst = b;
  *       // retry the operation.
  *       break;
- *   BUFFER_UNDERFLOW:
+ *   case BUFFER_UNDERFLOW:
  *       int netSize = engine.getSession().getPacketBufferSize();
  *       // Resize buffer if needed.
  *       if (netSize > src.capacity()) {


### PR DESCRIPTION
Can I please get a review for this trivial fix in the code sample in javadoc comment of `javax.net.ssl.SSLEngine` class?

I've run `make docs-image` locally and the generated javadoc after this change looks fine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255674](https://bugs.openjdk.java.net/browse/JDK-8255674): SSLEngine class description is missing "case" in switch statement


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4180/head:pull/4180` \
`$ git checkout pull/4180`

Update a local copy of the PR: \
`$ git checkout pull/4180` \
`$ git pull https://git.openjdk.java.net/jdk pull/4180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4180`

View PR using the GUI difftool: \
`$ git pr show -t 4180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4180.diff">https://git.openjdk.java.net/jdk/pull/4180.diff</a>

</details>
