### PR TITLE
8263445: Duplicate key compiler.err.expected.module in compiler.properties

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -2198,9 +2198,6 @@ compiler.err.enum.constant.not.expected=\
     enum constant not expected here
 
 ## The following are related in form, but do not easily fit the above paradigm.
-compiler.err.expected.module=\
-    ''module'' expected
-
 compiler.err.expected.module.or.open=\
     ''module'' or ''open'' expected
 


### PR DESCRIPTION
src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties  contains duplicate key:
compiler.err.expected.module

This fix removes the first occurrence of the key to remove the duplicity and keep the actual content of the property.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263445](https://bugs.openjdk.java.net/browse/JDK-8263445): Duplicate key compiler.err.expected.module in compiler.properties


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4186/head:pull/4186` \
`$ git checkout pull/4186`

Update a local copy of the PR: \
`$ git checkout pull/4186` \
`$ git pull https://git.openjdk.java.net/jdk pull/4186/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4186`

View PR using the GUI difftool: \
`$ git pr show -t 4186`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4186.diff">https://git.openjdk.java.net/jdk/pull/4186.diff</a>

</details>
