### PR TITLE
8267947: CI: Preserve consistency between has_subklass() and is_subclass_of()

### DIFF
--- a/src/hotspot/share/ci/ciInstanceKlass.hpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.hpp
@@ -152,16 +152,15 @@ public:
     return _has_finalizer; }
   bool                   has_subklass()   {
     assert(is_loaded(), "must be loaded");
-    if (_has_subklass == subklass_unknown ||
-        (_is_shared && _has_subklass == subklass_false)) {
-      if (flags().is_final()) {
-        return false;
-      } else {
-        return compute_shared_has_subklass();
-      }
+    if (_has_subklass == subklass_true) {
+      return true;
     }
-    return _has_subklass == subklass_true;
+    if (flags().is_final()) {
+      return false;
+    }
+    return compute_shared_has_subklass();
   }
+
   jint                   size_helper()  {
     return (Klass::layout_helper_size_in_bytes(layout_helper())
             >> LogHeapWordSize);

--- a/src/hotspot/share/ci/ciInstanceKlass.hpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.hpp
@@ -152,6 +152,10 @@ public:
     return _has_finalizer; }
   bool                   has_subklass()   {
     assert(is_loaded(), "must be loaded");
+    // Ignore cached subklass_false case.
+    // It could be invalidated by concurrent class loading and
+    // can result in type paradoxes during compilation when
+    // a subclass is observed, but has_subklass() returns false.
     if (_has_subklass == subklass_true) {
       return true;
     }

--- a/src/hotspot/share/ci/ciKlass.cpp
+++ b/src/hotspot/share/ci/ciKlass.cpp
@@ -78,11 +78,10 @@ bool ciKlass::is_subtype_of(ciKlass* that) {
   bool is_subtype;
   GUARDED_VM_ENTRY(is_subtype = get_Klass()->is_subtype_of(that->get_Klass());)
 
-#ifdef ASSERT
-  if (that->is_instance_klass() && !that->is_interface()) {
-    assert(!is_subtype || that->as_instance_klass()->has_subklass(), "inconsistent");
-  }
-#endif // ASSERT
+  // Ensure consistency with ciInstanceKlass::has_subklass().
+  assert(!that->is_instance_klass() || // array klasses are irrelevant
+          that->is_interface()      || // has_subklass is always false for interfaces
+         !is_subtype || that->as_instance_klass()->has_subklass(), "inconsistent");
 
   return is_subtype;
 }
@@ -101,11 +100,10 @@ bool ciKlass::is_subclass_of(ciKlass* that) {
   bool is_subclass;
   GUARDED_VM_ENTRY(is_subclass = get_Klass()->is_subclass_of(that->get_Klass());)
 
-#ifdef ASSERT
-  if (that->is_instance_klass() && !that->is_interface()) {
-    assert(!is_subclass || that->as_instance_klass()->has_subklass(), "inconsistent");
-  }
-#endif // ASSERT
+  // Ensure consistency with ciInstanceKlass::has_subklass().
+  assert(!that->is_instance_klass() || // array klasses are irrelevant
+          that->is_interface()      || // has_subklass is always false for interfaces
+         !is_subclass || that->as_instance_klass()->has_subklass(), "inconsistent");
 
   return is_subclass;
 }


### PR DESCRIPTION
CI caches `Klass::subklass() != NULL` query, but concurrent class loading can
invalidate the cached value. Though recorded dependency won't let the nmethod
to be installed, the inconcistency can manifest as type paradoxes until
compilation is finished. 

The fix caches only `true` value (since it can't change unless class unloading
takes place) and queries the VM otherwise.

Testing:
- [x] hs-tier1 - hs-tier6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267947](https://bugs.openjdk.java.net/browse/JDK-8267947): CI: Preserve consistency between has_subklass() and is_subclass_of()


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4269/head:pull/4269` \
`$ git checkout pull/4269`

Update a local copy of the PR: \
`$ git checkout pull/4269` \
`$ git pull https://git.openjdk.java.net/jdk pull/4269/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4269`

View PR using the GUI difftool: \
`$ git pr show -t 4269`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4269.diff">https://git.openjdk.java.net/jdk/pull/4269.diff</a>

</details>
