### PR TITLE
8268228: TSC is not used for CPUTimeStampCounter on AMD processor

### DIFF
--- a/src/hotspot/cpu/x86/rdtsc_x86.cpp
+++ b/src/hotspot/cpu/x86/rdtsc_x86.cpp
@@ -106,7 +106,10 @@ static jlong initialize_frequency() {
     tsc_freq = (double)VM_Version_Ext::maximum_qualified_cpu_frequency();
     os_to_tsc_conv_factor = tsc_freq / os_freq;
   }
-  if (tsc_freq == 0.0f) {
+
+  // If no invariant TSC, or the system failed to report a useful maximum frequency,
+  // use an estimation.
+  if (tsc_freq == 0.0) {
     // use measurements to estimate
     // a conversion factor and the tsc frequency
 

--- a/src/hotspot/cpu/x86/rdtsc_x86.cpp
+++ b/src/hotspot/cpu/x86/rdtsc_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,7 +105,8 @@ static jlong initialize_frequency() {
     // for invariant tsc platforms, take the maximum qualified cpu frequency
     tsc_freq = (double)VM_Version_Ext::maximum_qualified_cpu_frequency();
     os_to_tsc_conv_factor = tsc_freq / os_freq;
-  } else {
+  }
+  if (tsc_freq == 0.0f) {
     // use measurements to estimate
     // a conversion factor and the tsc frequency
 


### PR DESCRIPTION
I ran JVM on Ryzen 3300X, and I got following `jdk.CPUTimeStampCounter` event.

```
jdk.CPUTimeStampCounter {
  startTime = 10:41:14.993
  fastTimeEnabled = false
  fastTimeAutoEnabled = true
  osFrequency = 1000000000
  fastTimeFrequency = 1000000000
}
```

I confirmed 3300X supports Invariant TSC (so `fastTimeAutoEnabled` is set to `true`), however it does not seem to be used (`fastTimeEnabled` is `false`).

Frequency is come from brand string from CPUID (e.g. "Intel(R) Core(TM) i3-8145U CPU @ 2.10GHz"). However AMD processor (Ryzen at least) does not have it ("AMD Ryzen 3 3300X 4-Core Processor").
Fortunately rdtsc_x86.cpp can calculate the frequency like bogomips. We should fallback to it if we cannot get the frequency even if invariant TSC is supported.

After this change, I got following `jdk.CPUTimeStampCounter` event. Base clock of Ryzen 3 3300X is 3.8GHz, so `fastTimeFrequency` looks good.

```
jdk.CPUTimeStampCounter {
  startTime = 10:33:52.884
  fastTimeEnabled = true
  fastTimeAutoEnabled = true
  osFrequency = 10000000 Hz
  fastTimeFrequency = 3792929124 Hz
}
```

This problem is not only for JFR. I confirmed `Rdtsc` class is used in ticks.cpp , and it relates to GC code at least.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8268228](https://bugs.openjdk.java.net/browse/JDK-8268228): TSC is not used for CPUTimeStampCounter on AMD processor


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4350/head:pull/4350` \
`$ git checkout pull/4350`

Update a local copy of the PR: \
`$ git checkout pull/4350` \
`$ git pull https://git.openjdk.java.net/jdk pull/4350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4350`

View PR using the GUI difftool: \
`$ git pr show -t 4350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4350.diff">https://git.openjdk.java.net/jdk/pull/4350.diff</a>

</details>
