### PR TITLE
8267754: cds/appcds/loaderConstraints/LoaderConstraintsTest.java fails on x86_32 due to customized class loader is not supported

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/LoaderConstraintsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/LoaderConstraintsTest.java
@@ -110,8 +110,7 @@ public class LoaderConstraintsTest  {
     public static void main(String... args) throws Exception {
         appJar = ClassFileInstaller.writeJar("loader_constraints.jar", appClasses);
         doTest();
-        if (!Platform.isWindows() && Platform.is64bit()) {
-            // custom loaders are not supported on Windows or 32-bit systems yet.
+        if (Platform.areCustomLoadersSupportedForCDS()) {
             loaderJar = ClassFileInstaller.writeJar("custom_app_loader.jar", loaderClasses);
             doTestCustomLoader();
         }

--- a/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/LoaderConstraintsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/LoaderConstraintsTest.java
@@ -25,7 +25,7 @@
  * @test
  * @requires vm.cds
  * @summary Test class loader constraint checks for archived classes
- * @bug 8267347
+ * @bug 8267347 8267754
  * @library /test/lib
  *          /test/hotspot/jtreg/runtime/cds/appcds
  *          /test/hotspot/jtreg/runtime/cds/appcds/test-classes
@@ -110,8 +110,8 @@ public class LoaderConstraintsTest  {
     public static void main(String... args) throws Exception {
         appJar = ClassFileInstaller.writeJar("loader_constraints.jar", appClasses);
         doTest();
-        if (!Platform.isWindows()) {
-            // custom loaders are not supported on Windows yet.
+        if (!Platform.isWindows() && Platform.is64bit()) {
+            // custom loaders are not supported on Windows or 32-bit systems yet.
             loaderJar = ClassFileInstaller.writeJar("custom_app_loader.jar", loaderClasses);
             doTestCustomLoader();
         }


### PR DESCRIPTION
Hi all,

cds/appcds/loaderConstraints/LoaderConstraintsTest.java fails on x86_32.
This reason is that customized class loader is not supported on 32-bit systems [1].
It would be better to fix it.

Thanks.
Best regards,
Jie


[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/cds/classListParser.cpp#L440

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267754](https://bugs.openjdk.java.net/browse/JDK-8267754): cds/appcds/loaderConstraints/LoaderConstraintsTest.java fails on x86_32 due to customized class loader is not supported


### Reviewers
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4198/head:pull/4198` \
`$ git checkout pull/4198`

Update a local copy of the PR: \
`$ git checkout pull/4198` \
`$ git pull https://git.openjdk.java.net/jdk pull/4198/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4198`

View PR using the GUI difftool: \
`$ git pr show -t 4198`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4198.diff">https://git.openjdk.java.net/jdk/pull/4198.diff</a>

</details>
