### PR TITLE
8267985: Allow AsyncGetCallTrace and JFR to walk a stub frame

### DIFF
--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -122,7 +122,22 @@ bool frame::safe_for_sender(JavaThread *thread) {
       sender_sp = (intptr_t*) addr_at(sender_sp_offset);
       sender_unextended_sp = (intptr_t*) this->fp()[interpreter_frame_sender_sp_offset];
       saved_fp = (intptr_t*) this->fp()[link_offset];
+    } else if (StubRoutines::is_stub_code(pc())) {
+      // fp must be safe
+      if (!thread->is_in_full_stack_checked((address)this->fp())) {
+        return false;
+      }
 
+      sender_sp = (intptr_t*) addr_at(sender_sp_offset);
+      // Is sender_sp safe?
+      if (!thread->is_in_full_stack_checked((address)sender_sp)) {
+        return false;
+      }
+      sender_unextended_sp = sender_sp;
+      // On Intel the return_address is always the word on the stack
+      sender_pc = (address) this->fp()[return_addr_offset];
+      // Note: frame::sender_sp_offset is only valid for compiled frame
+      saved_fp = (intptr_t*) this->fp()[link_offset];
     } else {
       // must be some sort of compiled/runtime frame
       // fp does not have to be safe (although it could be check for c1?)
@@ -439,17 +454,33 @@ frame frame::sender_for_interpreter_frame(RegisterMap* map) const {
 frame frame::sender_for_compiled_frame(RegisterMap* map) const {
   assert(map != NULL, "map must be set");
 
-  // frame owned by optimizing compiler
-  assert(_cb->frame_size() >= 0, "must have non-zero frame size");
-  intptr_t* sender_sp = unextended_sp() + _cb->frame_size();
-  intptr_t* unextended_sp = sender_sp;
+  intptr_t* sender_sp;
+  intptr_t* sender_unextended_sp;
+  address sender_pc;
+  intptr_t** saved_fp_addr;
+  if (StubRoutines::is_stub_code(pc())) {
+    sender_sp = (intptr_t*) addr_at(sender_sp_offset);
+    sender_unextended_sp = sender_sp;
 
-  // On Intel the return_address is always the word on the stack
-  address sender_pc = (address) *(sender_sp-1);
+    // On Intel the return_address is always the word on the stack
+    sender_pc = (address) fp()[return_addr_offset];
 
-  // This is the saved value of EBP which may or may not really be an FP.
-  // It is only an FP if the sender is an interpreter frame (or C1?).
-  intptr_t** saved_fp_addr = (intptr_t**) (sender_sp - frame::sender_sp_offset);
+    // This is the saved value of EBP which may or may not really be an FP.
+    // It is only an FP if the sender is an interpreter frame (or C1?).
+    saved_fp_addr = (intptr_t**) addr_at(link_offset);
+  } else {
+    // frame owned by optimizing compiler
+    assert(_cb->frame_size() >= 0, "must have non-zero frame size");
+    sender_sp = unextended_sp() + _cb->frame_size();
+    sender_unextended_sp = sender_sp;
+
+    // On Intel the return_address is always the word on the stack
+    sender_pc = (address) *(sender_sp-1);
+
+    // This is the saved value of EBP which may or may not really be an FP.
+    // It is only an FP if the sender is an interpreter frame (or C1?).
+    saved_fp_addr = (intptr_t**) (sender_sp - frame::sender_sp_offset);
+  }
 
   if (map->update_map()) {
     // Tell GC to use argument oopmaps for some runtime stubs that need it.
@@ -467,7 +498,7 @@ frame frame::sender_for_compiled_frame(RegisterMap* map) const {
   }
 
   assert(sender_sp != sp(), "must have changed");
-  return frame(sender_sp, unextended_sp, *saved_fp_addr, sender_pc);
+  return frame(sender_sp, sender_unextended_sp, *saved_fp_addr, sender_pc);
 }
 
 


### PR DESCRIPTION
When the signal sent for AsyncGetCallTrace or JFR would land on a stub
(like arraycopy), it wouldn't be able to detect the sender (caller)
frame because `_cb->frame_size() == 0`.

Because we fully control how the prolog and epilog of stub code is
generated, we know there are two cases:
1. A stack frame is allocated via macroAssembler->enter(), and consists
in `push rbp; mov rsp, rbp;`.
2. No stack frames are allocated and rbp is left unchanged and rsp is
decremented with the `call` instruction that push the return `pc` on the
stack.

For case 1., we can easily know the sender frame by simply looking at
rbp, especially since we know that all stubs preserve the frame pointer
(on x86 at least).

For case 2., we end up returning the sender's sender, but that already
gives us more information than what we have today.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8267985](https://bugs.openjdk.java.net/browse/JDK-8267985): Allow AsyncGetCallTrace and JFR to walk a stub frame


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4274/head:pull/4274` \
`$ git checkout pull/4274`

Update a local copy of the PR: \
`$ git checkout pull/4274` \
`$ git pull https://git.openjdk.java.net/jdk pull/4274/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4274`

View PR using the GUI difftool: \
`$ git pr show -t 4274`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4274.diff">https://git.openjdk.java.net/jdk/pull/4274.diff</a>

</details>
