### PR TITLE
8268189: ProblemList compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java in -Xcomp mode

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -27,6 +27,8 @@
 #
 #############################################################################
 
+compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java 8268033 generic-x64
+
 runtime/cds/appcds/dynamicArchive/TestDynamicDumpAtOom.java 8267954 linux-x64
 
 vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java 8205957 generic-all


### PR DESCRIPTION
A trivial fix to ProblemList compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java in -Xcomp mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268189](https://bugs.openjdk.java.net/browse/JDK-8268189): ProblemList compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java in -Xcomp mode


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4344/head:pull/4344` \
`$ git checkout pull/4344`

Update a local copy of the PR: \
`$ git checkout pull/4344` \
`$ git pull https://git.openjdk.java.net/jdk pull/4344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4344`

View PR using the GUI difftool: \
`$ git pr show -t 4344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4344.diff">https://git.openjdk.java.net/jdk/pull/4344.diff</a>

</details>
