### PR TITLE
JDK-8267839: trivial mem leak in numa

### DIFF
--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -386,19 +386,17 @@ class Linux {
   // Returns true if bound to a single numa node, otherwise returns false.
   static bool is_bound_to_single_node() {
     int nodes = 0;
-    struct bitmask* bmp = NULL;
     unsigned int node = 0;
     unsigned int highest_node_number = 0;
 
-    if (_numa_get_membind != NULL && _numa_max_node != NULL && _numa_bitmask_isbitset != NULL) {
-      bmp = _numa_get_membind();
+    if (_numa_membind_bitmask != NULL && _numa_max_node != NULL && _numa_bitmask_isbitset != NULL) {
       highest_node_number = _numa_max_node();
     } else {
       return false;
     }
 
     for (node = 0; node <= highest_node_number; node++) {
-      if (_numa_bitmask_isbitset(bmp, node)) {
+      if (_numa_bitmask_isbitset(_numa_membind_bitmask, node)) {
         nodes++;
       }
     }


### PR DESCRIPTION
There is a trivial mem leak in numa related code. This patch is to use a stored bitmask* rather than get a new one.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267839](https://bugs.openjdk.java.net/browse/JDK-8267839): trivial mem leak in numa


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Contributors
 * Shoubing Ma `<mashoubing1@huawei.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4219/head:pull/4219` \
`$ git checkout pull/4219`

Update a local copy of the PR: \
`$ git checkout pull/4219` \
`$ git pull https://git.openjdk.java.net/jdk pull/4219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4219`

View PR using the GUI difftool: \
`$ git pr show -t 4219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4219.diff">https://git.openjdk.java.net/jdk/pull/4219.diff</a>

</details>
