### PR TITLE
8267845: Add @requires to avoid running G1 large pages test with wrong page size

### DIFF
--- a/test/hotspot/jtreg/gc/g1/TestLargePageUseForAuxMemory.java
+++ b/test/hotspot/jtreg/gc/g1/TestLargePageUseForAuxMemory.java
@@ -30,6 +30,7 @@ package gc.g1;
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @requires vm.gc.G1
+ * @requires vm.opt.LargePageSizeInBytes == null
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UseG1GC -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+IgnoreUnrecognizedVMOptions -XX:+UseLargePages gc.g1.TestLargePageUseForAuxMemory

--- a/test/hotspot/jtreg/gc/g1/TestLargePageUseForHeap.java
+++ b/test/hotspot/jtreg/gc/g1/TestLargePageUseForHeap.java
@@ -30,6 +30,7 @@ package gc.g1;
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @requires vm.gc.G1
+ * @requires vm.opt.LargePageSizeInBytes == null
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UseG1GC -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI


### PR DESCRIPTION
Please review this small test-fix.

**Summary**
These two tests try to verify that large pages are used correctly for the heap and the G1 internal data structures. The tests start separate processes that are run with specific arguments to know the expected outcome. The sub-processes don't inherit any parameters passed to the test. This is good, but if the parameter `LargePageSizeInBytes` is passed to the test, the driver process will run with this flag and pick up a different large page size than test-processes. This won't work since the driver will use its found large page size to verify the output from the test.

The simple fix is to simply not run this test if this flag is specified. For the test to work with this flag, more work has to be done to analyze how different page sizes will affect the test and for now I think this is the best approach.

**Testing**
Manual verification the the tests won't run if `LargePageSizeInBytes` is set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267845](https://bugs.openjdk.java.net/browse/JDK-8267845): Add @requires to avoid running G1 large pages test with wrong page size


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4226/head:pull/4226` \
`$ git checkout pull/4226`

Update a local copy of the PR: \
`$ git checkout pull/4226` \
`$ git pull https://git.openjdk.java.net/jdk pull/4226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4226`

View PR using the GUI difftool: \
`$ git pr show -t 4226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4226.diff">https://git.openjdk.java.net/jdk/pull/4226.diff</a>

</details>
