### PR TITLE
JDK-8268150: tier2: test/jdk/tools/jpackage/junit/junit.java needs updating for jtreg 6

### DIFF
--- a/test/jdk/tools/jpackage/junit/junit.java
+++ b/test/jdk/tools/jpackage/junit/junit.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @summary jpackage unit tests
- * @library ${jtreg.home}/lib/junit.jar
+ * @library ${jtreg.home}/lib/junit.jar ${jtreg.home}/lib/hamcrest.jar
  * @modules jdk.jpackage
  * @run shell run_junit.sh
  */


### PR DESCRIPTION
Please review a small test fix, to include hamcrest.jar, as required by the latest version of JUnit  in jtreg 6.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268150](https://bugs.openjdk.java.net/browse/JDK-8268150): tier2: test/jdk/tools/jpackage/junit/junit.java needs updating for jtreg 6


### Reviewers
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4328/head:pull/4328` \
`$ git checkout pull/4328`

Update a local copy of the PR: \
`$ git checkout pull/4328` \
`$ git pull https://git.openjdk.java.net/jdk pull/4328/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4328`

View PR using the GUI difftool: \
`$ git pr show -t 4328`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4328.diff">https://git.openjdk.java.net/jdk/pull/4328.diff</a>

</details>
