### PR TITLE
JDK-8246351: <code> elements in headings are of incorrect size

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/stylesheet.css
@@ -67,6 +67,9 @@ ul {
 }
 code, tt {
     font-family:'DejaVu Sans Mono', monospace;
+}
+:not(h1, h2, h3, h4, h5, h6) > code,
+:not(h1, h2, h3, h4, h5, h6) > tt {
     font-size:14px;
     padding-top:4px;
     margin-top:8px;


### PR DESCRIPTION
This is a simple fix to not set the font size and related spacings in `<code>` and `<tt>` elements when they occur inside a heading. The screenshot below shows the new rendered  text in Safari on Mac OS X (there is a `<code>` in the heading and there are several in the flow text).

<img width="699" alt="fontsize" src="https://user-images.githubusercontent.com/15975/120197515-4f97f480-c221-11eb-976a-7bcb040b05ae.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8246351](https://bugs.openjdk.java.net/browse/JDK-8246351): <code> elements in headings are of incorrect size


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4273/head:pull/4273` \
`$ git checkout pull/4273`

Update a local copy of the PR: \
`$ git checkout pull/4273` \
`$ git pull https://git.openjdk.java.net/jdk pull/4273/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4273`

View PR using the GUI difftool: \
`$ git pr show -t 4273`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4273.diff">https://git.openjdk.java.net/jdk/pull/4273.diff</a>

</details>
