### PR TITLE
8187649: ArrayIndexOutOfBoundsException in java.util.JapaneseImperialCalendar

### DIFF
--- a/src/java.base/share/classes/java/util/JapaneseImperialCalendar.java
+++ b/src/java.base/share/classes/java/util/JapaneseImperialCalendar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -886,7 +886,7 @@ class JapaneseImperialCalendar extends Calendar {
                 } else if (nfd >= (month1 + monthLength)) {
                     nfd = month1 + monthLength - 1;
                 }
-                set(DAY_OF_MONTH, (int)(nfd - month1) + 1);
+                set(DAY_OF_MONTH, getCalendarDate(nfd).getDayOfMonth());
                 return;
             }
 
@@ -1458,7 +1458,7 @@ class JapaneseImperialCalendar extends Calendar {
                     CalendarDate d = gcal.newCalendarDate(TimeZone.NO_TIMEZONE);
                     d.setDate(date.getNormalizedYear(), date.getMonth(), 1);
                     int dayOfWeek = gcal.getDayOfWeek(d);
-                    int monthLength = gcal.getMonthLength(d);
+                    int monthLength = actualMonthLength();
                     dayOfWeek -= getFirstDayOfWeek();
                     if (dayOfWeek < 0) {
                         dayOfWeek += 7;
@@ -2239,7 +2239,7 @@ class JapaneseImperialCalendar extends Calendar {
     private int actualMonthLength() {
         int length = jcal.getMonthLength(jdate);
         int eraIndex = getTransitionEraIndex(jdate);
-        if (eraIndex == -1) {
+        if (eraIndex != -1) {
             long transitionFixedDate = sinceFixedDates[eraIndex];
             CalendarDate d = eras[eraIndex].getSinceDate();
             if (transitionFixedDate <= cachedFixedDate) {

--- a/test/jdk/java/util/Calendar/CalendarTestScripts/JapaneseTests.java
+++ b/test/jdk/java/util/Calendar/CalendarTestScripts/JapaneseTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /*
  * @test
  * @summary tests Japanese Calendar.
- * @bug 4609228
+ * @bug 4609228 8187649
  * @modules java.base/sun.util
  *          java.base/sun.util.calendar
  * @compile

--- a/test/jdk/java/util/Calendar/CalendarTestScripts/japanese/japanese_roll.cts
+++ b/test/jdk/java/util/Calendar/CalendarTestScripts/japanese/japanese_roll.cts
@@ -435,12 +435,48 @@ test roll WEEK_OF_YEAR
 	check date BeforeMeiji $minyear Dec 25
 
 test WEEK_OF_MONTH
-	# Needs to wait for 6191841 fix. (WEEK_OF_MONTH needs to change
-	# ERA and YEAR in a transition month.)
+	use jcal
+	clear all
+
+	# Make sure this test does not throw AIOOBE
+	set date Heisei 1 Aug 1
+	roll week_of_month 1
+	check date Heisei 1 Aug 8
+
+	# Check transition dates
+	set date Showa 64 Jan 7
+	roll week_of_month 1
+	check date Showa 64 Jan 7
+	roll week_of_month -1
+	check date Showa 64 Jan 7
+
+	set date Heisei 1 Jan 31
+	roll week_of_month 1
+	check date Heisei 1 Jan 10
+	roll week_of_month -1
+	check date Heisei 1 Jan 31
 
 test DAY_OF_MONTH
-	# Needs to wait for 6191841 fix. (DAY_OF_MONTH needs to change
-	# ERA and YEAR in a transition month.)
+	use jcal
+	clear all
+
+	# Make sure this test does not throw AIOOBE
+	Set date Heisei 1 Aug 1
+	roll day_of_month 1
+	check date Heisei 1 Aug 2
+
+	# Check transition dates
+	set date Showa 64 Jan 7
+	roll day_of_month 1
+	check date Showa 64 Jan 1
+	roll day_of_month -1
+	check date Showa 64 Jan 7
+
+	set date Heisei 1 Jan 31
+	roll day_of_month 1
+	check date Heisei 1 Jan 8
+	roll day_of_month -1
+	check date Heisei 1 Jan 31
 
 test DAY_OF_YEAR
     use jcal


### PR DESCRIPTION
Please review the fix. The issue was informed yesterday by @amaembo that it offends some code analysis tools.
Although the fix is to change the condition error, it turned out that `JapaneseImperialCalendar.roll()` did not work for `WEEK_OF_MONTH` and `DAY_OF_MONTH`. There was an inherent issue where `GregorianCalendar` does not follow the `roll()` spec, i.e., "The MONTH must not change when the WEEK_OF_MONTH is rolled." during the Julian/Gregorian transition. JDK-6191841 seems to have tried to fix it but it was closed as `Future Project`...
So I simply fixed the `roll()` issue in `JapaneseImperialCalendar` to follow the spec here, which seems to be the intent of the original author.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8187649](https://bugs.openjdk.java.net/browse/JDK-8187649): ArrayIndexOutOfBoundsException in java.util.JapaneseImperialCalendar


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4191/head:pull/4191` \
`$ git checkout pull/4191`

Update a local copy of the PR: \
`$ git checkout pull/4191` \
`$ git pull https://git.openjdk.java.net/jdk pull/4191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4191`

View PR using the GUI difftool: \
`$ git pr show -t 4191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4191.diff">https://git.openjdk.java.net/jdk/pull/4191.diff</a>

</details>
