### PR TITLE
JDK-8247608: Javadoc: CSS margin is not applied consistently

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/stylesheet.css
@@ -281,7 +281,7 @@ dl.notes > dt {
     color:#4E4E4E;
 }
 dl.notes > dd {
-    margin:5px 0 10px 0;
+    margin:5px 10px 10px 0;
     font-size:14px;
     font-family:'DejaVu Serif', Georgia, "Times New Roman", Times, serif;
 }


### PR DESCRIPTION
This simple stylesheet change adds a 10px right side border to the `<dd>` element containing the contents of block tags. I'm attaching a screenshot with the fixed spacing, see JBS attachments for reproducer source code and before-screenshots.

<img width="713" alt="border" src="https://user-images.githubusercontent.com/15975/119998289-db671200-bfd0-11eb-95f7-a89ffe10cff4.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8247608](https://bugs.openjdk.java.net/browse/JDK-8247608): Javadoc: CSS margin is not applied consistently


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4250/head:pull/4250` \
`$ git checkout pull/4250`

Update a local copy of the PR: \
`$ git checkout pull/4250` \
`$ git pull https://git.openjdk.java.net/jdk pull/4250/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4250`

View PR using the GUI difftool: \
`$ git pr show -t 4250`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4250.diff">https://git.openjdk.java.net/jdk/pull/4250.diff</a>

</details>
