### PR TITLE
8265148: StackWatermarkSet being updated during AsyncGetCallTrace

### DIFF
--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -323,7 +323,7 @@ static bool find_initial_Java_frame(JavaThread* thread,
     // See if we can find a useful frame
     int loop_count;
     int loop_max = MaxJavaStackTraceDepth * 2;
-    RegisterMap map(thread, false);
+    RegisterMap map(thread, false, false);
 
     for (loop_count = 0; loop_max == 0 || loop_count < loop_max; loop_count++) {
       if (!candidate.safe_for_sender(thread)) return false;
@@ -337,7 +337,7 @@ static bool find_initial_Java_frame(JavaThread* thread,
   // We will hopefully be able to figure out something to do with it.
   int loop_count;
   int loop_max = MaxJavaStackTraceDepth * 2;
-  RegisterMap map(thread, false);
+  RegisterMap map(thread, false, false);
 
   for (loop_count = 0; loop_max == 0 || loop_count < loop_max; loop_count++) {
 
@@ -568,7 +568,6 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
   case _thread_in_vm_trans:
     {
       frame fr;
-
       // param isInJava == false - indicate we aren't in Java code
       if (!thread->pd_get_top_frame_for_signal_handler(&fr, ucontext, false)) {
         trace->num_frames = ticks_unknown_not_Java;  // -3 unknown frame

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -568,6 +568,7 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
   case _thread_in_vm_trans:
     {
       frame fr;
+
       // param isInJava == false - indicate we aren't in Java code
       if (!thread->pd_get_top_frame_for_signal_handler(&fr, ucontext, false)) {
         trace->num_frames = ticks_unknown_not_Java;  // -3 unknown frame


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265148](https://bugs.openjdk.java.net/browse/JDK-8265148): StackWatermarkSet being updated during AsyncGetCallTrace


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4217/head:pull/4217` \
`$ git checkout pull/4217`

Update a local copy of the PR: \
`$ git checkout pull/4217` \
`$ git pull https://git.openjdk.java.net/jdk pull/4217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4217`

View PR using the GUI difftool: \
`$ git pr show -t 4217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4217.diff">https://git.openjdk.java.net/jdk/pull/4217.diff</a>

</details>
