### PR TITLE
8268103: JNI functions incorrectly return a double after JDK-8265836

### DIFF
--- a/src/jdk.management/aix/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/aix/native/libmanagement_ext/UnixOperatingSystem.c
@@ -55,7 +55,7 @@ JNIEXPORT jlong JNICALL
 Java_com_sun_management_internal_OperatingSystemImpl_getHostTotalCpuTicks0
 (JNIEnv *env, jobject mbean)
 {
-    return -1.0;
+    return -1;
 }
 
 JNIEXPORT jint JNICALL

--- a/src/jdk.management/macosx/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/macosx/native/libmanagement_ext/UnixOperatingSystem.c
@@ -171,7 +171,7 @@ JNIEXPORT jlong JNICALL
 Java_com_sun_management_internal_OperatingSystemImpl_getHostTotalCpuTicks0
 (JNIEnv *env, jobject mbean)
 {
-    return -1.0;
+    return -1;
 }
 
 JNIEXPORT jint JNICALL


### PR DESCRIPTION
Please review this trivial patch.  Stubs should return `-1` for `jlong` rather than `-1.0` (`double`) on aix/macosx.

Thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268103](https://bugs.openjdk.java.net/browse/JDK-8268103): JNI functions incorrectly return a double after JDK-8265836


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4300/head:pull/4300` \
`$ git checkout pull/4300`

Update a local copy of the PR: \
`$ git checkout pull/4300` \
`$ git pull https://git.openjdk.java.net/jdk pull/4300/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4300`

View PR using the GUI difftool: \
`$ git pr show -t 4300`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4300.diff">https://git.openjdk.java.net/jdk/pull/4300.diff</a>

</details>
