### PR TITLE
JDK-8263389 IGV: Zooming changes the point that is currently centered

### DIFF
--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramScene.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramScene.java
@@ -156,6 +156,7 @@ public class DiagramScene extends ObjectScene implements DiagramViewer {
         if (newZoom > DiagramScene.ZOOM_MIN_FACTOR) {
             setZoomFactor(newZoom);
             validate();
+            getScrollPane().getViewport().validate();
             getScrollPane().getViewport().setViewPosition(new Point((int) (viewPosition.x / DiagramScene.ZOOM_INCREMENT), (int) (viewPosition.y / DiagramScene.ZOOM_INCREMENT)));
         }
     }
@@ -169,6 +170,7 @@ public class DiagramScene extends ObjectScene implements DiagramViewer {
         if (newZoom < DiagramScene.ZOOM_MAX_FACTOR) {
             setZoomFactor(newZoom);
             validate();
+            getScrollPane().getViewport().validate();
             getScrollPane().getViewport().setViewPosition(new Point((int) (viewPosition.x * DiagramScene.ZOOM_INCREMENT), (int) (viewPosition.y * DiagramScene.ZOOM_INCREMENT)));
         }
     }

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramScene.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramScene.java
@@ -151,13 +151,9 @@ public class DiagramScene extends ObjectScene implements DiagramViewer {
     @Override
     public void zoomOut() {
         double zoom = getZoomFactor();
-        Point viewPosition = getScrollPane().getViewport().getViewPosition();
         double newZoom = zoom / DiagramScene.ZOOM_INCREMENT;
         if (newZoom > DiagramScene.ZOOM_MIN_FACTOR) {
-            setZoomFactor(newZoom);
-            validate();
-            getScrollPane().getViewport().validate();
-            getScrollPane().getViewport().setViewPosition(new Point((int) (viewPosition.x / DiagramScene.ZOOM_INCREMENT), (int) (viewPosition.y / DiagramScene.ZOOM_INCREMENT)));
+            zoom(newZoom);
         }
     }
 
@@ -165,16 +161,21 @@ public class DiagramScene extends ObjectScene implements DiagramViewer {
     public void zoomIn() {
 
         double zoom = getZoomFactor();
-        Point viewPosition = getScrollPane().getViewport().getViewPosition();
         double newZoom = zoom * DiagramScene.ZOOM_INCREMENT;
         if (newZoom < DiagramScene.ZOOM_MAX_FACTOR) {
-            setZoomFactor(newZoom);
-            validate();
-            getScrollPane().getViewport().validate();
-            getScrollPane().getViewport().setViewPosition(new Point((int) (viewPosition.x * DiagramScene.ZOOM_INCREMENT), (int) (viewPosition.y * DiagramScene.ZOOM_INCREMENT)));
+            zoom(newZoom);
         }
     }
 
+    private void zoom(double newZoom) {
+        double currentZoom = getZoomFactor();
+        Point viewPosition = getScrollPane().getViewport().getViewPosition();
+        Rectangle viewRect = getScrollPane().getViewport().getViewRect();
+        setZoomFactor(newZoom);
+        validate();
+        getScrollPane().getViewport().validate();
+        getScrollPane().getViewport().setViewPosition(new Point((int) ((viewPosition.x + viewRect.width / 2) * newZoom / currentZoom - viewRect.width / 2), (int) ((viewPosition.y + viewRect.height / 2) * newZoom / currentZoom - viewRect.height / 2)));
+    }
 
     @Override
     public void centerFigures(List<Figure> list) {


### PR DESCRIPTION
Fixing the zoom issue on IGV. I tested this on Windows and Linux and zooming now works as expected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263389](https://bugs.openjdk.java.net/browse/JDK-8263389): IGV: Zooming changes the point that is currently centered


### Reviewers
 * [Richard Reingruber](https://openjdk.java.net/census#rrich) (@reinrich - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4291/head:pull/4291` \
`$ git checkout pull/4291`

Update a local copy of the PR: \
`$ git checkout pull/4291` \
`$ git pull https://git.openjdk.java.net/jdk pull/4291/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4291`

View PR using the GUI difftool: \
`$ git pr show -t 4291`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4291.diff">https://git.openjdk.java.net/jdk/pull/4291.diff</a>

</details>
