### PR TITLE
8263303: C2 compilation fails with assert(found_sfpt) failed: no node in loop that's not input to safepoint

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -1771,34 +1771,6 @@ void LoopNode::verify_strip_mined(int expect_skeleton) const {
     Node* sfpt = outer_le->in(0);
     assert(sfpt->Opcode() == Op_SafePoint, "where's the safepoint?");
     Node* inner_out = sfpt->in(0);
-    if (inner_out->outcnt() != 1) {
-      ResourceMark rm;
-      Unique_Node_List wq;
-
-      for (DUIterator_Fast imax, i = inner_out->fast_outs(imax); i < imax; i++) {
-        Node* u = inner_out->fast_out(i);
-        if (u == sfpt) {
-          continue;
-        }
-        wq.clear();
-        wq.push(u);
-        bool found_sfpt = false;
-        for (uint next = 0; next < wq.size() && !found_sfpt; next++) {
-          Node* n = wq.at(next);
-          for (DUIterator_Fast imax, i = n->fast_outs(imax); i < imax && !found_sfpt; i++) {
-            Node* u = n->fast_out(i);
-            if (u == sfpt) {
-              found_sfpt = true;
-            }
-            if (!u->is_CFG()) {
-              wq.push(u);
-            }
-          }
-        }
-        assert(found_sfpt, "no node in loop that's not input to safepoint");
-      }
-    }
-
     CountedLoopEndNode* cle = inner_out->in(0)->as_CountedLoopEnd();
     assert(cle == inner->loopexit_or_null(), "mismatch");
     bool has_skeleton = outer_le->in(1)->bottom_type()->singleton() && outer_le->in(1)->bottom_type()->is_int()->get_con() == 0;

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1990,7 +1990,7 @@ static void clone_outer_loop_helper(Node* n, const IdealLoopTree *loop, const Id
     Node* u = n->fast_out(j);
     assert(check_old_new || old_new[u->_idx] == NULL, "shouldn't have been cloned");
     if (!u->is_CFG() && (!check_old_new || old_new[u->_idx] == NULL)) {
-      Node* c = phase->get_ctrl(u);
+      Node* c = u->in(0) != NULL ? u->in(0) : phase->get_ctrl(u);
       IdealLoopTree* u_loop = phase->get_loop(c);
       assert(!loop->is_member(u_loop), "can be in outer loop or out of both loops only");
       if (outer_loop->is_member(u_loop)) {
@@ -2113,11 +2113,20 @@ void PhaseIdealLoop::clone_outer_loop(LoopNode* head, CloneLoopMode mode, IdealL
       Node* old = extra_data_nodes.at(i);
       clone_outer_loop_helper(old, loop, outer_loop, old_new, wq, this, true);
     }
+
+    Node* inner_out = sfpt->in(0);
+    if (inner_out->outcnt() > 1) {
+      clone_outer_loop_helper(inner_out, loop, outer_loop, old_new, wq, this, true);
+    }
+
     Node* new_ctrl = cl->outer_loop_exit();
     assert(get_loop(new_ctrl) != outer_loop, "must be out of the loop nest");
     for (uint i = 0; i < wq.size(); i++) {
       Node* n = wq.at(i);
       set_ctrl(n, new_ctrl);
+      if (n->in(0) != NULL) {
+        _igvn.replace_input_of(n, 0, new_ctrl);
+      }
       clone_outer_loop_helper(n, loop, outer_loop, old_new, wq, this, false);
     }
   } else {

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java
@@ -1,5 +1,3 @@
-// rr record ~/jdk-jdk/build/linux-x86_64-server-fastdebug/images/jdk/bin/java -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:+PrintCompilation -XX:CompileOnly=TestPinnedUseInOuterLSM::test -XX:CompileCommand=quiet -XX:PrintIdealGraphFile=graph.xml -XX:PrintIdealGraphLevel=2 -XX:+UseG1GC -XX:+TraceLoopOpts -XX:LoopUnrollLimit=0 TestPinnedUseInOuterLSM
-
 /*
  * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java
@@ -1,0 +1,67 @@
+// rr record ~/jdk-jdk/build/linux-x86_64-server-fastdebug/images/jdk/bin/java -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:+PrintCompilation -XX:CompileOnly=TestPinnedUseInOuterLSM::test -XX:CompileCommand=quiet -XX:PrintIdealGraphFile=graph.xml -XX:PrintIdealGraphLevel=2 -XX:+UseG1GC -XX:+TraceLoopOpts -XX:LoopUnrollLimit=0 TestPinnedUseInOuterLSM
+
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8263303
+ * @summary C2 compilation fails with assert(found_sfpt) failed: no node in loop that's not input to safepoint
+ *
+ * @run main/othervm -XX:-BackgroundCompilation -XX:LoopUnrollLimit=0 TestPinnedUseInOuterLSMUnusedBySfpt
+ *
+ */
+
+public class TestPinnedUseInOuterLSMUnusedBySfpt {
+    public static void main(String[] args) {
+        int[] array = new int[10000];
+        for (int i = 0; i < 20_000; i++) {
+            test(100, array, 42);
+            test(100, array, 0);
+        }
+    }
+
+    private static float test(int stop, int[] array, int val) {
+        if (array == null) {
+        }
+        int j;
+        for (j = 0; j < 10; j++) {
+
+        }
+        int i;
+        int v = 0;
+        float f = 1;
+        for (i = 0; i < 10000; i++) {
+            if ((j - 10) * i + val == 42) {
+                f *= 2;
+            } else {
+                f *= 3;
+            }
+            v = (j - 10) * array[i];
+            if (i % 10001 != i) {
+                return v;
+            }
+        }
+        return v + array[i-1] + f;
+    }
+}


### PR DESCRIPTION
The loop strip mining verification code catches a node which is pinned
in the outer strip mined loop but not referenced from the safepoint
node.

The test case is an example of how this could happen. The array[i]
load is referenced from the safepoint initially through:

(j - 10) * array[i]

It is sunk out of the inner loop and pinned in the outer loop. A
following loop opts round causes j - 10 to constant fold to 0 and as a
consequence the array load is no longer referenced from the safepoint
but pinned in the outer strip mined loop.

I tried to find a way to preserve the invariant that all nodes in the
outer strip mined loop are referenced from the safepoint but found no
robust way for that. So the fix removes that part of the verification
code.

This requires loop cloning code to be adjusted for nodes pinned in the
outer strip mined loop but not referenced from the safepoint.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263303](https://bugs.openjdk.java.net/browse/JDK-8263303): C2 compilation fails with assert(found_sfpt) failed: no node in loop that's not input to safepoint


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4278/head:pull/4278` \
`$ git checkout pull/4278`

Update a local copy of the PR: \
`$ git checkout pull/4278` \
`$ git pull https://git.openjdk.java.net/jdk pull/4278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4278`

View PR using the GUI difftool: \
`$ git pr show -t 4278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4278.diff">https://git.openjdk.java.net/jdk/pull/4278.diff</a>

</details>
