### PR TITLE
8267842: SIGSEGV in get_current_contended_monitor

### DIFF
--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -753,8 +753,9 @@ class JavaThread: public Thread {
 
   // For tracking the heavyweight monitor the thread is pending on.
   ObjectMonitor* current_pending_monitor() {
-    // Using atomic load to prevent compilers from reloading (ThreadService::get_current_contended_monitor).
-    // In case of concurrent modification, reloading pointer after NULL check must be prevented.
+    // Use Atomic::load() to prevent data race between concurrent modification and
+    // concurrent readers, e.g. ThreadService::get_current_contended_monitor().
+    // Especially, reloading pointer from thread after NULL check must be prevented.
     return Atomic::load(&_current_pending_monitor);
   }
   void set_current_pending_monitor(ObjectMonitor* monitor) {
@@ -767,7 +768,7 @@ class JavaThread: public Thread {
     return _current_pending_monitor_is_from_java;
   }
   ObjectMonitor* current_waiting_monitor() {
-    // Using atomic load as in current_pending_monitor.
+    // See the comment in current_pending_monitor() above.
     return Atomic::load(&_current_waiting_monitor);
   }
   void set_current_waiting_monitor(ObjectMonitor* monitor) {

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -745,9 +745,9 @@ class JavaThread: public Thread {
   // elided card-marks for performance along the fast-path.
   MemRegion     _deferred_card_mark;
 
-  ObjectMonitor* _current_pending_monitor;              // ObjectMonitor this thread is waiting to lock
+  ObjectMonitor* volatile _current_pending_monitor;     // ObjectMonitor this thread is waiting to lock
   bool           _current_pending_monitor_is_from_java; // locking is from Java code
-  ObjectMonitor* _current_waiting_monitor;              // ObjectMonitor on which this thread called Object.wait()
+  ObjectMonitor* volatile _current_waiting_monitor;     // ObjectMonitor on which this thread called Object.wait()
  public:
   volatile intptr_t _Stalled;
 

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -753,10 +753,12 @@ class JavaThread: public Thread {
 
   // For tracking the heavyweight monitor the thread is pending on.
   ObjectMonitor* current_pending_monitor() {
-    return _current_pending_monitor;
+    // Using atomic load to prevent compilers from reloading (ThreadService::get_current_contended_monitor).
+    // In case of concurrent modification, reloading pointer after NULL check must be prevented.
+    return Atomic::load(&_current_pending_monitor);
   }
   void set_current_pending_monitor(ObjectMonitor* monitor) {
-    _current_pending_monitor = monitor;
+    Atomic::store(&_current_pending_monitor, monitor);
   }
   void set_current_pending_monitor_is_from_java(bool from_java) {
     _current_pending_monitor_is_from_java = from_java;
@@ -765,10 +767,11 @@ class JavaThread: public Thread {
     return _current_pending_monitor_is_from_java;
   }
   ObjectMonitor* current_waiting_monitor() {
-    return _current_waiting_monitor;
+    // Using atomic load as in current_pending_monitor.
+    return Atomic::load(&_current_waiting_monitor);
   }
   void set_current_waiting_monitor(ObjectMonitor* monitor) {
-    _current_waiting_monitor = monitor;
+    Atomic::store(&_current_waiting_monitor, monitor);
   }
 
  private:

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -741,7 +741,7 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
   nonstatic_field(JavaThread,                  _vm_result_2,                                  Metadata*)                             \
   volatile_nonstatic_field(JavaThread,         _current_pending_monitor,                      ObjectMonitor*)                        \
   nonstatic_field(JavaThread,                  _current_pending_monitor_is_from_java,         bool)                                  \
-  volatile_nonstatic_field(JavaThread,          _current_waiting_monitor,                      ObjectMonitor*)                        \
+  volatile_nonstatic_field(JavaThread,         _current_waiting_monitor,                      ObjectMonitor*)                        \
   volatile_nonstatic_field(JavaThread,         _suspend_flags,                                uint32_t)                              \
   nonstatic_field(JavaThread,                  _async_exception_condition,                    JavaThread::AsyncExceptionCondition)   \
   nonstatic_field(JavaThread,                  _pending_async_exception,                      oop)                                   \

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -739,9 +739,9 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
   nonstatic_field(JavaThread,                  _anchor,                                       JavaFrameAnchor)                       \
   nonstatic_field(JavaThread,                  _vm_result,                                    oop)                                   \
   nonstatic_field(JavaThread,                  _vm_result_2,                                  Metadata*)                             \
-  nonstatic_field(JavaThread,                  _current_pending_monitor,                      ObjectMonitor*)                        \
+  volatile_nonstatic_field(JavaThread,         _current_pending_monitor,                      ObjectMonitor*)                        \
   nonstatic_field(JavaThread,                  _current_pending_monitor_is_from_java,         bool)                                  \
-  nonstatic_field(JavaThread,                  _current_waiting_monitor,                      ObjectMonitor*)                        \
+  volatile_nonstatic_field(JavaThread,          _current_waiting_monitor,                      ObjectMonitor*)                        \
   volatile_nonstatic_field(JavaThread,         _suspend_flags,                                uint32_t)                              \
   nonstatic_field(JavaThread,                  _async_exception_condition,                    JavaThread::AsyncExceptionCondition)   \
   nonstatic_field(JavaThread,                  _pending_async_exception,                      oop)                                   \

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -229,19 +229,14 @@ Handle ThreadService::get_current_contended_monitor(JavaThread* thread) {
   // inflated again and to be associated with a completely different
   // ObjectMonitor by the time this object reference is processed
   // by the caller.
-
-  // Using 'volatile' to prevent the compiler from generating code that
-  // reloads 'wait_obj' from memory when used below.
-  ObjectMonitor* volatile wait_obj = thread->current_waiting_monitor();
+  ObjectMonitor *wait_obj = thread->current_waiting_monitor();
 
   oop obj = NULL;
   if (wait_obj != NULL) {
     // thread is doing an Object.wait() call
     obj = wait_obj->object();
   } else {
-    // Using 'volatile' to prevent the compiler from generating code that
-    // reloads 'enter_obj' from memory when used below.
-    ObjectMonitor* volatile enter_obj = thread->current_pending_monitor();
+    ObjectMonitor *enter_obj = thread->current_pending_monitor();
     if (enter_obj != NULL) {
       // thread is trying to enter() an ObjectMonitor.
       obj = enter_obj->object();

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -229,14 +229,14 @@ Handle ThreadService::get_current_contended_monitor(JavaThread* thread) {
   // inflated again and to be associated with a completely different
   // ObjectMonitor by the time this object reference is processed
   // by the caller.
-  ObjectMonitor *wait_obj = thread->current_waiting_monitor();
+  ObjectMonitor* volatile wait_obj = thread->current_waiting_monitor();
 
   oop obj = NULL;
   if (wait_obj != NULL) {
     // thread is doing an Object.wait() call
     obj = wait_obj->object();
   } else {
-    ObjectMonitor *enter_obj = thread->current_pending_monitor();
+    ObjectMonitor* volatile enter_obj = thread->current_pending_monitor();
     if (enter_obj != NULL) {
       // thread is trying to enter() an ObjectMonitor.
       obj = enter_obj->object();

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -229,6 +229,9 @@ Handle ThreadService::get_current_contended_monitor(JavaThread* thread) {
   // inflated again and to be associated with a completely different
   // ObjectMonitor by the time this object reference is processed
   // by the caller.
+
+  // Using 'volatile' to prevent the compiler from generating code that
+  // reloads 'wait_obj' from memory when used below.
   ObjectMonitor* volatile wait_obj = thread->current_waiting_monitor();
 
   oop obj = NULL;
@@ -236,6 +239,8 @@ Handle ThreadService::get_current_contended_monitor(JavaThread* thread) {
     // thread is doing an Object.wait() call
     obj = wait_obj->object();
   } else {
+    // Using 'volatile' to prevent the compiler from generating code that
+    // reloads 'enter_obj' from memory when used below.
     ObjectMonitor* volatile enter_obj = thread->current_pending_monitor();
     if (enter_obj != NULL) {
       // thread is trying to enter() an ObjectMonitor.


### PR DESCRIPTION
We need a fix for crashes in get_current_contended_monitor due to concurrent modification of memory locations which are not declared volatile. See bug for details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267842](https://bugs.openjdk.java.net/browse/JDK-8267842): SIGSEGV in get_current_contended_monitor


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Yasumasa Suenaga](https://openjdk.java.net/census#ysuenaga) (@YaSuenag - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4224/head:pull/4224` \
`$ git checkout pull/4224`

Update a local copy of the PR: \
`$ git checkout pull/4224` \
`$ git pull https://git.openjdk.java.net/jdk pull/4224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4224`

View PR using the GUI difftool: \
`$ git pr show -t 4224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4224.diff">https://git.openjdk.java.net/jdk/pull/4224.diff</a>

</details>
