### PR TITLE
8268151: Vector API toShuffle optimization

### DIFF
--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -507,7 +507,11 @@ bool LibraryCallKit::inline_vector_shuffle_to_vector() {
   const TypeInstPtr* shuffle_box_type = TypeInstPtr::make_exact(TypePtr::NotNull, sbox_klass);
 
   // Unbox shuffle with true flag to indicate its load shuffle to vector
-  Node* shuffle_vec = unbox_vector(shuffle, shuffle_box_type, elem_bt, num_elem, true);
+  // shuffle is a byte array
+  Node* shuffle_vec = unbox_vector(shuffle, shuffle_box_type, T_BYTE, num_elem, true);
+
+  // cast byte to target element type
+  shuffle_vec = gvn().transform(VectorCastNode::make(cast_vopc, shuffle_vec, elem_bt, num_elem));
 
   ciKlass* vbox_klass = vector_klass->const_oop()->as_instance()->java_lang_Class_klass();
   const TypeInstPtr* vec_box_type = TypeInstPtr::make_exact(TypePtr::NotNull, vbox_klass);
@@ -1424,7 +1428,7 @@ bool LibraryCallKit::inline_vector_convert() {
 
   ciKlass* vbox_klass_from = vector_klass_from->const_oop()->as_instance()->java_lang_Class_klass();
   ciKlass* vbox_klass_to = vector_klass_to->const_oop()->as_instance()->java_lang_Class_klass();
-  if (is_vector_shuffle(vbox_klass_from) || is_vector_shuffle(vbox_klass_to)) {
+  if (is_vector_shuffle(vbox_klass_from)) {
     return false; // vector shuffles aren't supported
   }
   bool is_mask = is_vector_mask(vbox_klass_from);

--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -1243,10 +1243,7 @@ Node* VectorUnboxNode::Ideal(PhaseGVN* phase, bool can_reshape) {
           value = phase->transform(VectorStoreMaskNode::make(*phase, value, in_vt->element_basic_type(), in_vt->length()));
           return new VectorLoadMaskNode(value, out_vt);
         } else if (is_vector_shuffle) {
-          if (is_shuffle_to_vector()) {
-            // VectorUnbox (VectorBox vshuffle) ==> VectorCastB2X vshuffle
-            return new VectorCastB2XNode(value, out_vt);
-          } else {
+          if (!is_shuffle_to_vector()) {
             // VectorUnbox (VectorBox vshuffle) ==> VectorLoadShuffle vshuffle
             return new VectorLoadShuffleNode(value, out_vt);
           }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
@@ -331,23 +331,8 @@ final class Byte128Vector extends ByteVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Byte> toShuffleTemplate(AbstractSpecies<Byte> dsp) {
-        byte[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Byte> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     Byte128Shuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     Byte128Vector::toShuffleTemplate);
+        return super.toShuffleTemplate(Byte128Shuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
@@ -330,15 +330,24 @@ final class Byte128Vector extends ByteVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Byte> toShuffle() {
+    private final
+    VectorShuffle<Byte> toShuffleTemplate(AbstractSpecies<Byte> dsp) {
         byte[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Byte> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     Byte128Shuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     Byte128Vector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
@@ -330,15 +330,24 @@ final class Byte256Vector extends ByteVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Byte> toShuffle() {
+    private final
+    VectorShuffle<Byte> toShuffleTemplate(AbstractSpecies<Byte> dsp) {
         byte[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Byte> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     Byte256Shuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     Byte256Vector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
@@ -331,23 +331,8 @@ final class Byte256Vector extends ByteVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Byte> toShuffleTemplate(AbstractSpecies<Byte> dsp) {
-        byte[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Byte> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     Byte256Shuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     Byte256Vector::toShuffleTemplate);
+        return super.toShuffleTemplate(Byte256Shuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
@@ -331,23 +331,8 @@ final class Byte512Vector extends ByteVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Byte> toShuffleTemplate(AbstractSpecies<Byte> dsp) {
-        byte[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Byte> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     Byte512Shuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     Byte512Vector::toShuffleTemplate);
+        return super.toShuffleTemplate(Byte512Shuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
@@ -330,15 +330,24 @@ final class Byte512Vector extends ByteVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Byte> toShuffle() {
+    private final
+    VectorShuffle<Byte> toShuffleTemplate(AbstractSpecies<Byte> dsp) {
         byte[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Byte> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     Byte512Shuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     Byte512Vector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
@@ -330,15 +330,24 @@ final class Byte64Vector extends ByteVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Byte> toShuffle() {
+    private final
+    VectorShuffle<Byte> toShuffleTemplate(AbstractSpecies<Byte> dsp) {
         byte[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Byte> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     Byte64Shuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     Byte64Vector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
@@ -331,23 +331,8 @@ final class Byte64Vector extends ByteVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Byte> toShuffleTemplate(AbstractSpecies<Byte> dsp) {
-        byte[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Byte> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     Byte64Shuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     Byte64Vector::toShuffleTemplate);
+        return super.toShuffleTemplate(Byte64Shuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
@@ -330,15 +330,24 @@ final class ByteMaxVector extends ByteVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Byte> toShuffle() {
+    private final
+    VectorShuffle<Byte> toShuffleTemplate(AbstractSpecies<Byte> dsp) {
         byte[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Byte> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     ByteMaxShuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     ByteMaxVector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
@@ -331,23 +331,8 @@ final class ByteMaxVector extends ByteVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Byte> toShuffleTemplate(AbstractSpecies<Byte> dsp) {
-        byte[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Byte> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     ByteMaxShuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     ByteMaxVector::toShuffleTemplate);
+        return super.toShuffleTemplate(ByteMaxShuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -2177,6 +2177,29 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         return r1.blend(r0, valid);
     }
 
+    @ForceInline
+    private final
+    VectorShuffle<Byte> toShuffle0(ByteSpecies dsp) {
+        byte[] a = toArray();
+        int[] sa = new int[a.length];
+        for (int i = 0; i < a.length; i++) {
+            sa[i] = (int) a[i];
+        }
+        return VectorShuffle.fromArray(dsp, sa, 0);
+    }
+
+    /*package-private*/
+    @ForceInline
+    final
+    VectorShuffle<Byte> toShuffleTemplate(Class<?> shuffleType) {
+        ByteSpecies vsp = vspecies();
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     getClass(), byte.class, length(),
+                                     shuffleType, byte.class, length(),
+                                     this, vsp,
+                                     ByteVector::toShuffle0);
+    }
+
     /**
      * {@inheritDoc} <!--workaround-->
      */

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
@@ -324,15 +324,24 @@ final class Double128Vector extends DoubleVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Double> toShuffle() {
+    private final
+    VectorShuffle<Double> toShuffleTemplate(AbstractSpecies<Double> dsp) {
         double[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Double> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     Double128Shuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     Double128Vector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
@@ -325,23 +325,8 @@ final class Double128Vector extends DoubleVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Double> toShuffleTemplate(AbstractSpecies<Double> dsp) {
-        double[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Double> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     Double128Shuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     Double128Vector::toShuffleTemplate);
+        return super.toShuffleTemplate(Double128Shuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
@@ -324,15 +324,24 @@ final class Double256Vector extends DoubleVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Double> toShuffle() {
+    private final
+    VectorShuffle<Double> toShuffleTemplate(AbstractSpecies<Double> dsp) {
         double[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Double> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     Double256Shuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     Double256Vector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
@@ -325,23 +325,8 @@ final class Double256Vector extends DoubleVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Double> toShuffleTemplate(AbstractSpecies<Double> dsp) {
-        double[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Double> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     Double256Shuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     Double256Vector::toShuffleTemplate);
+        return super.toShuffleTemplate(Double256Shuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
@@ -324,15 +324,24 @@ final class Double512Vector extends DoubleVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Double> toShuffle() {
+    private final
+    VectorShuffle<Double> toShuffleTemplate(AbstractSpecies<Double> dsp) {
         double[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Double> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     Double512Shuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     Double512Vector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
@@ -325,23 +325,8 @@ final class Double512Vector extends DoubleVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Double> toShuffleTemplate(AbstractSpecies<Double> dsp) {
-        double[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Double> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     Double512Shuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     Double512Vector::toShuffleTemplate);
+        return super.toShuffleTemplate(Double512Shuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
@@ -324,15 +324,24 @@ final class Double64Vector extends DoubleVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Double> toShuffle() {
+    private final
+    VectorShuffle<Double> toShuffleTemplate(AbstractSpecies<Double> dsp) {
         double[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Double> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     Double64Shuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     Double64Vector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
@@ -325,23 +325,8 @@ final class Double64Vector extends DoubleVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Double> toShuffleTemplate(AbstractSpecies<Double> dsp) {
-        double[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Double> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     Double64Shuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     Double64Vector::toShuffleTemplate);
+        return super.toShuffleTemplate(Double64Shuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
@@ -325,23 +325,8 @@ final class DoubleMaxVector extends DoubleVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Double> toShuffleTemplate(AbstractSpecies<Double> dsp) {
-        double[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Double> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     DoubleMaxShuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     DoubleMaxVector::toShuffleTemplate);
+        return super.toShuffleTemplate(DoubleMaxShuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
@@ -324,15 +324,24 @@ final class DoubleMaxVector extends DoubleVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Double> toShuffle() {
+    private final
+    VectorShuffle<Double> toShuffleTemplate(AbstractSpecies<Double> dsp) {
         double[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Double> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     DoubleMaxShuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     DoubleMaxVector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -2090,6 +2090,29 @@ public abstract class DoubleVector extends AbstractVector<Double> {
         return r1.blend(r0, valid);
     }
 
+    @ForceInline
+    private final
+    VectorShuffle<Double> toShuffle0(DoubleSpecies dsp) {
+        double[] a = toArray();
+        int[] sa = new int[a.length];
+        for (int i = 0; i < a.length; i++) {
+            sa[i] = (int) a[i];
+        }
+        return VectorShuffle.fromArray(dsp, sa, 0);
+    }
+
+    /*package-private*/
+    @ForceInline
+    final
+    VectorShuffle<Double> toShuffleTemplate(Class<?> shuffleType) {
+        DoubleSpecies vsp = vspecies();
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     getClass(), double.class, length(),
+                                     shuffleType, byte.class, length(),
+                                     this, vsp,
+                                     DoubleVector::toShuffle0);
+    }
+
     /**
      * {@inheritDoc} <!--workaround-->
      */

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
@@ -325,23 +325,8 @@ final class Float128Vector extends FloatVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Float> toShuffleTemplate(AbstractSpecies<Float> dsp) {
-        float[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Float> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     Float128Shuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     Float128Vector::toShuffleTemplate);
+        return super.toShuffleTemplate(Float128Shuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
@@ -324,15 +324,24 @@ final class Float128Vector extends FloatVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Float> toShuffle() {
+    private final
+    VectorShuffle<Float> toShuffleTemplate(AbstractSpecies<Float> dsp) {
         float[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Float> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     Float128Shuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     Float128Vector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
@@ -324,15 +324,24 @@ final class Float256Vector extends FloatVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Float> toShuffle() {
+    private final
+    VectorShuffle<Float> toShuffleTemplate(AbstractSpecies<Float> dsp) {
         float[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Float> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     Float256Shuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     Float256Vector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
@@ -325,23 +325,8 @@ final class Float256Vector extends FloatVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Float> toShuffleTemplate(AbstractSpecies<Float> dsp) {
-        float[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Float> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     Float256Shuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     Float256Vector::toShuffleTemplate);
+        return super.toShuffleTemplate(Float256Shuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
@@ -324,15 +324,24 @@ final class Float512Vector extends FloatVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Float> toShuffle() {
+    private final
+    VectorShuffle<Float> toShuffleTemplate(AbstractSpecies<Float> dsp) {
         float[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Float> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     Float512Shuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     Float512Vector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
@@ -325,23 +325,8 @@ final class Float512Vector extends FloatVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Float> toShuffleTemplate(AbstractSpecies<Float> dsp) {
-        float[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Float> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     Float512Shuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     Float512Vector::toShuffleTemplate);
+        return super.toShuffleTemplate(Float512Shuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
@@ -325,23 +325,8 @@ final class Float64Vector extends FloatVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Float> toShuffleTemplate(AbstractSpecies<Float> dsp) {
-        float[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Float> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     Float64Shuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     Float64Vector::toShuffleTemplate);
+        return super.toShuffleTemplate(Float64Shuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
@@ -324,15 +324,24 @@ final class Float64Vector extends FloatVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Float> toShuffle() {
+    private final
+    VectorShuffle<Float> toShuffleTemplate(AbstractSpecies<Float> dsp) {
         float[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Float> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     Float64Shuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     Float64Vector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
@@ -324,15 +324,24 @@ final class FloatMaxVector extends FloatVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Float> toShuffle() {
+    private final
+    VectorShuffle<Float> toShuffleTemplate(AbstractSpecies<Float> dsp) {
         float[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Float> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     FloatMaxShuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     FloatMaxVector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
@@ -325,23 +325,8 @@ final class FloatMaxVector extends FloatVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Float> toShuffleTemplate(AbstractSpecies<Float> dsp) {
-        float[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Float> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     FloatMaxShuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     FloatMaxVector::toShuffleTemplate);
+        return super.toShuffleTemplate(FloatMaxShuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -2102,6 +2102,29 @@ public abstract class FloatVector extends AbstractVector<Float> {
         return r1.blend(r0, valid);
     }
 
+    @ForceInline
+    private final
+    VectorShuffle<Float> toShuffle0(FloatSpecies dsp) {
+        float[] a = toArray();
+        int[] sa = new int[a.length];
+        for (int i = 0; i < a.length; i++) {
+            sa[i] = (int) a[i];
+        }
+        return VectorShuffle.fromArray(dsp, sa, 0);
+    }
+
+    /*package-private*/
+    @ForceInline
+    final
+    VectorShuffle<Float> toShuffleTemplate(Class<?> shuffleType) {
+        FloatSpecies vsp = vspecies();
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     getClass(), float.class, length(),
+                                     shuffleType, byte.class, length(),
+                                     this, vsp,
+                                     FloatVector::toShuffle0);
+    }
+
     /**
      * {@inheritDoc} <!--workaround-->
      */

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
@@ -330,15 +330,24 @@ final class Int128Vector extends IntVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Integer> toShuffle() {
+    private final
+    VectorShuffle<Integer> toShuffleTemplate(AbstractSpecies<Integer> dsp) {
         int[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Integer> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     Int128Shuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     Int128Vector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
@@ -331,23 +331,8 @@ final class Int128Vector extends IntVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Integer> toShuffleTemplate(AbstractSpecies<Integer> dsp) {
-        int[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Integer> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     Int128Shuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     Int128Vector::toShuffleTemplate);
+        return super.toShuffleTemplate(Int128Shuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
@@ -330,15 +330,24 @@ final class Int256Vector extends IntVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Integer> toShuffle() {
+    private final
+    VectorShuffle<Integer> toShuffleTemplate(AbstractSpecies<Integer> dsp) {
         int[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Integer> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     Int256Shuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     Int256Vector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
@@ -331,23 +331,8 @@ final class Int256Vector extends IntVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Integer> toShuffleTemplate(AbstractSpecies<Integer> dsp) {
-        int[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Integer> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     Int256Shuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     Int256Vector::toShuffleTemplate);
+        return super.toShuffleTemplate(Int256Shuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
@@ -331,23 +331,8 @@ final class Int512Vector extends IntVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Integer> toShuffleTemplate(AbstractSpecies<Integer> dsp) {
-        int[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Integer> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     Int512Shuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     Int512Vector::toShuffleTemplate);
+        return super.toShuffleTemplate(Int512Shuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
@@ -330,15 +330,24 @@ final class Int512Vector extends IntVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Integer> toShuffle() {
+    private final
+    VectorShuffle<Integer> toShuffleTemplate(AbstractSpecies<Integer> dsp) {
         int[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Integer> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     Int512Shuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     Int512Vector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
@@ -330,15 +330,24 @@ final class Int64Vector extends IntVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Integer> toShuffle() {
+    private final
+    VectorShuffle<Integer> toShuffleTemplate(AbstractSpecies<Integer> dsp) {
         int[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Integer> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     Int64Shuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     Int64Vector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
@@ -331,23 +331,8 @@ final class Int64Vector extends IntVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Integer> toShuffleTemplate(AbstractSpecies<Integer> dsp) {
-        int[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Integer> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     Int64Shuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     Int64Vector::toShuffleTemplate);
+        return super.toShuffleTemplate(Int64Shuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
@@ -331,23 +331,8 @@ final class IntMaxVector extends IntVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Integer> toShuffleTemplate(AbstractSpecies<Integer> dsp) {
-        int[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Integer> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     IntMaxShuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     IntMaxVector::toShuffleTemplate);
+        return super.toShuffleTemplate(IntMaxShuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
@@ -330,15 +330,24 @@ final class IntMaxVector extends IntVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Integer> toShuffle() {
+    private final
+    VectorShuffle<Integer> toShuffleTemplate(AbstractSpecies<Integer> dsp) {
         int[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Integer> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     IntMaxShuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     IntMaxVector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -2176,6 +2176,29 @@ public abstract class IntVector extends AbstractVector<Integer> {
         return r1.blend(r0, valid);
     }
 
+    @ForceInline
+    private final
+    VectorShuffle<Integer> toShuffle0(IntSpecies dsp) {
+        int[] a = toArray();
+        int[] sa = new int[a.length];
+        for (int i = 0; i < a.length; i++) {
+            sa[i] = (int) a[i];
+        }
+        return VectorShuffle.fromArray(dsp, sa, 0);
+    }
+
+    /*package-private*/
+    @ForceInline
+    final
+    VectorShuffle<Integer> toShuffleTemplate(Class<?> shuffleType) {
+        IntSpecies vsp = vspecies();
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     getClass(), int.class, length(),
+                                     shuffleType, byte.class, length(),
+                                     this, vsp,
+                                     IntVector::toShuffle0);
+    }
+
     /**
      * {@inheritDoc} <!--workaround-->
      */

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
@@ -326,23 +326,8 @@ final class Long128Vector extends LongVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Long> toShuffleTemplate(AbstractSpecies<Long> dsp) {
-        long[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Long> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     Long128Shuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     Long128Vector::toShuffleTemplate);
+        return super.toShuffleTemplate(Long128Shuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
@@ -325,15 +325,24 @@ final class Long128Vector extends LongVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Long> toShuffle() {
+    private final
+    VectorShuffle<Long> toShuffleTemplate(AbstractSpecies<Long> dsp) {
         long[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Long> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     Long128Shuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     Long128Vector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
@@ -326,23 +326,8 @@ final class Long256Vector extends LongVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Long> toShuffleTemplate(AbstractSpecies<Long> dsp) {
-        long[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Long> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     Long256Shuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     Long256Vector::toShuffleTemplate);
+        return super.toShuffleTemplate(Long256Shuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
@@ -325,15 +325,24 @@ final class Long256Vector extends LongVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Long> toShuffle() {
+    private final
+    VectorShuffle<Long> toShuffleTemplate(AbstractSpecies<Long> dsp) {
         long[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Long> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     Long256Shuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     Long256Vector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
@@ -325,15 +325,24 @@ final class Long512Vector extends LongVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Long> toShuffle() {
+    private final
+    VectorShuffle<Long> toShuffleTemplate(AbstractSpecies<Long> dsp) {
         long[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Long> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     Long512Shuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     Long512Vector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
@@ -326,23 +326,8 @@ final class Long512Vector extends LongVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Long> toShuffleTemplate(AbstractSpecies<Long> dsp) {
-        long[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Long> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     Long512Shuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     Long512Vector::toShuffleTemplate);
+        return super.toShuffleTemplate(Long512Shuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
@@ -325,15 +325,24 @@ final class Long64Vector extends LongVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Long> toShuffle() {
+    private final
+    VectorShuffle<Long> toShuffleTemplate(AbstractSpecies<Long> dsp) {
         long[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Long> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     Long64Shuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     Long64Vector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
@@ -326,23 +326,8 @@ final class Long64Vector extends LongVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Long> toShuffleTemplate(AbstractSpecies<Long> dsp) {
-        long[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Long> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     Long64Shuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     Long64Vector::toShuffleTemplate);
+        return super.toShuffleTemplate(Long64Shuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
@@ -325,15 +325,24 @@ final class LongMaxVector extends LongVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Long> toShuffle() {
+    private final
+    VectorShuffle<Long> toShuffleTemplate(AbstractSpecies<Long> dsp) {
         long[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Long> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     LongMaxShuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     LongMaxVector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
@@ -326,23 +326,8 @@ final class LongMaxVector extends LongVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Long> toShuffleTemplate(AbstractSpecies<Long> dsp) {
-        long[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Long> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     LongMaxShuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     LongMaxVector::toShuffleTemplate);
+        return super.toShuffleTemplate(LongMaxShuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -2047,6 +2047,29 @@ public abstract class LongVector extends AbstractVector<Long> {
         return r1.blend(r0, valid);
     }
 
+    @ForceInline
+    private final
+    VectorShuffle<Long> toShuffle0(LongSpecies dsp) {
+        long[] a = toArray();
+        int[] sa = new int[a.length];
+        for (int i = 0; i < a.length; i++) {
+            sa[i] = (int) a[i];
+        }
+        return VectorShuffle.fromArray(dsp, sa, 0);
+    }
+
+    /*package-private*/
+    @ForceInline
+    final
+    VectorShuffle<Long> toShuffleTemplate(Class<?> shuffleType) {
+        LongSpecies vsp = vspecies();
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     getClass(), long.class, length(),
+                                     shuffleType, byte.class, length(),
+                                     this, vsp,
+                                     LongVector::toShuffle0);
+    }
+
     /**
      * {@inheritDoc} <!--workaround-->
      */

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
@@ -330,15 +330,24 @@ final class Short128Vector extends ShortVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Short> toShuffle() {
+    private final
+    VectorShuffle<Short> toShuffleTemplate(AbstractSpecies<Short> dsp) {
         short[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Short> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     Short128Shuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     Short128Vector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
@@ -331,23 +331,8 @@ final class Short128Vector extends ShortVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Short> toShuffleTemplate(AbstractSpecies<Short> dsp) {
-        short[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Short> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     Short128Shuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     Short128Vector::toShuffleTemplate);
+        return super.toShuffleTemplate(Short128Shuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
@@ -331,23 +331,8 @@ final class Short256Vector extends ShortVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Short> toShuffleTemplate(AbstractSpecies<Short> dsp) {
-        short[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Short> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     Short256Shuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     Short256Vector::toShuffleTemplate);
+        return super.toShuffleTemplate(Short256Shuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
@@ -330,15 +330,24 @@ final class Short256Vector extends ShortVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Short> toShuffle() {
+    private final
+    VectorShuffle<Short> toShuffleTemplate(AbstractSpecies<Short> dsp) {
         short[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Short> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     Short256Shuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     Short256Vector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
@@ -331,23 +331,8 @@ final class Short512Vector extends ShortVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Short> toShuffleTemplate(AbstractSpecies<Short> dsp) {
-        short[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Short> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     Short512Shuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     Short512Vector::toShuffleTemplate);
+        return super.toShuffleTemplate(Short512Shuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
@@ -330,15 +330,24 @@ final class Short512Vector extends ShortVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Short> toShuffle() {
+    private final
+    VectorShuffle<Short> toShuffleTemplate(AbstractSpecies<Short> dsp) {
         short[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Short> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     Short512Shuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     Short512Vector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
@@ -331,23 +331,8 @@ final class Short64Vector extends ShortVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Short> toShuffleTemplate(AbstractSpecies<Short> dsp) {
-        short[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Short> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     Short64Shuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     Short64Vector::toShuffleTemplate);
+        return super.toShuffleTemplate(Short64Shuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
@@ -330,15 +330,24 @@ final class Short64Vector extends ShortVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Short> toShuffle() {
+    private final
+    VectorShuffle<Short> toShuffleTemplate(AbstractSpecies<Short> dsp) {
         short[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Short> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     Short64Shuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     Short64Vector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
@@ -331,23 +331,8 @@ final class ShortMaxVector extends ShortVector {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<Short> toShuffleTemplate(AbstractSpecies<Short> dsp) {
-        short[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<Short> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     ShortMaxShuffle.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     ShortMaxVector::toShuffleTemplate);
+        return super.toShuffleTemplate(ShortMaxShuffle.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
@@ -330,15 +330,24 @@ final class ShortMaxVector extends ShortVector {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<Short> toShuffle() {
+    private final
+    VectorShuffle<Short> toShuffleTemplate(AbstractSpecies<Short> dsp) {
         short[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<Short> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     ShortMaxShuffle.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     ShortMaxVector::toShuffleTemplate);
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -2177,6 +2177,29 @@ public abstract class ShortVector extends AbstractVector<Short> {
         return r1.blend(r0, valid);
     }
 
+    @ForceInline
+    private final
+    VectorShuffle<Short> toShuffle0(ShortSpecies dsp) {
+        short[] a = toArray();
+        int[] sa = new int[a.length];
+        for (int i = 0; i < a.length; i++) {
+            sa[i] = (int) a[i];
+        }
+        return VectorShuffle.fromArray(dsp, sa, 0);
+    }
+
+    /*package-private*/
+    @ForceInline
+    final
+    VectorShuffle<Short> toShuffleTemplate(Class<?> shuffleType) {
+        ShortSpecies vsp = vspecies();
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     getClass(), short.class, length(),
+                                     shuffleType, byte.class, length(),
+                                     this, vsp,
+                                     ShortVector::toShuffle0);
+    }
+
     /**
      * {@inheritDoc} <!--workaround-->
      */

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -2446,6 +2446,29 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         return r1.blend(r0, valid);
     }
 
+    @ForceInline
+    private final
+    VectorShuffle<$Boxtype$> toShuffle0($Type$Species dsp) {
+        $type$[] a = toArray();
+        int[] sa = new int[a.length];
+        for (int i = 0; i < a.length; i++) {
+            sa[i] = (int) a[i];
+        }
+        return VectorShuffle.fromArray(dsp, sa, 0);
+    }
+
+    /*package-private*/
+    @ForceInline
+    final
+    VectorShuffle<$Boxtype$> toShuffleTemplate(Class<?> shuffleType) {
+        $Type$Species vsp = vspecies();
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     getClass(), $type$.class, length(),
+                                     shuffleType, byte.class, length(),
+                                     this, vsp,
+                                     $Type$Vector::toShuffle0);
+    }
+
     /**
      * {@inheritDoc} <!--workaround-->
      */

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
@@ -335,23 +335,8 @@ final class $vectortype$ extends $abstractvectortype$ {
     }
 
     @ForceInline
-    private final
-    VectorShuffle<$Boxtype$> toShuffleTemplate(AbstractSpecies<$Boxtype$> dsp) {
-        $type$[] a = toArray();
-        int[] sa = new int[a.length];
-        for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
-        }
-        return VectorShuffle.fromArray(VSPECIES, sa, 0);
-    }
-
-    @ForceInline
     public VectorShuffle<$Boxtype$> toShuffle() {
-        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     this.getClass(), ETYPE, VLENGTH,
-                                     $shuffletype$.class, byte.class, VLENGTH,
-                                     this, VSPECIES,
-                                     $vectortype$::toShuffleTemplate);
+        return super.toShuffleTemplate($shuffletype$.class); // specialize
     }
 
     // Specialized unary testing

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
@@ -334,15 +334,24 @@ final class $vectortype$ extends $abstractvectortype$ {
         return (long) super.reduceLanesTemplate(op, m);  // specialized
     }
 
-    @Override
     @ForceInline
-    public VectorShuffle<$Boxtype$> toShuffle() {
+    private final
+    VectorShuffle<$Boxtype$> toShuffleTemplate(AbstractSpecies<$Boxtype$> dsp) {
         $type$[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
             sa[i] = (int) a[i];
         }
         return VectorShuffle.fromArray(VSPECIES, sa, 0);
+    }
+
+    @ForceInline
+    public VectorShuffle<$Boxtype$> toShuffle() {
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                                     this.getClass(), ETYPE, VLENGTH,
+                                     $shuffletype$.class, byte.class, VLENGTH,
+                                     this, VSPECIES,
+                                     $vectortype$::toShuffleTemplate);
     }
 
     // Specialized unary testing


### PR DESCRIPTION
The Vector API toShuffle method can be optimized  using existing vector conversion intrinsic.

The following changes are made:
1) vector.toShuffle java implementation is changed to call VectorSupport.convert.
2) The conversion intrinsic (inline_vector_convert()) in vectorIntrinsics.cpp is changed to allow shuffle as a destination type.
3) The shuffle.toVector intrinsic (inline_vector_shuffle_to_vector()) in vectorIntrinsics.cpp now explicitly generates conversion node instead of performing conversion during unbox. This is to remove unnecessary boxing during back to back vector.toShuffle and shuffle.toVector calls. 

Best Regards,
Sandhya

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268151](https://bugs.openjdk.java.net/browse/JDK-8268151): Vector API toShuffle optimization


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4326/head:pull/4326` \
`$ git checkout pull/4326`

Update a local copy of the PR: \
`$ git checkout pull/4326` \
`$ git pull https://git.openjdk.java.net/jdk pull/4326/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4326`

View PR using the GUI difftool: \
`$ git pr show -t 4326`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4326.diff">https://git.openjdk.java.net/jdk/pull/4326.diff</a>

</details>
