### PR TITLE
JDK-8267936: PreserveAllAnnotations option isn't tested

### DIFF
--- a/test/jdk/java/lang/annotation/AnnotationType/AnnotationTypeChangedToRuntimeTest.java
+++ b/test/jdk/java/lang/annotation/AnnotationType/AnnotationTypeChangedToRuntimeTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Expose annotations made RUNTIME visible via Class.getAnnotation when -XX:+PreserveAllAnnotations is on
+ * @run main/othervm -XX:+PreserveAllAnnotations AnnotationTypeChangedToRuntimeTest
+ */
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * This test simulates a situation where an existing annotation with
+ * {@link RetentionPolicy#CLASS CLASS} retention was changed into
+ * {@link RetentionPolicy#RUNTIME RUNTIME} and we want to read
+ * its value during runtime with the help of
+ * -XX:+PreserveAllAnnotations option
+ */
+public class AnnotationTypeChangedToRuntimeTest {
+
+    @Retention(CLASS)
+    @AnnB
+    public @interface AnnA_v1 {
+    }
+
+    // An alternative version of AnnA_v1 with CLASS retention instead.
+    // Used to simulate separate compilation (see AltClassLoader below).
+    @Retention(RUNTIME)
+    @AnnB
+    public @interface AnnA_v2 {
+    }
+
+    @Retention(RUNTIME)
+    @AnnA_v1
+    public @interface AnnB {
+    }
+
+    @AnnA_v1
+    public static class TestTask implements Runnable {
+        @Override
+        public void run() {
+            AnnA_v1 ann1 = TestTask.class.getDeclaredAnnotation(AnnA_v1.class);
+            if (ann1 == null) {
+                throw new IllegalStateException(
+                    "@" + AnnA_v1.class.getSimpleName() +
+                    " should be visible at runtime");
+            }
+            AnnA_v1 ann2 = AnnB.class.getDeclaredAnnotation(AnnA_v1.class);
+            if (ann2 != null) {
+                throw new IllegalStateException(
+                    "@" + ann2.annotationType().getSimpleName() +
+                    " found on: " + AnnB.class.getName() +
+                    " should not be visible at runtime");
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        ClassLoader altLoader = new AltClassLoader(
+            AnnotationTypeChangedToRuntimeTest.class.getClassLoader());
+
+        Runnable altTask = (Runnable) Class.forName(
+            TestTask.class.getName(),
+            true,
+            altLoader).newInstance();
+
+        altTask.run();
+    }
+
+    /**
+     * A ClassLoader implementation that loads alternative implementations of
+     * classes. If class name ends with "_v1" it locates instead a class with
+     * name ending with "_v2" and loads that class instead.
+     */
+    static class AltClassLoader extends ClassLoader {
+        AltClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve)
+                throws ClassNotFoundException {
+            if (name.indexOf('.') < 0) { // root package is our class
+                synchronized (getClassLoadingLock(name)) {
+                    // First, check if the class has already been loaded
+                    Class<?> c = findLoadedClass(name);
+                    if (c == null) {
+                        c = findClass(name);
+                    }
+                    if (resolve) {
+                        resolveClass(c);
+                    }
+                    return c;
+                }
+            }
+            else { // not our class
+                return super.loadClass(name, resolve);
+            }
+        }
+
+        @Override
+        protected Class<?> findClass(String name)
+                throws ClassNotFoundException {
+            // special class name -> replace it with alternative name
+            if (name.endsWith("_v1")) {
+                String altName = name.substring(0, name.length() - 3) + "_v2";
+                String altPath = altName.replace('.', '/').concat(".class");
+                try (InputStream is = getResourceAsStream(altPath)) {
+                    if (is != null) {
+                        byte[] bytes = is.readAllBytes();
+                        // patch class bytes to contain original name
+                        for (int i = 0; i < bytes.length - 2; i++) {
+                            if (bytes[i] == '_' &&
+                                bytes[i + 1] == 'v' &&
+                                bytes[i + 2] == '2') {
+                                bytes[i + 2] = '1';
+                            }
+                        }
+                        return defineClass(name, bytes, 0, bytes.length);
+                    }
+                    else {
+                        throw new ClassNotFoundException(name);
+                    }
+                }
+                catch (IOException e) {
+                    throw new ClassNotFoundException(name, e);
+                }
+            }
+            else { // not special class name -> just load the class
+                String path = name.replace('.', '/').concat(".class");
+                try (InputStream is = getResourceAsStream(path)) {
+                    if (is != null) {
+                        byte[] bytes = is.readAllBytes();
+                        return defineClass(name, bytes, 0, bytes.length);
+                    }
+                    else {
+                        throw new ClassNotFoundException(name);
+                    }
+                }
+                catch (IOException e) {
+                    throw new ClassNotFoundException(name, e);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
There doesn't seem to be much support for the complete changes in #4245. To get at least something useful from that endeavor I have extracted the test for existing behavior of `-XX:+PreserveAllAnnotations` and I am offering it in this pull request without any changes to the JVM behavior.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8267936](https://bugs.openjdk.java.net/browse/JDK-8267936): PreserveAllAnnotations option isn't tested


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4280/head:pull/4280` \
`$ git checkout pull/4280`

Update a local copy of the PR: \
`$ git checkout pull/4280` \
`$ git pull https://git.openjdk.java.net/jdk pull/4280/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4280`

View PR using the GUI difftool: \
`$ git pr show -t 4280`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4280.diff">https://git.openjdk.java.net/jdk/pull/4280.diff</a>

</details>
