### PR TITLE
8267529: StringJoiner can create a String that breaks String::equals

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -3239,8 +3239,12 @@ public final class String
      */
     @ForceInline
     static String join(String prefix, String suffix, String delimiter, String[] elements, int size) {
-        int icoder = prefix.coder() | suffix.coder() | delimiter.coder();
-        long len = (long) prefix.length() + suffix.length() + (long) Math.max(0, size - 1) * delimiter.length();
+        int icoder = prefix.coder() | suffix.coder();
+        long len = (long) prefix.length() + suffix.length();
+        if (size > 1) { // when there are more than one element, size - 1 delimiters will be emitted
+            len += (long) (size - 1) * delimiter.length();
+            icoder |= delimiter.coder();
+        }
         // assert len > 0L; // max: (long) Integer.MAX_VALUE << 32
         // following loop wil add max: (long) Integer.MAX_VALUE * Integer.MAX_VALUE to len
         // so len can overflow at most once

--- a/test/jdk/java/lang/String/StringJoinTest.java
+++ b/test/jdk/java/lang/String/StringJoinTest.java
@@ -115,10 +115,12 @@ public class StringJoinTest {
     }
 
     public void testIgnoreDelimiterCoderJoin() {
-        // Ensure that joining a String with a UTF-16 delimiter
-        // produce a String with a latin-1 coder if the delimiter is
-        // not emitted
+        // 8267529: Ensure that joining zero or one latin-1 Strings with a UTF-16
+        // delimiter produce a String with a latin-1 coder, since the delimiter
+        // is not added.
+        assertEquals("", new StringJoiner("\u2013").toString());
         assertEquals("foo", new StringJoiner("\u2013").add("foo").toString());
+        assertEquals("", String.join("\u2013"));
         assertEquals("foo", String.join("\u2013", "foo"));
     }
 }

--- a/test/jdk/java/lang/String/StringJoinTest.java
+++ b/test/jdk/java/lang/String/StringJoinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,8 @@
  * questions.
  */
 /**
- * @test @bug 5015163
+ * @test
+ * @bug 5015163 8267529
  * @summary test String merge/join that is the inverse of String.split()
  * @run testng StringJoinTest
  * @author Jim Gish

--- a/test/jdk/java/lang/String/StringJoinTest.java
+++ b/test/jdk/java/lang/String/StringJoinTest.java
@@ -28,6 +28,7 @@
  */
 import java.util.ArrayList;
 import java.util.List;
+import java.util.StringJoiner;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
@@ -110,5 +111,13 @@ public class StringJoinTest {
     @Test(expectedExceptions = {NullPointerException.class})
     public void testJoinNullDelimiter() {
         String.join(null, JIM, JOHN);
+    }
+
+    public void testIgnoreDelimiterCoderJoin() {
+        // Ensure that joining a String with a UTF-16 delimiter
+        // produce a String with a latin-1 coder if the delimiter is
+        // not emitted
+        assertEquals("foo", new StringJoiner("\u2013").add("foo").toString());
+        assertEquals("foo", String.join("\u2013", "foo"));
     }
 }


### PR DESCRIPTION
This patch fixes a regression caused by https://bugs.openjdk.java.net/browse/JDK-8265237 where the result of String.join always get a UTF-16 coder if the delimiter is UTF-16, even when no delimiter is emitted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267529](https://bugs.openjdk.java.net/browse/JDK-8267529): StringJoiner can create a String that breaks String::equals


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to 0e2ca7cdabf645a7396653813df835fff2373b26


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4228/head:pull/4228` \
`$ git checkout pull/4228`

Update a local copy of the PR: \
`$ git checkout pull/4228` \
`$ git pull https://git.openjdk.java.net/jdk pull/4228/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4228`

View PR using the GUI difftool: \
`$ git pr show -t 4228`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4228.diff">https://git.openjdk.java.net/jdk/pull/4228.diff</a>

</details>
