### PR TITLE
8268267: Remove -Djavatest.security.noSecurityManager=true from jtreg runs

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -767,7 +767,7 @@ define SetupRunJtregTestBody
       -vmoption:-XX:MaxRAMPercentage=$$($1_JTREG_MAX_RAM_PERCENTAGE) \
       -vmoption:-Djava.io.tmpdir="$$($1_TEST_TMP_DIR)"
 
-  $1_JTREG_BASIC_OPTIONS += -automatic -ignore:quiet -Djavatest.security.noSecurityManager=true
+  $1_JTREG_BASIC_OPTIONS += -automatic -ignore:quiet
 
   # Make it possible to specify the JIB_DATA_DIR for tests using the
   # JIB Artifact resolver

--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -48,9 +48,6 @@ tools/javac/annotations/typeAnnotations/referenceinfos/Lambda.java              
 tools/javac/annotations/typeAnnotations/referenceinfos/NestedTypes.java         8057687    generic-all    emit correct byte code an attributes for type annotations
 tools/javac/warnings/suppress/TypeAnnotations.java                              8057683    generic-all    improve ordering of errors with type annotations
 tools/javac/modules/SourceInSymlinkTest.java                                    8180263    windows-all    fails when run on a subst drive
-tools/javac/processing/options/XprintRepeatingAnnotations.java                  8265611    generic-all    @compile/ref comparison fails when noSecurityManager=true
-tools/javac/processing/options/XprintDocComments.java                           8265611    generic-all    @compile/ref comparison fails when noSecurityManager=true
-tools/javac/processing/model/util/printing/module-info.java                     8265611    generic-all    @compile/ref comparison fails when noSecurityManager=true
 
 ###########################################################################
 #


### PR DESCRIPTION
Now that the default behavior of JDK 17 is still `-Djava.security.manager=allow`, we can remove the `-Djavatest.security.noSecurityManager=true` option from the jtreg command line inside `RunTests.gmk`. Three problem-listed langtools tests can also be liberated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268267](https://bugs.openjdk.java.net/browse/JDK-8268267): Remove -Djavatest.security.noSecurityManager=true from jtreg runs


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4364/head:pull/4364` \
`$ git checkout pull/4364`

Update a local copy of the PR: \
`$ git checkout pull/4364` \
`$ git pull https://git.openjdk.java.net/jdk pull/4364/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4364`

View PR using the GUI difftool: \
`$ git pr show -t 4364`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4364.diff">https://git.openjdk.java.net/jdk/pull/4364.diff</a>

</details>
