### PR TITLE
8268139: CDS ArchiveBuilder may reference unloaded classes

### DIFF
--- a/src/hotspot/share/cds/dynamicArchive.cpp
+++ b/src/hotspot/share/cds/dynamicArchive.cpp
@@ -109,6 +109,7 @@ public:
     DEBUG_ONLY(SystemDictionaryShared::NoClassLoadingMark nclm);
     SystemDictionaryShared::check_excluded_classes();
 
+    MutexLocker ml(DumpTimeTable_lock, Mutex::_no_safepoint_check_flag);
     init_header();
     gather_source_objs();
     reserve_buffer();

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -489,6 +489,7 @@ void VM_PopulateDumpSharedSpace::doit() {
   // that so we don't have to walk the SystemDictionary again.
   SystemDictionaryShared::check_excluded_classes();
 
+  MutexLocker ml(DumpTimeTable_lock, Mutex::_no_safepoint_check_flag);
   StaticArchiveBuilder builder;
   builder.gather_source_objs();
   builder.reserve_buffer();

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -429,7 +429,7 @@ DumpTimeLambdaProxyClassDictionary* _dumptime_lambda_proxy_class_dictionary = NU
 
 static void add_to_dump_time_lambda_proxy_class_dictionary(LambdaProxyClassKey key,
                                                            InstanceKlass* proxy_klass) {
-  assert(DumpTimeTable_lock->owned_by_self(), "sanity");
+  assert_lock_strong(DumpTimeTable_lock);
   if (_dumptime_lambda_proxy_class_dictionary == NULL) {
     _dumptime_lambda_proxy_class_dictionary =
       new (ResourceObj::C_HEAP, mtClass)DumpTimeLambdaProxyClassDictionary();

--- a/src/hotspot/share/classfile/systemDictionaryShared.hpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.hpp
@@ -207,6 +207,7 @@ private:
                                  const ClassFileStream* cfs,
                                  TRAPS);
   static DumpTimeSharedClassInfo* find_or_allocate_info_for(InstanceKlass* k);
+  static DumpTimeSharedClassInfo* find_or_allocate_info_for_locked(InstanceKlass* k);
   static void write_dictionary(RunTimeSharedDictionary* dictionary,
                                bool is_builtin);
   static void write_lambda_proxy_class_dictionary(LambdaProxyClassDictionary* dictionary);


### PR DESCRIPTION
During CDS dump, we enter a safepoint (e.g., `VM_PopulateDynamicDumpSharedSpace`) and run `ArchiveBuilder::gather_source_objs()` to collect all classes to be dumped. However, some of these classes may belong to custom class loaders that are no longer alive. While we are still inside the safepoint, concurrent GC operations may free these class loaders (see https://github.com/openjdk/jdk/pull/4286). Thus `ArchiveBuilder` may end up referencing unloaded classes.

The fix:

(1) Add a class `k` to ArchiveBuilder only if `k->class_loader_data()->is_alive()`

(2) All the classes added to `ArchiveBuilder` are taken from `DumpTimeSharedClassTable`. When a class is loaded, it's added to this table. When a class is unloaded, it's removed from this table (via `SystemDictionaryShared::remove_dumptime_info`). This table is protected by `DumpTimeTable_lock`. To make sure that this table is not changed during the CDS safepoint, we grab this lock before calling `ArchiveBuilder::gather_source_objs()`, and release this lock only when the CDS dump is finished. As a result, in step (1) above, when we call `k->class_loader_data()->is_alive()`, we are sure that `k` itself has not been deallocated and is still a valid pointer.

Testing -- Mach5 tiers 1-4 in progress

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268139](https://bugs.openjdk.java.net/browse/JDK-8268139): CDS ArchiveBuilder may reference unloaded classes


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to 49ae57aed856f445bc3e0563123c6eacc199e32c
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4322/head:pull/4322` \
`$ git checkout pull/4322`

Update a local copy of the PR: \
`$ git checkout pull/4322` \
`$ git pull https://git.openjdk.java.net/jdk pull/4322/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4322`

View PR using the GUI difftool: \
`$ git pr show -t 4322`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4322.diff">https://git.openjdk.java.net/jdk/pull/4322.diff</a>

</details>
