### PR TITLE
8267928: Loop predicate gets inexact loop limit before PhaseIdealLoop::rc_predicate

### DIFF
--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -1158,6 +1158,7 @@ bool PhaseIdealLoop::loop_predication_impl_helper(IdealLoopTree *loop, ProjNode*
     // Limit is not exact.
     // Calculate exact limit here.
     // Note, counted loop's test is '<' or '>'.
+    loop->compute_trip_count(this);
     Node* limit   = exact_limit(loop);
     int  stride   = cl->stride()->get_int();
 


### PR DESCRIPTION
Loop predicate gets inexact loop limit(LoopLimitNode) from exact_limit(even if the limit is statically known) and does unnecessary overflow checking when generating lower bound test(rc_predicate). The reason is rather straightforward: exact_limit fails to see a HasExactTripCount flag since it would be set after performing loop predicate(iteration_split).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267928](https://bugs.openjdk.java.net/browse/JDK-8267928): Loop predicate gets inexact loop limit before PhaseIdealLoop::rc_predicate


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4247/head:pull/4247` \
`$ git checkout pull/4247`

Update a local copy of the PR: \
`$ git checkout pull/4247` \
`$ git pull https://git.openjdk.java.net/jdk pull/4247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4247`

View PR using the GUI difftool: \
`$ git pr show -t 4247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4247.diff">https://git.openjdk.java.net/jdk/pull/4247.diff</a>

</details>
