### PR TITLE
JDK-8268146: fix for JDK-8266254 fails validate-source

### DIFF
--- a/test/lib-test/TEST.ROOT
+++ b/test/lib-test/TEST.ROOT
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Please review a fix to add a missing ','

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8268146](https://bugs.openjdk.java.net/browse/JDK-8268146): fix for JDK-8266254 fails validate-source


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4324/head:pull/4324` \
`$ git checkout pull/4324`

Update a local copy of the PR: \
`$ git checkout pull/4324` \
`$ git pull https://git.openjdk.java.net/jdk pull/4324/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4324`

View PR using the GUI difftool: \
`$ git pr show -t 4324`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4324.diff">https://git.openjdk.java.net/jdk/pull/4324.diff</a>

</details>
