### PR TITLE
8267805: Add UseVtableBasedCHA to the list of JVM flags known to jtreg

### DIFF
--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -313,6 +313,7 @@ public class VMProps implements Callable<Map<String, String>> {
         vmOptFinalFlag(map, "UseCompressedOops");
         vmOptFinalFlag(map, "EnableJVMCI");
         vmOptFinalFlag(map, "EliminateAllocations");
+        vmOptFinalFlag(map, "UseVtableBasedCHA");
     }
 
     /**


### PR DESCRIPTION
A trivial change to enable `vm.opt.final.UseVtableBasedCHA` usage in `@requires`. 

It was omitted in #3727 and `compiler/cha/StrengthReduceInterfaceCall` hasn't been executed since then. 

Testing:
- [x] hs-tier1 - hs-tier4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267805](https://bugs.openjdk.java.net/browse/JDK-8267805): Add UseVtableBasedCHA to the list of JVM flags known to jtreg


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4210/head:pull/4210` \
`$ git checkout pull/4210`

Update a local copy of the PR: \
`$ git checkout pull/4210` \
`$ git pull https://git.openjdk.java.net/jdk pull/4210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4210`

View PR using the GUI difftool: \
`$ git pr show -t 4210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4210.diff">https://git.openjdk.java.net/jdk/pull/4210.diff</a>

</details>
