### PR TITLE
8267683: rfc7301Grease8F value not displayed correctly in SSLParameters javadoc

### DIFF
--- a/src/java.base/share/classes/javax/net/ssl/SSLParameters.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -660,7 +660,7 @@ public class SSLParameters {
      *     String HUK_UN_I = new String(bytes, StandardCharsets.ISO_8859_1);
      *
      *     // 0x00-0xFF:  1 byte
-     *     String rfc7301Grease8F = "\u005c008F\u005c008F";
+     *     String rfc7301Grease8F = "\u005cu008F\u005cu008F";
      *
      *     SSLParameters p = sslSocket.getSSLParameters();
      *     p.setApplicationProtocols(new String[] {

--- a/src/java.base/share/classes/javax/net/ssl/SSLParameters.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLParameters.java
@@ -660,7 +660,7 @@ public class SSLParameters {
      *     String HUK_UN_I = new String(bytes, StandardCharsets.ISO_8859_1);
      *
      *     // 0x00-0xFF:  1 byte
-     *     String rfc7301Grease8F = "\u005cu008F\u005cu008F";
+     *     String rfc7301Grease8A = "\u005cu008A\u005cu008A";
      *
      *     SSLParameters p = sslSocket.getSSLParameters();
      *     p.setApplicationProtocols(new String[] {


### PR DESCRIPTION
Simple typo fix.  Somehow the trailing "u" got omitted, so the code won't parse when fed into the compiler.

Resulting javadoc output now compiles.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267683](https://bugs.openjdk.java.net/browse/JDK-8267683): rfc7301Grease8F value not displayed correctly in SSLParameters javadoc


### Reviewers
 * [Sean Coffey](https://openjdk.java.net/census#coffeys) (@coffeys - **Reviewer**) ⚠️ Review applies to 7d155bbe600be1452dd190a4ae1c31a30e587a62


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4193/head:pull/4193` \
`$ git checkout pull/4193`

Update a local copy of the PR: \
`$ git checkout pull/4193` \
`$ git pull https://git.openjdk.java.net/jdk pull/4193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4193`

View PR using the GUI difftool: \
`$ git pr show -t 4193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4193.diff">https://git.openjdk.java.net/jdk/pull/4193.diff</a>

</details>
