### PR TITLE
8266019: StreamResult(File) writes to incorrect file path if # is part of the file path

### DIFF
--- a/src/java.xml/share/classes/javax/xml/transform/stream/StreamResult.java
+++ b/src/java.xml/share/classes/javax/xml/transform/stream/StreamResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,9 +28,10 @@ package javax.xml.transform.stream;
 import javax.xml.transform.Result;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.io.Writer;
-import java.net.MalformedURLException;
 
 /**
  * <p>Acts as an holder for a transformation result,
@@ -95,10 +96,12 @@ public class StreamResult implements Result {
      * @param f Must a non-null File reference.
      */
     public StreamResult(File f) {
-        //convert file to appropriate URI, f.toURI().toASCIIString()
-        //converts the URI to string as per rule specified in
-        //RFC 2396,
-        setSystemId(f.toURI().toASCIIString());
+        try {
+            outputStream = new FileOutputStream(f);
+        } catch (FileNotFoundException ex) {
+            // fall back to the original implementation for compatibility
+            setSystemId(f.toURI().toASCIIString());
+        }
     }
 
     /**

--- a/test/jaxp/javax/xml/jaxp/unittest/transform/ResultTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/transform/ResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,32 +24,40 @@
 package transform;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.io.StringReader;
+import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import javax.xml.stream.XMLEventWriter;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamWriter;
+import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stax.StAXResult;
+import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.helpers.DefaultHandler;
 
 /*
  * @test
- * @bug 8238183
+ * @bug 8238183 8266019
  * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
  * @run testng/othervm transform.ResultTest
  * @summary Verifies that the output of a transformation is well-formed when
  *          StAXResult is used.
  */
 public class ResultTest {
+    public static final String TEST_DIR = System.getProperty("test.classes", ".");
+
     // The XML contains a comment before the root element
     final static String XML =
             "<?xml version=\"1.0\" ?>\n"
@@ -64,6 +72,25 @@ public class ResultTest {
         } catch (Exception e) {
             throw new RuntimeException(e.getMessage());
         }
+    }
+
+    /**
+     * @bug 8266019
+     * Verifies that a StreamResult created with a File is processed correctly.
+     *
+     * @throws Exception if test fails
+     */
+    @Test
+    public void testStreamResult() throws Exception {
+        File f = new File(TEST_DIR + "/output/#/dom.xml");
+        f.getParentFile().mkdirs();
+
+        Document dom = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        dom.appendChild(dom.createElement("root"));
+
+        Transformer tr = TransformerFactory.newInstance().newTransformer();
+        tr.setOutputProperty(OutputKeys.INDENT, "yes");
+        tr.transform(new DOMSource(dom), new StreamResult(f));
     }
 
     /**


### PR DESCRIPTION
Special characters are different in File and URI. Treat File input as File using FileInputStream instead of converting to an URI, but fall back to URI in case of error for compatibility (in error handling).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266019](https://bugs.openjdk.java.net/browse/JDK-8266019): StreamResult(File) writes to incorrect file path if # is part of the file path


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4318/head:pull/4318` \
`$ git checkout pull/4318`

Update a local copy of the PR: \
`$ git checkout pull/4318` \
`$ git pull https://git.openjdk.java.net/jdk pull/4318/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4318`

View PR using the GUI difftool: \
`$ git pr show -t 4318`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4318.diff">https://git.openjdk.java.net/jdk/pull/4318.diff</a>

</details>
