### PR TITLE
JDK-8267930: Refine code for loading hsdis library

### DIFF
--- a/src/hotspot/share/compiler/disassembler.cpp
+++ b/src/hotspot/share/compiler/disassembler.cpp
@@ -755,10 +755,10 @@ address decode_env::decode_instructions(address start, address end, address orig
 // Each method will create a decode_env before decoding.
 // You can call the decode_env methods directly if you already have one.
 
-void* Disassembler::dll_load(char* buf, int offset, size_t buflen, char* ebuf, size_t ebuflen, outputStream* st) {
-  if (offset + strlen(hsdis_library_name) + strlen(os::dll_file_extension()) < buflen) {
-    strcpy(&buf[offset], hsdis_library_name);
-    strcat(&buf[offset], os::dll_file_extension());
+void* Disassembler::dll_load(char* buf, int offset, int buflen, char* ebuf, int ebuflen, outputStream* st) {
+  int sz = buflen - offset;
+  int written = jio_snprintf(&buf[offset], sz, "%s%s", hsdis_library_name, os::dll_file_extension());
+  if (written < sz) { // written successfully, not truncated.
     if (Verbose) st->print_cr("Trying to load: %s", buf);
     return os::dll_load(buf, ebuf, ebuflen);
   } else if (Verbose) {

--- a/src/hotspot/share/compiler/disassembler.cpp
+++ b/src/hotspot/share/compiler/disassembler.cpp
@@ -815,10 +815,10 @@ bool Disassembler::load_library(outputStream* st) {
   // 4. hsdis-<arch>.so  (using LD_LIBRARY_PATH)
   if (jvm_offset >= 0) {
     // 1. <home>/lib/<vm>/libhsdis-<arch>.so
-    _library = dll_load(buf, jvm_offset, sizeof buf, ebuf, sizeof ebuf, st);
+    _library = dll_load(buf, sizeof buf, jvm_offset, ebuf, sizeof ebuf, st);
     if (_library == NULL && lib_offset >= 0) {
       // 2. <home>/lib/<vm>/hsdis-<arch>.so
-      _library = dll_load(buf, lib_offset, sizeof buf, ebuf, sizeof ebuf, st);
+      _library = dll_load(buf, sizeof buf, lib_offset, ebuf, sizeof ebuf, st);
     }
     if (_library == NULL && lib_offset > 0) {
       // 3. <home>/lib/hsdis-<arch>.so
@@ -826,12 +826,12 @@ bool Disassembler::load_library(outputStream* st) {
       const char* p = strrchr(buf, *os::file_separator());
       if (p != NULL) {
         lib_offset = p - buf + 1;
-        _library = dll_load(buf, lib_offset, sizeof buf, ebuf, sizeof ebuf, st);
+        _library = dll_load(buf, sizeof buf, lib_offset, ebuf, sizeof ebuf, st);
       }
     }
   }
   if (_library == NULL) {
-    _library = dll_load(buf, 0, sizeof buf, ebuf, sizeof ebuf, st);
+    _library = dll_load(buf, sizeof buf, 0, ebuf, sizeof ebuf, st);
   }
 
   // load the decoder function to use.

--- a/src/hotspot/share/compiler/disassembler.cpp
+++ b/src/hotspot/share/compiler/disassembler.cpp
@@ -755,8 +755,8 @@ address decode_env::decode_instructions(address start, address end, address orig
 // Each method will create a decode_env before decoding.
 // You can call the decode_env methods directly if you already have one.
 
-void* Disassembler::dll_load(char* buf, int offset, char* ebuf, int ebuflen, outputStream* st) {
-  if (offset + strlen(hsdis_library_name) + strlen(os::dll_file_extension()) < JVM_MAXPATHLEN) {
+void* Disassembler::dll_load(char* buf, int offset, size_t buflen, char* ebuf, size_t ebuflen, outputStream* st) {
+  if (offset + strlen(hsdis_library_name) + strlen(os::dll_file_extension()) < buflen) {
     strcpy(&buf[offset], hsdis_library_name);
     strcat(&buf[offset], os::dll_file_extension());
     if (Verbose) st->print_cr("Trying to load: %s", buf);
@@ -815,10 +815,10 @@ bool Disassembler::load_library(outputStream* st) {
   // 4. hsdis-<arch>.so  (using LD_LIBRARY_PATH)
   if (jvm_offset >= 0) {
     // 1. <home>/lib/<vm>/libhsdis-<arch>.so
-    _library = dll_load(buf, jvm_offset, ebuf, sizeof ebuf, st);
+    _library = dll_load(buf, jvm_offset, sizeof buf, ebuf, sizeof ebuf, st);
     if (_library == NULL && lib_offset >= 0) {
       // 2. <home>/lib/<vm>/hsdis-<arch>.so
-      _library = dll_load(buf, lib_offset, ebuf, sizeof ebuf, st);
+      _library = dll_load(buf, lib_offset, sizeof buf, ebuf, sizeof ebuf, st);
     }
     if (_library == NULL && lib_offset > 0) {
       // 3. <home>/lib/hsdis-<arch>.so
@@ -826,12 +826,12 @@ bool Disassembler::load_library(outputStream* st) {
       const char* p = strrchr(buf, *os::file_separator());
       if (p != NULL) {
         lib_offset = p - buf + 1;
-        _library = dll_load(buf, lib_offset, ebuf, sizeof ebuf, st);
+        _library = dll_load(buf, lib_offset, sizeof buf, ebuf, sizeof ebuf, st);
       }
     }
   }
   if (_library == NULL) {
-    _library = dll_load(buf, 0, ebuf, sizeof ebuf, st);
+    _library = dll_load(buf, 0, sizeof buf, ebuf, sizeof ebuf, st);
   }
 
   // load the decoder function to use.

--- a/src/hotspot/share/compiler/disassembler.cpp
+++ b/src/hotspot/share/compiler/disassembler.cpp
@@ -755,6 +755,17 @@ address decode_env::decode_instructions(address start, address end, address orig
 // Each method will create a decode_env before decoding.
 // You can call the decode_env methods directly if you already have one.
 
+void* Disassembler::dll_load(char* buf, int offset, char* ebuf, int ebuflen, outputStream* st) {
+  if (offset + strlen(hsdis_library_name) + strlen(os::dll_file_extension()) < JVM_MAXPATHLEN) {
+    strcpy(&buf[offset], hsdis_library_name);
+    strcat(&buf[offset], os::dll_file_extension());
+    if (Verbose) st->print_cr("Trying to load: %s", buf);
+    return os::dll_load(buf, ebuf, ebuflen);
+  } else if (Verbose) {
+    st->print_cr("Try to load hsdis library failed: the length of path is beyond the OS limit");
+  }
+  return NULL;
+}
 
 bool Disassembler::load_library(outputStream* st) {
   // Do not try to load multiple times. Failed once -> fails always.
@@ -804,24 +815,10 @@ bool Disassembler::load_library(outputStream* st) {
   // 4. hsdis-<arch>.so  (using LD_LIBRARY_PATH)
   if (jvm_offset >= 0) {
     // 1. <home>/lib/<vm>/libhsdis-<arch>.so
-    if (jvm_offset + strlen(hsdis_library_name) + strlen(os::dll_file_extension()) < JVM_MAXPATHLEN) {
-      strcpy(&buf[jvm_offset], hsdis_library_name);
-      strcat(&buf[jvm_offset], os::dll_file_extension());
-      if (Verbose) st->print_cr("Trying to load: %s", buf);
-      _library = os::dll_load(buf, ebuf, sizeof ebuf);
-    } else {
-      if (Verbose) st->print_cr("Try to load hsdis library failed: the length of path is beyond the OS limit");
-    }
+    _library = dll_load(buf, jvm_offset, ebuf, sizeof ebuf, st);
     if (_library == NULL && lib_offset >= 0) {
       // 2. <home>/lib/<vm>/hsdis-<arch>.so
-      if (lib_offset + strlen(hsdis_library_name) + strlen(os::dll_file_extension()) < JVM_MAXPATHLEN) {
-        strcpy(&buf[lib_offset], hsdis_library_name);
-        strcat(&buf[lib_offset], os::dll_file_extension());
-        if (Verbose) st->print_cr("Trying to load: %s", buf);
-        _library = os::dll_load(buf, ebuf, sizeof ebuf);
-      } else {
-        if (Verbose) st->print_cr("Try to load hsdis library failed: the length of path is beyond the OS limit");
-      }
+      _library = dll_load(buf, lib_offset, ebuf, sizeof ebuf, st);
     }
     if (_library == NULL && lib_offset > 0) {
       // 3. <home>/lib/hsdis-<arch>.so
@@ -829,23 +826,12 @@ bool Disassembler::load_library(outputStream* st) {
       const char* p = strrchr(buf, *os::file_separator());
       if (p != NULL) {
         lib_offset = p - buf + 1;
-        if (lib_offset + strlen(hsdis_library_name) + strlen(os::dll_file_extension()) < JVM_MAXPATHLEN) {
-          strcpy(&buf[lib_offset], hsdis_library_name);
-          strcat(&buf[lib_offset], os::dll_file_extension());
-          if (Verbose) st->print_cr("Trying to load: %s", buf);
-          _library = os::dll_load(buf, ebuf, sizeof ebuf);
-        } else {
-          if (Verbose) st->print_cr("Try to load hsdis library failed: the length of path is beyond the OS limit");
-        }
+        _library = dll_load(buf, lib_offset, ebuf, sizeof ebuf, st);
       }
     }
   }
   if (_library == NULL) {
-    // 4. hsdis-<arch>.so  (using LD_LIBRARY_PATH)
-    strcpy(&buf[0], hsdis_library_name);
-    strcat(&buf[0], os::dll_file_extension());
-    if (Verbose) st->print_cr("Trying to load: %s via LD_LIBRARY_PATH or equivalent", buf);
-    _library = os::dll_load(buf, ebuf, sizeof ebuf);
+    _library = dll_load(buf, 0, ebuf, sizeof ebuf, st);
   }
 
   // load the decoder function to use.

--- a/src/hotspot/share/compiler/disassembler.cpp
+++ b/src/hotspot/share/compiler/disassembler.cpp
@@ -755,7 +755,7 @@ address decode_env::decode_instructions(address start, address end, address orig
 // Each method will create a decode_env before decoding.
 // You can call the decode_env methods directly if you already have one.
 
-void* Disassembler::dll_load(char* buf, int offset, int buflen, char* ebuf, int ebuflen, outputStream* st) {
+void* Disassembler::dll_load(char* buf, int buflen, int offset, char* ebuf, int ebuflen, outputStream* st) {
   int sz = buflen - offset;
   int written = jio_snprintf(&buf[offset], sz, "%s%s", hsdis_library_name, os::dll_file_extension());
   if (written < sz) { // written successfully, not truncated.

--- a/src/hotspot/share/compiler/disassembler.hpp
+++ b/src/hotspot/share/compiler/disassembler.hpp
@@ -65,7 +65,7 @@ class Disassembler : public AbstractDisassembler {
   // No output at all if stream is NULL. Can be overridden
   // with -Verbose flag, in which case output goes to tty.
   static bool load_library(outputStream* st = NULL);
-  static void* dll_load(char* buf, int offset, char* ebuf, int ebuflen, outputStream* st);
+  static void* dll_load(char* buf, int offset, size_t buflen, char* ebuf, int ebuflen, outputStream* st);
 
   // Check if the two addresses are on the same page.
   static bool is_same_page(address a1, address a2) {

--- a/src/hotspot/share/compiler/disassembler.hpp
+++ b/src/hotspot/share/compiler/disassembler.hpp
@@ -65,7 +65,7 @@ class Disassembler : public AbstractDisassembler {
   // No output at all if stream is NULL. Can be overridden
   // with -Verbose flag, in which case output goes to tty.
   static bool load_library(outputStream* st = NULL);
-  static void* dll_load(char* buf, int offset, int buflen, char* ebuf, int ebuflen, outputStream* st);
+  static void* dll_load(char* buf, int buflen, int offset, char* ebuf, int ebuflen, outputStream* st);
 
   // Check if the two addresses are on the same page.
   static bool is_same_page(address a1, address a2) {

--- a/src/hotspot/share/compiler/disassembler.hpp
+++ b/src/hotspot/share/compiler/disassembler.hpp
@@ -65,7 +65,7 @@ class Disassembler : public AbstractDisassembler {
   // No output at all if stream is NULL. Can be overridden
   // with -Verbose flag, in which case output goes to tty.
   static bool load_library(outputStream* st = NULL);
-  static void* dll_load(char* buf, int offset, size_t buflen, char* ebuf, int ebuflen, outputStream* st);
+  static void* dll_load(char* buf, int offset, size_t buflen, char* ebuf, size_t ebuflen, outputStream* st);
 
   // Check if the two addresses are on the same page.
   static bool is_same_page(address a1, address a2) {

--- a/src/hotspot/share/compiler/disassembler.hpp
+++ b/src/hotspot/share/compiler/disassembler.hpp
@@ -65,7 +65,7 @@ class Disassembler : public AbstractDisassembler {
   // No output at all if stream is NULL. Can be overridden
   // with -Verbose flag, in which case output goes to tty.
   static bool load_library(outputStream* st = NULL);
-  static void* dll_load(char* buf, int offset, size_t buflen, char* ebuf, size_t ebuflen, outputStream* st);
+  static void* dll_load(char* buf, int offset, int buflen, char* ebuf, int ebuflen, outputStream* st);
 
   // Check if the two addresses are on the same page.
   static bool is_same_page(address a1, address a2) {

--- a/src/hotspot/share/compiler/disassembler.hpp
+++ b/src/hotspot/share/compiler/disassembler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,6 +65,7 @@ class Disassembler : public AbstractDisassembler {
   // No output at all if stream is NULL. Can be overridden
   // with -Verbose flag, in which case output goes to tty.
   static bool load_library(outputStream* st = NULL);
+  static void* dll_load(char* buf, int offset, char* ebuf, int ebuflen, outputStream* st);
 
   // Check if the two addresses are on the same page.
   static bool is_same_page(address a1, address a2) {


### PR DESCRIPTION
code for loading hsdis library is redundant, this is to simplify it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267930](https://bugs.openjdk.java.net/browse/JDK-8267930): Refine code for loading hsdis library


### Reviewers
 * [Wang Huang](https://openjdk.java.net/census#whuang) (@Wanghuang-Huawei - Author) ⚠️ Review applies to fa902ead1cfba1bbde1223576f63c8c664ecbed3
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Yasumasa Suenaga](https://openjdk.java.net/census#ysuenaga) (@YaSuenag - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4260/head:pull/4260` \
`$ git checkout pull/4260`

Update a local copy of the PR: \
`$ git checkout pull/4260` \
`$ git pull https://git.openjdk.java.net/jdk pull/4260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4260`

View PR using the GUI difftool: \
`$ git pr show -t 4260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4260.diff">https://git.openjdk.java.net/jdk/pull/4260.diff</a>

</details>
