### PR TITLE
8267353: java/net/SctpSanity.java fails due to Protocol not supported

### DIFF
--- a/test/jdk/java/net/SctpSanity.java
+++ b/test/jdk/java/net/SctpSanity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 8232097
+ * @bug 8232097 8267353
  * @summary Basic sanity for creation of SCTP channels
  * @modules jdk.sctp
  * @run main/othervm SctpSanity 1
@@ -44,8 +44,27 @@ import static java.lang.System.out;
  * the system-level support is not configured.
  */
 public class SctpSanity {
+    static boolean isSCTPSupported() {
+        try {
+            SctpChannel c = SctpChannel.open();
+            c.close();
+            return true;
+        } catch (IOException ioe) {
+            ioe.printStackTrace();
+        } catch (UnsupportedOperationException e) {
+            out.println(e);
+        }
+
+        return false;
+    }
 
     public static void main(String... args) throws IOException {
+        if (!isSCTPSupported()) {
+            out.println("SCTP protocol is not supported");
+            out.println("Test cannot be run");
+            return;
+        }
+
         switch (Integer.valueOf(args[0])) {
             case 1: testSctpChannel();        break;
             case 2: testSctpServerChannel();  break;


### PR DESCRIPTION
Hi all,

java/net/SctpSanity.java fails on some of our test machines due to Protocol not supported.
The reason is that the test fails to detect all the cases when a machine doesn't support SCTP.

The fix just follows what are done in [1][2][3] to detect unsupported paltforms at the beginning.

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk/blob/master/test/jdk/com/sun/nio/sctp/SctpMultiChannel/Util.java#L59
[2] https://github.com/openjdk/jdk/blob/master/test/jdk/com/sun/nio/sctp/SctpServerChannel/Util.java#L59
[3] https://github.com/openjdk/jdk/blob/master/test/jdk/com/sun/nio/sctp/SctpChannel/Util.java#L59

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8267353](https://bugs.openjdk.java.net/browse/JDK-8267353): java/net/SctpSanity.java fails due to Protocol not supported


### Contributors
 * Junji Wang `<junjiwang@tencent.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4199/head:pull/4199` \
`$ git checkout pull/4199`

Update a local copy of the PR: \
`$ git checkout pull/4199` \
`$ git pull https://git.openjdk.java.net/jdk pull/4199/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4199`

View PR using the GUI difftool: \
`$ git pr show -t 4199`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4199.diff">https://git.openjdk.java.net/jdk/pull/4199.diff</a>

</details>
