### PR TITLE
8268164: Adopt cast notation for WorkerThread conversions

### DIFF
--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -40,7 +40,6 @@
 #include "oops/oop.inline.hpp"
 #include "runtime/java.hpp"
 #include "runtime/nonJavaThread.hpp"
-#include "runtime/thread.inline.hpp"
 
 ReferencePolicy* ReferenceProcessor::_always_clear_soft_ref_policy = NULL;
 ReferencePolicy* ReferenceProcessor::_default_soft_ref_policy      = NULL;
@@ -931,8 +930,7 @@ inline DiscoveredList* ReferenceProcessor::get_discovered_list(ReferenceType rt)
   if (_discovery_is_mt) {
     // During a multi-threaded discovery phase,
     // each thread saves to its "own" list.
-    Thread* thr = Thread::current();
-    id = thr->as_Worker_thread()->id();
+    id = WorkerThread::cast(Thread::current())->id();
   } else {
     // single-threaded discovery, we save in round-robin
     // fashion to each of the lists.

--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -930,7 +930,7 @@ inline DiscoveredList* ReferenceProcessor::get_discovered_list(ReferenceType rt)
   if (_discovery_is_mt) {
     // During a multi-threaded discovery phase,
     // each thread saves to its "own" list.
-    id = WorkerThread::cast(Thread::current())->id();
+    id = WorkerThread::current()->id();
   } else {
     // single-threaded discovery, we save in round-robin
     // fashion to each of the lists.

--- a/src/hotspot/share/runtime/nonJavaThread.hpp
+++ b/src/hotspot/share/runtime/nonJavaThread.hpp
@@ -108,7 +108,7 @@ class WorkerThread: public NamedThread {
   }
 
   static WorkerThread* cast(Thread* t) {
-    assert(t->is_Worker_thread(), "incorrect cast to const WorkerThread");
+    assert(t->is_Worker_thread(), "incorrect cast to WorkerThread");
     return static_cast<WorkerThread*>(t);
   }
 

--- a/src/hotspot/share/runtime/nonJavaThread.hpp
+++ b/src/hotspot/share/runtime/nonJavaThread.hpp
@@ -103,6 +103,11 @@ class WorkerThread: public NamedThread {
  private:
   uint _id;
  public:
+  static WorkerThread* cast(Thread* t) {
+    assert(t->is_Worker_thread(), "incorrect cast to const WorkerThread");
+    return static_cast<WorkerThread*>(t);
+  }
+
   WorkerThread() : _id(0)               { }
   virtual bool is_Worker_thread() const { return true; }
 

--- a/src/hotspot/share/runtime/nonJavaThread.hpp
+++ b/src/hotspot/share/runtime/nonJavaThread.hpp
@@ -103,6 +103,10 @@ class WorkerThread: public NamedThread {
  private:
   uint _id;
  public:
+  static WorkerThread* current() {
+    return WorkerThread::cast(Thread::current());
+  }
+
   static WorkerThread* cast(Thread* t) {
     assert(t->is_Worker_thread(), "incorrect cast to const WorkerThread");
     return static_cast<WorkerThread*>(t);

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -356,7 +356,6 @@ class Thread: public ThreadShadow {
   virtual bool is_active_Java_thread() const         { return false; }
 
   // Casts
-  inline const WorkerThread* as_Worker_thread() const;
   inline JavaThread* as_Java_thread();
   inline const JavaThread* as_Java_thread() const;
 

--- a/src/hotspot/share/runtime/thread.inline.hpp
+++ b/src/hotspot/share/runtime/thread.inline.hpp
@@ -66,11 +66,6 @@ inline void Thread::set_threads_hazard_ptr(ThreadsList* new_list) {
   Atomic::release_store_fence(&_threads_hazard_ptr, new_list);
 }
 
-inline const WorkerThread* Thread::as_Worker_thread() const {
-  assert(is_Worker_thread(), "incorrect cast to const WorkerThread");
-  return static_cast<const WorkerThread*>(this);
-}
-
 #if defined(__APPLE__) && defined(AARCH64)
 inline void Thread::init_wx() {
   assert(this == Thread::current(), "should only be called for current thread");


### PR DESCRIPTION
Followup of JDK-8267916 (#4240), the same refactoring for `WorkerThread`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268164](https://bugs.openjdk.java.net/browse/JDK-8268164): Adopt cast notation for WorkerThread conversions


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to daf5990f588893e1ce69b13cb6c353f9bddcdbea
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4334/head:pull/4334` \
`$ git checkout pull/4334`

Update a local copy of the PR: \
`$ git checkout pull/4334` \
`$ git pull https://git.openjdk.java.net/jdk pull/4334/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4334`

View PR using the GUI difftool: \
`$ git pr show -t 4334`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4334.diff">https://git.openjdk.java.net/jdk/pull/4334.diff</a>

</details>
