### PR TITLE
8264975: java/net/DatagramSocket/DatagramSocketMulticasting.java fails infrequently

### DIFF
--- a/test/jdk/java/net/DatagramSocket/DatagramSocketMulticasting.java
+++ b/test/jdk/java/net/DatagramSocket/DatagramSocketMulticasting.java
@@ -38,14 +38,12 @@ import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.MulticastSocket;
 import java.net.NetworkInterface;
 import java.net.ProtocolFamily;
 import java.net.SocketAddress;
 import java.net.SocketException;
 import java.net.SocketOption;
 import java.net.SocketTimeoutException;
-import java.nio.channels.DatagramChannel;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -59,6 +57,7 @@ import static java.net.StandardSocketOptions.IP_MULTICAST_IF;
 import static java.net.StandardSocketOptions.IP_MULTICAST_LOOP;
 import static java.net.StandardSocketOptions.IP_MULTICAST_TTL;
 import static java.net.StandardSocketOptions.SO_REUSEADDR;
+import static jdk.test.lib.NetworkConfiguration.isSameInterface;
 
 public class DatagramSocketMulticasting {
     static final ProtocolFamily UNSPEC = () -> "UNSPEC";
@@ -239,7 +238,7 @@ public class DatagramSocketMulticasting {
 
         // setOption(IP_MULTICAST_IF)
         s.setOption(IP_MULTICAST_IF, ni);
-        assertTrue(s.getOption(IP_MULTICAST_IF).equals(ni));
+        assertTrue(isSameInterface(s.getOption(IP_MULTICAST_IF), ni));
 
         // bad values for IP_MULTICAST_IF
         assertThrows(IllegalArgumentException.class,

--- a/test/jdk/java/net/DatagramSocket/SendReceiveMaxSize.java
+++ b/test/jdk/java/net/DatagramSocket/SendReceiveMaxSize.java
@@ -79,6 +79,7 @@ public class SendReceiveMaxSize {
         IPSupport.throwSkippedExceptionIfNonOperational();
         HOST_ADDR = InetAddress.getLocalHost();
         BUF_LIMIT = (HOST_ADDR instanceof Inet6Address) ? IPV6_SNDBUF : IPV4_SNDBUF;
+        System.out.printf("Host address: %s, Buffer limit: %d%n", HOST_ADDR, BUF_LIMIT);
     }
 
     @DataProvider

--- a/test/lib/jdk/test/lib/NetworkConfiguration.java
+++ b/test/lib/jdk/test/lib/NetworkConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -90,6 +91,35 @@ public class NetworkConfiguration {
 
     private static boolean isIPv6LinkLocal(InetAddress a) {
         return Inet6Address.class.isInstance(a) && a.isLinkLocalAddress();
+    }
+
+    /**
+     * Returns true if the two interfaces point to the same network interface.
+     *
+     * @implNote
+     * This method first looks at whether the two interfaces are
+     * {@linkplain NetworkInterface#equals(Object) equals}, and if so it returns
+     * true. Otherwise, it looks at whether the two interfaces have the same
+     * {@linkplain NetworkInterface#getName() name} and
+     * {@linkplain NetworkInterface#getIndex() index}, and if so returns true.
+     * Otherwise, it returns false.
+     *
+     * @apiNote
+     * This method ignores differences in the addresses to which the network
+     * interfaces are bound, to cater for possible reconfiguration that might
+     * have happened between the time at which each interface configuration
+     * was looked up.
+     *
+     * @param ni1 A network interface, may be {@code null}
+     * @param ni2 An other network interface, may be {@code null}
+     * @return {@code true} if the two network interfaces have the same name
+     *         and index, {@code false} otherwise.
+     */
+    public static boolean isSameInterface(NetworkInterface ni1, NetworkInterface ni2) {
+        if (Objects.equals(ni1, ni2)) return true;
+        if (ni1 == null || ni2 == null) return false;
+        if (ni1.getIndex() != ni2.getIndex()) return false;
+        return Objects.equals(ni1.getName(), ni2.getName());
     }
 
     public static boolean isTestable(NetworkInterface nif) {

--- a/test/lib/jdk/test/lib/NetworkConfiguration.java
+++ b/test/lib/jdk/test/lib/NetworkConfiguration.java
@@ -117,6 +117,9 @@ public class NetworkConfiguration {
      */
     public static boolean isSameInterface(NetworkInterface ni1, NetworkInterface ni2) {
         if (Objects.equals(ni1, ni2)) return true;
+        // Objects equals has taken care of the case where
+        // ni1 == ni2 so either they are both non-null or only
+        // one of them is null - in which case they can't be equal.
         if (ni1 == null || ni2 == null) return false;
         if (ni1.getIndex() != ni2.getIndex()) return false;
         return Objects.equals(ni1.getName(), ni2.getName());


### PR DESCRIPTION
Please find below a fix that will make `java/net/DatagramSocket/DatagramSocketMulticasting.java` more resilient to the rare case where addresses bound to a network interfaces are updated while the test is running.

Instead of using `NetworkInterface::equals` to compare network interfaces, the test now use `NetworkConfiguration::isSameInterface` which only looks at the network interface name and index and ignore the addresses which are bound to it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264975](https://bugs.openjdk.java.net/browse/JDK-8264975): java/net/DatagramSocket/DatagramSocketMulticasting.java fails infrequently


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4313/head:pull/4313` \
`$ git checkout pull/4313`

Update a local copy of the PR: \
`$ git checkout pull/4313` \
`$ git pull https://git.openjdk.java.net/jdk pull/4313/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4313`

View PR using the GUI difftool: \
`$ git pr show -t 4313`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4313.diff">https://git.openjdk.java.net/jdk/pull/4313.diff</a>

</details>
