### PR TITLE
8267924: Misleading G1 eager reclaim detail logging

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3393,6 +3393,16 @@ class G1PrepareEvacuationTask : public AbstractGangTask {
         _g1h->set_humongous_reclaim_candidate(index, false);
         _g1h->register_region_with_region_attr(hr);
       }
+      log_debug(gc, humongous)("Humongous region %u (object size " SIZE_FORMAT " @ " PTR_FORMAT ") remset " SIZE_FORMAT " code roots " SIZE_FORMAT " marked %d reclaim candidate %d type array %d",
+                               index,
+                               (size_t)cast_to_oop(hr->bottom())->size() * HeapWordSize,
+                               p2i(hr->bottom()),
+                               hr->rem_set()->occupied(),
+                               hr->rem_set()->strong_code_roots_list_length(),
+                               _g1h->concurrent_mark()->next_mark_bitmap()->is_marked(hr->bottom()),
+                               _g1h->is_humongous_reclaim_candidate(index),
+                               cast_to_oop(hr->bottom())->is_typeArray()
+                              );
       _worker_humongous_total++;
 
       return false;

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -146,12 +146,6 @@ public:
               "Only eagerly reclaiming type arrays is supported, but the object "
               PTR_FORMAT " is not.", p2i(r->bottom()));
 
-    log_debug(gc, humongous)("Reclaimed humongous region %u (object size " SIZE_FORMAT " @ " PTR_FORMAT ")",
-                             region_idx,
-                             (size_t)obj->size() * HeapWordSize,
-                             p2i(r->bottom())
-                            );
-
     G1ConcurrentMark* const cm = g1h->concurrent_mark();
     cm->humongous_object_eagerly_reclaimed(r);
     assert(!cm->is_marked_in_prev_bitmap(obj) && !cm->is_marked_in_next_bitmap(obj),
@@ -170,6 +164,11 @@ public:
       r = next;
     } while (r != nullptr);
 
+    log_debug(gc, humongous)("Reclaimed humongous region %u (object size " SIZE_FORMAT " @ " PTR_FORMAT ")",
+                             region_idx,
+                             (size_t)obj->size() * HeapWordSize,
+                             p2i(r->bottom())
+                            );
     return false;
   }
 

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -138,18 +138,7 @@ public:
     // required because stale remembered sets might reference locations that
     // are currently allocated into.
     uint region_idx = r->hrm_index();
-    if (!g1h->is_humongous_reclaim_candidate(region_idx) ||
-        !r->rem_set()->is_empty()) {
-      log_debug(gc, humongous)("Live humongous region %u object size " SIZE_FORMAT " start " PTR_FORMAT "  with remset " SIZE_FORMAT " code roots " SIZE_FORMAT " is marked %d reclaim candidate %d type array %d",
-                               region_idx,
-                               (size_t)obj->size() * HeapWordSize,
-                               p2i(r->bottom()),
-                               r->rem_set()->occupied(),
-                               r->rem_set()->strong_code_roots_list_length(),
-                               next_bitmap->is_marked(r->bottom()),
-                               g1h->is_humongous_reclaim_candidate(region_idx),
-                               obj->is_typeArray()
-                              );
+    if (!g1h->is_humongous_reclaim_candidate(region_idx)) {
       return false;
     }
 
@@ -157,15 +146,10 @@ public:
               "Only eagerly reclaiming type arrays is supported, but the object "
               PTR_FORMAT " is not.", p2i(r->bottom()));
 
