### PR TITLE
8267583: jmod fails on symlink to class file

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jmod/JmodTask.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jmod/JmodTask.java
@@ -674,7 +674,8 @@ public class JmodTask {
         Set<String> findPackages(Path dir) {
             try {
                 return Files.find(dir, Integer.MAX_VALUE,
-                                  ((path, attrs) -> attrs.isRegularFile()))
+                                  ((path, attrs) -> attrs.isRegularFile()),
+                                  FileVisitOption.FOLLOW_LINKS)
                         .map(dir::relativize)
                         .filter(path -> isResource(path.toString()))
                         .map(path -> toPackageName(path))


### PR DESCRIPTION
FileVisitOption.FOLLOW_LINKS used. Test extended for file symlinks case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267583](https://bugs.openjdk.java.net/browse/JDK-8267583): jmod fails on symlink to class file


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4202/head:pull/4202` \
`$ git checkout pull/4202`

Update a local copy of the PR: \
`$ git checkout pull/4202` \
`$ git pull https://git.openjdk.java.net/jdk pull/4202/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4202`

View PR using the GUI difftool: \
`$ git pr show -t 4202`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4202.diff">https://git.openjdk.java.net/jdk/pull/4202.diff</a>

</details>
