### PR TITLE
8267687: ModXNode::Ideal optimization is better than Parse::do_irem

### DIFF
--- a/src/hotspot/share/opto/parse.hpp
+++ b/src/hotspot/share/opto/parse.hpp
@@ -502,8 +502,6 @@ class Parse : public GraphKit {
   void modd();
   void l2f();
 
-  void do_irem();
-
   // implementation of _get* and _put* bytecodes
   void do_getstatic() { do_field_access(true,  false); }
   void do_getfield () { do_field_access(true,  true); }
@@ -544,7 +542,6 @@ class Parse : public GraphKit {
                                 Node* val, const Type* tval);
   void    maybe_add_predicate_after_if(Block* path);
   IfNode* jump_if_fork_int(Node* a, Node* b, BoolTest::mask mask, float prob, float cnt);
-  Node*   jump_if_join(Node* iffalse, Node* iftrue);
   void    jump_if_true_fork(IfNode *ifNode, int dest_bci_if_true, bool unc);
   void    jump_if_false_fork(IfNode *ifNode, int dest_bci_if_false, bool unc);
   void    jump_if_always_fork(int dest_bci_if_true, bool unc);

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -218,17 +218,6 @@ IfNode* Parse::jump_if_fork_int(Node* a, Node* b, BoolTest::mask mask, float pro
   return iff;
 }
 
-// return Region node
-Node* Parse::jump_if_join(Node* iffalse, Node* iftrue) {
-  Node *region  = new RegionNode(3); // 2 results
-  record_for_igvn(region);
-  region->init_req(1, iffalse);
-  region->init_req(2, iftrue );
-  _gvn.set_type(region, Type::CONTROL);
-  region = _gvn.transform(region);
-  set_control (region);
-  return region;
-}
 
 // sentinel value for the target bci to mark never taken branches
 // (according to profiling)
@@ -1156,50 +1145,6 @@ void Parse::l2f() {
   Node* res = _gvn.transform(new ProjNode(c, TypeFunc::Parms + 0));
 
   push(res);
-}
-
-void Parse::do_irem() {
-  // Must keep both values on the expression-stack during null-check
-  zero_check_int(peek());
-  // Compile-time detect of null-exception?
-  if (stopped())  return;
-
-  Node* b = pop();
-  Node* a = pop();
-
-  const Type *t = _gvn.type(b);
-  if (t != Type::TOP) {
-    const TypeInt *ti = t->is_int();
-    if (ti->is_con()) {
-      int divisor = ti->get_con();
-      // check for positive power of 2
-      if (divisor > 0 &&
-          (divisor & ~(divisor-1)) == divisor) {
-        // yes !
-        Node *mask = _gvn.intcon((divisor - 1));
-        // Sigh, must handle negative dividends
-        Node *zero = _gvn.intcon(0);
-        IfNode *ifff = jump_if_fork_int(a, zero, BoolTest::lt, PROB_FAIR, COUNT_UNKNOWN);
-        Node *iff = _gvn.transform( new IfFalseNode(ifff) );
-        Node *ift = _gvn.transform( new IfTrueNode (ifff) );
-        Node *reg = jump_if_join(ift, iff);
-        Node *phi = PhiNode::make(reg, NULL, TypeInt::INT);
-        // Negative path; negate/and/negate
-        Node *neg = _gvn.transform( new SubINode(zero, a) );
-        Node *andn= _gvn.transform( new AndINode(neg, mask) );
-        Node *negn= _gvn.transform( new SubINode(zero, andn) );
-        phi->init_req(1, negn);
-        // Fast positive case
-        Node *andx = _gvn.transform( new AndINode(a, mask) );
-        phi->init_req(2, andx);
-        // Push the merge
-        push( _gvn.transform(phi) );
-        return;
-      }
-    }
-  }
-  // Default case
-  push( _gvn.transform( new ModINode(control(),a,b) ) );
 }
 
 // Handle jsr and jsr_w bytecode
@@ -2196,7 +2141,13 @@ void Parse::do_one_bytecode() {
     break;
 
   case Bytecodes::_irem:
-    do_irem();
+    // Must keep both values on the expression-stack during null-check
+    zero_check_int(peek());
+    // Compile-time detect of null-exception?
+    if (stopped())  return;
+    b = pop();
+    a = pop();
+    push(_gvn.transform(new ModINode(control(), a, b)));
     break;
   case Bytecodes::_idiv:
     // Must keep both values on the expression-stack during null-check

--- a/test/micro/org/openjdk/bench/vm/compiler/ModPowerOf2.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/ModPowerOf2.java
@@ -92,4 +92,46 @@ public class ModPowerOf2 {
         }
         return sum;
     }
+
+    @Benchmark
+    public int testMixedPowerOf2() {
+        int sum = 0;
+        for (int i = 0; i < 1000; i++) {
+            sum += i % -1;
+            sum += i % 1;
+            sum += i % -2;
+            sum += i % 2;
+            sum += i % -4;
+            sum += i % 4;
+            sum += i % -8;
+            sum += i % 8;
+            sum += i % -16;
+            sum += i % 16;
+            sum += i % -32;
+            sum += i % 32;
+            sum += i % -64;
+            sum += i % 64;
+            sum += i % -128;
+            sum += i % 128;
+            sum += i % -256;
+            sum += i % 256;
+            sum += i % -512;
+            sum += i % 512;
+            sum += i % -1024;
+            sum += i % 1024;
+            sum += i % -2048;
+            sum += i % 2048;
+            sum += i % -4096;
+            sum += i % 4096;
+            sum += i % -8192;
+            sum += i % 8192;
+            sum += i % -16384;
+            sum += i % 16384;
+            sum += i % -32768;
+            sum += i % 32768;
+            sum += i % -65536;
+            sum += i % 65536;
+        }
+        return sum;
+    }
 }

