### PR TITLE
8267945: ZGC: Revert NUMA changes (JDK-8266217 and JDK-8241354) after JDK-8241423

### DIFF
--- a/src/hotspot/os/bsd/gc/z/zNUMA_bsd.cpp
+++ b/src/hotspot/os/bsd/gc/z/zNUMA_bsd.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 #include "gc/z/zNUMA.hpp"
 
 void ZNUMA::pd_initialize() {
-  _state = Disabled;
+  _enabled = false;
 }
 
 uint32_t ZNUMA::count() {

--- a/src/hotspot/os/linux/gc/z/zNUMA_linux.cpp
+++ b/src/hotspot/os/linux/gc/z/zNUMA_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,39 +24,17 @@
 #include "gc/z/zCPU.inline.hpp"
 #include "gc/z/zErrno.hpp"
 #include "gc/z/zNUMA.hpp"
-#include "gc/z/zNUMA.inline.hpp"
 #include "gc/z/zSyscall_linux.hpp"
 #include "runtime/globals.hpp"
-#include "runtime/globals_extension.hpp"
 #include "runtime/os.hpp"
 #include "utilities/debug.hpp"
 
-static bool numa_memory_id(void* addr, uint32_t* id) {
-  return ZSyscall::get_mempolicy((int*)id, NULL, 0, addr, MPOL_F_NODE | MPOL_F_ADDR) != -1;
-}
-
-static bool is_numa_supported() {
-  // Test if syscall is available
-  uint32_t dummy = 0;
-  const bool available = numa_memory_id(&dummy, &dummy);
-
-  if (!available && !FLAG_IS_DEFAULT(UseNUMA)) {
-    warning("NUMA support disabled, system call get_mempolicy not available");
-  }
-
-  return available;
-}
-
 void ZNUMA::pd_initialize() {
-  if (!UseNUMA) {
-    _state = Disabled;
-  } else {
-    _state = is_numa_supported() ? Enabled : Unsupported;
-  }
+  _enabled = UseNUMA;
 }
 
 uint32_t ZNUMA::count() {
-  if (!is_enabled()) {
+  if (!_enabled) {
     // NUMA support not enabled
     return 1;
   }
@@ -65,7 +43,7 @@ uint32_t ZNUMA::count() {
 }
 
 uint32_t ZNUMA::id() {
-  if (!is_enabled()) {
+  if (!_enabled) {
     // NUMA support not enabled
     return 0;
   }
@@ -74,14 +52,14 @@ uint32_t ZNUMA::id() {
 }
 
 uint32_t ZNUMA::memory_id(uintptr_t addr) {
-  if (!is_enabled()) {
+  if (!_enabled) {
     // NUMA support not enabled, assume everything belongs to node zero
     return 0;
   }
 
   uint32_t id = (uint32_t)-1;
 
-  if (!numa_memory_id((void*)addr, &id)) {
+  if (ZSyscall::get_mempolicy((int*)&id, NULL, 0, (void*)addr, MPOL_F_NODE | MPOL_F_ADDR) == -1) {
     ZErrno err;
     fatal("Failed to get NUMA id for memory at " PTR_FORMAT " (%s)", addr, err.to_string());
   }

--- a/src/hotspot/os/windows/gc/z/zNUMA_windows.cpp
+++ b/src/hotspot/os/windows/gc/z/zNUMA_windows.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 #include "gc/z/zNUMA.hpp"
 
 void ZNUMA::pd_initialize() {
-  _state = Disabled;
+  _enabled = false;
 }
 
 uint32_t ZNUMA::count() {

--- a/src/hotspot/share/gc/z/zNUMA.cpp
+++ b/src/hotspot/share/gc/z/zNUMA.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,28 +24,18 @@
 #include "precompiled.hpp"
 #include "gc/shared/gcLogPrecious.hpp"
 #include "gc/z/zNUMA.hpp"
-#include "gc/z/zNUMA.inline.hpp"
 
-ZNUMA::State ZNUMA::_state;
+bool ZNUMA::_enabled;
 
 void ZNUMA::initialize() {
   pd_initialize();
 
   log_info_p(gc, init)("NUMA Support: %s", to_string());
-  if (is_enabled()) {
+  if (_enabled) {
     log_info_p(gc, init)("NUMA Nodes: %u", count());
   }
 }
 
 const char* ZNUMA::to_string() {
-  switch (_state) {
-  case Enabled:
-    return "Enabled";
-
-  case Unsupported:
-    return "Unsupported";
-
-  default:
-    return "Disabled";
-  }
+  return _enabled ? "Enabled" : "Disabled";
 }

--- a/src/hotspot/share/gc/z/zNUMA.hpp
+++ b/src/hotspot/share/gc/z/zNUMA.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,13 +28,7 @@
 
 class ZNUMA : public AllStatic {
 private:
-  enum State {
-    Disabled,
-    Enabled,
-    Unsupported
-  };
-
-  static State _state;
+  static bool _enabled;
 
   static void pd_initialize();
 

--- a/src/hotspot/share/gc/z/zNUMA.inline.hpp
+++ b/src/hotspot/share/gc/z/zNUMA.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
 #include "gc/z/zNUMA.hpp"
 
 inline bool ZNUMA::is_enabled() {
-  return _state == Enabled;
+  return _enabled;
 }
 
 #endif // SHARE_GC_Z_ZNUMA_INLINE_HPP


### PR DESCRIPTION
Hi all,

As discussed here [1], JDK-8266217 and JDK-8241354 make no sense after JDK-8241423.
```
8266217: ZGC: Improve the -Xlog:gc+init output for NUMA
8241354: ZGC still crashes in containers with NUMA due to get_mempolicy is disabled by default
```

It would be better to revert the changes.

The patch was prepared like this:
```
# Revert JDK-8266217
git diff 5ecef01c4a9 5d8c1cc8a05 > r8266217.diff
patch -p1 < r8266217.diff   # patch applied cleanly

# Revert JDK-8241354
git diff 794cefe8f92 23180f848f0 > r8241354.diff
patch -p1 < r8241354.diff   # patch applied cleanly
```

Testing:
  - hotspot/jtreg/gc/z on Linux/x64 and MacOSX.

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk/pull/4205#issuecomment-849390011

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267945](https://bugs.openjdk.java.net/browse/JDK-8267945): ZGC: Revert NUMA changes (JDK-8266217 and JDK-8241354) after JDK-8241423


### Reviewers
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4252/head:pull/4252` \
`$ git checkout pull/4252`

Update a local copy of the PR: \
`$ git checkout pull/4252` \
`$ git pull https://git.openjdk.java.net/jdk pull/4252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4252`

View PR using the GUI difftool: \
`$ git pr show -t 4252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4252.diff">https://git.openjdk.java.net/jdk/pull/4252.diff</a>

</details>
