### PR TITLE
8268023: Improve diagnostic for HandshakeFailureTest

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -468,7 +468,9 @@ class Http2Connection  {
         Function<String, CompletableFuture<Void>> checkAlpnCF = (alpn) -> {
             CompletableFuture<Void> cf = new MinimalFuture<>();
             SSLEngine engine = aconn.getEngine();
-            assert Objects.equals(alpn, engine.getApplicationProtocol());
+            String engineAlpn = engine.getApplicationProtocol();
+            assert Objects.equals(alpn, engineAlpn)
+                    : "alpn: %s, engine: %s".formatted(alpn, engineAlpn);
 
             DEBUG_LOGGER.log("checkSSLConfig: alpn: %s", alpn );
 

--- a/test/jdk/java/net/httpclient/HandshakeFailureTest.java
+++ b/test/jdk/java/net/httpclient/HandshakeFailureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -266,7 +266,7 @@ public class HandshakeFailureTest {
         original.printStackTrace(System.out);
         throw new RuntimeException(
                 "Not found expected SSLHandshakeException in "
-                        + original);
+                        + original, original);
     }
 
     /** Common super type for PlainServer and SSLServer. */


### PR DESCRIPTION
Please find below a trivial change to improve diagnostic in case of failure in the HandshakeFailureTest.
The AssertionError observed will have more information next time it fires, and the stack trace will appear as the cause of the runtime exception thrown by the test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268023](https://bugs.openjdk.java.net/browse/JDK-8268023): Improve diagnostic for HandshakeFailureTest


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4281/head:pull/4281` \
`$ git checkout pull/4281`

Update a local copy of the PR: \
`$ git checkout pull/4281` \
`$ git pull https://git.openjdk.java.net/jdk pull/4281/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4281`

View PR using the GUI difftool: \
`$ git pr show -t 4281`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4281.diff">https://git.openjdk.java.net/jdk/pull/4281.diff</a>

</details>
