### PR TITLE
8265444: Javadocs: jdk.jshell - small typo

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/package-info.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@
  * <p>
  * Any change to the compilation status of a snippet is reported with a
  * {@link jdk.jshell.SnippetEvent}.  There are three major kinds of
- * changes to the status of a snippet: it can created with <code>eval</code>,
+ * changes to the status of a snippet: it can be created with <code>eval</code>,
  * it can be dropped from the active source state with
  * {@link jdk.jshell.JShell#drop(jdk.jshell.Snippet)}, and it can have
  * its status updated as a result of a status change in another snippet.


### PR DESCRIPTION
Fixing typo in jdk.jshell's javadoc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265444](https://bugs.openjdk.java.net/browse/JDK-8265444): Javadocs:  jdk.jshell - small typo


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4336/head:pull/4336` \
`$ git checkout pull/4336`

Update a local copy of the PR: \
`$ git checkout pull/4336` \
`$ git pull https://git.openjdk.java.net/jdk pull/4336/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4336`

View PR using the GUI difftool: \
`$ git pr show -t 4336`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4336.diff">https://git.openjdk.java.net/jdk/pull/4336.diff</a>

</details>
