### PR TITLE
8268138: docs build error after JDK-8263332 integration

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordingStream.java
@@ -423,7 +423,7 @@ public final class RecordingStream implements AutoCloseable, EventStream {
      *         have {@code FilePermission} to write to the destination path
      *
      * @see RecordingStream#setMaxAge(Duration)
-     * @see RecordingStream#setMaxSize(Duration)
+     * @see RecordingStream#setMaxSize(long)
      */
     public void dump(Path destination) throws IOException {
         Objects.requireNonNull(destination);

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
@@ -582,7 +582,7 @@ public final class RemoteRecordingStream implements EventStream {
      *         have {@code FilePermission} to write to the destination path
      *
      * @see RemoteRecordingStream#setMaxAge(Duration)
-     * @see RemoteRecordingStream#setMaxSize(Duration)
+     * @see RemoteRecordingStream#setMaxSize(long)
      */
     public void dump(Path destination) throws IOException {
         Objects.requireNonNull(destination);


### PR DESCRIPTION
Hi,

Could I have a review of a fix that takes care of a couple of Javadoc issues.

Testing: make docs locally.

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268138](https://bugs.openjdk.java.net/browse/JDK-8268138): docs build error after JDK-8263332 integration


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4319/head:pull/4319` \
`$ git checkout pull/4319`

Update a local copy of the PR: \
`$ git checkout pull/4319` \
`$ git pull https://git.openjdk.java.net/jdk pull/4319/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4319`

View PR using the GUI difftool: \
`$ git pr show -t 4319`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4319.diff">https://git.openjdk.java.net/jdk/pull/4319.diff</a>

</details>
