### PR TITLE
JDK-8268185: Update GitHub Actions for jtreg 6

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -67,7 +67,7 @@ jobs:
         if: steps.check_submit.outputs.should_run != 'false'
 
       - name: Determine the jtreg ref to checkout
-        run: "echo JTREG_REF=jtreg${{ fromJson(steps.check_deps.outputs.dependencies).JTREG_VERSION }}-${{ fromJson(steps.check_deps.outputs.dependencies).JTREG_BUILD }} >> $GITHUB_ENV"
+        run: "echo JTREG_REF=jtreg-${{ fromJson(steps.check_deps.outputs.dependencies).JTREG_VERSION }}+${{ fromJson(steps.check_deps.outputs.dependencies).JTREG_BUILD }} >> $GITHUB_ENV"
         if: steps.check_submit.outputs.should_run != 'false'
 
       - name: Check if a jtreg image is present in the cache
@@ -87,7 +87,7 @@ jobs:
         if: steps.check_submit.outputs.should_run != 'false' && steps.jtreg.outputs.cache-hit != 'true'
 
       - name: Build jtreg
-        run: sh make/build-all.sh ${JAVA_HOME_8_X64}
+        run: sh make/build.sh --jdk ${JAVA_HOME_8_X64}
         working-directory: jtreg
         if: steps.check_submit.outputs.should_run != 'false' && steps.jtreg.outputs.cache-hit != 'true'
 

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -87,7 +87,7 @@ jobs:
         if: steps.check_submit.outputs.should_run != 'false' && steps.jtreg.outputs.cache-hit != 'true'
 
       - name: Build jtreg
-        run: sh make/build.sh --jdk ${JAVA_HOME_8_X64}
+        run: bash make/build.sh --jdk ${JAVA_HOME_8_X64}
         working-directory: jtreg
         if: steps.check_submit.outputs.should_run != 'false' && steps.jtreg.outputs.cache-hit != 'true'
 

--- a/make/conf/test-dependencies
+++ b/make/conf/test-dependencies
@@ -26,8 +26,8 @@
 # Versions and download locations for dependencies used by pre-submit testing.
 
 BOOT_JDK_VERSION=16
-JTREG_VERSION=5.1
-JTREG_BUILD=b01
+JTREG_VERSION=6
+JTREG_BUILD=1
 GTEST_VERSION=1.8.1
 
 LINUX_X64_BOOT_JDK_FILENAME=openjdk-16_linux-x64_bin.tar.gz


### PR DESCRIPTION
Please review changes to the GitHub Actions for the repo, to use jtreg 6.

There are three small parts to the change:

1. The version info is updated in `make/conf/test-dependencies`
2. The new `make/build.sh` script is used to build `jtreg`, instead of the earlier `build-all.sh` script
3. The format of the tag in the jtreg repo is changed to follow OpenJDK conventions.

Tested implicitly with GitHub Actions on my fork, seen here:
https://github.com/jonathan-gibbons/jdk/actions/runs/903574304

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268185](https://bugs.openjdk.java.net/browse/JDK-8268185): Update GitHub Actions for jtreg 6


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4343/head:pull/4343` \
`$ git checkout pull/4343`

Update a local copy of the PR: \
`$ git checkout pull/4343` \
`$ git pull https://git.openjdk.java.net/jdk pull/4343/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4343`

View PR using the GUI difftool: \
`$ git pr show -t 4343`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4343.diff">https://git.openjdk.java.net/jdk/pull/4343.diff</a>

</details>
