### PR TITLE
8263323: Debug Agent help output includes invalid URL

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -859,7 +859,8 @@ printUsage(void)
  "               Java Debugger JDWP Agent Library\n"
  "               --------------------------------\n"
  "\n"
- "  (see http://java.sun.com/products/jpda for more information)\n"
+ "  (See the \"Oracle VM Invocation Options\" section of the JPDA\n"
+ "   \"Connection and Invocation Details\" document for more information.)\n"
  "\n"
  "jdwp usage: java " AGENTLIB "=[help]|[<option>=<value>, ...]\n"
  "\n"

--- a/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.c
@@ -859,7 +859,7 @@ printUsage(void)
  "               Java Debugger JDWP Agent Library\n"
  "               --------------------------------\n"
  "\n"
- "  (See the \"Oracle VM Invocation Options\" section of the JPDA\n"
+ "  (See the \"VM Invocation Options\" section of the JPDA\n"
  "   \"Connection and Invocation Details\" document for more information.)\n"
  "\n"
  "jdwp usage: java " AGENTLIB "=[help]|[<option>=<value>, ...]\n"


### PR DESCRIPTION
Rather than embed a URL in the help output, which needs to be updated if the location of docs ever changes, just include a description of the document so it can be looked up. The output now looks like:

```
$ ./java -agentlib:jdwp=help
               Java Debugger JDWP Agent Library
               --------------------------------

  (See the "Oracle VM Invocation Options" section of the JPDA
   "Connection and Invocation Details" document for more information.)

jdwp usage: java -agentlib:jdwp=[help]|[<option>=<value>, ...]

Option Name and Value            Description                       Default
---------------------            -----------                       -------
suspend=y|n                      wait on startup?                  y
transport=<name>                 transport spec                    none
...
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263323](https://bugs.openjdk.java.net/browse/JDK-8263323): Debug Agent help output includes invalid URL


### Reviewers
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to 8e8e6c951f8f9c147f81ba28ff2b0486f4591bfa
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4352/head:pull/4352` \
`$ git checkout pull/4352`

Update a local copy of the PR: \
`$ git checkout pull/4352` \
`$ git pull https://git.openjdk.java.net/jdk pull/4352/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4352`

View PR using the GUI difftool: \
`$ git pr show -t 4352`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4352.diff">https://git.openjdk.java.net/jdk/pull/4352.diff</a>

</details>
