### PR TITLE
8267939: Clarify the specification of iterator and spliterator forEachRemaining

### DIFF
--- a/src/java.base/share/classes/java/util/PrimitiveIterator.java
+++ b/src/java.base/share/classes/java/util/PrimitiveIterator.java
@@ -68,10 +68,18 @@ import java.util.function.LongConsumer;
 public interface PrimitiveIterator<T, T_CONS> extends Iterator<T> {
 
     /**
-     * Performs the given action for each remaining element, in the order
-     * elements occur when iterating, until all elements have been processed
-     * or the action throws an exception.  Errors or runtime exceptions
-     * thrown by the action are relayed to the caller.
+     * Performs the given action for each remaining element until all elements
+     * have been processed or the action throws an exception.  Actions are
+     * performed in the order of iteration, if that order is specified.
+     * Exceptions thrown by the action are relayed to the caller.
+     * <p>
+     * The behavior of an iterator is unspecified if the action modifies the
+     * collection in any way (even by calling the {@link #remove remove} method
+     * or other mutator methods of {@code Iterator} subtypes),
+     * unless an overriding class has specified a concurrent modification policy.
+     * <p>
+     * Subsequent behavior of an iterator is unspecified if the action throws an
+     * exception.
      *
      * @param action The action to be performed for each element
      * @throws NullPointerException if the specified action is null
@@ -94,20 +102,13 @@ public interface PrimitiveIterator<T, T_CONS> extends Iterator<T> {
         int nextInt();
 
         /**
-         * Performs the given action for each remaining element until all elements
-         * have been processed or the action throws an exception.  Actions are
-         * performed in the order of iteration, if that order is specified.
-         * Exceptions thrown by the action are relayed to the caller.
-         *
+         * {@inheritDoc}
          * @implSpec
          * <p>The default implementation behaves as if:
          * <pre>{@code
          *     while (hasNext())
          *         action.accept(nextInt());
          * }</pre>
-         *
-         * @param action The action to be performed for each element
-         * @throws NullPointerException if the specified action is null
          */
         default void forEachRemaining(IntConsumer action) {
             Objects.requireNonNull(action);
@@ -168,20 +169,13 @@ public interface PrimitiveIterator<T, T_CONS> extends Iterator<T> {
         long nextLong();
 
         /**
-         * Performs the given action for each remaining element until all elements
-         * have been processed or the action throws an exception.  Actions are
-         * performed in the order of iteration, if that order is specified.
-         * Exceptions thrown by the action are relayed to the caller.
-         *
+         * {@inheritDoc}
          * @implSpec
          * <p>The default implementation behaves as if:
          * <pre>{@code
          *     while (hasNext())
          *         action.accept(nextLong());
          * }</pre>
-         *
-         * @param action The action to be performed for each element
-         * @throws NullPointerException if the specified action is null
          */
         default void forEachRemaining(LongConsumer action) {
             Objects.requireNonNull(action);
@@ -241,20 +235,13 @@ public interface PrimitiveIterator<T, T_CONS> extends Iterator<T> {
         double nextDouble();
 
         /**
-         * Performs the given action for each remaining element until all elements
-         * have been processed or the action throws an exception.  Actions are
-         * performed in the order of iteration, if that order is specified.
-         * Exceptions thrown by the action are relayed to the caller.
-         *
+         * {@inheritDoc}
          * @implSpec
          * <p>The default implementation behaves as if:
          * <pre>{@code
          *     while (hasNext())
          *         action.accept(nextDouble());
          * }</pre>
-         *
-         * @param action The action to be performed for each element
-         * @throws NullPointerException if the specified action is null
          */
         default void forEachRemaining(DoubleConsumer action) {
             Objects.requireNonNull(action);

--- a/src/java.base/share/classes/java/util/PrimitiveIterator.java
+++ b/src/java.base/share/classes/java/util/PrimitiveIterator.java
@@ -74,8 +74,8 @@ public interface PrimitiveIterator<T, T_CONS> extends Iterator<T> {
      * Exceptions thrown by the action are relayed to the caller.
      * <p>
      * The behavior of an iterator is unspecified if the action modifies the
-     * collection in any way (even by calling the {@link #remove remove} method
-     * or other mutator methods of {@code Iterator} subtypes),
+     * source of elements in any way (even by calling the {@link #remove remove}
+     * method or other mutator methods of {@code Iterator} subtypes),
      * unless an overriding class has specified a concurrent modification policy.
      * <p>
      * Subsequent behavior of an iterator is unspecified if the action throws an

--- a/src/java.base/share/classes/java/util/Spliterator.java
+++ b/src/java.base/share/classes/java/util/Spliterator.java
@@ -300,6 +300,9 @@ public interface Spliterator<T> {
      * Spliterator is {@link #ORDERED} the action is performed on the
      * next element in encounter order.  Exceptions thrown by the
      * action are relayed to the caller.
+     * <p>
+     * Subsequent behavior of a spliterator is unspecified if the action throws
+     * an exception.
      *
      * @param action The action
      * @return {@code false} if no remaining elements existed
@@ -314,6 +317,9 @@ public interface Spliterator<T> {
      * throws an exception.  If this Spliterator is {@link #ORDERED}, actions
      * are performed in encounter order.  Exceptions thrown by the action
      * are relayed to the caller.
+     * <p>
+     * Subsequent behavior of a spliterator is unspecified if the action throws
+     * an exception.
      *
      * @implSpec
      * The default implementation repeatedly invokes {@link #tryAdvance} until
@@ -613,6 +619,9 @@ public interface Spliterator<T> {
          * Spliterator is {@link #ORDERED} the action is performed on the
          * next element in encounter order.  Exceptions thrown by the
          * action are relayed to the caller.
+         * <p>
+         * Subsequent behavior of a spliterator is unspecified if the action throws
+         * an exception.
          *
          * @param action The action
          * @return {@code false} if no remaining elements existed
@@ -628,6 +637,9 @@ public interface Spliterator<T> {
          * action throws an exception.  If this Spliterator is {@link #ORDERED},
          * actions are performed in encounter order.  Exceptions thrown by the
          * action are relayed to the caller.
+         * <p>
+         * Subsequent behavior of a spliterator is unspecified if the action throws
+         * an exception.
          *
          * @implSpec
          * The default implementation repeatedly invokes {@link #tryAdvance}


### PR DESCRIPTION
The specification of `forEachRemaining`, accepting a primitive functional interface, on the primitive iterators is updated to be the same as for `Iterator.forEachRemaining`, specifically the following is added:

```java
     * <p>
     * Subsequent behavior of an iterator is unspecified if the action throws an
     * exception.
```

In addition the specification of `tryAdvance` and `forEachRemaining` on `Spliterator` and the primitive specializations are also updated to include a similar statement:

```java
     * Subsequent behavior of a spliterator is unspecified if the action throws
     * an exception.
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267939](https://bugs.openjdk.java.net/browse/JDK-8267939): Clarify the specification of iterator and spliterator forEachRemaining


### Reviewers
 * [Stuart Marks](https://openjdk.java.net/census#smarks) (@stuart-marks - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4290/head:pull/4290` \
`$ git checkout pull/4290`

Update a local copy of the PR: \
`$ git checkout pull/4290` \
`$ git pull https://git.openjdk.java.net/jdk pull/4290/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4290`

View PR using the GUI difftool: \
`$ git pr show -t 4290`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4290.diff">https://git.openjdk.java.net/jdk/pull/4290.diff</a>

</details>
