### PR TITLE
8262017: C2: assert(n != __null) failed: Bad immediate dominator info.

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2397,25 +2397,6 @@ void PhaseIdealLoop::add_constraint(jlong stride_con, jlong scale_con, Node* off
     //       I > (low_limit-offset)/scale
     //   )
 
-    if (low_limit->get_long() == -max_jint) {
-      // If offset > 0, then low_limit - offset will either
-      // underflow or if offset = 1, a division by -1 will still be
-      // min_int. To avoid these problems, we replace the positive
-      // offset with 0. This is done with an AND:
-      // offset = offset & offset >> 63
-      Node* shift = _igvn.intcon(63);
-      set_ctrl(shift, C->root());
-      Node* sign = new RShiftLNode(offset, shift);
-      register_new_node(sign, pre_ctrl);
-      offset = new AndLNode(offset, sign);
-      register_new_node(offset, pre_ctrl);
-    } else {
-      assert(low_limit->get_long() == 0, "wrong low limit for range check");
-      // The only problem here is when offset == min_int:
-      // 0-min_int == min_int. It may be fine for stride > 0
-      // but for stride < 0, limit will be < original_limit. To avoid it
-      // max(pre_limit, original_limit) is used in do_range_check().
-    }
     *pre_limit = adjust_limit(!is_positive_stride, scale, offset, low_limit, *pre_limit, pre_ctrl, round);
   } else {
     // Negative stride*scale: the affine function is decreasing,
@@ -2445,25 +2426,6 @@ void PhaseIdealLoop::add_constraint(jlong stride_con, jlong scale_con, Node* off
     //     else /* scale > 0 and stride < 0 */
     //       I > (low_limit-(offset+1))/scale
     //   )
-    if (low_limit->get_long() == -max_jint) {
-      // If offset+1 > 0, then low_limit - (offset+1) will either
-      // underflow or if offset = 0, a division by -1 will still be
-      // min_int. To avoid these problems, we replace the positive
-      // "offset+1" (plus_one) with 0. This is done with an AND:
-      // plus_one = "offset+1" & "offset+1" >> 63
-      Node* shift = _igvn.intcon(63);
-      set_ctrl(shift, C->root());
-      Node* sign = new RShiftLNode(plus_one, shift);
-      register_new_node(sign, pre_ctrl);
-      plus_one = new AndLNode(plus_one, sign);
-      register_new_node(plus_one, pre_ctrl);
-    } else {
-      assert(low_limit->get_long() == 0, "wrong low limit for range check");
-      // The only problem here is when offset == max_int:
-      // low_limit - max_int+1 = 0 - min_int = min_int.
-      // But this is fine since the main-loop will either
-      // have less iterations or will be skipped.
-    }
     *main_limit = adjust_limit(is_positive_stride, scale, plus_one, low_limit, *main_limit, pre_ctrl, false);
   }
 }

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2352,6 +2352,7 @@ Node* PhaseIdealLoop::adjust_limit(bool is_positive_stride, Node* scale, Node* o
   } else {
     inner_result_long = MaxNode::signed_min(limit, _igvn.longcon(max_jint), TypeLong::LONG, _igvn);
   }
+  set_subtree_ctrl(inner_result_long, false);
 
   // Outer MINL/MAXL:
   // The comparison is done with long values but the result is the converted back to int by using CmovI.

--- a/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckLimits.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckLimits.java
@@ -24,7 +24,8 @@
 /*
  * @test
  * @bug 8262017
- * @summary Dominator failure because ConvL2I node becomes TOP due to missing case in overflow/underflow handling in range check elimination.
+ * @summary Dominator failure because ConvL2I node becomes TOP due to missing overflow/underflow handling in range check elimination
+ *          in PhaseIdealLoop::add_constraint().
  * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileCommand=compileonly,compiler.rangechecks.TestRangeCheckLimits::*
  *                   compiler.rangechecks.TestRangeCheckLimits
  */
@@ -38,12 +39,15 @@
     static int iFld;
 
     public static void main(String[] k) {
-        test();
-        test2();
+        // Test all cases in PhaseIdealLoop::add_constraint().
+        testPositiveCaseMainLoop();
+        testNegativeCaseMainLoop();
+        testPositiveCasePreLoop();
+        testNegativeCasePreLoop();
     }
