### PR TITLE
8267968: [PPC64] Use prefixed load and addi instructions for better performance in POWER10

### DIFF
--- a/src/hotspot/cpu/ppc/assembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.cpp
@@ -347,7 +347,7 @@ void Assembler::load_const(Register d, long x, Register tmp) {
 // Generate prefixed or non-prefixed addi, or addis based on the immediate value
 // Emit a nop if a prefixed addi is going to cross a 64-byte boundary.
 // (See Section 1.6 of Power ISA Version 3.1)
-void Assembler::paddi_or_addi(Register d, Register s, long si34) {
+void Assembler::paddi_or_addi_r0ok(Register d, Register s, long si34) {
   if (is_simm16(si34)) {
     addi_r0ok(d, s, (int)si34);
   } else if (is_simm32(si34) && (si34 & 0xffff) == 0) {

--- a/src/hotspot/cpu/ppc/assembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.cpp
@@ -356,10 +356,10 @@ void Assembler::paddi_or_addi(Register d, Register s, long si34) {
     if (is_aligned(reinterpret_cast<uintptr_t>(pc()) + BytesPerInstWord, 64) ||
         code_section()->scratch_emit()) {
       // Always emit a nop if the target is a scratch buffer, otherwise fill_buffer() may raise
-      // an assertion failure because the size of actually generated code can be larger than that
-      // in scratch_emit phase. A difference of code buffer addresses for the two phases can result
-      // in different number of nops for alignment. By emitting a nop before every paddi, we avoid
-      // buffer overrun in acrual code generation phase.
+      // an assertion failure because the size of actual generated code can be larger than that
+      // in the scratch_emit phase. A difference of code buffer addresses for the two phases can
+      // result in different number of nops for alignment. By emitting a nop before every paddi,
+      // we avoid a buffer overrun in the actual code generation phase.
       nop();
     }
     paddi_r0ok(d, s, si34);
@@ -393,7 +393,7 @@ int Assembler::load_const_optimized(Register d, long x, Register tmp,
   }
 
   // pli can require a nop for alignement depending on the code address, so we don't use pli
-  // when the caller expects the number of generated code is always the same.
+  // when the caller expects the amount of generated code is always the same.
   bool use_pli = (PowerArchitecturePPC64 >= 10 && !fixed_size);
 
   if (d == R0) { // Can't use addi.
@@ -451,7 +451,7 @@ int Assembler::load_const_optimized(Register d, long x, Register tmp,
           if (xc) { oris(d, d, (unsigned short)xc); }
           if (xd) { ori( d, d, (unsigned short)xd); }
         } else {
-          // Exploit instruction level parallelism if we have a tmp register.
+          // Exploit instruction-level parallelism if we have a tmp register.
           bool xc_loaded = (xd & 0x8000) ? (xc != -1) : (xc != 0);
           if (xa_loaded) {
             lis(tmp, xa);
@@ -597,7 +597,7 @@ int Assembler::add_const_optimized(Register d, Register s, long x, Register tmp,
 
   // Case 3: Can use paddi. (However, paddi can require a nop for alignement depending
   //                         on the code address, so we don't use paddi when the caller
-  //                         expects the number of generated code is always the same.
+  //                         expects the amount of generated code is always the same.
   if (PowerArchitecturePPC64 >= 10 && !fixed_size) {
     long xd = x & 0x3FFFFFFFFL; // Lowest 34-bit chunk.
     rem = (x >> 34) + (xd >> 33);

--- a/src/hotspot/cpu/ppc/assembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2015 SAP SE. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/ppc/assembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.hpp
@@ -2594,7 +2594,7 @@ class Assembler : public AbstractAssembler {
          int load_const_optimized(Register d, long a,  Register tmp = noreg,
                                   bool return_simm16_rest = false, bool fixed_size = false);
   inline int load_const_optimized(Register d, void* a, Register tmp = noreg,
-				  bool return_simm16_rest = false, bool fixed_size = false) {
+                                  bool return_simm16_rest = false, bool fixed_size = false) {
     return load_const_optimized(d, (long)(unsigned long)a, tmp, return_simm16_rest, fixed_size);
   }
 

--- a/src/hotspot/cpu/ppc/assembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.hpp
@@ -2616,9 +2616,13 @@ class Assembler : public AbstractAssembler {
 
  private:
   // Helper function used in load_const_optimized() and add_const_optimized()
-  void paddi_or_addi(Register d, Register s, long si34);
-  void pli_or_li(    Register d, long si34) {
-    paddi_or_addi(d, R0, si34);
+  void paddi_or_addi_r0ok(Register d, Register s, long si34);
+  void paddi_or_addi(Register d, Register s, long si34) {
+    assert(s != R0, "r0 not allowed");
+    paddi_or_addi_r0ok(d, s, si34);
+  }
+  void pli_or_li(Register d, long si34) {
+    paddi_or_addi_r0ok(d, R0, si34);
   }
 
  public:

--- a/src/hotspot/cpu/ppc/assembler_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.inline.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/ppc/assembler_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.inline.hpp
@@ -385,6 +385,42 @@ inline void Assembler::stdbrx( Register d, Register s1, Register s2) { emit_int3
 inline void Assembler::st_ptr(Register d, int b, Register s1) { std(d, b, s1); }
 inline void Assembler::st_ptr(Register d, ByteSize b, Register s1) { std(d, in_bytes(b), s1); }
 
+// Prefixed instructions, introduced by POWER10
+inline void Assembler::plfs( FloatRegister d, long si34, Register s1, bool r) {
+  emit_int32(PLFS_PREFIX_OPCODE | r_eo(r) | d0_eo(si34));
+  emit_int32(PLFS_SUFFIX_OPCODE | frt(d)  | ra0mem(s1) | d1_eo(si34));
+}
+
+inline void Assembler::plfs( FloatRegister d, long si34, Register s1) {
+  emit_int32(PLFS_PREFIX_OPCODE | r_eo(0) | d0_eo(si34));
+  emit_int32(PLFS_SUFFIX_OPCODE | frt(d)  | ra0mem(s1) | d1_eo(si34));
+}
+
+inline void Assembler::plfd( FloatRegister d, long si34, Register s1, bool r) {
+  emit_int32(PLFD_PREFIX_OPCODE | r_eo(r) | d0_eo(si34));
+  emit_int32(PLFD_SUFFIX_OPCODE | frt(d)  | ra0mem(s1) | d1_eo(si34));
+}
+
+inline void Assembler::plfd( FloatRegister d, long si34, Register s1) {
+  emit_int32(PLFD_PREFIX_OPCODE | r_eo(0) | d0_eo(si34));
+  emit_int32(PLFD_SUFFIX_OPCODE | frt(d)  | ra0mem(s1) | d1_eo(si34));
+}
+
+inline void Assembler::pld( Register d, long si34, Register s1, bool r) {
+  emit_int32(PLD_PREFIX_OPCODE  | r_eo(r) | d0_eo(si34));
+  emit_int32(PLD_SUFFIX_OPCODE  | rt(d)   | ra0mem(s1) | d1_eo(si34));
+}
+
+inline void Assembler::pld( Register d, long si34, Register s1) {
+  emit_int32(PLD_PREFIX_OPCODE  | r_eo(0) | d0_eo(si34));
+  emit_int32(PLD_SUFFIX_OPCODE  | rt(d)   | ra0mem(s1) | d1_eo(si34));
+}
+
+inline void Assembler::pld( Register d, long si34) {
+  emit_int32(PLD_PREFIX_OPCODE  | r_eo(1) | d0_eo(si34));
+  emit_int32(PLD_SUFFIX_OPCODE  | rt(d)   | d1_eo(si34));
+}
+
 // PPC 1, section 3.3.13 Move To/From System Register Instructions
 inline void Assembler::mtlr( Register s1)         { emit_int32(MTLR_OPCODE  | rs(s1)); }
 inline void Assembler::mflr( Register d )         { emit_int32(MFLR_OPCODE  | rt(d)); }

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -287,8 +287,9 @@ bool MacroAssembler::is_load_const_from_method_toc_at(address a) {
      const address inst2_addr = inst1_addr + BytesPerInstWord;
      const int inst2 = *(int *)inst2_addr;
 
-     // The relocation points to the pld.  Currently, CallDynamicJavaDirectSched_ExNode and
-     // CallLeaf(NoFP)Direct_ExNode are the only nodes that require relocation and use pld
+     // The case a relocation points to a pld.  Currently, CallDynamicJavaDirectSched_ExNode and
+     // CallLeaf(NoFP)Direct_ExNode are the only nodes that require relocation and use pld, and
+     // call this function
      if (is_pld_prefix(inst1) && is_pld_suffix(inst2)) {
        return true;
      }
@@ -308,6 +309,9 @@ int MacroAssembler::get_offset_of_load_const_from_method_toc_at(address a) {
   if (is_ld(inst1)) {
     return inv_d1_field(inst1);
   } else if (PowerArchitecturePPC64 >= 10 && is_pld_prefix(inst1)) {
+    // The case a relocation points to a pld.  Currently, CallDynamicJavaDirectSched_ExNode and
+    // CallLeaf(NoFP)Direct_ExNode are the only nodes that require relocation and use pld, and
+    // call this function
     return (get_imm18(inst1_addr, 0) << 16) + (get_imm(inst1_addr, 1) & 0xffff);
   } else if (is_addis(inst1)) {
     const int dst = inv_rt_field(inst1);

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -1174,6 +1174,22 @@ int loadConL34Node::compute_padding(int current_offset) const {
   return compute_prefix_padding(current_offset);
 }
 
+int loadConLNode::compute_padding(int current_offset) const {
+  return compute_prefix_padding(current_offset);
+}
+
+int loadConPNode::compute_padding(int current_offset) const {
+  return compute_prefix_padding(current_offset);
+}
+
+int loadConFNode::compute_padding(int current_offset) const {
+  return compute_prefix_padding(current_offset);
+}
+
+int loadConDNode::compute_padding(int current_offset) const {
+  return compute_prefix_padding(current_offset);
+}
+
 int addI_reg_imm32Node::compute_padding(int current_offset) const {
   return compute_prefix_padding(current_offset);
 }
@@ -2621,22 +2637,28 @@ encode %{
     C2_MacroAssembler _masm(&cbuf);
     int toc_offset = 0;
 
-    address const_toc_addr;
-    // Create a non-oop constant, no relocation needed.
-    // If it is an IC, it has a virtual_call_Relocation.
-    const_toc_addr = __ long_constant((jlong)$src$$constant);
-    if (const_toc_addr == NULL) {
-      ciEnv::current()->record_out_of_memory_failure();
-      return;
+    if (!ra_->C->output()->in_scratch_emit_size()) {
+      address const_toc_addr;
+      // Create a non-oop constant, no relocation needed.
+      // If it is an IC, it has a virtual_call_Relocation.
+      const_toc_addr = __ long_constant((jlong)$src$$constant);
+      if (const_toc_addr == NULL) {
+        ciEnv::current()->record_out_of_memory_failure();
+        return;
+      }
+
+      // Get the constant's TOC offset.
+      toc_offset = __ offset_to_method_toc(const_toc_addr);
+
+      // Keep the current instruction offset in mind.
+      ((loadConLNode*)this)->_cbuf_insts_offset = __ offset();
     }
 
-    // Get the constant's TOC offset.
-    toc_offset = __ offset_to_method_toc(const_toc_addr);
-
-    // Keep the current instruction offset in mind.
-    ((loadConLNode*)this)->_cbuf_insts_offset = __ offset();
-
-    __ ld($dst$$Register, toc_offset, $toc$$Register);
+    if(Assembler::is_simm16(toc_offset) || PowerArchitecturePPC64 <= 9) {
+      __ ld($dst$$Register, toc_offset, $toc$$Register);
+    } else {
+      __ pld($dst$$Register, toc_offset, $toc$$Register);
+    }
   %}
 
   enc_class enc_load_long_constL_hi(iRegLdst dst, iRegLdst toc, immL src) %{
@@ -2681,7 +2703,7 @@ loadConLNodesTuple loadConLNodesTuple_create(PhaseRegAlloc *ra_, Node *toc, immL
   loadConLNodesTuple nodes;
 
   const bool large_constant_pool = true; // TODO: PPC port C->cfg()->_consts_size > 4000;
-  if (large_constant_pool) {
+  if (large_constant_pool && PowerArchitecturePPC64 <= 9) {
     // Create new nodes.
     loadConL_hiNode *m1 = new loadConL_hiNode();
     loadConL_loNode *m2 = new loadConL_loNode();
@@ -2759,7 +2781,7 @@ loadConLReplicatedNodesTuple loadConLReplicatedNodesTuple_create(Compile *C, Pha
   loadConLReplicatedNodesTuple nodes;
 
   const bool large_constant_pool = true; // TODO: PPC port C->cfg()->_consts_size > 4000;
-  if (large_constant_pool) {
+  if (large_constant_pool && PowerArchitecturePPC64 <= 9) {
     // Create new nodes.
     loadConL_hiNode *m1 = new  loadConL_hiNode();
     loadConL_loNode *m2 = new  loadConL_loNode();
@@ -2817,6 +2839,8 @@ loadConLReplicatedNodesTuple loadConLReplicatedNodesTuple_create(Compile *C, Pha
 
     // inputs for new nodes
     m2->add_req(NULL, toc);
+    m3->add_req(NULL, m2);
+    m4->add_req(NULL, m3);
 
     // operands for new nodes
     m2->_opnds[0] = new  iRegLdstOper(); // dst
@@ -2865,8 +2889,9 @@ encode %{
                                 ra_->get_reg_second(this), ra_->get_reg_first(this));
 
     // Push new nodes.
+    if (loadConLNodes._small)    nodes->push(loadConLNodes._small);
     if (loadConLNodes._large_hi) nodes->push(loadConLNodes._large_hi);
-    if (loadConLNodes._last)     nodes->push(loadConLNodes._last);
+    if (loadConLNodes._large_lo) nodes->push(loadConLNodes._large_lo);
 
     // some asserts
     assert(nodes->length() >= 1, "must have created at least 1 node");
@@ -2878,31 +2903,37 @@ encode %{
     C2_MacroAssembler _masm(&cbuf);
     int toc_offset = 0;
 
-    intptr_t val = $src$$constant;
-    relocInfo::relocType constant_reloc = $src->constant_reloc();  // src
-    address const_toc_addr;
-    if (constant_reloc == relocInfo::oop_type) {
-      // Create an oop constant and a corresponding relocation.
-      AddressLiteral a = __ allocate_oop_address((jobject)val);
-      const_toc_addr = __ address_constant((address)a.value(), RelocationHolder::none);
-      __ relocate(a.rspec());
-    } else if (constant_reloc == relocInfo::metadata_type) {
-      AddressLiteral a = __ constant_metadata_address((Metadata *)val);
-      const_toc_addr = __ address_constant((address)a.value(), RelocationHolder::none);
-      __ relocate(a.rspec());
+    if (!ra_->C->output()->in_scratch_emit_size()) {
+      intptr_t val = $src$$constant;
+      relocInfo::relocType constant_reloc = $src->constant_reloc();  // src
+      address const_toc_addr;
+      if (constant_reloc == relocInfo::oop_type) {
+        // Create an oop constant and a corresponding relocation.
+        AddressLiteral a = __ allocate_oop_address((jobject)val);
+        const_toc_addr = __ address_constant((address)a.value(), RelocationHolder::none);
+        __ relocate(a.rspec());
+      } else if (constant_reloc == relocInfo::metadata_type) {
+        AddressLiteral a = __ constant_metadata_address((Metadata *)val);
+        const_toc_addr = __ address_constant((address)a.value(), RelocationHolder::none);
+        __ relocate(a.rspec());
+      } else {
+        // Create a non-oop constant, no relocation needed.
+        const_toc_addr = __ long_constant((jlong)$src$$constant);
+      }
+
+      if (const_toc_addr == NULL) {
+        ciEnv::current()->record_out_of_memory_failure();
+        return;
+      }
+      // Get the constant's TOC offset.
+      toc_offset = __ offset_to_method_toc(const_toc_addr);
+    }
+
+    if(Assembler::is_simm16(toc_offset) || PowerArchitecturePPC64 <= 9) {
+      __ ld($dst$$Register, toc_offset, $toc$$Register);
     } else {
-      // Create a non-oop constant, no relocation needed.
-      const_toc_addr = __ long_constant((jlong)$src$$constant);
+      __ pld($dst$$Register, toc_offset, $toc$$Register);
     }
-
-    if (const_toc_addr == NULL) {
-      ciEnv::current()->record_out_of_memory_failure();
-      return;
-    }
-    // Get the constant's TOC offset.
-    toc_offset = __ offset_to_method_toc(const_toc_addr);
-
-    __ ld($dst$$Register, toc_offset, $toc$$Register);
   %}
 
   enc_class enc_load_long_constP_hi(iRegLdst dst, immP src, iRegLdst toc) %{
@@ -2944,7 +2975,7 @@ encode %{
   // expand.
   enc_class postalloc_expand_load_ptr_constant(iRegPdst dst, immP src, iRegLdst toc) %{
     const bool large_constant_pool = true; // TODO: PPC port C->cfg()->_consts_size > 4000;
-    if (large_constant_pool) {
+    if (large_constant_pool && PowerArchitecturePPC64 <= 9) {
       // Create new nodes.
       loadConP_hiNode *m1 = new loadConP_hiNode();
       loadConP_loNode *m2 = new loadConP_loNode();
@@ -2997,7 +3028,7 @@ encode %{
     bool large_constant_pool = true; // TODO: PPC port C->cfg()->_consts_size > 4000;
 
     MachNode *m2;
-    if (large_constant_pool) {
+    if (large_constant_pool && PowerArchitecturePPC64 <= 9) {
       m2 = new loadConFCompNode();
     } else {
       m2 = new loadConFNode();
@@ -3021,7 +3052,7 @@ encode %{
     bool large_constant_pool = true; // TODO: PPC port C->cfg()->_consts_size > 4000;
 
     MachNode *m2;
-    if (large_constant_pool) {
+    if (large_constant_pool && PowerArchitecturePPC64 <= 9) {
       m2 = new loadConDCompNode();
     } else {
       m2 = new loadConDNode();
@@ -3404,8 +3435,9 @@ encode %{
                                 ra_->get_reg_second(this), ra_->get_reg_first(this));
 
     // Push new nodes.
+    if (loadConLNodes._small)    nodes->push(loadConLNodes._small);
     if (loadConLNodes._large_hi) nodes->push(loadConLNodes._large_hi);
-    if (loadConLNodes._last)     nodes->push(loadConLNodes._last);
+    if (loadConLNodes._large_lo) nodes->push(loadConLNodes._large_lo);
 
     assert(nodes->length() >= 1, "must have created at least 1 node");
     assert(loadConLNodes._last->bottom_type()->isa_long(), "must be long");
@@ -3424,6 +3456,7 @@ encode %{
                                 ra_->get_reg_second(this), ra_->get_reg_first(this));
 
     // Push new nodes.
+    if (loadConLNodes._small)    { nodes->push(loadConLNodes._small); }
     if (loadConLNodes._large_hi) { nodes->push(loadConLNodes._large_hi); }
     if (loadConLNodes._large_lo) { nodes->push(loadConLNodes._large_lo); }
     if (loadConLNodes._moved)    { nodes->push(loadConLNodes._moved); }
@@ -3634,8 +3667,9 @@ encode %{
     assert(Matcher::inline_cache_reg() == OptoReg::Name(R19_num), "ic reg should be R19");
 
     // Push new nodes.
+    if (loadConLNodes_IC._small)    nodes->push(loadConLNodes_IC._small);
     if (loadConLNodes_IC._large_hi) nodes->push(loadConLNodes_IC._large_hi);
-    if (loadConLNodes_IC._last)     nodes->push(loadConLNodes_IC._last);
+    if (loadConLNodes_IC._large_lo) nodes->push(loadConLNodes_IC._large_lo);
     nodes->push(call);
   %}
 
@@ -3825,13 +3859,16 @@ encode %{
     ra_->set1(mtctr->_idx, OptoReg::Name(SR_CTR_num));
 
     // Insert the new nodes.
+    if (loadConLNodes_Entry._small)    nodes->push(loadConLNodes_Entry._small);
     if (loadConLNodes_Entry._large_hi) nodes->push(loadConLNodes_Entry._large_hi);
-    if (loadConLNodes_Entry._last)     nodes->push(loadConLNodes_Entry._last);
+    if (loadConLNodes_Entry._large_lo) nodes->push(loadConLNodes_Entry._large_lo);
 #if !defined(ABI_ELFv2)
+    if (loadConLNodes_Env._small)      nodes->push(loadConLNodes_Env._small);
     if (loadConLNodes_Env._large_hi)   nodes->push(loadConLNodes_Env._large_hi);
-    if (loadConLNodes_Env._last)       nodes->push(loadConLNodes_Env._last);
+    if (loadConLNodes_Env._large_lo)   nodes->push(loadConLNodes_Env._large_lo);
+    if (loadConLNodes_Toc._small)      nodes->push(loadConLNodes_Toc._small);
     if (loadConLNodes_Toc._large_hi)   nodes->push(loadConLNodes_Toc._large_hi);
-    if (loadConLNodes_Toc._last)       nodes->push(loadConLNodes_Toc._last);
+    if (loadConLNodes_Toc._large_lo)   nodes->push(loadConLNodes_Toc._large_lo);
 #endif
     nodes->push(mtctr);
     nodes->push(call);
@@ -4256,6 +4293,17 @@ operand immL() %{
   interface(CONST_INTER);
 %}
 
+// Operand to avoid match of loadConL.
+// This operand can be used to avoid matching of an instruct
+// with chain rule.
+operand immL_NM() %{
+  match(ConL);
+  predicate(false);
+  op_cost(40);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
 operand immLmax30() %{
   predicate((n->get_long() <= 30));
   match(ConL);
@@ -4378,6 +4426,17 @@ operand immF() %{
   interface(CONST_INTER);
 %}
 
+// Operand to avoid match of loadConF.
+// This operand can be used to avoid matching of an instruct
+// with chain rule.
+operand immF_NM() %{
+  match(ConF);
+  predicate(false);
+  op_cost(40);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
 // Float Immediate: +0.0f.
 operand immF_0() %{
   predicate(jint_cast(n->getf()) == 0);
@@ -4391,6 +4450,17 @@ operand immF_0() %{
 // Double Immediate
 operand immD() %{
   match(ConD);
+  op_cost(40);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
+// Operand to avoid match of loadConD.
+// This operand can be used to avoid matching of an instruct
+// with chain rule.
+operand immD_NM() %{
+  match(ConD);
+  predicate(false);
   op_cost(40);
   format %{ %}
   interface(CONST_INTER);
@@ -5964,8 +6034,15 @@ instruct loadConLhighest16_Ex(iRegLdst dst, immLhighest16 src) %{
 %}
 
 // Expand node for constant pool load: small offset.
-instruct loadConL(iRegLdst dst, immL src, iRegLdst toc) %{
-  effect(DEF dst, USE src, USE toc);
+// The match rule is needed to generate alignment_required() and compute_padding(),
+// however this node should never match. The use of predicate is not
+// possible since ADLC forbids predicates for chain rules. The higher
+// costs do not prevent matching in this case. For that reason the
+// operand immL_NM with predicate(false) is used.
+// On Power 10 and up, this instruction is also used for larger offset upto signed 32-bit.
+instruct loadConL(iRegLdst dst, immL_NM src, iRegLdst toc) %{
+  match(Set dst src);
+  effect(TEMP toc);
   ins_cost(MEMORY_REF_COST);
 
   ins_num_consts(1);
@@ -5974,9 +6051,10 @@ instruct loadConL(iRegLdst dst, immL src, iRegLdst toc) %{
   ins_field_cbuf_insts_offset(int);
 
   format %{ "LD      $dst, offset, $toc \t// load long $src from TOC" %}
-  size(4);
+  size(8);
   ins_encode( enc_load_long_constL(dst, src, toc) );
   ins_pipe(pipe_class_memory);
+  ins_alignment(2);
 %}
 
 // Expand node for constant pool load: large offset.
@@ -6246,6 +6324,7 @@ instruct loadConP0or1(iRegPdst dst, immP_0or1 src) %{
 // possible since ADLC forbids predicates for chain rules. The higher
 // costs do not prevent matching in this case. For that reason the
 // operand immP_NM with predicate(false) is used.
+// On Power 10 and up, this instruction is also used for larger offset upto signed 32-bit.
 instruct loadConP(iRegPdst dst, immP_NM src, iRegLdst toc) %{
   match(Set dst src);
   effect(TEMP toc);
@@ -6253,9 +6332,10 @@ instruct loadConP(iRegPdst dst, immP_NM src, iRegLdst toc) %{
   ins_num_consts(1);
 
   format %{ "LD      $dst, offset, $toc \t// load ptr $src from TOC" %}
-  size(4);
+  size(8);
   ins_encode( enc_load_long_constP(dst, src, toc) );
   ins_pipe(pipe_class_memory);
+  ins_alignment(2);
 %}
 
 // Expand node for constant pool load: large offset.
@@ -6309,23 +6389,36 @@ instruct loadConP_Ex(iRegPdst dst, immP src) %{
 %}
 
 // Expand node for constant pool load: small offset.
-instruct loadConF(regF dst, immF src, iRegLdst toc) %{
-  effect(DEF dst, USE src, USE toc);
+// The match rule is needed to generate alignment_required() and compute_padding(),
+// however this node should never match. The use of predicate is not
+// possible since ADLC forbids predicates for chain rules. The higher
+// costs do not prevent matching in this case. For that reason the
+// operand immF_NM with predicate(false) is used.
+// On Power 10 and up, this instruction is also used for larger offset upto signed 32-bit.
+instruct loadConF(regF dst, immF_NM src, iRegLdst toc) %{
+  match(Set dst src);
+  effect(TEMP toc);
   ins_cost(MEMORY_REF_COST);
 
   ins_num_consts(1);
 
   format %{ "LFS     $dst, offset, $toc \t// load float $src from TOC" %}
-  size(4);
+  size(8);
   ins_encode %{
     address float_address = __ float_constant($src$$constant);
     if (float_address == NULL) {
       ciEnv::current()->record_out_of_memory_failure();
       return;
     }
-    __ lfs($dst$$FloatRegister, __ offset_to_method_toc(float_address), $toc$$Register);
+    int offset = __ offset_to_method_toc(float_address);
+    if (Assembler::is_simm16(offset) || PowerArchitecturePPC64 <= 9) {
+      __ lfs($dst$$FloatRegister, offset, $toc$$Register);
+    } else {
+      __ plfs($dst$$FloatRegister, offset, $toc$$Register);
+    }
   %}
   ins_pipe(pipe_class_memory);
+  ins_alignment(2);
 %}
 
 // Expand node for constant pool load: large offset.
@@ -6371,14 +6464,21 @@ instruct loadConF_Ex(regF dst, immF src) %{
 %}
 
 // Expand node for constant pool load: small offset.
-instruct loadConD(regD dst, immD src, iRegLdst toc) %{
-  effect(DEF dst, USE src, USE toc);
+// The match rule is needed to generate alignment_required() and compute_padding(),
+// however this node should never match. The use of predicate is not
+// possible since ADLC forbids predicates for chain rules. The higher
+// costs do not prevent matching in this case. For that reason the
+// operand immD_NM with predicate(false) is used.
+// On Power 10 and up, this instruction is also used for larger offset upto signed 32-bit.
+instruct loadConD(regD dst, immD_NM src, iRegLdst toc) %{
+  match(Set dst src);
+  effect(TEMP toc);
   ins_cost(MEMORY_REF_COST);
 
   ins_num_consts(1);
 
   format %{ "LFD     $dst, offset, $toc \t// load double $src from TOC" %}
-  size(4);
+  size(8);
   ins_encode %{
     address float_address = __ double_constant($src$$constant);
     if (float_address == NULL) {
@@ -6386,9 +6486,14 @@ instruct loadConD(regD dst, immD src, iRegLdst toc) %{
       return;
     }
     int offset =  __ offset_to_method_toc(float_address);
-    __ lfd($dst$$FloatRegister, offset, $toc$$Register);
+    if (Assembler::is_simm16(offset) || PowerArchitecturePPC64 <= 9) {
+      __ lfd($dst$$FloatRegister, offset, $toc$$Register);
+    } else {
+      __ plfd($dst$$FloatRegister, offset, $toc$$Register);
+    }
   %}
   ins_pipe(pipe_class_memory);
+  ins_alignment(2);
 %}
 
 // Expand node for constant pool load: large offset.

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -6039,7 +6039,7 @@ instruct loadConLhighest16_Ex(iRegLdst dst, immLhighest16 src) %{
 // possible since ADLC forbids predicates for chain rules. The higher
 // costs do not prevent matching in this case. For that reason the
 // operand immL_NM with predicate(false) is used.
-// On Power 10 and up, this instruction is also used for larger offset upto signed 32-bit.
+// On Power 10 and up, this instruction is also used for larger offsets upto signed 32-bit.
 instruct loadConL(iRegLdst dst, immL_NM src, iRegLdst toc) %{
   match(Set dst src);
   effect(TEMP toc);
@@ -6324,7 +6324,7 @@ instruct loadConP0or1(iRegPdst dst, immP_0or1 src) %{
 // possible since ADLC forbids predicates for chain rules. The higher
 // costs do not prevent matching in this case. For that reason the
 // operand immP_NM with predicate(false) is used.
-// On Power 10 and up, this instruction is also used for larger offset upto signed 32-bit.
+// On Power 10 and up, this instruction is also used for larger offsets upto signed 32-bit.
 instruct loadConP(iRegPdst dst, immP_NM src, iRegLdst toc) %{
   match(Set dst src);
   effect(TEMP toc);
@@ -6394,7 +6394,7 @@ instruct loadConP_Ex(iRegPdst dst, immP src) %{
 // possible since ADLC forbids predicates for chain rules. The higher
 // costs do not prevent matching in this case. For that reason the
 // operand immF_NM with predicate(false) is used.
-// On Power 10 and up, this instruction is also used for larger offset upto signed 32-bit.
+// On Power 10 and up, this instruction is also used for larger offsets upto signed 32-bit.
 instruct loadConF(regF dst, immF_NM src, iRegLdst toc) %{
   match(Set dst src);
   effect(TEMP toc);
@@ -6469,7 +6469,7 @@ instruct loadConF_Ex(regF dst, immF src) %{
 // possible since ADLC forbids predicates for chain rules. The higher
 // costs do not prevent matching in this case. For that reason the
 // operand immD_NM with predicate(false) is used.
-// On Power 10 and up, this instruction is also used for larger offset upto signed 32-bit.
+// On Power 10 and up, this instruction is also used for larger offsets upto signed 32-bit.
 instruct loadConD(regD dst, immD_NM src, iRegLdst toc) %{
   match(Set dst src);
   effect(TEMP toc);

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -2888,10 +2888,9 @@ encode %{
       loadConLNodesTuple_create(ra_, n_toc, op_src,
                                 ra_->get_reg_second(this), ra_->get_reg_first(this));
 
-    // Push new nodes.
-    if (loadConLNodes._small)    nodes->push(loadConLNodes._small);
+    // Push new nodes. Note that _last points to the same node as either _large_lo or _small.
     if (loadConLNodes._large_hi) nodes->push(loadConLNodes._large_hi);
-    if (loadConLNodes._large_lo) nodes->push(loadConLNodes._large_lo);
+    if (loadConLNodes._last)     nodes->push(loadConLNodes._last);
 
     // some asserts
     assert(nodes->length() >= 1, "must have created at least 1 node");
@@ -3434,10 +3433,9 @@ encode %{
       loadConLNodesTuple_create(ra_, n_toc, op_repl,
                                 ra_->get_reg_second(this), ra_->get_reg_first(this));
 
-    // Push new nodes.
-    if (loadConLNodes._small)    nodes->push(loadConLNodes._small);
+    // Push new nodes. Note that _last points to the same node as either _large_lo or _small.
     if (loadConLNodes._large_hi) nodes->push(loadConLNodes._large_hi);
-    if (loadConLNodes._large_lo) nodes->push(loadConLNodes._large_lo);
+    if (loadConLNodes._last)     nodes->push(loadConLNodes._last);
 
     assert(nodes->length() >= 1, "must have created at least 1 node");
     assert(loadConLNodes._last->bottom_type()->isa_long(), "must be long");
@@ -3666,10 +3664,9 @@ encode %{
     // Only the inline cache is associated with a register.
     assert(Matcher::inline_cache_reg() == OptoReg::Name(R19_num), "ic reg should be R19");
 
-    // Push new nodes.
-    if (loadConLNodes_IC._small)    nodes->push(loadConLNodes_IC._small);
+    // Push new nodes. Note that _last points to the same node as either _large_lo or _small.
     if (loadConLNodes_IC._large_hi) nodes->push(loadConLNodes_IC._large_hi);
-    if (loadConLNodes_IC._large_lo) nodes->push(loadConLNodes_IC._large_lo);
+    if (loadConLNodes_IC._last)     nodes->push(loadConLNodes_IC._last);
     nodes->push(call);
   %}
 
@@ -3858,17 +3855,14 @@ encode %{
     // registers
     ra_->set1(mtctr->_idx, OptoReg::Name(SR_CTR_num));
 
-    // Insert the new nodes.
-    if (loadConLNodes_Entry._small)    nodes->push(loadConLNodes_Entry._small);
+    // Insert the new nodes. Note that _last points to the same node as either _large_lo or _small.
     if (loadConLNodes_Entry._large_hi) nodes->push(loadConLNodes_Entry._large_hi);
-    if (loadConLNodes_Entry._large_lo) nodes->push(loadConLNodes_Entry._large_lo);
+    if (loadConLNodes_Entry._last)     nodes->push(loadConLNodes_Entry._last);
 #if !defined(ABI_ELFv2)
-    if (loadConLNodes_Env._small)      nodes->push(loadConLNodes_Env._small);
     if (loadConLNodes_Env._large_hi)   nodes->push(loadConLNodes_Env._large_hi);
-    if (loadConLNodes_Env._large_lo)   nodes->push(loadConLNodes_Env._large_lo);
-    if (loadConLNodes_Toc._small)      nodes->push(loadConLNodes_Toc._small);
+    if (loadConLNodes_Env._last)       nodes->push(loadConLNodes_Env._last);
     if (loadConLNodes_Toc._large_hi)   nodes->push(loadConLNodes_Toc._large_hi);
-    if (loadConLNodes_Toc._large_lo)   nodes->push(loadConLNodes_Toc._large_lo);
+    if (loadConLNodes_Toc._last)       nodes->push(loadConLNodes_Toc._last);
 #endif
     nodes->push(mtctr);
     nodes->push(call);


### PR DESCRIPTION
The POWER10 processor supports prefixed load and addi instructions that have larger displacement field of up to 34-bits. We can reduce instruction cycles to load constant from TOC and load an immediate value to a register.

Assembler::{load|add}_const_optimized() and LoadCon[LPFD]Nodes are modified to use prefixed instructions, with fixing other functions that are affected by this change.

I ran jtreg test on both POWER10 and POWER8 machines by using "make test-tier1" and verified no additional fails by this change. I also ran DaCapo, Renaissance, and SPECjbb2015 on both of them and verified they run successfully.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8267968](https://bugs.openjdk.java.net/browse/JDK-8267968): [PPC64] Use prefixed load and addi instructions for better performance in POWER10


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4267/head:pull/4267` \
`$ git checkout pull/4267`

Update a local copy of the PR: \
`$ git checkout pull/4267` \
`$ git pull https://git.openjdk.java.net/jdk pull/4267/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4267`

View PR using the GUI difftool: \
`$ git pr show -t 4267`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4267.diff">https://git.openjdk.java.net/jdk/pull/4267.diff</a>

</details>
