### PR TITLE
8268014: Build failure on SUSE Linux Enterprise Server 11.4 (s390x) due to 'SYS_get_mempolicy' was not declared

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2961,35 +2961,6 @@ void* os::Linux::libnuma_v2_dlsym(void* handle, const char* name) {
   return dlvsym(handle, name, "libnuma_1.2");
 }
 
-#ifndef SYS_get_mempolicy
-  #ifdef __NR_get_mempolicy
-    #define SYS_get_mempolicy __NR_get_mempolicy
-  #else
-    // ia64: 1260, i386: 275, x86_64: 239, s390x: 236, powerpc: 260
-    #ifdef __ia64__
-      #define SYS_get_mempolicy 1260
-    #else
-      #ifdef __i386__
-        #define SYS_get_mempolicy 275
-      #else
-        #ifdef __x86_64__
-          #define SYS_get_mempolicy 239
-        #else
-          #ifdef __s390x__
-            #define SYS_get_mempolicy 236
-          #else
-            #ifdef __powerpc__
-              #define SYS_get_mempolicy 260
-            #else
-              #error define get_mempolicy for the arch
-            #endif
-          #endif
-        #endif
-      #endif
-    #endif
-  #endif
-#endif
-
 // Check numa dependent syscalls
 static bool numa_syscall_check() {
   // NUMA APIs depend on several syscalls. E.g., get_mempolicy is required for numa_get_membind and
@@ -2997,10 +2968,12 @@ static bool numa_syscall_check() {
   // Especially in dockers, get_mempolicy is not allowed with the default configuration. So it's necessary
   // to check whether the syscalls are available. Currently, only get_mempolicy is checked since checking
   // others like mbind would cause unexpected side effects.
+#ifdef SYS_get_mempolicy
   int dummy = 0;
   if (syscall(SYS_get_mempolicy, &dummy, NULL, 0, (void*)&dummy, 3) == -1) {
     return false;
   }
+#endif
 
   return true;
 }

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2961,9 +2961,33 @@ void* os::Linux::libnuma_v2_dlsym(void* handle, const char* name) {
   return dlvsym(handle, name, "libnuma_1.2");
 }
 
-#if !defined(SYS_get_mempolicy) && defined(S390)
-// No SYS_get_mempolicy definition on SUSE Linux Enterprise Server 11.4 (s390x)
-#define SYS_get_mempolicy __NR_get_mempolicy
+#ifndef SYS_get_mempolicy
+  #ifdef __NR_get_mempolicy
+    #define SYS_get_mempolicy __NR_get_mempolicy
+  #else
+    // ia64: 1260, i386: 275, x86_64: 239, s390x: 236, powerpc: 260
+    #ifdef __ia64__
+      #define SYS_get_mempolicy 1260
+    #else
+      #ifdef __i386__
+        #define SYS_get_mempolicy 275
+      #else
+        #ifdef __x86_64__
+          #define SYS_get_mempolicy 239
+        #else
+          #ifdef __s390x__
+            #define SYS_get_mempolicy 236
+          #else
+            #ifdef __powerpc__
+              #define SYS_get_mempolicy 260
+            #else
+              #error define get_mempolicy for the arch
+            #endif
+          #endif
+        #endif
+      #endif
+    #endif
+  #endif
 #endif
 
 // Check numa dependent syscalls

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2961,6 +2961,31 @@ void* os::Linux::libnuma_v2_dlsym(void* handle, const char* name) {
   return dlvsym(handle, name, "libnuma_1.2");
 }
 
+#ifndef SYS_get_mempolicy
+// ia64: 1260, i386: 275, x86_64: 239, s390x: 236, powerpc: 260
+  #ifdef __ia64__
+    #define SYS_get_mempolicy 1260
+  #else
+    #ifdef __i386__
+      #define SYS_get_mempolicy 275
+    #else
+      #ifdef __x86_64__
+        #define SYS_get_mempolicy 239
+      #else
+        #ifdef __s390x__
+          #define SYS_get_mempolicy 236
+        #else
+          #ifdef __powerpc__
+            #define SYS_get_mempolicy 260
+          #else
+            #error define get_mempolicy for the arch
+          #endif
+        #endif
+      #endif
+    #endif
+  #endif
+#endif
+
 // Check numa dependent syscalls
 static bool numa_syscall_check() {
   // NUMA APIs depend on several syscalls. E.g., get_mempolicy is required for numa_get_membind and

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2962,23 +2962,27 @@ void* os::Linux::libnuma_v2_dlsym(void* handle, const char* name) {
 }
 
 #ifndef SYS_get_mempolicy
-// ia64: 1260, i386: 275, x86_64: 239, s390x: 236, powerpc: 260
-  #ifdef __ia64__
-    #define SYS_get_mempolicy 1260
+  #ifdef __NR_get_mempolicy
+    #define SYS_get_mempolicy __NR_get_mempolicy
   #else
-    #ifdef __i386__
-      #define SYS_get_mempolicy 275
+    // ia64: 1260, i386: 275, x86_64: 239, s390x: 236, powerpc: 260
+    #ifdef __ia64__
+      #define SYS_get_mempolicy 1260
     #else
-      #ifdef __x86_64__
-        #define SYS_get_mempolicy 239
+      #ifdef __i386__
+        #define SYS_get_mempolicy 275
       #else
-        #ifdef __s390x__
-          #define SYS_get_mempolicy 236
+        #ifdef __x86_64__
+          #define SYS_get_mempolicy 239
         #else
-          #ifdef __powerpc__
-            #define SYS_get_mempolicy 260
+          #ifdef __s390x__
+            #define SYS_get_mempolicy 236
           #else
-            #error define get_mempolicy for the arch
+            #ifdef __powerpc__
+              #define SYS_get_mempolicy 260
+            #else
+              #error define get_mempolicy for the arch
+            #endif
           #endif
         #endif
       #endif

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2961,33 +2961,9 @@ void* os::Linux::libnuma_v2_dlsym(void* handle, const char* name) {
   return dlvsym(handle, name, "libnuma_1.2");
 }
 
-#ifndef SYS_get_mempolicy
-  #ifdef __NR_get_mempolicy
-    #define SYS_get_mempolicy __NR_get_mempolicy
-  #else
-    // ia64: 1260, i386: 275, x86_64: 239, s390x: 236, powerpc: 260
-    #ifdef __ia64__
-      #define SYS_get_mempolicy 1260
-    #else
-      #ifdef __i386__
-        #define SYS_get_mempolicy 275
-      #else
-        #ifdef __x86_64__
-          #define SYS_get_mempolicy 239
-        #else
-          #ifdef __s390x__
-            #define SYS_get_mempolicy 236
-          #else
-            #ifdef __powerpc__
-              #define SYS_get_mempolicy 260
-            #else
-              #error define get_mempolicy for the arch
-            #endif
-          #endif
-        #endif
-      #endif
-    #endif
-  #endif
+#if !defined(SYS_get_mempolicy) && defined(S390)
+// No SYS_get_mempolicy definition on SUSE Linux Enterprise Server 11.4 (s390x)
+#define SYS_get_mempolicy __NR_get_mempolicy
 #endif
 
 // Check numa dependent syscalls


### PR DESCRIPTION
Hi all,

Please review the patch which fixes the build failure on SUSE Linux Enterprise Server 11.4 (s390x).

@dholmes-ora had reminded me of this bug in [1].
But I missed the fact that ZGC is currently only built on x64 and aarch64.
And I'm sorry for this breakage.

The sys_call numbers of get_mempolicy for different platforms are just copied from the libnuma source code [2].

Thanks.
Best regards,
Jie


[1] https://github.com/openjdk/jdk/pull/4205#discussion_r639708293
[2] https://github.com/numactl/numactl/blob/master/syscall.c

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268014](https://bugs.openjdk.java.net/browse/JDK-8268014): Build failure on SUSE Linux Enterprise Server 11.4 (s390x) due to 'SYS_get_mempolicy' was not declared


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to 9fc63d7e50225b6d8faf4ba1cf0813e1b1a23187
 * [Matthias Baesken](https://openjdk.java.net/census#mbaesken) (@MBaesken - **Reviewer**) ⚠️ Review applies to 73f6b8d930b54f6e575b8a438c03a34ba90f4cbc


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4277/head:pull/4277` \
`$ git checkout pull/4277`

Update a local copy of the PR: \
`$ git checkout pull/4277` \
`$ git pull https://git.openjdk.java.net/jdk pull/4277/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4277`

View PR using the GUI difftool: \
`$ git pr show -t 4277`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4277.diff">https://git.openjdk.java.net/jdk/pull/4277.diff</a>

</details>
