### PR TITLE
8267721: Enable sun/security/pkcs11 tests for Amazon Linux 2 AArch64

### DIFF
--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -690,7 +690,8 @@ public abstract class PKCS11Test {
                 "/usr/lib/arm-linux-gnueabihf/nss/" });
         osMap.put("Linux-aarch64-64", new String[] {
                 "/usr/lib/aarch64-linux-gnu/",
-                "/usr/lib/aarch64-linux-gnu/nss/" });
+                "/usr/lib/aarch64-linux-gnu/nss/",
+                "/usr/lib64/" });
         return osMap;
     }
 


### PR DESCRIPTION
Tests sun/security/pkcs11 are skipped on AArch64 Linux when they cannot find NSS libraries in one of the directories {'/usr/lib/aarch64-linux-gnu/', '/usr/lib/aarch64-linux-gnu/nss/'}. On Amazon Linux 2 the libraries are in /usr/lib64. 

This patch adds '/usr/lib64' to the search list of directories.
Test:
- Before the patch
```
$ make run-test TEST=sun/security/pkcs11
$ cd build
$ find . -name '*.jtr' -exec grep 'find NSS' {} \; | wc -l
129
```
- After the patch
```
$ make run-test TEST=sun/security/pkcs11
$ cd build
$ find . -name '*.jtr' -exec grep 'find NSS' {} \; | wc -l
0
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267721](https://bugs.openjdk.java.net/browse/JDK-8267721): Enable sun/security/pkcs11 tests for Amazon Linux 2 AArch64


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4207/head:pull/4207` \
`$ git checkout pull/4207`

Update a local copy of the PR: \
`$ git checkout pull/4207` \
`$ git pull https://git.openjdk.java.net/jdk pull/4207/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4207`

View PR using the GUI difftool: \
`$ git pr show -t 4207`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4207.diff">https://git.openjdk.java.net/jdk/pull/4207.diff</a>

</details>
