### PR TITLE
8267938: (sctp) SCTP channel factory methods should check platform support

### DIFF
--- a/src/jdk.sctp/unix/native/libsctp/SctpNet.c
+++ b/src/jdk.sctp/unix/native/libsctp/SctpNet.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -190,7 +190,13 @@ JNIEXPORT jint JNICALL Java_sun_nio_ch_sctp_SctpNet_socket0
     fd = socket(domain, (oneToOne ? SOCK_STREAM : SOCK_SEQPACKET), IPPROTO_SCTP);
 
     if (fd < 0) {
-        return handleSocketError(env, errno);
+        if (errno == EPROTONOSUPPORT || errno == ESOCKTNOSUPPORT) {
+            JNU_ThrowByNameWithLastError(env, "java/lang/UnsupportedOperationException",
+                                         "Protocol not supported");
+            return IOS_THROWN;
+        } else {
+            return handleSocketError(env, errno);
+        }
     }
 
     /* Enable events */


### PR DESCRIPTION
The SCTP channel factory methods, namely SctpChannel::open, SctpServerChannel::open, and SctpMultiChannel::open, are specified to throw UnsupportedOperationException, if the SCTP protocol is not supported. Currently, underlying platform support is assumed once the appropriate libsctp.so.1 library is present (along with its supported interface functions). This may not always be the case, e.g. if the Linux sctp kernel module is not present or loaded. In which case a SocketException is thrown.

It would be more appropriate to check for EPROTONOSUPPORT and ESOCKTNOSUPPORT, and throw UOE rather than SE.

The existing java/net/SctpSanity.java tests already covers this case, when run on platforms without support.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267938](https://bugs.openjdk.java.net/browse/JDK-8267938): (sctp) SCTP channel factory methods should check platform support


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Vyom Tewari](https://openjdk.java.net/census#vtewari) (@vyommani - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4246/head:pull/4246` \
`$ git checkout pull/4246`

Update a local copy of the PR: \
`$ git checkout pull/4246` \
`$ git pull https://git.openjdk.java.net/jdk pull/4246/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4246`

View PR using the GUI difftool: \
`$ git pr show -t 4246`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4246.diff">https://git.openjdk.java.net/jdk/pull/4246.diff</a>

</details>
