### PR TITLE
8268127: Shenandoah: Heap size may be too small for region to align to large page size

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
@@ -54,11 +54,13 @@ void ShenandoahArguments::initialize() {
 
   FLAG_SET_DEFAULT(ShenandoahVerifyOptoBarriers,     false);
 #endif
-
-  if (UseLargePages && (MaxHeapSize / os::large_page_size()) < ShenandoahHeapRegion::MIN_NUM_REGIONS) {
-    warning("Large pages size (" SIZE_FORMAT "K) is too large to afford page-sized regions, disabling large pages",
-            os::large_page_size() / K);
-    FLAG_SET_DEFAULT(UseLargePages, false);
+  if (UseLargePages) {
+    int large_page_size = os::large_page_size();
+    if ((align_up(MaxHeapSize, large_page_size) / large_page_size) < ShenandoahHeapRegion::MIN_NUM_REGIONS) {
+      warning("Large pages size (" SIZE_FORMAT "K) is too large to afford page-sized regions, disabling uncommit",
+              os::large_page_size() / K);
+      FLAG_SET_DEFAULT(ShenandoahUncommit, false);
+    }
   }
 
   // Enable NUMA by default. While Shenandoah is not NUMA-aware, enabling NUMA makes

--- a/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
@@ -56,9 +56,9 @@ void ShenandoahArguments::initialize() {
 #endif
 
   if (UseLargePages && (MaxHeapSize / os::large_page_size()) < ShenandoahHeapRegion::MIN_NUM_REGIONS) {
-    warning("Large pages size (" SIZE_FORMAT "K) is too large to afford page-sized regions, disabling uncommit",
+    warning("Large pages size (" SIZE_FORMAT "K) is too large to afford page-sized regions, disabling large pages",
             os::large_page_size() / K);
-    FLAG_SET_DEFAULT(ShenandoahUncommit, false);
+    FLAG_SET_DEFAULT(UseLargePages, false);
   }
 
   // Enable NUMA by default. While Shenandoah is not NUMA-aware, enabling NUMA makes

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -179,10 +179,11 @@ jint ShenandoahHeap::initialize() {
   size_t bitmap_page_size = UseLargePages ? (size_t)os::large_page_size() : (size_t)os::vm_page_size();
   size_t region_page_size = UseLargePages ? (size_t)os::large_page_size() : (size_t)os::vm_page_size();
 
+  log_info(gc)("Setup heap, size: " SIZE_FORMAT "K, region size: " SIZE_FORMAT "K and region count: " SIZE_FORMAT,
+              max_byte_size / K, reg_size_bytes / K, _num_regions);
   //
   // Reserve and commit memory for heap
   //
-
   ReservedHeapSpace heap_rs = Universe::reserve_heap(max_byte_size, heap_alignment);
   initialize_reserved_region(heap_rs);
   _heap_region = MemRegion((HeapWord*)heap_rs.base(), heap_rs.size() / HeapWordSize);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -467,7 +467,7 @@ size_t ShenandoahHeapRegion::block_size(const HeapWord* p) const {
   }
 }
 
-void ShenandoahHeapRegion::setup_sizes(size_t max_heap_size) {
+void ShenandoahHeapRegion::setup_sizes(size_t& max_heap_size) {
   // Absolute minimums we should not ever break.
   static const size_t MIN_REGION_SIZE = 256*K;
 
@@ -542,13 +542,28 @@ void ShenandoahHeapRegion::setup_sizes(size_t max_heap_size) {
     region_size = ShenandoahRegionSize;
   }
 
-  // Make sure region size is at least one large page, if enabled.
-  // The heap sizes would be rounded by heap initialization code by
-  // page size, so we need to round up the region size too, to cover
-  // the heap exactly.
+  // Make sure region size and heap size are page aligned.
+  // If large pages are used, we ensure that region size is aligned to large page size if
+  // heap size is large enough to accommodate minimal number of regions. Otherwise, we align
+  // region size to regular page size.
+
+  // Figure out page size to use, and aligns up heap to page size
+  int page_size = os::vm_page_size();
   if (UseLargePages) {
-    region_size = MAX2(region_size, os::large_page_size());
+    int large_page_size = os::large_page_size();
+    max_heap_size = align_up(max_heap_size, large_page_size);
+    if ((max_heap_size / align_up(region_size, large_page_size)) >= MIN_NUM_REGIONS) {
+      page_size = large_page_size;
+    } else {
+      // Should have been checked during argument initialization
+      assert(!ShenandoahUncommit, "Uncommit requires region size aligns to underline page size");
+    }
+  } else {
+    max_heap_size = align_up(max_heap_size, page_size);
   }
+
+  // Align region size to page size
+  region_size = align_up(region_size, page_size);
 
   int region_size_log = log2i(region_size);
   // Recalculate the region size to make sure it's a power of

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -251,7 +251,7 @@ public:
 
   static const size_t MIN_NUM_REGIONS = 10;
 
-  static void setup_sizes(size_t max_heap_size);
+  static void setup_sizes(size_t& max_heap_size);
 
   double empty_time() {
     return _empty_time;


### PR DESCRIPTION
TestLargePages.java failed on Linux AArch64, where large page size is 500M, and the test is configured to run with much smaller heap, e.g. 131M.

This is *not* AArch64 specific, just none of our regular test machines has large page setup.

I purpose two invariants:
1) Heap size always aligns up to page size that is requested.
2) Region size always aligns up to page size that is requested if heap is large enough to accommodate them. Otherwise, it aligns up to regular page size.

This partially reverts JDK-8266802.

Obviously, this is a corner case and is unlikely seen in real word. The alternative is to disable UseLargePages if heap size is too small, e.g. align_up(heap_size, page_size) < MIN_NUM_REGIONS.

Test:
  hotspot_gc_shenandoah
 