### PR TITLE
8238213: Method resolution should stop on static error

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -3417,7 +3417,7 @@ public class Resolve {
          */
         final boolean shouldStop(Symbol sym, MethodResolutionPhase phase) {
             return phase.ordinal() > maxPhase.ordinal() ||
-                !sym.kind.isResolutionError() || sym.kind == AMBIGUOUS;
+                 !sym.kind.isResolutionError() || sym.kind == AMBIGUOUS || sym.kind == STATICERR;
         }
 
         /**

--- a/test/langtools/tools/javac/static_error/ShouldStopOnStaticError.java
+++ b/test/langtools/tools/javac/static_error/ShouldStopOnStaticError.java
@@ -1,0 +1,19 @@
+/**
+ * @test /nodynamiccopyright/
+ * @bug 8238213
+ * @summary Method resolution should stop on static error
+ * @compile/fail/ref=ShouldStopOnStaticError.out -XDrawDiagnostics ShouldStopOnStaticError.java
+ */
+
+public class ShouldStopOnStaticError {
+    static void foo() {
+        test1(5.0);
+        test2((Double)5.0);
+    }
+
+    void test1(double d) {}
+    void test1(Double d) {}
+
+    void test2(Number n) {}
+    static void test2(Double... d) {}
+}

--- a/test/langtools/tools/javac/static_error/ShouldStopOnStaticError.out
+++ b/test/langtools/tools/javac/static_error/ShouldStopOnStaticError.out
@@ -1,0 +1,3 @@
+ShouldStopOnStaticError.java:10:9: compiler.err.non-static.cant.be.ref: kindname.method, test1(double)
+ShouldStopOnStaticError.java:11:9: compiler.err.non-static.cant.be.ref: kindname.method, test2(java.lang.Number)
+2 errors


### PR DESCRIPTION
Please review this fix that is stopping method resolution if a static error is found. Currently javac rejecting code like:
```
public class Test {
    public static void main(String[] args) {
        test(5.0);
    }
  
    void test(double d) {}
    void test(Double d) {}
}
```
but for the wrong reason. Basically it is that the invocation of method `test` is ambiguous as if both were applicable when it should fail at the end of the first overload resolution phase indicating that the non-static method test(double) can't be referred from a static context. This patch is fixing this issue.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8238213](https://bugs.openjdk.java.net/browse/JDK-8238213): Method resolution should stop on static error


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4351/head:pull/4351` \
`$ git checkout pull/4351`

Update a local copy of the PR: \
`$ git checkout pull/4351` \
`$ git pull https://git.openjdk.java.net/jdk pull/4351/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4351`

View PR using the GUI difftool: \
`$ git pr show -t 4351`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4351.diff">https://git.openjdk.java.net/jdk/pull/4351.diff</a>

</details>
