### PR TITLE
8268214: Use system zlib and disable dtrace when building linux-aarch64 at Oracle

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -491,6 +491,8 @@ var getJibProfilesProfiles = function (input, common, data) {
             dependencies: ["devkit", "gtest", "build_devkit", "pandoc"],
             configure_args: [
                 "--openjdk-target=aarch64-linux-gnu",
+                "--with-zlib=system",
+                "--disable-dtrace",
 		"--enable-compatible-cds-alignment",
             ],
         },


### PR DESCRIPTION
Mimic what's being done on linux-x64 for consistency.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268214](https://bugs.openjdk.java.net/browse/JDK-8268214): Use system zlib and disable dtrace when building linux-aarch64 at Oracle


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4347/head:pull/4347` \
`$ git checkout pull/4347`

Update a local copy of the PR: \
`$ git checkout pull/4347` \
`$ git pull https://git.openjdk.java.net/jdk pull/4347/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4347`

View PR using the GUI difftool: \
`$ git pr show -t 4347`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4347.diff">https://git.openjdk.java.net/jdk/pull/4347.diff</a>

</details>
