### PR TITLE
JDK-8259806: Clean up terminology on the "All Classes" page

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllClassesIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllClassesIndexWriter.java
@@ -92,7 +92,7 @@ public class AllClassesIndexWriter extends HtmlDocletWriter {
      * Print all the classes in the file.
      */
     protected void buildAllClassesFile() throws DocFileIOException {
-        String label = resources.getText("doclet.All_Classes");
+        String label = resources.getText("doclet.All_Classes_And_Interfaces");
         Content allClassesContent = new ContentBuilder();
         addContents(allClassesContent);
         Content mainContent = new ContentBuilder();
@@ -131,7 +131,7 @@ public class AllClassesIndexWriter extends HtmlDocletWriter {
                 }
             }
         }
-        Content titleContent = contents.allClassesLabel;
+        Content titleContent = contents.allClassesAndInterfacesLabel;
         Content pHeading = HtmlTree.HEADING_TITLE(Headings.PAGE_TITLE_HEADING,
                 HtmlStyle.title, titleContent);
         Content headerDiv = HtmlTree.DIV(HtmlStyle.header, pHeading);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Contents.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Contents.java
@@ -51,7 +51,6 @@ import jdk.javadoc.internal.doclets.toolkit.util.VisibleMemberTable;
  */
 public class Contents {
 
-    public final Content allClassesLabel;
     public final Content allClassesAndInterfacesLabel;
     public final Content allImplementedInterfacesLabel;
     public final Content allModulesLabel;
@@ -196,7 +195,6 @@ public class Contents {
     Contents(HtmlConfiguration configuration) {
         this.resources = configuration.getDocResources();
 
-        allClassesLabel = getNonBreakResource("doclet.All_Classes");
         this.allClassesAndInterfacesLabel = getContent("doclet.All_Classes_And_Interfaces");
         allImplementedInterfacesLabel = getContent("doclet.All_Implemented_Interfaces");
         allModulesLabel = getNonBreakResource("doclet.All_Modules");

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HelpWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HelpWriter.java
@@ -77,7 +77,7 @@ public class HelpWriter extends HtmlDocletWriter {
         // yes, INDEX is correct in the following line
         overviewLink = links.createLink(DocPaths.INDEX, resources.getText("doclet.Overview"));
         allPackagesLink = links.createLink(DocPaths.ALLPACKAGES_INDEX, resources.getText("doclet.All_Packages"));
-        allClassesLink = links.createLink(DocPaths.ALLCLASSES_INDEX, resources.getText("doclet.All_Classes"));
+        allClassesLink = links.createLink(DocPaths.ALLCLASSES_INDEX, resources.getText("doclet.All_Classes_And_Interfaces"));
         DocPath dp = options.splitIndex()
                 ? DocPaths.INDEX_FILES.resolve(DocPaths.indexN(1))
                 : DocPaths.INDEX_ALL;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlIndexBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlIndexBuilder.java
@@ -169,7 +169,7 @@ public class HtmlIndexBuilder extends IndexBuilder {
             add(item);
         }
         IndexItem item = IndexItem.of(IndexItem.Category.TYPES,
-                resources.getText("doclet.All_Classes"),
+                resources.getText("doclet.All_Classes_And_Interfaces"),
                 DocPaths.ALLCLASSES_INDEX);
         add(item);
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
@@ -252,7 +252,7 @@ doclet.help.index.body=\
     The {0} contains an alphabetic index of all classes, interfaces, constructors, methods, \
     and fields in the documentation, as well as summary pages such as {1}.
 doclet.help.all_classes.head=\
-    All Classes
+    All Classes and Interfaces
 # 0: link to All Classes page
 doclet.help.all_classes.body=\
     The {0} page contains an alphabetic index of all classes and interfaces contained in the \

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets.properties
@@ -140,7 +140,6 @@ doclet.AnnotationInterfaces=Annotation Interfaces
 doclet.Exceptions=Exceptions
 doclet.Errors=Errors
 doclet.Classes=Classes
-doclet.All_Classes=All Classes
 doclet.All_Classes_And_Interfaces=All Classes and Interfaces
 doclet.All_Superinterfaces=All Superinterfaces:
 doclet.All_Implemented_Interfaces=All Implemented Interfaces:

--- a/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
+++ b/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
@@ -1439,13 +1439,14 @@ public class TestModules extends JavadocTester {
                     <table summary="Package Summary table, listing packages, and an explanation">""");
         checkOutput("type-search-index.js", true,
                 """
-                    {"l":"All Classes","u":"allclasses-index.html"}""");
+                    {"l":"All Classes and Interfaces","u":"allclasses-index.html"}""");
         checkOutput("package-search-index.js", true,
                 """
                     {"l":"All Packages","u":"allpackages-index.html"}""");
         checkOutput("index-all.html", true,
                 """
-                    <br><a href="allclasses-index.html">All&nbsp;Classes</a><span class="vertical-se\
-                    parator">|</span><a href="allpackages-index.html">All&nbsp;Packages</a>""");
+                    <br><a href="allclasses-index.html">All&nbsp;Classes&nbsp;and&nbsp;Interfaces</a\
+                    ><span class="vertical-separator">|</span><a href="allpackages-index.html">All&n\
+                    bsp;Packages</a>""");
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testPackagePage/TestPackagePage.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackagePage/TestPackagePage.java
@@ -101,13 +101,14 @@ public class TestPackagePage extends JavadocTester {
                     """);
         checkOutput("type-search-index.js", true,
                 """
-                    {"l":"All Classes","u":"allclasses-index.html"}""");
+                    {"l":"All Classes and Interfaces","u":"allclasses-index.html"}""");
         checkOutput("package-search-index.js", true,
                 """
                     {"l":"All Packages","u":"allpackages-index.html"}""");
         checkOutput("index-all.html", true,
                 """
-                    <br><a href="allclasses-index.html">All&nbsp;Classes</a><span class="vertical-se\
-                    parator">|</span><a href="allpackages-index.html">All&nbsp;Packages</a>""");
+                    <br><a href="allclasses-index.html">All&nbsp;Classes&nbsp;and&nbsp;Interfaces</a\
+                    ><span class="vertical-separator">|</span><a href="allpackages-index.html">All&n\
+                    bsp;Packages</a>""");
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
+++ b/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
@@ -540,8 +540,9 @@ public class TestSearch extends JavadocTester {
                     <dt><a href="../pkg/package-summary.html#SingleWord" class="search-tag-link">Sin\
                     gleWord</a> - Search tag in package pkg</dt>""",
                 """
-                    <br><a href="../allclasses-index.html">All&nbsp;Classes</a><span class="vertical\
-                    -separator">|</span><a href="../allpackages-index.html">All&nbsp;Packages</a>""");
+                    <br><a href="../allclasses-index.html">All&nbsp;Classes&nbsp;and&nbsp;Interfaces\
+                    </a><span class="vertical-separator">|</span><a href="../allpackages-index.html"\
+                    >All&nbsp;Packages</a>""");
         checkOutput("index-files/index-10.html", true,
                 """
                     <dt><a href="../pkg/package-summary.html#phrasewithspaces" class="search-tag-lin\
@@ -846,13 +847,14 @@ public class TestSearch extends JavadocTester {
                     """);
         checkOutput("type-search-index.js", true,
                 """
-                    {"l":"All Classes","u":"allclasses-index.html"}""");
+                    {"l":"All Classes and Interfaces","u":"allclasses-index.html"}""");
         checkOutput("package-search-index.js", true,
                 """
                     {"l":"All Packages","u":"allpackages-index.html"}""");
         checkOutput("index-all.html", true,
-                    """
-                        <br><a href="allclasses-index.html">All&nbsp;Classes</a><span class="vertical-se\
-                        parator">|</span><a href="allpackages-index.html">All&nbsp;Packages</a>""");
+                """
+                    <br><a href="allclasses-index.html">All&nbsp;Classes&nbsp;and&nbsp;Interface\
+                    s</a><span class="vertical-separator">|</span><a href="allpackages-index.htm\
+                    l">All&nbsp;Packages</a>""");
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testUnnamedPackage/TestUnnamedPackage.java
+++ b/test/langtools/jdk/javadoc/doclet/testUnnamedPackage/TestUnnamedPackage.java
@@ -96,7 +96,7 @@ public class TestUnnamedPackage extends JavadocTester {
 
         checkOutput("type-search-index.js", true,
                 """
-                    {"l":"All Classes","u":"allclasses-index.html"}""");
+                    {"l":"All Classes and Interfaces","u":"allclasses-index.html"}""");
 
         checkOutput("package-search-index.js", true,
                 """
@@ -104,12 +104,13 @@ public class TestUnnamedPackage extends JavadocTester {
 
         checkOutput("index-all.html", true,
                 """
-                    <br><a href="allclasses-index.html">All&nbsp;Classes</a><span class="vertical-se\
-                    parator">|</span><a href="allpackages-index.html">All&nbsp;Packages</a>""");
+                    <br><a href="allclasses-index.html">All&nbsp;Classes&nbsp;and&nbsp;Interfaces</a\
+                    ><span class="vertical-separator">|</span><a href="allpackages-index.html">All&n\
+                    bsp;Packages</a>""");
 
         checkOutput("type-search-index.js", true,
                 """
-                    {"l":"All Classes","u":"allclasses-index.html"}""",
+                    {"l":"All Classes and Interfaces","u":"allclasses-index.html"}""",
                 """
                     {"p":"<Unnamed>","l":"C"}""");
 


### PR DESCRIPTION
This is a simple change to replace the "All Classes" with "All Classes and Interfaces" in the heading of and references to the page of the same name.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259806](https://bugs.openjdk.java.net/browse/JDK-8259806): Clean up terminology on the "All Classes" page


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4270/head:pull/4270` \
`$ git checkout pull/4270`

Update a local copy of the PR: \
`$ git checkout pull/4270` \
`$ git pull https://git.openjdk.java.net/jdk pull/4270/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4270`

View PR using the GUI difftool: \
`$ git pr show -t 4270`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4270.diff">https://git.openjdk.java.net/jdk/pull/4270.diff</a>

</details>
