### PR TITLE
JDK-8267176: StandardDoclet should provide access to Reporter and Locale

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/StandardDoclet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/StandardDoclet.java
@@ -107,8 +107,8 @@ public class StandardDoclet implements Doclet {
      * {@return the locale for this doclet}
      *
      * @see #init(Locale, Reporter)
-	 *
-	 * @since 17
+     *
+     * @since 17
      */
     public Locale getLocale() {
         return htmlDoclet.getConfiguration().getLocale();
@@ -118,8 +118,8 @@ public class StandardDoclet implements Doclet {
      * {@return the reporter for this doclet}
      *
      * @see #init(Locale, Reporter)
-	 *
-	 * @since 17
+     *
+     * @since 17
      */
     public Reporter getReporter() {
         return htmlDoclet.getConfiguration().getReporter();

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/StandardDoclet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/StandardDoclet.java
@@ -102,4 +102,26 @@ public class StandardDoclet implements Doclet {
     public boolean run(DocletEnvironment docEnv) {
         return htmlDoclet.run(docEnv);
     }
+
+    /**
+     * {@return the locale for this doclet}
+     *
+     * @see #init(Locale, Reporter)
+	 *
+	 * @since 17
+     */
+    public Locale getLocale() {
+        return htmlDoclet.getConfiguration().getLocale();
+    }
+
+    /**
+     * {@return the reporter for this doclet}
+     *
+     * @see #init(Locale, Reporter)
+	 *
+	 * @since 17
+     */
+    public Reporter getReporter() {
+        return htmlDoclet.getConfiguration().getReporter();
+    }
 }

--- a/test/langtools/jdk/javadoc/doclet/testDiagsLineCaret/MyTaglet.java
+++ b/test/langtools/jdk/javadoc/doclet/testDiagsLineCaret/MyTaglet.java
@@ -55,21 +55,7 @@ public class MyTaglet implements Taglet {
         Taglet.super.init(env, doclet);
         docEnv = env;
 
-        // The following should be as simple as
-        //      reporter = ((StandardDoclet) doclet).getReporter();
-        // JDK-8267176
-        try {
-            StandardDoclet sd = (StandardDoclet) doclet;
-            Field htmlDocletField = sd.getClass().getDeclaredField("htmlDoclet");
-            htmlDocletField.setAccessible(true);
-            Object htmlDoclet = htmlDocletField.get(sd);
-            Method getConfigurationMethod = htmlDoclet.getClass().getDeclaredMethod("getConfiguration");
-            Object config = getConfigurationMethod.invoke(htmlDoclet);
-            Method getReporterMethod = config.getClass().getMethod(("getReporter"));
-            reporter = (Reporter) getReporterMethod.invoke(config);
-        } catch (ReflectiveOperationException e) {
-            throw new IllegalStateException(e);
-        }
+        reporter = ((StandardDoclet) doclet).getReporter();
     }
 
     @Override

--- a/test/langtools/jdk/javadoc/doclet/testDiagsLineCaret/TestDiagsLineCaret.java
+++ b/test/langtools/jdk/javadoc/doclet/testDiagsLineCaret/TestDiagsLineCaret.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug      8267126
+ * @bug      8267126 8267176
  * @summary  javadoc should show "line and caret" for diagnostics
  * @library  /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool


### PR DESCRIPTION
Please review a simple change for StandardDoclet to expose the locale and reporter with which it was initialized.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267176](https://bugs.openjdk.java.net/browse/JDK-8267176): StandardDoclet should provide access to Reporter and Locale


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.java.net/census#hannesw) (@hns - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4233/head:pull/4233` \
`$ git checkout pull/4233`

Update a local copy of the PR: \
`$ git checkout pull/4233` \
`$ git pull https://git.openjdk.java.net/jdk pull/4233/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4233`

View PR using the GUI difftool: \
`$ git pr show -t 4233`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4233.diff">https://git.openjdk.java.net/jdk/pull/4233.diff</a>

</details>
