### PR TITLE
8267666: Add option to jcmd GC.heap_dump to use existing file

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -2665,9 +2665,7 @@ int os::open(const char *path, int oflag, int mode) {
 // create binary file, rewriting existing file if required
 int os::create_binary_file(const char* path, bool rewrite_existing) {
   int oflags = O_WRONLY | O_CREAT;
-  if (!rewrite_existing) {
-    oflags |= O_EXCL;
-  }
+  oflags |= rewrite_existing ? O_TRUNC : O_EXCL;
   return ::open64(path, oflags, S_IREAD | S_IWRITE);
 }
 

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2355,9 +2355,7 @@ int os::open(const char *path, int oflag, int mode) {
 // create binary file, rewriting existing file if required
 int os::create_binary_file(const char* path, bool rewrite_existing) {
   int oflags = O_WRONLY | O_CREAT;
-  if (!rewrite_existing) {
-    oflags |= O_EXCL;
-  }
+  oflags |= rewrite_existing ? O_TRUNC : O_EXCL;
   return ::open(path, oflags, S_IREAD | S_IWRITE);
 }
 

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4949,9 +4949,7 @@ int os::open(const char *path, int oflag, int mode) {
 // create binary file, rewriting existing file if required
 int os::create_binary_file(const char* path, bool rewrite_existing) {
   int oflags = O_WRONLY | O_CREAT;
-  if (!rewrite_existing) {
-    oflags |= O_EXCL;
-  }
+  oflags |= rewrite_existing ? O_TRUNC : O_EXCL;
   return ::open64(path, oflags, S_IREAD | S_IWRITE);
 }
 

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4731,9 +4731,7 @@ bool os::dir_is_empty(const char* path) {
 // create binary file, rewriting existing file if required
 int os::create_binary_file(const char* path, bool rewrite_existing) {
   int oflags = _O_CREAT | _O_WRONLY | _O_BINARY;
-  if (!rewrite_existing) {
-    oflags |= _O_EXCL;
-  }
+  oflags |= rewrite_existing ? O_TRUNC : O_EXCL;
   return ::open(path, oflags, _S_IREAD | _S_IWRITE);
 }
 

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4731,7 +4731,7 @@ bool os::dir_is_empty(const char* path) {
 // create binary file, rewriting existing file if required
 int os::create_binary_file(const char* path, bool rewrite_existing) {
   int oflags = _O_CREAT | _O_WRONLY | _O_BINARY;
-  oflags |= rewrite_existing ? O_TRUNC : O_EXCL;
+  oflags |= rewrite_existing ? _O_TRUNC : _O_EXCL;
   return ::open(path, oflags, _S_IREAD | _S_IWRITE);
 }
 

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -469,7 +469,7 @@ HeapDumpDCmd::HeapDumpDCmd(outputStream* output, bool heap) :
   _gzip("-gz", "If specified, the heap dump is written in gzipped format "
                "using the given compression level. 1 (recommended) is the fastest, "
                "9 the strongest compression.", "INT", false, "1"),
-  _rewrite("-rewrite", "If specified and the dump file exists, the file will be rewritten",
+  _rewrite("-rewrite", "If specified, the dump file will be rewritten if it exists",
            "BOOLEAN", false, "false") {
   _dcmdparser.add_dcmd_option(&_all);
   _dcmdparser.add_dcmd_argument(&_filename);

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -468,10 +468,13 @@ HeapDumpDCmd::HeapDumpDCmd(outputStream* output, bool heap) :
        "BOOLEAN", false, "false"),
   _gzip("-gz", "If specified, the heap dump is written in gzipped format "
                "using the given compression level. 1 (recommended) is the fastest, "
-               "9 the strongest compression.", "INT", false, "1") {
+               "9 the strongest compression.", "INT", false, "1"),
+  _rewrite("-rewrite", "If specified and the dump file exists, the file will be rewritten",
+           "BOOLEAN", false, "false") {
   _dcmdparser.add_dcmd_option(&_all);
   _dcmdparser.add_dcmd_argument(&_filename);
   _dcmdparser.add_dcmd_option(&_gzip);
+  _dcmdparser.add_dcmd_option(&_rewrite);
 }
 
 void HeapDumpDCmd::execute(DCmdSource source, TRAPS) {
@@ -490,7 +493,7 @@ void HeapDumpDCmd::execute(DCmdSource source, TRAPS) {
   // This helps reduces the amount of unreachable objects in the dump
   // and makes it easier to browse.
   HeapDumper dumper(!_all.value() /* request GC if _all is false*/);
-  dumper.dump(_filename.value(), output(), (int) level);
+  dumper.dump(_filename.value(), output(), (int) level, _rewrite.value());
 }
 
 ClassHistogramDCmd::ClassHistogramDCmd(outputStream* output, bool heap) :

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -469,12 +469,12 @@ HeapDumpDCmd::HeapDumpDCmd(outputStream* output, bool heap) :
   _gzip("-gz", "If specified, the heap dump is written in gzipped format "
                "using the given compression level. 1 (recommended) is the fastest, "
                "9 the strongest compression.", "INT", false, "1"),
-  _rewrite("-rewrite", "If specified, the dump file will be rewritten if it exists",
+  _overwrite("-overwrite", "If specified, the dump file will be overwritten if it exists",
            "BOOLEAN", false, "false") {
   _dcmdparser.add_dcmd_option(&_all);
   _dcmdparser.add_dcmd_argument(&_filename);
   _dcmdparser.add_dcmd_option(&_gzip);
-  _dcmdparser.add_dcmd_option(&_rewrite);
+  _dcmdparser.add_dcmd_option(&_overwrite);
 }
 
 void HeapDumpDCmd::execute(DCmdSource source, TRAPS) {
@@ -493,7 +493,7 @@ void HeapDumpDCmd::execute(DCmdSource source, TRAPS) {
   // This helps reduces the amount of unreachable objects in the dump
   // and makes it easier to browse.
   HeapDumper dumper(!_all.value() /* request GC if _all is false*/);
-  dumper.dump(_filename.value(), output(), (int) level, _rewrite.value());
+  dumper.dump(_filename.value(), output(), (int) level, _overwrite.value());
 }
 
 ClassHistogramDCmd::ClassHistogramDCmd(outputStream* output, bool heap) :

--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -314,7 +314,7 @@ protected:
   DCmdArgument<char*> _filename;
   DCmdArgument<bool>  _all;
   DCmdArgument<jlong> _gzip;
-  DCmdArgument<bool> _rewrite;
+  DCmdArgument<bool> _overwrite;
 public:
   HeapDumpDCmd(outputStream* output, bool heap);
   static const char* name() {

--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -314,6 +314,7 @@ protected:
   DCmdArgument<char*> _filename;
   DCmdArgument<bool>  _all;
   DCmdArgument<jlong> _gzip;
+  DCmdArgument<bool> _rewrite;
 public:
   HeapDumpDCmd(outputStream* output, bool heap);
   static const char* name() {

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -1905,7 +1905,7 @@ void VM_HeapDumper::dump_stack_traces() {
 }
 
 // dump the heap to given path.
-int HeapDumper::dump(const char* path, outputStream* out, int compression) {
+int HeapDumper::dump(const char* path, outputStream* out, int compression, bool rewrite) {
   assert(path != NULL && strlen(path) > 0, "path missing");
 
   // print message in interactive case
@@ -1928,7 +1928,7 @@ int HeapDumper::dump(const char* path, outputStream* out, int compression) {
     }
   }
 
-  DumpWriter writer(new (std::nothrow) FileWriter(path), compressor);
+  DumpWriter writer(new (std::nothrow) FileWriter(path, rewrite), compressor);
 
   if (writer.error() != NULL) {
     set_error(writer.error());

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -1905,7 +1905,7 @@ void VM_HeapDumper::dump_stack_traces() {
 }
 
 // dump the heap to given path.
-int HeapDumper::dump(const char* path, outputStream* out, int compression, bool rewrite) {
+int HeapDumper::dump(const char* path, outputStream* out, int compression, bool overwrite) {
   assert(path != NULL && strlen(path) > 0, "path missing");
 
   // print message in interactive case
@@ -1928,7 +1928,7 @@ int HeapDumper::dump(const char* path, outputStream* out, int compression, bool 
     }
   }
 
-  DumpWriter writer(new (std::nothrow) FileWriter(path, rewrite), compressor);
+  DumpWriter writer(new (std::nothrow) FileWriter(path, overwrite), compressor);
 
   if (writer.error() != NULL) {
     set_error(writer.error());

--- a/src/hotspot/share/services/heapDumper.hpp
+++ b/src/hotspot/share/services/heapDumper.hpp
@@ -71,7 +71,7 @@ class HeapDumper : public StackObj {
   // dumps the heap to the specified file, returns 0 if success.
   // additional info is written to out if not NULL.
   // compression >= 0 creates a gzipped file with the given compression level.
-  int dump(const char* path, outputStream* out = NULL, int compression = -1);
+  int dump(const char* path, outputStream* out = NULL, int compression = -1, bool rewrite = false);
 
   // returns error message (resource allocated), or NULL if no error
   char* error_as_C_string() const;

--- a/src/hotspot/share/services/heapDumper.hpp
+++ b/src/hotspot/share/services/heapDumper.hpp
@@ -71,7 +71,7 @@ class HeapDumper : public StackObj {
   // dumps the heap to the specified file, returns 0 if success.
   // additional info is written to out if not NULL.
   // compression >= 0 creates a gzipped file with the given compression level.
-  int dump(const char* path, outputStream* out = NULL, int compression = -1, bool rewrite = false);
+  int dump(const char* path, outputStream* out = NULL, int compression = -1, bool overwrite = false);
 
   // returns error message (resource allocated), or NULL if no error
   char* error_as_C_string() const;

--- a/src/hotspot/share/services/heapDumperCompression.cpp
+++ b/src/hotspot/share/services/heapDumperCompression.cpp
@@ -34,7 +34,7 @@
 char const* FileWriter::open_writer() {
   assert(_fd < 0, "Must not already be open");
 
-  _fd = os::create_binary_file(_path, false);    // don't replace existing file
+  _fd = os::create_binary_file(_path, _rewrite);
 
   if (_fd < 0) {
     return os::strerror(errno);

--- a/src/hotspot/share/services/heapDumperCompression.cpp
+++ b/src/hotspot/share/services/heapDumperCompression.cpp
@@ -34,7 +34,7 @@
 char const* FileWriter::open_writer() {
   assert(_fd < 0, "Must not already be open");
 
-  _fd = os::create_binary_file(_path, _rewrite);
+  _fd = os::create_binary_file(_path, _overwrite);
 
   if (_fd < 0) {
     return os::strerror(errno);

--- a/src/hotspot/share/services/heapDumperCompression.hpp
+++ b/src/hotspot/share/services/heapDumperCompression.hpp
@@ -61,11 +61,11 @@ public:
 class FileWriter : public AbstractWriter {
 private:
   char const* _path;
-  bool _rewrite;
+  bool _overwrite;
   int _fd;
 
 public:
-  FileWriter(char const* path, bool rewrite) : _path(path), _rewrite(rewrite), _fd(-1) { }
+  FileWriter(char const* path, bool overwrite) : _path(path), _overwrite(overwrite), _fd(-1) { }
 
   ~FileWriter();
 

--- a/src/hotspot/share/services/heapDumperCompression.hpp
+++ b/src/hotspot/share/services/heapDumperCompression.hpp
@@ -61,10 +61,11 @@ public:
 class FileWriter : public AbstractWriter {
 private:
   char const* _path;
+  bool _rewrite;
   int _fd;
 
 public:
-  FileWriter(char const* path) : _path(path), _fd(-1) { }
+  FileWriter(char const* path, bool rewrite) : _path(path), _rewrite(rewrite), _fd(-1) { }
 
   ~FileWriter();
 

--- a/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpTest.java
@@ -50,13 +50,15 @@ import jdk.test.lib.dcmd.PidJcmdExecutor;
 public class HeapDumpTest {
     protected String heapDumpArgs = "";
 
-    public void run(CommandExecutor executor) throws IOException {
+    public void run(CommandExecutor executor, boolean rewrite) throws IOException {
         File dump = new File("jcmd.gc.heap_dump." + System.currentTimeMillis() + ".hprof");
-        if (dump.exists()) {
+        if (!rewrite && dump.exists()) {
             dump.delete();
+        } else if (rewrite) {
+            dump.createNewFile();
         }
 
-        String cmd = "GC.heap_dump " + heapDumpArgs + " " + dump.getAbsolutePath();
+        String cmd = "GC.heap_dump " + (rewrite ? "-rewrite " : "") + heapDumpArgs + " " + dump.getAbsolutePath();
         executor.execute(cmd);
 
         verifyHeapDump(dump);
@@ -85,7 +87,12 @@ public class HeapDumpTest {
     /* GC.heap_dump is not available over JMX, running jcmd pid executor instead */
     @Test
     public void pid() throws IOException {
-        run(new PidJcmdExecutor());
+        run(new PidJcmdExecutor(), false);
+    }
+
+    @Test
+    public void pidRewrite() throws IOException {
+        run(new PidJcmdExecutor(), true);
     }
 }
 

--- a/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpTest.java
@@ -50,15 +50,15 @@ import jdk.test.lib.dcmd.PidJcmdExecutor;
 public class HeapDumpTest {
     protected String heapDumpArgs = "";
 
-    public void run(CommandExecutor executor, boolean rewrite) throws IOException {
+    public void run(CommandExecutor executor, boolean overwrite) throws IOException {
         File dump = new File("jcmd.gc.heap_dump." + System.currentTimeMillis() + ".hprof");
-        if (!rewrite && dump.exists()) {
+        if (!overwrite && dump.exists()) {
             dump.delete();
-        } else if (rewrite) {
+        } else if (overwrite) {
             dump.createNewFile();
         }
 
-        String cmd = "GC.heap_dump " + (rewrite ? "-rewrite " : "") + heapDumpArgs + " " + dump.getAbsolutePath();
+        String cmd = "GC.heap_dump " + (overwrite ? "-overwrite " : "") + heapDumpArgs + " " + dump.getAbsolutePath();
         executor.execute(cmd);
 
         verifyHeapDump(dump);


### PR DESCRIPTION
Please review a small change that adds an option to GC.heap_dump to use an existing file. 

The option is necessary if the target file is a predefined file-like object, like a named pipe. This opens up a lot of possibilities to process a heap dump without storing it to the file system first.

Reviews of the CSR linked to the bug would be appreciated as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267666](https://bugs.openjdk.java.net/browse/JDK-8267666): Add option to jcmd GC.heap_dump to use existing file


### Reviewers
 * [Ralf Schmelter](https://openjdk.java.net/census#rschmelter) (@schmelter-sap - Committer)
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4183/head:pull/4183` \
`$ git checkout pull/4183`

Update a local copy of the PR: \
`$ git checkout pull/4183` \
`$ git pull https://git.openjdk.java.net/jdk pull/4183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4183`

View PR using the GUI difftool: \
`$ git pr show -t 4183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4183.diff">https://git.openjdk.java.net/jdk/pull/4183.diff</a>

</details>
