### PR TITLE
8265891: (ch) InputStream returned by Channels.newInputStream should override transferTo

### DIFF
--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -53,7 +53,7 @@ public abstract class InputStream implements Closeable {
     // use when skipping.
     private static final int MAX_SKIP_BUFFER_SIZE = 2048;
 
-    private static final int DEFAULT_BUFFER_SIZE = 8192;
+    private static final int DEFAULT_BUFFER_SIZE = 16 * 8192;
 
     /**
      * Constructor for subclasses to call.

--- a/src/java.base/share/classes/java/nio/channels/Channels.java
+++ b/src/java.base/share/classes/java/nio/channels/Channels.java
@@ -152,7 +152,7 @@ public final class Channels {
         /**
          * @param ch The channel wrapped by this stream.
          */
-        public ChannelOutputStream(final WritableByteChannel ch) {
+        public ChannelOutputStream(WritableByteChannel ch) {
             this.ch = ch;
         }
 

--- a/src/java.base/share/classes/java/nio/channels/Channels.java
+++ b/src/java.base/share/classes/java/nio/channels/Channels.java
@@ -143,10 +143,8 @@ public final class Channels {
             public synchronized int read(byte[] bs, int off, int len)
                     throws IOException
             {
-                if ((off < 0) || (off > bs.length) || (len < 0) ||
-                    ((off + len) > bs.length) || ((off + len) < 0)) {
-                    throw new IndexOutOfBoundsException();
-                } else if (len == 0) {
+                Objects.checkFromIndexSize(off, len, bs.length);
+                if (len == 0) {
                     return 0;
                 }
 

--- a/src/java.base/share/classes/java/nio/channels/Channels.java
+++ b/src/java.base/share/classes/java/nio/channels/Channels.java
@@ -41,6 +41,7 @@ import java.nio.channels.spi.AbstractInterruptibleChannel;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import sun.nio.ch.ChannelInputStream;
+import sun.nio.ch.ChannelOutputStream;
 import sun.nio.cs.StreamDecoder;
 import sun.nio.cs.StreamEncoder;
 
@@ -62,40 +63,6 @@ import sun.nio.cs.StreamEncoder;
 public final class Channels {
 
     private Channels() { throw new Error("no instances"); }
-
-    /**
-     * Write all remaining bytes in buffer to the given channel.
-     * If the channel is selectable then it must be configured blocking.
-     */
-    private static void writeFullyImpl(WritableByteChannel ch, ByteBuffer bb)
-        throws IOException
-    {
-        while (bb.remaining() > 0) {
-            int n = ch.write(bb);
-            if (n <= 0)
-                throw new RuntimeException("no bytes written");
-        }
-    }
-
-    /**
-     * Write all remaining bytes in buffer to the given channel.
-     *
-     * @throws  IllegalBlockingModeException
-     *          If the channel is selectable and configured non-blocking.
-     */
-    private static void writeFully(WritableByteChannel ch, ByteBuffer bb)
-        throws IOException
-    {
-        if (ch instanceof SelectableChannel sc) {
-            synchronized (sc.blockingLock()) {
-                if (!sc.isBlocking())
-                    throw new IllegalBlockingModeException();
-                writeFullyImpl(ch, bb);
-            }
-        } else {
-            writeFullyImpl(ch, bb);
-        }
-    }
 
     // -- Byte streams from channels --
 
@@ -137,65 +104,6 @@ public final class Channels {
     public static OutputStream newOutputStream(WritableByteChannel ch) {
         Objects.requireNonNull(ch, "ch");
         return new ChannelOutputStream(ch);
-    }
-
-    /**
-     * @since 18
-     */
-    public static class ChannelOutputStream extends OutputStream {
-
-        private final WritableByteChannel ch;
-        private ByteBuffer bb;
-        private byte[] bs;       // Invoker's previous array
-        private byte[] b1;
-
-        /**
-         * @param ch The channel wrapped by this stream.
-         */
-        public ChannelOutputStream(WritableByteChannel ch) {
-            this.ch = ch;
-        }
-
-        /**
-         * @return The channel wrapped by this stream.
-         */
-        public WritableByteChannel channel() {
-            return ch;
-        }
-
-        @Override
-        public synchronized void write(int b) throws IOException {
-            if (b1 == null)
-                b1 = new byte[1];
-            b1[0] = (byte) b;
-            this.write(b1);
-        }
-
-        @Override
-        public synchronized void write(byte[] bs, int off, int len)
-                throws IOException
-        {
-            if ((off < 0) || (off > bs.length) || (len < 0) ||
-                ((off + len) > bs.length) || ((off + len) < 0)) {
-                throw new IndexOutOfBoundsException();
-            } else if (len == 0) {
-                return;
-            }
-            ByteBuffer bb = ((this.bs == bs)
-                             ? this.bb
-                             : ByteBuffer.wrap(bs));
-            bb.limit(Math.min(off + len, bb.capacity()));
-            bb.position(off);
-            this.bb = bb;
-            this.bs = bs;
-            Channels.writeFully(ch, bb);
-        }
-
-        @Override
-        public void close() throws IOException {
-            ch.close();
-        }
-
     }
 
     /**

--- a/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
@@ -172,10 +172,10 @@ public class ChannelInputStream
     private static long transfer(FileChannel src, WritableByteChannel dst) throws IOException {
         long bytesWritten = 0L;
         long srcPos = src.position();
-        long srcSize = src.size();
         try {
-            for (long n = srcSize - srcPos; bytesWritten < n;)
+            while (srcPos + bytesWritten < src.size()) {
                 bytesWritten += src.transferTo(srcPos + bytesWritten, Long.MAX_VALUE, dst);
+            }
             return bytesWritten;
         } finally {
             src.position(srcPos + bytesWritten);
@@ -186,10 +186,10 @@ public class ChannelInputStream
         long bytesWritten = 0L;
         long dstPos = dst.position();
         long srcPos = src.position();
-        long srcSize = src.size();
         try {
-            for (long n = srcSize - srcPos; bytesWritten < n;)
+            while (srcPos + bytesWritten < src.size()) {
                 bytesWritten += dst.transferFrom(src, dstPos + bytesWritten, Long.MAX_VALUE);
+            }
             return bytesWritten;
         } finally {
             dst.position(dstPos + bytesWritten);

--- a/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
@@ -201,18 +201,18 @@ public class ChannelInputStream
         long dstPos = dst.position();
         ByteBuffer bb = Util.getTemporaryDirectBuffer(TRANSFER_SIZE);
         try {
-            int r;
+            int bytesRead;
             do {
                 bytesWritten += dst.transferFrom(src, dstPos + bytesWritten, Long.MAX_VALUE);
-                r = src.read(bb); // detect end-of-stream
-                if (r > -1) {
+                bytesRead = src.read(bb); // detect end-of-stream
+                if (bytesRead > -1) {
                     bb.flip();
                     while (bb.hasRemaining())
                         dst.write(bb);
                     bb.clear();
-                    bytesWritten += r;
+                    bytesWritten += bytesRead;
                 }
-            } while (r > -1);
+            } while (bytesRead > -1);
             return bytesWritten;
         } finally {
             dst.position(dstPos + bytesWritten);
@@ -224,12 +224,12 @@ public class ChannelInputStream
         long bytesWritten = 0L;
         ByteBuffer bb = Util.getTemporaryDirectBuffer(TRANSFER_SIZE);
         try {
-            for (int r = src.read(bb); r > -1; r = src.read(bb)) {
+            for (int bytesRead = src.read(bb); bytesRead > -1; bytesRead = src.read(bb)) {
                 bb.flip();
                 while (bb.hasRemaining())
                     dst.write(bb);
                 bb.clear();
-                bytesWritten += r;
+                bytesWritten += bytesRead;
             }
             return bytesWritten;
         } finally {

--- a/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
@@ -146,6 +146,8 @@ public class ChannelInputStream
 
     @Override
     public long transferTo(OutputStream out) throws IOException {
+        Objects.requireNonNull(out, "out");
+
         if (out instanceof ChannelOutputStream cos) {
             WritableByteChannel oc = cos.channel();
 

--- a/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
@@ -156,6 +156,9 @@ public class ChannelInputStream
             }
 
             if (wbc instanceof FileChannel fc) {
+                if (ch instanceof SelectableChannel sc && !sc.isBlocking())
+                    throw new IllegalBlockingModeException();
+
                 if (ch instanceof SeekableByteChannel sbc) {
                     return transfer(sbc, fc);
                 }

--- a/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
@@ -145,37 +145,37 @@ public class ChannelInputStream
     private static final int TRANSFER_SIZE = 8192;
 
     @Override
-    public long transferTo(final OutputStream out) throws IOException {
+    public long transferTo(OutputStream out) throws IOException {
         if (out instanceof Channels.ChannelOutputStream) {
-            final var oc = ((Channels.ChannelOutputStream) out).channel();
+            var oc = ((Channels.ChannelOutputStream) out).channel();
 
             if (ch instanceof FileChannel) {
-                final var fc = (FileChannel) ch;
-                final var pos = fc.position();
-                final var size = fc.size();
+                var fc = (FileChannel) ch;
+                var pos = fc.position();
+                var size = fc.size();
                 var i = 0L;
-                for (final var n = size - pos; i < n;
+                for (var n = size - pos; i < n;
                   i += fc.transferTo(pos + i, Long.MAX_VALUE, oc));
                 fc.position(size);
                 return i;
             }
 
             if (oc instanceof FileChannel) {
-                final var fc = (FileChannel) oc;
-                final var fcpos = fc.position();
+                var fc = (FileChannel) oc;
+                var fcpos = fc.position();
 
                 if (ch instanceof SeekableByteChannel) {
-                    final var pos = ((SeekableByteChannel) ch).position();
-                    final var size = ((SeekableByteChannel) ch).size();
+                    var pos = ((SeekableByteChannel) ch).position();
+                    var size = ((SeekableByteChannel) ch).size();
                     var i = 0L;
-                    for (final var n = size - pos; i < n;
+                    for (var n = size - pos; i < n;
                       i += fc.transferFrom(ch, fcpos + i, Long.MAX_VALUE));
                     fc.position(fcpos + i);
                     return i;
                 }
 
                 try {
-                    final var bb = Util.getTemporaryDirectBuffer(TRANSFER_SIZE);
+                    var bb = Util.getTemporaryDirectBuffer(TRANSFER_SIZE);
                     var i = 0L;
                     int r;
                     do {
@@ -197,7 +197,7 @@ public class ChannelInputStream
             }
 
             try {
-                final var bb = Util.getTemporaryDirectBuffer(TRANSFER_SIZE);
+                var bb = Util.getTemporaryDirectBuffer(TRANSFER_SIZE);
                 var i = 0L;
                 for (var r = ch.read(bb); r > -1; r = ch.read(bb)) {
                     bb.flip();

--- a/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
@@ -147,36 +147,36 @@ public class ChannelInputStream
     @Override
     public long transferTo(OutputStream out) throws IOException {
         if (out instanceof ChannelOutputStream) {
-            var oc = ((ChannelOutputStream) out).channel();
+            WritableByteChannel oc = ((ChannelOutputStream) out).channel();
 
             if (ch instanceof FileChannel) {
-                var fc = (FileChannel) ch;
-                var pos = fc.position();
-                var size = fc.size();
-                var i = 0L;
-                for (var n = size - pos; i < n;
+                FileChannel fc = (FileChannel) ch;
+                long pos = fc.position();
+                long size = fc.size();
+                long i = 0L;
+                for (long n = size - pos; i < n;
                   i += fc.transferTo(pos + i, Long.MAX_VALUE, oc));
                 fc.position(size);
                 return i;
             }
 
             if (oc instanceof FileChannel) {
-                var fc = (FileChannel) oc;
-                var fcpos = fc.position();
+                FileChannel fc = (FileChannel) oc;
+                long fcpos = fc.position();
 
                 if (ch instanceof SeekableByteChannel) {
-                    var pos = ((SeekableByteChannel) ch).position();
-                    var size = ((SeekableByteChannel) ch).size();
-                    var i = 0L;
-                    for (var n = size - pos; i < n;
+                    long pos = ((SeekableByteChannel) ch).position();
+                    long size = ((SeekableByteChannel) ch).size();
+                    long i = 0L;
+                    for (long n = size - pos; i < n;
                       i += fc.transferFrom(ch, fcpos + i, Long.MAX_VALUE));
                     fc.position(fcpos + i);
                     return i;
                 }
 
                 try {
-                    var bb = Util.getTemporaryDirectBuffer(TRANSFER_SIZE);
-                    var i = 0L;
+                    ByteBuffer bb = Util.getTemporaryDirectBuffer(TRANSFER_SIZE);
+                    long i = 0L;
                     int r;
                     do {
                         i += fc.transferFrom(ch, fcpos + i, Long.MAX_VALUE);
@@ -197,9 +197,9 @@ public class ChannelInputStream
             }
 
             try {
-                var bb = Util.getTemporaryDirectBuffer(TRANSFER_SIZE);
-                var i = 0L;
-                for (var r = ch.read(bb); r > -1; r = ch.read(bb)) {
+                ByteBuffer bb = Util.getTemporaryDirectBuffer(TRANSFER_SIZE);
+                long i = 0L;
+                for (int r = ch.read(bb); r > -1; r = ch.read(bb)) {
                     bb.flip();
                     while (bb.hasRemaining())
                       oc.write(bb);

--- a/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
@@ -146,11 +146,10 @@ public class ChannelInputStream
 
     @Override
     public long transferTo(OutputStream out) throws IOException {
-        if (out instanceof ChannelOutputStream) {
-            WritableByteChannel oc = ((ChannelOutputStream) out).channel();
+        if (out instanceof ChannelOutputStream cos) {
+            WritableByteChannel oc = cos.channel();
 
-            if (ch instanceof FileChannel) {
-                FileChannel fc = (FileChannel) ch;
+            if (ch instanceof FileChannel fc) {
                 long pos = fc.position();
                 long size = fc.size();
                 long i = 0L;
@@ -160,13 +159,12 @@ public class ChannelInputStream
                 return i;
             }
 
-            if (oc instanceof FileChannel) {
-                FileChannel fc = (FileChannel) oc;
+            if (oc instanceof FileChannel fc) {
                 long fcpos = fc.position();
 
-                if (ch instanceof SeekableByteChannel) {
-                    long pos = ((SeekableByteChannel) ch).position();
-                    long size = ((SeekableByteChannel) ch).size();
+                if (ch instanceof SeekableByteChannel sbc) {
+                    long pos = sbc.position();
+                    long size = sbc.size();
                     long i = 0L;
                     for (long n = size - pos; i < n;
                       i += fc.transferFrom(ch, fcpos + i, Long.MAX_VALUE));

--- a/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
@@ -172,8 +172,8 @@ public class ChannelInputStream
                     return i;
                 }
 
+                ByteBuffer bb = Util.getTemporaryDirectBuffer(TRANSFER_SIZE);
                 try {
-                    ByteBuffer bb = Util.getTemporaryDirectBuffer(TRANSFER_SIZE);
                     long i = 0L;
                     int r;
                     do {
@@ -194,8 +194,8 @@ public class ChannelInputStream
                 }
             }
 
+            ByteBuffer bb = Util.getTemporaryDirectBuffer(TRANSFER_SIZE);
             try {
-                ByteBuffer bb = Util.getTemporaryDirectBuffer(TRANSFER_SIZE);
                 long i = 0L;
                 for (int r = ch.read(bb); r > -1; r = ch.read(bb)) {
                     bb.flip();

--- a/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
@@ -146,8 +146,8 @@ public class ChannelInputStream
 
     @Override
     public long transferTo(OutputStream out) throws IOException {
-        if (out instanceof Channels.ChannelOutputStream) {
-            var oc = ((Channels.ChannelOutputStream) out).channel();
+        if (out instanceof ChannelOutputStream) {
+            var oc = ((ChannelOutputStream) out).channel();
 
             if (ch instanceof FileChannel) {
                 var fc = (FileChannel) ch;

--- a/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
@@ -153,8 +153,8 @@ public class ChannelInputStream
                 long pos = fc.position();
                 long size = fc.size();
                 long i = 0L;
-                for (long n = size - pos; i < n;
-                  i += fc.transferTo(pos + i, Long.MAX_VALUE, oc));
+                for (long n = size - pos; i < n;)
+                    i += fc.transferTo(pos + i, Long.MAX_VALUE, oc);
                 fc.position(size);
                 return i;
             }
@@ -166,8 +166,8 @@ public class ChannelInputStream
                     long pos = sbc.position();
                     long size = sbc.size();
                     long i = 0L;
-                    for (long n = size - pos; i < n;
-                      i += fc.transferFrom(ch, fcpos + i, Long.MAX_VALUE));
+                    for (long n = size - pos; i < n;)
+                        i += fc.transferFrom(ch, fcpos + i, Long.MAX_VALUE);
                     fc.position(fcpos + i);
                     return i;
                 }
@@ -182,7 +182,7 @@ public class ChannelInputStream
                         if (r > -1) {
                             bb.flip();
                             while (bb.hasRemaining())
-                              oc.write(bb);
+                                oc.write(bb);
                             bb.clear();
                             i += r;
                         }
@@ -200,7 +200,7 @@ public class ChannelInputStream
                 for (int r = ch.read(bb); r > -1; r = ch.read(bb)) {
                     bb.flip();
                     while (bb.hasRemaining())
-                      oc.write(bb);
+                        oc.write(bb);
                     bb.clear();
                     i += r;
                 }

--- a/src/java.base/share/classes/sun/nio/ch/ChannelOutputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelOutputStream.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.nio.ch;
+
+import java.io.*;
+import java.nio.*;
+import java.nio.channels.*;
+import java.nio.channels.spi.*;
+import java.util.Objects;
+
+/**
+ * This class is defined here rather than in java.nio.channels.Channels
+ * so that it will be visible to java.nio.channels.Channels and
+ * sun.nio.ch.ChannelInputStream but not be part of the java.base module API.
+ *
+ *
+ * @author Mark Reinhold
+ * @author Mike McCloskey
+ * @author JSR-51 Expert Group
+ * @since 18
+ */
+public class ChannelOutputStream extends OutputStream {
+
+    /**
+     * Write all remaining bytes in buffer to the given channel.
+     * If the channel is selectable then it must be configured blocking.
+     */
+    private static void writeFullyImpl(WritableByteChannel ch, ByteBuffer bb)
+        throws IOException
+    {
+        while (bb.remaining() > 0) {
+            int n = ch.write(bb);
+            if (n <= 0)
+                throw new RuntimeException("no bytes written");
+        }
+    }
+
+    /**
+     * Write all remaining bytes in buffer to the given channel.
+     *
+     * @throws  IllegalBlockingModeException
+     *          If the channel is selectable and configured non-blocking.
+     */
+    private static void writeFully(WritableByteChannel ch, ByteBuffer bb)
+        throws IOException
+    {
+        if (ch instanceof SelectableChannel sc) {
+            synchronized (sc.blockingLock()) {
+                if (!sc.isBlocking())
+                    throw new IllegalBlockingModeException();
+                writeFullyImpl(ch, bb);
+            }
+        } else {
+            writeFullyImpl(ch, bb);
+        }
+    }
+
+    private final WritableByteChannel ch;
+    private ByteBuffer bb;
+    private byte[] bs;       // Invoker's previous array
+    private byte[] b1;
+
+    /**
+     * @param ch The channel wrapped by this stream.
+     */
+    public ChannelOutputStream(WritableByteChannel ch) {
+        this.ch = ch;
+    }
+
+    /**
+     * @return The channel wrapped by this stream.
+     */
+    WritableByteChannel channel() {
+        return ch;
+    }
+
+    @Override
+    public synchronized void write(int b) throws IOException {
+        if (b1 == null)
+            b1 = new byte[1];
+        b1[0] = (byte) b;
+        this.write(b1);
+    }
+
+    @Override
+    public synchronized void write(byte[] bs, int off, int len)
+        throws IOException {
+        if ((off < 0) || (off > bs.length) || (len < 0) ||
+            ((off + len) > bs.length) || ((off + len) < 0)) {
+            throw new IndexOutOfBoundsException();
+        } else if (len == 0) {
+            return;
+        }
+        ByteBuffer bb = ((this.bs == bs)
+                         ? this.bb
+                         : ByteBuffer.wrap(bs));
+        bb.limit(Math.min(off + len, bb.capacity()));
+        bb.position(off);
+        this.bb = bb;
+        this.bs = bs;
+        writeFully(ch, bb);
+    }
+
+    @Override
+    public void close() throws IOException {
+        ch.close();
+    }
+
+}

--- a/src/java.base/share/classes/sun/nio/ch/ChannelOutputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelOutputStream.java
@@ -108,10 +108,8 @@ public class ChannelOutputStream extends OutputStream {
     @Override
     public synchronized void write(byte[] bs, int off, int len)
         throws IOException {
-        if ((off < 0) || (off > bs.length) || (len < 0) ||
-            ((off + len) > bs.length) || ((off + len) < 0)) {
-            throw new IndexOutOfBoundsException();
-        } else if (len == 0) {
+        Objects.checkFromIndexSize(off, len, bs.length);
+        if (len == 0) {
             return;
         }
         ByteBuffer bb = ((this.bs == bs)

--- a/test/jdk/sun/nio/ch/ChannelInputStream/TransferTo.java
+++ b/test/jdk/sun/nio/ch/ChannelInputStream/TransferTo.java
@@ -23,508 +23,211 @@
 
 import static java.lang.String.format;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.FilterInputStream;
-import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.ByteBuffer;
-import java.nio.MappedByteBuffer;
+import java.net.URI;
+import java.net.URLDecoder;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
-import java.nio.channels.FileLock;
-import java.nio.channels.ReadableByteChannel;
-import java.nio.channels.WritableByteChannel;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 
 /*
  * @test
- * @bug 8066867
+ * @bug 8265891
  * @summary tests whether sun.nio.ChannelInputStream.transferTo conforms to the
  *          InputStream.transferTo contract defined in the javadoc
  * @key randomness
  */
 public class TransferTo {
 
-	public static void main(String[] args) throws IOException {
-		test(defaultInput(), defaultOutput());
-		test(fileChannelInput(), defaultOutput());
-	}
-
-	private static void test(InputStreamProvider inputStreamProvider, OutputStreamProvider outputStreamProvider) throws IOException {
-		ifOutIsNullThenNpeIsThrown(inputStreamProvider, outputStreamProvider);
-		ifExceptionInInputNeitherStreamIsClosed(inputStreamProvider, outputStreamProvider);
-		ifExceptionInOutputNeitherStreamIsClosed(inputStreamProvider, outputStreamProvider);
-		onReturnNeitherStreamIsClosed(inputStreamProvider, outputStreamProvider);
-		onReturnInputIsAtEnd(inputStreamProvider, outputStreamProvider);
-		contents(inputStreamProvider, outputStreamProvider);
-	}
-
-	private static void ifOutIsNullThenNpeIsThrown(InputStreamProvider inputStreamProvider, OutputStreamProvider outputStreamProvider) throws IOException {
-		try (InputStream in = inputStreamProvider.input()) {
-			assertThrowsNPE(() -> in.transferTo(null), "out");
-		}
-
-		try (InputStream in = inputStreamProvider.input((byte) 1)) {
-			assertThrowsNPE(() -> in.transferTo(null), "out");
-		}
-
-		try (InputStream in = inputStreamProvider.input((byte) 1, (byte) 2)) {
-			assertThrowsNPE(() -> in.transferTo(null), "out");
-		}
-
-		InputStream in = null;
-		try {
-			InputStream fin = in = inputStreamProvider.newThrowingInputStream();
-			// null check should precede everything else:
-			// InputStream shouldn't be touched if OutputStream is null
-			assertThrowsNPE(() -> fin.transferTo(null), "out");
-		} finally {
-			if (in != null)
-				try {
-					in.close();
-				} catch (IOException ignored) {
-				}
-		}
-	}
-
-	private static void ifExceptionInInputNeitherStreamIsClosed(InputStreamProvider inputStreamProvider, OutputStreamProvider outputStreamProvider)
-			throws IOException {
-		transferToThenCheckIfAnyClosed(inputStreamProvider.input(0, new byte[] { 1, 2, 3 }), outputStreamProvider.output());
-		transferToThenCheckIfAnyClosed(inputStreamProvider.input(1, new byte[] { 1, 2, 3 }), outputStreamProvider.output());
-		transferToThenCheckIfAnyClosed(inputStreamProvider.input(2, new byte[] { 1, 2, 3 }), outputStreamProvider.output());
-	}
-
-	private static void ifExceptionInOutputNeitherStreamIsClosed(InputStreamProvider inputStreamProvider, OutputStreamProvider outputStreamProvider)
-			throws IOException {
-		transferToThenCheckIfAnyClosed(inputStreamProvider.input(new byte[] { 1, 2, 3 }), outputStreamProvider.output(0));
-		transferToThenCheckIfAnyClosed(inputStreamProvider.input(new byte[] { 1, 2, 3 }), outputStreamProvider.output(1));
-		transferToThenCheckIfAnyClosed(inputStreamProvider.input(new byte[] { 1, 2, 3 }), outputStreamProvider.output(2));
-	}
-
-	private static void transferToThenCheckIfAnyClosed(InputStream input, OutputStream output) throws IOException {
-		try (CloseLoggingInputStream in = new CloseLoggingInputStream(input); CloseLoggingOutputStream out = new CloseLoggingOutputStream(output)) {
-			boolean thrown = false;
-			try {
-				in.transferTo(out);
-			} catch (IOException ignored) {
-				thrown = true;
-			}
-			if (!thrown)
-				throw new AssertionError();
-
-			if (in.wasClosed() || out.wasClosed())
-				throw new AssertionError();
-		}
-	}
-
-	private static void onReturnNeitherStreamIsClosed(InputStreamProvider inputStreamProvider, OutputStreamProvider outputStreamProvider) throws IOException {
-		try (CloseLoggingInputStream in = new CloseLoggingInputStream(inputStreamProvider.input(new byte[] { 1, 2, 3 }));
-				CloseLoggingOutputStream out = new CloseLoggingOutputStream(outputStreamProvider.output())) {
-
-			in.transferTo(out);
-
-			if (in.wasClosed() || out.wasClosed())
-				throw new AssertionError();
-		}
-	}
-
-	private static void onReturnInputIsAtEnd(InputStreamProvider inputStreamProvider, OutputStreamProvider outputStreamProvider) throws IOException {
-		try (InputStream in = inputStreamProvider.input(new byte[] { 1, 2, 3 }); OutputStream out = outputStreamProvider.output()) {
-
-			in.transferTo(out);
-
-			if (in.read() != -1)
-				throw new AssertionError();
-		}
-	}
-
-	private static void contents(InputStreamProvider inputStreamProvider, OutputStreamProvider outputStreamProvider) throws IOException {
-		checkTransferredContents(inputStreamProvider, outputStreamProvider, new byte[0]);
-		checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(1024, 4096));
-		// to span through several batches
-		checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(16384, 16384));
-	}
-
-	private static void checkTransferredContents(InputStreamProvider inputStreamProvider, OutputStreamProvider outputStreamProvider, byte[] bytes)
-			throws IOException {
-		try (InputStream in = inputStreamProvider.input(bytes); RecordingOutputStream out = outputStreamProvider.recordingOutput()) {
-			in.transferTo(out);
-
-			byte[] outBytes = out.toByteArray();
-			if (!Arrays.equals(bytes, outBytes))
-				throw new AssertionError(format("bytes.length=%s, outBytes.length=%s", bytes.length, outBytes.length));
-		}
-	}
-
-	private static byte[] createRandomBytes(int min, int maxRandomAdditive) {
-		Random rnd = new Random();
-		byte[] bytes = new byte[min + rnd.nextInt(maxRandomAdditive)];
-		rnd.nextBytes(bytes);
-		return bytes;
-	}
-
-	private static interface InputStreamProvider {
-		InputStream input(byte... bytes);
-
-		InputStream input(int exceptionPosition, byte... bytes);
-
-		InputStream newThrowingInputStream();
-	}
-
-	private static abstract class RecordingOutputStream extends OutputStream {
-		abstract byte[] toByteArray();
-	}
-
-	private static interface OutputStreamProvider {
-		OutputStream output();
-
-		OutputStream output(int exceptionPosition);
-
-		RecordingOutputStream recordingOutput();
-	}
-
-	private static InputStreamProvider defaultInput() {
-		return new InputStreamProvider() {
-
-			@Override
-			public InputStream input(byte... bytes) {
-				return this.input(-1, bytes);
-			}
-
-			@Override
-			public InputStream input(int exceptionPosition, byte... bytes) {
-				return new InputStream() {
-
-					int pos;
-
-					@Override
-					public int read() throws IOException {
-						if (this.pos == exceptionPosition)
-							// because of the pesky IOException swallowing in
-							// java.io.InputStream.read(byte[], int, int)
-							// pos++;
-							throw new IOException();
-
-						if (this.pos >= bytes.length)
-							return -1;
-						return bytes[this.pos++] & 0xff;
-					}
-				};
-			}
-
-			@Override
-			public InputStream newThrowingInputStream() {
-				return new InputStream() {
-
-					boolean closed;
-
-					@Override
-					public int read(byte[] b) throws IOException {
-						throw new IOException();
-					}
-
-					@Override
-					public int read(byte[] b, int off, int len) throws IOException {
-						throw new IOException();
-					}
-
-					@Override
-					public long skip(long n) throws IOException {
-						throw new IOException();
-					}
-
-					@Override
-					public int available() throws IOException {
-						throw new IOException();
-					}
-
-					@Override
-					public void close() throws IOException {
-						if (!this.closed) {
-							this.closed = true;
-							throw new IOException();
-						}
-					}
-
-					@Override
-					public void reset() throws IOException {
-						throw new IOException();
-					}
-
-					@Override
-					public int read() throws IOException {
-						throw new IOException();
-					}
-				};
-			}
-		};
-	}
-
-	private static OutputStreamProvider defaultOutput() {
-		return new OutputStreamProvider() {
-
-			@Override
-			public OutputStream output() {
-				return this.output(-1);
-			}
-
-			@Override
-			public OutputStream output(int exceptionPosition) {
-				return new OutputStream() {
-
-					int pos;
-
-					@Override
-					public void write(int b) throws IOException {
-						if (this.pos++ == exceptionPosition)
-							throw new IOException();
-					}
-				};
-			}
-
-			@Override
-			public RecordingOutputStream recordingOutput() {
-				return new RecordingOutputStream() {
-					private ByteArrayOutputStream recorder = new ByteArrayOutputStream();
-
-					@Override
-					public void write(int b) {
-						this.recorder.write(b);
-					}
-
-					@Override
-					byte[] toByteArray() {
-						return this.recorder.toByteArray();
-					}
-				};
-			}
-		};
-	}
-
-	private static InputStreamProvider fileChannelInput() {
-		return new InputStreamProvider() {
-
-			@Override
-			public InputStream input(byte... bytes) {
-				return this.input(-1, bytes);
-			}
-
-			@Override
-			public InputStream input(int exceptionPosition, byte... bytes) {
-				return Channels.newInputStream(new AbstractFileChannel() {
-
-					@Override
-					public long transferTo(long position, long count, WritableByteChannel target) throws IOException {
-						int bytesToWrite = (int) (exceptionPosition < 0 ? count : exceptionPosition - position);
-						ByteBuffer buffer = ByteBuffer.wrap(bytes, (int) position, bytesToWrite);
-						int bytesWritten = target.write(buffer);
-						if (exceptionPosition >= 0)
-							throw new IOException();
-						return bytesWritten;
-					}
-				});
-			}
-
-			@Override
-			public InputStream newThrowingInputStream() {
-				return new InputStream() {
-
-					boolean closed;
-
-					@Override
-					public int read(byte[] b) throws IOException {
-						throw new IOException();
-					}
-
-					@Override
-					public int read(byte[] b, int off, int len) throws IOException {
-						throw new IOException();
-					}
-
-					@Override
-					public long skip(long n) throws IOException {
-						throw new IOException();
-					}
-
-					@Override
-					public int available() throws IOException {
-						throw new IOException();
-					}
-
-					@Override
-					public void close() throws IOException {
-						if (!this.closed) {
-							this.closed = true;
-							throw new IOException();
-						}
-					}
-
-					@Override
-					public void reset() throws IOException {
-						throw new IOException();
-					}
-
-					@Override
-					public int read() throws IOException {
-						throw new IOException();
-					}
-				};
-			}
-		};
-	}
-
-	private static class CloseLoggingInputStream extends FilterInputStream {
-
-		boolean closed;
-
-		CloseLoggingInputStream(InputStream in) {
-			super(in);
-		}
-
-		@Override
-		public void close() throws IOException {
-			this.closed = true;
-			super.close();
-		}
-
-		boolean wasClosed() {
-			return this.closed;
-		}
-	}
-
-	private static class CloseLoggingOutputStream extends FilterOutputStream {
-
-		boolean closed;
-
-		CloseLoggingOutputStream(OutputStream out) {
-			super(out);
-		}
-
-		@Override
-		public void close() throws IOException {
-			this.closed = true;
-			super.close();
-		}
-
-		boolean wasClosed() {
-			return this.closed;
-		}
-	}
-
-	public interface Thrower {
-		public void run() throws Throwable;
-	}
-
-	public static void assertThrowsNPE(Thrower thrower, String message) {
-		assertThrows(thrower, NullPointerException.class, message);
-	}
-
-	public static <T extends Throwable> void assertThrows(Thrower thrower, Class<T> throwable, String message) {
-		Throwable thrown;
-		try {
-			thrower.run();
-			thrown = null;
-		} catch (Throwable caught) {
-			thrown = caught;
-		}
-
-		if (!throwable.isInstance(thrown)) {
-			String caught = thrown == null ? "nothing" : thrown.getClass().getCanonicalName();
-			throw new AssertionError(format("Expected to catch %s, but caught %s", throwable, caught), thrown);
-		}
-
-		if (thrown != null && !message.equals(thrown.getMessage()))
-			throw new AssertionError(format("Expected exception message to be '%s', but it's '%s'", message, thrown.getMessage()));
-	}
-
-	private static abstract class AbstractFileChannel extends FileChannel {
-
-		@Override
-		public int read(ByteBuffer dst) throws IOException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public long read(ByteBuffer[] dsts, int offset, int length) throws IOException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public int write(ByteBuffer src) throws IOException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public long position() throws IOException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public FileChannel position(long newPosition) throws IOException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public long size() throws IOException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public FileChannel truncate(long size) throws IOException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void force(boolean metaData) throws IOException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public long transferTo(long position, long count, WritableByteChannel target) throws IOException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public long transferFrom(ReadableByteChannel src, long position, long count) throws IOException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public int read(ByteBuffer dst, long position) throws IOException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public int write(ByteBuffer src, long position) throws IOException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public MappedByteBuffer map(MapMode mode, long position, long size) throws IOException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public FileLock lock(long position, long size, boolean shared) throws IOException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public FileLock tryLock(long position, long size, boolean shared) throws IOException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		protected void implCloseChannel() throws IOException {
-			// do nothing
-		}
-	}
+    public static void main(String[] args) throws Exception {
+        test(fileChannelInput(), writableByteChannelOutput());
+        test(seekableByteChannelInput(), fileChannelOutput());
+        test(readableByteChannelInput(), fileChannelOutput());
+        test(readableByteChannelInput(), writableByteChannelOutput());
+        test(readableByteChannelInput(), defaultOutput());
+    }
+
+    private static void test(InputStreamProvider inputStreamProvider, OutputStreamProvider outputStreamProvider)
+            throws Exception {
+        ifOutIsNullThenNpeIsThrown(inputStreamProvider);
+        contents(inputStreamProvider, outputStreamProvider);
+    }
+
+    private static void ifOutIsNullThenNpeIsThrown(InputStreamProvider inputStreamProvider) throws Exception {
+        try (InputStream in = inputStreamProvider.input()) {
+            assertThrowsNPE(() -> in.transferTo(null), "out");
+        }
+
+        try (InputStream in = inputStreamProvider.input((byte) 1)) {
+            assertThrowsNPE(() -> in.transferTo(null), "out");
+        }
+
+        try (InputStream in = inputStreamProvider.input((byte) 1, (byte) 2)) {
+            assertThrowsNPE(() -> in.transferTo(null), "out");
+        }
+    }
+
+    private static void contents(InputStreamProvider inputStreamProvider, OutputStreamProvider outputStreamProvider)
+            throws Exception {
+        checkTransferredContents(inputStreamProvider, outputStreamProvider, new byte[0]);
+        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(1024, 4096));
+        // to span through several batches
+        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(16384, 16384));
+    }
+
+    private static void checkTransferredContents(InputStreamProvider inputStreamProvider,
+            OutputStreamProvider outputStreamProvider, byte[] inBytes) throws Exception {
+        AtomicReference<Supplier<byte[]>> recorder = new AtomicReference<>();
+        try (InputStream in = inputStreamProvider.input(inBytes);
+                OutputStream out = outputStreamProvider.output(recorder::set)) {
+            in.transferTo(out);
+
+            byte[] outBytes = recorder.get().get();
+
+            if (!Arrays.equals(inBytes, outBytes))
+                throw new AssertionError(
+                        format("bytes.length=%s, outBytes.length=%s", inBytes.length, outBytes.length));
+        }
+    }
+
+    private static byte[] createRandomBytes(int min, int maxRandomAdditive) {
+        Random rnd = new Random();
+        byte[] bytes = new byte[min + rnd.nextInt(maxRandomAdditive)];
+        rnd.nextBytes(bytes);
+        return bytes;
+    }
+
+    private static interface InputStreamProvider {
+        InputStream input(byte... bytes) throws Exception;
+    }
+
+    private static interface OutputStreamProvider {
+        OutputStream output(Consumer<Supplier<byte[]>> spy) throws Exception;
+    }
+
+    private static OutputStreamProvider defaultOutput() {
+        return new OutputStreamProvider() {
+            @Override
+            public OutputStream output(Consumer<Supplier<byte[]>> spy) {
+                ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+                spy.accept(outputStream::toByteArray);
+                return outputStream;
+            }
+        };
+    }
+
+    private static InputStreamProvider fileChannelInput() {
+        return new InputStreamProvider() {
+            @Override
+            public InputStream input(byte... bytes) throws Exception {
+                Path path = Files.createTempFile(null, null);
+                Files.write(path, bytes);
+                FileChannel fileChannel = FileChannel.open(path);
+                return Channels.newInputStream(fileChannel);
+            }
+        };
+    }
+
+    private static InputStreamProvider seekableByteChannelInput() {
+        return new InputStreamProvider() {
+            @Override
+            public InputStream input(byte... bytes) throws Exception {
+                Path temporaryJarFile = Files.createTempFile(null, ".zip");
+                try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(temporaryJarFile))) {
+                    JarEntry jarEntry = new JarEntry("raw-bytes");
+                    out.putNextEntry(jarEntry);
+                    out.write(bytes);
+                    out.closeEntry();
+                }
+                FileSystem zipFileSystem = FileSystems.newFileSystem(new URI("jar",
+                        URLDecoder.decode(temporaryJarFile.toUri().toString(), StandardCharsets.UTF_8), null),
+                        Collections.emptyMap(), null);
+                SeekableByteChannel sbc = zipFileSystem.provider().newByteChannel(zipFileSystem.getPath("raw-bytes"),
+                        Collections.singleton(StandardOpenOption.READ));
+                return Channels.newInputStream(sbc);
+            }
+        };
+    }
+
+    private static InputStreamProvider readableByteChannelInput() {
+        return new InputStreamProvider() {
+            @Override
+            public InputStream input(byte... bytes) throws Exception {
+                return Channels.newInputStream(Channels.newChannel(new ByteArrayInputStream(bytes)));
+            }
+        };
+    }
+
+    private static OutputStreamProvider fileChannelOutput() {
+        return new OutputStreamProvider() {
+            public OutputStream output(Consumer<Supplier<byte[]>> spy) throws Exception {
+                Path path = Files.createTempFile(null, null);
+                FileChannel fileChannel = FileChannel.open(path, StandardOpenOption.WRITE);
+                spy.accept(() -> {
+                    try {
+                        return Files.readAllBytes(path);
+                    } catch (IOException e) {
+                        return null;
+                    }
+                });
+                return Channels.newOutputStream(fileChannel);
+            }
+        };
+    }
+
+    private static OutputStreamProvider writableByteChannelOutput() {
+        return new OutputStreamProvider() {
+            public OutputStream output(Consumer<Supplier<byte[]>> spy) throws Exception {
+                ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+                spy.accept(outputStream::toByteArray);
+                return Channels.newOutputStream(Channels.newChannel(outputStream));
+            }
+        };
+    }
+
+    public interface Thrower {
+        public void run() throws Throwable;
+    }
+
+    public static void assertThrowsNPE(Thrower thrower, String message) {
+        assertThrows(thrower, NullPointerException.class, message);
+    }
+
+    public static <T extends Throwable> void assertThrows(Thrower thrower, Class<T> throwable, String message) {
+        Throwable thrown;
+        try {
+            thrower.run();
+            thrown = null;
+        } catch (Throwable caught) {
+            thrown = caught;
+        }
+
+        if (!throwable.isInstance(thrown)) {
+            String caught = thrown == null ? "nothing" : thrown.getClass().getCanonicalName();
+            throw new AssertionError(format("Expected to catch %s, but caught %s", throwable, caught), thrown);
+        }
+
+        if (thrown != null && !message.equals(thrown.getMessage())) {
+            throw new AssertionError(
+                    format("Expected exception message to be '%s', but it's '%s'", message, thrown.getMessage()));
+        }
+    }
 }

--- a/test/jdk/sun/nio/ch/ChannelInputStream/sun/nio/ch/TransferTo.java
+++ b/test/jdk/sun/nio/ch/ChannelInputStream/sun/nio/ch/TransferTo.java
@@ -1,0 +1,524 @@
+package sun.nio.ch;
+/*
+ * Copyright (c) 2014, 2021 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import static java.lang.String.format;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FilterInputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.util.Arrays;
+import java.util.Random;
+
+/*
+ * @test
+ * @bug 8066867
+ * @summary tests whether sun.nio.ChannelInputStream.transferTo conforms to the
+ *          InputStream.transferTo contract defined in the javadoc
+ * @key randomness
+ */
+public class TransferTo {
+
+	public static void main(final String[] args) throws IOException {
+		test(defaultInput(), defaultOutput());
+		test(fileChannelInput(), defaultOutput());
+	}
+
+	private static void test(final InputStreamProvider inputStreamProvider, final OutputStreamProvider outputStreamProvider) throws IOException {
+		ifOutIsNullThenNpeIsThrown(inputStreamProvider, outputStreamProvider);
+		ifExceptionInInputNeitherStreamIsClosed(inputStreamProvider, outputStreamProvider);
+		ifExceptionInOutputNeitherStreamIsClosed(inputStreamProvider, outputStreamProvider);
+		onReturnNeitherStreamIsClosed(inputStreamProvider, outputStreamProvider);
+		onReturnInputIsAtEnd(inputStreamProvider, outputStreamProvider);
+		contents(inputStreamProvider, outputStreamProvider);
+	}
+
+	private static void ifOutIsNullThenNpeIsThrown(final InputStreamProvider inputStreamProvider, final OutputStreamProvider outputStreamProvider)
+			throws IOException {
+		try (InputStream in = inputStreamProvider.input()) {
+			assertThrowsNPE(() -> in.transferTo(null), "out");
+		}
+
+		try (InputStream in = inputStreamProvider.input((byte) 1)) {
+			assertThrowsNPE(() -> in.transferTo(null), "out");
+		}
+
+		try (InputStream in = inputStreamProvider.input((byte) 1, (byte) 2)) {
+			assertThrowsNPE(() -> in.transferTo(null), "out");
+		}
+
+		InputStream in = null;
+		try {
+			final InputStream fin = in = inputStreamProvider.newThrowingInputStream();
+			// null check should precede everything else:
+			// InputStream shouldn't be touched if OutputStream is null
+			assertThrowsNPE(() -> fin.transferTo(null), "out");
+		} finally {
+			if (in != null)
+				try {
+					in.close();
+				} catch (final IOException ignored) {
+				}
+		}
+	}
+
+	private static void ifExceptionInInputNeitherStreamIsClosed(final InputStreamProvider inputStreamProvider, final OutputStreamProvider outputStreamProvider)
+			throws IOException {
+		transferToThenCheckIfAnyClosed(inputStreamProvider.input(0, new byte[] { 1, 2, 3 }), outputStreamProvider.output());
+		transferToThenCheckIfAnyClosed(inputStreamProvider.input(1, new byte[] { 1, 2, 3 }), outputStreamProvider.output());
+		transferToThenCheckIfAnyClosed(inputStreamProvider.input(2, new byte[] { 1, 2, 3 }), outputStreamProvider.output());
+	}
+
+	private static void ifExceptionInOutputNeitherStreamIsClosed(final InputStreamProvider inputStreamProvider, final OutputStreamProvider outputStreamProvider)
+			throws IOException {
+		transferToThenCheckIfAnyClosed(inputStreamProvider.input(new byte[] { 1, 2, 3 }), outputStreamProvider.output(0));
+		transferToThenCheckIfAnyClosed(inputStreamProvider.input(new byte[] { 1, 2, 3 }), outputStreamProvider.output(1));
+		transferToThenCheckIfAnyClosed(inputStreamProvider.input(new byte[] { 1, 2, 3 }), outputStreamProvider.output(2));
+	}
+
+	private static void transferToThenCheckIfAnyClosed(final InputStream input, final OutputStream output) throws IOException {
+		try (CloseLoggingInputStream in = new CloseLoggingInputStream(input); CloseLoggingOutputStream out = new CloseLoggingOutputStream(output)) {
+			boolean thrown = false;
+			try {
+				in.transferTo(out);
+			} catch (final IOException ignored) {
+				thrown = true;
+			}
+			if (!thrown)
+				throw new AssertionError();
+
+			if (in.wasClosed() || out.wasClosed())
+				throw new AssertionError();
+		}
+	}
+
+	private static void onReturnNeitherStreamIsClosed(final InputStreamProvider inputStreamProvider, final OutputStreamProvider outputStreamProvider)
+			throws IOException {
+		try (CloseLoggingInputStream in = new CloseLoggingInputStream(inputStreamProvider.input(new byte[] { 1, 2, 3 }));
+				CloseLoggingOutputStream out = new CloseLoggingOutputStream(outputStreamProvider.output())) {
+
+			in.transferTo(out);
+
+			if (in.wasClosed() || out.wasClosed())
+				throw new AssertionError();
+		}
+	}
+
+	private static void onReturnInputIsAtEnd(final InputStreamProvider inputStreamProvider, final OutputStreamProvider outputStreamProvider)
+			throws IOException {
+		try (InputStream in = inputStreamProvider.input(new byte[] { 1, 2, 3 }); OutputStream out = outputStreamProvider.output()) {
+
+			in.transferTo(out);
+
+			if (in.read() != -1)
+				throw new AssertionError();
+		}
+	}
+
+	private static void contents(final InputStreamProvider inputStreamProvider, final OutputStreamProvider outputStreamProvider) throws IOException {
+		checkTransferredContents(inputStreamProvider, outputStreamProvider, new byte[0]);
+		checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(1024, 4096));
+		// to span through several batches
+		checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(16384, 16384));
+	}
+
+	private static void checkTransferredContents(final InputStreamProvider inputStreamProvider, final OutputStreamProvider outputStreamProvider,
+			final byte[] bytes) throws IOException {
+		try (InputStream in = inputStreamProvider.input(bytes); RecordingOutputStream out = outputStreamProvider.recordingOutput()) {
+			in.transferTo(out);
+
+			final byte[] outBytes = out.toByteArray();
+			if (!Arrays.equals(bytes, outBytes))
+				throw new AssertionError(format("bytes.length=%s, outBytes.length=%s", bytes.length, outBytes.length));
+		}
+	}
+
+	private static byte[] createRandomBytes(final int min, final int maxRandomAdditive) {
+		final Random rnd = new Random();
+		final byte[] bytes = new byte[min + rnd.nextInt(maxRandomAdditive)];
+		rnd.nextBytes(bytes);
+		return bytes;
+	}
+
+	private static interface InputStreamProvider {
+		InputStream input(byte... bytes);
+
+		InputStream input(int exceptionPosition, byte... bytes);
+
+		InputStream newThrowingInputStream();
+	}
+
+	private static abstract class RecordingOutputStream extends OutputStream {
+		abstract byte[] toByteArray();
+	}
+
+	private static interface OutputStreamProvider {
+		OutputStream output();
+
+		OutputStream output(int exceptionPosition);
+
+		RecordingOutputStream recordingOutput();
+	}
+
+	private static InputStreamProvider defaultInput() {
+		return new InputStreamProvider() {
+
+			@Override
+			public InputStream input(final byte... bytes) {
+				return this.input(-1, bytes);
+			}
+
+			@Override
+			public InputStream input(final int exceptionPosition, final byte... bytes) {
+				return new InputStream() {
+
+					int pos;
+
+					@Override
+					public int read() throws IOException {
+						if (this.pos == exceptionPosition)
+							// because of the pesky IOException swallowing in
+							// java.io.InputStream.read(byte[], int, int)
+							// pos++;
+							throw new IOException();
+
+						if (this.pos >= bytes.length)
+							return -1;
+						return bytes[this.pos++] & 0xff;
+					}
+				};
+			}
+
+			@Override
+			public InputStream newThrowingInputStream() {
+				return new InputStream() {
+
+					boolean closed;
+
+					@Override
+					public int read(final byte[] b) throws IOException {
+						throw new IOException();
+					}
+
+					@Override
+					public int read(final byte[] b, final int off, final int len) throws IOException {
+						throw new IOException();
+					}
+
+					@Override
+					public long skip(final long n) throws IOException {
+						throw new IOException();
+					}
+
+					@Override
+					public int available() throws IOException {
+						throw new IOException();
+					}
+
+					@Override
+					public void close() throws IOException {
+						if (!this.closed) {
+							this.closed = true;
+							throw new IOException();
+						}
+					}
+
+					@Override
+					public void reset() throws IOException {
+						throw new IOException();
+					}
+
+					@Override
+					public int read() throws IOException {
+						throw new IOException();
+					}
+				};
+			}
+		};
+	}
+
+	private static OutputStreamProvider defaultOutput() {
+		return new OutputStreamProvider() {
+
+			@Override
+			public OutputStream output() {
+				return this.output(-1);
+			}
+
+			@Override
+			public OutputStream output(final int exceptionPosition) {
+				return new OutputStream() {
+
+					int pos;
+
+					@Override
+					public void write(final int b) throws IOException {
+						if (this.pos++ == exceptionPosition)
+							throw new IOException();
+					}
+				};
+			}
+
+			@Override
+			public RecordingOutputStream recordingOutput() {
+				return new RecordingOutputStream() {
+					private final ByteArrayOutputStream recorder = new ByteArrayOutputStream();
+
+					@Override
+					public void write(final int b) {
+						this.recorder.write(b);
+					}
+
+					@Override
+					byte[] toByteArray() {
+						return this.recorder.toByteArray();
+					}
+				};
+			}
+		};
+	}
+
+	private static InputStreamProvider fileChannelInput() {
+		return new InputStreamProvider() {
+
+			@Override
+			public InputStream input(final byte... bytes) {
+				return this.input(-1, bytes);
+			}
+
+			@Override
+			public InputStream input(final int exceptionPosition, final byte... bytes) {
+				return new ChannelInputStream(new AbstractFileChannel() {
+					// Override the needed method and let it throw then
+				});
+			}
+
+			@Override
+			public InputStream newThrowingInputStream() {
+				return new InputStream() {
+
+					boolean closed;
+
+					@Override
+					public int read(final byte[] b) throws IOException {
+						throw new IOException();
+					}
+
+					@Override
+					public int read(final byte[] b, final int off, final int len) throws IOException {
+						throw new IOException();
+					}
+
+					@Override
+					public long skip(final long n) throws IOException {
+						throw new IOException();
+					}
+
+					@Override
+					public int available() throws IOException {
+						throw new IOException();
+					}
+
+					@Override
+					public void close() throws IOException {
+						if (!this.closed) {
+							this.closed = true;
+							throw new IOException();
+						}
+					}
+
+					@Override
+					public void reset() throws IOException {
+						throw new IOException();
+					}
+
+					@Override
+					public int read() throws IOException {
+						throw new IOException();
+					}
+				};
+			}
+		};
+	}
+
+	private static class CloseLoggingInputStream extends FilterInputStream {
+
+		boolean closed;
+
+		CloseLoggingInputStream(final InputStream in) {
+			super(in);
+		}
+
+		@Override
+		public void close() throws IOException {
+			this.closed = true;
+			super.close();
+		}
+
+		boolean wasClosed() {
+			return this.closed;
+		}
+	}
+
+	private static class CloseLoggingOutputStream extends FilterOutputStream {
+
+		boolean closed;
+
+		CloseLoggingOutputStream(final OutputStream out) {
+			super(out);
+		}
+
+		@Override
+		public void close() throws IOException {
+			this.closed = true;
+			super.close();
+		}
+
+		boolean wasClosed() {
+			return this.closed;
+		}
+	}
+
+	public interface Thrower {
+		public void run() throws Throwable;
+	}
+
+	public static void assertThrowsNPE(final Thrower thrower, final String message) {
+		assertThrows(thrower, NullPointerException.class, message);
+	}
+
+	public static <T extends Throwable> void assertThrows(final Thrower thrower, final Class<T> throwable, final String message) {
+		Throwable thrown;
+		try {
+			thrower.run();
+			thrown = null;
+		} catch (final Throwable caught) {
+			thrown = caught;
+		}
+
+		if (!throwable.isInstance(thrown)) {
+			final String caught = thrown == null ? "nothing" : thrown.getClass().getCanonicalName();
+			throw new AssertionError(format("Expected to catch %s, but caught %s", throwable, caught), thrown);
+		}
+
+		if (thrown != null && !message.equals(thrown.getMessage()))
+			throw new AssertionError(format("Expected exception message to be '%s', but it's '%s'", message, thrown.getMessage()));
+	}
+
+	private static abstract class AbstractFileChannel extends FileChannel {
+
+		@Override
+		public int read(final ByteBuffer dst) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public long read(final ByteBuffer[] dsts, final int offset, final int length) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int write(final ByteBuffer src) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public long write(final ByteBuffer[] srcs, final int offset, final int length) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public long position() throws IOException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public FileChannel position(final long newPosition) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public long size() throws IOException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public FileChannel truncate(final long size) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void force(final boolean metaData) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public long transferTo(final long position, final long count, final WritableByteChannel target) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public long transferFrom(final ReadableByteChannel src, final long position, final long count) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int read(final ByteBuffer dst, final long position) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int write(final ByteBuffer src, final long position) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public MappedByteBuffer map(final MapMode mode, final long position, final long size) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public FileLock lock(final long position, final long size, final boolean shared) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public FileLock tryLock(final long position, final long size, final boolean shared) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		protected void implCloseChannel() throws IOException {
+			throw new UnsupportedOperationException();
+		}
+	}
+}


### PR DESCRIPTION
This PR-*draft* is **work in progress** and an invitation to discuss a possible solution for issue [JDK-8265891](https://bugs.openjdk.java.net/browse/JDK-8265891). It is *not yet* intended for a final review.

As proposed in JDK-8265891, this PR provides an implementation for `Channels.newInputStream().transferTo()` which provide superior performance compared to the current implementation. The changes are:
* Prevents transfers through the JVM heap as much as possibly by offloading to deeper levels via NIO, hence allowing the operating system to optimize the transfer.
* Using more JRE heap in the fallback case when no NIO is possible (still only KiBs, hence mostl ynegligible even on SBCs) to better perform on modern hardware / fast I/O devides.

Using JMH I have benchmarked both, the original implementation and this implementation, and (depending on the used hardware and use case) performance change was approx. doubled performance. So this PoC proofs that it makes sense to finalize this work and turn it into an actual OpenJDK contribution. 

I encourage everybody to discuss this draft:
* Are there valid arguments for *not* doing this change?
* Is there a *better* way to improve performance of `Channels.newInputStream().transferTo()`?
* How to go on from here: What is missing to get this ready for an actual review?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8265891](https://bugs.openjdk.java.net/browse/JDK-8265891): (ch) InputStream returned by Channels.newInputStream should override transferTo


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4263/head:pull/4263` \
`$ git checkout pull/4263`

Update a local copy of the PR: \
`$ git checkout pull/4263` \
`$ git pull https://git.openjdk.java.net/jdk pull/4263/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4263`

View PR using the GUI difftool: \
`$ git pr show -t 4263`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4263.diff">https://git.openjdk.java.net/jdk/pull/4263.diff</a>

</details>
