### PR TITLE
8267921: Remove redundant loop from sun.reflect.misc.ReflectUtil.privateCheckPackageAccess()

### DIFF
--- a/src/java.base/share/classes/sun/reflect/misc/ReflectUtil.java
+++ b/src/java.base/share/classes/sun/reflect/misc/ReflectUtil.java
@@ -124,10 +124,6 @@ public final class ReflectUtil {
      * NOTE: should only be called if a SecurityManager is installed
      */
     private static void privateCheckPackageAccess(SecurityManager s, Class<?> clazz) {
-        while (clazz.isArray()) {
-            clazz = clazz.getComponentType();
-        }
-
         String pkg = clazz.getPackageName();
         if (!pkg.isEmpty()) {
             s.checkPackageAccess(pkg);


### PR DESCRIPTION
This a tiny follop-up of https://github.com/openjdk/jdk/pull/3571.

The loop in `sun.reflect.misc.ReflectUtil.privateCheckPackageAccess()` is redundant since `Class.getPackageName()` will already return the package name of the innermost component type.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267921](https://bugs.openjdk.java.net/browse/JDK-8267921): Remove redundant loop from sun.reflect.misc.ReflectUtil.privateCheckPackageAccess()


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4268/head:pull/4268` \
`$ git checkout pull/4268`

Update a local copy of the PR: \
`$ git checkout pull/4268` \
`$ git pull https://git.openjdk.java.net/jdk pull/4268/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4268`

View PR using the GUI difftool: \
`$ git pr show -t 4268`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4268.diff">https://git.openjdk.java.net/jdk/pull/4268.diff</a>

</details>