--- a/test/micro/org/openjdk/bench/vm/compiler/ModPowerOf2.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/ModPowerOf2.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2021, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ * 
+ */
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Test for x % 2^n (n is constant)
+ */
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+public class ModPowerOf2 {
+    @Benchmark
+    public int testPositivePowerOf2() {
+        int sum = 0;
+        for (int i = 0; i < 1000; i++) {
+            sum += i % 1;
+            sum += i % 2;
+            sum += i % 4;
+            sum += i % 8;
+            sum += i % 16;
+            sum += i % 32;
+            sum += i % 64;
+            sum += i % 128;
+            sum += i % 256;
+            sum += i % 512;
+            sum += i % 1024;
+            sum += i % 2048;
+            sum += i % 4096;
+            sum += i % 8192;
+            sum += i % 16384;
+            sum += i % 32768;
+            sum += i % 65536;
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int testNegativePowerOf2() {
+        int sum = 0;
+        for (int i = 0; i < 1000; i++) {
+            sum += i % -1;
+            sum += i % -2;
+            sum += i % -4;
+            sum += i % -8;
+            sum += i % -16;
+            sum += i % -32;
+            sum += i % -64;
+            sum += i % -128;
+            sum += i % -256;
+            sum += i % -512;
+            sum += i % -1024;
+            sum += i % -2048;
+            sum += i % -4096;
+            sum += i % -8192;
+            sum += i % -16384;
+            sum += i % -32768;
+            sum += i % -65536;
+        }
+        return sum;
+    }
+}

--- a/test/micro/org/openjdk/bench/vm/compiler/ModPowerOf2.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/ModPowerOf2.java
@@ -19,7 +19,7 @@
  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  * or visit www.oracle.com if you need additional information or have any
  * questions.
- * 
+ *
  */
 package org.openjdk.bench.vm.compiler;
 


### PR DESCRIPTION
Hi all,

Can I have a review of this change? I noticed there are two almost the same optimizations for % operation. For x%y, both Parse::do_irem and ModXNode::ideal are optimized for a special case that divisor y is `2^n` constant value. It turns out that ModXNode::Ideal optimization is better than Parse::do_irem in a simple microbenchmark(Please check out JBS attachment for more detailed benchmark result), 

### Implementation
- ModXNode::Ideal opt:
https://github.com/openjdk/jdk/blob/cc687fd43ade6be8760c559f3ffa909c5937727c/src/hotspot/share/opto/divnode.cpp#L112-L160

- Parse::do_irem opt:
https://github.com/openjdk/jdk/blob/cc687fd43ade6be8760c559f3ffa909c5937727c/src/hotspot/share/opto/parse2.cpp#L1171-L1196

### JMH Microbenchmark
- x64
```
ModXNode::Ideal opt:
Benchmark                         Mode  Cnt     Score     Error  Units
ModPowerOf2.testNegativePowerOf2  avgt   25  8746.608 ± 139.777  ns/op
ModPowerOf2.testPositivePowerOf2  avgt   25  8735.545 ±  86.145  ns/op

Parse::do_irem opt:
Benchmark                         Mode  Cnt     Score   Error  Units
ModPowerOf2.testNegativePowerOf2  avgt   25  8693.797 ± 7.844  ns/op
ModPowerOf2.testPositivePowerOf2  avgt   25  6618.652 ± 1.739  ns/op
```

- AArch64
```
ModXNode::Ideal opt:
Benchmark                         Mode  Cnt     Score   Error  Units
ModPowerOf2.testNegativePowerOf2  avgt   25  6758.299 ± 4.452  ns/op
ModPowerOf2.testPositivePowerOf2  avgt   25  6759.533 ± 2.791  ns/op

Parse::do_irem opt:
Benchmark                         Mode  Cnt     Score   Error  Units
ModPowerOf2.testNegativePowerOf2  avgt   25  6757.868 ± 4.044  ns/op
ModPowerOf2.testPositivePowerOf2  avgt   25  6546.034 ± 0.794  ns/op
```

In summary, ModXNode::Ideal is better than Parse::do_irem on x64 platform, benchmark results are also reproducible. I guess the reason is that Parse::do_irem generates cmp and jmp while ModXNode::Ideal does not. On AArch64 platform, the two optimizations are almost the same according to benchmark results. I am not familiar with AArch64 so I can not give a constructive answer.


### Assembly
- source code
```java
static int foo15(int k){
    return k%8;
}
```

- x64

ModXNode::Ideal opt:
```
[Verified Entry Point]
  # {method} {0x00007f0ded401ec8} 'foo15' '(I)I' in 'CheckIndex'
  # parm0:    rsi       = int
  #           [sp+0x20]  (sp of caller)
  0x00007f0e4952e780:   sub    $0x18,%rsp
  0x00007f0e4952e787:   mov    %rbp,0x10(%rsp)              ;*synchronization entry
                                                            ; - CheckIndex::foo15@-1 (line 125)
  0x00007f0e4952e78c:   mov    %esi,%r10d
  0x00007f0e4952e78f:   sar    $0x1f,%r10d
  0x00007f0e4952e793:   shr    $0x1d,%r10d
  0x00007f0e4952e797:   add    %esi,%r10d
  0x00007f0e4952e79a:   and    $0xfffffffffffffff8,%r10d
  0x00007f0e4952e79e:   mov    %esi,%eax
  0x00007f0e4952e7a0:   sub    %r10d,%eax                   ;*irem {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - CheckIndex::foo15@3 (line 125)
  0x00007f0e4952e7a3:   add    $0x10,%rsp
  0x00007f0e4952e7a7:   pop    %rbp
  0x00007f0e4952e7a8:   cmp    0x340(%r15),%rsp             ;   {poll_return}
  0x00007f0e4952e7af:   ja     0x00007f0e4952e7b6
  0x00007f0e4952e7b5:   retq   
  0x00007f0e4952e7b6:   mov    $0x7f0e4952e7a8,%r10         ;   {internal_word}
  0x00007f0e4952e7c0:   mov    %r10,0x358(%r15)
  0x00007f0e4952e7c7:   jmpq   0x00007f0e49506100           ;   {runtime_call SafepointBlob}
  0x00007f0e4952e7cc:   hlt  
  						...   ; omit remaining hlt(s)
  
```

Parse::do_irem opt:
```
[Verified Entry Point]
  # {method} {0x00007fbab9c01ec8} 'foo15' '(I)I' in 'CheckIndex'
  # parm0:    rsi       = int
  #           [sp+0x20]  (sp of caller)
  0x00007fbb1552db00:   sub    $0x18,%rsp
  0x00007fbb1552db07:   mov    %rbp,0x10(%rsp)              ;*synchronization entry
                                                            ; - CheckIndex::foo15@-1 (line 125)
  0x00007fbb1552db0c:   test   %esi,%esi
  0x00007fbb1552db0e:   jge    0x00007fbb1552db2c
  0x00007fbb1552db10:   neg    %esi
  0x00007fbb1552db12:   and    $0x7,%esi
  0x00007fbb1552db15:   mov    %esi,%eax
  0x00007fbb1552db17:   neg    %eax
  0x00007fbb1552db19:   add    $0x10,%rsp
  0x00007fbb1552db1d:   pop    %rbp
  0x00007fbb1552db1e:   cmp    0x340(%r15),%rsp             ;   {poll_return}
  0x00007fbb1552db25:   ja     0x00007fbb1552db33
  0x00007fbb1552db2b:   retq   
  0x00007fbb1552db2c:   mov    %esi,%eax
  0x00007fbb1552db2e:   and    $0x7,%eax                    ;*irem {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - CheckIndex::foo15@3 (line 125)
  0x00007fbb1552db31:   jmp    0x00007fbb1552db19
  0x00007fbb1552db33:   mov    $0x7fbb1552db1e,%r10         ;   {internal_word}
  0x00007fbb1552db3d:   mov    %r10,0x358(%r15)
  0x00007fbb1552db44:   jmpq   0x00007fbb15505100           ;   {runtime_call SafepointBlob}
  0x00007fbb1552db49:   hlt    
						...   ; omit remaining hlt(s)   
```

- AArch64

ModXNode::Ideal opt:
```
[Verified Entry Point]
  # {method} {0x0000ffff3d000218} 'foo15' '(I)I' in 'CheckIndex'
  # parm0:    c_rarg1   = int
  #           [sp+0x20]  (sp of caller)
  0x0000ffff9d4f7580:   nop
  0x0000ffff9d4f7584:   sub	sp, sp, #0x20
  0x0000ffff9d4f7588:   stp	x29, x30, [sp, #16]         ;*synchronization entry
                                                            ; - CheckIndex::foo15@-1 (line 3)
  0x0000ffff9d4f758c:   asr	w10, w1, #31
  0x0000ffff9d4f7590:   add	w11, w1, w10, lsr #29
  0x0000ffff9d4f7594:   and	w10, w11, #0xfffffff8
  0x0000ffff9d4f7598:   sub	w0, w1, w10                 ;*irem {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - CheckIndex::foo15@3 (line 3)
  0x0000ffff9d4f759c:   ldp	x29, x30, [sp, #16]
  0x0000ffff9d4f75a0:   add	sp, sp, #0x20
  0x0000ffff9d4f75a4:   ldr	x8, [x28, #832]             ;   {poll_return}
  0x0000ffff9d4f75a8:   cmp	sp, x8
  0x0000ffff9d4f75ac:   b.hi	0x0000ffff9d4f75b4  // b.pmore
  0x0000ffff9d4f75b0:   ret
  0x0000ffff9d4f75b4:   adr	x8, 0x0000ffff9d4f75a4      ;   {internal_word}
  0x0000ffff9d4f75b8:   str	x8, [x28, #856]
  0x0000ffff9d4f75bc:   b	0x0000ffff9d4cd600          ;   {runtime_call SafepointBlob}
```

Parse::do_irem opt:
```
[Verified Entry Point]
  # {method} {0x0000ffff1c800218} 'foo15' '(I)I' in 'CheckIndex'
  # parm0:    c_rarg1   = int
  #           [sp+0x20]  (sp of caller)
  0x0000ffff7d4f7580:   nop
  0x0000ffff7d4f7584:   sub	sp, sp, #0x20
  0x0000ffff7d4f7588:   stp	x29, x30, [sp, #16]         ;*synchronization entry
                                                            ; - CheckIndex::foo15@-1 (line 3)
  0x0000ffff7d4f758c:   tbz	w1, #31, 0x0000ffff7d4f75b4
  0x0000ffff7d4f7590:   neg	w10, w1
  0x0000ffff7d4f7594:   and	w11, w10, #0x7
  0x0000ffff7d4f7598:   neg	w0, w11
  0x0000ffff7d4f759c:   ldp	x29, x30, [sp, #16]
  0x0000ffff7d4f75a0:   add	sp, sp, #0x20
  0x0000ffff7d4f75a4:   ldr	x8, [x28, #832]             ;   {poll_return}
  0x0000ffff7d4f75a8:   cmp	sp, x8
  0x0000ffff7d4f75ac:   b.hi	0x0000ffff7d4f75bc  // b.pmore
  0x0000ffff7d4f75b0:   ret
  0x0000ffff7d4f75b4:   and	w0, w1, #0x7                ;*irem {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - CheckIndex::foo15@3 (line 3)
  0x0000ffff7d4f75b8:   b	0x0000ffff7d4f759c
  0x0000ffff7d4f75bc:   adr	x8, 0x0000ffff7d4f75a4      ;   {internal_word}
  0x0000ffff7d4f75c0:   str	x8, [x28, #856]
  0x0000ffff7d4f75c4:   b	0x0000ffff7d4cd600          ;   {runtime_call SafepointBlob}
  0x0000ffff7d4f75c8:   .inst	0x00000000 ; undefined
                        ...   ; omit remaining .inst(s)
```

### Ideal graph:
----------------
![ideal_graph](https://user-images.githubusercontent.com/5010047/119525589-34585f80-bdb1-11eb-9d7e-e3962cd7f789.jpg)
(Parse opt(left) vs Ideal opt(right))

Thanks!
Yang

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267687](https://bugs.openjdk.java.net/browse/JDK-8267687): ModXNode::Ideal optimization is better than Parse::do_irem


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**) ⚠️ Review applies to 319394060fe76187a4ca9ff9e283166de2ad1789
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4188/head:pull/4188` \
`$ git checkout pull/4188`

Update a local copy of the PR: \
`$ git checkout pull/4188` \
`$ git pull https://git.openjdk.java.net/jdk pull/4188/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4188`

View PR using the GUI difftool: \
`$ git pr show -t 4188`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4188.diff">https://git.openjdk.java.net/jdk/pull/4188.diff</a>

</details>
