### PR TITLE
8267879: ClassLoaderMetaspace destructor asserts on !_frozen

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -478,13 +478,6 @@ char* VM_PopulateDumpSharedSpace::dump_read_only_tables() {
 void VM_PopulateDumpSharedSpace::doit() {
   HeapShared::run_full_gc_in_vm_thread();
 
-  // We should no longer allocate anything from the metaspace, so that:
-  //
-  // (1) Metaspace::allocate might trigger GC if we have run out of
-  //     committed metaspace, but we can't GC because we're running
-  //     in the VM thread.
-  // (2) ArchiveBuilder needs to work with a stable set of MetaspaceObjs.
-  Metaspace::freeze();
   DEBUG_ONLY(SystemDictionaryShared::NoClassLoadingMark nclm);
 
   FileMapInfo::check_nonempty_dir_in_shared_path_table();

--- a/src/hotspot/share/memory/classLoaderMetaspace.cpp
+++ b/src/hotspot/share/memory/classLoaderMetaspace.cpp
@@ -81,8 +81,6 @@ ClassLoaderMetaspace::ClassLoaderMetaspace(Mutex* lock, Metaspace::MetaspaceType
 }
 
 ClassLoaderMetaspace::~ClassLoaderMetaspace() {
-  Metaspace::assert_not_frozen();
-
   UL(debug, "dies.");
 
   delete _non_class_space_arena;
@@ -92,7 +90,6 @@ ClassLoaderMetaspace::~ClassLoaderMetaspace() {
 
 // Allocate word_size words from Metaspace.
 MetaWord* ClassLoaderMetaspace::allocate(size_t word_size, Metaspace::MetadataType mdType) {
-  Metaspace::assert_not_frozen();
   if (Metaspace::is_class_space_allocation(mdType)) {
     return class_space_arena()->allocate(word_size);
   } else {
@@ -103,7 +100,6 @@ MetaWord* ClassLoaderMetaspace::allocate(size_t word_size, Metaspace::MetadataTy
 // Attempt to expand the GC threshold to be good for at least another word_size words
 // and allocate. Returns NULL if failure. Used during Metaspace GC.
 MetaWord* ClassLoaderMetaspace::expand_and_allocate(size_t word_size, Metaspace::MetadataType mdType) {
-  Metaspace::assert_not_frozen();
   size_t delta_bytes = MetaspaceGC::delta_capacity_until_GC(word_size * BytesPerWord);
   assert(delta_bytes > 0, "Must be");
 
@@ -135,7 +131,6 @@ MetaWord* ClassLoaderMetaspace::expand_and_allocate(size_t word_size, Metaspace:
 // Prematurely returns a metaspace allocation to the _block_freelists
 // because it is not needed anymore.
 void ClassLoaderMetaspace::deallocate(MetaWord* ptr, size_t word_size, bool is_class) {
-  Metaspace::assert_not_frozen();
   if (Metaspace::using_class_space() && is_class) {
     class_space_arena()->deallocate(ptr, word_size);
   } else {

--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -535,8 +535,6 @@ void MetaspaceGC::compute_new_size() {
 
 const MetaspaceTracer* Metaspace::_tracer = NULL;
 
-DEBUG_ONLY(bool Metaspace::_frozen = false;)
-
 bool Metaspace::initialized() {
   return metaspace::MetaspaceContext::context_nonclass() != NULL
       LP64_ONLY(&& (using_class_space() ? Metaspace::class_space_is_initialized() : true));
@@ -851,7 +849,6 @@ MetaWord* Metaspace::allocate(ClassLoaderData* loader_data, size_t word_size,
                               MetaspaceObj::Type type) {
   assert(word_size <= Metaspace::max_allocation_word_size(),
          "allocation size too large (" SIZE_FORMAT ")", word_size);
-  assert(!_frozen, "sanity");
 
   assert(loader_data != NULL, "Should never pass around a NULL loader_data. "
         "ClassLoaderData::the_null_class_loader_data() should have been used.");

--- a/src/hotspot/share/memory/metaspace.hpp
+++ b/src/hotspot/share/memory/metaspace.hpp
@@ -62,8 +62,6 @@ public:
 
 private:
 
-  DEBUG_ONLY(static bool   _frozen;)
-
   static const MetaspaceTracer* _tracer;
 
   static bool _initialized;
@@ -71,13 +69,6 @@ private:
 public:
 
   static const MetaspaceTracer* tracer() { return _tracer; }
-  static void freeze() {
-    assert(DumpSharedSpaces, "sanity");
-    DEBUG_ONLY(_frozen = true;)
-  }
-  static void assert_not_frozen() {
-    assert(!_frozen, "sanity");
-  }
 
  private:
 


### PR DESCRIPTION
Summary: The assert was a false negative. `Metaspace::freeze()` is obsolete and should be removed.

The original reason for the `Metaspace::freeze()` API was to ensure that the safepoint portion of -Xshare:dump, i.e., `VM_PopulateDumpSharedSpace::doit()` does not call `Metaspace::allocate()`, which might cause a GC, resulting in  a deadlock.

However, since [JDK-8264149](https://bugs.openjdk.java.net/browse/JDK-8264149), GC would happen only with the `TRAPS` version of `Metaspace::allocate()`. Since [JDK-8252685](https://bugs.openjdk.java.net/browse/JDK-8252685), `TRAPS` must be a `JavaThread`. This means that you can no longer cause a GC inside safepoint code by calling `Metaspace::allocate()`.

`Metaspace::assert_not_frozen()` was also called by the `ClassLoaderMetaspace` allocation/deallocation functions, but none of these would cause GC. Also, anyone calling these function while a safepoint is in progress (such as the ZGC code that triggered this assert) must ensure that they won't affect any code that concurrently traverses metaspace objects inside the safepoint. Such safeguard logic is already done at a higher level, we don't need the low-level asserts inside  the `ClassLoaderMetaspace` allocation/deallocation functions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267879](https://bugs.openjdk.java.net/browse/JDK-8267879): ClassLoaderMetaspace destructor asserts on !_frozen


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4286/head:pull/4286` \
`$ git checkout pull/4286`

Update a local copy of the PR: \
`$ git checkout pull/4286` \
`$ git pull https://git.openjdk.java.net/jdk pull/4286/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4286`

View PR using the GUI difftool: \
`$ git pr show -t 4286`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4286.diff">https://git.openjdk.java.net/jdk/pull/4286.diff</a>

</details>
