### PR TITLE
8267917: mark hotspot containers tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/containers/cgroup/PlainRead.java
+++ b/test/hotspot/jtreg/containers/cgroup/PlainRead.java
@@ -25,6 +25,7 @@
  * @test PlainRead
  * @key cgroups
  * @requires os.family == "linux"
+ * @requires vm.flagless
  * @library /testlibrary /test/lib
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/containers/docker/TestJcmdWithSideCar.java
+++ b/test/hotspot/jtreg/containers/docker/TestJcmdWithSideCar.java
@@ -30,10 +30,11 @@
  *          is paired with a sidecar container by sharing certain aspects of container
  *          namespace such as PID namespace, specific sub-directories, IPC and more.
  * @requires docker.support
- * @library /test/lib
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  *          jdk.jartool/sun.tools.jar
+ * @library /test/lib
  * @build EventGeneratorLoop
  * @run driver TestJcmdWithSideCar
  */


### PR DESCRIPTION
Hi all,

could you please review this tiny and trivial patch that adds `@requires vm.flagless` to two container tests that, supposedly, ignore external VM flags?

attn: @mseledts

Cheers,
-- Igor

/cc hotspot-runtime hotspot

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267917](https://bugs.openjdk.java.net/browse/JDK-8267917): mark hotspot containers tests which ignore external VM flags


### Reviewers
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4241/head:pull/4241` \
`$ git checkout pull/4241`

Update a local copy of the PR: \
`$ git checkout pull/4241` \
`$ git pull https://git.openjdk.java.net/jdk pull/4241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4241`

View PR using the GUI difftool: \
`$ git pr show -t 4241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4241.diff">https://git.openjdk.java.net/jdk/pull/4241.diff</a>

</details>
