### PR TITLE
8237388: serviceability/dcmd/framework/VMVersionTest.java fails with connection refused error.

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/framework/TestProcessLauncher.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/framework/TestProcessLauncher.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,12 +61,12 @@ public class TestProcessLauncher {
         Binder binder = new Binder(argHandler, log);
         binder.prepareForPipeConnection(argHandler);
 
+        pipe = IOPipe.startDebuggerPipe(binder);
+
         String cmd = prepareLaunch(java, argHandler.getPipePort());
 
         Debugee debuggee = binder.startLocalDebugee(cmd);
         debuggee.redirectOutput(log);
-
-        pipe = new IOPipe(debuggee);
 
         String line = pipe.readln();
         if (!"ready".equals(line)) {

--- a/test/hotspot/jtreg/serviceability/dcmd/framework/process/TestJavaProcess.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/framework/process/TestJavaProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class TestJavaProcess {
         log("Waiting for the quit command from the test ...");
         String cmd = pipe.readln();
         int exitCode = PASSED;
-        if (cmd.equals("quit")) {
+        if ("quit".equals(cmd)) {
             log("'quit' received");
         } else {
             log("Invalid command received " + cmd);

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/IOPipe.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/IOPipe.java
@@ -24,6 +24,7 @@
 package nsk.share.jpda;
 
 import nsk.share.*;
+import nsk.share.jdi.Binder;
 
 /**
  * This class implements communicational channel between
@@ -42,8 +43,6 @@ public class IOPipe extends SocketIOPipe {
 
     public static final String PIPE_LOG_PREFIX = "IOPipe> ";
 
-    private DebugeeProcess debugee;
-
     /**
       * Make <code>IOPipe</code> at debugee's side.
       *
@@ -61,7 +60,9 @@ public class IOPipe extends SocketIOPipe {
       * Make <code>IOPipe</code> at debugger's side
       * with given <code>Debugee</code> mirror.
       *
-      * @deprecated Use Debugee.createIOPipe() instead.
+      * @deprecated Preferred way is to start IOPipe before launching debuggee process.
+      *
+      * @see #startDebuggerPipe
       */
     @Deprecated
     public IOPipe(DebugeeProcess debugee) {
@@ -70,8 +71,7 @@ public class IOPipe extends SocketIOPipe {
                 debugee.getArgumentHandler().getPipePortNumber(),
                 (long)debugee.getArgumentHandler().getWaitTime() * 60 * 1000,
                 true);
-
-        this.debugee = debugee;
+        setServerSocket(debugee.getPipeServerSocket());
     }
 
     /**
@@ -81,12 +81,22 @@ public class IOPipe extends SocketIOPipe {
         super("IOPipe", log, PIPE_LOG_PREFIX, host, port, timeout, listening);
     }
 
-    protected void connect() {
-        if (listening) {
-            setServerSocket(debugee.getPipeServerSocket());
-            setConnectingProcess(debugee.getProcess());
-        }
+    /**
+     * Creates and starts listening <code>IOPipe</code> at debugger side.
+     */
+    public static IOPipe startDebuggerPipe(Binder binder) {
+        IOPipe ioPipe = new IOPipe(binder.getLog(),
+                binder.getArgumentHandler().getDebugeeHost(),
+                binder.getArgumentHandler().getPipePortNumber(),
+                (long)binder.getArgumentHandler().getWaitTime() * 60 * 1000,
+                true);
+        ioPipe.setServerSocket(binder.getPipeServerSocket());
+        ioPipe.startListening();
+        return ioPipe;
+    }
 
+
+    protected void connect() {
         super.connect();
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/SocketConnection.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/SocketConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,8 +52,6 @@ class BasicSocketConnection {
     protected InputStream sin = null;
 
     protected OutputStream sout = null;
-
-    protected Process connectingProcess = null;
 
     protected volatile boolean connected = false;
 
@@ -257,11 +255,6 @@ class BasicSocketConnection {
                 } catch (ConnectException e) {
                     logger.display("Attempt #" + i + " to attach for " + name + " connection failed:\n\t" + e);
                     lastException = e;
-                    // check if listening process still alive
-                    if (!checkConnectingProcess()) {
-                        shouldStop = true;
-                        throw new Failure("Break attaching to " + name + " connection: " + "listening process exited");
-                    }
                     // sleep between attempts
                     try {
                         Thread.sleep(DebugeeBinder.CONNECT_TRY_DELAY);
@@ -308,31 +301,6 @@ class BasicSocketConnection {
      */
     public Socket getSocket() {
         return socket;
-    }
-
-    /**
-     * Return true if another connecting process is still alive.
-     */
-    public boolean checkConnectingProcess() {
-        if (connectingProcess == null) {
-            // no process to check
-            return true;
-        }
-        try {
-            int exitCode = connectingProcess.exitValue();
-        } catch (IllegalThreadStateException e) {
-            // process is still alive
-            return true;
-        }
-        // process exited
-        return false;
-    }
-
-    /**
-     * Set another connecting process to control if it is still alive.
-     */
-    public void setConnectingProcess(Process process) {
-        connectingProcess = process;
     }
 
     /**


### PR DESCRIPTION
nsk test framework for testing jdi/jdwp assumes that the test launch debuggee first and then creates IOPipe to communicate with debuggee (debugger listens, debugee connects to the IOPipe socket).
This makes possible failure when debuggee tries to connect before debugger starts listening.
The fix changes logic of the tests to start listening on IOPipe socket before launch debuggee.
Other tests which use IOPipe/SocketIOPipe and have the same issue (there are a lot of them) will be fixes as separate issues.

Couple details about the fix:
- debugee.getPipeServerSocket() just calls binder.getPipeServerSocket(), returned ServerSocket can be changed only by DebugeeBinder.prepareForPipeConnection which is called by some tests;
- connectingProcess logic is broken. The only place it's used is BasicSocketConnection.checkConnectingProcess, which is called from SocketConnection.continueAttach. But continueAttach is called from debuggee code (listening == false) while connectingProcess is set only from debugger code (listening == true). So it didn't work and I dropped it.

Testing: all tests which use IOPipe/SocketIOPipe classes:
- test/hotspot/jtreg/serviceability/dcmd/framework
- test/hotspot/jtreg/vmTestbase/nsk/jdi
- test/hotspot/jtreg/vmTestbase/nsk/jdwp
