### PR TITLE
8267943: Improve performance of EventWriter by improving varint encoding implementation

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventWriter.java
@@ -328,10 +328,20 @@ public final class EventWriter {
     }
 
     private void putUncheckedLong(long v) {
-        int length = VARINT_LENGTHS[Long.numberOfLeadingZeros(v)];
-        for (int i = 0; i < length; i++) {
-            putUncheckedByte(((byte) ((v & 0x7F) | 0x80)));
+        if ((v & ~0x7FL) != 0) {
+            putUncheckedByte((byte)((v & 0x7F) | 0x80));
             v >>>= 7;
+            if ((v & ~0x7FL) != 0) {
+                putUncheckedByte((byte)((v & 0x7F) | 0x80));
+                v >>>= 7;
+                if ((v & ~0x7FL) != 0) {
+                    int length = VARINT_LENGTHS[Long.numberOfLeadingZeros(v)];
+                    for (int i = 0; i < length; i++) {
+                        putUncheckedByte(((byte) ((v & 0x7F) | 0x80)));
+                        v >>>= 7;
+                    }
+                }
+            }
         }
         putUncheckedByte((byte) v);
     }


### PR DESCRIPTION
This PR improves the performance of committing events with numeric correlation ids by precomputing the number of continuation bytes required by each varint and storing them in a lookup table addressable by the input `long`'s leading zero count. In some rough [benchmarks](https://github.com/richardstartin/jfr-events/blob/master/src/main/java/io/github/richardstartin/jfrevents/CommitEventBenchmark.java), this shows a negligible regression for committing empty events, but a 15% improvement for committing an event with two random 64 bit identifiers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8267943](https://bugs.openjdk.java.net/browse/JDK-8267943): Improve performance of EventWriter by improving varint encoding implementation


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4251/head:pull/4251` \
`$ git checkout pull/4251`

Update a local copy of the PR: \
`$ git checkout pull/4251` \
`$ git pull https://git.openjdk.java.net/jdk pull/4251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4251`

View PR using the GUI difftool: \
`$ git pr show -t 4251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4251.diff">https://git.openjdk.java.net/jdk/pull/4251.diff</a>

</details>
