### PR TITLE
8267564: JDK-8252971 causes SPECjbb2015 socket exceptions on Windows when MKS is installed

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/UnixDomainSockets.java
+++ b/src/java.base/share/classes/sun/nio/ch/UnixDomainSockets.java
@@ -160,7 +160,7 @@ class UnixDomainSockets {
         return n;
     }
 
-    private static native boolean socketSupported();
+    private static native boolean init();
 
     private static native int socket0() throws IOException;
 
@@ -176,6 +176,6 @@ class UnixDomainSockets {
     static {
         // Load all required native libs
         IOUtil.load();
-        supported = socketSupported();
+        supported = init();
     }
 }

--- a/src/java.base/unix/native/libnio/ch/UnixDomainSockets.c
+++ b/src/java.base/unix/native/libnio/ch/UnixDomainSockets.c
@@ -95,7 +95,7 @@ jint unixSocketAddressToSockaddr(JNIEnv *env, jbyteArray path, struct sockaddr_u
 }
 
 JNIEXPORT jboolean JNICALL
-Java_sun_nio_ch_UnixDomainSockets_socketSupported(JNIEnv *env, jclass cl)
+Java_sun_nio_ch_UnixDomainSockets_init(JNIEnv *env, jclass cl)
 {
     return JNI_TRUE;
 }

--- a/src/java.base/windows/native/libnio/ch/UnixDomainSockets.c
+++ b/src/java.base/windows/native/libnio/ch/UnixDomainSockets.c
@@ -104,7 +104,7 @@ static int cmpGuid(GUID *g1, GUID *g2) {
 static WSAPROTOCOL_INFOW provider;
 
 JNIEXPORT jboolean JNICALL
-Java_sun_nio_ch_UnixDomainSockets_socketSupported(JNIEnv *env, jclass cl)
+Java_sun_nio_ch_UnixDomainSockets_init(JNIEnv *env, jclass cl)
 {
     WSAPROTOCOL_INFOW info[5]; // if not large enough, a buffer is malloc'd
     LPWSAPROTOCOL_INFOW infoPtr = &info[0];


### PR DESCRIPTION
Hi,

This fixes a problem where unix domain sockets are available on Windows from third party winsock drivers (other than the Microsoft implementation in Windows 10/2019). These are available (unexpectedly) on earlier Windows releases and are not supported by Java. 

The fix is to search for the expected winsock service provider ID and specifically use that one when creating sockets. Previously, we just attempted to create a unix domain socket, and once that succeeded we assumed we had the right service provider.

I haven't included a regression test because the environment to reproduce the issue is not part of the standard test configuration. Also, the new code is well exercised by existing tests.

Thanks,
Michael.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267564](https://bugs.openjdk.java.net/browse/JDK-8267564): JDK-8252971 causes SPECjbb2015 socket exceptions on Windows when MKS is installed


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4339/head:pull/4339` \
`$ git checkout pull/4339`

Update a local copy of the PR: \
`$ git checkout pull/4339` \
`$ git pull https://git.openjdk.java.net/jdk pull/4339/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4339`

View PR using the GUI difftool: \
`$ git pr show -t 4339`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4339.diff">https://git.openjdk.java.net/jdk/pull/4339.diff</a>

</details>
