### PR TITLE
8265309: com/sun/jndi/dns/ConfigTests/Timeout.java fails with "Address already in use" BindException

### DIFF
--- a/src/jdk.naming.dns/share/classes/com/sun/jndi/dns/DnsClient.java
+++ b/src/jdk.naming.dns/share/classes/com/sun/jndi/dns/DnsClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -407,35 +407,30 @@ public class DnsClient {
                 // Packets may only be sent to or received from this server address
                 udpSocket.connect(server, port);
                 int pktTimeout = (timeout * (1 << retry));
-                try {
-                    udpSocket.send(opkt);
+                udpSocket.send(opkt);
 
-                    // timeout remaining after successive 'receive()'
-                    int timeoutLeft = pktTimeout;
-                    int cnt = 0;
-                    do {
-                        if (debug) {
-                           cnt++;
-                            dprint("Trying RECEIVE(" +
-                                    cnt + ") retry(" + (retry + 1) +
-                                    ") for:" + xid  + "    sock-timeout:" +
-                                    timeoutLeft + " ms.");
-                        }
-                        udpSocket.setSoTimeout(timeoutLeft);
-                        long start = System.currentTimeMillis();
-                        udpSocket.receive(ipkt);
-                        long end = System.currentTimeMillis();
+                // timeout remaining after successive 'receive()'
+                int timeoutLeft = pktTimeout;
+                int cnt = 0;
+                do {
+                    if (debug) {
+                        cnt++;
+                        dprint("Trying RECEIVE(" +
+                                cnt + ") retry(" + (retry + 1) +
+                                ") for:" + xid + "    sock-timeout:" +
+                                timeoutLeft + " ms.");
+                    }
+                    udpSocket.setSoTimeout(timeoutLeft);
+                    long start = System.currentTimeMillis();
+                    udpSocket.receive(ipkt);
+                    long end = System.currentTimeMillis();
 
-                        byte[] data = ipkt.getData();
-                        if (isMatchResponse(data, xid)) {
-                            return data;
-                        }
-                        timeoutLeft = pktTimeout - ((int) (end - start));
-                    } while (timeoutLeft > minTimeout);
-
-                } finally {
-                    udpSocket.disconnect();
-                }
+                    byte[] data = ipkt.getData();
+                    if (isMatchResponse(data, xid)) {
+                        return data;
+                    }
+                    timeoutLeft = pktTimeout - ((int) (end - start));
+                } while (timeoutLeft > minTimeout);
                 return null; // no matching packet received within the timeout
             }
         }

--- a/test/jdk/com/sun/jndi/dns/ConfigTests/Timeout.java
+++ b/test/jdk/com/sun/jndi/dns/ConfigTests/Timeout.java
@@ -30,7 +30,7 @@ import java.time.Instant;
 
 /*
  * @test
- * @bug 8200151
+ * @bug 8200151 8265309
  * @summary Tests that we can set the initial UDP timeout interval and the
  *          number of retries.
  * @library ../lib/


### PR DESCRIPTION
Hi,

`com/sun/jndi/dns/ConfigTests/Timeout.java ` was seen failing intermittently with "Address already in use" `BindException`. The reason of this failure is that `disconnect` call in JNDI `DnsClient` fails to rebind the datagram socket to the original port during `disconnect` call (the failure is in `DatagramChannel::repairSocket`).   
Since Datagram socket is not reused and closed after the failure `finally` block with the `disconnect` call can be removed.

The fix was tested with all available JNDI/DNS tests, and no failures related to the change were observed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265309](https://bugs.openjdk.java.net/browse/JDK-8265309): com/sun/jndi/dns/ConfigTests/Timeout.java fails with "Address already in use" BindException


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4227/head:pull/4227` \
`$ git checkout pull/4227`

Update a local copy of the PR: \
`$ git checkout pull/4227` \
`$ git pull https://git.openjdk.java.net/jdk pull/4227/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4227`

View PR using the GUI difftool: \
`$ git pr show -t 4227`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4227.diff">https://git.openjdk.java.net/jdk/pull/4227.diff</a>

</details>
