### PR TITLE
8267569: java.io.File.equals contains misleading Javadoc

### DIFF
--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -2223,9 +2223,9 @@ public class File
      * On UNIX systems, alphabetic case is significant in comparing pathnames;
      * on Microsoft Windows systems it is not.
      *
-     * @implNote The abstract pathname equality test is equivalent to
-     *           {@code compareTo((File)obj) == 0}.  This method does not
-     *           access the file system and the file is not required to exist.
+     * @apiNote This method only tests whether the abstract pathnames are equal;
+     *          it does not access the file system and the file is not required
+     *          to exist.
      *
      * @param   obj   The object to be compared with this abstract pathname
      *
@@ -2234,7 +2234,6 @@ public class File
      *
      * @see #compareTo(File)
      * @see java.nio.file.Files#isSameFile(Path,Path)
-     * @see java.nio.file.Path#equals(Object)
      */
     public boolean equals(Object obj) {
         if (obj instanceof File file) {

--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -2196,8 +2196,8 @@ public class File
     /**
      * Compares two abstract pathnames lexicographically.  The ordering
      * defined by this method depends upon the underlying system.  On UNIX
-     * systems, alphabetic case is significant in comparing pathnames; on Microsoft Windows
-     * systems it is not.
+     * systems, alphabetic case is significant in comparing pathnames; on
+     * Microsoft Windows systems it is not.
      *
      * @param   pathname  The abstract pathname to be compared to this abstract
      *                    pathname
@@ -2221,14 +2221,18 @@ public class File
      * abstract pathname.  Whether or not two abstract
      * pathnames are equal depends upon the underlying operating system.
      * On UNIX systems, alphabetic case is significant in comparing pathnames;
-     * on Microsoft Windows systems it is not.  This method does not
-     * access the file and the file is not required to exist.
+     * on Microsoft Windows systems it is not.
+     *
+     * @implNote The abstract pathname equality test is equivalent to
+     *           {@code compareTo((File)obj) == 0}.  This method does not
+     *           access the file system and the file is not required to exist.
      *
      * @param   obj   The object to be compared with this abstract pathname
      *
      * @return  {@code true} if and only if the objects are the same;
      *          {@code false} otherwise
      *
+     * @see #compareTo(File)
      * @see java.nio.file.Files#isSameFile(Path,Path)
      * @see java.nio.file.Path#equals(Object)
      */

--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -2217,16 +2217,20 @@ public class File
     /**
      * Tests this abstract pathname for equality with the given object.
      * Returns {@code true} if and only if the argument is not
-     * {@code null} and is an abstract pathname that denotes the same file
-     * or directory as this abstract pathname.  Whether or not two abstract
-     * pathnames are equal depends upon the underlying system.  On UNIX
-     * systems, alphabetic case is significant in comparing pathnames; on Microsoft Windows
-     * systems it is not.
+     * {@code null} and is an abstract pathname that is the same as this
+     * abstract pathname.  Whether or not two abstract
+     * pathnames are equal depends upon the underlying operating system.
+     * On UNIX systems, alphabetic case is significant in comparing pathnames;
+     * on Microsoft Windows systems it is not.  This method does not
+     * access the file and the file is not required to exist.
      *
      * @param   obj   The object to be compared with this abstract pathname
      *
      * @return  {@code true} if and only if the objects are the same;
      *          {@code false} otherwise
+     *
+     * @see java.nio.file.Files#isSameFile(Path,Path)
+     * @see java.nio.file.Path#equals(Object)
      */
     public boolean equals(Object obj) {
         if (obj instanceof File file) {


### PR DESCRIPTION
Modify the specification of `java.io.File.equals` to clarify that equality is based only on a comparison of abstract pathnames as opposed to the file system objects that the `File`s represent.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267569](https://bugs.openjdk.java.net/browse/JDK-8267569): java.io.File.equals contains misleading Javadoc


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Brent Christian](https://openjdk.java.net/census#bchristi) (@bchristi-git - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4232/head:pull/4232` \
`$ git checkout pull/4232`

Update a local copy of the PR: \
`$ git checkout pull/4232` \
`$ git pull https://git.openjdk.java.net/jdk pull/4232/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4232`

View PR using the GUI difftool: \
`$ git pr show -t 4232`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4232.diff">https://git.openjdk.java.net/jdk/pull/4232.diff</a>

</details>
