### PR TITLE
8267817: [TEST] Remove unnecessary init in test/micro/org/openjdk/bench/javax/crypto/full/AESGCMBench:setup

### DIFF
--- a/test/micro/org/openjdk/bench/javax/crypto/full/AESGCMBench.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/full/AESGCMBench.java
@@ -82,8 +82,6 @@ public class AESGCMBench extends CryptoBase {
         encryptCipher.init(Cipher.ENCRYPT_MODE, ks, gcm_spec);
         encryptCipher.updateAAD(aad);
         decryptCipher = makeCipher(prov, algorithm);
-        decryptCipher.init(Cipher.DECRYPT_MODE, ks, encryptCipher.getParameters().getParameterSpec(GCMParameterSpec.class));
-        decryptCipher.updateAAD(aad);
         data = fillRandom(new byte[dataSize]);
         encryptedData = encryptCipher.doFinal(data);
     }


### PR DESCRIPTION
decryptCipher will be reinitialized in decrypt, which will loses all previously-acquired state. Therefore, it's not necessary to initialize in setup.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267817](https://bugs.openjdk.java.net/browse/JDK-8267817): [TEST] Remove unnecessary init in test/micro/org/openjdk/bench/javax/crypto/full/AESGCMBench:setup


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4215/head:pull/4215` \
`$ git checkout pull/4215`

Update a local copy of the PR: \
`$ git checkout pull/4215` \
`$ git pull https://git.openjdk.java.net/jdk pull/4215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4215`

View PR using the GUI difftool: \
`$ git pr show -t 4215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4215.diff">https://git.openjdk.java.net/jdk/pull/4215.diff</a>

</details>
