### PR TITLE
8267375: Aarch64: JVM crashes with option -XX:PrintIdealGraphLevel=3 on SVE backend

### DIFF
--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -1096,6 +1096,7 @@ Type::Category Type::category() const {
     case Type::VectorX:
     case Type::VectorY:
     case Type::VectorZ:
+    case Type::VectorMask:
     case Type::AnyPtr:
     case Type::RawPtr:
     case Type::OopPtr:

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorInsertByte.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorInsertByte.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021, Huawei Technologies Co. Ltd. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import jdk.incubator.vector.ByteVector;
+import jdk.incubator.vector.VectorSpecies;
+
+/*
+ * @test
+ * @bug 8267375
+ * @requires os.arch == "aarch64" & vm.debug == true & vm.compiler2.enabled
+ * @modules jdk.incubator.vector
+ * @run main/othervm -XX:CompileCommand=compileonly,compiler.vectorapi.TestVectorInsertByte::* -XX:PrintIdealGraphLevel=3 -XX:PrintIdealGraphFile=TestVectorInsertByte.xml compiler.vectorapi.TestVectorInsertByte
+ */
+
+public class TestVectorInsertByte {
+    static final VectorSpecies<Byte> SPECIESb = ByteVector.SPECIES_MAX;
+
+    static final int INVOC_COUNT = 50000;
+    static final int size = SPECIESb.length();
+
+    static byte[] ab = new byte[size];
+    static byte[] rb = new byte[size];
+
+    static void init() {
+        for (int i = 0; i < size; i++) {
+            ab[i] = (byte) (size - 1 - i);
+        }
+    }
+
+    static void testByteVectorInsert() {
+        ByteVector av = ByteVector.fromArray(SPECIESb, ab, 0);
+        av = av.withLane(0, (byte) (0));
+        av.intoArray(rb, 0);
+    }
+
+    public static void main(String[] args) {
+        init();
+        for (int ic = 0; ic < INVOC_COUNT; ic++) {
+            testByteVectorInsert();
+        }
+    }
+}


### PR DESCRIPTION
Reason: 

```
operand pRegGov()
%{
  constraint(ALLOC_IN_RC(gov_pr));
  match(RegVectMask);
  op_cost(0);
  format %{ %}
  interface(REG_INTER);
%}
```
if `pRegGov` is used as a `TEMP`, like :

```
instruct insertB_small(vReg dst, vReg src, iRegIorL2I val, immI idx, pRegGov pTmp, rFlagsReg cr)
%{
  predicate(UseSVE > 0 && n->as_Vector()->length() <= 32 &&
            n->bottom_type()->is_vect()->element_basic_type() == T_BYTE);
  match(Set dst (VectorInsert (Binary src val) idx));
  effect(TEMP_DEF dst, TEMP pTmp, KILL cr); // here
```

It will have the type `Type::VectorMask` in `MachTempNode` which is generated from `Expand`. However, we miss `Type::VectorMask` in `Type::category()`.

We can fix this bug simply by adding `case Type::VectorMask` in `Type::category()`.

Although now we can only reproduce this bug on AArch64,  it should be added for all platforms with predicate support.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267375](https://bugs.openjdk.java.net/browse/JDK-8267375): Aarch64: JVM crashes with option -XX:PrintIdealGraphLevel=3 on SVE backend


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Contributors
 * Wang Huang `<whuang@openjdk.org>`
 * Ai Jiaming `<aijiaming1@huawei.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4239/head:pull/4239` \
`$ git checkout pull/4239`

Update a local copy of the PR: \
`$ git checkout pull/4239` \
`$ git pull https://git.openjdk.java.net/jdk pull/4239/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4239`

View PR using the GUI difftool: \
`$ git pr show -t 4239`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4239.diff">https://git.openjdk.java.net/jdk/pull/4239.diff</a>

</details>
