### PR TITLE
8267703: runtime/cds/appcds/cacheObject/HeapFragmentationTest.java crashed with OutOfMemory

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -680,6 +680,11 @@ void G1ConcurrentMark::cleanup_for_next_mark() {
 
 void G1ConcurrentMark::clear_next_bitmap(WorkGang* workers) {
   assert_at_safepoint_on_vm_thread();
+  // To avoid fragmentation the full collection requesting to clear the bitmap
+  // might use fewer workers than available. To ensure the bitmap is cleared
+  // as efficiently as possible the number of active workers are temporarily
+  // increased to include all currently created workers.
+  WithUpdatedActiveWorkers update(workers, workers->created_workers());
   clear_bitmap(_next_mark_bitmap, workers, false);
 }
 

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -95,8 +95,7 @@ uint G1FullCollector::calc_active_workers() {
   uint active_worker_limit = WorkerPolicy::calc_active_workers(max_worker_count, current_active_workers, 0);
 
   // Finally consider the amount of used regions.
-  uint regions_per_worker = (uint) (HeapSizePerGCThread / G1HeapRegionSize);
-  uint used_worker_limit = MAX2((heap->num_used_regions() / regions_per_worker), 1u);
+  uint used_worker_limit = MAX2(heap->num_used_regions(), 1u);
 
   // Update active workers to the lower of the limits.
   uint worker_count = MIN3(heap_waste_worker_limit, active_worker_limit, used_worker_limit);

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -94,10 +94,15 @@ uint G1FullCollector::calc_active_workers() {
   uint current_active_workers = heap->workers()->active_workers();
   uint active_worker_limit = WorkerPolicy::calc_active_workers(max_worker_count, current_active_workers, 0);
 
+  // Finally consider the amount of used regions.
+  uint regions_per_worker = (uint) (HeapSizePerGCThread / G1HeapRegionSize);
+  uint used_worker_limit = MAX2((heap->num_used_regions() / regions_per_worker), 1u);
+
   // Update active workers to the lower of the limits.
-  uint worker_count = MIN2(heap_waste_worker_limit, active_worker_limit);
-  log_debug(gc, task)("Requesting %u active workers for full compaction (waste limited workers: %u, adaptive workers: %u)",
-                      worker_count, heap_waste_worker_limit, active_worker_limit);
+  uint worker_count = MIN3(heap_waste_worker_limit, active_worker_limit, used_worker_limit);
+  log_debug(gc, task)("Requesting %u active workers for full compaction (waste limited workers: %u, "
+                      "adaptive workers: %u, used limited workers: %u)",
+                      worker_count, heap_waste_worker_limit, active_worker_limit, used_worker_limit);
   worker_count = heap->workers()->update_active_workers(worker_count);
   log_info(gc, task)("Using %u workers of %u for full compaction", worker_count, max_worker_count);
 

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -95,7 +95,8 @@ uint G1FullCollector::calc_active_workers() {
   uint active_worker_limit = WorkerPolicy::calc_active_workers(max_worker_count, current_active_workers, 0);
 
   // Finally consider the amount of used regions.
-  uint used_worker_limit = MAX2(heap->num_used_regions(), 1u);
+  uint used_worker_limit = heap->num_used_regions();
+  assert(used_worker_limit > 0, "Should never have zero used regions.");
 
   // Update active workers to the lower of the limits.
   uint worker_count = MIN3(heap_waste_worker_limit, active_worker_limit, used_worker_limit);


### PR DESCRIPTION
Please review this change to lower fragmentation when heap usage is low.

**Summary**
The above test case fails because the G1 Full GC fails to compact the single used region below the needed threshold. In this case the region needs to be compacted below region index 400 to be able to fit the large array. The reason this fails is that the full GC uses a lot of parallel workers and if the system is under load it is possible that the worker finding the region to compact hasn't been able to claim any regions low enough in the heap to compact the live objects to.

To fix this we can add a third thing to consider in the code calculating the number of workers to use for a given compaction. So far we only look at keeping the waste down and using the default adaptive calculations. If we also consider how much is used we can get a lower worker count in cases like this and that will make it much more likely to succeed with the compaction. In this case it will guarantee it since there is a single region used, so there will be only one worker and then it will compact the region to the bottom of the heap.

**Testing**
Manual verification that this will cause these collections to only use a single worker. Also currently running some performance regression testing to make sure this doesn't cause any big regressions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267703](https://bugs.openjdk.java.net/browse/JDK-8267703): runtime/cds/appcds/cacheObject/HeapFragmentationTest.java crashed with OutOfMemory


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4225/head:pull/4225` \
`$ git checkout pull/4225`

Update a local copy of the PR: \
`$ git checkout pull/4225` \
`$ git pull https://git.openjdk.java.net/jdk pull/4225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4225`

View PR using the GUI difftool: \
`$ git pr show -t 4225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4225.diff">https://git.openjdk.java.net/jdk/pull/4225.diff</a>

</details>
