### PR TITLE
8268227: java/foreign/TestUpcall.java still times out

### DIFF
--- a/test/jdk/java/foreign/TestDowncall.java
+++ b/test/jdk/java/foreign/TestDowncall.java
@@ -28,7 +28,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestDowncall
  *
- * @run testng/othervm/timeout=240
+ * @run testng/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
  *   --enable-native-access=ALL-UNNAMED
  *   TestDowncall
  */

--- a/test/jdk/java/foreign/TestUpcall.java
+++ b/test/jdk/java/foreign/TestUpcall.java
@@ -28,7 +28,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm/timeout=240
+ * @run testng/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
  *   --enable-native-access=ALL-UNNAMED
  *   TestUpcall
  */


### PR DESCRIPTION
Turns out that adding more timeout is a lost cause here. The root cause of the slowdown when running the test in debug build is:

https://bugs.openjdk.java.net/browse/JDK-8266074

Which has also caused related test issues:

https://bugs.openjdk.java.net/browse/JDK-8268095

So, the fix (at least temporarily) is to run method handle-heavy tests with the -XX:-VerifyDependency options.

On my machine, execution time of these tests on debug goes from 10 minutes down to less than 1.

Since `-XX:-VerifyDependencies` cannot be specified on non-debug build, the `-XX:+IgnoreUnrecognizedVMOptions` is also passed (thanks Vlad for the tip!).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268227](https://bugs.openjdk.java.net/browse/JDK-8268227): java/foreign/TestUpcall.java still times out


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4355/head:pull/4355` \
`$ git checkout pull/4355`

Update a local copy of the PR: \
`$ git checkout pull/4355` \
`$ git pull https://git.openjdk.java.net/jdk pull/4355/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4355`

View PR using the GUI difftool: \
`$ git pr show -t 4355`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4355.diff">https://git.openjdk.java.net/jdk/pull/4355.diff</a>

</details>
