### PR TITLE
8267995: Add reference to JVMS class file format in Lookup::defineHiddenClass

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -1933,9 +1933,9 @@ public class MethodHandles {
          * of the lookup class of this {@code Lookup}.</li>
          *
          * <li> The purported representation in {@code bytes} must be a {@code ClassFile}
-         * structure of a supported major and minor version. The major and minor version
-         * may differ from the {@code class} file version of the lookup class of this
-         * {@code Lookup}.</li>
+         * structure (JVMS {@jvms 4.1}) of a supported major and minor version.
+         * The major and minor version may differ from the {@code class} file version
+         * of the lookup class of this {@code Lookup}.</li>
          *
          * <li> The value of {@code this_class} must be a valid index in the
          * {@code constant_pool} table, and the entry at that index must be a valid


### PR DESCRIPTION
Trivial javadoc change to add a reference to JVMS 4.1 in `Lookup::defineHiddenClass` such that the reference like `this_class` would be referred to JVMS for details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267995](https://bugs.openjdk.java.net/browse/JDK-8267995): Add reference to JVMS class file format in Lookup::defineHiddenClass


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4340/head:pull/4340` \
`$ git checkout pull/4340`

Update a local copy of the PR: \
`$ git checkout pull/4340` \
`$ git pull https://git.openjdk.java.net/jdk pull/4340/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4340`

View PR using the GUI difftool: \
`$ git pr show -t 4340`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4340.diff">https://git.openjdk.java.net/jdk/pull/4340.diff</a>

</details>
