### PR TITLE
8266159: macOS ARM + Metal pipeline shows artifacts on Swing Menu with Java L&F

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/shaders.metal
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/shaders.metal
@@ -46,6 +46,7 @@ struct AAVertexInput {
 
 struct ColShaderInOut {
     float4 position [[position]];
+    float  ptSize [[point_size]];
     half4  color;
 };
 
@@ -58,6 +59,7 @@ struct AAShaderInOut {
 
 struct StencilShaderInOut {
     float4 position [[position]];
+    float  ptSize [[point_size]];
     char color;
 };
 
@@ -81,6 +83,7 @@ struct GradShaderInOut {
 
 struct ColShaderInOut_XOR {
     float4 position [[position]];
+    float  ptSize [[point_size]];
     float2 orig_pos;
     half4  color;
 };
@@ -164,6 +167,7 @@ vertex ColShaderInOut vert_col(VertexInput in [[stage_in]],
     ColShaderInOut out;
     float4 pos4 = float4(in.position, 0.0, 1.0);
     out.position = transform.transformMatrix*pos4;
+    out.ptSize = 1.0;
     out.color = half4(uniforms.color.r, uniforms.color.g, uniforms.color.b, uniforms.color.a);
     return out;
 }
@@ -186,6 +190,7 @@ vertex StencilShaderInOut vert_stencil(VertexInput in [[stage_in]],
     StencilShaderInOut out;
     float4 pos4 = float4(in.position, 0.0, 1.0);
     out.position = transform.transformMatrix * pos4;
+    out.ptSize = 1.0;
     out.color = 0xFF;
     return out;
 }
@@ -671,6 +676,7 @@ vertex ColShaderInOut_XOR vert_col_xorMode(VertexInput in [[stage_in]],
     ColShaderInOut_XOR out;
     float4 pos4 = float4(in.position, 0.0, 1.0);
     out.position = transform.transformMatrix*pos4;
+    out.ptSize = 1.0;
     out.orig_pos = in.position;
     out.color = half4(uniforms.color.r, uniforms.color.g, uniforms.color.b, uniforms.color.a);
     return out;

--- a/test/jdk/java/awt/Graphics/DrawOvalTest.java
+++ b/test/jdk/java/awt/Graphics/DrawOvalTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @key headful
+ * @bug 8266159
+ * @summary Test to detect regression in pixel drawing.
+ *          A small circle is drawn and boundary pixels are compared to expected pixels.
+ *          Note : this test is specifically written for uiScale=1.0
+ * @run main/othervm -Dsun.java2d.uiScale=1.0 DrawOvalTest
+ */
+
+import javax.imageio.ImageIO;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsEnvironment;
+import java.awt.Transparency;
+import java.awt.image.BufferedImage;
+import java.awt.image.VolatileImage;
+import java.io.File;
+import java.io.IOException;
+
+public class DrawOvalTest {
+    public static void main(String[] args) throws IOException {
+        GraphicsConfiguration gc = GraphicsEnvironment.getLocalGraphicsEnvironment()
+                .getDefaultScreenDevice().getDefaultConfiguration();
+        VolatileImage vi = gc.createCompatibleVolatileImage(10, 10, Transparency.TRANSLUCENT);
+
+        // Draw test rendering sequence
+        render(vi.createGraphics());
+
+        BufferedImage snapshot = vi.getSnapshot();
+
+        // Pixel color sequence expected after test rendering is complete
+        // Blue color = -16776961
+        // Red color  = -65536
+        int sequence[] = {
+            -16776961,
+            -16776961,
+            -16776961,
+            -65536,
+            -65536,
+            -65536,
+            -65536,
+            -16776961,
+            -16776961,
+            -16776961
+        };
+
+        // Test the color of pixels at the image boundary
+        for (int i = 0; i < snapshot.getWidth(); i++) {
+
+            // Test first row, last row, first column and last column
+            if ( snapshot.getRGB(i, 0) != sequence[i] ||
+                 snapshot.getRGB(i, 9) != sequence[i] ||
+                 snapshot.getRGB(0, i) != sequence[i] ||
+                 snapshot.getRGB(9, i) != sequence[i] ) {
+                ImageIO.write(snapshot, "png", new File("DrawOvalTest_snapshot.png"));
+                throw new RuntimeException("Test failed.");
+            }
+        }
+    }
+
+    private static void render(Graphics2D g2) {
+        g2.setColor(Color.BLUE);
+        g2.fillRect(0, 0, 10, 10);
+        g2.setColor(Color.RED);
+        g2.drawOval(0, 0, 9, 9);
+    }
+}

--- a/test/jdk/java/awt/Graphics/DrawOvalTest.java
+++ b/test/jdk/java/awt/Graphics/DrawOvalTest.java
@@ -49,9 +49,14 @@ public class DrawOvalTest {
         VolatileImage vi = gc.createCompatibleVolatileImage(10, 10, Transparency.TRANSLUCENT);
 
         // Draw test rendering sequence
-        render(vi.createGraphics());
+        BufferedImage snapshot = null;
+        Graphics2D g2 = vi.createGraphics();
 
-        BufferedImage snapshot = vi.getSnapshot();
+        do {
+            vi.validate(gc);
+            render(g2);
+            snapshot = vi.getSnapshot();
+        } while (vi.contentsLost());
 
         // Pixel color sequence expected after test rendering is complete
         // Blue color = -16776961


### PR DESCRIPTION
This PR fixes an issue exclusively seen on Apple M1 systems when SwingSet2 demo is run with uiScale=1.0.

**Issue :**
SwingSet2 Demo - As reported in JBS description
J2DDemo - As reported in a comment on JBS

**Root Cause :** 
DrawPixel path is used only with uiScale=1.0. 
MTLPrimitiveTypePoint is used to draw a pixel while encoding a render command.
As mentioned in the documentation -
https://developer.apple.com/documentation/metal/mtlprimitivetype/mtlprimitivetypepoint?language=objc

"The vertex shader must provide [[point_size]], or the point size is undefined."

In our shader functions, we do not define this point size. It is harmless on x86_64 based mac systems, but causes visual artifacts on M1 mac systems.

**Solution :**
 Explicitly define point size in shader functions that draw MTLPrimitiveTypePoint.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266159](https://bugs.openjdk.java.net/browse/JDK-8266159): macOS ARM + Metal pipeline shows artifacts on Swing Menu with Java L&F


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**) ⚠️ Review applies to 751c85cfa00eceb215e294097afcf9cd423b66d8
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to 751c85cfa00eceb215e294097afcf9cd423b66d8


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4356/head:pull/4356` \
`$ git checkout pull/4356`

Update a local copy of the PR: \
`$ git checkout pull/4356` \
`$ git pull https://git.openjdk.java.net/jdk pull/4356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4356`

View PR using the GUI difftool: \
`$ git pr show -t 4356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4356.diff">https://git.openjdk.java.net/jdk/pull/4356.diff</a>

</details>
