### PR TITLE
8264800: cleanup Threads_lock comments in JVM/TI function headers

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -140,8 +140,7 @@ JvmtiEnv::Deallocate(unsigned char* mem) {
   return deallocate(mem);
 } /* end Deallocate */
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
+// java_thread - protected by ThreadsListHandle and pre-checked
 // data - NULL is a valid value, must be checked
 jvmtiError
 JvmtiEnv::SetThreadLocalStorage(JavaThread* java_thread, const void* data) {
@@ -162,8 +161,7 @@ JvmtiEnv::SetThreadLocalStorage(JavaThread* java_thread, const void* data) {
 } /* end SetThreadLocalStorage */
 
 
-// Threads_lock NOT held
-// thread - NOT pre-checked
+// thread - NOT protected by ThreadsListHandle and NOT pre-checked
 // data_ptr - pre-checked for NULL
 jvmtiError
 JvmtiEnv::GetThreadLocalStorage(jthread thread, void** data_ptr) {
@@ -839,8 +837,7 @@ JvmtiEnv::GetJLocationFormat(jvmtiJlocationFormat* format_ptr) {
   // Thread functions
   //
 
-// Threads_lock NOT held
-// thread - NOT pre-checked
+// thread - NOT protected by ThreadsListHandle and NOT pre-checked
 // thread_state_ptr - pre-checked for NULL
 jvmtiError
 JvmtiEnv::GetThreadState(jthread thread, jint* thread_state_ptr) {
@@ -936,8 +933,7 @@ JvmtiEnv::GetAllThreads(jint* threads_count_ptr, jthread** threads_ptr) {
 } /* end GetAllThreads */
 
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
+// java_thread - protected by ThreadsListHandle and pre-checked
 jvmtiError
 JvmtiEnv::SuspendThread(JavaThread* java_thread) {
   // don't allow hidden thread suspend request.
@@ -1018,8 +1014,7 @@ JvmtiEnv::SuspendThreadList(jint request_count, const jthread* request_list, jvm
 } /* end SuspendThreadList */
 
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
+// java_thread - protected by ThreadsListHandle and pre-checked
 jvmtiError
 JvmtiEnv::ResumeThread(JavaThread* java_thread) {
   // don't allow hidden thread resume request.
@@ -1071,8 +1066,7 @@ JvmtiEnv::ResumeThreadList(jint request_count, const jthread* request_list, jvmt
 } /* end ResumeThreadList */
 
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
+// java_thread - protected by ThreadsListHandle and pre-checked
 jvmtiError
 JvmtiEnv::StopThread(JavaThread* java_thread, jobject exception) {
   oop e = JNIHandles::resolve_external_guard(exception);
@@ -1085,8 +1079,7 @@ JvmtiEnv::StopThread(JavaThread* java_thread, jobject exception) {
 } /* end StopThread */
 
 
-// Threads_lock NOT held
-// thread - NOT pre-checked
+// thread - NOT protected by ThreadsListHandle and NOT pre-checked
 jvmtiError
 JvmtiEnv::InterruptThread(jthread thread) {
   JavaThread* current_thread  = JavaThread::current();
@@ -1107,8 +1100,7 @@ JvmtiEnv::InterruptThread(jthread thread) {
 } /* end InterruptThread */
 
 
-// Threads_lock NOT held
-// thread - NOT pre-checked
+// thread - NOT protected by ThreadsListHandle and NOT pre-checked
 // info_ptr - pre-checked for NULL
 jvmtiError
 JvmtiEnv::GetThreadInfo(jthread thread, jvmtiThreadInfo* info_ptr) {
@@ -1180,8 +1172,7 @@ JvmtiEnv::GetThreadInfo(jthread thread, jvmtiThreadInfo* info_ptr) {
 } /* end GetThreadInfo */
 
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
+// java_thread - protected by ThreadsListHandle and pre-checked
 // owned_monitor_count_ptr - pre-checked for NULL
 // owned_monitors_ptr - pre-checked for NULL
 jvmtiError
@@ -1230,8 +1221,7 @@ JvmtiEnv::GetOwnedMonitorInfo(JavaThread* java_thread, jint* owned_monitor_count
 } /* end GetOwnedMonitorInfo */
 
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
+// java_thread - protected by ThreadsListHandle and pre-checked
 // monitor_info_count_ptr - pre-checked for NULL
 // monitor_info_ptr - pre-checked for NULL
 jvmtiError
@@ -1284,8 +1274,7 @@ JvmtiEnv::GetOwnedMonitorStackDepthInfo(JavaThread* java_thread, jint* monitor_i
 } /* end GetOwnedMonitorStackDepthInfo */
 
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
+// java_thread - protected by ThreadsListHandle and pre-checked
 // monitor_ptr - pre-checked for NULL
 jvmtiError
 JvmtiEnv::GetCurrentContendedMonitor(JavaThread* java_thread, jobject* monitor_ptr) {
@@ -1306,8 +1295,7 @@ JvmtiEnv::GetCurrentContendedMonitor(JavaThread* java_thread, jobject* monitor_p
 } /* end GetCurrentContendedMonitor */
 
 
-// Threads_lock NOT held
-// thread - NOT pre-checked
+// thread - NOT protected by ThreadsListHandle and NOT pre-checked
 // proc - pre-checked for NULL
 // arg - NULL is a valid value, must be checked
 jvmtiError
@@ -1521,8 +1509,7 @@ JvmtiEnv::GetThreadGroupChildren(jthreadGroup group, jint* thread_count_ptr, jth
   // Stack Frame functions
   //
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
+// java_thread - protected by ThreadsListHandle and pre-checked
 // max_frame_count - pre-checked to be greater than or equal to 0
 // frame_buffer - pre-checked for NULL
 // count_ptr - pre-checked for NULL
@@ -1600,8 +1587,7 @@ JvmtiEnv::GetThreadListStackTraces(jint thread_count, const jthread* thread_list
 } /* end GetThreadListStackTraces */
 
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
+// java_thread - protected by ThreadsListHandle and pre-checked
 // count_ptr - pre-checked for NULL
 jvmtiError
 JvmtiEnv::GetFrameCount(JavaThread* java_thread, jint* count_ptr) {
@@ -1627,8 +1613,7 @@ JvmtiEnv::GetFrameCount(JavaThread* java_thread, jint* count_ptr) {
 } /* end GetFrameCount */
 
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
+// java_thread - protected by ThreadsListHandle and pre-checked
 jvmtiError
 JvmtiEnv::PopFrame(JavaThread* java_thread) {
   // retrieve or create the state
@@ -1656,9 +1641,7 @@ JvmtiEnv::PopFrame(JavaThread* java_thread) {
 } /* end PopFrame */
 
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
-// java_thread - unchecked
+// java_thread - protected by ThreadsListHandle and pre-checked
 // depth - pre-checked as non-negative
 // method_ptr - pre-checked for NULL
 // location_ptr - pre-checked for NULL
@@ -1680,9 +1663,7 @@ JvmtiEnv::GetFrameLocation(JavaThread* java_thread, jint depth, jmethodID* metho
 } /* end GetFrameLocation */
 
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
-// java_thread - unchecked
+// java_thread - protected by ThreadsListHandle and pre-checked
 // depth - pre-checked as non-negative
 jvmtiError
 JvmtiEnv::NotifyFramePop(JavaThread* java_thread, jint depth) {
@@ -1706,8 +1687,7 @@ JvmtiEnv::NotifyFramePop(JavaThread* java_thread, jint depth) {
   // Force Early Return functions
   //
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
+// java_thread - protected by ThreadsListHandle and pre-checked
 jvmtiError
 JvmtiEnv::ForceEarlyReturnObject(JavaThread* java_thread, jobject value) {
   jvalue val;
@@ -1716,8 +1696,7 @@ JvmtiEnv::ForceEarlyReturnObject(JavaThread* java_thread, jobject value) {
 } /* end ForceEarlyReturnObject */
 
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
+// java_thread - protected by ThreadsListHandle and pre-checked
 jvmtiError
 JvmtiEnv::ForceEarlyReturnInt(JavaThread* java_thread, jint value) {
   jvalue val;
@@ -1726,8 +1705,7 @@ JvmtiEnv::ForceEarlyReturnInt(JavaThread* java_thread, jint value) {
 } /* end ForceEarlyReturnInt */
 
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
+// java_thread - protected by ThreadsListHandle and pre-checked
 jvmtiError
 JvmtiEnv::ForceEarlyReturnLong(JavaThread* java_thread, jlong value) {
   jvalue val;
@@ -1736,8 +1714,7 @@ JvmtiEnv::ForceEarlyReturnLong(JavaThread* java_thread, jlong value) {
 } /* end ForceEarlyReturnLong */
 
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
+// java_thread - protected by ThreadsListHandle and pre-checked
 jvmtiError
 JvmtiEnv::ForceEarlyReturnFloat(JavaThread* java_thread, jfloat value) {
   jvalue val;
@@ -1746,8 +1723,7 @@ JvmtiEnv::ForceEarlyReturnFloat(JavaThread* java_thread, jfloat value) {
 } /* end ForceEarlyReturnFloat */
 
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
+// java_thread - protected by ThreadsListHandle and pre-checked
 jvmtiError
 JvmtiEnv::ForceEarlyReturnDouble(JavaThread* java_thread, jdouble value) {
   jvalue val;
@@ -1756,8 +1732,7 @@ JvmtiEnv::ForceEarlyReturnDouble(JavaThread* java_thread, jdouble value) {
 } /* end ForceEarlyReturnDouble */
 
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
+// java_thread - protected by ThreadsListHandle and pre-checked
 jvmtiError
 JvmtiEnv::ForceEarlyReturnVoid(JavaThread* java_thread) {
   jvalue val;
@@ -1935,9 +1910,7 @@ JvmtiEnv::IterateOverInstancesOfClass(oop k_mirror, jvmtiHeapObjectFilter object
   // Local Variable functions
   //
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
-// java_thread - unchecked
+// java_thread - protected by ThreadsListHandle and pre-checked
 // depth - pre-checked as non-negative
 // value_ptr - pre-checked for NULL
 jvmtiError
@@ -1958,9 +1931,7 @@ JvmtiEnv::GetLocalObject(JavaThread* java_thread, jint depth, jint slot, jobject
   }
 } /* end GetLocalObject */
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
-// java_thread - unchecked
+// java_thread - protected by ThreadsListHandle and pre-checked
 // depth - pre-checked as non-negative
 // value - pre-checked for NULL
 jvmtiError
@@ -1982,9 +1953,7 @@ JvmtiEnv::GetLocalInstance(JavaThread* java_thread, jint depth, jobject* value_p
 } /* end GetLocalInstance */
 
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
-// java_thread - unchecked
+// java_thread - protected by ThreadsListHandle and pre-checked
 // depth - pre-checked as non-negative
 // value_ptr - pre-checked for NULL
 jvmtiError
@@ -2000,9 +1969,7 @@ JvmtiEnv::GetLocalInt(JavaThread* java_thread, jint depth, jint slot, jint* valu
 } /* end GetLocalInt */
 
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
-// java_thread - unchecked
+// java_thread - protected by ThreadsListHandle and pre-checked
 // depth - pre-checked as non-negative
 // value_ptr - pre-checked for NULL
 jvmtiError
@@ -2018,9 +1985,7 @@ JvmtiEnv::GetLocalLong(JavaThread* java_thread, jint depth, jint slot, jlong* va
 } /* end GetLocalLong */
 
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
-// java_thread - unchecked
+// java_thread - protected by ThreadsListHandle and pre-checked
 // depth - pre-checked as non-negative
 // value_ptr - pre-checked for NULL
 jvmtiError
@@ -2036,9 +2001,7 @@ JvmtiEnv::GetLocalFloat(JavaThread* java_thread, jint depth, jint slot, jfloat* 
 } /* end GetLocalFloat */
 
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
-// java_thread - unchecked
+// java_thread - protected by ThreadsListHandle and pre-checked
 // depth - pre-checked as non-negative
 // value_ptr - pre-checked for NULL
 jvmtiError
@@ -2054,9 +2017,7 @@ JvmtiEnv::GetLocalDouble(JavaThread* java_thread, jint depth, jint slot, jdouble
 } /* end GetLocalDouble */
 
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
-// java_thread - unchecked
+// java_thread - protected by ThreadsListHandle and pre-checked
 // depth - pre-checked as non-negative
 jvmtiError
 JvmtiEnv::SetLocalObject(JavaThread* java_thread, jint depth, jint slot, jobject value) {
@@ -2071,9 +2032,7 @@ JvmtiEnv::SetLocalObject(JavaThread* java_thread, jint depth, jint slot, jobject
 } /* end SetLocalObject */
 
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
-// java_thread - unchecked
+// java_thread - protected by ThreadsListHandle and pre-checked
 // depth - pre-checked as non-negative
 jvmtiError
 JvmtiEnv::SetLocalInt(JavaThread* java_thread, jint depth, jint slot, jint value) {
@@ -2088,9 +2047,7 @@ JvmtiEnv::SetLocalInt(JavaThread* java_thread, jint depth, jint slot, jint value
 } /* end SetLocalInt */
 
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
-// java_thread - unchecked
+// java_thread - protected by ThreadsListHandle and pre-checked
 // depth - pre-checked as non-negative
 jvmtiError
 JvmtiEnv::SetLocalLong(JavaThread* java_thread, jint depth, jint slot, jlong value) {
@@ -2105,9 +2062,7 @@ JvmtiEnv::SetLocalLong(JavaThread* java_thread, jint depth, jint slot, jlong val
 } /* end SetLocalLong */
 
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
-// java_thread - unchecked
+// java_thread - protected by ThreadsListHandle and pre-checked
 // depth - pre-checked as non-negative
 jvmtiError
 JvmtiEnv::SetLocalFloat(JavaThread* java_thread, jint depth, jint slot, jfloat value) {
@@ -2122,9 +2077,7 @@ JvmtiEnv::SetLocalFloat(JavaThread* java_thread, jint depth, jint slot, jfloat v
 } /* end SetLocalFloat */
 
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
-// java_thread - unchecked
+// java_thread - protected by ThreadsListHandle and pre-checked
 // depth - pre-checked as non-negative
 jvmtiError
 JvmtiEnv::SetLocalDouble(JavaThread* java_thread, jint depth, jint slot, jdouble value) {
@@ -3393,8 +3346,7 @@ JvmtiEnv::GetThreadCpuTimerInfo(jvmtiTimerInfo* info_ptr) {
 } /* end GetThreadCpuTimerInfo */
 
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
+// java_thread - protected by ThreadsListHandle and pre-checked
 // nanos_ptr - pre-checked for NULL
 jvmtiError
 JvmtiEnv::GetThreadCpuTime(JavaThread* java_thread, jlong* nanos_ptr) {

--- a/src/hotspot/share/prims/jvmtiEnv.xsl
+++ b/src/hotspot/share/prims/jvmtiEnv.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0"?> 
 <!--
- Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -110,15 +110,13 @@ JvmtiEnv::</xsl:text>
   <xsl:choose>
     <xsl:when test="count(@impl)=0 or not(contains(@impl,'noconvert'))">
       <xsl:text>
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked</xsl:text>
+// java_thread - protected by ThreadsListHandle and pre-checked</xsl:text>
     </xsl:when>
     <xsl:otherwise>
       <xsl:text>
-// Threads_lock NOT held
 // </xsl:text>
       <xsl:value-of select="$name"/>
-      <xsl:text> - NOT pre-checked</xsl:text>
+      <xsl:text> - NOT protected by ThreadsListHandle and NOT pre-checked</xsl:text>
     </xsl:otherwise>
   </xsl:choose>
 </xsl:template>
@@ -132,7 +130,6 @@ JvmtiEnv::</xsl:text>
 <xsl:template match="jframeID" mode="advice">
   <xsl:param name="name"/>
   <xsl:text>
-// java_thread - unchecked 
 // depth - pre-checked as non-negative</xsl:text>
 </xsl:template>
 

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -1364,8 +1364,7 @@ JvmtiEnvBase::check_top_frame(Thread* current_thread, JavaThread* java_thread,
 // The ForceEarlyReturn forces return from method so the execution
 // continues at the bytecode following the method call.
 
-// Threads_lock NOT held, java_thread not protected by lock
-// java_thread - pre-checked
+// java_thread - protected by ThreadsListHandle and pre-checked
 
 jvmtiError
 JvmtiEnvBase::force_early_return(JavaThread* java_thread, jvalue value, TosState tos) {


### PR DESCRIPTION
A trivial fix to cleanup Threads_lock comments in JVM/TI function headers.

Also remove errant text added by the jframeID XSL template code:

```
// java_thread - unchecked
// depth - pre-checked as non-negative
```

The first line about `jthread` is output in error.
Only the second line about `depth` should be included.

This fix is tested with a Mach5 Tier1 job set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264800](https://bugs.openjdk.java.net/browse/JDK-8264800): cleanup Threads_lock comments in JVM/TI function headers


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Robbin Ehn](https://openjdk.java.net/census#rehn) (@robehn - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4254/head:pull/4254` \
`$ git checkout pull/4254`

Update a local copy of the PR: \
`$ git checkout pull/4254` \
`$ git pull https://git.openjdk.java.net/jdk pull/4254/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4254`

View PR using the GUI difftool: \
`$ git pr show -t 4254`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4254.diff">https://git.openjdk.java.net/jdk/pull/4254.diff</a>

</details>
