### PR TITLE
8267579: Thread::cooked_allocated_bytes() hits assert(left >= right) failed: avoid underflow

### DIFF
--- a/src/hotspot/share/gc/shared/threadLocalAllocBuffer.cpp
+++ b/src/hotspot/share/gc/shared/threadLocalAllocBuffer.cpp
@@ -31,6 +31,7 @@
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
 #include "oops/oop.inline.hpp"
+#include "runtime/atomic.hpp"
 #include "runtime/perfData.hpp"
 #include "runtime/thread.inline.hpp"
 #include "runtime/threadSMR.hpp"
@@ -472,4 +473,12 @@ void ThreadLocalAllocStats::publish() {
 size_t ThreadLocalAllocBuffer::end_reserve() {
   size_t reserve_size = Universe::heap()->tlab_alloc_reserve();
   return MAX2(reserve_size, (size_t)_reserve_for_allocation_prefetch);
+}
+
+const HeapWord* ThreadLocalAllocBuffer::start_relaxed() const {
+  return Atomic::load(&_start);
+}
+
+const HeapWord* ThreadLocalAllocBuffer::top_relaxed() const {
+  return Atomic::load(&_top);
 }

--- a/src/hotspot/share/gc/shared/threadLocalAllocBuffer.hpp
+++ b/src/hotspot/share/gc/shared/threadLocalAllocBuffer.hpp
@@ -129,6 +129,10 @@ public:
   size_t refill_waste_limit() const              { return _refill_waste_limit; }
   size_t bytes_since_last_sample_point() const   { return _bytes_since_last_sample_point; }
 
+  // For external inspection.
+  const HeapWord* start_relaxed() const;
+  const HeapWord* top_relaxed() const;
+
   // Allocate size HeapWords. The memory is NOT initialized to zero.
   inline HeapWord* allocate(size_t size);
 

--- a/src/hotspot/share/runtime/thread.inline.hpp
+++ b/src/hotspot/share/runtime/thread.inline.hpp
@@ -43,8 +43,8 @@ inline jlong Thread::cooked_allocated_bytes() {
   if (UseTLAB) {
     // These reads are unsynchronized and unordered with the thread updating its tlab pointers.
     // Use only if top > start && used_bytes <= max_tlab_size_bytes.
-    const HeapWord* const top = tlab().top();
-    const HeapWord* const start = tlab().start();
+    const HeapWord* const top = tlab().top_relaxed();
+    const HeapWord* const start = tlab().start_relaxed();
     if (top <= start) {
       return allocated_bytes;
     }

--- a/src/hotspot/share/runtime/thread.inline.hpp
+++ b/src/hotspot/share/runtime/thread.inline.hpp
@@ -41,13 +41,20 @@
 inline jlong Thread::cooked_allocated_bytes() {
   jlong allocated_bytes = Atomic::load_acquire(&_allocated_bytes);
   if (UseTLAB) {
-    size_t used_bytes = tlab().used_bytes();
+    // These reads are unsynchronized and unordered with the thread updating its tlab pointers.
+    // Use only if top > start && used_bytes <= max_tlab_size_bytes.
+    const HeapWord* const top = tlab().top();
+    const HeapWord* const start = tlab().start();
+    if (top <= start) {
+      return allocated_bytes;
+    }
+    const size_t used_bytes = pointer_delta(top, start, 1);
+    // Comparing used_bytes with the maximum allowed size will ensure
+    // that we don't add the used bytes from a semi-initialized TLAB
+    // ending up with incorrect values. There is still a race between
+    // incrementing _allocated_bytes and clearing the TLAB, that might
+    // cause double counting in rare cases.
     if (used_bytes <= ThreadLocalAllocBuffer::max_size_in_bytes()) {
-      // Comparing used_bytes with the maximum allowed size will ensure
-      // that we don't add the used bytes from a semi-initialized TLAB
-      // ending up with incorrect values. There is still a race between
-      // incrementing _allocated_bytes and clearing the TLAB, that might
-      // cause double counting in rare cases.
       return allocated_bytes + used_bytes;
     }
   }

--- a/src/hotspot/share/runtime/thread.inline.hpp
+++ b/src/hotspot/share/runtime/thread.inline.hpp
@@ -49,12 +49,12 @@ inline jlong Thread::cooked_allocated_bytes() {
       return allocated_bytes;
     }
     const size_t used_bytes = pointer_delta(top, start, 1);
-    // Comparing used_bytes with the maximum allowed size will ensure
-    // that we don't add the used bytes from a semi-initialized TLAB
-    // ending up with incorrect values. There is still a race between
-    // incrementing _allocated_bytes and clearing the TLAB, that might
-    // cause double counting in rare cases.
     if (used_bytes <= ThreadLocalAllocBuffer::max_size_in_bytes()) {
+      // Comparing used_bytes with the maximum allowed size will ensure
+      // that we don't add the used bytes from a semi-initialized TLAB
+      // ending up with incorrect values. There is still a race between
+      // incrementing _allocated_bytes and clearing the TLAB, that might
+      // cause double counting in rare cases.
       return allocated_bytes + used_bytes;
     }
   }


### PR DESCRIPTION
This is a workaround to avoid hitting the assert that was recently added to pointer_delta(). 

The implementation of cooked_allocated_bytes() is perhaps questionable, in that it reads tlab pointers optimistically. However, the functionality has been in place for a long time, and the impact of changing its behavior more substantially is unknown at this time, hence this defensive workaround to reduce noise and problems seen in general testing.

Testing: tier1, tier2, tier6, tier8

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267579](https://bugs.openjdk.java.net/browse/JDK-8267579): Thread::cooked_allocated_bytes() hits assert(left >= right) failed: avoid underflow


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4363/head:pull/4363` \
`$ git checkout pull/4363`

Update a local copy of the PR: \
`$ git checkout pull/4363` \
`$ git pull https://git.openjdk.java.net/jdk pull/4363/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4363`

View PR using the GUI difftool: \
`$ git pr show -t 4363`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4363.diff">https://git.openjdk.java.net/jdk/pull/4363.diff</a>

</details>
