### PR TITLE
8267221: jshell feedback is incorrect when creating method with array varargs parameter

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -4555,6 +4555,7 @@ public class JavacParser implements Parser {
 
         if (createNewLevel) {
             mostInnerType = to(F.at(token.pos).TypeArray(mostInnerType));
+            origEndPos = getEndPos(mostInnerType);
         }
 
         JCExpression mostInnerTypeToReturn = mostInnerType;

--- a/test/langtools/jdk/jshell/MethodsTest.java
+++ b/test/langtools/jdk/jshell/MethodsTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8080357 8167643 8187359 8199762 8080353 8246353 8247456
+ * @bug 8080357 8167643 8187359 8199762 8080353 8246353 8247456 8267221
  * @summary Tests for EvaluationState.methods
  * @build KullaTesting TestingInputStream ExpectedDiagnostic
  * @run testng MethodsTest
@@ -373,5 +373,15 @@ public class MethodsTest extends KullaTesting {
         assertEval("java.util.stream.IntStream.of(2).mapToObj(int[]::new);");
         assertNumberOfActiveMethods(0);
         assertActiveKeys();
+    }
+
+    //JDK-8267221:
+    public void testMethodArrayParameters() {
+        MethodSnippet m1 = methodKey(assertEval("void m1(int... p) { }", added(VALID)));
+        assertEquals(m1.parameterTypes(), "int...");
+        MethodSnippet m2 = methodKey(assertEval("void m2(int[]... p) { }", added(VALID)));
+        assertEquals(m2.parameterTypes(), "int[]...");
+        MethodSnippet m3 = methodKey(assertEval("void m3(int[][] p) { }", added(VALID)));
+        assertEquals(m3.parameterTypes(), "int[][]");
     }
 }


### PR DESCRIPTION
When writing something like `void t(int[]... p) {}` into JShell, one gets:
```
jshell> void t(int[]... p) {}
|  created method t(int[])
```

Note the wrong parameter type `int[]` instead of `int[]...` or at least `int[][]`. The reason is that the span of the type is incorrect when the type is varargs. The proposed patch is an attempt to fix the span.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267221](https://bugs.openjdk.java.net/browse/JDK-8267221): jshell feedback is incorrect when creating method with array varargs parameter


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4187/head:pull/4187` \
`$ git checkout pull/4187`

Update a local copy of the PR: \
`$ git checkout pull/4187` \
`$ git pull https://git.openjdk.java.net/jdk pull/4187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4187`

View PR using the GUI difftool: \
`$ git pr show -t 4187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4187.diff">https://git.openjdk.java.net/jdk/pull/4187.diff</a>

</details>
