### PR TITLE
8267800: Remove the '_dirty' set in BCEscapeAnalyzer

### DIFF
--- a/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
@@ -188,10 +188,6 @@ void BCEscapeAnalyzer::set_global_escape(ArgumentMap vars, bool merge) {
   }
 }
 
-void BCEscapeAnalyzer::set_dirty(ArgumentMap vars) {
-  clear_bits(vars, _dirty);
-}
-
 void BCEscapeAnalyzer::set_modified(ArgumentMap vars, int offs, int size) {
 
   for (int i = 0; i < _arg_size; i++) {
@@ -490,7 +486,6 @@ void BCEscapeAnalyzer::iterate_one_block(ciBlock *blk, StateInfo &state, Growabl
           ArgumentMap array = state.apop();
           set_method_escape(array);
           state.apush(unknown_obj);
-          set_dirty(array);
         }
         break;
       case Bytecodes::_istore:
@@ -1451,7 +1446,6 @@ BCEscapeAnalyzer::BCEscapeAnalyzer(ciMethod* method, BCEscapeAnalyzer* parent)
     , _arg_local(_arena)
     , _arg_stack(_arena)
     , _arg_returned(_arena)
-    , _dirty(_arena)
     , _return_local(false)
     , _return_allocated(false)
     , _allocated_escapes(false)
@@ -1463,7 +1457,6 @@ BCEscapeAnalyzer::BCEscapeAnalyzer(ciMethod* method, BCEscapeAnalyzer* parent)
     _arg_local.clear();
     _arg_stack.clear();
     _arg_returned.clear();
-    _dirty.clear();
     Arena* arena = CURRENT_ENV->arena();
     _arg_modified = (uint *) arena->Amalloc(_arg_size * sizeof(uint));
     Copy::zero_to_bytes(_arg_modified, _arg_size * sizeof(uint));

--- a/src/hotspot/share/ci/bcEscapeAnalyzer.hpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.hpp
@@ -54,7 +54,6 @@ class BCEscapeAnalyzer : public ResourceObj {
   VectorSet         _arg_local;
   VectorSet         _arg_stack;
   VectorSet         _arg_returned;
-  VectorSet         _dirty;
   enum{ ARG_OFFSET_MAX = 31};
   uint              *_arg_modified;
 
@@ -84,7 +83,6 @@ class BCEscapeAnalyzer : public ResourceObj {
   void clear_bits(ArgumentMap vars, VectorSet &bs);
   void set_method_escape(ArgumentMap vars);
   void set_global_escape(ArgumentMap vars, bool merge = false);
-  void set_dirty(ArgumentMap vars);
   void set_modified(ArgumentMap vars, int offs, int size);
 
   bool is_recursive_call(ciMethod* callee);


### PR DESCRIPTION
Hi,

Could I have a review of this change?

The content of `_dirty` in  `BCEscapeAnalyzer` is only updated when processing `_aaload`. And it will not affect the results of the analysis because its content is never used.
IIUC, I think we should remove this set.

Thanks,
Denghui

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267800](https://bugs.openjdk.java.net/browse/JDK-8267800): Remove the '_dirty' set in BCEscapeAnalyzer


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4208/head:pull/4208` \
`$ git checkout pull/4208`

Update a local copy of the PR: \
`$ git checkout pull/4208` \
`$ git pull https://git.openjdk.java.net/jdk pull/4208/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4208`

View PR using the GUI difftool: \
`$ git pr show -t 4208`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4208.diff">https://git.openjdk.java.net/jdk/pull/4208.diff</a>

</details>
