### PR TITLE
8267958: [TESTBUG] cds DynamicLoaderConstraintsTest.java timed out

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/LoaderConstraintsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/LoaderConstraintsTest.java
@@ -22,10 +22,9 @@
  */
 
 /**
- * @test
+ * @test id=default-cl
  * @requires vm.cds
  * @summary Test class loader constraint checks for archived classes
- * @bug 8267347 8267754
  * @library /test/lib
  *          /test/hotspot/jtreg/runtime/cds/appcds
  *          /test/hotspot/jtreg/runtime/cds/appcds/test-classes
@@ -33,6 +32,20 @@
  *          jdk.httpserver
  * @run driver LoaderConstraintsTest
  */
+
+/**
+ * @test id=custom-cl
+ * @requires vm.cds.custom.loaders
+ * @summary Test class loader constraint checks for archived classes with custom class loader
+ * @bug 8267347
+ * @library /test/lib
+ *          /test/hotspot/jtreg/runtime/cds/appcds
+ *          /test/hotspot/jtreg/runtime/cds/appcds/test-classes
+ * @modules java.base/jdk.internal.misc
+ *          jdk.httpserver
+ * @run driver LoaderConstraintsTest custom
+ */
+
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
@@ -109,8 +122,9 @@ public class LoaderConstraintsTest  {
 
     public static void main(String... args) throws Exception {
         appJar = ClassFileInstaller.writeJar("loader_constraints.jar", appClasses);
-        doTest();
-        if (Platform.areCustomLoadersSupportedForCDS()) {
+        if (args.length == 0) {
+            doTest();
+        } else {
             loaderJar = ClassFileInstaller.writeJar("custom_app_loader.jar", loaderClasses);
             doTestCustomLoader();
         }


### PR DESCRIPTION
[JDK-8267347](https://bugs.openjdk.java.net/browse/JDK-8267347) doubles the amount of time spent inside this test. It's better to split the test into two parts as suggested by @iignatev in https://github.com/openjdk/jdk/pull/4198#discussion_r641343393

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267958](https://bugs.openjdk.java.net/browse/JDK-8267958): [TESTBUG] cds DynamicLoaderConstraintsTest.java timed out


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4287/head:pull/4287` \
`$ git checkout pull/4287`

Update a local copy of the PR: \
`$ git checkout pull/4287` \
`$ git pull https://git.openjdk.java.net/jdk pull/4287/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4287`

View PR using the GUI difftool: \
`$ git pr show -t 4287`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4287.diff">https://git.openjdk.java.net/jdk/pull/4287.diff</a>

</details>
