### PR TITLE
8267886: ProblemList javax/management/remote/mandatory/connection/RMIConnector_NPETest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -595,6 +595,8 @@ javax/management/MBeanServer/OldMBeanServerTest.java            8030957 aix-all
 
 javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java 8042215 generic-all
 
+javax/management/remote/mandatory/connection/RMIConnector_NPETest.java 8267887 generic-all
+
 ############################################################################
 
 # jdk_net


### PR DESCRIPTION
A trivial fix to ProblemList javax/management/remote/mandatory/connection/RMIConnector_NPETest.java.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267886](https://bugs.openjdk.java.net/browse/JDK-8267886): ProblemList javax/management/remote/mandatory/connection/RMIConnector_NPETest.java


### Reviewers
 * [Stuart Marks](https://openjdk.java.net/census#smarks) (@stuart-marks - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4231/head:pull/4231` \
`$ git checkout pull/4231`

Update a local copy of the PR: \
`$ git checkout pull/4231` \
`$ git pull https://git.openjdk.java.net/jdk pull/4231/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4231`

View PR using the GUI difftool: \
`$ git pr show -t 4231`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4231.diff">https://git.openjdk.java.net/jdk/pull/4231.diff</a>

</details>
