### PR TITLE
8264624: change the guarantee() calls added by JDK-8264123 to assert() calls

### DIFF
--- a/src/hotspot/share/runtime/threadSMR.cpp
+++ b/src/hotspot/share/runtime/threadSMR.cpp
@@ -280,8 +280,8 @@ class ScanHazardPtrGatherProtectedThreadsClosure : public ThreadClosure {
       if (thread->cmpxchg_threads_hazard_ptr(NULL, current_list) == current_list) return;
     }
 
-    guarantee(ThreadsList::is_valid(current_list), "current_list="
-              INTPTR_FORMAT " is not valid!", p2i(current_list));
+    assert(ThreadsList::is_valid(current_list), "current_list="
+           INTPTR_FORMAT " is not valid!", p2i(current_list));
 
     // The current JavaThread has a hazard ptr (ThreadsList reference)
     // which might be _java_thread_list or it might be an older
@@ -311,13 +311,15 @@ class ScanHazardPtrGatherThreadsListClosure : public ThreadClosure {
     if (thread == NULL) return;
     ThreadsList *hazard_ptr = thread->get_threads_hazard_ptr();
     if (hazard_ptr == NULL) return;
+#ifdef ASSERT
     if (!Thread::is_hazard_ptr_tagged(hazard_ptr)) {
       // We only validate hazard_ptrs that are not tagged since a tagged
       // hazard ptr can be deleted at any time.
-      guarantee(ThreadsList::is_valid(hazard_ptr), "hazard_ptr=" INTPTR_FORMAT
-                " for thread=" INTPTR_FORMAT " is not valid!", p2i(hazard_ptr),
-                p2i(thread));
+      assert(ThreadsList::is_valid(hazard_ptr), "hazard_ptr=" INTPTR_FORMAT
+             " for thread=" INTPTR_FORMAT " is not valid!", p2i(hazard_ptr),
+             p2i(thread));
     }
+#endif
     // In this closure we always ignore the tag that might mark this
     // hazard ptr as not yet verified. If we happen to catch an
     // unverified hazard ptr that is subsequently discarded (not
@@ -380,9 +382,9 @@ class ValidateHazardPtrsClosure : public ThreadClosure {
     // If the hazard ptr is unverified, then ignore it since it could
     // be deleted at any time now.
     if (Thread::is_hazard_ptr_tagged(hazard_ptr)) return;
-    guarantee(ThreadsList::is_valid(hazard_ptr), "hazard_ptr=" INTPTR_FORMAT
-              " for thread=" INTPTR_FORMAT " is not valid!", p2i(hazard_ptr),
-              p2i(thread));
+    assert(ThreadsList::is_valid(hazard_ptr), "hazard_ptr=" INTPTR_FORMAT
+           " for thread=" INTPTR_FORMAT " is not valid!", p2i(hazard_ptr),
+           p2i(thread));
   }
 };
 
@@ -557,10 +559,10 @@ void SafeThreadsListPtr::release_stable_list() {
     // An exiting thread might be waiting in smr_delete(); we need to
     // check with delete_lock to be sure.
     ThreadsSMRSupport::release_stable_list_wake_up(_has_ref_count);
-    guarantee(_previous == NULL || ThreadsList::is_valid(_previous->_list),
-              "_previous->_list=" INTPTR_FORMAT
-              " is not valid after calling release_stable_list_wake_up!",
-              p2i(_previous->_list));
+    assert(_previous == NULL || ThreadsList::is_valid(_previous->_list),
+           "_previous->_list=" INTPTR_FORMAT
+           " is not valid after calling release_stable_list_wake_up!",
+           p2i(_previous->_list));
   }
 }
 

--- a/src/hotspot/share/runtime/threadSMR.hpp
+++ b/src/hotspot/share/runtime/threadSMR.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -206,7 +206,9 @@ public:
   JavaThread* find_JavaThread_from_java_tid(jlong java_tid) const;
   bool includes(const JavaThread * const p) const;
 
+#ifdef ASSERT
   static bool is_valid(ThreadsList* list) { return list->_magic == THREADS_LIST_MAGIC; }
+#endif
 };
 
 // An abstract safe ptr to a ThreadsList comprising either a stable hazard ptr


### PR DESCRIPTION
A trivial fix to change the guarantee() calls added by JDK-8264123 to assert() calls.

Tested with Mach5 Tier1.