-
-    public static void test() {
-        int e, f, g, h[] = new int[a];
+    
+    public static void testPositiveCaseMainLoop() {
+        int e, f, g = 0, h[] = new int[a];
         double i[] = new double[a];
         long j = 9;
         Helper.init(h, 3);
@@ -52,21 +56,50 @@
                 b = e;
             }
             i[1] = b;
-            // In RC: flipped to negative stride*scale
-            for (g = 8; 168 > g; g += 2) {
-                j = g;
-                if (j < 3) {
+            for (g = 8; g < 168; g += 2) {
+                j = g - 5;
+                if (j > Integer.MAX_VALUE - 1) {
+                    switch (3) {
+                        case 3:
+                    }
+                }
+            }
+            
+        }
+        if (g != 168) {
+            throw new RuntimeException("fail");
+        }
+        lFld = j;
+    }
+
+    
+    public static void testPositiveCasePreLoop() {
+        int e, f, g = 0, h[] = new int[a];
+        double i[] = new double[a];
+        long j = 9;
+        Helper.init(h, 3);
+        for (e = 5; e < 154; e++) {
+            for (f = 1; f < 169; f += 2) {
+                b = e;
+            }
+            i[1] = b;
+            for (g = 8; g < 168; g += 2) {
+                j = g + 5;
+                if (j > 180) {
                     switch (3) {
                         case 3:
                     }
                 }
             }
         }
+        if (g != 168) {
+            throw new RuntimeException("fail");
+        }
         lFld = j;
     }
-
-    public static void test2() {
-        int e, f, g, h[] = new int[a];
+    
+    public static void testNegativeCaseMainLoop() {
+        int e, f, g = 0, h[] = new int[a];
         double i[] = new double[a];
         long j = 9;
         Helper.init(h, 3);
@@ -75,15 +108,43 @@
                 b = e;
             }
             i[1] = b;
-            // In RC: flipped to positive stride*scale
-            for (g = 168; 8 < g; g -= 2) {
-                j = g - 1;
-                if (j < 3) {
+            for (g = 8; g < 168; g += 2) {
+                j = g;
+                if (j < 5) {
                     switch (3) {
                         case 3:
                     }
                 }
             }
+        }
+        if (g != 168) {
+            throw new RuntimeException("fail");
+        }
+        lFld = j;
+    }
+    
+    
+    public static void testNegativeCasePreLoop() {
+        int e, f, g = 0, h[] = new int[a];
+        double i[] = new double[a];
+        long j = 9;
+        Helper.init(h, 3);
+        for (e = 5; e < 154; e++) {
+            for (f = 1; f < 169; f += 2) {
+                b = e;
+            }
+            i[1] = b;
+            for (g = 168; g > 8; g -= 2) {
+                j = g - 5;
+                if (j > Integer.MAX_VALUE - 1) {
+                    switch (3) {
+                        case 3:
+                    }
+                }
+            }
+        }
+        if (g != 8) {
+            throw new RuntimeException("fail");
         }
         lFld = j;
     }

--- a/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckLimits.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckLimits.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8262017
+ * @summary Dominator failure because ConvL2I node becomes TOP due to missing case in overflow/underflow handling in range check elimination.
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileCommand=compileonly,compiler.rangechecks.TestRangeCheckLimits::*
+ *                   compiler.rangechecks.TestRangeCheckLimits
+ */
+
+ package compiler.rangechecks;
+
+ public class TestRangeCheckLimits {
+    static int a = 400;
+    static volatile int b;
+    static long lFld;
+    static int iFld;
+
+    public static void main(String[] k) {
+        test();
+    }
+
+    public static void test() {
+        int e, f, g, h[] = new int[a];
+        double i[] = new double[a];
+        long j = 9;
+        Helper.init(h, 3);
+        for (e = 5; e < 154; e++) {
+            for (f = 1; f < 169; f += 2) {
+                b = e;
+            }
+            i[1] = b;
+            for (g = 8; 168 > g; g += 2) {
+                j = g;
+                if (j < 3) {
+                    switch (3) {
+                        case 3:
+                    }
+                }
+            }
+        }
+        lFld = j;
+    }
+}
+
+class Helper {
+    public static void init(int[] a, int seed) {
+        for (int j = 0; j < a.length; j++) {
+            a[j] = (j % 2 == 0) ? seed + j : seed - j;
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckLimits.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckLimits.java
@@ -45,7 +45,7 @@
         testPositiveCasePreLoop();
         testNegativeCasePreLoop();
     }
-    
+
     public static void testPositiveCaseMainLoop() {
         int e, f, g = 0, h[] = new int[a];
         double i[] = new double[a];
@@ -64,7 +64,6 @@
                     }
                 }
             }
-            
         }
         if (g != 168) {
             throw new RuntimeException("fail");
@@ -72,7 +71,7 @@
         lFld = j;
     }
 
-    
+
     public static void testPositiveCasePreLoop() {
         int e, f, g = 0, h[] = new int[a];
         double i[] = new double[a];
@@ -97,7 +96,7 @@
         }
         lFld = j;
     }
