### PR TITLE
JDK-8266254: Update to use jtreg 6

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1133,10 +1133,9 @@ var getJibProfilesDependencies = function (input, common) {
         jtreg: {
             server: "jpg",
             product: "jtreg",
-            version: "5.1",
-            build_number: "b01",
-            checksum_file: "MD5_VALUES",
-            file: "bundles/jtreg_bin-5.1.zip",
+            version: "6",
+            build_number: "1",
+            file: "bundles/jtreg-6+1.zip",
             environment_name: "JT_HOME",
             environment_path: input.get("jtreg", "home_path") + "/bin",
             configure_args: "--with-jtreg=" + input.get("jtreg", "home_path"),

--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -78,7 +78,7 @@ requires.properties= \
     jdk.containerized
 
 # Minimum jtreg version
-requiredVersion=5.1 b1
+requiredVersion=6+1
 
 # Path to libraries in the topmost test directory. This is needed so @library
 # does not need ../../../ notation to reach them

--- a/test/jaxp/TEST.ROOT
+++ b/test/jaxp/TEST.ROOT
@@ -23,7 +23,7 @@ modules=java.xml
 groups=TEST.groups
 
 # Minimum jtreg version
-requiredVersion=5.1 b1
+requiredVersion=6+1
 
 # Path to libraries in the topmost test directory. This is needed so @library
 # does not need ../../ notation to reach them

--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -67,7 +67,7 @@ requires.properties= \
     jdk.containerized
 
 # Minimum jtreg version
-requiredVersion=5.1 b1
+requiredVersion=6+1
 
 # Path to libraries in the topmost test directory. This is needed so @library
 # does not need ../../ notation to reach them

--- a/test/jdk/java/lang/ModuleTests/addXXX/test/module-info.java
+++ b/test/jdk/java/lang/ModuleTests/addXXX/test/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/ModuleTests/addXXX/test/module-info.java
+++ b/test/jdk/java/lang/ModuleTests/addXXX/test/module-info.java
@@ -21,10 +21,10 @@
  * questions.
  */
 module test {
-    exports test to testng;
+    exports test to org.testng;
 
     requires m2;
     requires m3;
     requires m4;
-    requires testng;
+    requires org.testng;
 }

--- a/test/jdk/java/lang/invoke/MethodHandles/privateLookupIn/test/module-info.java
+++ b/test/jdk/java/lang/invoke/MethodHandles/privateLookupIn/test/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/invoke/MethodHandles/privateLookupIn/test/module-info.java
+++ b/test/jdk/java/lang/invoke/MethodHandles/privateLookupIn/test/module-info.java
@@ -22,6 +22,6 @@
  */
 
 module test {
-   requires testng;
-   exports p to testng;   // TestNG invokes the public methods
+   requires org.testng;
+   exports p to org.testng;   // TestNG invokes the public methods
 }

--- a/test/jdk/java/lang/invoke/modules/m1/module-info.java
+++ b/test/jdk/java/lang/invoke/modules/m1/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/invoke/modules/m1/module-info.java
+++ b/test/jdk/java/lang/invoke/modules/m1/module-info.java
@@ -22,6 +22,6 @@
  */
 module m1 {
     requires m2;
-    requires testng;
+    requires org.testng;
     exports p1;
 }

--- a/test/jdk/java/lang/invoke/modules/m3/module-info.java
+++ b/test/jdk/java/lang/invoke/modules/m3/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/invoke/modules/m3/module-info.java
+++ b/test/jdk/java/lang/invoke/modules/m3/module-info.java
@@ -24,7 +24,7 @@
 module m3 {
     requires m4;
     requires m5;
-    requires testng;
+    requires org.testng;
     requires java.management;
     exports c1;
     opens c2 to m5;

--- a/test/jdk/java/util/ServiceLoader/security/test/module-info.java
+++ b/test/jdk/java/util/ServiceLoader/security/test/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/util/ServiceLoader/security/test/module-info.java
+++ b/test/jdk/java/util/ServiceLoader/security/test/module-info.java
@@ -36,6 +36,6 @@ module test {
     provides S4 with P4;
     provides S5 with P5;
     provides S6 with P6;
-    requires testng;
-    exports p to testng;
+    requires org.testng;
+    exports p to org.testng;
 }

--- a/test/langtools/TEST.ROOT
+++ b/test/langtools/TEST.ROOT
@@ -15,7 +15,7 @@ keys=intermittent randomness
 groups=TEST.groups
 
 # Minimum jtreg version
-requiredVersion=5.1 b1
+requiredVersion=6+1
 
 # Use new module options
 useNewOptions=true

--- a/test/lib-test/TEST.ROOT
+++ b/test/lib-test/TEST.ROOT
@@ -29,7 +29,7 @@
 keys=randomness
 
 # Minimum jtreg version
-requiredVersion=5.1 b1
+requiredVersion=6+1
 
 # Path to libraries in the topmost test directory. This is needed so @library
 # does not need ../../ notation to reach them

--- a/test/lib-test/TEST.ROOT
+++ b/test/lib-test/TEST.ROOT
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Please review the change to update to using jtreg 6. 

The primary change is to the jib-profiles.js file, which specifies the version of jtreg to use, for those systems that rely on this file. In addition, the `requiredVersion` has been updated in the various `TEST.ROOT` files.

All the tests that could be updated ahead of time have been updated. There are a few tests remaining that need to be done at this time, because of the change in the module name for TestNG 7.3. It changed from a default of `testng` to an explicit `org.testng`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8266254](https://bugs.openjdk.java.net/browse/JDK-8266254): Update to use jtreg 6
 * [JDK-8265020](https://bugs.openjdk.java.net/browse/JDK-8265020): tests must be updated for new TestNG module name


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to 0d1e554a2b8075f4a9039db91300c38db36ce5be
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to 0d1e554a2b8075f4a9039db91300c38db36ce5be
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to 0d1e554a2b8075f4a9039db91300c38db36ce5be
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to 0d1e554a2b8075f4a9039db91300c38db36ce5be
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to 0d1e554a2b8075f4a9039db91300c38db36ce5be
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**) ⚠️ Review applies to 0d1e554a2b8075f4a9039db91300c38db36ce5be


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4315/head:pull/4315` \
`$ git checkout pull/4315`

Update a local copy of the PR: \
`$ git checkout pull/4315` \
`$ git pull https://git.openjdk.java.net/jdk pull/4315/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4315`

View PR using the GUI difftool: \
`$ git pr show -t 4315`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4315.diff">https://git.openjdk.java.net/jdk/pull/4315.diff</a>

</details>
