### PR TITLE
8248877: Document API contract for MetaspaceObj subtypes

### DIFF
--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -263,10 +263,11 @@ class ClassLoaderData;
 class MetaspaceClosure;
 
 class MetaspaceObj {
-  // This class has no virtual functions (except for Metadata and its
-  // subtypes). Nevertheless, there are some functions that all subtypes of
-  // MetaspaceObj are expected to implement, so that templates which are
-  // defined for this class hierarchy can work uniformly.
+  // There are functions that all subtypes of MetaspaceObj are expected
+  // to implement, so that templates which are defined for this class hierarchy
+  // can work uniformly. Within the sub-hierarchy of Metadata, these are virtuals.
+  // Elsewhere in the hierarchy of MetaspaceObj, type(), size(), and/or on_stack()
+  // can be static if constant.
   //
   // The following functions are required by MetaspaceClosure:
   //   void metaspace_pointers_do(MetaspaceClosure* it) { <walk my refs> }
@@ -274,12 +275,8 @@ class MetaspaceObj {
   //   MetaspaceObj::Type type() const { return <This>Type; }
   //
   // The following functions are required by MetadataFactory::free_metadata():
-  //   bool on_stack() { return false; } // DEBUG only
+  //   bool on_stack() { return false; }
   //   void deallocate_contents(ClassLoaderData* loader_data);
-  //
-  // Within the sub-hierarchy of Metadata, these are virtuals.
-  // Elsewhere in the hierarchy of MetaspaceObj, type() and/or size() can be static
-  // if constant.
 
   friend class VMStructs;
   // When CDS is enabled, all shared metaspace objects are mapped

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -263,6 +263,24 @@ class ClassLoaderData;
 class MetaspaceClosure;
 
 class MetaspaceObj {
+  // This class has no virtual functions (except for Metadata and its
+  // subtypes). Nevertheless, there are some functions that all subtypes of
+  // MetaspaceObj are expected to implement, so that templates which are
+  // defined for this class hierarchy can work uniformly.
+  //
+  // The following functions are required by MetaspaceClosure:
+  //   void metaspace_pointers_do(MetaspaceClosure* it) { <walk my refs> }
+  //   int size() const { return align_up(sizeof(<This>), wordSize) / wordSize; }
+  //   MetaspaceObj::Type type() const { return <This>Type; }
+  //
+  // The following functions are required by MetadataFactory::free_metadata():
+  //   bool on_stack() { return false; } // DEBUG only
+  //   void deallocate_contents(ClassLoaderData* loader_data);
+  //
+  // Within the sub-hierarchy of Metadata, these are virtuals.
+  // Elsewhere in the hierarchy of MetaspaceObj, type() and/or size() can be static
+  // if constant.
+
   friend class VMStructs;
   // When CDS is enabled, all shared metaspace objects are mapped
   // into a single contiguous memory block, so we can use these


### PR DESCRIPTION
This PR adds documentation for the (non-virtual) functions that subtypes of MetaspaceObj are required to implement in order for certain templates to work properly. 

Requested by @rose00 (sorry I took a long time ....).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248877](https://bugs.openjdk.java.net/browse/JDK-8248877): Document API contract for MetaspaceObj subtypes


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to b0db2f3609ecf1374eb5273199f4072533bda2d6
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4327/head:pull/4327` \
`$ git checkout pull/4327`

Update a local copy of the PR: \
`$ git checkout pull/4327` \
`$ git pull https://git.openjdk.java.net/jdk pull/4327/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4327`

View PR using the GUI difftool: \
`$ git pr show -t 4327`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4327.diff">https://git.openjdk.java.net/jdk/pull/4327.diff</a>

</details>