-    log_debug(gc, humongous)("Dead humongous region %u object size " SIZE_FORMAT " start " PTR_FORMAT " with remset " SIZE_FORMAT " code roots " SIZE_FORMAT " is marked %d reclaim candidate %d type array %d",
+    log_debug(gc, humongous)("Reclaimed humongous region %u (object size " SIZE_FORMAT " @ " PTR_FORMAT ")",
                              region_idx,
                              (size_t)obj->size() * HeapWordSize,
-                             p2i(r->bottom()),
-                             r->rem_set()->occupied(),
-                             r->rem_set()->strong_code_roots_list_length(),
-                             next_bitmap->is_marked(r->bottom()),
-                             g1h->is_humongous_reclaim_candidate(region_idx),
-                             obj->is_typeArray()
+                             p2i(r->bottom())
                             );
 
     G1ConcurrentMark* const cm = g1h->concurrent_mark();

--- a/test/hotspot/jtreg/gc/g1/TestG1TraceEagerReclaimHumongousObjects.java
+++ b/test/hotspot/jtreg/gc/g1/TestG1TraceEagerReclaimHumongousObjects.java
@@ -52,6 +52,7 @@ public class TestG1TraceEagerReclaimHumongousObjects {
 
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
+    System.out.println(output.getStdout());
     // As G1ReclaimDeadHumongousObjectsAtYoungGC is set(default), below logs should be displayed.
     output.shouldContain("Humongous Reclaim");
     output.shouldContain("Humongous Total");
@@ -60,8 +61,8 @@ public class TestG1TraceEagerReclaimHumongousObjects {
 
     // As G1TraceReclaimDeadHumongousObjectsAtYoungGC is set and GCWithHumongousObjectTest has humongous objects,
     // these logs should be displayed.
-    output.shouldContain("Live humongous");
-    output.shouldContain("Dead humongous region");
+    output.shouldContain("Humongous region");
+    output.shouldContain("Reclaimed humongous region");
     output.shouldHaveExitValue(0);
   }
 


### PR DESCRIPTION
Hi,

  can I have reviews for this change that brushes up `gc+humongous` logging?

In particular, during review of some logs several issues were found with the logging.
Both the "Live humongous region" and "Dead humongous region" logs
  * the remset count is always zero at the point of printing (end of gc) because G1 never pushes new cross-region references into remembered set entries during gc, and for candidates we actually just flushed them
  * the reclaim candidate flag is always zero at that point: if it got a "Live humongous" message, the source of that information must be false at that point. If "Dead humongous", it must have been true (one). 

This change modifies the log output to try to give useful information: first, g1 prints information for all humongous regions when deciding whether something is a candidate. This means that the printed information is current. At the end of gc only reclaimed regions are printed, repeating the information from the printout at the beginning does not give more information.

E.g. a sample output from the test case

First, all humongous regions
```
Humongous region 0 (object size 41943056 @ 0x00000000f8000000) remset 0 code roots 0 marked 0 reclaim candidate 1 type array 1
Humongous region 71 (object size 25165840 @ 0x00000000fc700000) remset 0 code roots 0 marked 0 reclaim candidate 1 type array 1
Humongous region 41 (object size 4194320 @ 0x00000000fa900000) remset 0 code roots 0 marked 0 reclaim candidate 1 type array 1
Humongous region 46 (object size 25165840 @ 0x00000000fae00000) remset 0 code roots 0 marked 0 reclaim candidate 1 type array 1
```
Later only reclaimed ones:
```
Reclaimed humongous region 46 (object size 25165840 @ 0x00000000fae00000)
```

Instead of currently:

```
Live humongous region 789 object size 2160888 start 0x00000006e2a00000  with remset 1 code roots 0 is marked 0 reclaim candidate 0 type array 0
```
or 
```
Dead humongous region 182 object size 16777232 start 0x000000074b600000 with remset 0 code roots 0 is marked 0 reclaim candidate 1 type array 1
```

This unfortunately kind of invalidates some websites trying to explain these log messages, but I still prefer to have useful output.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267924](https://bugs.openjdk.java.net/browse/JDK-8267924): Misleading G1 eager reclaim detail logging


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Committer) ⚠️ Review applies to fca34468cd35a97fe58496ae03c6d3d732034b40
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to fca34468cd35a97fe58496ae03c6d3d732034b40


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4305/head:pull/4305` \
`$ git checkout pull/4305`

Update a local copy of the PR: \
`$ git checkout pull/4305` \
`$ git pull https://git.openjdk.java.net/jdk pull/4305/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4305`

View PR using the GUI difftool: \
`$ git pr show -t 4305`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4305.diff">https://git.openjdk.java.net/jdk/pull/4305.diff</a>

</details>
