### PR TITLE
8268119: Rename copy_os_cpu.inline.hpp files to copy_os_cpu.hpp

### DIFF
--- a/src/hotspot/cpu/aarch64/copy_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/copy_aarch64.hpp
@@ -26,11 +26,7 @@
 #ifndef CPU_AARCH64_COPY_AARCH64_HPP
 #define CPU_AARCH64_COPY_AARCH64_HPP
 
-// Inline functions for memory copy and fill.
-
-// Contains inline asm implementations
-#include OS_CPU_HEADER_INLINE(copy)
-
+#include OS_CPU_HEADER(copy)
 
 static void pd_fill_to_words(HeapWord* tohw, size_t count, juint value) {
   julong* to = (julong*) tohw;

--- a/src/hotspot/cpu/arm/copy_arm.hpp
+++ b/src/hotspot/cpu/arm/copy_arm.hpp
@@ -25,12 +25,7 @@
 #ifndef CPU_ARM_COPY_ARM_HPP
 #define CPU_ARM_COPY_ARM_HPP
 
-#include "utilities/macros.hpp"
-
-// Inline functions for memory copy and fill.
-
-// Contains inline asm implementations
-#include OS_CPU_HEADER_INLINE(copy)
+#include OS_CPU_HEADER(copy)
 
 static void pd_fill_to_words(HeapWord* tohw, size_t count, juint value) {
   juint* to = (juint*)tohw;

--- a/src/hotspot/cpu/x86/copy_x86.hpp
+++ b/src/hotspot/cpu/x86/copy_x86.hpp
@@ -25,10 +25,7 @@
 #ifndef CPU_X86_COPY_X86_HPP
 #define CPU_X86_COPY_X86_HPP
 
-// Inline functions for memory copy and fill.
-
-// Contains inline asm implementations
-#include OS_CPU_HEADER_INLINE(copy)
+#include OS_CPU_HEADER(copy)
 
 static void pd_fill_to_words(HeapWord* tohw, size_t count, juint value) {
 #ifdef AMD64

--- a/src/hotspot/os_cpu/bsd_aarch64/copy_bsd_aarch64.hpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/copy_bsd_aarch64.hpp
@@ -24,8 +24,8 @@
  *
  */
 
-#ifndef OS_CPU_BSD_AARCH64_COPY_BSD_AARCH64_INLINE_HPP
-#define OS_CPU_BSD_AARCH64_COPY_BSD_AARCH64_INLINE_HPP
+#ifndef OS_CPU_BSD_AARCH64_COPY_BSD_AARCH64_HPP
+#define OS_CPU_BSD_AARCH64_COPY_BSD_AARCH64_HPP
 
 #define COPY_SMALL(from, to, count)                                     \
 {                                                                       \
@@ -186,4 +186,4 @@ static void pd_arrayof_conjoint_oops(const HeapWord* from, HeapWord* to, size_t 
   _Copy_arrayof_conjoint_jlongs(from, to, count);
 }
 
-#endif // OS_CPU_BSD_AARCH64_COPY_BSD_AARCH64_INLINE_HPP
+#endif // OS_CPU_BSD_AARCH64_COPY_BSD_AARCH64_HPP

--- a/src/hotspot/os_cpu/bsd_x86/copy_bsd_x86.hpp
+++ b/src/hotspot/os_cpu/bsd_x86/copy_bsd_x86.hpp
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef OS_CPU_BSD_X86_COPY_BSD_X86_INLINE_HPP
-#define OS_CPU_BSD_X86_COPY_BSD_X86_INLINE_HPP
+#ifndef OS_CPU_BSD_X86_COPY_BSD_X86_HPP
+#define OS_CPU_BSD_X86_COPY_BSD_X86_HPP
 
 static void pd_conjoint_words(const HeapWord* from, HeapWord* to, size_t count) {
 #ifdef AMD64
@@ -306,4 +306,4 @@ static void pd_arrayof_conjoint_oops(const HeapWord* from, HeapWord* to, size_t 
 #endif // AMD64
 }
 
-#endif // OS_CPU_BSD_X86_COPY_BSD_X86_INLINE_HPP
+#endif // OS_CPU_BSD_X86_COPY_BSD_X86_HPP

--- a/src/hotspot/os_cpu/linux_aarch64/copy_linux_aarch64.hpp
+++ b/src/hotspot/os_cpu/linux_aarch64/copy_linux_aarch64.hpp
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef OS_CPU_LINUX_AARCH64_COPY_LINUX_AARCH64_INLINE_HPP
-#define OS_CPU_LINUX_AARCH64_COPY_LINUX_AARCH64_INLINE_HPP
+#ifndef OS_CPU_LINUX_AARCH64_COPY_LINUX_AARCH64_HPP
+#define OS_CPU_LINUX_AARCH64_COPY_LINUX_AARCH64_HPP
 
 #define COPY_SMALL(from, to, count)                                     \
 {                                                                       \
@@ -185,4 +185,4 @@ static void pd_arrayof_conjoint_oops(const HeapWord* from, HeapWord* to, size_t 
   _Copy_arrayof_conjoint_jlongs(from, to, count);
 }
 
-#endif // OS_CPU_LINUX_AARCH64_COPY_LINUX_AARCH64_INLINE_HPP
+#endif // OS_CPU_LINUX_AARCH64_COPY_LINUX_AARCH64_HPP

--- a/src/hotspot/os_cpu/linux_x86/copy_linux_x86.hpp
+++ b/src/hotspot/os_cpu/linux_x86/copy_linux_x86.hpp
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef OS_CPU_LINUX_X86_COPY_LINUX_X86_INLINE_HPP
-#define OS_CPU_LINUX_X86_COPY_LINUX_X86_INLINE_HPP
+#ifndef OS_CPU_LINUX_X86_COPY_LINUX_X86_HPP
+#define OS_CPU_LINUX_X86_COPY_LINUX_X86_HPP
 
 static void pd_conjoint_words(const HeapWord* from, HeapWord* to, size_t count) {
 #ifdef AMD64
@@ -306,4 +306,4 @@ static void pd_arrayof_conjoint_oops(const HeapWord* from, HeapWord* to, size_t 
 #endif // AMD64
 }
 
-#endif // OS_CPU_LINUX_X86_COPY_LINUX_X86_INLINE_HPP
+#endif // OS_CPU_LINUX_X86_COPY_LINUX_X86_HPP

--- a/src/hotspot/os_cpu/windows_x86/copy_windows_x86.hpp
+++ b/src/hotspot/os_cpu/windows_x86/copy_windows_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,23 +22,54 @@
  *
  */
 
-#ifndef OS_CPU_LINUX_ARM_COPY_LINUX_ARM_INLINE_HPP
-#define OS_CPU_LINUX_ARM_COPY_LINUX_ARM_INLINE_HPP
+#ifndef OS_CPU_WINDOWS_X86_COPY_WINDOWS_X86_HPP
+#define OS_CPU_WINDOWS_X86_COPY_WINDOWS_X86_HPP
 
 static void pd_conjoint_words(const HeapWord* from, HeapWord* to, size_t count) {
-  _Copy_conjoint_words(from, to, count * HeapWordSize);
+  (void)memmove(to, from, count * HeapWordSize);
 }
 
 static void pd_disjoint_words(const HeapWord* from, HeapWord* to, size_t count) {
-  _Copy_disjoint_words(from, to, count * HeapWordSize);
+#ifdef AMD64
+  switch (count) {
+  case 8:  to[7] = from[7];
+  case 7:  to[6] = from[6];
+  case 6:  to[5] = from[5];
+  case 5:  to[4] = from[4];
+  case 4:  to[3] = from[3];
+  case 3:  to[2] = from[2];
+  case 2:  to[1] = from[1];
+  case 1:  to[0] = from[0];
+  case 0:  break;
+  default:
+    (void)memcpy(to, from, count * HeapWordSize);
+    break;
+  }
+#else
+  (void)memcpy(to, from, count * HeapWordSize);
+#endif // AMD64
 }
 
 static void pd_disjoint_words_atomic(const HeapWord* from, HeapWord* to, size_t count) {
-  pd_disjoint_words(from, to, count);
+  switch (count) {
+  case 8:  to[7] = from[7];
+  case 7:  to[6] = from[6];
+  case 6:  to[5] = from[5];
+  case 5:  to[4] = from[4];
+  case 4:  to[3] = from[3];
+  case 3:  to[2] = from[2];
+  case 2:  to[1] = from[1];
+  case 1:  to[0] = from[0];
+  case 0:  break;
+  default: while (count-- > 0) {
+             *to++ = *from++;
+           }
+           break;
+  }
 }
 
 static void pd_aligned_conjoint_words(const HeapWord* from, HeapWord* to, size_t count) {
-  pd_conjoint_words(from, to, count);
+  (void)memmove(to, from, count * HeapWordSize);
 }
 
 static void pd_aligned_disjoint_words(const HeapWord* from, HeapWord* to, size_t count) {
@@ -46,7 +77,7 @@ static void pd_aligned_disjoint_words(const HeapWord* from, HeapWord* to, size_t
 }
 
 static void pd_conjoint_bytes(const void* from, void* to, size_t count) {
-  memmove(to, from, count);
+  (void)memmove(to, from, count);
 }
 
 static void pd_conjoint_bytes_atomic(const void* from, void* to, size_t count) {
@@ -54,26 +85,93 @@ static void pd_conjoint_bytes_atomic(const void* from, void* to, size_t count) {
 }
 
 static void pd_conjoint_jshorts_atomic(const jshort* from, jshort* to, size_t count) {
-  _Copy_conjoint_jshorts_atomic(from, to, count * BytesPerShort);
+  if (from > to) {
+    while (count-- > 0) {
+      // Copy forwards
+      *to++ = *from++;
+    }
+  } else {
+    from += count - 1;
+    to   += count - 1;
+    while (count-- > 0) {
+      // Copy backwards
+      *to-- = *from--;
+    }
+  }
 }
 
 static void pd_conjoint_jints_atomic(const jint* from, jint* to, size_t count) {
-  assert(HeapWordSize == BytesPerInt, "heapwords and jints must be the same size");
-  // pd_conjoint_words is word-atomic in this implementation.
-  pd_conjoint_words((const HeapWord*)from, (HeapWord*)to, count);
+  if (from > to) {
+    while (count-- > 0) {
+      // Copy forwards
+      *to++ = *from++;
+    }
+  } else {
+    from += count - 1;
+    to   += count - 1;
+    while (count-- > 0) {
+      // Copy backwards
+      *to-- = *from--;
+    }
+  }
 }
 
 static void pd_conjoint_jlongs_atomic(const jlong* from, jlong* to, size_t count) {
-  _Copy_conjoint_jlongs_atomic(from, to, count * BytesPerLong);
+#ifdef AMD64
+  assert(BytesPerLong == BytesPerOop, "jlongs and oops must be the same size");
+  pd_conjoint_oops_atomic((const oop*)from, (oop*)to, count);
+#else
+  // Guarantee use of fild/fistp or xmm regs via some asm code, because compilers won't.
+  __asm {
+    mov    eax, from;
+    mov    edx, to;
+    mov    ecx, count;
+    cmp    eax, edx;
+    jbe    downtest;
+    jmp    uptest;
+  up:
+    fild   qword ptr [eax];
+    fistp  qword ptr [edx];
+    add    eax, 8;
+    add    edx, 8;
+  uptest:
+    sub    ecx, 1;
+    jge    up;
+    jmp    done;
+  down:
+    fild   qword ptr [eax][ecx*8];
+    fistp  qword ptr [edx][ecx*8];
+  downtest:
+    sub    ecx, 1;
+    jge    down;
+  done:;
+  }
+#endif // AMD64
 }
 
 static void pd_conjoint_oops_atomic(const oop* from, oop* to, size_t count) {
-  assert(BytesPerHeapOop == BytesPerInt, "32-bit architecture");
-  pd_conjoint_jints_atomic((const jint*)from, (jint*)to, count);
+  // Do better than this: inline memmove body  NEEDS CLEANUP
+  if (from > to) {
+    while (count-- > 0) {
+      // Copy forwards
+      *to++ = *from++;
+    }
+  } else {
+    from += count - 1;
+    to   += count - 1;
+    while (count-- > 0) {
+      // Copy backwards
+      *to-- = *from--;
+    }
+  }
 }
 
 static void pd_arrayof_conjoint_bytes(const HeapWord* from, HeapWord* to, size_t count) {
-  pd_conjoint_bytes_atomic((const void*)from, (void*)to, count);
+#ifdef AMD64
+  pd_conjoint_bytes_atomic(from, to, count);
+#else
+  pd_conjoint_bytes(from, to, count);
+#endif // AMD64
 }
 
 static void pd_arrayof_conjoint_jshorts(const HeapWord* from, HeapWord* to, size_t count) {
@@ -92,4 +190,4 @@ static void pd_arrayof_conjoint_oops(const HeapWord* from, HeapWord* to, size_t 
   pd_conjoint_oops_atomic((const oop*)from, (oop*)to, count);
 }
 
-#endif // OS_CPU_LINUX_ARM_COPY_LINUX_ARM_INLINE_HPP
+#endif // OS_CPU_WINDOWS_X86_COPY_WINDOWS_X86_HPP


### PR DESCRIPTION
Today we transitively include the `copy_<os>_<cpu>.inline.hpp` files from `copy.hpp`. This is goes against the HotSpot Style Guide that states:

> .inline.hpp files should only be included in .cpp or .inline.hpp files.

The `copy_<os>_<cpu>.inline.hpp` don't include any other HotSpot files, so I propose that we simply rename them to `copy_<os>_<cpu>.hpp`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268119](https://bugs.openjdk.java.net/browse/JDK-8268119): Rename copy_os_cpu.inline.hpp files to copy_os_cpu.hpp


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4311/head:pull/4311` \
`$ git checkout pull/4311`

Update a local copy of the PR: \
`$ git checkout pull/4311` \
`$ git pull https://git.openjdk.java.net/jdk pull/4311/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4311`

View PR using the GUI difftool: \
`$ git pr show -t 4311`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4311.diff">https://git.openjdk.java.net/jdk/pull/4311.diff</a>

</details>
