### PR TITLE
8267937: Wrong indentation in G1 gc+phases log for free cset subphases 

### DIFF
--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
@@ -487,8 +487,8 @@ double G1GCPhaseTimes::print_post_evacuate_collection_set() const {
   }
   debug_phase(_gc_par_phases[RedirtyCards], 1);
   debug_phase(_gc_par_phases[FreeCollectionSet], 1);
-  trace_phase(_gc_par_phases[YoungFreeCSet], true, 2);
-  trace_phase(_gc_par_phases[NonYoungFreeCSet], true, 2);
+  trace_phase(_gc_par_phases[YoungFreeCSet], true, 1);
+  trace_phase(_gc_par_phases[NonYoungFreeCSet], true, 1);
 
   trace_time("Serial Free Collection Set", _recorded_serial_free_cset_time_ms);
 


### PR DESCRIPTION
Hi all,

  JDK-8214327: Join parallel phases post evacuation messed up some indentation of logging:
  
The current gc+phases=trace looks as follows:
 ```
[0.059s][debug][gc,phases   ] GC(1)       Redirty Logged Cards (ms):     Min:  0.0, Avg:  0.0, Max:  0.0, Diff:  0.0, Sum:  0.0, Workers: 3
[0.059s][debug][gc,phases   ] GC(1)         Redirtied Cards:               Min: 0, Avg: 184.3, Max: 531, Diff: 531, Sum: 553, Workers: 3
[0.059s][debug][gc,phases   ] GC(1)       Free Collection Set (ms):      Min:  0.0, Avg:  0.0, Max:  0.0, Diff:  0.0, Sum:  0.0, Workers: 3
[0.059s][trace][gc,phases   ] GC(1)           Young Free Collection Set (ms): Min:  0.0, Avg:  0.0, Max:  0.0, Diff:  0.0, Sum:  0.0, Workers: 1
[0.059s][trace][gc,phases   ] GC(1)           Non-Young Free Collection Set (ms): skipped
```
`Young Free Collection Set` and `Non-Young Free Collection set` are indented one level too many.

This change fixes this.

Testing: manual testing, there is no indentation check for log messages

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267937](https://bugs.openjdk.java.net/browse/JDK-8267937): Wrong indentation in G1 gc+phases log for free cset subphases


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Committer)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4249/head:pull/4249` \
`$ git checkout pull/4249`

Update a local copy of the PR: \
`$ git checkout pull/4249` \
`$ git pull https://git.openjdk.java.net/jdk pull/4249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4249`

View PR using the GUI difftool: \
`$ git pr show -t 4249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4249.diff">https://git.openjdk.java.net/jdk/pull/4249.diff</a>

</details>
