### PR TITLE
8267708: Remove references to com.sun.tools.javadoc.**

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTrees.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTrees.java
@@ -624,12 +624,10 @@ public class JavacTrees extends DocTrees {
         return null;
     }
 
-    /** @see com.sun.tools.javadoc.ClassDocImpl#findField */
     private VarSymbol findField(ClassSymbol tsym, Name fieldName) {
         return searchField(tsym, fieldName, new HashSet<>());
     }
 
-    /** @see com.sun.tools.javadoc.ClassDocImpl#searchField */
     private VarSymbol searchField(ClassSymbol tsym, Name fieldName, Set<ClassSymbol> searched) {
         if (searched.contains(tsym)) {
             return null;
@@ -676,7 +674,6 @@ public class JavacTrees extends DocTrees {
         return null;
     }
 
-    /** @see com.sun.tools.javadoc.ClassDocImpl#findConstructor */
     MethodSymbol findConstructor(ClassSymbol tsym, List<Type> paramTypes) {
         for (Symbol sym : tsym.members().getSymbolsByName(names.init)) {
             if (sym.kind == MTH) {
@@ -688,12 +685,10 @@ public class JavacTrees extends DocTrees {
         return null;
     }
 
-    /** @see com.sun.tools.javadoc.ClassDocImpl#findMethod */
     private MethodSymbol findMethod(ClassSymbol tsym, Name methodName, List<Type> paramTypes) {
         return searchMethod(tsym, methodName, paramTypes, new HashSet<>());
     }
 
-    /** @see com.sun.tools.javadoc.ClassDocImpl#searchMethod */
     private MethodSymbol searchMethod(ClassSymbol tsym, Name methodName,
                                        List<Type> paramTypes, Set<ClassSymbol> searched) {
         //### Note that this search is not necessarily what the compiler would do!
@@ -775,7 +770,6 @@ public class JavacTrees extends DocTrees {
         return null;
     }
 
-    /** @see com.sun.tools.javadoc.ClassDocImpl */
     private boolean hasParameterTypes(MethodSymbol method, List<Type> paramTypes) {
         if (paramTypes == null)
             return true;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
@@ -312,11 +312,6 @@ public class Log extends AbstractLog {
 
     /**
      * Construct a log with given I/O redirections.
-     * @deprecated
-     * This constructor is provided to support the supported but now-deprecated javadoc entry point
-     *      com.sun.tools.javadoc.Main.execute(String programName,
-     *          PrintWriter errWriter, PrintWriter warnWriter, PrintWriter noticeWriter,
-     *          String defaultDocletClassName, String... args)
      */
     @Deprecated
     protected Log(Context context, PrintWriter errWriter, PrintWriter warnWriter, PrintWriter noticeWriter) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
@@ -312,6 +312,10 @@ public class Log extends AbstractLog {
 
     /**
      * Construct a log with given I/O redirections.
+     * @deprecated
+     * This constructor is provided to support
+     *      jdk.javadoc.internal.tool.Messager.Messager(com.sun.tools.javac.util.Context,
+     *          java.lang.String, java.io.PrintWriter, java.io.PrintWriter)
      */
     @Deprecated
     protected Log(Context context, PrintWriter errWriter, PrintWriter warnWriter, PrintWriter noticeWriter) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseOptions.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -932,7 +932,7 @@ public abstract class BaseOptions {
         protected Option(Resources resources, String keyBase, String name, int argCount) {
             this.names = name.trim().split("\\s+");
             if (keyBase == null) {
-                keyBase = "doclet.usage." + names[0].toLowerCase().replaceAll("^-+", "");
+                keyBase = "doclet.usage." + Utils.toLowerCase(names[0]).replaceAll("^-+", "");
             }
             String desc = getOptionsMessage(resources, keyBase + ".description");
             if (desc.isEmpty()) {
@@ -995,7 +995,7 @@ public abstract class BaseOptions {
                 } else if (matchCase) {
                     return name.equals(option);
                 }
-                return name.toLowerCase().equals(option.toLowerCase());
+                return name.equalsIgnoreCase(option);
             }
             return false;
         }

--- a/test/langtools/jdk/javadoc/tool/CheckResourceKeys.java
+++ b/test/langtools/jdk/javadoc/tool/CheckResourceKeys.java
@@ -227,7 +227,7 @@ public class CheckResourceKeys {
             }
 
             // special handling for code strings synthesized in
-            // com.sun.tools.javadoc.Messager
+            // jdk.javadoc.internal.tool.Messager
             results.add("javadoc.error.msg");
             results.add("javadoc.note.msg");
             results.add("javadoc.note.pos.msg");

--- a/test/langtools/tools/javac/NoStringToLower.java
+++ b/test/langtools/tools/javac/NoStringToLower.java
@@ -68,7 +68,8 @@ public class NoStringToLower {
                 "com.sun.tools.javah",
                 "com.sun.tools.javap",
                 "com.sun.tools.jdeps",
-                "com.sun.tools.sjavac"
+                "com.sun.tools.sjavac",
+                "jdk.javadoc"
             };
             for (String pkg: pkgs) {
                 for (JavaFileObject fo: fm.list(javacLoc,

--- a/test/langtools/tools/javac/NoStringToLower.java
+++ b/test/langtools/tools/javac/NoStringToLower.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,10 +63,8 @@ public class NoStringToLower {
                 "javax.tools",
                 "com.sun.source",
                 "com.sun.tools.classfile",
-                "com.sun.tools.doclet",
                 "com.sun.tools.doclint",
                 "com.sun.tools.javac",
-                "com.sun.tools.javadoc",
                 "com.sun.tools.javah",
                 "com.sun.tools.javap",
                 "com.sun.tools.jdeps",

--- a/test/langtools/tools/javac/T8003967/DetectMutableStaticFields.java
+++ b/test/langtools/tools/javac/T8003967/DetectMutableStaticFields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,12 +73,9 @@ public class DetectMutableStaticFields {
     private final String[] packagesToSeekFor = new String[] {
         "javax.tools",
         "javax.lang.model",
-        "com.sun.javadoc",
         "com.sun.source",
         "com.sun.tools.classfile",
-        "com.sun.tools.doclets",
         "com.sun.tools.javac",
-        "com.sun.tools.javadoc",
         "com.sun.tools.javah",
         "com.sun.tools.javap",
         "jdk.javadoc"
@@ -91,7 +88,6 @@ public class DetectMutableStaticFields {
 
     static {
         ignore("javax/tools/ToolProvider", "instance");
-        ignore("jdk/javadoc/internal/tool/Start", "versionRB");
         ignore("com/sun/tools/javah/JavahTask", "versionRB");
         ignore("com/sun/tools/classfile/Dependencies$DefaultFilter", "instance");
         ignore("com/sun/tools/javap/JavapTask", "versionRB");


### PR DESCRIPTION
Although the `com.sun.tools.javadoc.**` packages were removed in JDK-8215584, some references to them remain, mainly in the form of links in doc comments. Some of those links refer to classes that never existed, which I reckon is due to a typo; for example, this reference

    com.sun.tools.javadoc.ClassDocImpl#findField

should've looked like this

    com.sun.tools.javadoc.main.ClassDocImpl#findField

Grep showed that some tests also use `com.sun.tools.javadoc` and some other extinct packages. However, it is unclear if those "references" should also be removed:

1. https://github.com/openjdk/jdk/blob/739769c8fc4b496f08a92225a12d07414537b6c0/test/langtools/tools/javac/NoStringToLower.java#L60-L74
2. https://github.com/openjdk/jdk/blob/739769c8fc4b496f08a92225a12d07414537b6c0/test/langtools/tools/javac/T8003967/DetectMutableStaticFields.java#L73-L85

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267708](https://bugs.openjdk.java.net/browse/JDK-8267708): Remove references to com.sun.tools.javadoc.**


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4192/head:pull/4192` \
`$ git checkout pull/4192`

Update a local copy of the PR: \
`$ git checkout pull/4192` \
`$ git pull https://git.openjdk.java.net/jdk pull/4192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4192`

View PR using the GUI difftool: \
`$ git pr show -t 4192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4192.diff">https://git.openjdk.java.net/jdk/pull/4192.diff</a>

</details>
