### PR TITLE
JDK-8268147: need to update reference to testng module for jtreg6

### DIFF
--- a/test/jdk/java/foreign/handles/lookup_module/module-info.java
+++ b/test/jdk/java/foreign/handles/lookup_module/module-info.java
@@ -22,7 +22,7 @@
  */
 
 open module lookup_module {
-    requires testng;
+    requires org.testng;
     requires jdk.incubator.foreign;
     requires invoker_module;
     exports handle.lookup;


### PR DESCRIPTION
Please review a test fix to refer to the new name of the TestNG module.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268147](https://bugs.openjdk.java.net/browse/JDK-8268147): need to update reference to testng module for jtreg6


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4325/head:pull/4325` \
`$ git checkout pull/4325`

Update a local copy of the PR: \
`$ git checkout pull/4325` \
`$ git pull https://git.openjdk.java.net/jdk pull/4325/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4325`

View PR using the GUI difftool: \
`$ git pr show -t 4325`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4325.diff">https://git.openjdk.java.net/jdk/pull/4325.diff</a>

</details>
