### PR TITLE
8268118: Rename bytes_os_cpu.inline.hpp files to bytes_os_cpu.hpp

### DIFF
--- a/src/hotspot/cpu/aarch64/bytes_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/bytes_aarch64.hpp
@@ -61,6 +61,6 @@ class Bytes: AllStatic {
 
 
 // The following header contains the implementations of swap_u2, swap_u4, and swap_u8[_base]
-#include OS_CPU_HEADER_INLINE(bytes)
+#include OS_CPU_HEADER(bytes)
 
 #endif // CPU_AARCH64_BYTES_AARCH64_HPP

--- a/src/hotspot/cpu/arm/bytes_arm.hpp
+++ b/src/hotspot/cpu/arm/bytes_arm.hpp
@@ -184,6 +184,6 @@ class Bytes: AllStatic {
 
 
 // The following header contains the implementations of swap_u2, swap_u4, and swap_u8
-#include OS_CPU_HEADER_INLINE(bytes)
+#include OS_CPU_HEADER(bytes)
 
 #endif // CPU_ARM_BYTES_ARM_HPP

--- a/src/hotspot/cpu/ppc/bytes_ppc.hpp
+++ b/src/hotspot/cpu/ppc/bytes_ppc.hpp
@@ -266,6 +266,6 @@ class Bytes: AllStatic {
 #endif // VM_LITTLE_ENDIAN
 };
 
-#include OS_CPU_HEADER_INLINE(bytes)
+#include OS_CPU_HEADER(bytes)
 
 #endif // CPU_PPC_BYTES_PPC_HPP

--- a/src/hotspot/cpu/s390/bytes_s390.hpp
+++ b/src/hotspot/cpu/s390/bytes_s390.hpp
@@ -51,7 +51,7 @@ class Bytes: AllStatic {
   static inline void put_native_u8(address p, u8 x) { *(u8*)p = x; }
 
   // The following header contains the implementations of swap_u2, swap_u4, and swap_u8.
-#include OS_CPU_HEADER_INLINE(bytes)
+#include OS_CPU_HEADER(bytes)
 
   // Efficient reading and writing of unaligned unsigned data in Java byte ordering (i.e. big-endian ordering)
   static inline u2   get_Java_u2(address p) { return get_native_u2(p); }

--- a/src/hotspot/cpu/x86/bytes_x86.hpp
+++ b/src/hotspot/cpu/x86/bytes_x86.hpp
@@ -122,6 +122,6 @@ class Bytes: AllStatic {
 };
 
 // The following header contains the implementations of swap_u2, swap_u4, and swap_u8[_base]
-#include OS_CPU_HEADER_INLINE(bytes)
+#include OS_CPU_HEADER(bytes)
 
 #endif // CPU_X86_BYTES_X86_HPP

--- a/src/hotspot/cpu/zero/bytes_zero.hpp
+++ b/src/hotspot/cpu/zero/bytes_zero.hpp
@@ -156,7 +156,7 @@ class Bytes: AllStatic {
 // The following header contains the implementations of swap_u2,
 // swap_u4, and swap_u8
 
-#include OS_CPU_HEADER_INLINE(bytes)
+#include OS_CPU_HEADER(bytes)
 
 #endif // VM_LITTLE_ENDIAN
 

--- a/src/hotspot/os_cpu/aix_ppc/bytes_aix_ppc.hpp
+++ b/src/hotspot/os_cpu/aix_ppc/bytes_aix_ppc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,23 +22,11 @@
  *
  */
 
-#ifndef OS_CPU_WINDOWS_X86_BYTES_WINDOWS_X86_INLINE_HPP
-#define OS_CPU_WINDOWS_X86_BYTES_WINDOWS_X86_INLINE_HPP
+#ifndef OS_CPU_AIX_PPC_BYTES_AIX_PPC_HPP
+#define OS_CPU_AIX_PPC_BYTES_AIX_PPC_HPP
 
-#include <stdlib.h>
+#if defined(VM_LITTLE_ENDIAN)
+// Aix is not little endian.
+#endif // VM_LITTLE_ENDIAN
 
-// Efficient swapping of data bytes from Java byte
-// ordering to native byte ordering and vice versa.
-inline u2 Bytes::swap_u2(u2 x) {
-  return (u2) _byteswap_ushort((unsigned short) x);
-}
-
-inline u4 Bytes::swap_u4(u4 x) {
-  return (u4) _byteswap_ulong((unsigned long) x);
-}
-
-inline u8 Bytes::swap_u8(u8 x) {
-  return (u8) _byteswap_uint64((unsigned __int64) x);
-}
-
-#endif // OS_CPU_WINDOWS_X86_BYTES_WINDOWS_X86_INLINE_HPP
+#endif // OS_CPU_AIX_PPC_BYTES_AIX_PPC_HPP

--- a/src/hotspot/os_cpu/bsd_aarch64/bytes_bsd_aarch64.hpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/bytes_bsd_aarch64.hpp
@@ -1,5 +1,7 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,26 +24,33 @@
  *
  */
 
-#ifndef OS_CPU_LINUX_ARM_BYTES_LINUX_ARM_INLINE_HPP
-#define OS_CPU_LINUX_ARM_BYTES_LINUX_ARM_INLINE_HPP
+#ifndef OS_CPU_BSD_AARCH64_BYTES_BSD_AARCH64_HPP
+#define OS_CPU_BSD_AARCH64_BYTES_BSD_AARCH64_HPP
 
-#include <byteswap.h>
+#ifdef __APPLE__
+#include <libkern/OSByteOrder.h>
+#endif
+
+#if defined(__APPLE__)
+#  define bswap_16(x) OSSwapInt16(x)
+#  define bswap_32(x) OSSwapInt32(x)
+#  define bswap_64(x) OSSwapInt64(x)
+#else
+#  error "Unimplemented"
+#endif
 
 // Efficient swapping of data bytes from Java byte
 // ordering to native byte ordering and vice versa.
-inline u2 Bytes::swap_u2(u2 x) {
-  // TODO: ARM - optimize
+inline u2   Bytes::swap_u2(u2 x) {
   return bswap_16(x);
 }
 
-inline u4 Bytes::swap_u4(u4 x) {
-  // TODO: ARM - optimize
+inline u4   Bytes::swap_u4(u4 x) {
   return bswap_32(x);
 }
 
 inline u8 Bytes::swap_u8(u8 x) {
-  // TODO: ARM - optimize
   return bswap_64(x);
 }
 
-#endif // OS_CPU_LINUX_ARM_BYTES_LINUX_ARM_INLINE_HPP
+#endif // OS_CPU_BSD_AARCH64_BYTES_BSD_AARCH64_HPP

--- a/src/hotspot/os_cpu/bsd_x86/bytes_bsd_x86.hpp
+++ b/src/hotspot/os_cpu/bsd_x86/bytes_bsd_x86.hpp
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef OS_CPU_BSD_X86_BYTES_BSD_X86_INLINE_HPP
-#define OS_CPU_BSD_X86_BYTES_BSD_X86_INLINE_HPP
+#ifndef OS_CPU_BSD_X86_BYTES_BSD_X86_HPP
+#define OS_CPU_BSD_X86_BYTES_BSD_X86_HPP
 
 #ifdef __APPLE__
 #include <libkern/OSByteOrder.h>
@@ -98,4 +98,4 @@ inline u8 Bytes::swap_u8(u8 x) {
 }
 #endif // !AMD64
 
-#endif // OS_CPU_BSD_X86_BYTES_BSD_X86_INLINE_HPP
+#endif // OS_CPU_BSD_X86_BYTES_BSD_X86_HPP

--- a/src/hotspot/os_cpu/bsd_zero/bytes_bsd_zero.hpp
+++ b/src/hotspot/os_cpu/bsd_zero/bytes_bsd_zero.hpp
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2014, Red Hat Inc. All rights reserved.
- * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,28 +22,41 @@
  *
  */
 
-#ifndef OS_CPU_BSD_AARCH64_BYTES_BSD_AARCH64_INLINE_HPP
-#define OS_CPU_BSD_AARCH64_BYTES_BSD_AARCH64_INLINE_HPP
-
-#ifdef __APPLE__
-#include <libkern/OSByteOrder.h>
-#endif
-
-#if defined(__APPLE__)
-#  define bswap_16(x) OSSwapInt16(x)
-#  define bswap_32(x) OSSwapInt32(x)
-#  define bswap_64(x) OSSwapInt64(x)
-#else
-#  error "Unimplemented"
-#endif
+#ifndef OS_CPU_BSD_ZERO_BYTES_BSD_ZERO_HPP
+#define OS_CPU_BSD_ZERO_BYTES_BSD_ZERO_HPP
 
 // Efficient swapping of data bytes from Java byte
 // ordering to native byte ordering and vice versa.
-inline u2   Bytes::swap_u2(u2 x) {
+
+#ifdef __APPLE__
+#  include <libkern/OSByteOrder.h>
+#else
+#  include <sys/endian.h>
+#endif
+
+#if defined(__APPLE__)
+#  define bswap_16(x)   OSSwapInt16(x)
+#  define bswap_32(x)   OSSwapInt32(x)
+#  define bswap_64(x)   OSSwapInt64(x)
+#elif defined(__OpenBSD__)
+#  define bswap_16(x)   swap16(x)
+#  define bswap_32(x)   swap32(x)
+#  define bswap_64(x)   swap64(x)
+#elif defined(__NetBSD__)
+#  define bswap_16(x)   bswap16(x)
+#  define bswap_32(x)   bswap32(x)
+#  define bswap_64(x)   bswap64(x)
+#else
+#  define bswap_16(x) __bswap16(x)
+#  define bswap_32(x) __bswap32(x)
+#  define bswap_64(x) __bswap64(x)
+#endif
+
+inline u2 Bytes::swap_u2(u2 x) {
   return bswap_16(x);
 }
 
-inline u4   Bytes::swap_u4(u4 x) {
+inline u4 Bytes::swap_u4(u4 x) {
   return bswap_32(x);
 }
 
@@ -53,4 +64,4 @@ inline u8 Bytes::swap_u8(u8 x) {
   return bswap_64(x);
 }
 
-#endif // OS_CPU_BSD_AARCH64_BYTES_BSD_AARCH64_INLINE_HPP
+#endif // OS_CPU_BSD_ZERO_BYTES_BSD_ZERO_HPP

--- a/src/hotspot/os_cpu/linux_aarch64/bytes_linux_aarch64.hpp
+++ b/src/hotspot/os_cpu/linux_aarch64/bytes_linux_aarch64.hpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2020, Microsoft Corporation. All rights reserved.
+ * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,25 +23,23 @@
  *
  */
 
-#ifndef OS_CPU_WINDOWS_AARCH64_BYTES_WINDOWS_AARCH64_INLINE_HPP
-#define OS_CPU_WINDOWS_AARCH64_BYTES_WINDOWS_AARCH64_INLINE_HPP
+#ifndef OS_CPU_LINUX_AARCH64_BYTES_LINUX_AARCH64_HPP
+#define OS_CPU_LINUX_AARCH64_BYTES_LINUX_AARCH64_HPP
 
-#include <stdlib.h>
+#include <byteswap.h>
 
 // Efficient swapping of data bytes from Java byte
 // ordering to native byte ordering and vice versa.
 inline u2   Bytes::swap_u2(u2 x) {
-  return _byteswap_ushort(x);
+  return bswap_16(x);
 }
 
 inline u4   Bytes::swap_u4(u4 x) {
-  return _byteswap_ulong(x);
+  return bswap_32(x);
 }
 
 inline u8 Bytes::swap_u8(u8 x) {
-  return _byteswap_uint64(x);
+  return bswap_64(x);
 }
 
-#pragma warning(default: 4035) // Enable warning 4035: no return value
-
-#endif // OS_CPU_WINDOWS_AARCH64_BYTES_WINDOWS_AARCH64_INLINE_HPP
+#endif // OS_CPU_LINUX_AARCH64_BYTES_LINUX_AARCH64_HPP

--- a/src/hotspot/os_cpu/linux_arm/bytes_linux_arm.hpp
+++ b/src/hotspot/os_cpu/linux_arm/bytes_linux_arm.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,24 +22,26 @@
  *
  */
 
-#ifndef OS_CPU_LINUX_ZERO_BYTES_LINUX_ZERO_INLINE_HPP
-#define OS_CPU_LINUX_ZERO_BYTES_LINUX_ZERO_INLINE_HPP
-
-// Efficient swapping of data bytes from Java byte
-// ordering to native byte ordering and vice versa.
+#ifndef OS_CPU_LINUX_ARM_BYTES_LINUX_ARM_HPP
+#define OS_CPU_LINUX_ARM_BYTES_LINUX_ARM_HPP
 
 #include <byteswap.h>
 
+// Efficient swapping of data bytes from Java byte
+// ordering to native byte ordering and vice versa.
 inline u2 Bytes::swap_u2(u2 x) {
+  // TODO: ARM - optimize
   return bswap_16(x);
 }
 
 inline u4 Bytes::swap_u4(u4 x) {
+  // TODO: ARM - optimize
   return bswap_32(x);
 }
 
 inline u8 Bytes::swap_u8(u8 x) {
+  // TODO: ARM - optimize
   return bswap_64(x);
 }
 
-#endif // OS_CPU_LINUX_ZERO_BYTES_LINUX_ZERO_INLINE_HPP
+#endif // OS_CPU_LINUX_ARM_BYTES_LINUX_ARM_HPP

--- a/src/hotspot/os_cpu/linux_ppc/bytes_linux_ppc.hpp
+++ b/src/hotspot/os_cpu/linux_ppc/bytes_linux_ppc.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016 SAP SE. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2014 Google Inc.  All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,24 +23,17 @@
  *
  */
 
-#ifndef OS_CPU_LINUX_S390_BYTES_LINUX_S390_INLINE_HPP
-#define OS_CPU_LINUX_S390_BYTES_LINUX_S390_INLINE_HPP
+#ifndef OS_CPU_LINUX_PPC_BYTES_LINUX_PPC_HPP
+#define OS_CPU_LINUX_PPC_BYTES_LINUX_PPC_HPP
+
+#if defined(VM_LITTLE_ENDIAN)
+#include <byteswap.h>
 
 // Efficient swapping of data bytes from Java byte
 // ordering to native byte ordering and vice versa.
+inline u2 Bytes::swap_u2(u2 x) { return bswap_16(x); }
+inline u4 Bytes::swap_u4(u4 x) { return bswap_32(x); }
+inline u8 Bytes::swap_u8(u8 x) { return bswap_64(x); }
+#endif // VM_LITTLE_ENDIAN
 
-#include <byteswap.h>
-
-inline u2 swap_u2(u2 x) {
-  return bswap_16(x);
-}
-
-inline u4 swap_u4(u4 x) {
-  return bswap_32(x);
-}
-
-inline u8 swap_u8(u8 x) {
-  return bswap_64(x);
-}
-
-#endif // OS_CPU_LINUX_S390_BYTES_LINUX_S390_INLINE_HPP
+#endif // OS_CPU_LINUX_PPC_BYTES_LINUX_PPC_HPP

--- a/src/hotspot/os_cpu/linux_s390/bytes_linux_s390.hpp
+++ b/src/hotspot/os_cpu/linux_s390/bytes_linux_s390.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2014 Google Inc.  All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,17 +23,24 @@
  *
  */
 
-#ifndef OS_CPU_LINUX_PPC_BYTES_LINUX_PPC_INLINE_HPP
-#define OS_CPU_LINUX_PPC_BYTES_LINUX_PPC_INLINE_HPP
-
-#if defined(VM_LITTLE_ENDIAN)
-#include <byteswap.h>
+#ifndef OS_CPU_LINUX_S390_BYTES_LINUX_S390_HPP
+#define OS_CPU_LINUX_S390_BYTES_LINUX_S390_HPP
 
 // Efficient swapping of data bytes from Java byte
 // ordering to native byte ordering and vice versa.
-inline u2 Bytes::swap_u2(u2 x) { return bswap_16(x); }
-inline u4 Bytes::swap_u4(u4 x) { return bswap_32(x); }
-inline u8 Bytes::swap_u8(u8 x) { return bswap_64(x); }
-#endif // VM_LITTLE_ENDIAN
 
-#endif // OS_CPU_LINUX_PPC_BYTES_LINUX_PPC_INLINE_HPP
+#include <byteswap.h>
+
+inline u2 swap_u2(u2 x) {
+  return bswap_16(x);
+}
+
+inline u4 swap_u4(u4 x) {
+  return bswap_32(x);
+}
+
+inline u8 swap_u8(u8 x) {
+  return bswap_64(x);
+}
+
+#endif // OS_CPU_LINUX_S390_BYTES_LINUX_S390_HPP

--- a/src/hotspot/os_cpu/linux_x86/bytes_linux_x86.hpp
+++ b/src/hotspot/os_cpu/linux_x86/bytes_linux_x86.hpp
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2014, Red Hat Inc. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,23 +22,58 @@
  *
  */
 
-#ifndef OS_CPU_LINUX_AARCH64_BYTES_LINUX_AARCH64_INLINE_HPP
-#define OS_CPU_LINUX_AARCH64_BYTES_LINUX_AARCH64_INLINE_HPP
+#ifndef OS_CPU_LINUX_X86_BYTES_LINUX_X86_HPP
+#define OS_CPU_LINUX_X86_BYTES_LINUX_X86_HPP
 
 #include <byteswap.h>
 
 // Efficient swapping of data bytes from Java byte
 // ordering to native byte ordering and vice versa.
 inline u2   Bytes::swap_u2(u2 x) {
+#ifdef AMD64
   return bswap_16(x);
+#else
+  u2 ret;
+  __asm__ __volatile__ (
+    "movw %0, %%ax;"
+    "xchg %%al, %%ah;"
+    "movw %%ax, %0"
+    :"=r" (ret)      // output : register 0 => ret
+    :"0"  (x)        // input  : x => register 0
+    :"ax", "0"       // clobbered registers
+  );
+  return ret;
+#endif // AMD64
 }
 
 inline u4   Bytes::swap_u4(u4 x) {
+#ifdef AMD64
   return bswap_32(x);
+#else
+  u4 ret;
+  __asm__ __volatile__ (
+    "bswap %0"
+    :"=r" (ret)      // output : register 0 => ret
+    :"0"  (x)        // input  : x => register 0
+    :"0"             // clobbered register
+  );
+  return ret;
+#endif // AMD64
 }
 
+#ifdef AMD64
 inline u8 Bytes::swap_u8(u8 x) {
   return bswap_64(x);
 }
+#else
+// Helper function for swap_u8
+inline u8   Bytes::swap_u8_base(u4 x, u4 y) {
+  return (((u8)swap_u4(x))<<32) | swap_u4(y);
+}
 
-#endif // OS_CPU_LINUX_AARCH64_BYTES_LINUX_AARCH64_INLINE_HPP
+inline u8 Bytes::swap_u8(u8 x) {
+  return swap_u8_base(*(u4*)&x, *(((u4*)&x)+1));
+}
+#endif // !AMD64
+
+#endif // OS_CPU_LINUX_X86_BYTES_LINUX_X86_HPP

--- a/src/hotspot/os_cpu/linux_zero/bytes_linux_zero.hpp
+++ b/src/hotspot/os_cpu/linux_zero/bytes_linux_zero.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,58 +22,24 @@
  *
  */
 
-#ifndef OS_CPU_LINUX_X86_BYTES_LINUX_X86_INLINE_HPP
-#define OS_CPU_LINUX_X86_BYTES_LINUX_X86_INLINE_HPP
-
-#include <byteswap.h>
+#ifndef OS_CPU_LINUX_ZERO_BYTES_LINUX_ZERO_HPP
+#define OS_CPU_LINUX_ZERO_BYTES_LINUX_ZERO_HPP
 
 // Efficient swapping of data bytes from Java byte
 // ordering to native byte ordering and vice versa.
-inline u2   Bytes::swap_u2(u2 x) {
-#ifdef AMD64
+
+#include <byteswap.h>
+
+inline u2 Bytes::swap_u2(u2 x) {
   return bswap_16(x);
-#else
-  u2 ret;
-  __asm__ __volatile__ (
-    "movw %0, %%ax;"
-    "xchg %%al, %%ah;"
-    "movw %%ax, %0"
-    :"=r" (ret)      // output : register 0 => ret
-    :"0"  (x)        // input  : x => register 0
-    :"ax", "0"       // clobbered registers
-  );
-  return ret;
-#endif // AMD64
 }
 
-inline u4   Bytes::swap_u4(u4 x) {
-#ifdef AMD64
+inline u4 Bytes::swap_u4(u4 x) {
   return bswap_32(x);
-#else
-  u4 ret;
-  __asm__ __volatile__ (
-    "bswap %0"
-    :"=r" (ret)      // output : register 0 => ret
-    :"0"  (x)        // input  : x => register 0
-    :"0"             // clobbered register
-  );
-  return ret;
-#endif // AMD64
 }
 
-#ifdef AMD64
 inline u8 Bytes::swap_u8(u8 x) {
   return bswap_64(x);
 }
-#else
-// Helper function for swap_u8
-inline u8   Bytes::swap_u8_base(u4 x, u4 y) {
-  return (((u8)swap_u4(x))<<32) | swap_u4(y);
-}
 
-inline u8 Bytes::swap_u8(u8 x) {
-  return swap_u8_base(*(u4*)&x, *(((u4*)&x)+1));
-}
-#endif // !AMD64
-
-#endif // OS_CPU_LINUX_X86_BYTES_LINUX_X86_INLINE_HPP
+#endif // OS_CPU_LINUX_ZERO_BYTES_LINUX_ZERO_HPP

--- a/src/hotspot/os_cpu/windows_aarch64/bytes_windows_aarch64.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/bytes_windows_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Microsoft Corporation. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,11 +22,25 @@
  *
  */
 
-#ifndef OS_CPU_AIX_PPC_BYTES_AIX_PPC_INLINE_HPP
-#define OS_CPU_AIX_PPC_BYTES_AIX_PPC_INLINE_HPP
+#ifndef OS_CPU_WINDOWS_AARCH64_BYTES_WINDOWS_AARCH64_HPP
+#define OS_CPU_WINDOWS_AARCH64_BYTES_WINDOWS_AARCH64_HPP
 
-#if defined(VM_LITTLE_ENDIAN)
-// Aix is not little endian.
-#endif // VM_LITTLE_ENDIAN
+#include <stdlib.h>
 
-#endif // OS_CPU_AIX_PPC_BYTES_AIX_PPC_INLINE_HPP
+// Efficient swapping of data bytes from Java byte
+// ordering to native byte ordering and vice versa.
+inline u2   Bytes::swap_u2(u2 x) {
+  return _byteswap_ushort(x);
+}
+
+inline u4   Bytes::swap_u4(u4 x) {
+  return _byteswap_ulong(x);
+}
+
+inline u8 Bytes::swap_u8(u8 x) {
+  return _byteswap_uint64(x);
+}
+
+#pragma warning(default: 4035) // Enable warning 4035: no return value
+
+#endif // OS_CPU_WINDOWS_AARCH64_BYTES_WINDOWS_AARCH64_HPP

--- a/src/hotspot/os_cpu/windows_x86/bytes_windows_x86.hpp
+++ b/src/hotspot/os_cpu/windows_x86/bytes_windows_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,46 +22,23 @@
  *
  */
 
-#ifndef OS_CPU_BSD_ZERO_BYTES_BSD_ZERO_INLINE_HPP
-#define OS_CPU_BSD_ZERO_BYTES_BSD_ZERO_INLINE_HPP
+#ifndef OS_CPU_WINDOWS_X86_BYTES_WINDOWS_X86_HPP
+#define OS_CPU_WINDOWS_X86_BYTES_WINDOWS_X86_HPP
+
+#include <stdlib.h>
 
 // Efficient swapping of data bytes from Java byte
 // ordering to native byte ordering and vice versa.
-
-#ifdef __APPLE__
-#  include <libkern/OSByteOrder.h>
-#else
-#  include <sys/endian.h>
-#endif
-
-#if defined(__APPLE__)
-#  define bswap_16(x)   OSSwapInt16(x)
-#  define bswap_32(x)   OSSwapInt32(x)
-#  define bswap_64(x)   OSSwapInt64(x)
-#elif defined(__OpenBSD__)
-#  define bswap_16(x)   swap16(x)
-#  define bswap_32(x)   swap32(x)
-#  define bswap_64(x)   swap64(x)
-#elif defined(__NetBSD__)
-#  define bswap_16(x)   bswap16(x)
-#  define bswap_32(x)   bswap32(x)
-#  define bswap_64(x)   bswap64(x)
-#else
-#  define bswap_16(x) __bswap16(x)
-#  define bswap_32(x) __bswap32(x)
-#  define bswap_64(x) __bswap64(x)
-#endif
-
 inline u2 Bytes::swap_u2(u2 x) {
-  return bswap_16(x);
+  return (u2) _byteswap_ushort((unsigned short) x);
 }
 
 inline u4 Bytes::swap_u4(u4 x) {
-  return bswap_32(x);
+  return (u4) _byteswap_ulong((unsigned long) x);
 }
 
 inline u8 Bytes::swap_u8(u8 x) {
-  return bswap_64(x);
+  return (u8) _byteswap_uint64((unsigned __int64) x);
 }
 
-#endif // OS_CPU_BSD_ZERO_BYTES_BSD_ZERO_INLINE_HPP
+#endif // OS_CPU_WINDOWS_X86_BYTES_WINDOWS_X86_HPP


### PR DESCRIPTION
Today we transitively include the `bytes_<os>_<cpu>.inline.hpp` files from `bytes.hpp`. This is goes against the HotSpot Style Guide that states:

> .inline.hpp files should only be included in .cpp or .inline.hpp files.

The `bytes_<os>_<cpu>.inline.hpp` don't include any other HotSpot files, so I propose that we simply rename them to `bytes_<os>_<cpu>.hpp`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268118](https://bugs.openjdk.java.net/browse/JDK-8268118): Rename bytes_os_cpu.inline.hpp files to bytes_os_cpu.hpp


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4310/head:pull/4310` \
`$ git checkout pull/4310`

Update a local copy of the PR: \
`$ git checkout pull/4310` \
`$ git pull https://git.openjdk.java.net/jdk pull/4310/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4310`

View PR using the GUI difftool: \
`$ git pr show -t 4310`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4310.diff">https://git.openjdk.java.net/jdk/pull/4310.diff</a>

</details>
