### PR TITLE
8264302: Create implementation for Accessibility native peer for Splitpane java role

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -67,6 +67,7 @@ static jobject sAccessibilityClass = NULL;
     [rolesMap setObject:@"GroupAccessibility" forKey:@"internalframe"];
     [rolesMap setObject:@"GroupAccessibility" forKey:@"swingcomponent"];
     [rolesMap setObject:@"ToolbarAccessibility" forKey:@"toolbar"];
+    [rolesMap setObject:@"SplitpaneAccessibility" forKey:@"splitpane"];
 
     /*
      * All the components below should be ignored by the accessibility subsystem,

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SplitpaneAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SplitpaneAccessibility.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "JavaComponentAccessibility.h"
+#import "GroupAccessibility.h"
+
+#import <AppKit/AppKit.h>
+
+@interface SplitpaneAccessibility : GroupAccessibility {
+
+};
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SplitpaneAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SplitpaneAccessibility.m
@@ -24,8 +24,6 @@
  */
 
 #import "SplitpaneAccessibility.h"
-#import "ThreadUtilities.h"
-#import "JNIUtilities.h"
 
 /*
  * Implementation of the accessibility peer for the ScrollBar role
@@ -34,7 +32,6 @@
 
 - (NSAccessibilityRole _Nonnull)accessibilityRole
 {
-    NSLog(@"In splitpane get role");
     return NSAccessibilitySplitGroupRole;
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SplitpaneAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SplitpaneAccessibility.m
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "SplitpaneAccessibility.h"
+#import "ThreadUtilities.h"
+#import "JNIUtilities.h"
+
+/*
+ * Implementation of the accessibility peer for the ScrollBar role
+ */
+@implementation SplitpaneAccessibility
+
+- (NSAccessibilityRole _Nonnull)accessibilityRole
+{
+    NSLog(@"In splitpane get role");
+    return NSAccessibilitySplitGroupRole;
+}
+
+@end


### PR DESCRIPTION
Create implementation for Accessibility native peer for Splitpane java role. I have tested it using the SwingSet2 and splitpane demo from https://docs.oracle.com/javase/tutorial/uiswing/examples/components/index.html#SplitPaneDemo.
The do not see any inconsistency in Vo behaviour before and after the changes.