### PR TITLE
8199318: add idempotent copy operation for Map.Entry

### DIFF
--- a/src/java.base/share/classes/java/util/AbstractMap.java
+++ b/src/java.base/share/classes/java/util/AbstractMap.java
@@ -735,9 +735,9 @@ public abstract class AbstractMap<K,V> implements Map<K,V> {
      * @apiNote
      * Instances of this class are not necessarily immutable, as the key
      * and value may be mutable. An instance of <i>this specific class</i>
-     * is <i>unmodifiable,</i> because the key and value references cannot be
+     * is unmodifiable, because the key and value references cannot be
      * changed. A reference of this <i>type</i> may not be unmodifiable,
-     * as a subclass may be modifiable or provide the appearance of modifiability.
+     * as a subclass may be modifiable or may provide the appearance of modifiability.
      * <p>
      * This class may be convenient in methods that return thread-safe snapshots of
      * key-value mappings. For alternatives, see the

--- a/src/java.base/share/classes/java/util/AbstractMap.java
+++ b/src/java.base/share/classes/java/util/AbstractMap.java
@@ -593,7 +593,7 @@ public abstract class AbstractMap<K,V> implements Map<K,V> {
     /**
      * An Entry maintaining a key and a value.  The value may be
      * changed using the {@code setValue} method. Instances of
-     * this class are not associated with any map's entry set view.
+     * this class are not associated with any map's entry-set view.
      *
      * @apiNote
      * This class facilitates the process of building custom map
@@ -730,7 +730,7 @@ public abstract class AbstractMap<K,V> implements Map<K,V> {
     /**
      * An unmodifiable Entry maintaining a key and a value.  This class
      * does not support the {@code setValue} method. Instances of
-     * this class are not associated with any map's entry set view.
+     * this class are not associated with any map's entry-set view.
      *
      * @apiNote
      * Instances of this class are not necessarily immutable, as the key
@@ -802,7 +802,10 @@ public abstract class AbstractMap<K,V> implements Map<K,V> {
          * Replaces the value corresponding to this entry with the specified
          * value (optional operation).  This implementation simply throws
          * {@code UnsupportedOperationException}, as this class implements
-         * an <i>immutable</i> map entry.
+         * an unmodifiable map entry.
+         *
+         * @implSpec
+         * The implementation in this class always throws {@code UnsupportedOperationException}.
          *
          * @param value new value to be stored in this entry
          * @return (Does not return)

--- a/src/java.base/share/classes/java/util/AbstractMap.java
+++ b/src/java.base/share/classes/java/util/AbstractMap.java
@@ -728,18 +728,21 @@ public abstract class AbstractMap<K,V> implements Map<K,V> {
     }
 
     /**
-     * An Entry maintaining an immutable key and value.  This class
+     * An unmodifiable Entry maintaining a key and a value.  This class
      * does not support the {@code setValue} method. Instances of
      * this class are not associated with any map's entry set view.
      *
      * @apiNote
-     * An instance of this <i>class</i> is immutable (strictly speaking,
-     * unmodifiable). However, holding a reference of this <i>type</i>
-     * does not guarantee unmodifiability, as a subclass may allow
-     * modification.
+     * Instances of this class are not necessarily immutable, as the key
+     * and value may be mutable. An instance of <i>this specific class</i>
+     * is <i>unmodifiable,</i> because the key and value references cannot be
+     * changed. A reference of this <i>type</i> may not be unmodifiable,
+     * as a subclass may be modifiable or provide the appearance of modifiability.
      * <p>
      * This class may be convenient in methods that return thread-safe snapshots of
-     * key-value mappings.
+     * key-value mappings. For alternatives, see the
+     * {@link Map#entry Map.entry} and {@link Map.Entry#copyOf Entry.copyOf}
+     * methods.
      *
      * @since 1.6
      */

--- a/src/java.base/share/classes/java/util/AbstractMap.java
+++ b/src/java.base/share/classes/java/util/AbstractMap.java
@@ -741,7 +741,7 @@ public abstract class AbstractMap<K,V> implements Map<K,V> {
      * <p>
      * This class may be convenient in methods that return thread-safe snapshots of
      * key-value mappings. For alternatives, see the
-     * {@link Map#entry Map.entry} and {@link Map.Entry#copyOf Entry.copyOf}
+     * {@link Map#entry Map::entry} and {@link Map.Entry#copyOf Map.Entry::copyOf}
      * methods.
      *
      * @since 1.6

--- a/src/java.base/share/classes/java/util/AbstractMap.java
+++ b/src/java.base/share/classes/java/util/AbstractMap.java
@@ -592,8 +592,11 @@ public abstract class AbstractMap<K,V> implements Map<K,V> {
 
     /**
      * An Entry maintaining a key and a value.  The value may be
-     * changed using the {@code setValue} method.  This class
-     * facilitates the process of building custom map
+     * changed using the {@code setValue} method. Instances of
+     * this class are not associated with any map's entry set view.
+     *
+     * @apiNote
+     * This class facilitates the process of building custom map
      * implementations. For example, it may be convenient to return
      * arrays of {@code SimpleEntry} instances in method
      * {@code Map.entrySet().toArray}.
@@ -726,8 +729,16 @@ public abstract class AbstractMap<K,V> implements Map<K,V> {
 
     /**
      * An Entry maintaining an immutable key and value.  This class
-     * does not support method {@code setValue}.  This class may be
-     * convenient in methods that return thread-safe snapshots of
+     * does not support the {@code setValue} method. Instances of
+     * this class are not associated with any map's entry set view.
+     *
+     * @apiNote
+     * An instance of this <i>class</i> is immutable (strictly speaking,
+     * unmodifiable). However, holding a reference of this <i>type</i>
+     * does not guarantee unmodifiability, as a subclass may allow
+     * modification.
+     * <p>
+     * This class may be convenient in methods that return thread-safe snapshots of
      * key-value mappings.
      *
      * @since 1.6

--- a/src/java.base/share/classes/java/util/Map.java
+++ b/src/java.base/share/classes/java/util/Map.java
@@ -393,9 +393,9 @@ public interface Map<K, V> {
     Set<Map.Entry<K, V>> entrySet();
 
     /**
-     * A map entry (key-value pair). The entry may be unmodifiable, or the
+     * A map entry (key-value pair). The Entry may be unmodifiable, or the
      * value may be modifiable if the optional {@code setValue} method is
-     * implemented. The entry may be independent of any map, or it may represent
+     * implemented. The Entry may be independent of any map, or it may represent
      * an entry of the entry-set view of a map.
      * <p>
      * Instances of the {@code Map.Entry} interface may be obtained by iterating

--- a/src/java.base/share/classes/java/util/Map.java
+++ b/src/java.base/share/classes/java/util/Map.java
@@ -393,14 +393,21 @@ public interface Map<K, V> {
     Set<Map.Entry<K, V>> entrySet();
 
     /**
-     * A map entry (key-value pair).  The {@code Map.entrySet} method returns
-     * a collection-view of the map, whose elements are of this class.  The
-     * <i>only</i> way to obtain a reference to a map entry is from the
-     * iterator of this collection-view.  These {@code Map.Entry} objects are
-     * valid <i>only</i> for the duration of the iteration; more formally,
-     * the behavior of a map entry is undefined if the backing map has been
+     * A map entry (key-value pair). The entry may be unmodifiable, or
+     * the value may be modified, if the optional {@code setValue} method
+     * is implemented. The entry may be independent of any map or it
+     * may represent one entry of a view of a map, as described below.
+     * <p>
+     * The {@code Map.entrySet} method returns a collection-view of the map,
+     * whose elements are of this class. These {@code Map.Entry} objects
+     * themselves views of the entries of the map, and they are valid
+     * <i>only</i> for the duration of the iteration over the entry set view.
+     * The behavior of such a map entry is undefined if the backing map has been
      * modified after the entry was returned by the iterator, except through
      * the {@code setValue} operation on the map entry.
+     * <p>
+     * A map entry from a map's entry set can be "disconnected" from the map
+     * through use of the {@link #copyOf copyOf} method.
      *
      * @see Map#entrySet()
      * @since 1.2
@@ -558,6 +565,35 @@ public interface Map<K, V> {
             Objects.requireNonNull(cmp);
             return (Comparator<Map.Entry<K, V>> & Serializable)
                 (c1, c2) -> cmp.compare(c1.getValue(), c2.getValue());
+        }
+
+        /**
+         * Returns a copy of the given map entry. The returned entry is not associated with
+         * any map. The returned entry has the same characteristics as the entry returned
+         * by the {@link Map.entry} method.
+         *
+         * @apiNote
+         * An entry obtained from a map's entry set is a view of an entry of that map. The
+         * {@code copyOf} method may be used to create an entry object, containing the same
+         * key and value, that is independent of any map.
+         *
+         * @implNote
+         * If the given entry was obtained from a call to {@code copyOf},
+         * calling copyOf will generally not create another copy.
+         *
+         * @param e the entry to be copied
+         * @return a map entry equal to the given entry
+         * @throws NullPointerException if e is null or if the key or value is null
+         * @since 14
+         */
+        public static <K, V> Map.Entry<K, V> copyOf(Map.Entry<? extends K, ? extends V> e) {
+            if (e instanceof KeyValueHolder) {
+                @SuppressWarnings("unchecked")
+                Map.Entry<K, V> r = (Map.Entry<K, V>)e;
+                return r;
+            } else {
+                return Map.entry(e.getKey(), e.getValue());
+            }
         }
     }
 

--- a/src/java.base/share/classes/java/util/Map.java
+++ b/src/java.base/share/classes/java/util/Map.java
@@ -396,18 +396,24 @@ public interface Map<K, V> {
      * A map entry (key-value pair). The entry may be unmodifiable, or
      * the value may be modified, if the optional {@code setValue} method
      * is implemented. The entry may be independent of any map or it
-     * may represent one entry of a view of a map, as described below.
+     * may represent one entry of an entry-set view of a map.
      * <p>
-     * The {@code Map.entrySet} method returns a collection-view of the map,
-     * whose elements are of this class. These {@code Map.Entry} objects
-     * themselves views of the entries of the map, and they are valid
-     * <i>only</i> for the duration of the iteration over the entry set view.
-     * The behavior of such a map entry is undefined if the backing map has been
-     * modified after the entry was returned by the iterator, except through
-     * the {@code setValue} operation on the map entry.
-     * <p>
-     * A map entry from a map's entry set can be "disconnected" from the map
-     * through use of the {@link #copyOf copyOf} method.
+     * The {@link #entrySet Map.entrySet} method returns a view of the map.
+     * This view is a Set whose elements are instances of this interface.
+     * These Map.Entry objects are themselves views of the entries
+     * of the map. If supported by the backing Map, a change to an entry's
+     * value via the {@link Map.Entry#setValue setValue} will be visible
+     * in the backing Map. This connection to the backing Map is valid
+     * <i>only</i> for the duration of iteration over the entry-set view.
+     * The behavior of such a Map.Entry is undefined if the backing map
+     * has been modified after the entry was returned by the iterator, except
+     * through the {@code setValue} operation on the entry. In particular,
+     * a change to the value of a mapping in the backing Map might or might
+     * not be visible in the corresponding Entry element of the entry-set view.
+     *
+     * @apiNote
+     * An Entry from a map's entry set can be disconnected from the backing map
+     * through use of the {@link Map.Entry#copyOf copyOf} method.
      *
      * @see Map#entrySet()
      * @since 1.2
@@ -570,27 +576,29 @@ public interface Map<K, V> {
         /**
          * Returns a copy of the given map entry. The returned entry is not associated with
          * any map. The returned entry has the same characteristics as the entry returned
-         * by the {@link Map.entry} method.
+         * by the {@link Map#entry Map.entry} method.
          *
          * @apiNote
-         * An entry obtained from a map's entry set is a view of an entry of that map. The
-         * {@code copyOf} method may be used to create an entry object, containing the same
-         * key and value, that is independent of any map.
+         * An entry obtained from a Map's entry set is a view of an entry of that Map. This
+         * method may be used to create an entry object, containing the same key and value,
+         * that is independent of any map.
          *
          * @implNote
-         * If the given entry was obtained from a call to {@code copyOf},
+         * If the given entry was obtained from a call to {@code copyOf} or {@code Map.entry},
          * calling copyOf will generally not create another copy.
          *
+         * @param <K> the type of the key
+         * @param <V> the type of the value
          * @param e the entry to be copied
          * @return a map entry equal to the given entry
          * @throws NullPointerException if e is null or if the key or value is null
-         * @since 14
+         * @since 17
          */
+        @SuppressWarnings("unchecked")
         public static <K, V> Map.Entry<K, V> copyOf(Map.Entry<? extends K, ? extends V> e) {
+            Objects.requireNonNull(e);
             if (e instanceof KeyValueHolder) {
-                @SuppressWarnings("unchecked")
-                Map.Entry<K, V> r = (Map.Entry<K, V>)e;
-                return r;
+                return (Map.Entry<K, V>) e;
             } else {
                 return Map.entry(e.getKey(), e.getValue());
             }

--- a/src/java.base/share/classes/java/util/Map.java
+++ b/src/java.base/share/classes/java/util/Map.java
@@ -393,27 +393,29 @@ public interface Map<K, V> {
     Set<Map.Entry<K, V>> entrySet();
 
     /**
-     * A map entry (key-value pair). The entry may be unmodifiable, or
-     * the value may be modified, if the optional {@code setValue} method
-     * is implemented. The entry may be independent of any map or it
-     * may represent one entry of an entry-set view of a map.
+     * A map entry (key-value pair). The entry may be unmodifiable, or the
+     * value may be modifiable if the optional {@code setValue} method is
+     * implemented. The entry may be independent of any map, or it may represent
+     * an entry of the entry-set view of a map.
      * <p>
-     * The {@link #entrySet Map.entrySet} method returns a view of the map.
-     * This view is a Set whose elements are instances of this interface.
-     * These Map.Entry objects are themselves views of the entries
-     * of the map. If supported by the backing Map, a change to an entry's
-     * value via the {@link Map.Entry#setValue setValue} will be visible
-     * in the backing Map. This connection to the backing Map is valid
+     * Instances of the {@code Map.Entry} interface may be obtained by iterating
+     * the entry-set view of a map. These instances maintain a connection to the
+     * original, backing map. This connection to the backing map is valid
      * <i>only</i> for the duration of iteration over the entry-set view.
-     * The behavior of such a Map.Entry is undefined if the backing map
-     * has been modified after the entry was returned by the iterator, except
-     * through the {@code setValue} operation on the entry. In particular,
-     * a change to the value of a mapping in the backing Map might or might
-     * not be visible in the corresponding Entry element of the entry-set view.
+     * During iteration of the entry-set view, if supported by the backing map,
+     * a change to a {@code Map.Entry}'s value via the
+     * {@link Map.Entry#setValue setValue} method will be visible in the backing map.
+     * <p>
+     * The behavior of such a {@code Map.Entry} instance is undefined outside of
+     * iteration of the map's entry-set view. It is also undefined if the backing
+     * map has been modified after the {@code Map.Entry} was returned by the
+     * iterator, except through the {@code Map.Entry.setValue} method. In particular,
+     * a change to the value of a mapping in the backing map might or might not be
+     * visible in the corresponding {@code Map.Entry} element of the entry-set view.
      *
      * @apiNote
-     * An Entry from a map's entry set can be disconnected from the backing map
-     * through use of the {@link Map.Entry#copyOf copyOf} method.
+     * A {@code Map.Entry} obtained from a map's entry-set view can be disconnected
+     * from the backing map through use of the {@link Map.Entry#copyOf copyOf} method.
      *
      * @see Map#entrySet()
      * @since 1.2
@@ -574,24 +576,24 @@ public interface Map<K, V> {
         }
 
         /**
-         * Returns a copy of the given map entry. The returned entry is not associated with
-         * any map. The returned entry has the same characteristics as the entry returned
-         * by the {@link Map#entry Map.entry} method.
+         * Returns a copy of the given {@code Map.Entry}. The returned instance is not
+         * associated with any map. The returned instance has the same characteristics
+         * as instances returned by the {@link Map#entry Map.entry} method.
          *
          * @apiNote
-         * An entry obtained from a Map's entry set is a view of an entry of that Map. This
-         * method may be used to create an entry object, containing the same key and value,
-         * that is independent of any map.
+         * An instance obtained from a map's entry-set view has a connection to that map.
+         * The {@code copyOf}  method may be used to create a {@code Map.Entry} instance,
+         * containing the same key and value, that is independent of any map.
          *
          * @implNote
          * If the given entry was obtained from a call to {@code copyOf} or {@code Map.entry},
-         * calling copyOf will generally not create another copy.
+         * calling {@code copyOf} will generally not create another copy.
          *
          * @param <K> the type of the key
          * @param <V> the type of the value
          * @param e the entry to be copied
          * @return a map entry equal to the given entry
-         * @throws NullPointerException if e is null or if the key or value is null
+         * @throws NullPointerException if e is null or if either of its key or value is null
          * @since 17
          */
         @SuppressWarnings("unchecked")

--- a/src/java.base/share/classes/java/util/Map.java
+++ b/src/java.base/share/classes/java/util/Map.java
@@ -405,7 +405,6 @@ public interface Map<K, V> {
      * During iteration of the entry-set view, if supported by the backing map,
      * a change to a {@code Map.Entry}'s value via the
      * {@link Map.Entry#setValue setValue} method will be visible in the backing map.
-     * <p>
      * The behavior of such a {@code Map.Entry} instance is undefined outside of
      * iteration of the map's entry-set view. It is also undefined if the backing
      * map has been modified after the {@code Map.Entry} was returned by the
@@ -414,8 +413,13 @@ public interface Map<K, V> {
      * visible in the corresponding {@code Map.Entry} element of the entry-set view.
      *
      * @apiNote
-     * A {@code Map.Entry} obtained from a map's entry-set view can be disconnected
-     * from the backing map through use of the {@link Map.Entry#copyOf copyOf} method.
+     * It is possible to create a {@code Map.Entry} instance that is disconnected
+     * from a backing map by using the {@link Map.Entry#copyOf copyOf} method. For example,
+     * the following creates a snapshot of a map's entries that is guaranteed not to
+     * change even if the original map is modified:
+     * <pre> {@code
+     * var entries = map.entrySet().stream().map(Map.Entry::copyOf).toList()
+     * }</pre>
      *
      * @see Map#entrySet()
      * @since 1.2
@@ -578,7 +582,7 @@ public interface Map<K, V> {
         /**
          * Returns a copy of the given {@code Map.Entry}. The returned instance is not
          * associated with any map. The returned instance has the same characteristics
-         * as instances returned by the {@link Map#entry Map.entry} method.
+         * as instances returned by the {@link Map#entry Map::entry} method.
          *
          * @apiNote
          * An instance obtained from a map's entry-set view has a connection to that map.
@@ -586,7 +590,7 @@ public interface Map<K, V> {
          * containing the same key and value, that is independent of any map.
          *
          * @implNote
-         * If the given entry was obtained from a call to {@code copyOf} or {@code Map.entry},
+         * If the given entry was obtained from a call to {@code copyOf} or {@code Map::entry},
          * calling {@code copyOf} will generally not create another copy.
          *
          * @param <K> the type of the key

--- a/test/jdk/java/util/Map/MapFactories.java
+++ b/test/jdk/java/util/Map/MapFactories.java
@@ -34,7 +34,6 @@ import java.util.Iterator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.testng.annotations.DataProvider;
@@ -45,8 +44,8 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 /*
  * @test
@@ -470,7 +469,7 @@ public class MapFactories {
         Map<Integer, String> copy = Map.copyOf(map);
     }
 
-    // Map.entry() tests
+    // Map::entry tests
 
     @Test(expectedExceptions=NullPointerException.class)
     public void entryWithNullKeyDisallowed() {
@@ -487,17 +486,6 @@ public class MapFactories {
         Map.entry("a", "b").setValue("x");
     }
 
-    @Test(expectedExceptions=UnsupportedOperationException.class)
-    public void entryCopySetValueDisallowed() {
-        var e = new AbstractMap.SimpleEntry<>("a", "b");
-        Map.Entry.copyOf(e).setValue("x");
-    }
-
-    @Test(expectedExceptions=NullPointerException.class)
-    public void entryCopyNullDisallowed() {
-        Map.Entry.copyOf(null);
-    }
-
     @Test
     public void entryBasicTests() {
         Map.Entry<String,String> kvh1 = Map.entry("xyzzy", "plugh");
@@ -508,12 +496,38 @@ public class MapFactories {
         assertTrue(sie.equals(kvh1));
         assertFalse(kvh2.equals(sie));
         assertFalse(sie.equals(kvh2));
-        assertEquals(sie.hashCode(), kvh1.hashCode());
-        assertEquals(sie.toString(), kvh1.toString());
+        assertEquals(kvh1.hashCode(), sie.hashCode());
+        assertEquals(kvh1.toString(), sie.toString());
+    }
+
+    // Map.Entry::copyOf tests
+
+    @Test(expectedExceptions=NullPointerException.class)
+    public void entryCopyNullDisallowed() {
+        Map.Entry.copyOf(null);
     }
 
     @Test
-    public void entryCopyTests() {
+    public void entryCopyWithNullKeyDisallowed() {
+        var e = new AbstractMap.SimpleEntry<>(null, "b");
+        assertThrows(NullPointerException.class, () -> Map.Entry.copyOf(e));
+    }
+
+    @Test
+    public void entryCopyWithNullValueDisallowed() {
+        var e = new AbstractMap.SimpleEntry<>("a", null);
+        assertThrows(NullPointerException.class, () -> Map.Entry.copyOf(e));
+    }
+
+    @Test
+    public void entryCopySetValueDisallowed() {
+        var e = new AbstractMap.SimpleEntry<>("a", "b");
+        var c = Map.Entry.copyOf(e);
+        assertThrows(UnsupportedOperationException.class, () -> c.setValue("x"));
+    }
+
+    @Test
+    public void entryCopyBasicTests() {
         Map.Entry<String,String> orig = new AbstractMap.SimpleImmutableEntry<>("xyzzy", "plugh");
         Map.Entry<String,String> copy1 = Map.Entry.copyOf(orig);
         Map.Entry<String,String> copy2 = Map.Entry.copyOf(copy1);
@@ -527,6 +541,9 @@ public class MapFactories {
 
         assertNotSame(orig, copy1);
         assertSame(copy1, copy2);
+
+        assertEquals(copy1.hashCode(), orig.hashCode());
+        assertEquals(copy1.toString(), orig.toString());
     }
 
     // compile-time test of wildcards

--- a/test/jdk/java/util/Map/MapFactories.java
+++ b/test/jdk/java/util/Map/MapFactories.java
@@ -481,9 +481,10 @@ public class MapFactories {
         Map.Entry<Integer,String> e = Map.entry(0, null);
     }
 
-    @Test(expectedExceptions=UnsupportedOperationException.class)
+    @Test
     public void entrySetValueDisallowed() {
-        Map.entry("a", "b").setValue("x");
+        var e = Map.entry("a", "b");
+        assertThrows(UnsupportedOperationException.class, () -> e.setValue("x"));
     }
 
     @Test

--- a/test/jdk/java/util/Map/MapFactories.java
+++ b/test/jdk/java/util/Map/MapFactories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -482,6 +482,22 @@ public class MapFactories {
         Map.Entry<Integer,String> e = Map.entry(0, null);
     }
 
+    @Test(expectedExceptions=UnsupportedOperationException.class)
+    public void entrySetValueDisallowed() {
+        Map.entry("a", "b").setValue("x");
+    }
+
+    @Test(expectedExceptions=UnsupportedOperationException.class)
+    public void entryCopySetValueDisallowed() {
+        var e = new AbstractMap.SimpleEntry<>("a", "b");
+        Map.Entry.copyOf(e).setValue("x");
+    }
+
+    @Test(expectedExceptions=NullPointerException.class)
+    public void entryCopyNullDisallowed() {
+        Map.Entry.copyOf(null);
+    }
+
     @Test
     public void entryBasicTests() {
         Map.Entry<String,String> kvh1 = Map.entry("xyzzy", "plugh");
@@ -494,6 +510,23 @@ public class MapFactories {
         assertFalse(sie.equals(kvh2));
         assertEquals(sie.hashCode(), kvh1.hashCode());
         assertEquals(sie.toString(), kvh1.toString());
+    }
+
+    @Test
+    public void entryCopyTests() {
+        Map.Entry<String,String> orig = new AbstractMap.SimpleImmutableEntry<>("xyzzy", "plugh");
+        Map.Entry<String,String> copy1 = Map.Entry.copyOf(orig);
+        Map.Entry<String,String> copy2 = Map.Entry.copyOf(copy1);
+
+        assertEquals(orig, copy1);
+        assertEquals(copy1, orig);
+        assertEquals(orig, copy2);
+        assertEquals(copy2, orig);
+        assertEquals(copy1, copy2);
+        assertEquals(copy2, copy1);
+
+        assertNotSame(orig, copy1);
+        assertSame(copy1, copy2);
     }
 
     // compile-time test of wildcards


### PR DESCRIPTION
I'm fixing this along with a couple intertwined issues.

1. Add Map.Entry::copyOf as an idempotent copy operation.

2. Clarify that AbstractMap.SimpleImmutableEntry is itself unmodifiable (not really immutable) but that subclasses can be modifiable.

3. Clarify some confusing, historical wording about Map.Entry instances being obtainable only via iteration of a Map's entry-set view. This was never really true, since anyone could implement the Map.Entry interface, and it certainly was not true since JDK 1.6 when SimpleEntry and SimpleImmutableEntry were added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8199318](https://bugs.openjdk.java.net/browse/JDK-8199318): add idempotent copy operation for Map.Entry


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to 841a154c2e59a961de05c436b8e05d10357c8c71
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4295/head:pull/4295` \
`$ git checkout pull/4295`

Update a local copy of the PR: \
`$ git checkout pull/4295` \
`$ git pull https://git.openjdk.java.net/jdk pull/4295/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4295`

View PR using the GUI difftool: \
`$ git pr show -t 4295`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4295.diff">https://git.openjdk.java.net/jdk/pull/4295.diff</a>

</details>
