### PR TITLE
8268167: MultipleLogins.java failure on macosx-aarch64

### DIFF
--- a/test/jdk/sun/security/pkcs11/Provider/MultipleLogins.java
+++ b/test/jdk/sun/security/pkcs11/Provider/MultipleLogins.java
@@ -50,7 +50,9 @@ public class MultipleLogins {
         for (int i =0; i < NUM_PROVIDERS; i++) {
             String nssConfig = PKCS11Test.getNssConfig();
             if (nssConfig == null) {
-                throw new RuntimeException("issue setting up config");
+                // No test framework support yet. Ignore
+                System.out.println("No NSS config found. Skipping.");
+                return;
             }
             providers[i] =
                     (SunPKCS11)PKCS11Test.newPKCS11Provider()


### PR DESCRIPTION
MultipleLogins.java should skip test where NSS support is not present

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268167](https://bugs.openjdk.java.net/browse/JDK-8268167): MultipleLogins.java failure on macosx-aarch64


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4333/head:pull/4333` \
`$ git checkout pull/4333`

Update a local copy of the PR: \
`$ git checkout pull/4333` \
`$ git pull https://git.openjdk.java.net/jdk pull/4333/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4333`

View PR using the GUI difftool: \
`$ git pr show -t 4333`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4333.diff">https://git.openjdk.java.net/jdk/pull/4333.diff</a>

</details>
