### PR TITLE
JDK-8267562: G1: Missing BOT in Open Archive regions causes long pauses

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -2049,8 +2049,10 @@ void FileMapInfo::fixup_mapped_heap_regions() {
                                                   num_open_archive_heap_ranges);
 
     // Populate the open archive regions' G1BlockOffsetTableParts. That ensures
-    // fast G1BlockOffsetTablePart::block_start operations for a given address
-    // within the open archive regions during G1RemSet::refine_card_concurrently.
+    // fast G1BlockOffsetTablePart::block_start operations for any given address
+    // within the open archive regions when trying to find start of an object
+    // (e.g. during card table scanning).
+    //
     // This is only needed for open archive regions, but not the closed archive
     // regions, because objects in closed archive regions are 'immutable'.
     G1CollectedHeap::heap()->populate_archive_regions_bot_part(open_archive_heap_ranges,

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -2053,8 +2053,10 @@ void FileMapInfo::fixup_mapped_heap_regions() {
     // within the open archive regions when trying to find start of an object
     // (e.g. during card table scanning).
     //
-    // This is only needed for open archive regions, but not the closed archive
-    // regions, because objects in closed archive regions are 'immutable'.
+    // This is only needed for open archive regions but not the closed archive
+    // regions, because objects in closed archive regions never reference objects
+    // outside the closed archive regions and they are immutable. So we never
+    // need their BOT during garbage collection.
     G1CollectedHeap::heap()->populate_archive_regions_bot_part(open_archive_heap_ranges,
                                                                num_open_archive_heap_ranges);
   }

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -2047,6 +2047,14 @@ void FileMapInfo::fixup_mapped_heap_regions() {
     assert(open_archive_heap_ranges != NULL, "NULL open_archive_heap_ranges array with non-zero count");
     G1CollectedHeap::heap()->fill_archive_regions(open_archive_heap_ranges,
                                                   num_open_archive_heap_ranges);
+
+    // Populate the open archive regions' G1BlockOffsetTableParts. That ensures
+    // fast G1BlockOffsetTablePart::block_start operations for a given address
+    // within the open archive regions during G1RemSet::refine_card_concurrently.
+    // This is only needed for open archive regions, but not the closed archive
+    // regions, because objects in closed archive regions are 'immutable'.
+    G1CollectedHeap::heap()->populate_archive_regions_bot_part(open_archive_heap_ranges,
+                                                               num_open_archive_heap_ranges);
   }
 }
 

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
@@ -82,6 +82,19 @@ G1BlockOffsetTablePart::G1BlockOffsetTablePart(G1BlockOffsetTable* array, HeapRe
 {
 }
 
+void G1BlockOffsetTablePart::update() {
+  HeapWord* next_addr = _hr->bottom();
+  HeapWord* const limit = _hr->top();
+
+  HeapWord* prev_addr;
+  while (next_addr < limit) {
+    prev_addr = next_addr;
+    next_addr  = prev_addr + block_size(prev_addr);
+    alloc_block(prev_addr, next_addr);
+  }
+  assert(next_addr == limit, "Should stop the scan at the limit.");
+}
+
 // The arguments follow the normal convention of denoting
 // a right-open interval: [start, end)
 void G1BlockOffsetTablePart:: set_remainder_to_point_to_start(HeapWord* start, HeapWord* end) {

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -185,6 +185,8 @@ public:
   //  The elements of the array are initialized to zero.
   G1BlockOffsetTablePart(G1BlockOffsetTable* array, HeapRegion* hr);
 
+  void update();
+
   void verify() const;
 
   // Returns the address of the start of the block containing "addr", or

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -712,6 +712,27 @@ inline HeapWord* G1CollectedHeap::attempt_allocation(size_t min_word_size,
   return result;
 }
 
+void G1CollectedHeap::populate_archive_regions_bot_part(MemRegion* ranges, size_t count) {
+  assert(!is_init_completed(), "Expect to be called at JVM init time");
+  assert(ranges != NULL, "MemRegion array NULL");
+  assert(count != 0, "No MemRegions provided");
+
+  HeapWord* st = ranges[0].start();
+  HeapWord* last = ranges[count-1].last();
+  HeapRegion* hr_st = _hrm.addr_to_region(st);
+  HeapRegion* hr_last = _hrm.addr_to_region(last);
+
+  HeapRegion* hr_curr = hr_st;
+  while (hr_curr != NULL) {
+    hr_curr->update_bot();
+    if (hr_curr != hr_last) {
+      hr_curr = _hrm.next_region_in_heap(hr_curr);
+    } else {
+      hr_curr = NULL;
+    }
+  }
+}
+
 void G1CollectedHeap::dealloc_archive_regions(MemRegion* ranges, size_t count) {
   assert(!is_init_completed(), "Expect to be called at JVM init time");
   assert(ranges != NULL, "MemRegion array NULL");

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -740,6 +740,10 @@ public:
   // alloc_archive_regions, and after class loading has occurred.
   void fill_archive_regions(MemRegion* range, size_t count);
 
+  // Populate the G1BlockOffsetTablePart for archived regions with the given
+  // memory ranges.
+  void populate_archive_regions_bot_part(MemRegion* range, size_t count);
+
   // For each of the specified MemRegions, uncommit the containing G1 regions
   // which had been allocated by alloc_archive_regions. This should be called
   // rather than fill_archive_regions at JVM init time if the archive file

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
@@ -84,7 +84,7 @@ bool G1FullGCPrepareTask::G1CalculatePointersClosure::do_heap_region(HeapRegion*
         // lack BOT information for performance reasons.
         // Recreate BOT information of high live ratio young regions here to keep expected
         // performance during scanning their card tables in the collection pauses later.
-        update_bot(hr);
+        hr->update_bot();
       }
       log_trace(gc, phases)("Phase 2: skip compaction region index: %u, live words: " SIZE_FORMAT,
                             hr->hrm_index(), _collector->live_words(hr->hrm_index()));
@@ -144,22 +144,6 @@ bool G1FullGCPrepareTask::G1CalculatePointersClosure::should_compact(HeapRegion*
   size_t live_words_threshold = _collector->scope()->region_compaction_threshold();
   // High live ratio region will not be compacted.
   return live_words <= live_words_threshold;
-}
-
-void G1FullGCPrepareTask::G1CalculatePointersClosure::update_bot(HeapRegion* hr) {
-  HeapWord* const limit = hr->top();
-  HeapWord* next_addr = hr->bottom();
-  HeapWord* threshold = hr->initialize_threshold();
-  HeapWord* prev_addr;
-  while (next_addr < limit) {
-    prev_addr = next_addr;
-    next_addr = _bitmap->get_next_marked_addr(next_addr + 1, limit);
-
-    if (next_addr > threshold) {
-      threshold = hr->cross_threshold(prev_addr, next_addr);
-    }
-  }
-  assert(next_addr == limit, "Should stop the scan at the limit.");
 }
 
 void G1FullGCPrepareTask::G1CalculatePointersClosure::reset_region_metadata(HeapRegion* hr) {

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
@@ -63,7 +63,6 @@ protected:
     bool should_compact(HeapRegion* hr);
     void prepare_for_compaction(HeapRegion* hr);
     void prepare_for_compaction_work(G1FullGCCompactionPoint* cp, HeapRegion* hr);
-    void update_bot(HeapRegion* hr);
 
     void reset_region_metadata(HeapRegion* hr);
 

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -194,6 +194,10 @@ public:
     _bot_part.reset_bot();
   }
 
+  void update_bot() {
+    _bot_part.update();
+  }
+
 private:
   // The remembered set for this region.
   HeapRegionRemSet* _rem_set;


### PR DESCRIPTION
Populate G1BlockOffsetTableParts and associated G1BlockOffsetTable::_offset_array entries for 'open' archive regions during VM initialization at runtime.

G1BlockOffsetTable divides the covered space (Java heap) into “N”-word subregions (“N” is from 2^”LogN”). It uses an _offset_array to tell how far back it must go to find the start of a block that contains the first word of a subregion. Every G1 region (is a G1ContiguousSpace) owns a G1BlockOffsetTablePart (associates to part of the _offset_array), which covers space of the current region. For a mapped open archive heap region with pre-populated Java objects, its G1BlockOffsetTablePart is never setup at runtime because there is no allocation done within the region. As a result, G1BlockOffsetTablePart::block_start() always does lookup from the start (bottom) of an open archive region when called at runtime, regardless if the given 'addr' is near the bottom, top or in the middle of the region. The lookup becomes linear, instead of O(2^LogN). Large heap region size makes the situation worse and young-gen pauses longer.

Removed G1FullGCPrepareTask::G1CalculatePointersClosure::update_bot (introduced by JDK-8264987 change, https://github.com/openjdk/jdk/pull/3459). It's merged as G1BlockOffsetTablePart::update, which is used for Survivor-turned-to-Old regions in full gc and open archive region. Thanks Thomas Schatzl  for pointing to JDK-8264987 change for code reuse.

Tested with tier1 and hotspot_gc tests on linux_x86. Appreciate any help for testing other platforms and more tiers. Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267562](https://bugs.openjdk.java.net/browse/JDK-8267562): G1: Missing BOT in Open Archive regions causes long pauses


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 0ab6edc73596948021f72b57621d0dc61a56fe69
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**) ⚠️ Review applies to 297b3e05ff2a0f96a1ba8b3ac4715f87d87d43b0


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4265/head:pull/4265` \
`$ git checkout pull/4265`

Update a local copy of the PR: \
`$ git checkout pull/4265` \
`$ git pull https://git.openjdk.java.net/jdk pull/4265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4265`

View PR using the GUI difftool: \
`$ git pr show -t 4265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4265.diff">https://git.openjdk.java.net/jdk/pull/4265.diff</a>

</details>
