### PR TITLE
8268178: Extract sender frame parsing to CodeBlob::FrameParser

### DIFF
--- a/src/hotspot/cpu/aarch64/codeBlob_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/codeBlob_aarch64.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "code/codeBlob.hpp"
+#include "code/compiledMethod.hpp"
+#include "interpreter/interpreter.hpp"
+#include "runtime/frame.hpp"
+
+bool CodeBlob::FrameParser::sender_frame(JavaThread *thread, address pc, intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, bool fp_safe,
+    address* sender_pc, intptr_t** sender_sp, intptr_t** sender_unextended_sp, intptr_t*** saved_fp) {
+  // must be some sort of compiled/runtime frame
+  // fp does not have to be safe (although it could be check for c1?)
+
+  assert(sender_pc != NULL, "invariant");
+  assert(sender_sp != NULL, "invariant");
+
+  // check for a valid frame_size, otherwise we are unlikely to get a valid sender_pc
+  if (_cb->frame_size() <= 0) {
+    return false;
+  }
+
+  *sender_sp = unextended_sp + _cb->frame_size();
+  // Is sender_sp safe?
+  if (thread != NULL && !thread->is_in_full_stack_checked((address)*sender_sp)) {
+    return false;
+  }
+  *sender_pc = (address)*((*sender_sp) - frame::return_addr_offset);
+
+  if (sender_unextended_sp) *sender_unextended_sp = *sender_sp;
+  // Note: frame::sender_sp_offset is only valid for compiled frame
+  if (saved_fp) *saved_fp = (intptr_t**)((*sender_sp) - frame::sender_sp_offset);
+
+  return true;
+}
+
+bool InterpreterBlob::FrameParser::sender_frame(JavaThread *thread, address pc, intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, bool fp_safe,
+    address* sender_pc, intptr_t** sender_sp, intptr_t** sender_unextended_sp, intptr_t*** saved_fp) {
+
+  assert(sender_pc != NULL, "invariant");
+  assert(sender_sp != NULL, "invariant");
+
+  // fp must be safe
+  if (!fp_safe) {
+    return false;
+  }
+
+  *sender_pc = (address)*(fp + frame::return_addr_offset);
+  // for interpreted frames, the value below is the sender "raw" sp,
+  // which can be different from the sender unextended sp (the sp seen
+  // by the sender) because of current frame local variables
+  *sender_sp = fp + frame::sender_sp_offset;
+
+  if (sender_unextended_sp) *sender_unextended_sp = (intptr_t*)*(fp + frame::interpreter_frame_sender_sp_offset);
+  if (saved_fp) *saved_fp = (intptr_t**)(fp + frame::link_offset);
+
+  return true;
+}

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -56,6 +56,8 @@ void RegisterMap::check_location_valid() {
 // Profiling/safepoint support
 
 bool frame::safe_for_sender(JavaThread *thread) {
+  ResourceMark rm;
+
   address   sp = (address)_sp;
   address   fp = (address)_fp;
   address   unextended_sp = (address)_unextended_sp;
@@ -117,45 +119,15 @@ bool frame::safe_for_sender(JavaThread *thread) {
       return fp_safe && is_entry_frame_valid(thread);
     }
 
-    intptr_t* sender_sp = NULL;
-    intptr_t* sender_unextended_sp = NULL;
-    address   sender_pc = NULL;
-    intptr_t* saved_fp =  NULL;
-
-    if (is_interpreted_frame()) {
-      // fp must be safe
-      if (!fp_safe) {
-        return false;
-      }
-
-      sender_pc = (address) this->fp()[return_addr_offset];
-      // for interpreted frames, the value below is the sender "raw" sp,
-      // which can be different from the sender unextended sp (the sp seen
-      // by the sender) because of current frame local variables
-      sender_sp = (intptr_t*) addr_at(sender_sp_offset);
-      sender_unextended_sp = (intptr_t*) this->fp()[interpreter_frame_sender_sp_offset];
-      saved_fp = (intptr_t*) this->fp()[link_offset];
-
-    } else {
-      // must be some sort of compiled/runtime frame
-      // fp does not have to be safe (although it could be check for c1?)
-
-      // check for a valid frame_size, otherwise we are unlikely to get a valid sender_pc
-      if (_cb->frame_size() <= 0) {
-        return false;
-      }
-
-      sender_sp = _unextended_sp + _cb->frame_size();
-      // Is sender_sp safe?
-      if (!thread->is_in_full_stack_checked((address)sender_sp)) {
-        return false;
-      }
-      sender_unextended_sp = sender_sp;
-      sender_pc = (address) *(sender_sp-1);
-      // Note: frame::sender_sp_offset is only valid for compiled frame
-      saved_fp = (intptr_t*) *(sender_sp - frame::sender_sp_offset);
+    intptr_t*  sender_sp = NULL;
+    intptr_t*  sender_unextended_sp = NULL;
+    address    sender_pc = NULL;
+    intptr_t** saved_fp =  NULL;
+    if (!_cb->frame_parser()->sender_frame(
+          thread, _pc, (intptr_t*)sp, (intptr_t*)unextended_sp, (intptr_t*)fp, fp_safe,
+            &sender_pc, &sender_sp, &sender_unextended_sp, &saved_fp)) {
+      return false;
     }
-
 
     // If the potential sender is the interpreter then we can do some more checking
     if (Interpreter::contains(sender_pc)) {
@@ -164,13 +136,13 @@ bool frame::safe_for_sender(JavaThread *thread) {
       // only if the sender is interpreted/call_stub (c1 too?) are we certain that the saved fp
       // is really a frame pointer.
 
-      if (!thread->is_in_stack_range_excl((address)saved_fp, (address)sender_sp)) {
+      if (!thread->is_in_stack_range_excl((address)*saved_fp, (address)sender_sp)) {
         return false;
       }
 
       // construct the potential sender
 
-      frame sender(sender_sp, sender_unextended_sp, saved_fp, sender_pc);
+      frame sender(sender_sp, sender_unextended_sp, *saved_fp, sender_pc);
 
       return sender.is_interpreted_frame_valid(thread);
 
@@ -199,13 +171,13 @@ bool frame::safe_for_sender(JavaThread *thread) {
 
     // Could be the call_stub
     if (StubRoutines::returns_to_call_stub(sender_pc)) {
-      if (!thread->is_in_stack_range_excl((address)saved_fp, (address)sender_sp)) {
+      if (!thread->is_in_stack_range_excl((address)*saved_fp, (address)sender_sp)) {
         return false;
       }
 
       // construct the potential sender
 
-      frame sender(sender_sp, sender_unextended_sp, saved_fp, sender_pc);
+      frame sender(sender_sp, sender_unextended_sp, *saved_fp, sender_pc);
 
       // Validate the JavaCallWrapper an entry frame must have
       address jcw = (address)sender.entry_frame_call_wrapper();
@@ -453,18 +425,21 @@ frame frame::sender_for_interpreter_frame(RegisterMap* map) const {
 //------------------------------------------------------------------------------
 // frame::sender_for_compiled_frame
 frame frame::sender_for_compiled_frame(RegisterMap* map) const {
+  ResourceMark rm;
+
   // we cannot rely upon the last fp having been saved to the thread
   // in C2 code but it will have been pushed onto the stack. so we
   // have to find it relative to the unextended sp
 
   assert(_cb->frame_size() >= 0, "must have non-zero frame size");
-  intptr_t* l_sender_sp = unextended_sp() + _cb->frame_size();
-  intptr_t* unextended_sp = l_sender_sp;
 
-  // the return_address is always the word on the stack
-  address sender_pc = (address) *(l_sender_sp-1);
-
-  intptr_t** saved_fp_addr = (intptr_t**) (l_sender_sp - frame::sender_sp_offset);
+  intptr_t*  l_sender_sp;
+  intptr_t*  l_unextended_sp;
+  address    l_sender_pc;
+  intptr_t** l_saved_fp;
+  _cb->frame_parser()->sender_frame(
+    NULL, pc(), sp(), unextended_sp(), fp(), true,
+      &l_sender_pc, &l_sender_sp, &l_unextended_sp, &l_saved_fp);
 
   // assert (sender_sp() == l_sender_sp, "should be");
   // assert (*saved_fp_addr == link(), "should be");
@@ -482,10 +457,10 @@ frame frame::sender_for_compiled_frame(RegisterMap* map) const {
     // oopmap for it so we must fill in its location as if there was
     // an oopmap entry since if our caller was compiled code there
     // could be live jvm state in it.
-    update_map_with_saved_link(map, saved_fp_addr);
+    update_map_with_saved_link(map, l_saved_fp);
   }
 
-  return frame(l_sender_sp, unextended_sp, *saved_fp_addr, sender_pc);
+  return frame(l_sender_sp, l_unextended_sp, *l_saved_fp, l_sender_pc);
 }
 
 //------------------------------------------------------------------------------

--- a/src/hotspot/cpu/arm/codeBlob_arm.cpp
+++ b/src/hotspot/cpu/arm/codeBlob_arm.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "code/codeBlob.hpp"
+#include "code/compiledMethod.hpp"
+#include "interpreter/interpreter.hpp"
+#include "runtime/frame.hpp"
+
+bool CodeBlob::FrameParser::sender_frame(JavaThread *thread, address pc, intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, bool fp_safe,
+    address* sender_pc, intptr_t** sender_sp, intptr_t** sender_unextended_sp, intptr_t*** saved_fp) {
+  // must be some sort of compiled/runtime frame
+  // fp does not have to be safe (although it could be check for c1?)
+
+  assert(sender_pc != NULL, "invariant");
+  assert(sender_sp != NULL, "invariant");
+
+  *sender_sp = unextended_sp + _cb->frame_size();
+  // Is sender_sp safe?
+  if (thread != NULL && !thread->is_in_full_stack_checked((address)*sender_sp)) {
+    return false;
+  }
+  // With our calling conventions, the return_address should
+  // end up being the word on the stack
+  *sender_pc = (address)*((*sender_sp) - frame::sender_sp_offset + frame::return_addr_offset);
+
+  if (sender_unextended_sp) *sender_unextended_sp = *sender_sp;
+  if (saved_fp) *saved_fp = (intptr_t**)((*sender_sp) - frame::sender_sp_offset + frame::link_offset);
+
+  return true;
+}
+
+bool InterpreterBlob::FrameParser::sender_frame(JavaThread *thread, address pc, intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, bool fp_safe,
+    address* sender_pc, intptr_t** sender_sp, intptr_t** sender_unextended_sp, intptr_t*** saved_fp) {
+
+  assert(sender_pc != NULL, "invariant");
+  assert(sender_sp != NULL, "invariant");
+
+  // fp must be safe
+  if (!fp_safe) {
+    return false;
+  }
+
+  *sender_pc = (address)*(fp + frame::return_addr_offset);
+  *sender_sp = fp + frame::sender_sp_offset;
+
+  return true;
+}

--- a/src/hotspot/cpu/arm/frame_arm.cpp
+++ b/src/hotspot/cpu/arm/frame_arm.cpp
@@ -54,6 +54,8 @@ void RegisterMap::check_location_valid() {
 // Profiling/safepoint support
 
 bool frame::safe_for_sender(JavaThread *thread) {
+  ResourceMark rm;
+
   address   sp = (address)_sp;
   address   fp = (address)_fp;
   address   unextended_sp = (address)_unextended_sp;
@@ -98,28 +100,10 @@ bool frame::safe_for_sender(JavaThread *thread) {
 
     intptr_t* sender_sp = NULL;
     address   sender_pc = NULL;
-
-    if (is_interpreted_frame()) {
-      // fp must be safe
-      if (!fp_safe) {
-        return false;
-      }
-
-      sender_pc = (address) this->fp()[return_addr_offset];
-      sender_sp = (intptr_t*) addr_at(sender_sp_offset);
-
-    } else {
-      // must be some sort of compiled/runtime frame
-      // fp does not have to be safe (although it could be check for c1?)
-
-      sender_sp = _unextended_sp + _cb->frame_size();
-      // Is sender_sp safe?
-      if (!thread->is_in_full_stack_checked((address)sender_sp)) {
-        return false;
-      }
-      // With our calling conventions, the return_address should
-      // end up being the word on the stack
-      sender_pc = (address) *(sender_sp - sender_sp_offset + return_addr_offset);
+    if (!_cb->frame_parser()->sender_frame(
+          thread, _pc, (intptr_t*)sp, (intptr_t*)unextended_sp, (intptr_t*)fp, fp_safe,
+            &sender_pc, &sender_sp, NULL, NULL)) {
+      return false;
     }
 
     // We must always be able to find a recognizable pc
@@ -388,18 +372,21 @@ frame frame::sender_for_interpreter_frame(RegisterMap* map) const {
 }
 
 frame frame::sender_for_compiled_frame(RegisterMap* map) const {
+  ResourceMark rm;
+
   assert(map != NULL, "map must be set");
 
   // frame owned by optimizing compiler
+
   assert(_cb->frame_size() >= 0, "must have non-zero frame size");
-  intptr_t* sender_sp = unextended_sp() + _cb->frame_size();
-  intptr_t* unextended_sp = sender_sp;
 
-  address sender_pc = (address) *(sender_sp - sender_sp_offset + return_addr_offset);
-
-  // This is the saved value of FP which may or may not really be an FP.
-  // It is only an FP if the sender is an interpreter frame (or C1?).
-  intptr_t** saved_fp_addr = (intptr_t**) (sender_sp - sender_sp_offset + link_offset);
+  intptr_t*  l_sender_sp;
+  intptr_t*  l_unextended_sp;
+  address    l_sender_pc;
+  intptr_t** l_saved_fp;
+  _cb->frame_parser()->sender_frame(
+    NULL, pc(), sp(), unextended_sp(), fp(), true,
+      &l_sender_pc, &l_sender_sp, &l_unextended_sp, &l_saved_fp);
 
   if (map->update_map()) {
     // Tell GC to use argument oopmaps for some runtime stubs that need it.
@@ -413,11 +400,11 @@ frame frame::sender_for_compiled_frame(RegisterMap* map) const {
     // Since the prolog does the save and restore of FP there is no oopmap
     // for it so we must fill in its location as if there was an oopmap entry
     // since if our caller was compiled code there could be live jvm state in it.
-    update_map_with_saved_link(map, saved_fp_addr);
+    update_map_with_saved_link(map, l_saved_fp);
   }
 
-  assert(sender_sp != sp(), "must have changed");
-  return frame(sender_sp, unextended_sp, *saved_fp_addr, sender_pc);
+  assert(l_sender_sp != sp(), "must have changed");
+  return frame(l_sender_sp, l_unextended_sp, *l_saved_fp, l_sender_pc);
 }
 
 frame frame::sender(RegisterMap* map) const {

--- a/src/hotspot/cpu/ppc/codeBlob_ppc.cpp
+++ b/src/hotspot/cpu/ppc/codeBlob_ppc.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "code/codeBlob.hpp"
+#include "code/compiledMethod.hpp"
+#include "interpreter/interpreter.hpp"
+#include "runtime/frame.hpp"
+
+bool CodeBlob::FrameParser::sender_frame(JavaThread *thread, address pc, intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, bool fp_safe,
+    address* sender_pc, intptr_t** sender_sp, intptr_t** sender_unextended_sp, intptr_t*** saved_fp) {
+  // must be some sort of compiled/runtime frame
+  // fp does not have to be safe (although it could be check for c1?)
+
+  assert(sender_pc != NULL, "invariant");
+  assert(sender_sp != NULL, "invariant");
+
+  frame::abi_minframe* sender_abi = (frame::abi_minframe*) fp;
+  *sender_sp = (intptr_t*) fp;
+  *sender_pc = (address) sender_abi->lr;
+
+  return true;
+}
+
+bool InterpreterBlob::FrameParser::sender_frame(JavaThread *thread, address pc, intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, bool fp_safe,
+    address* sender_pc, intptr_t** sender_sp, intptr_t** sender_unextended_sp, intptr_t*** saved_fp) {
+  return CodeBlob::FrameParser::sender_frame(thread, pc, sp, unextended_sp, fp, fp_safe,
+                                             sender_pc, sender_sp, sender_unextended_sp, saved_fp);
+}

--- a/src/hotspot/cpu/ppc/frame_ppc.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.hpp
@@ -384,14 +384,6 @@
   inline frame(intptr_t* sp, address pc);
   inline frame(intptr_t* sp, address pc, intptr_t* unextended_sp);
 
- private:
-
-  intptr_t* compiled_sender_sp(CodeBlob* cb) const;
-  address*  compiled_sender_pc_addr(CodeBlob* cb) const;
-  address*  sender_pc_addr(void) const;
-
- public:
-
   inline ijava_state* get_ijava_state() const;
   // Some convenient register frame setters/getters for deoptimization.
   inline intptr_t* interpreter_frame_esp() const;

--- a/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
@@ -103,9 +103,6 @@ inline intptr_t* frame::unextended_sp() const {
 inline address frame::sender_pc() const {
   return (address)callers_abi()->lr;
 }
-inline address* frame::sender_pc_addr() const {
-  return (address*)&(callers_abi()->lr);
-}
 
 // All frames have this field.
 inline intptr_t* frame::sender_sp() const {

--- a/src/hotspot/cpu/s390/codeBlob_s390.cpp
+++ b/src/hotspot/cpu/s390/codeBlob_s390.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "code/codeBlob.hpp"
+#include "code/compiledMethod.hpp"
+#include "interpreter/interpreter.hpp"
+#include "runtime/frame.hpp"
+
+bool CodeBlob::FrameParser::sender_frame(JavaThread *thread, address pc, intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, bool fp_safe,
+    address* sender_pc, intptr_t** sender_sp, intptr_t** sender_unextended_sp, intptr_t*** saved_fp) {
+  // must be some sort of compiled/runtime frame
+  // fp does not have to be safe (although it could be check for c1?)
+
+  assert(sender_pc != NULL, "invariant");
+  assert(sender_sp != NULL, "invariant");
+
+  frame::z_abi_160* sender_abi = (frame::z_abi_160*) fp;
+  *sender_sp = (intptr_t*) sender_abi->callers_sp;
+  *sender_pc = (address) sender_abi->return_pc;
+
+  return true;
+}
+
+bool InterpreterBlob::FrameParser::sender_frame(JavaThread *thread, address pc, intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, bool fp_safe,
+    address* sender_pc, intptr_t** sender_sp, intptr_t** sender_unextended_sp, intptr_t*** saved_fp) {
+  return CodeBlob::FrameParser::sender_frame(thread, pc, sp, unextended_sp, fp, fp_safe,
+                                             sender_pc, sender_sp, sender_unextended_sp, saved_fp);
+}

--- a/src/hotspot/cpu/s390/frame_s390.cpp
+++ b/src/hotspot/cpu/s390/frame_s390.cpp
@@ -55,6 +55,8 @@ void RegisterMap::check_location_valid() {
 // Profiling/safepoint support
 
 bool frame::safe_for_sender(JavaThread *thread) {
+  ResourceMark rm;
+
   bool safe = false;
   address sp = (address)_sp;
   address fp = (address)_fp;
@@ -110,9 +112,13 @@ bool frame::safe_for_sender(JavaThread *thread) {
       return false;
     }
 
-    z_abi_160* sender_abi = (z_abi_160*) fp;
-    intptr_t* sender_sp = (intptr_t*) sender_abi->callers_sp;
-    address   sender_pc = (address) sender_abi->return_pc;
+    intptr_t* sender_sp = NULL;
+    address   sender_pc = NULL;
+    if (!_cb->frame_parser()->sender_frame(
+          thread, _pc, (intptr_t*)sp, (intptr_t*)unextended_sp, (intptr_t*)fp, fp_safe,
+            &sender_pc, &sender_sp, NULL, NULL)) {
+      return false;
+    }
 
     // We must always be able to find a recognizable pc.
     CodeBlob* sender_blob = CodeCache::find_blob_unsafe(sender_pc);
@@ -214,11 +220,17 @@ frame frame::sender_for_interpreter_frame(RegisterMap *map) const {
 }
 
 frame frame::sender_for_compiled_frame(RegisterMap *map) const {
+  ResourceMark rm;
+
   assert(map != NULL, "map must be set");
+
   // Frame owned by compiler.
 
-  address pc = *compiled_sender_pc_addr(_cb);
-  frame caller(compiled_sender_sp(_cb), pc);
+  intptr_t*  l_sender_sp;
+  address    l_sender_pc;
+  _cb->frame_parser()->sender_frame(
+    NULL, pc(), sp(), unextended_sp(), fp(), true,
+      &l_sender_pc, &l_sender_sp, NULL, NULL);
 
   // Now adjust the map.
 
@@ -231,7 +243,7 @@ frame frame::sender_for_compiled_frame(RegisterMap *map) const {
     }
   }
 
-  return caller;
+  return frame(l_sender_sp, l_sender_pc);
 }
 
 intptr_t* frame::compiled_sender_sp(CodeBlob* cb) const {

--- a/src/hotspot/cpu/x86/codeBlob_x86.cpp
+++ b/src/hotspot/cpu/x86/codeBlob_x86.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "code/codeBlob.hpp"
+#include "code/compiledMethod.hpp"
+#include "interpreter/interpreter.hpp"
+#include "runtime/frame.hpp"
+
+bool CodeBlob::FrameParser::sender_frame(JavaThread *thread, address pc, intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, bool fp_safe,
+    address* sender_pc, intptr_t** sender_sp, intptr_t** sender_unextended_sp, intptr_t*** saved_fp) {
+  // must be some sort of compiled/runtime frame
+  // fp does not have to be safe (although it could be check for c1?)
+
+  assert(sender_pc != NULL, "invariant");
+  assert(sender_sp != NULL, "invariant");
+
+  // check for a valid frame_size, otherwise we are unlikely to get a valid sender_pc
+  if (_cb->frame_size() <= 0) {
+    return false;
+  }
+
+  *sender_sp = unextended_sp + _cb->frame_size();
+  // Is sender_sp safe?
+  if (thread != NULL && !thread->is_in_full_stack_checked((address)*sender_sp)) {
+    return false;
+  }
+  // On Intel the return_address is always the word on the stack
+  *sender_pc = (address)*((*sender_sp) - frame::return_addr_offset);
+
+  if (sender_unextended_sp) *sender_unextended_sp = *sender_sp;
+  // Note: frame::sender_sp_offset is only valid for compiled frame
+  if (saved_fp) *saved_fp = (intptr_t**)((*sender_sp) - frame::sender_sp_offset);
+
+  return true;
+}
+
+bool InterpreterBlob::FrameParser::sender_frame(JavaThread *thread, address pc, intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, bool fp_safe,
+    address* sender_pc, intptr_t** sender_sp, intptr_t** sender_unextended_sp, intptr_t*** saved_fp) {
+
+  assert(sender_pc != NULL, "invariant");
+  assert(sender_sp != NULL, "invariant");
+
+  // fp must be safe
+  if (!fp_safe) {
+    return false;
+  }
+
+  *sender_pc = (address)*(fp + frame::return_addr_offset);
+  // for interpreted frames, the value below is the sender "raw" sp,
+  // which can be different from the sender unextended sp (the sp seen
+  // by the sender) because of current frame local variables
+  *sender_sp = fp + frame::sender_sp_offset;
+
+  if (sender_unextended_sp) *sender_unextended_sp = (intptr_t*)*(fp + frame::interpreter_frame_sender_sp_offset);
+  if (saved_fp) *saved_fp = (intptr_t**)(fp + frame::link_offset);
+
+  return true;
+}

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -54,6 +54,8 @@ void RegisterMap::check_location_valid() {
 // Profiling/safepoint support
 
 bool frame::safe_for_sender(JavaThread *thread) {
+  ResourceMark rm;
+
   address   sp = (address)_sp;
   address   fp = (address)_fp;
   address   unextended_sp = (address)_unextended_sp;
@@ -106,46 +108,15 @@ bool frame::safe_for_sender(JavaThread *thread) {
       return fp_safe;
     }
 
-    intptr_t* sender_sp = NULL;
-    intptr_t* sender_unextended_sp = NULL;
-    address   sender_pc = NULL;
-    intptr_t* saved_fp =  NULL;
-
-    if (is_interpreted_frame()) {
-      // fp must be safe
-      if (!fp_safe) {
-        return false;
-      }
-
-      sender_pc = (address) this->fp()[return_addr_offset];
-      // for interpreted frames, the value below is the sender "raw" sp,
-      // which can be different from the sender unextended sp (the sp seen
-      // by the sender) because of current frame local variables
-      sender_sp = (intptr_t*) addr_at(sender_sp_offset);
-      sender_unextended_sp = (intptr_t*) this->fp()[interpreter_frame_sender_sp_offset];
-      saved_fp = (intptr_t*) this->fp()[link_offset];
-
-    } else {
-      // must be some sort of compiled/runtime frame
-      // fp does not have to be safe (although it could be check for c1?)
-
-      // check for a valid frame_size, otherwise we are unlikely to get a valid sender_pc
-      if (_cb->frame_size() <= 0) {
-        return false;
-      }
-
-      sender_sp = _unextended_sp + _cb->frame_size();
-      // Is sender_sp safe?
-      if (!thread->is_in_full_stack_checked((address)sender_sp)) {
-        return false;
-      }
-      sender_unextended_sp = sender_sp;
-      // On Intel the return_address is always the word on the stack
-      sender_pc = (address) *(sender_sp-1);
-      // Note: frame::sender_sp_offset is only valid for compiled frame
-      saved_fp = (intptr_t*) *(sender_sp - frame::sender_sp_offset);
+    intptr_t*  sender_sp = NULL;
+    intptr_t*  sender_unextended_sp = NULL;
+    address    sender_pc = NULL;
+    intptr_t** saved_fp =  NULL;
+    if (!_cb->frame_parser()->sender_frame(
+          thread, _pc, (intptr_t*)sp, (intptr_t*)unextended_sp, (intptr_t*)fp, fp_safe,
+            &sender_pc, &sender_sp, &sender_unextended_sp, &saved_fp)) {
+      return false;
     }
-
 
     // If the potential sender is the interpreter then we can do some more checking
     if (Interpreter::contains(sender_pc)) {
@@ -154,13 +125,13 @@ bool frame::safe_for_sender(JavaThread *thread) {
       // only if the sender is interpreted/call_stub (c1 too?) are we certain that the saved ebp
       // is really a frame pointer.
 
-      if (!thread->is_in_stack_range_excl((address)saved_fp, (address)sender_sp)) {
+      if (!thread->is_in_stack_range_excl((address)*saved_fp, (address)sender_sp)) {
         return false;
       }
 
       // construct the potential sender
 
-      frame sender(sender_sp, sender_unextended_sp, saved_fp, sender_pc);
+      frame sender(sender_sp, sender_unextended_sp, *saved_fp, sender_pc);
 
       return sender.is_interpreted_frame_valid(thread);
 
@@ -189,13 +160,13 @@ bool frame::safe_for_sender(JavaThread *thread) {
 
     // Could be the call_stub
     if (StubRoutines::returns_to_call_stub(sender_pc)) {
-      if (!thread->is_in_stack_range_excl((address)saved_fp, (address)sender_sp)) {
+      if (!thread->is_in_stack_range_excl((address)*saved_fp, (address)sender_sp)) {
         return false;
       }
 
       // construct the potential sender
 
-      frame sender(sender_sp, sender_unextended_sp, saved_fp, sender_pc);
+      frame sender(sender_sp, sender_unextended_sp, *saved_fp, sender_pc);
 
       // Validate the JavaCallWrapper an entry frame must have
       address jcw = (address)sender.entry_frame_call_wrapper();
@@ -467,19 +438,21 @@ frame frame::sender_for_interpreter_frame(RegisterMap* map) const {
 //------------------------------------------------------------------------------
 // frame::sender_for_compiled_frame
 frame frame::sender_for_compiled_frame(RegisterMap* map) const {
+  ResourceMark rm;
+
   assert(map != NULL, "map must be set");
 
   // frame owned by optimizing compiler
+
   assert(_cb->frame_size() >= 0, "must have non-zero frame size");
-  intptr_t* sender_sp = unextended_sp() + _cb->frame_size();
-  intptr_t* unextended_sp = sender_sp;
 
-  // On Intel the return_address is always the word on the stack
-  address sender_pc = (address) *(sender_sp-1);
-
-  // This is the saved value of EBP which may or may not really be an FP.
-  // It is only an FP if the sender is an interpreter frame (or C1?).
-  intptr_t** saved_fp_addr = (intptr_t**) (sender_sp - frame::sender_sp_offset);
+  intptr_t*  l_sender_sp = NULL;
+  intptr_t*  l_unextended_sp = NULL;
+  address    l_sender_pc = NULL;
+  intptr_t** l_saved_fp = NULL;
+  _cb->frame_parser()->sender_frame(
+    NULL, pc(), sp(), unextended_sp(), fp(), true,
+      &l_sender_pc, &l_sender_sp, &l_unextended_sp, &l_saved_fp);
 
   if (map->update_map()) {
     // Tell GC to use argument oopmaps for some runtime stubs that need it.
@@ -493,11 +466,11 @@ frame frame::sender_for_compiled_frame(RegisterMap* map) const {
     // Since the prolog does the save and restore of EBP there is no oopmap
     // for it so we must fill in its location as if there was an oopmap entry
     // since if our caller was compiled code there could be live jvm state in it.
-    update_map_with_saved_link(map, saved_fp_addr);
+    update_map_with_saved_link(map, l_saved_fp);
   }
 
-  assert(sender_sp != sp(), "must have changed");
-  return frame(sender_sp, unextended_sp, *saved_fp_addr, sender_pc);
+  assert(l_sender_sp != sp(), "must have changed");
+  return frame(l_sender_sp, l_unextended_sp, *l_saved_fp, l_sender_pc);
 }
 
 

--- a/src/hotspot/cpu/zero/codeBlob_zero.cpp
+++ b/src/hotspot/cpu/zero/codeBlob_zero.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "code/codeBlob.hpp"
+#include "code/compiledMethod.hpp"
+#include "interpreter/interpreter.hpp"
+#include "runtime/frame.hpp"
+
+bool CodeBlob::FrameParser::sender_frame(JavaThread *thread, address pc, intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, bool fp_safe,
+    address* sender_pc, intptr_t** sender_sp, intptr_t** sender_unextended_sp, intptr_t*** saved_fp) {
+  ShouldNotCallThis();
+  return false;
+}
+
+bool InterpreterBlob::FrameParser::sender_frame(JavaThread *thread, address pc, intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, bool fp_safe,
+    address* sender_pc, intptr_t** sender_sp, intptr_t** sender_unextended_sp, intptr_t*** saved_fp) {
+  return CodeBlob::FrameParser::sender_frame(thread, pc, sp, unextended_sp, fp, fp_safe,
+                                             sender_pc, sender_sp, sender_unextended_sp, saved_fp);
+}

--- a/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
+++ b/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
@@ -53,10 +53,10 @@ void ZeroInterpreter::initialize_stub() {
   if (_code != NULL) return;
 
   // generate interpreter
-  int code_size = InterpreterCodeSize;
-  NOT_PRODUCT(code_size *= 4;)  // debug uses extra interpreter code space
-  _code = new StubQueue(new InterpreterCodeletInterface, code_size, NULL,
-                         "Interpreter");
+  // debug uses extra interpreter code space
+  BufferBlob* blob = InterpreterBlob::create(InterpreterCodeSize NOT_PRODUCT( * 4));
+  assert(blob != NULL, "invariant");
+  _code = new StubQueue(new InterpreterCodeletInterface, blob, NULL);
 }
 
 void ZeroInterpreter::initialize_code() {

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -59,6 +59,7 @@ struct CodeBlobType {
 //    VtableBlob         : Used for holding vtable chunks
 //    MethodHandlesAdapterBlob : Used to hold MethodHandles adapters
 //    OptimizedEntryBlob : Used for upcalls from native code
+//    InterpreterBlob    : Used to hold Interpreter
 //   RuntimeStub         : Call to VM runtime methods
 //   SingletonBlob       : Super-class for all blobs that exist in only one instance
 //    DeoptimizationBlob : Used for deoptimization
@@ -138,6 +139,7 @@ public:
   virtual bool is_adapter_blob() const                { return false; }
   virtual bool is_vtable_blob() const                 { return false; }
   virtual bool is_method_handles_adapter_blob() const { return false; }
+  virtual bool is_interpreter_blob() const            { return false; }
   virtual bool is_compiled() const                    { return false; }
   virtual bool is_optimized_entry_blob() const                  { return false; }
 
@@ -192,6 +194,18 @@ public:
   bool is_frame_complete_at(address addr) const  { return _frame_complete_offset != CodeOffsets::frame_never_safe &&
                                                           code_contains(addr) && addr >= code_begin() + _frame_complete_offset; }
   int frame_complete_offset() const              { return _frame_complete_offset; }
+
+  // Profiling/safepoint support
+  class FrameParser: public ResourceObj {
+   protected:
+    const CodeBlob* _cb;
+   public:
+    FrameParser(const CodeBlob* cb) : _cb(cb) {}
+    virtual bool sender_frame(JavaThread *thread, address pc, intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, bool fp_safe,
+      address* sender_pc, intptr_t** sender_sp, intptr_t** sender_unextended_sp, intptr_t*** saved_fp);
+  };
+
+  virtual FrameParser* frame_parser() const { return new FrameParser(this); }
 
   // CodeCache support: really only used by the nmethods, but in order to get
   // asserts and certain bookkeeping to work in the CodeCache they are defined
@@ -336,7 +350,6 @@ public:
   address content_end() const { return _content_end; }
 };
 
-
 class RuntimeBlob : public CodeBlob {
   friend class VMStructs;
  public:
@@ -358,6 +371,12 @@ class RuntimeBlob : public CodeBlob {
     OopMapSet*  oop_maps,
     bool        caller_must_gc_arguments = false
   );
+
+  // Profiling/safepoint support
+  class FrameParser : public CodeBlob::FrameParser {
+   public:
+    FrameParser(const RuntimeBlob* cb) : CodeBlob::FrameParser(cb) {}
+  };
 
   // GC support
   virtual bool is_alive() const                  = 0;
@@ -385,6 +404,7 @@ class BufferBlob: public RuntimeBlob {
   friend class VtableBlob;
   friend class MethodHandlesAdapterBlob;
   friend class OptimizedEntryBlob;
+  friend class InterpreterBlob;
   friend class WhiteBox;
 
  private:
@@ -407,6 +427,12 @@ class BufferBlob: public RuntimeBlob {
 
   // Typing
   virtual bool is_buffer_blob() const            { return true; }
+
+  // Profiling/safepoint support
+  class FrameParser : public RuntimeBlob::FrameParser {
+   public:
+    FrameParser(const BufferBlob* cb) : RuntimeBlob::FrameParser(cb) {}
+  };
 
   // GC/Verification support
   void preserve_callee_argument_oops(frame fr, const RegisterMap* reg_map, OopClosure* f)  { /* nothing to do */ }
@@ -461,6 +487,32 @@ public:
 
   // Typing
   virtual bool is_method_handles_adapter_blob() const { return true; }
+};
+
+
+//----------------------------------------------------------------------------------------------------
+// InterpreterBlob: used to hold Interpreter
+
+class InterpreterBlob: public BufferBlob {
+private:
+  InterpreterBlob(int size)                          : BufferBlob("Interpreter", size) {}
+
+public:
+  // Creation
+  static InterpreterBlob* create(int buffer_size);
+
+  // Typing
+  virtual bool is_interpreter_blob() const { return true; }
+
+  // Profiling/safepoint support
+  class FrameParser : public BufferBlob::FrameParser {
+   public:
+    FrameParser(const InterpreterBlob* cb) : BufferBlob::FrameParser(cb) {}
+    virtual bool sender_frame(JavaThread *thread, address pc, intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, bool fp_safe,
+      address* sender_pc, intptr_t** sender_sp, intptr_t** sender_unextended_sp, intptr_t*** saved_fp);
+  };
+
+  virtual FrameParser* frame_parser() const { return new FrameParser(this); }
 };
 
 

--- a/src/hotspot/share/code/icBuffer.cpp
+++ b/src/hotspot/share/code/icBuffer.cpp
@@ -140,7 +140,12 @@ void ICStub::print() {
 
 void InlineCacheBuffer::initialize() {
   if (_buffer != NULL) return; // already initialized
-  _buffer = new StubQueue(new ICStubInterface, 10*K, InlineCacheBuffer_lock, "InlineCacheBuffer");
+  int code_size = align_up((int)(10*K), 2*BytesPerWord);
+  BufferBlob* blob = BufferBlob::create("InlineCacheBuffer", code_size);
+  if (blob == NULL) {
+    vm_exit_out_of_memory(code_size, OOM_MALLOC_ERROR, "CodeCache: no room for InlineCacheBuffer");
+  }
+  _buffer = new StubQueue(new ICStubInterface, blob, InlineCacheBuffer_lock);
   assert (_buffer != NULL, "cannot allocate InlineCacheBuffer");
 }
 

--- a/src/hotspot/share/code/stubs.cpp
+++ b/src/hotspot/share/code/stubs.cpp
@@ -64,13 +64,8 @@
 // ITS CORRECTNESS! THIS CODE IS MORE SUBTLE THAN IT LOOKS!
 
 
-StubQueue::StubQueue(StubInterface* stub_interface, int buffer_size,
-                     Mutex* lock, const char* name) : _mutex(lock) {
-  intptr_t size = align_up(buffer_size, 2*BytesPerWord);
-  BufferBlob* blob = BufferBlob::create(name, size);
-  if( blob == NULL) {
-    vm_exit_out_of_memory(size, OOM_MALLOC_ERROR, "CodeCache: no room for %s", name);
-  }
+StubQueue::StubQueue(StubInterface* stub_interface, BufferBlob* blob,
+                     Mutex* lock) : _mutex(lock) {
   _stub_interface  = stub_interface;
   _buffer_size     = blob->content_size();
   _buffer_limit    = blob->content_size();

--- a/src/hotspot/share/code/stubs.hpp
+++ b/src/hotspot/share/code/stubs.hpp
@@ -173,8 +173,7 @@ class StubQueue: public CHeapObj<mtCode> {
   void  stub_print(Stub* s)                      { _stub_interface->print(s); }
 
  public:
-  StubQueue(StubInterface* stub_interface, int buffer_size, Mutex* lock,
-            const char* name);
+  StubQueue(StubInterface* stub_interface, BufferBlob* blob, Mutex* lock);
   ~StubQueue();
 
   // General queue info

--- a/src/hotspot/share/interpreter/templateInterpreter.cpp
+++ b/src/hotspot/share/interpreter/templateInterpreter.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "code/codeBlob.hpp"
 #include "interpreter/interpreter.hpp"
 #include "interpreter/interpreterRuntime.hpp"
 #include "interpreter/interp_masm.hpp"
@@ -45,10 +46,10 @@ void TemplateInterpreter::initialize_stub() {
          "dispatch table too small");
 
   // allocate interpreter
-  int code_size = InterpreterCodeSize;
-  NOT_PRODUCT(code_size *= 4;)  // debug uses extra interpreter code space
-  _code = new StubQueue(new InterpreterCodeletInterface, code_size, NULL,
-                        "Interpreter");
+  // debug uses extra interpreter code space
+  BufferBlob* blob = InterpreterBlob::create(InterpreterCodeSize NOT_PRODUCT( * 4));
+  assert(blob != NULL, "invariant");
+  _code = new StubQueue(new InterpreterCodeletInterface, blob, NULL);
 }
 
 void TemplateInterpreter::initialize_code() {


### PR DESCRIPTION
Whether and how a frame is setup is controlled by the code generator
for the specific CodeBlock. The CodeBlock is then in the best place to know how
to parse the sender's frame from the current frame in the given CodeBlock.

This refactoring proposes to extract this parsing out of `frame` and into a
`CodeBlock::FrameParser`. This FrameParser is then specialized in the relevant
inherited children of CodeBlock.

This change is to largely facilitate adding new supported cases for JDK-8252417 [1]
like runtime stubs.

[1] https://bugs.openjdk.java.net/browse/JDK-8252417

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8268178](https://bugs.openjdk.java.net/browse/JDK-8268178): Extract sender frame parsing to CodeBlob::FrameParser


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4337/head:pull/4337` \
`$ git checkout pull/4337`

Update a local copy of the PR: \
`$ git checkout pull/4337` \
`$ git pull https://git.openjdk.java.net/jdk pull/4337/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4337`

View PR using the GUI difftool: \
`$ git pr show -t 4337`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4337.diff">https://git.openjdk.java.net/jdk/pull/4337.diff</a>

</details>
