### PR TITLE
8268095: CDS MethodHandle tests should add -XX:-VerifyDependencies

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/CDSMHTest_generate.sh
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/CDSMHTest_generate.sh
@@ -79,6 +79,7 @@ do
 import org.junit.Test;
 
 import java.io.File;
+import jdk.test.lib.Platform;
 
 public class $i extends DynamicArchiveTestBase {
     @Test
@@ -96,6 +97,10 @@ public class $i extends DynamicArchiveTestBase {
     static void testImpl() throws Exception {
         String topArchiveName = getNewArchiveName();
         String appJar = JarBuilder.build("MH", new File(classDir), null);
+        // Disable VerifyDpendencies when running with debug build because
+        // the test requires a lot more time to execute with the option enabled.
+        String verifyOpt =
+            Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "-showversion";
 
         String[] classPaths = javaClassPath.split(File.pathSeparator);
         String junitJar = null;
@@ -107,7 +112,7 @@ public class $i extends DynamicArchiveTestBase {
         }
 
         dumpAndRun(topArchiveName, "-Xlog:cds,cds+dynamic=debug,class+load=trace",
-            "-cp", appJar + ps + junitJar,
+            "-cp", appJar + ps + junitJar, verifyOpt,
             mainClass, testPackageName + "." + testClassName);
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesAsCollectorTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesAsCollectorTest.java
@@ -47,6 +47,7 @@
 import org.junit.Test;
 
 import java.io.File;
+import jdk.test.lib.Platform;
 
 public class MethodHandlesAsCollectorTest extends DynamicArchiveTestBase {
     @Test
@@ -64,6 +65,10 @@ public class MethodHandlesAsCollectorTest extends DynamicArchiveTestBase {
     static void testImpl() throws Exception {
         String topArchiveName = getNewArchiveName();
         String appJar = JarBuilder.build("MH", new File(classDir), null);
+        // Disable VerifyDpendencies when running with debug build because
+        // the test requires a lot more time to execute with the option enabled.
+        String verifyOpt =
+            Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "-showversion";
 
         String[] classPaths = javaClassPath.split(File.pathSeparator);
         String junitJar = null;
@@ -75,7 +80,7 @@ public class MethodHandlesAsCollectorTest extends DynamicArchiveTestBase {
         }
 
         dumpAndRun(topArchiveName, "-Xlog:cds,cds+dynamic=debug,class+load=trace",
-            "-cp", appJar + ps + junitJar,
+            "-cp", appJar + ps + junitJar, verifyOpt,
             mainClass, testPackageName + "." + testClassName);
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesCastFailureTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesCastFailureTest.java
@@ -47,6 +47,7 @@
 import org.junit.Test;
 
 import java.io.File;
+import jdk.test.lib.Platform;
 
 public class MethodHandlesCastFailureTest extends DynamicArchiveTestBase {
     @Test
@@ -64,6 +65,10 @@ public class MethodHandlesCastFailureTest extends DynamicArchiveTestBase {
     static void testImpl() throws Exception {
         String topArchiveName = getNewArchiveName();
         String appJar = JarBuilder.build("MH", new File(classDir), null);
+        // Disable VerifyDpendencies when running with debug build because
+        // the test requires a lot more time to execute with the option enabled.
+        String verifyOpt =
+            Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "-showversion";
 
         String[] classPaths = javaClassPath.split(File.pathSeparator);
         String junitJar = null;
@@ -75,7 +80,7 @@ public class MethodHandlesCastFailureTest extends DynamicArchiveTestBase {
         }
 
         dumpAndRun(topArchiveName, "-Xlog:cds,cds+dynamic=debug,class+load=trace",
-            "-cp", appJar + ps + junitJar,
+            "-cp", appJar + ps + junitJar, verifyOpt,
             mainClass, testPackageName + "." + testClassName);
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesGeneralTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesGeneralTest.java
@@ -47,6 +47,7 @@
 import org.junit.Test;
 
 import java.io.File;
+import jdk.test.lib.Platform;
 
 public class MethodHandlesGeneralTest extends DynamicArchiveTestBase {
     @Test
@@ -64,6 +65,10 @@ public class MethodHandlesGeneralTest extends DynamicArchiveTestBase {
     static void testImpl() throws Exception {
         String topArchiveName = getNewArchiveName();
         String appJar = JarBuilder.build("MH", new File(classDir), null);
+        // Disable VerifyDpendencies when running with debug build because
+        // the test requires a lot more time to execute with the option enabled.
+        String verifyOpt =
+            Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "-showversion";
 
         String[] classPaths = javaClassPath.split(File.pathSeparator);
         String junitJar = null;
@@ -75,7 +80,7 @@ public class MethodHandlesGeneralTest extends DynamicArchiveTestBase {
         }
 
         dumpAndRun(topArchiveName, "-Xlog:cds,cds+dynamic=debug,class+load=trace",
-            "-cp", appJar + ps + junitJar,
+            "-cp", appJar + ps + junitJar, verifyOpt,
             mainClass, testPackageName + "." + testClassName);
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesInvokersTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesInvokersTest.java
@@ -47,6 +47,7 @@
 import org.junit.Test;
 
 import java.io.File;
+import jdk.test.lib.Platform;
 
 public class MethodHandlesInvokersTest extends DynamicArchiveTestBase {
     @Test
@@ -64,6 +65,10 @@ public class MethodHandlesInvokersTest extends DynamicArchiveTestBase {
     static void testImpl() throws Exception {
         String topArchiveName = getNewArchiveName();
         String appJar = JarBuilder.build("MH", new File(classDir), null);
+        // Disable VerifyDpendencies when running with debug build because
+        // the test requires a lot more time to execute with the option enabled.
+        String verifyOpt =
+            Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "-showversion";
 
         String[] classPaths = javaClassPath.split(File.pathSeparator);
         String junitJar = null;
@@ -75,7 +80,7 @@ public class MethodHandlesInvokersTest extends DynamicArchiveTestBase {
         }
 
         dumpAndRun(topArchiveName, "-Xlog:cds,cds+dynamic=debug,class+load=trace",
-            "-cp", appJar + ps + junitJar,
+            "-cp", appJar + ps + junitJar, verifyOpt,
             mainClass, testPackageName + "." + testClassName);
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesPermuteArgumentsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesPermuteArgumentsTest.java
@@ -47,6 +47,7 @@
 import org.junit.Test;
 
 import java.io.File;
+import jdk.test.lib.Platform;
 
 public class MethodHandlesPermuteArgumentsTest extends DynamicArchiveTestBase {
     @Test
@@ -64,6 +65,10 @@ public class MethodHandlesPermuteArgumentsTest extends DynamicArchiveTestBase {
     static void testImpl() throws Exception {
         String topArchiveName = getNewArchiveName();
         String appJar = JarBuilder.build("MH", new File(classDir), null);
+        // Disable VerifyDpendencies when running with debug build because
+        // the test requires a lot more time to execute with the option enabled.
+        String verifyOpt =
+            Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "-showversion";
 
         String[] classPaths = javaClassPath.split(File.pathSeparator);
         String junitJar = null;
@@ -75,7 +80,7 @@ public class MethodHandlesPermuteArgumentsTest extends DynamicArchiveTestBase {
         }
 
         dumpAndRun(topArchiveName, "-Xlog:cds,cds+dynamic=debug,class+load=trace",
-            "-cp", appJar + ps + junitJar,
+            "-cp", appJar + ps + junitJar, verifyOpt,
             mainClass, testPackageName + "." + testClassName);
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesSpreadArgumentsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/methodHandles/MethodHandlesSpreadArgumentsTest.java
@@ -47,6 +47,7 @@
 import org.junit.Test;
 
 import java.io.File;
+import jdk.test.lib.Platform;
 
 public class MethodHandlesSpreadArgumentsTest extends DynamicArchiveTestBase {
     @Test
@@ -64,6 +65,10 @@ public class MethodHandlesSpreadArgumentsTest extends DynamicArchiveTestBase {
     static void testImpl() throws Exception {
         String topArchiveName = getNewArchiveName();
         String appJar = JarBuilder.build("MH", new File(classDir), null);
+        // Disable VerifyDpendencies when running with debug build because
+        // the test requires a lot more time to execute with the option enabled.
+        String verifyOpt =
+            Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "-showversion";
 
         String[] classPaths = javaClassPath.split(File.pathSeparator);
         String junitJar = null;
@@ -75,7 +80,7 @@ public class MethodHandlesSpreadArgumentsTest extends DynamicArchiveTestBase {
         }
 
         dumpAndRun(topArchiveName, "-Xlog:cds,cds+dynamic=debug,class+load=trace",
-            "-cp", appJar + ps + junitJar,
+            "-cp", appJar + ps + junitJar, verifyOpt,
             mainClass, testPackageName + "." + testClassName);
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/CDSMHTest_generate.sh
+++ b/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/CDSMHTest_generate.sh
@@ -82,6 +82,7 @@ import java.io.File;
 import jdk.test.lib.cds.CDSOptions;
 import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.Platform;
 
 public class $i {
     @Test
@@ -100,6 +101,10 @@ public class $i {
         String appJar = JarBuilder.build("MH", new File(classDir), null);
         String classList = testClassName + ".list";
         String archiveName = testClassName + ".jsa";
+        // Disable VerifyDpendencies when running with debug build because
+        // the test requires a lot more time to execute with the option enabled.
+        String verifyOpt =
+            Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "-showversion";
 
         String[] classPaths = javaClassPath.split(File.pathSeparator);
         String junitJar = null;
@@ -113,7 +118,7 @@ public class $i {
         String jars = appJar + ps + junitJar;
 
         // dump class list
-        CDSTestUtils.dumpClassList(classList, "-cp", jars, mainClass,
+        CDSTestUtils.dumpClassList(classList, "-cp", jars, verifyOpt, mainClass,
                                    testPackageName + "." + testClassName);
 
         // create archive with the class list
@@ -126,7 +131,7 @@ public class $i {
 
         // run with archive
         CDSOptions runOpts = (new CDSOptions())
-            .addPrefix("-cp", jars, "-Xlog:class+load,cds=debug")
+            .addPrefix("-cp", jars, "-Xlog:class+load,cds=debug", verifyOpt)
             .setArchiveName(archiveName)
             .setUseVersion(false)
             .addSuffix(mainClass, testPackageName + "." + testClassName);

--- a/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/MethodHandlesAsCollectorTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/MethodHandlesAsCollectorTest.java
@@ -50,6 +50,7 @@ import java.io.File;
 import jdk.test.lib.cds.CDSOptions;
 import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.Platform;
 
 public class MethodHandlesAsCollectorTest {
     @Test
@@ -68,6 +69,10 @@ public class MethodHandlesAsCollectorTest {
         String appJar = JarBuilder.build("MH", new File(classDir), null);
         String classList = testClassName + ".list";
         String archiveName = testClassName + ".jsa";
+        // Disable VerifyDpendencies when running with debug build because
+        // the test requires a lot more time to execute with the option enabled.
+        String verifyOpt =
+            Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "-showversion";
 
         String[] classPaths = javaClassPath.split(File.pathSeparator);
         String junitJar = null;
@@ -81,7 +86,7 @@ public class MethodHandlesAsCollectorTest {
         String jars = appJar + ps + junitJar;
 
         // dump class list
-        CDSTestUtils.dumpClassList(classList, "-cp", jars, mainClass,
+        CDSTestUtils.dumpClassList(classList, "-cp", jars, verifyOpt, mainClass,
                                    testPackageName + "." + testClassName);
 
         // create archive with the class list
@@ -94,7 +99,7 @@ public class MethodHandlesAsCollectorTest {
 
         // run with archive
         CDSOptions runOpts = (new CDSOptions())
-            .addPrefix("-cp", jars, "-Xlog:class+load,cds=debug")
+            .addPrefix("-cp", jars, "-Xlog:class+load,cds=debug", verifyOpt)
             .setArchiveName(archiveName)
             .setUseVersion(false)
             .addSuffix(mainClass, testPackageName + "." + testClassName);

--- a/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/MethodHandlesCastFailureTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/MethodHandlesCastFailureTest.java
@@ -50,6 +50,7 @@ import java.io.File;
 import jdk.test.lib.cds.CDSOptions;
 import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.Platform;
 
 public class MethodHandlesCastFailureTest {
     @Test
@@ -68,6 +69,10 @@ public class MethodHandlesCastFailureTest {
         String appJar = JarBuilder.build("MH", new File(classDir), null);
         String classList = testClassName + ".list";
         String archiveName = testClassName + ".jsa";
+        // Disable VerifyDpendencies when running with debug build because
+        // the test requires a lot more time to execute with the option enabled.
+        String verifyOpt =
+            Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "-showversion";
 
         String[] classPaths = javaClassPath.split(File.pathSeparator);
         String junitJar = null;
@@ -81,7 +86,7 @@ public class MethodHandlesCastFailureTest {
         String jars = appJar + ps + junitJar;
 
         // dump class list
-        CDSTestUtils.dumpClassList(classList, "-cp", jars, mainClass,
+        CDSTestUtils.dumpClassList(classList, "-cp", jars, verifyOpt, mainClass,
                                    testPackageName + "." + testClassName);
 
         // create archive with the class list
@@ -94,7 +99,7 @@ public class MethodHandlesCastFailureTest {
 
         // run with archive
         CDSOptions runOpts = (new CDSOptions())
-            .addPrefix("-cp", jars, "-Xlog:class+load,cds=debug")
+            .addPrefix("-cp", jars, "-Xlog:class+load,cds=debug", verifyOpt)
             .setArchiveName(archiveName)
             .setUseVersion(false)
             .addSuffix(mainClass, testPackageName + "." + testClassName);

--- a/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/MethodHandlesGeneralTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/MethodHandlesGeneralTest.java
@@ -50,6 +50,7 @@ import java.io.File;
 import jdk.test.lib.cds.CDSOptions;
 import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.Platform;
 
 public class MethodHandlesGeneralTest {
     @Test
@@ -68,6 +69,10 @@ public class MethodHandlesGeneralTest {
         String appJar = JarBuilder.build("MH", new File(classDir), null);
         String classList = testClassName + ".list";
         String archiveName = testClassName + ".jsa";
+        // Disable VerifyDpendencies when running with debug build because
+        // the test requires a lot more time to execute with the option enabled.
+        String verifyOpt =
+            Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "-showversion";
 
         String[] classPaths = javaClassPath.split(File.pathSeparator);
         String junitJar = null;
@@ -81,7 +86,7 @@ public class MethodHandlesGeneralTest {
         String jars = appJar + ps + junitJar;
 
         // dump class list
-        CDSTestUtils.dumpClassList(classList, "-cp", jars, mainClass,
+        CDSTestUtils.dumpClassList(classList, "-cp", jars, verifyOpt, mainClass,
                                    testPackageName + "." + testClassName);
 
         // create archive with the class list
@@ -94,7 +99,7 @@ public class MethodHandlesGeneralTest {
 
         // run with archive
         CDSOptions runOpts = (new CDSOptions())
-            .addPrefix("-cp", jars, "-Xlog:class+load,cds=debug")
+            .addPrefix("-cp", jars, "-Xlog:class+load,cds=debug", verifyOpt)
             .setArchiveName(archiveName)
             .setUseVersion(false)
             .addSuffix(mainClass, testPackageName + "." + testClassName);

--- a/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/MethodHandlesInvokersTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/MethodHandlesInvokersTest.java
@@ -50,6 +50,7 @@ import java.io.File;
 import jdk.test.lib.cds.CDSOptions;
 import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.Platform;
 
 public class MethodHandlesInvokersTest {
     @Test
@@ -68,6 +69,10 @@ public class MethodHandlesInvokersTest {
         String appJar = JarBuilder.build("MH", new File(classDir), null);
         String classList = testClassName + ".list";
         String archiveName = testClassName + ".jsa";
+        // Disable VerifyDpendencies when running with debug build because
+        // the test requires a lot more time to execute with the option enabled.
+        String verifyOpt =
+            Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "-showversion";
 
         String[] classPaths = javaClassPath.split(File.pathSeparator);
         String junitJar = null;
@@ -81,7 +86,7 @@ public class MethodHandlesInvokersTest {
         String jars = appJar + ps + junitJar;
 
         // dump class list
-        CDSTestUtils.dumpClassList(classList, "-cp", jars, mainClass,
+        CDSTestUtils.dumpClassList(classList, "-cp", jars, verifyOpt, mainClass,
                                    testPackageName + "." + testClassName);
 
         // create archive with the class list
@@ -94,7 +99,7 @@ public class MethodHandlesInvokersTest {
 
         // run with archive
         CDSOptions runOpts = (new CDSOptions())
-            .addPrefix("-cp", jars, "-Xlog:class+load,cds=debug")
+            .addPrefix("-cp", jars, "-Xlog:class+load,cds=debug", verifyOpt)
             .setArchiveName(archiveName)
             .setUseVersion(false)
             .addSuffix(mainClass, testPackageName + "." + testClassName);

--- a/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/MethodHandlesPermuteArgumentsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/MethodHandlesPermuteArgumentsTest.java
@@ -50,6 +50,7 @@ import java.io.File;
 import jdk.test.lib.cds.CDSOptions;
 import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.Platform;
 
 public class MethodHandlesPermuteArgumentsTest {
     @Test
@@ -68,6 +69,10 @@ public class MethodHandlesPermuteArgumentsTest {
         String appJar = JarBuilder.build("MH", new File(classDir), null);
         String classList = testClassName + ".list";
         String archiveName = testClassName + ".jsa";
+        // Disable VerifyDpendencies when running with debug build because
+        // the test requires a lot more time to execute with the option enabled.
+        String verifyOpt =
+            Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "-showversion";
 
         String[] classPaths = javaClassPath.split(File.pathSeparator);
         String junitJar = null;
@@ -81,7 +86,7 @@ public class MethodHandlesPermuteArgumentsTest {
         String jars = appJar + ps + junitJar;
 
         // dump class list
-        CDSTestUtils.dumpClassList(classList, "-cp", jars, mainClass,
+        CDSTestUtils.dumpClassList(classList, "-cp", jars, verifyOpt, mainClass,
                                    testPackageName + "." + testClassName);
 
         // create archive with the class list
@@ -94,7 +99,7 @@ public class MethodHandlesPermuteArgumentsTest {
 
         // run with archive
         CDSOptions runOpts = (new CDSOptions())
-            .addPrefix("-cp", jars, "-Xlog:class+load,cds=debug")
+            .addPrefix("-cp", jars, "-Xlog:class+load,cds=debug", verifyOpt)
             .setArchiveName(archiveName)
             .setUseVersion(false)
             .addSuffix(mainClass, testPackageName + "." + testClassName);

--- a/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/MethodHandlesSpreadArgumentsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/methodHandles/MethodHandlesSpreadArgumentsTest.java
@@ -50,6 +50,7 @@ import java.io.File;
 import jdk.test.lib.cds.CDSOptions;
 import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.Platform;
 
 public class MethodHandlesSpreadArgumentsTest {
     @Test
@@ -68,6 +69,10 @@ public class MethodHandlesSpreadArgumentsTest {
         String appJar = JarBuilder.build("MH", new File(classDir), null);
         String classList = testClassName + ".list";
         String archiveName = testClassName + ".jsa";
+        // Disable VerifyDpendencies when running with debug build because
+        // the test requires a lot more time to execute with the option enabled.
+        String verifyOpt =
+            Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "-showversion";
 
         String[] classPaths = javaClassPath.split(File.pathSeparator);
         String junitJar = null;
@@ -81,7 +86,7 @@ public class MethodHandlesSpreadArgumentsTest {
         String jars = appJar + ps + junitJar;
 
         // dump class list
-        CDSTestUtils.dumpClassList(classList, "-cp", jars, mainClass,
+        CDSTestUtils.dumpClassList(classList, "-cp", jars, verifyOpt, mainClass,
                                    testPackageName + "." + testClassName);
 
         // create archive with the class list
@@ -94,7 +99,7 @@ public class MethodHandlesSpreadArgumentsTest {
 
         // run with archive
         CDSOptions runOpts = (new CDSOptions())
-            .addPrefix("-cp", jars, "-Xlog:class+load,cds=debug")
+            .addPrefix("-cp", jars, "-Xlog:class+load,cds=debug", verifyOpt)
             .setArchiveName(archiveName)
             .setUseVersion(false)
             .addSuffix(mainClass, testPackageName + "." + testClassName);


### PR DESCRIPTION
Please review this patch for disabling the `VerifyDependencies` option when running the CDS MethodHandle tests with debug build. It reduces the time required for running the tests a lot.
e.g. total time for running the `appcds/methodHandles/MethodHandlesSpreadArgumentsTest.java` test with debug build:
before 489.102s
after 62.721s

The patch passed tier1 and tier2 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268095](https://bugs.openjdk.java.net/browse/JDK-8268095): CDS MethodHandle tests should add -XX:-VerifyDependencies


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4338/head:pull/4338` \
`$ git checkout pull/4338`

Update a local copy of the PR: \
`$ git checkout pull/4338` \
`$ git pull https://git.openjdk.java.net/jdk pull/4338/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4338`

View PR using the GUI difftool: \
`$ git pr show -t 4338`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4338.diff">https://git.openjdk.java.net/jdk/pull/4338.diff</a>

</details>
