### PR TITLE
8241423: NUMA APIs fail to work in dockers due to dependent syscalls are disabled by default

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2962,7 +2962,8 @@ void* os::Linux::libnuma_v2_dlsym(void* handle, const char* name) {
 }
 
 bool os::Linux::libnuma_init() {
-  if (sched_getcpu() != -1) { // Requires sched_getcpu() support
+  // Requires sched_getcpu() and numa dependent syscalls support
+  if ((sched_getcpu() != -1) && numa_syscall_check()) {
     void *handle = dlopen("libnuma.so.1", RTLD_LAZY);
     if (handle != NULL) {
       set_numa_node_to_cpus(CAST_TO_FN_PTR(numa_node_to_cpus_func_t,
@@ -4475,6 +4476,21 @@ void os::Linux::numa_init() {
       UseAdaptiveNUMAChunkSizing = false;
     }
   }
+}
+
+// Check numa dependent syscalls
+bool os::Linux::numa_syscall_check() {
+  // NUMA APIs depend on several syscalls. E.g., get_mempolicy is required for numa_get_membind and
+  // numa_get_interleave_mask. But these dependent syscalls can be unsupported for various reasons.
+  // Especially in dockers, get_mempolicy is not allowed with the default configuration. So it's necessary
+  // to check whether the syscalls are available. Currently, only get_mempolicy is checked since checking
+  // others like mbind would cause unexpected side effects.
+  int dummy = 0;
+  if (syscall(SYS_get_mempolicy, &dummy, NULL, 0, (void*)&dummy, 3) == -1) {
+    return false;
+  }
+
+  return true;
 }
 
 // this is called _after_ the global arguments have been parsed

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -180,6 +180,7 @@ class Linux {
 
  private:
   static void numa_init();
+  static bool numa_syscall_check();
   static void expand_stack_to(address bottom);
 
   typedef int (*sched_getcpu_func_t)(void);

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -180,7 +180,6 @@ class Linux {
 
  private:
   static void numa_init();
-  static bool numa_syscall_check();
   static void expand_stack_to(address bottom);
 
   typedef int (*sched_getcpu_func_t)(void);


### PR DESCRIPTION
Hi all,

NUMA APIs fail to work in dockers due to dependent syscalls are disabled by default.

NUMA APIs depend on several syscalls.
E.g., `get_mempolicy` is required for `numa_get_membind` and `numa_get_interleave_mask`.
But these dependent syscalls can be unsupported for various reasons.
Especially in dockers, `get_mempolicy` is not allowed with the default configuration [1].
So it's necessary to check whether the syscalls are available.

In theory, all NUMA-related syscalls should be checked.
But it seems hard to do so because some of them like `mbind` would cause unexpected side effects.
So only `get_mempolicy` is checked in the fix, which is already enough for all the default dockers.
And this can be refined in the future if it turns out to be a problem.

Thanks.
Best regards,
Jie

[1] https://docs.docker.com/engine/security/seccomp/

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8241423](https://bugs.openjdk.java.net/browse/JDK-8241423): NUMA APIs fail to work in dockers due to dependent syscalls are disabled by default


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4205/head:pull/4205` \
`$ git checkout pull/4205`

Update a local copy of the PR: \
`$ git checkout pull/4205` \
`$ git pull https://git.openjdk.java.net/jdk pull/4205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4205`

View PR using the GUI difftool: \
`$ git pr show -t 4205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4205.diff">https://git.openjdk.java.net/jdk/pull/4205.diff</a>

</details>
