### PR TITLE
JDK-8149138: [javadoc] Fix SerialFormBuilder eliminate String bashing

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialFieldWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlSerialFieldWriter.java
@@ -110,28 +110,9 @@ public class HtmlSerialFieldWriter extends FieldWriterImpl
     }
 
     @Override
-    public void addMemberHeader(TypeElement fieldType, String fieldTypeStr,
-            String fieldDimensions, String fieldName, Content contentTree) {
-        Content nameContent = Text.of(fieldName);
-        Content heading = HtmlTree.HEADING(Headings.SerializedForm.MEMBER_HEADING, nameContent);
-        contentTree.add(heading);
-        Content pre = new HtmlTree(TagName.PRE);
-        if (fieldType == null) {
-            pre.add(fieldTypeStr);
-        } else {
-            Content fieldContent = writer.getLink(new HtmlLinkInfo(
-                    configuration, HtmlLinkInfo.Kind.SERIAL_MEMBER, fieldType));
-            pre.add(fieldContent);
-        }
-        pre.add(fieldDimensions + " ");
-        pre.add(fieldName);
-        contentTree.add(pre);
-    }
-
-    @Override
     public void addMemberHeader(TypeMirror fieldType, String fieldName, Content contentTree) {
         Content nameContent = Text.of(fieldName);
-        Content heading = HtmlTree.HEADING(TagName.H5, nameContent);
+        Content heading = HtmlTree.HEADING(Headings.SerializedForm.MEMBER_HEADING, nameContent);
         contentTree.add(heading);
         Content pre = new HtmlTree(TagName.PRE);
         Content fieldContent = writer.getLink(new HtmlLinkInfo(

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/SerializedFormWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/SerializedFormWriter.java
@@ -231,19 +231,6 @@ public interface SerializedFormWriter {
          * Adds the member header.
          *
          * @param fieldType the type of the field
-         * @param fieldTypeStr the type of the field in string format, used
-         *                     only if the type cannot be linked
-         * @param fieldDimensions the dimensions of the field
-         * @param fieldName the name of the field
-         * @param contentTree content tree to which the member header will be added
-         */
-        void addMemberHeader(TypeElement fieldType, String fieldTypeStr, String fieldDimensions,
-                             String fieldName, Content contentTree);
-
-        /**
-         * Adds the member header.
-         *
-         * @param fieldType the type of the field
          * @param fieldName the name of the field
          * @param contentTree content tree to which the member header will be added
          */

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/SerializedFormBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/SerializedFormBuilder.java
@@ -35,6 +35,7 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeMirror;
 
 import com.sun.source.doctree.SerialFieldTree;
 import com.sun.source.doctree.SerialTree;
@@ -478,22 +479,8 @@ public class SerializedFormBuilder extends AbstractBuilder {
             if (tag.getName() == null || tag.getType() == null)  // ignore malformed @serialField tags
                 continue;
             Content fieldsContentTree = fieldWriter.getFieldsContentHeader(tag.equals(tags.last()));
-            TypeElement te = ch.getReferencedClass(tag);
-            String fieldType = ch.getReferencedMemberName(tag);
-            if (te != null && utils.isPrimitive(te.asType())) {
-                fieldType = utils.getTypeName(te.asType(), false);
-                te = null;
-            }
-            String refSignature = ch.getReferencedSignature(tag);
-            // TODO: Print the signature directly, if it is an array, the
-            // current DocTree APIs makes it very hard to distinguish
-            // an as these are returned back as "Array" a DeclaredType.
-            if (refSignature != null && refSignature.endsWith("[]")) {
-                te = null;
-                fieldType = refSignature;
-            }
-            fieldWriter.addMemberHeader(te, fieldType, "",
-                    tag.getName().getName().toString(), fieldsContentTree);
+            TypeMirror type = ch.getReferencedType(tag);
+            fieldWriter.addMemberHeader(type, tag.getName().getName().toString(), fieldsContentTree);
             fieldWriter.addMemberDescription(field, tag, fieldsContentTree);
             serializableFieldsTree.add(fieldsContentTree);
         }

--- a/test/langtools/jdk/javadoc/doclet/testSerializedForm/SerializedForm.java
+++ b/test/langtools/jdk/javadoc/doclet/testSerializedForm/SerializedForm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,14 +32,19 @@ public class SerializedForm implements Serializable {
     /**
      * @serialField name String a test
      * @serialField longs Long[] the longs
+     * @serialField i int an int
+     * @serialField  m double[][] the doubles
+     * @serialField next SerializedForm a linked reference
      * @see TestSerializedForm
      */
     @Deprecated
     private static final ObjectStreamField[] serialPersistentFields = {
         new ObjectStreamField("i", int.class),
+        new ObjectStreamField("m", double[][].class),
         new ObjectStreamField("count", Integer.TYPE),
         new ObjectStreamField("name", String.class),
-        new ObjectStreamField("longs", Long[].class)
+        new ObjectStreamField("longs", Long[].class),
+        new ObjectStreamField("next", SerializedForm.class)
     };
 
     /**

--- a/test/langtools/jdk/javadoc/doclet/testSerializedForm/TestSerializedForm.java
+++ b/test/langtools/jdk/javadoc/doclet/testSerializedForm/TestSerializedForm.java
@@ -108,14 +108,29 @@ public class TestSerializedForm extends JavadocTester {
                     <h4>Serialized Fields</h4>
                     <ul class="block-list">
                     <li class="block-list">
+                    <h5>i</h5>
+                    <pre>int i</pre>
+                    <div class="block">an int</div>
+                    </li>
+                    <li class="block-list">
                     <h5>longs</h5>
-                    <pre>Long[] longs</pre>
+                    <pre>java.lang.Long[] longs</pre>
                     <div class="block">the longs</div>
+                    </li>
+                    <li class="block-list">
+                    <h5>m</h5>
+                    <pre>double[][] m</pre>
+                    <div class="block">the doubles</div>
                     </li>
                     <li class="block-list">
                     <h5>name</h5>
                     <pre>java.lang.String name</pre>
-                    <div class="block">a test</div>""");
+                    <div class="block">a test</div>
+                    </li>
+                    <li class="block-list">
+                    <h5>next</h5>
+                    <pre><a href="SerializedForm.html" title="class in Unnamed Package">SerializedForm</a> next</pre>
+                    <div class="block">a linked reference</div>""");
     }
 
     @Test
@@ -160,14 +175,29 @@ public class TestSerializedForm extends JavadocTester {
                     <h4>Serialized Fields</h4>
                     <ul class="block-list">
                     <li class="block-list">
+                    <h5>i</h5>
+                    <pre>int i</pre>
+                    <div class="block">an int</div>
+                    </li>
+                    <li class="block-list">
                     <h5>longs</h5>
-                    <pre>Long[] longs</pre>
+                    <pre>java.lang.Long[] longs</pre>
                     <div class="block">the longs</div>
+                    </li>
+                    <li class="block-list">
+                    <h5>m</h5>
+                    <pre>double[][] m</pre>
+                    <div class="block">the doubles</div>
                     </li>
                     <li class="block-list">
                     <h5>name</h5>
                     <pre>java.lang.String name</pre>
-                    <div class="block">a test</div>""");
+                    <div class="block">a test</div>
+                    </li>
+                    <li class="block-list">
+                    <h5>next</h5>
+                    <pre><a href="SerializedForm.html" title="class in Unnamed Package">SerializedForm</a> next</pre>
+                    <div class="block">a linked reference</div>""");
     }
 
     @Test
@@ -180,8 +210,10 @@ public class TestSerializedForm extends JavadocTester {
         checkExit(Exit.OK);
 
         checkOrder("serialized-form.html",
-                "int[] a1",
-                "int[][] a2",
+                """
+                    int[] a1""",
+                """
+                    int[][] a2""",
                 """
                     <a href="pkg2/Fields.html" title="class in pkg2">Fields</a>[][] doubleArray""",
                 """


### PR DESCRIPTION
Removal of ugly old code in `SerializedFormBuilder.java`. Luckily there already is a clean overloaded method in the associated writer that we can use, so this is mostly a removal of code that is no longer used.

I also enhanced the test to cover more cases such as primitive arrays and linked references.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8149138](https://bugs.openjdk.java.net/browse/JDK-8149138): [javadoc] Fix SerialFormBuilder eliminate String bashing


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4284/head:pull/4284` \
`$ git checkout pull/4284`

Update a local copy of the PR: \
`$ git checkout pull/4284` \
`$ git pull https://git.openjdk.java.net/jdk pull/4284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4284`

View PR using the GUI difftool: \
`$ git pr show -t 4284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4284.diff">https://git.openjdk.java.net/jdk/pull/4284.diff</a>

</details>
