### PR TITLE
8268222: javax/xml/jaxp/unittest/transform/Bug6216226Test.java failed, cannot delete file

### DIFF
--- a/src/java.xml/share/classes/javax/xml/transform/stream/StreamResult.java
+++ b/src/java.xml/share/classes/javax/xml/transform/stream/StreamResult.java
@@ -28,8 +28,6 @@ package javax.xml.transform.stream;
 import javax.xml.transform.Result;
 
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.io.Writer;
 
@@ -96,12 +94,10 @@ public class StreamResult implements Result {
      * @param f Must a non-null File reference.
      */
     public StreamResult(File f) {
-        try {
-            outputStream = new FileOutputStream(f);
-        } catch (FileNotFoundException ex) {
-            // fall back to the original implementation for compatibility
-            setSystemId(f.toURI().toASCIIString());
-        }
+        //convert file to appropriate URI, f.toURI().toASCIIString()
+        //converts the URI to string as per rule specified in
+        //RFC 2396,
+        setSystemId(f.toURI().toASCIIString());
     }
 
     /**


### PR DESCRIPTION
Revert changes in StreamResult.java made through https://github.com/openjdk/jdk/pull/4318 since it was creating a file stream on behalf of the Transformer, which resulted in a leaking file handle because the Transformer would only close files it opened.

This change instead replace the problematic file-uri-url-file conversion code with nio Paths. While we generally don't make such changes if it's not necessary as Apache still supports older versions of the JDK, we are okay with a code level 8.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268222](https://bugs.openjdk.java.net/browse/JDK-8268222): javax/xml/jaxp/unittest/transform/Bug6216226Test.java failed, cannot delete file


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4353/head:pull/4353` \
`$ git checkout pull/4353`

Update a local copy of the PR: \
`$ git checkout pull/4353` \
`$ git pull https://git.openjdk.java.net/jdk pull/4353/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4353`

View PR using the GUI difftool: \
`$ git pr show -t 4353`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4353.diff">https://git.openjdk.java.net/jdk/pull/4353.diff</a>

</details>
