### PR TITLE
8212155: Race condition when posting dynamic_code_generated event leads to JVM crash

### DIFF
--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -2289,8 +2289,8 @@ void JvmtiExport::post_dynamic_code_generated_while_holding_locks(const char* na
   // register the stub with the current dynamic code event collector
   // Cannot take safepoint here so do not use state_for to get
   // jvmti thread state.
-  // The collector and/or state might be NULL if JvmtiDynamicCodeEventCollector has been initialized
-  // while JVMTI_EVENT_DYNAMIC_CODE_GENERATED was disabled
+  // The collector and/or state might be NULL if JvmtiDynamicCodeEventCollector
+  // has been initialized while JVMTI_EVENT_DYNAMIC_CODE_GENERATED was disabled.
   JvmtiThreadState* state = JavaThread::current()->jvmti_thread_state();
   if (state != NULL) {
     JvmtiDynamicCodeEventCollector *collector = state->get_dynamic_code_event_collector();

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -2289,13 +2289,15 @@ void JvmtiExport::post_dynamic_code_generated_while_holding_locks(const char* na
   // register the stub with the current dynamic code event collector
   // Cannot take safepoint here so do not use state_for to get
   // jvmti thread state.
+  // The collector and/or state might be NULL if JvmtiDynamicCodeEventCollector has been initialized
+  // while JVMTI_EVENT_DYNAMIC_CODE_GENERATED was disabled
   JvmtiThreadState* state = JavaThread::current()->jvmti_thread_state();
-  // state can only be NULL if the current thread is exiting which
-  // should not happen since we're trying to post an event
-  guarantee(state != NULL, "attempt to register stub via an exiting thread");
-  JvmtiDynamicCodeEventCollector* collector = state->get_dynamic_code_event_collector();
-  guarantee(collector != NULL, "attempt to register stub without event collector");
-  collector->register_stub(name, code_begin, code_end);
+  if (state != NULL) {
+    JvmtiDynamicCodeEventCollector *collector = state->get_dynamic_code_event_collector();
+    if (collector != NULL) {
+      collector->register_stub(name, code_begin, code_end);
+    }
+  }
 }
 
 // Collect all the vm internally allocated objects which are visible to java world

--- a/test/hotspot/jtreg/serviceability/jvmti/DynamicCodeGenerated/DynamicCodeGeneratedTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/DynamicCodeGenerated/DynamicCodeGeneratedTest.java
@@ -47,7 +47,7 @@ public class DynamicCodeGeneratedTest {
         t.setDaemon(true);
         t.start();
 
-        for (int i = 0; i < 10_000; i++) {
+        for (int i = 0; i < 2000; i++) {
             new Thread(() -> {
                 String result = "string" + System.currentTimeMillis();
                 Reference.reachabilityFence(result);

--- a/test/hotspot/jtreg/serviceability/jvmti/DynamicCodeGenerated/DynamicCodeGeneratedTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/DynamicCodeGenerated/DynamicCodeGeneratedTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8212155
+ * @summary Test concurrent enabling and posting of DynamicCodeGenerated events.
+ * @requires vm.jvmti
+ * @library /test/lib
+ * @run main/othervm/native -agentlib:DynamicCodeGenerated DynamicCodeGeneratedTest
+ */
+
+import java.lang.ref.Reference;
+
+public class DynamicCodeGeneratedTest {
+    static {
+        System.loadLibrary("DynamicCodeGenerated");
+    }
+    public static native void changeEventNotificationMode();
+
+    public static void main(String[] args) {
+        // Try to enable DynamicCodeGenerated event while it is posted
+        // using JvmtiDynamicCodeEventCollector from VtableStubs::find_stub
+        Thread t = new Thread(() -> {
+            changeEventNotificationMode();
+        });
+        t.setDaemon(true);
+        t.start();
+
+        for (int i = 0; i < 10_000; i++) {
+            new Thread(() -> {
+                String result = "string" + System.currentTimeMillis();
+                Reference.reachabilityFence(result);
+            }).start();
+        }
+    }
+}

--- a/test/hotspot/jtreg/serviceability/jvmti/DynamicCodeGenerated/libDynamicCodeGenerated.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/DynamicCodeGenerated/libDynamicCodeGenerated.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <string.h>
+#include <jvmti.h>
+
+jvmtiEnv* jvmti;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+JNIEXPORT
+void JNICALL Java_DynamicCodeGeneratedTest_changeEventNotificationMode(JNIEnv* jni, jclass cls) {
+  while(true) {
+    jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_DYNAMIC_CODE_GENERATED, NULL);
+    jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_DYNAMIC_CODE_GENERATED, NULL);
+  }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+void JNICALL DynamicCodeGenerated(jvmtiEnv* jvmti, const char* name, const void* address, jint length) {
+
+}
+
+jint Agent_OnLoad(JavaVM* vm, char* options, void* reserved) {
+    vm->GetEnv((void**)&jvmti, JVMTI_VERSION_1_0);
+    jvmtiEventCallbacks callbacks;
+    memset(&callbacks, 0, sizeof(callbacks));
+    callbacks.DynamicCodeGenerated = DynamicCodeGenerated;
+    jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks));
+
+    return 0;
+}

--- a/test/hotspot/jtreg/serviceability/jvmti/DynamicCodeGenerated/libDynamicCodeGenerated.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/DynamicCodeGenerated/libDynamicCodeGenerated.cpp
@@ -24,7 +24,7 @@
 #include <string.h>
 #include <jvmti.h>
 
-jvmtiEnv* jvmti;
+static jvmtiEnv* jvmti = NULL;
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,7 +32,7 @@ extern "C" {
 
 JNIEXPORT
 void JNICALL Java_DynamicCodeGeneratedTest_changeEventNotificationMode(JNIEnv* jni, jclass cls) {
-  while(true) {
+  while (true) {
     jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_DYNAMIC_CODE_GENERATED, NULL);
     jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_DYNAMIC_CODE_GENERATED, NULL);
   }


### PR DESCRIPTION
Fixed a race condition between posting and enabling DynamicCodeGenerated event.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8212155](https://bugs.openjdk.java.net/browse/JDK-8212155): Race condition when posting dynamic_code_generated event leads to JVM crash


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to c650f446379d5d9a24182a6f913b57d39c436dd3
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4331/head:pull/4331` \
`$ git checkout pull/4331`

Update a local copy of the PR: \
`$ git checkout pull/4331` \
`$ git pull https://git.openjdk.java.net/jdk pull/4331/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4331`

View PR using the GUI difftool: \
`$ git pr show -t 4331`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4331.diff">https://git.openjdk.java.net/jdk/pull/4331.diff</a>

</details>
