### PR TITLE
8267904: C2 crash when compile negative Arrays.copyOf length after loop

### DIFF
--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -1718,7 +1718,7 @@ Node *AllocateArrayNode::make_ideal_length(const TypeOopPtr* oop_type, PhaseTran
       InitializeNode* init = initialization();
       assert(init != NULL, "initialization not found");
       length = new CastIINode(length, narrow_length_type);
-      length->set_req(0, init->proj_out_or_null(0));
+      length->set_req(TypeFunc::Control, init->proj_out_or_null(TypeFunc::Control));
     }
   }
 

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -3981,9 +3981,7 @@ Node* GraphKit::new_array(Node* klass_node,     // array klass (maybe variable)
   if (map()->find_edge(length) >= 0) {
     Node* ccast = alloc->make_ideal_length(ary_type, &_gvn);
     if (ccast != length) {
-      _gvn.set_type_bottom(ccast);
       ccast = _gvn.transform(ccast);
-      record_for_igvn(ccast);
       replace_in_map(length, ccast);
     }
   }

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -3982,6 +3982,7 @@ Node* GraphKit::new_array(Node* klass_node,     // array klass (maybe variable)
     Node* ccast = alloc->make_ideal_length(ary_type, &_gvn);
     if (ccast != length) {
       _gvn.set_type_bottom(ccast);
+      ccast = _gvn.transform(ccast);
       record_for_igvn(ccast);
       replace_in_map(length, ccast);
     }

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4465,7 +4465,6 @@ void LibraryCallKit::arraycopy_move_allocation_here(AllocateArrayNode* alloc, No
         }
 #endif
         C->gvn_replace_by(init_out, alloc_length);
-        record_for_igvn(init_out);
       }
     }
     C->gvn_replace_by(init->proj_out(TypeFunc::Control), alloc->in(0));

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4507,9 +4507,7 @@ void LibraryCallKit::arraycopy_move_allocation_here(AllocateArrayNode* alloc, No
     if (map()->find_edge(length) >= 0) {
       Node* ccast = alloc->make_ideal_length(ary_type, &_gvn);
       if (ccast != length) {
-        _gvn.set_type_bottom(ccast);
         ccast = _gvn.transform(ccast);
-        record_for_igvn(ccast);
         replace_in_map(length, ccast);
       }
     }

--- a/test/hotspot/jtreg/compiler/c2/TestNegativeArrayCopyAfterLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/TestNegativeArrayCopyAfterLoop.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8267904
+ * @requires vm.compiler2.enabled
+ * @summary C2 inline array_copy move CastIINode(Array Length) before allocation cause crash.
+ * @run main/othervm compiler.c2.TestNegativeArrayCopyAfterLoop
+ */
+
+package compiler.c2;
+import java.util.Arrays;
+
+class test {
+    public static int exp_count = 0;
+    public int in1 = -4096;
+    test (){
+        try {
+            short sha4[] = new short[1012];
+            for (int i = 0; i < sha4.length; i++) {
+              sha4[i] = 9;
+            }
+            Arrays.copyOf(sha4, in1);
+        } catch (Exception ex) {
+            exp_count++;
+        }
+    }
+}
+
+public class TestNegativeArrayCopyAfterLoop {
+    public static void main(String[] args) {
+        for (int i = 0; i < 20000; i++) {
+            new test();
+        }
+        if (test.exp_count == 20000) {
+            System.out.println("TEST PASSED");
+        }
+    }
+}


### PR DESCRIPTION
C2 crash when Arrays.copyOf has a negative length after a loop. This happens in release and debug build. Test and hs_err are in JBS.

Crash reason is:
- CastIINode is created in GraphKit::new_array (in AllocateArrayNode::make_ideal_length), Cast array lenght  to range [0, maxint-2]. This is safe when allocation is success and CastIINode 's input control is InitializeNode's proj control.
- In LibraryCallKit::inline_arraycopy, InitializeNode's proj control's use nodes' control is replaced with AllocateArrayNode's input control (in LibraryCallKit::arraycopy_move_allocation_here). This is necessary to move allocation after array copy checks. But this also includes CastIINode.
```
   C->gvn_replace_by(init->proj_out(TypeFunc::Control), alloc->in(0));
```
- CastIINode's control is also adjust to AllocateArrayNode's input control, which is illegal state in laster IGVN phase, casting a negative to [0, maxint-2].
- This cause control and nodes after loop become top and removed. The previous loop has no fall-through edge and crash.

Fix is:
- In LibraryCallKit::arraycopy_move_allocation_here
    - Before replacing init->proj_out(TypeFunc::Control) in, find and replace  CastIINode nodes with original array length.
    - After move allocation node, create CastIINode again if necessary.

Before fix:  node 250 is CastII which should be after InitializeNode.
![image](https://user-images.githubusercontent.com/70356247/119938428-f7fa4e80-bfbe-11eb-925e-c239620c73f3.png)

After fix: all arry copy check is performed on original array length node 203
![image](https://user-images.githubusercontent.com/70356247/119938532-2415cf80-bfbf-11eb-98c6-76e6b19b691f.png)

New test test/hotspot/jtreg/compiler/c2/TestNegativeArrayCopyAfterLoop.java is added and pass.
Tests performs on Linux X64 and no regression
- Tier1/2/3/hotspot_all_no_apps on release and fastdebug build.
- Tier1/2/3 with option "-XX:-TieredCompilation -Xbatch" on fastdebug build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267904](https://bugs.openjdk.java.net/browse/JDK-8267904): C2 crash when compile negative Arrays.copyOf length after loop


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**) ⚠️ Review applies to ef4465064e555c4adba186668731c2352c279c55
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4238/head:pull/4238` \
`$ git checkout pull/4238`

Update a local copy of the PR: \
`$ git checkout pull/4238` \
`$ git pull https://git.openjdk.java.net/jdk pull/4238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4238`

View PR using the GUI difftool: \
`$ git pr show -t 4238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4238.diff">https://git.openjdk.java.net/jdk/pull/4238.diff</a>

</details>
