### PR TITLE
8268087: Update documentation of the JPasswordField

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JPasswordField.java
+++ b/src/java.desktop/share/classes/javax/swing/JPasswordField.java
@@ -60,11 +60,11 @@ import javax.swing.text.Segment;
  * If an application needs the input methods support, please use the
  * inherited method, <code>enableInputMethods(true)</code>.
  * <p>
- * <strong>Warning:</strong> The text entered in {@code JPasswordField} displays
- * something that was typed and does not show the original characters. This
- * doesn't prevent the password from appearing in the system memory. For
- * handling confidential information such as the password text, refer to the
- * relevant section at
+ * <strong>Warning:</strong> The {@code JPasswordField} will not show the
+ * original characters that were typed, instead displaying alternative text or
+ * graphics. However this doesn't prevent the password from appearing in the
+ * system memory. For handling confidential information such as the password
+ * text, refer to the relevant section at
  * <a href="https://www.oracle.com/java/technologies/javase/seccodeguide.html">
  * Secure Coding Guidelines</a>.
  * <p>

--- a/src/java.desktop/share/classes/javax/swing/JPasswordField.java
+++ b/src/java.desktop/share/classes/javax/swing/JPasswordField.java
@@ -60,6 +60,14 @@ import javax.swing.text.Segment;
  * If an application needs the input methods support, please use the
  * inherited method, <code>enableInputMethods(true)</code>.
  * <p>
+ * <strong>Warning:</strong> The text entered in JPasswordField displays
+ * something that was typed and does not show the original characters. This
+ * doesn't prevent the password from appearing in the system memory. For
+ * handling confidential information such as the password text, refer to the
+ * relevant section at
+ * <a href="https://www.oracle.com/java/technologies/javase/seccodeguide.html">
+ * Secure Coding Guidelines</a>.
+ * <p>
  * <strong>Warning:</strong> Swing is not thread safe. For more
  * information see <a
  * href="package-summary.html#threading">Swing's Threading

--- a/src/java.desktop/share/classes/javax/swing/JPasswordField.java
+++ b/src/java.desktop/share/classes/javax/swing/JPasswordField.java
@@ -60,7 +60,7 @@ import javax.swing.text.Segment;
  * If an application needs the input methods support, please use the
  * inherited method, <code>enableInputMethods(true)</code>.
  * <p>
- * <strong>Warning:</strong> The text entered in JPasswordField displays
+ * <strong>Warning:</strong> The text entered in {@code JPasswordField} displays
  * something that was typed and does not show the original characters. This
  * doesn't prevent the password from appearing in the system memory. For
  * handling confidential information such as the password text, refer to the


### PR DESCRIPTION
Some useful documentation was added to the JPasswordField.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268087](https://bugs.openjdk.java.net/browse/JDK-8268087): Update documentation of the JPasswordField


### Reviewers
 * [Tejpal Rebari](https://openjdk.java.net/census#trebari) (@trebari - Committer) ⚠️ Review applies to ff208b78b514d8ddaae142acfacaab07fe780826
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**) ⚠️ Review applies to ff208b78b514d8ddaae142acfacaab07fe780826
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4296/head:pull/4296` \
`$ git checkout pull/4296`

Update a local copy of the PR: \
`$ git checkout pull/4296` \
`$ git pull https://git.openjdk.java.net/jdk pull/4296/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4296`

View PR using the GUI difftool: \
`$ git pr show -t 4296`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4296.diff">https://git.openjdk.java.net/jdk/pull/4296.diff</a>

</details>
