### PR TITLE
8266631: StandardJavaFileManager: getJavaFileObjects() impl violates the spec

### DIFF
--- a/src/java.compiler/share/classes/javax/tools/StandardJavaFileManager.java
+++ b/src/java.compiler/share/classes/javax/tools/StandardJavaFileManager.java
@@ -192,14 +192,14 @@ public interface StandardJavaFileManager extends JavaFileManager {
      * @implSpec
      * The default implementation lazily converts each path to a file and calls
      * {@link #getJavaFileObjectsFromFiles(Iterable) getJavaFileObjectsFromFiles}.
-     * IllegalArgumentException will be thrown if any of the paths
-     * cannot be converted to a file at the point the conversion happens.
+     * {@linkplain IllegalArgumentException IllegalArgumentException} will be thrown
+     * if any of the paths cannot be converted to a file at the point the conversion happens.
      *
      * @param paths a list of paths
      * @return a list of file objects
      * @throws IllegalArgumentException if the list of paths includes
      * a directory or if this file manager does not support any of the
-     * given paths.
+     * given paths
      *
      * @since 13
      */
@@ -214,8 +214,8 @@ public interface StandardJavaFileManager extends JavaFileManager {
      * @implSpec
      * The default implementation lazily converts each path to a file and calls
      * {@link #getJavaFileObjectsFromPaths(Collection) getJavaFileObjectsFromPaths}.
-     * IllegalArgumentException will be thrown if any of the paths
-     * cannot be converted to a file at the point the conversion happens.
+     * {@linkplain IllegalArgumentException IllegalArgumentException} will be thrown
+     * if any of the paths cannot be converted to a file at the point the conversion happens.
      *
      * @param paths a list of paths
      * @return a list of file objects
@@ -248,7 +248,8 @@ public interface StandardJavaFileManager extends JavaFileManager {
      * @param files an array of files
      * @return a list of file objects
      * @throws IllegalArgumentException if the array of files includes
-     * a directory
+     * a directory or if this file manager does not support any of the
+     * given paths
      * @throws NullPointerException if the given array contains null
      * elements
      */
@@ -262,13 +263,17 @@ public interface StandardJavaFileManager extends JavaFileManager {
      *     getJavaFileObjectsFromPaths({@linkplain java.util.Arrays#asList Arrays.asList}(paths))
      * </pre>
      *
+     * @implSpec
+     * The default implementation will only throw {@linkplain NullPointerException NullPointerException}
+     * if {@linkplain #getJavaFileObjectsFromPaths(Collection)} throws it.
+     *
      * @param paths an array of paths
      * @return a list of file objects
      * @throws IllegalArgumentException if the array of files includes
-     * a directory
+     * a directory or if this file manager does not support any of the
+     * given paths
      * @throws NullPointerException if the given array contains null
-     * elements and the given element is used by
-     * {@linkplain #getJavaFileObjectsFromPaths(Collection)}.
+     * elements
      *
      * @since 9
      */

--- a/src/java.compiler/share/classes/javax/tools/StandardJavaFileManager.java
+++ b/src/java.compiler/share/classes/javax/tools/StandardJavaFileManager.java
@@ -190,10 +190,10 @@ public interface StandardJavaFileManager extends JavaFileManager {
      * Returns file objects representing the given paths.
      *
      * @implSpec
-     * The default implementation converts each path to a file and calls
-     * {@link #getJavaFileObjectsFromFiles getJavaObjectsFromFiles}.
+     * The default implementation lazily converts each path to a file and calls
+     * {@link #getJavaFileObjectsFromFiles(Iterable) getJavaFileObjectsFromFiles}.
      * IllegalArgumentException will be thrown if any of the paths
-     * cannot be converted to a file.
+     * cannot be converted to a file at the point the conversion happens.
      *
      * @param paths a list of paths
      * @return a list of file objects
@@ -212,10 +212,10 @@ public interface StandardJavaFileManager extends JavaFileManager {
      * Returns file objects representing the given paths.
      *
      * @implSpec
-     * The default implementation converts each path to a file and calls
-     * {@link #getJavaFileObjectsFromFiles getJavaObjectsFromFiles}.
+     * The default implementation lazily converts each path to a file and calls
+     * {@link #getJavaFileObjectsFromPaths(Collection) getJavaFileObjectsFromPaths}.
      * IllegalArgumentException will be thrown if any of the paths
-     * cannot be converted to a file.
+     * cannot be converted to a file at the point the conversion happens.
      *
      * @param paths a list of paths
      * @return a list of file objects
@@ -267,7 +267,8 @@ public interface StandardJavaFileManager extends JavaFileManager {
      * @throws IllegalArgumentException if the array of files includes
      * a directory
      * @throws NullPointerException if the given array contains null
-     * elements
+     * elements and the given element is used by
+     * {@linkplain #getJavaFileObjectsFromPaths(Collection)}.
      *
      * @since 9
      */
@@ -332,10 +333,11 @@ public interface StandardJavaFileManager extends JavaFileManager {
      * will be cancelled.
      *
      * @implSpec
-     * The default implementation converts each path to a file and calls
-     * {@link #getJavaFileObjectsFromFiles getJavaObjectsFromFiles}.
+     * The default implementation lazily converts each path to a file and calls
+     * {@link #setLocation setLocation}.
      * {@linkplain IllegalArgumentException IllegalArgumentException}
-     * will be thrown if any of the paths cannot be converted to a file.
+     * will be thrown if any of the paths cannot be converted to a file at
+     * the point the conversion happens.
      *
      * @param location a location
      * @param paths a list of paths, if {@code null} use the default


### PR DESCRIPTION
This improves javadoc/specification of several StandardJavaFileManager methods, as requested in these bugs:
https://bugs.openjdk.java.net/browse/JDK-8266631
https://bugs.openjdk.java.net/browse/JDK-8266596
https://bugs.openjdk.java.net/browse/JDK-8266591
https://bugs.openjdk.java.net/browse/JDK-8266590

The CSR is here:
https://bugs.openjdk.java.net/browse/JDK-8268260

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ The change requires a CSR request to be approved.

### Issues
 * [JDK-8266631](https://bugs.openjdk.java.net/browse/JDK-8266631): StandardJavaFileManager: getJavaFileObjects() impl violates the spec
 * [JDK-8266596](https://bugs.openjdk.java.net/browse/JDK-8266596): StandardJavaFileManager: default impls of setLocationFromPaths(), getJavaFileObjectsFromPaths() methods don't throw IllegalArgumentException as specified
 * [JDK-8266591](https://bugs.openjdk.java.net/browse/JDK-8266591): StandardJavaFileManager::getJavaFileObjectsFromPaths() methods contain a typo in their spec
 * [JDK-8266590](https://bugs.openjdk.java.net/browse/JDK-8266590): StandardJavaFileManager::setLocationFromPaths() spec contains an error


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**) ⚠️ Review applies to eeb976f0d7fb21be3beb1db6aeaf06d010ba50c0


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4360/head:pull/4360` \
`$ git checkout pull/4360`

Update a local copy of the PR: \
`$ git checkout pull/4360` \
`$ git pull https://git.openjdk.java.net/jdk pull/4360/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4360`

View PR using the GUI difftool: \
`$ git pr show -t 4360`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4360.diff">https://git.openjdk.java.net/jdk/pull/4360.diff</a>

</details>
