### PR TITLE
8267972: Inline cache cleaning is not monotonic

### DIFF
--- a/src/hotspot/share/code/compiledIC.cpp
+++ b/src/hotspot/share/code/compiledIC.cpp
@@ -515,7 +515,7 @@ void CompiledIC::compute_monomorphic_entry(const methodHandle& method,
   CompiledMethod* method_code = method->code();
 
   address entry = NULL;
-  if (method_code != NULL && method_code->is_in_use()) {
+  if (method_code != NULL && method_code->is_in_use() && !method_code->is_unloading()) {
     assert(method_code->is_compiled(), "must be compiled");
     // Call to compiled code
     //
@@ -641,7 +641,7 @@ void CompiledStaticCall::set(const StaticCallInfo& info) {
 void CompiledStaticCall::compute_entry(const methodHandle& m, bool caller_is_nmethod, StaticCallInfo& info) {
   CompiledMethod* m_code = m->code();
   info._callee = m;
-  if (m_code != NULL && m_code->is_in_use()) {
+  if (m_code != NULL && m_code->is_in_use() && !m_code->is_unloading()) {
     info._to_interpreter = false;
     info._entry  = m_code->verified_entry_point();
   } else {


### PR DESCRIPTION
When inline cache cleaning of a concurrent code cache unloading cycle happens concurrent to a mutator installing values into an inline cache, the mutator has to be careful not to undo the cleaning performed by a GC thread. Otherwise the GC can clean an inline cache that points at an is_unloading() nmethod, and then the mutator installs a reference back to an is_unloading() nmethod. Then despite the GC having traversed the code cache cleaning up inline caches, we can not be certain that there are no longer inline caches pointing at is_unloading() nmethods.
The fix is relatively simple: when computing the entry for inline caches and static calls, we today check that the target nmethod is_in_use(). We have to check that it is_in_use() && !is_unloading(), to install such code pointers, for completeness.
Testing: tier1-7 tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267972](https://bugs.openjdk.java.net/browse/JDK-8267972): Inline cache cleaning is not monotonic


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4361/head:pull/4361` \
`$ git checkout pull/4361`

Update a local copy of the PR: \
`$ git checkout pull/4361` \
`$ git pull https://git.openjdk.java.net/jdk pull/4361/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4361`

View PR using the GUI difftool: \
`$ git pr show -t 4361`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4361.diff">https://git.openjdk.java.net/jdk/pull/4361.diff</a>

</details>