-    
+
     public static void testNegativeCaseMainLoop() {
         int e, f, g = 0, h[] = new int[a];
         double i[] = new double[a];
@@ -122,8 +121,8 @@
         }
         lFld = j;
     }
-    
-    
+
+
     public static void testNegativeCasePreLoop() {
         int e, f, g = 0, h[] = new int[a];
         double i[] = new double[a];

--- a/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckLimits.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckLimits.java
@@ -39,6 +39,7 @@
 
     public static void main(String[] k) {
         test();
+        test2();
     }
 
     public static void test() {
@@ -51,8 +52,32 @@
                 b = e;
             }
             i[1] = b;
+            // In RC: flipped to negative stride*scale
             for (g = 8; 168 > g; g += 2) {
                 j = g;
+                if (j < 3) {
+                    switch (3) {
+                        case 3:
+                    }
+                }
+            }
+        }
+        lFld = j;
+    }
+
+    public static void test2() {
+        int e, f, g, h[] = new int[a];
+        double i[] = new double[a];
+        long j = 9;
+        Helper.init(h, 3);
+        for (e = 5; e < 154; e++) {
+            for (f = 1; f < 169; f += 2) {
+                b = e;
+            }
+            i[1] = b;
+            // In RC: flipped to positive stride*scale
+            for (g = 168; 8 < g; g -= 2) {
+                j = g - 1;
                 if (j < 3) {
                     switch (3) {
                         case 3:


### PR DESCRIPTION
The wrong dominance information is caused by a `ConvL2I` node whose input gets a wrong type which is out of the range of the `ConvL2I`. As a consequence, the node becomes top and some data nodes are folded away which eventually results in the dominance assertion failure.

The wrong type information can be traced back to the overflow/underflow handling in range check elimination. Originally, the code in `PhaseIdealLoop::add_constraint()` covered the following special case for the adjustment of the pre loop limit:
https://github.com/openjdk/jdk/blob/cd33abb136d415455090cef4fe6211d9e6940948/src/hotspot/share/opto/loopTransform.cpp#L2423-L2456

This code, however, was removed later by accident:
https://github.com/openjdk/jdk/commit/afd852ccb8f8d36c721963ba68de695ce3e0e23d#diff-6a59f91cb710d682247df87c75faf602f0ff9f87e2855ead1b80719704fbedffL2370-L2394

This was only revealed after enabling more precise type information for phi nodes in [JDK-8257813](https://bugs.openjdk.java.net/browse/JDK-8257813) after which the testcase starts to fail.

The proposed fix is straight forward to reintroduce the wrongly removed code and adapt it to long instead of int.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262017](https://bugs.openjdk.java.net/browse/JDK-8262017): C2: assert(n != __null) failed: Bad immediate dominator info.


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4362/head:pull/4362` \
`$ git checkout pull/4362`

Update a local copy of the PR: \
`$ git checkout pull/4362` \
`$ git pull https://git.openjdk.java.net/jdk pull/4362/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4362`

View PR using the GUI difftool: \
`$ git pr show -t 4362`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4362.diff">https://git.openjdk.java.net/jdk/pull/4362.diff</a>

</details>
