### PR TITLE
8267653: Remove Mutex::_safepoint_check_sometimes

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
@@ -540,7 +540,7 @@ void ShenandoahReferenceProcessor::enqueue_references(bool concurrent) {
     enqueue_references_locked();
   } else {
     // Heap_lock protects external pending list
-    MonitorLocker ml(Heap_lock, Mutex::_no_safepoint_check_flag);
+    MonitorLocker ml(Heap_lock);
 
     enqueue_references_locked();
 

--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -261,11 +261,6 @@ Mutex::~Mutex() {
   os::free(const_cast<char*>(_name));
 }
 
-// Only Threads_lock and Heap_lock may be safepoint_check_sometimes.
-bool is_sometimes_ok(const char* name) {
-  return (strcmp(name, "Threads_lock") == 0 || strcmp(name, "Heap_lock") == 0);
-}
-
 Mutex::Mutex(int Rank, const char * name, bool allow_vm_block,
              SafepointCheckRequired safepoint_check_required) : _owner(NULL) {
   assert(os::mutex_init_done(), "Too early!");
@@ -276,9 +271,6 @@ Mutex::Mutex(int Rank, const char * name, bool allow_vm_block,
   _rank            = Rank;
   _safepoint_check_required = safepoint_check_required;
   _skip_rank_check = false;
-
-  assert(_safepoint_check_required != _safepoint_check_sometimes || is_sometimes_ok(name),
-         "Lock has _safepoint_check_sometimes %s", name);
 
   assert(_rank > special || _safepoint_check_required == _safepoint_check_never,
          "Special locks or below should never safepoint");
@@ -306,7 +298,6 @@ void Mutex::print_on_error(outputStream* st) const {
 const char* print_safepoint_check(Mutex::SafepointCheckRequired safepoint_check) {
   switch (safepoint_check) {
   case Mutex::_safepoint_check_never:     return "safepoint_check_never";
-  case Mutex::_safepoint_check_sometimes: return "safepoint_check_sometimes";
   case Mutex::_safepoint_check_always:    return "safepoint_check_always";
   default: return "";
   }

--- a/src/hotspot/share/runtime/mutex.hpp
+++ b/src/hotspot/share/runtime/mutex.hpp
@@ -132,11 +132,6 @@ class Mutex : public CHeapObj<mtSynchronizer> {
   // _safepoint_check_never, that means that whenever the lock is acquired by a JavaThread
   // it will verify that it is done without a safepoint check.
 
-
-  // There are a couple of existing locks that will sometimes have a safepoint check and
-  // sometimes not when acquired by a JavaThread, but these locks are set up carefully
-  // to avoid deadlocks. TODO: Fix these locks and remove _safepoint_check_sometimes.
-
   // TODO: Locks that are shared between JavaThreads and NonJavaThreads
   // should never encounter a safepoint check while they are held, or else a
   // deadlock can occur. We should check this by noting which
@@ -155,17 +150,12 @@ class Mutex : public CHeapObj<mtSynchronizer> {
   enum class SafepointCheckRequired {
     _safepoint_check_never,       // Mutexes with this value will cause errors
                                   // when acquired by a JavaThread with a safepoint check.
-    _safepoint_check_sometimes,   // A couple of special locks are acquired by JavaThreads sometimes
-                                  // with and sometimes without safepoint checks. These
-                                  // locks will not produce errors when locked.
     _safepoint_check_always       // Mutexes with this value will cause errors
                                   // when acquired by a JavaThread without a safepoint check.
   };
   // Bring the enumerator names into class scope.
   static const SafepointCheckRequired _safepoint_check_never =
     SafepointCheckRequired::_safepoint_check_never;
-  static const SafepointCheckRequired _safepoint_check_sometimes =
-    SafepointCheckRequired::_safepoint_check_sometimes;
   static const SafepointCheckRequired _safepoint_check_always =
     SafepointCheckRequired::_safepoint_check_always;
 

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -285,7 +285,7 @@ void mutex_init() {
   def(JNICritical_lock             , PaddedMonitor, nonleaf,     true,  _safepoint_check_always); // used for JNI critical regions
   def(AdapterHandlerLibrary_lock   , PaddedMutex  , nonleaf,     true,  _safepoint_check_always);
 
-  def(Heap_lock                    , PaddedMonitor, nonleaf+1,   false, _safepoint_check_sometimes);  // Doesn't safepoint check during termination.
+  def(Heap_lock                    , PaddedMonitor, nonleaf+1,   false, _safepoint_check_always); // Doesn't safepoint check during termination.
   def(JfieldIdCreation_lock        , PaddedMutex  , nonleaf+1,   true,  _safepoint_check_always); // jfieldID, Used in VM_Operation
 
   def(CompiledIC_lock              , PaddedMutex  , nonleaf+2,   false, _safepoint_check_never);      // locks VtableStubs_lock, InlineCacheBuffer_lock

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -3417,7 +3417,7 @@ void Threads::destroy_vm() {
     // queue until after the vm thread is dead. After this point,
     // we'll never emerge out of the safepoint before the VM exits.
 
-    MutexLocker ml(Heap_lock, Mutex::_no_safepoint_check_flag);
+    MutexLocker ml(Heap_lock);
 
     VMThread::wait_for_vm_thread_exit();
     assert(SafepointSynchronize::is_at_safepoint(), "VM thread should exit at Safepoint");

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -3416,7 +3416,11 @@ void Threads::destroy_vm() {
     // to prevent this. The GC vm_operations will not be able to
     // queue until after the vm thread is dead. After this point,
     // we'll never emerge out of the safepoint before the VM exits.
+    // Assert that the thread is terminated so that acquiring the
+    // Heap_lock doesn't cause the terminated thread to participate in
+    // the safepoint protocol.
 
+    assert(thread->is_terminated(), "must be terminated here");
     MutexLocker ml(Heap_lock);
 
     VMThread::wait_for_vm_thread_exit();


### PR DESCRIPTION
Since SR_lock is removed, this state of declaring locks as sometimes safepoint checking and not is no longer used.  JavaThreads either always or never check for safepoint, depending on the lock.  The Heap_lock was always a bit special because it's taken by a JavaThread after it exits, but the code in mutex::lock_contended already deals with this (ie doesn't safepoint check while exiting).
Tested with tier 2-3 and tier1 in progress.
Thanks to Zhengu for testing and confirming shenandoah (I built and ran shenandoah tests too).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267653](https://bugs.openjdk.java.net/browse/JDK-8267653): Remove Mutex::_safepoint_check_sometimes


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to d7f55efe8f295a0df7be4f2c3df611a680b4ae4a
 * [Patricio Chilano Mateo](https://openjdk.java.net/census#pchilanomate) (@pchilano - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4184/head:pull/4184` \
`$ git checkout pull/4184`

Update a local copy of the PR: \
`$ git checkout pull/4184` \
`$ git pull https://git.openjdk.java.net/jdk pull/4184/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4184`

View PR using the GUI difftool: \
`$ git pr show -t 4184`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4184.diff">https://git.openjdk.java.net/jdk/pull/4184.diff</a>

</details>
