### PR TITLE
8267686: C2: PrintIdealGraphFile supports parameterization

### DIFF
--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -736,9 +736,13 @@ void IdealGraphPrinter::init_file_stream(const char* file_name, bool use_multipl
     } else {
       st.print("%s%d", file_name, _file_count);
     }
-    _output = new (ResourceObj::C_HEAP, mtCompiler) fileStream(st.as_string(), "w");
+    const char* format_file_name = make_log_name(st.as_string(), NULL);
+    _output = new (ResourceObj::C_HEAP, mtCompiler) fileStream(format_file_name, "w");
+    FREE_C_HEAP_ARRAY(char, format_file_name);
   } else {
-    _output = new (ResourceObj::C_HEAP, mtCompiler) fileStream(file_name, append ? "a" : "w");
+    const char* format_file_name = make_log_name(file_name, NULL);
+    _output = new (ResourceObj::C_HEAP, mtCompiler) fileStream(format_file_name, append ? "a" : "w");
+    FREE_C_HEAP_ARRAY(char, format_file_name);
   }
   if (use_multiple_files) {
     assert(!append, "append should only be used for debugging with a single file");


### PR DESCRIPTION
When analyzing C2 problems in jcstress[1], which starts multiple JVMs.  If parsing %p%t is not supported, the file specified by PrintIdealGraphFile will be opened repeatedly.

Example
```
java -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:CICompilerCount=1 -XX:PrintIdealGraphLevel=3 -XX:PrintIdealGraphFile=ideal-%p-%t.xml -XX:CompileCommand="print *jcstress::lambda\$sanityCheck_Footprints\$2" -jar jcstress.jar -c 64 -f 1 -iters 1 -t org.openjdk.jcstress.tests.locks.stamped.StampedLockPairwiseTests
```

Implemented by referring to `DumpLoadedClassList` 

[1] https://mail.openjdk.java.net/pipermail/jdk8u-dev/2021-January/013278.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8267686](https://bugs.openjdk.java.net/browse/JDK-8267686): C2: PrintIdealGraphFile supports parameterization


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4201/head:pull/4201` \
`$ git checkout pull/4201`

Update a local copy of the PR: \
`$ git checkout pull/4201` \
`$ git pull https://git.openjdk.java.net/jdk pull/4201/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4201`

View PR using the GUI difftool: \
`$ git pr show -t 4201`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4201.diff">https://git.openjdk.java.net/jdk/pull/4201.diff</a>

</details>
