### PR TITLE
8268131: 2 java/foreign tests timed out

### DIFF
--- a/test/jdk/java/foreign/TestDowncall.java
+++ b/test/jdk/java/foreign/TestDowncall.java
@@ -28,7 +28,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestDowncall
  *
- * @run testng/othervm
+ * @run testng/othervm/timeout=720
  *   --enable-native-access=ALL-UNNAMED
  *   TestDowncall
  */

--- a/test/jdk/java/foreign/TestDowncall.java
+++ b/test/jdk/java/foreign/TestDowncall.java
@@ -28,7 +28,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestDowncall
  *
- * @run testng/othervm/timeout=720
+ * @run testng/othervm/timeout=240
  *   --enable-native-access=ALL-UNNAMED
  *   TestDowncall
  */

--- a/test/jdk/java/foreign/TestResourceScope.java
+++ b/test/jdk/java/foreign/TestResourceScope.java
@@ -127,7 +127,14 @@ public class TestResourceScope {
         // if no cleaner, close - not all segments might have been added to the scope!
         // if cleaner, don't unset the scope - after all, the scope is kept alive by threads
         if (cleaner == null) {
-            scope.close();
+            while (true) {
+                try {
+                    scope.close();
+                    break;
+                } catch (IllegalStateException ise) {
+                    // scope is acquired (by add) - wait some more
+                }
+            }
         }
 
         threads.forEach(t -> {

--- a/test/jdk/java/foreign/TestUpcall.java
+++ b/test/jdk/java/foreign/TestUpcall.java
@@ -28,7 +28,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm
+ * @run testng/othervm/timeout=720
  *   --enable-native-access=ALL-UNNAMED
  *   TestUpcall
  */

--- a/test/jdk/java/foreign/TestUpcall.java
+++ b/test/jdk/java/foreign/TestUpcall.java
@@ -28,7 +28,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm/timeout=720
+ * @run testng/othervm/timeout=240
  *   --enable-native-access=ALL-UNNAMED
  *   TestUpcall
  */


### PR DESCRIPTION
This patch increases time out for both TestUpcall and TestDowncall. These tests were already long-running, but with JEP-412, they were beefed up even more, so now they time out on some debug builds.

This patch also address a minor issue in TestResourceScope which can sometimes lead to intermittent failure, depending on how threads are scheduled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268131](https://bugs.openjdk.java.net/browse/JDK-8268131): 2 java/foreign tests timed out


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to b432907653ecf3acb902053db5de4b80069a234d


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4321/head:pull/4321` \
`$ git checkout pull/4321`

Update a local copy of the PR: \
`$ git checkout pull/4321` \
`$ git pull https://git.openjdk.java.net/jdk pull/4321/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4321`

View PR using the GUI difftool: \
`$ git pr show -t 4321`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4321.diff">https://git.openjdk.java.net/jdk/pull/4321.diff</a>

</details>
