### PR TITLE
JDK-8267385 Create NSAccessibilityElement implementation for JavaComp…

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaAccessibilityAction.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaAccessibilityAction.h
@@ -26,6 +26,10 @@
 #import <AppKit/AppKit.h>
 #import <jni.h>
 
+extern NSMutableDictionary *sActions;
+extern NSMutableDictionary *sActionSelectors;
+extern NSMutableArray *sAllActionSelectors;
+void initializeActions();
 
 @protocol JavaAccessibilityAction
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaAccessibilityAction.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaAccessibilityAction.m
@@ -29,6 +29,10 @@
 #import "ThreadUtilities.h"
 #import "JNIUtilities.h"
 
+NSMutableDictionary *sActions = nil;
+NSMutableDictionary *sActionSelectors = nil;
+NSMutableArray *sAllActionSelectors = nil;
+void initializeActions();
 
 @implementation JavaAxAction
 
@@ -148,3 +152,31 @@
 }
 
 @end
+
+void initializeActions() {
+    int actionsCount = 5;
+
+    sActions = [[NSMutableDictionary alloc] initWithCapacity:actionsCount];
+
+    [sActions setObject:NSAccessibilityPressAction forKey:@"click"];
+    [sActions setObject:NSAccessibilityIncrementAction forKey:@"increment"];
+    [sActions setObject:NSAccessibilityDecrementAction forKey:@"decrement"];
+    [sActions setObject:NSAccessibilityShowMenuAction forKey:@"togglePopup"];
+    [sActions setObject:NSAccessibilityPressAction forKey:@"toggleExpand"];
+    
+    sActionSelectors = [[NSMutableDictionary alloc] initWithCapacity:actionsCount];
+
+    [sActionSelectors setObject:NSStringFromSelector(@selector(accessibilityPerformPress)) forKey:NSAccessibilityPressAction];
+    [sActionSelectors setObject:NSStringFromSelector(@selector(accessibilityPerformShowMenu)) forKey:NSAccessibilityShowMenuAction];
+    [sActionSelectors setObject:NSStringFromSelector(@selector(accessibilityPerformDecrement)) forKey:NSAccessibilityDecrementAction];
+    [sActionSelectors setObject:NSStringFromSelector(@selector(accessibilityPerformIncrement)) forKey:NSAccessibilityIncrementAction];
+    [sActionSelectors setObject:NSStringFromSelector(@selector(accessibilityPerformPick)) forKey:NSAccessibilityPickAction];
+
+    sAllActionSelectors = [[NSMutableArray alloc] initWithCapacity:actionsCount];
+
+    [sAllActionSelectors addObject:NSStringFromSelector(@selector(accessibilityPerformPick))];
+    [sAllActionSelectors addObject:NSStringFromSelector(@selector(accessibilityPerformIncrement))];
+    [sAllActionSelectors addObject:NSStringFromSelector(@selector(accessibilityPerformDecrement))];
+    [sAllActionSelectors addObject:NSStringFromSelector(@selector(accessibilityPerformShowMenu))];
+    [sAllActionSelectors addObject:NSStringFromSelector(@selector(accessibilityPerformPress))];
+}

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaAccessibilityUtilities.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaAccessibilityUtilities.h
@@ -60,3 +60,5 @@ void JavaAccessibilitySetAttributeValue(id element, NSString *attribute, id valu
 void JavaAccessibilityRaiseSetAttributeToIllegalTypeException(const char *functionName, id element, NSString *attribute, id value);
 void JavaAccessibilityRaiseUnimplementedAttributeException(const char *functionName, id element, NSString *attribute);
 void JavaAccessibilityRaiseIllegalParameterTypeException(const char *functionName, id element, NSString *attribute, id parameter);
+BOOL ObjectEquals(JNIEnv *env, jobject a, jobject b, jobject component);
+NSNumber* JavaNumberToNSNumber(JNIEnv *env, jobject jnumber);

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
@@ -29,7 +29,6 @@
 // <https://www.ibm.com/able/guidelines/java/snsjavagjfc.html>
 
 #import "JavaComponentAccessibility.h"
-#import "a11y/CommonComponentAccessibility.h"
 #import "sun_lwawt_macosx_CAccessibility.h"
 
 #import <AppKit/AppKit.h>
@@ -44,6 +43,12 @@
 #import "ThreadUtilities.h"
 #import "JNIUtilities.h"
 #import "AWTView.h"
+
+// these constants are duplicated in CAccessibility.java
+#define JAVA_AX_ALL_CHILDREN (-1)
+#define JAVA_AX_SELECTED_CHILDREN (-2)
+#define JAVA_AX_VISIBLE_CHILDREN (-3)
+// If the value is >=0, it's an index
 
 // GET* macros defined in JavaAccessibilityUtilities.h, so they can be shared.
 static jclass sjc_CAccessibility = NULL;
@@ -82,7 +87,7 @@ static jclass sjc_CAccessible = NULL;
 static NSMutableDictionary *sAttributeNamesForRoleCache = nil;
 static NSObject *sAttributeNamesLOCK = nil;
 
-@interface TabGroupAccessibility : JavaComponentAccessibility {
+@interface TabGroupLegacyAccessibility : JavaComponentAccessibility {
     NSInteger _numTabs;
 }
 
@@ -362,21 +367,18 @@ static NSObject *sAttributeNamesLOCK = nil;
 
     // otherwise, create a new instance
     JavaComponentAccessibility *newChild = nil;
-    newChild = [CommonComponentAccessibility getComponentAccessibility:javaRole];
-    if (newChild == nil) {
-        if ([javaRole isEqualToString:@"pagetablist"]) {
-            newChild = [TabGroupAccessibility alloc];
-        } else if ([javaRole isEqualToString:@"table"]) {
-            newChild = [TableAccessibility alloc];
+    if ([javaRole isEqualToString:@"pagetablist"]) {
+        newChild = [TabGroupLegacyAccessibility alloc];
+    } else if ([javaRole isEqualToString:@"table"]) {
+        newChild = [TableAccessibility alloc];
+    } else {
+        NSString *nsRole = [sRoles objectForKey:javaRole];
+        if ([nsRole isEqualToString:NSAccessibilityStaticTextRole] ||
+            [nsRole isEqualToString:NSAccessibilityTextAreaRole] ||
+            [nsRole isEqualToString:NSAccessibilityTextFieldRole]) {
+            newChild = [JavaTextAccessibility alloc];
         } else {
-            NSString *nsRole = [sRoles objectForKey:javaRole];
-            if ([nsRole isEqualToString:NSAccessibilityStaticTextRole] ||
-                [nsRole isEqualToString:NSAccessibilityTextAreaRole] ||
-                [nsRole isEqualToString:NSAccessibilityTextFieldRole]) {
-                newChild = [JavaTextAccessibility alloc];
-            } else {
-                newChild = [JavaComponentAccessibility alloc];
-            }
+            newChild = [JavaComponentAccessibility alloc];
         }
     }
 
@@ -387,7 +389,7 @@ static NSObject *sAttributeNamesLOCK = nil;
     // This is the only way to know if the menu is opening; visible state change
     // can't be caught because the listeners are not set up in time.
     if ( [javaRole isEqualToString:@"popupmenu"] &&
-         ![[parent javaRole] isEqualToString:@"combobox"] ) {
+        ![[parent javaRole] isEqualToString:@"combobox"] ) {
         [newChild postMenuOpened];
     }
 
@@ -902,32 +904,6 @@ static NSObject *sAttributeNamesLOCK = nil;
         index = [fParent accessibilityIndexOfChild:self];
     }
     return index;
-}
-
-/*
- * The java/lang/Number concrete class could be for any of the Java primitive
- * numerical types or some other subclass.
- * All existing A11Y code uses Integer so that is what we look for first
- * But all must be able to return a double and NSNumber accepts a double,
- * so that's the fall back.
- */
-static NSNumber* JavaNumberToNSNumber(JNIEnv *env, jobject jnumber) {
-    if (jnumber == NULL) {
-        return nil;
-    }
-    DECLARE_CLASS_RETURN(jnumber_Class, "java/lang/Number", nil);
-    DECLARE_CLASS_RETURN(jinteger_Class, "java/lang/Integer", nil);
-    DECLARE_METHOD_RETURN(jm_intValue, jnumber_Class, "intValue", "()I", nil);
-    DECLARE_METHOD_RETURN(jm_doubleValue, jnumber_Class, "doubleValue", "()D", nil);
-    if ((*env)->IsInstanceOf(env, jnumber, jinteger_Class)) {
-        jint i = (*env)->CallIntMethod(env, jnumber, jm_intValue);
-        CHECK_EXCEPTION();
-        return [NSNumber numberWithInteger:i];
-    } else {
-        jdouble d = (*env)->CallDoubleMethod(env, jnumber, jm_doubleValue);
-        CHECK_EXCEPTION();
-        return [NSNumber numberWithDouble:d];
-    }
 }
 
 // Element's maximum value (id)
@@ -1600,7 +1576,7 @@ JNI_COCOA_ENTER(env);
 JNI_COCOA_EXIT(env);
 }
 
-@implementation TabGroupAccessibility
+@implementation TabGroupLegacyAccessibility
 
 - (id)initWithParent:(NSObject *)parent withEnv:(JNIEnv *)env withAccessible:(jobject)accessible withIndex:(jint)index withView:(NSView *)view withJavaRole:(NSString *)javaRole
 {
@@ -1802,9 +1778,6 @@ JNI_COCOA_EXIT(env);
 
 @end
 
-
-static BOOL ObjectEquals(JNIEnv *env, jobject a, jobject b, jobject component);
-
 @implementation TabGroupControlAccessibility
 
 - (id)initWithParent:(NSObject *)parent withEnv:(JNIEnv *)env withAccessible:(jobject)accessible withIndex:(jint)index withTabGroup:(jobject)tabGroup withView:(NSView *)view withJavaRole:(NSString *)javaRole
@@ -1907,30 +1880,3 @@ static BOOL ObjectEquals(JNIEnv *env, jobject a, jobject b, jobject component);
     return [self getTableInfo:JAVA_AX_COLS];
 }
 @end
-
-/*
- * Returns Object.equals for the two items
- * This may use LWCToolkit.invokeAndWait(); don't call while holding fLock
- * and try to pass a component so the event happens on the correct thread.
- */
-static BOOL ObjectEquals(JNIEnv *env, jobject a, jobject b, jobject component)
-{
-    DECLARE_CLASS_RETURN(sjc_Object, "java/lang/Object", NO);
-    DECLARE_METHOD_RETURN(jm_equals, sjc_Object, "equals", "(Ljava/lang/Object;)Z", NO);
-
-    if ((a == NULL) && (b == NULL)) return YES;
-    if ((a == NULL) || (b == NULL)) return NO;
-
-    if (pthread_main_np() != 0) {
-        // If we are on the AppKit thread
-        DECLARE_CLASS_RETURN(sjc_LWCToolkit, "sun/lwawt/macosx/LWCToolkit", NO);
-        DECLARE_STATIC_METHOD_RETURN(jm_doEquals, sjc_LWCToolkit, "doEquals",
-                                     "(Ljava/lang/Object;Ljava/lang/Object;Ljava/awt/Component;)Z", NO);
-        return (*env)->CallStaticBooleanMethod(env, sjc_LWCToolkit, jm_doEquals, a, b, component);
-        CHECK_EXCEPTION();
-    }
-
-    jboolean jb = (*env)->CallBooleanMethod(env, a, jm_equals, b);
-    CHECK_EXCEPTION();
-    return jb;
-}

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ButtonAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ButtonAccessibility.m
@@ -36,12 +36,22 @@
 
 - (NSString * _Nullable)accessibilityLabel
 {
-    return [self accessibilityTitleAttribute];
+    return [super accessibilityLabel];
 }
 
 - (BOOL)accessibilityPerformPress
 {
     return [self performAccessibleAction:0];
+}
+
+- (NSRect)accessibilityFrame
+{
+    return [super accessibilityFrame];
+}
+
+- (id)accessibilityParent
+{
+    return [super accessibilityParent];
 }
 
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CheckboxAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CheckboxAccessibility.m
@@ -39,7 +39,7 @@
 - (id _Nonnull) accessibilityValue
 {
     AWT_ASSERT_APPKIT_THREAD;
-    return [self accessibilityValueAttribute];
+    return [super accessibilityValue];
 }
 
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.h
@@ -26,7 +26,9 @@
 #ifndef JAVA_COMPONENT_ACCESSIBILITY
 #define JAVA_COMPONENT_ACCESSIBILITY
 
-#import "JavaComponentAccessibility.h"
+#include "jni.h"
+
+#import <AppKit/AppKit.h>
 #import "JavaAccessibilityUtilities.h"
 
 // these constants are duplicated in CAccessibility.java
@@ -35,14 +37,65 @@
 #define JAVA_AX_VISIBLE_CHILDREN (-3)
 // If the value is >=0, it's an index
 
-@interface CommonComponentAccessibility : JavaComponentAccessibility <NSAccessibilityElement> {
+@interface CommonComponentAccessibility : NSAccessibilityElement {
+    NSView *fView;
+    NSObject *fParent;
 
+    NSString *fNSRole;
+    NSString *fJavaRole;
+
+    jint fIndex;
+    jobject fAccessible;
+    jobject fComponent;
+
+    NSMutableDictionary *fActions;
+    NSMutableArray *fActionSelectors;
+    NSObject *fActionsLOCK;
 }
+
+@property(nonnull, readonly) NSArray *actionSelectors;
+
+- (id _Nonnull)initWithParent:(NSObject* _Nonnull)parent withEnv:(JNIEnv _Nonnull * _Nonnull)env withAccessible:(jobject _Nullable)accessible withIndex:(jint)index withView:(NSView* _Nonnull)view withJavaRole:(NSString* _Nullable)javaRole;
+- (void)unregisterFromCocoaAXSystem;
+- (void)postValueChanged;
+- (void)postSelectedTextChanged;
+- (void)postSelectionChanged;
+- (void)postTitleChanged;
+- (BOOL)isEqual:(nonnull id)anObject;
+- (BOOL)isAccessibleWithEnv:(JNIEnv _Nonnull * _Nonnull)env forAccessible:(nonnull jobject)accessible;
+
++ (void)postFocusChanged:(nullable id)message;
+
 + (void) initializeRolesMap;
-+ (JavaComponentAccessibility * _Nullable) getComponentAccessibility:(NSString * _Nonnull)role;
+
++ (CommonComponentAccessibility* _Nullable) getComponentAccessibility:(NSString* _Nonnull)role;
+
++ (NSArray* _Nullable)childrenOfParent:(CommonComponentAccessibility* _Nonnull)parent withEnv:(JNIEnv _Nonnull * _Nonnull)env withChildrenCode:(NSInteger)whichChildren allowIgnored:(BOOL)allowIgnored;
++ (CommonComponentAccessibility* _Nullable) createWithParent:(CommonComponentAccessibility* _Nullable)parent accessible:(jobject _Nonnull)jaccessible role:(NSString* _Nonnull)javaRole index:(jint)index withEnv:(JNIEnv _Nonnull * _Nonnull)env withView:(NSView* _Nonnull)view;
++ (CommonComponentAccessibility* _Nullable) createWithAccessible:(jobject _Nonnull)jaccessible role:(NSString* _Nonnull)role index:(jint)index withEnv:(JNIEnv _Nonnull * _Nonnull)env withView:(NSView* _Nonnull)view;
++ (CommonComponentAccessibility* _Nullable) createWithAccessible:(jobject _Nonnull)jaccessible withEnv:(JNIEnv _Nonnull * _Nonnull)env withView:(NSView* _Nonnull)view;
+
+- (jobject _Nullable)axContextWithEnv:(JNIEnv _Nonnull * _Nonnull)env;
+- (NSView* _Nonnull)view;
+- (NSWindow* _Nonnull)window;
+- (id _Nonnull)parent;
+- (NSString* _Nonnull)javaRole;
+
+- (BOOL)isMenu;
+- (BOOL)isSelected:(JNIEnv _Nonnull * _Nonnull)env;
+- (BOOL)isSelectable:(JNIEnv _Nonnull * _Nonnull)env;
+- (BOOL)isVisible:(JNIEnv _Nonnull * _Nonnull)env;
+
+- (NSArray* _Nullable)accessibleChildrenWithChildCode:(NSInteger)childCode;
+
+- (NSDictionary* _Nullable)getActions:(JNIEnv _Nonnull * _Nonnull)env;
+- (void)getActionsWithEnv:(JNIEnv _Nonnull * _Nonnull)env;
+- (BOOL)accessiblePerformAction:(NSAccessibilityActionName _Nonnull)actionName;
+
+- (BOOL)performAccessibleAction:(int)index;
+
 - (NSRect)accessibilityFrame;
 - (id _Nullable)accessibilityParent;
-- (BOOL)performAccessibleAction:(int)index;
 - (BOOL)isAccessibilityElement;
 @end
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -24,16 +24,45 @@
  */
 
 #import "CommonComponentAccessibility.h"
-#import "JNIUtilities.h"
+#import <AppKit/AppKit.h>
+#import <JavaRuntimeSupport/JavaRuntimeSupport.h>
+#import <dlfcn.h>
+#import "JavaAccessibilityAction.h"
+#import "JavaAccessibilityUtilities.h"
 #import "ThreadUtilities.h"
+#import "JNIUtilities.h"
+#import "AWTView.h"
 
+// GET* macros defined in JavaAccessibilityUtilities.h, so they can be shared.
 static jclass sjc_CAccessibility = NULL;
-static jmethodID sjm_getAccessibleComponent = NULL;
 
+static jmethodID sjm_getAccessibleName = NULL;
+#define GET_ACCESSIBLENAME_METHOD_RETURN(ret) \
+    GET_CACCESSIBILITY_CLASS_RETURN(ret); \
+    GET_STATIC_METHOD_RETURN(sjm_getAccessibleName, sjc_CAccessibility, "getAccessibleName", \
+                     "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/String;", ret);
+
+static jmethodID jm_getChildrenAndRoles = NULL;
+#define GET_CHILDRENANDROLES_METHOD_RETURN(ret) \
+    GET_CACCESSIBILITY_CLASS_RETURN(ret); \
+    GET_STATIC_METHOD_RETURN(jm_getChildrenAndRoles, sjc_CAccessibility, "getChildrenAndRoles",\
+                      "(Ljavax/accessibility/Accessible;Ljava/awt/Component;IZ)[Ljava/lang/Object;", ret);
+
+static jmethodID sjm_getAccessibleComponent = NULL;
 #define GET_ACCESSIBLECOMPONENT_STATIC_METHOD_RETURN(ret) \
     GET_CACCESSIBILITY_CLASS_RETURN(ret); \
     GET_STATIC_METHOD_RETURN(sjm_getAccessibleComponent, sjc_CAccessibility, "getAccessibleComponent", \
            "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/AccessibleComponent;", ret);
+
+static jmethodID sjm_getAccessibleIndexInParent = NULL;
+#define GET_ACCESSIBLEINDEXINPARENT_STATIC_METHOD_RETURN(ret) \
+    GET_CACCESSIBILITY_CLASS_RETURN(ret); \
+    GET_STATIC_METHOD_RETURN(sjm_getAccessibleIndexInParent, sjc_CAccessibility, "getAccessibleIndexInParent", \
+                             "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)I", ret);
+
+static jclass sjc_CAccessible = NULL;
+#define GET_CACCESSIBLE_CLASS_RETURN(ret) \
+    GET_CLASS_RETURN(sjc_CAccessible, "sun/lwawt/macosx/CAccessible", ret);
 
 static NSMutableDictionary * _Nullable rolesMap;
 NSString *const IgnoreClassName = @"IgnoreAccessibility";
@@ -43,6 +72,41 @@ static jobject sAccessibilityClass = NULL;
  * Common ancestor for all the accessibility peers that implements the new method-based accessibility API
  */
 @implementation CommonComponentAccessibility
+
+- (BOOL)isMenu
+{
+    id role = [self accessibilityRole];
+    return [role isEqualToString:NSAccessibilityMenuBarRole] || [role isEqualToString:NSAccessibilityMenuRole] || [role isEqualToString:NSAccessibilityMenuItemRole];
+}
+
+- (BOOL)isSelected:(JNIEnv *)env
+{
+    if (fIndex == -1) {
+        return NO;
+    }
+
+    return isChildSelected(env, ((CommonComponentAccessibility *)[self parent])->fAccessible, fIndex, fComponent);
+}
+
+- (BOOL)isSelectable:(JNIEnv *)env
+{
+    jobject axContext = [self axContextWithEnv:env];
+    BOOL selectable = isSelectable(env, axContext, fComponent);
+    (*env)->DeleteLocalRef(env, axContext);
+    return selectable;
+}
+
+- (BOOL)isVisible:(JNIEnv *)env
+{
+    if (fIndex == -1) {
+        return NO;
+    }
+
+    jobject axContext = [self axContextWithEnv:env];
+    BOOL showing = isShowing(env, axContext, fComponent);
+    (*env)->DeleteLocalRef(env, axContext);
+    return showing;
+}
 
 + (void) initializeRolesMap {
     /*
@@ -131,7 +195,7 @@ static jobject sAccessibilityClass = NULL;
  * If new implementation of the accessible component peer for the given role exists
  * return the allocated class otherwise return nil to let old implementation being initialized
  */
-+ (JavaComponentAccessibility *) getComponentAccessibility:(NSString *)role
++ (CommonComponentAccessibility *) getComponentAccessibility:(NSString *)role
 {
     AWT_ASSERT_APPKIT_THREAD;
     if (rolesMap == nil) {
@@ -142,10 +206,468 @@ static jobject sAccessibilityClass = NULL;
     if (className != nil) {
         return [NSClassFromString(className) alloc];
     }
-    return nil;
+    return [CommonComponentAccessibility alloc];
+}
+
+- (id)initWithParent:(NSObject *)parent withEnv:(JNIEnv *)env withAccessible:(jobject)accessible withIndex:(jint)index withView:(NSView *)view withJavaRole:(NSString *)javaRole
+{
+    self = [super init];
+    if (self)
+    {
+        fParent = [parent retain];
+        fView = [view retain];
+        fJavaRole = [javaRole retain];
+
+        fAccessible = (*env)->NewWeakGlobalRef(env, accessible);
+        (*env)->ExceptionClear(env); // in case of OOME
+        jobject jcomponent = [(AWTView *)fView awtComponent:env];
+        fComponent = (*env)->NewWeakGlobalRef(env, jcomponent);
+        (*env)->DeleteLocalRef(env, jcomponent);
+
+        fIndex = index;
+
+        fActions = nil;
+        fActionSelectors = nil;
+        fActionsLOCK = [[NSObject alloc] init];
+    }
+    return self;
+}
+
+- (void)unregisterFromCocoaAXSystem
+{
+    AWT_ASSERT_APPKIT_THREAD;
+    static dispatch_once_t initialize_unregisterUniqueId_once;
+    static void (*unregisterUniqueId)(id);
+    dispatch_once(&initialize_unregisterUniqueId_once, ^{
+        void *jrsFwk = dlopen("/System/Library/Frameworks/JavaVM.framework/Frameworks/JavaRuntimeSupport.framework/JavaRuntimeSupport", RTLD_LAZY | RTLD_LOCAL);
+        unregisterUniqueId = dlsym(jrsFwk, "JRSAccessibilityUnregisterUniqueIdForUIElement");
+    });
+    if (unregisterUniqueId) unregisterUniqueId(self);
+}
+
+- (void)dealloc
+{
+    [self unregisterFromCocoaAXSystem];
+
+    JNIEnv *env = [ThreadUtilities getJNIEnvUncached];
+
+    (*env)->DeleteWeakGlobalRef(env, fAccessible);
+    fAccessible = NULL;
+
+    (*env)->DeleteWeakGlobalRef(env, fComponent);
+    fComponent = NULL;
+
+    [fParent release];
+    fParent = nil;
+
+    [fNSRole release];
+    fNSRole = nil;
+
+    [fJavaRole release];
+    fJavaRole = nil;
+
+    [fView release];
+    fView = nil;
+
+    [fActions release];
+    fActions = nil;
+
+    [fActionsLOCK release];
+    fActionsLOCK = nil;
+
+    [fActionSelectors release];
+    fActionSelectors = nil;
+
+    [super dealloc];
+}
+
+- (void)postValueChanged
+{
+    AWT_ASSERT_APPKIT_THREAD;
+    NSAccessibilityPostNotification(self, NSAccessibilityValueChangedNotification);
+}
+
+- (void)postSelectedTextChanged
+{
+    AWT_ASSERT_APPKIT_THREAD;
+    NSAccessibilityPostNotification(self, NSAccessibilitySelectedTextChangedNotification);
+}
+
+- (void)postSelectionChanged
+{
+    AWT_ASSERT_APPKIT_THREAD;
+    NSAccessibilityPostNotification(self, NSAccessibilitySelectedChildrenChangedNotification);
+}
+
+-(void)postTitleChanged
+{
+    AWT_ASSERT_APPKIT_THREAD;
+    NSAccessibilityPostNotification(self, NSAccessibilityTitleChangedNotification);
+}
+
+- (void)postMenuOpened
+{
+    AWT_ASSERT_APPKIT_THREAD;
+    NSAccessibilityPostNotification(self, (NSString *)kAXMenuOpenedNotification);
+}
+
+- (void)postMenuClosed
+{
+    AWT_ASSERT_APPKIT_THREAD;
+    NSAccessibilityPostNotification(self, (NSString *)kAXMenuClosedNotification);
+}
+
+- (void)postMenuItemSelected
+{
+    AWT_ASSERT_APPKIT_THREAD;
+    NSAccessibilityPostNotification(self, (NSString *)kAXMenuItemSelectedNotification);
+}
+
+- (BOOL)isEqual:(id)anObject
+{
+    if (![anObject isKindOfClass:[self class]]) return NO;
+    CommonComponentAccessibility *accessibility = (CommonComponentAccessibility *)anObject;
+
+    JNIEnv* env = [ThreadUtilities getJNIEnv];
+    return (*env)->IsSameObject(env, accessibility->fAccessible, fAccessible);
+}
+
+- (BOOL)isAccessibleWithEnv:(JNIEnv *)env forAccessible:(jobject)accessible
+{
+    return (*env)->IsSameObject(env, fAccessible, accessible);
+}
+
++ (void)initialize
+{
+    if (sRoles == nil) {
+        initializeRoles();
+    }
+    if (sActions == nil) {
+        initializeActions();
+    }
+}
+
++ (void)postFocusChanged:(id)message
+{
+    AWT_ASSERT_APPKIT_THREAD;
+    NSAccessibilityPostNotification([NSApp accessibilityFocusedUIElement], NSAccessibilityFocusedUIElementChangedNotification);
+}
+
++ (jobject) getCAccessible:(jobject)jaccessible withEnv:(JNIEnv *)env {
+    DECLARE_CLASS_RETURN(sjc_Accessible, "javax/accessibility/Accessible", NULL);
+    GET_CACCESSIBLE_CLASS_RETURN(NULL);
+    DECLARE_STATIC_METHOD_RETURN(sjm_getCAccessible, sjc_CAccessible, "getCAccessible",
+                                "(Ljavax/accessibility/Accessible;)Lsun/lwawt/macosx/CAccessible;", NULL);
+    if ((*env)->IsInstanceOf(env, jaccessible, sjc_CAccessible)) {
+        return jaccessible;
+    } else if ((*env)->IsInstanceOf(env, jaccessible, sjc_Accessible)) {
+        jobject o = (*env)->CallStaticObjectMethod(env, sjc_CAccessible,  sjm_getCAccessible, jaccessible);
+        CHECK_EXCEPTION();
+        return o;
+    }
+    return NULL;
+}
+
++ (NSArray *)childrenOfParent:(CommonComponentAccessibility *)parent withEnv:(JNIEnv *)env withChildrenCode:(NSInteger)whichChildren allowIgnored:(BOOL)allowIgnored
+{
+    if (parent->fAccessible == NULL) return nil;
+    GET_CHILDRENANDROLES_METHOD_RETURN(nil);
+    jobjectArray jchildrenAndRoles = (jobjectArray)(*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getChildrenAndRoles,
+                  parent->fAccessible, parent->fComponent, whichChildren, allowIgnored);
+    CHECK_EXCEPTION();
+    if (jchildrenAndRoles == NULL) return nil;
+
+    jsize arrayLen = (*env)->GetArrayLength(env, jchildrenAndRoles);
+    NSMutableArray *children = [NSMutableArray arrayWithCapacity:arrayLen/2]; //childrenAndRoles array contains two elements (child, role) for each child
+
+    NSInteger i;
+    NSUInteger childIndex = (whichChildren >= 0) ? whichChildren : 0; // if we're getting one particular child, make sure to set its index correctly
+    for(i = 0; i < arrayLen; i+=2)
+    {
+        jobject /* Accessible */ jchild = (*env)->GetObjectArrayElement(env, jchildrenAndRoles, i);
+        jobject /* String */ jchildJavaRole = (*env)->GetObjectArrayElement(env, jchildrenAndRoles, i+1);
+
+        NSString *childJavaRole = nil;
+        if (jchildJavaRole != NULL) {
+            DECLARE_CLASS_RETURN(sjc_AccessibleRole, "javax/accessibility/AccessibleRole", nil);
+            DECLARE_FIELD_RETURN(sjf_key, sjc_AccessibleRole, "key", "Ljava/lang/String;", nil);
+            jobject jkey = (*env)->GetObjectField(env, jchildJavaRole, sjf_key);
+            CHECK_EXCEPTION();
+            childJavaRole = JavaStringToNSString(env, jkey);
+            (*env)->DeleteLocalRef(env, jkey);
+        }
+
+        CommonComponentAccessibility *child = [self createWithParent:parent accessible:jchild role:childJavaRole index:childIndex withEnv:env withView:parent->fView];
+
+        (*env)->DeleteLocalRef(env, jchild);
+        (*env)->DeleteLocalRef(env, jchildJavaRole);
+
+        [children addObject:child];
+        childIndex++;
+    }
+    (*env)->DeleteLocalRef(env, jchildrenAndRoles);
+
+    return children;
+}
+
++ (CommonComponentAccessibility *) createWithAccessible:(jobject)jaccessible withEnv:(JNIEnv *)env withView:(NSView *)view
+{
+    GET_ACCESSIBLEINDEXINPARENT_STATIC_METHOD_RETURN(nil);
+    CommonComponentAccessibility *ret = nil;
+    jobject jcomponent = [(AWTView *)view awtComponent:env];
+    jint index = (*env)->CallStaticIntMethod(env, sjc_CAccessibility, sjm_getAccessibleIndexInParent, jaccessible, jcomponent);
+    CHECK_EXCEPTION();
+    if (index >= 0) {
+      NSString *javaRole = getJavaRole(env, jaccessible, jcomponent);
+      ret = [self createWithAccessible:jaccessible role:javaRole index:index withEnv:env withView:view];
+    }
+    (*env)->DeleteLocalRef(env, jcomponent);
+    return ret;
+}
+
++ (CommonComponentAccessibility *) createWithAccessible:(jobject)jaccessible role:(NSString *)javaRole index:(jint)index withEnv:(JNIEnv *)env withView:(NSView *)view
+{
+    return [self createWithParent:nil accessible:jaccessible role:javaRole index:index withEnv:env withView:view];
+}
+
++ (CommonComponentAccessibility *) createWithParent:(CommonComponentAccessibility *)parent accessible:(jobject)jaccessible role:(NSString *)javaRole index:(jint)index withEnv:(JNIEnv *)env withView:(NSView *)view
+{
+    GET_CACCESSIBLE_CLASS_RETURN(NULL);
+    DECLARE_FIELD_RETURN(jf_ptr, sjc_CAccessible, "ptr", "J", NULL);
+    // try to fetch the jCAX from Java, and return autoreleased
+    jobject jCAX = [CommonComponentAccessibility getCAccessible:jaccessible withEnv:env];
+    if (jCAX == NULL) return nil;
+    CommonComponentAccessibility *value = (CommonComponentAccessibility *) jlong_to_ptr((*env)->GetLongField(env, jCAX, jf_ptr));
+    if (value != nil) {
+        (*env)->DeleteLocalRef(env, jCAX);
+        return [[value retain] autorelease];
+    }
+
+    // otherwise, create a new instance
+    CommonComponentAccessibility *newChild = [CommonComponentAccessibility getComponentAccessibility:javaRole];;
+
+    // must init freshly -alloc'd object
+    [newChild initWithParent:parent withEnv:env withAccessible:jCAX withIndex:index withView:view withJavaRole:javaRole]; // must init new instance
+
+    // If creating a JPopupMenu (not a combobox popup list) need to fire menuOpened.
+    // This is the only way to know if the menu is opening; visible state change
+    // can't be caught because the listeners are not set up in time.
+    if ( [javaRole isEqualToString:@"popupmenu"] &&
+         ![[parent javaRole] isEqualToString:@"combobox"] ) {
+        [newChild postMenuOpened];
+    }
+
+    // must hard retain pointer poked into Java object
+    [newChild retain];
+    (*env)->SetLongField(env, jCAX, jf_ptr, ptr_to_jlong(newChild));
+    (*env)->DeleteLocalRef(env, jCAX);
+
+    // return autoreleased instance
+    return [newChild autorelease];
+}
+
+- (NSDictionary *)getActions:(JNIEnv *)env
+{
+    @synchronized(fActionsLOCK) {
+        if (fActions == nil) {
+            [self getActionsWithEnv:env];
+        }
+    }
+
+    return fActions;
+}
+
+- (void)getActionsWithEnv:(JNIEnv *)env
+{
+    GET_CACCESSIBILITY_CLASS();
+    DECLARE_STATIC_METHOD(jm_getAccessibleAction, sjc_CAccessibility, "getAccessibleAction",
+                           "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/AccessibleAction;");
+
+    jobject axAction = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getAccessibleAction, fAccessible, fComponent);
+    CHECK_EXCEPTION();
+    if (axAction != NULL) {
+        jclass jc_AccessibleAction = NULL;
+        GET_CLASS(jc_AccessibleAction, "javax/accessibility/AccessibleAction");
+        jmethodID jm_getAccessibleActionCount = NULL;
+        GET_METHOD(jm_getAccessibleActionCount, jc_AccessibleAction, "getAccessibleActionCount", "()I");
+        jint count = (*env)->CallIntMethod(env, axAction, jm_getAccessibleActionCount);
+        fActions = [[NSMutableDictionary alloc] initWithCapacity:count];
+        fActionSelectors = [[NSMutableArray alloc] initWithCapacity:count];
+        for (int i =0; i < count; i++) {
+            JavaAxAction *action = [[JavaAxAction alloc] initWithEnv:env withAccessibleAction:axAction withIndex:i withComponent:fComponent];
+            if ([fParent isKindOfClass:[CommonComponentAccessibility class]] &&
+                [(CommonComponentAccessibility *)fParent isMenu] &&
+                [[sActions objectForKey:[action getDescription]] isEqualToString:NSAccessibilityPressAction]) {
+                [fActions setObject:action forKey:NSAccessibilityPickAction];
+                [fActionSelectors addObject:[sActionSelectors objectForKey:NSAccessibilityPickAction]];
+            } else {
+                [fActions setObject:action forKey:[sActions objectForKey:[action getDescription]]];
+                [fActionSelectors addObject:[sActionSelectors objectForKey:[sActions objectForKey:[action getDescription]]]];
+            }
+            [action release];
+        }
+        (*env)->DeleteLocalRef(env, axAction);
+    }
+}
+
+- (BOOL)accessiblePerformAction:(NSAccessibilityActionName)actionName {
+    NSMutableDictionary *currentAction = [self getActions:[ThreadUtilities getJNIEnv]];
+    if (currentAction == nil) {
+        return NO;
+    }
+    if ([[currentAction allKeys] containsObject:actionName]) {
+        [(JavaAxAction *)[currentAction objectForKey:actionName] perform];
+        return YES;;
+    }
+    return NO;
+}
+
+- (NSArray *)actionSelectors {
+    @synchronized(fActionsLOCK) {
+        if (fActionSelectors == nil) {
+            [self getActionsWithEnv:[ThreadUtilities getJNIEnv]];
+        }
+    }
+
+    return [NSArray arrayWithArray:fActionSelectors];
+}
+
+- (NSArray *)accessibleChildrenWithChildCode:(NSInteger)childCode
+{
+    JNIEnv* env = [ThreadUtilities getJNIEnv];
+    NSArray *children = [CommonComponentAccessibility childrenOfParent:self
+                                                    withEnv:env
+                                                    withChildrenCode:childCode
+                                                    allowIgnored:NO];
+
+    NSArray *value = nil;
+    if ([children count] > 0) {
+        value = children;
+    }
+
+    return value;
+}
+
+- (NSView *)view
+{
+    return fView;
+}
+
+- (NSWindow *)window
+{
+    return [[self view] window];
+}
+
+- (id)parent
+{
+    if(fParent == nil) {
+        JNIEnv* env = [ThreadUtilities getJNIEnv];
+        GET_CACCESSIBILITY_CLASS_RETURN(nil);
+        DECLARE_STATIC_METHOD_RETURN(sjm_getAccessibleParent, sjc_CAccessibility, "getAccessibleParent",
+                                 "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/Accessible;", nil);
+        GET_CACCESSIBLE_CLASS_RETURN(nil);
+        DECLARE_STATIC_METHOD_RETURN(sjm_getSwingAccessible, sjc_CAccessible, "getSwingAccessible",
+                                 "(Ljavax/accessibility/Accessible;)Ljavax/accessibility/Accessible;", nil);
+        DECLARE_CLASS_RETURN(sjc_Window, "java/awt/Window", nil);
+
+        jobject jparent = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility,  sjm_getAccessibleParent, fAccessible, fComponent);
+        CHECK_EXCEPTION();
+
+        if (jparent == NULL) {
+            fParent = fView;
+        } else {
+            AWTView *view = fView;
+            jobject jax = (*env)->CallStaticObjectMethod(env, sjc_CAccessible, sjm_getSwingAccessible, fAccessible);
+            CHECK_EXCEPTION();
+
+            if ((*env)->IsInstanceOf(env, jax, sjc_Window)) {
+                // In this case jparent is an owner toplevel and we should retrieve its own view
+                view = [AWTView awtView:env ofAccessible:jparent];
+            }
+            if (view != nil) {
+                fParent = [CommonComponentAccessibility createWithAccessible:jparent withEnv:env withView:view];
+            }
+            if (fParent == nil) {
+                fParent = fView;
+            }
+            (*env)->DeleteLocalRef(env, jparent);
+            (*env)->DeleteLocalRef(env, jax );
+        }
+        [fParent retain];
+    }
+    return fParent;
+}
+
+- (NSString *)javaRole
+{
+    if(fJavaRole == nil) {
+        JNIEnv* env = [ThreadUtilities getJNIEnv];
+        fJavaRole = getJavaRole(env, fAccessible, fComponent);
+        [fJavaRole retain];
+    }
+    return fJavaRole;
+}
+
+- (jobject)axContextWithEnv:(JNIEnv *)env
+{
+    return getAxContext(env, fAccessible, fComponent);
 }
 
 // NSAccessibilityElement protocol implementation
+
+- (BOOL)isAccessibilityElement
+{
+    return ![[self accessibilityRole] isEqualToString:JavaAccessibilityIgnore];
+}
+
+- (NSString *)accessibilityLabel
+{
+    JNIEnv* env = [ThreadUtilities getJNIEnv];
+
+    GET_ACCESSIBLENAME_METHOD_RETURN(nil);
+    jobject val = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, sjm_getAccessibleName, fAccessible, fComponent);
+    CHECK_EXCEPTION();
+    if (val == NULL) {
+        return nil;
+    }
+    NSString* str = JavaStringToNSString(env, val);
+    (*env)->DeleteLocalRef(env, val);
+    return str;
+}
+
+- (NSString *)accessibilityHelp
+{
+    JNIEnv* env = [ThreadUtilities getJNIEnv];
+
+    GET_CACCESSIBILITY_CLASS_RETURN(nil);
+    DECLARE_STATIC_METHOD_RETURN(sjm_getAccessibleDescription, sjc_CAccessibility, "getAccessibleDescription",
+                                 "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/String;", nil);
+    jobject val = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility,
+                                   sjm_getAccessibleDescription, fAccessible, fComponent);
+    CHECK_EXCEPTION();
+    if (val == NULL) {
+        return nil;
+    }
+    NSString* str = JavaStringToNSString(env, val);
+    (*env)->DeleteLocalRef(env, val);
+    return str;
+}
+
+- (NSArray *)accessibilityChildren
+{
+    return [self accessibleChildrenWithChildCode:JAVA_AX_ALL_CHILDREN];
+}
+
+- (NSArray *)accessibilitySelectedChildren
+{
+    return [self accessibleChildrenWithChildCode:JAVA_AX_SELECTED_CHILDREN];
+}
+
+- (NSArray *)accessibilityVisibleChildren
+{
+    return [self accessibleChildrenWithChildCode:JAVA_AX_VISIBLE_CHILDREN];
+}
+
 - (NSRect)accessibilityFrame
 {
     JNIEnv* env = [ThreadUtilities getJNIEnv];
@@ -167,10 +689,373 @@ static jobject sAccessibilityClass = NULL;
 
 - (id _Nullable)accessibilityParent
 {
-    return [self accessibilityParentAttribute];
+    return NSAccessibilityUnignoredAncestor([self parent]);
+}
+
+- (BOOL)isAccessibilityEnabled
+{
+    JNIEnv* env = [ThreadUtilities getJNIEnv];
+    GET_CACCESSIBILITY_CLASS_RETURN(NO);
+    DECLARE_STATIC_METHOD_RETURN(jm_isEnabled, sjc_CAccessibility, "isEnabled", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Z", NO);
+
+    BOOL value = (*env)->CallStaticBooleanMethod(env, sjc_CAccessibility, jm_isEnabled, fAccessible, fComponent);
+    CHECK_EXCEPTION();
+    if (!value) {
+        NSLog(@"WARNING: %s called on component that has no accessible component: %@", __FUNCTION__, self);
+    }
+    return value;
+}
+
+- (id)accessibilityApplicationFocusedUIElement
+{
+    return [self accessibilityFocusedUIElement];
+}
+
+- (NSAccessibilityRole)accessibilityRole
+{
+    if (fNSRole == nil) {
+        NSString *javaRole = [self javaRole];
+        fNSRole = [sRoles objectForKey:javaRole];
+        // The sRoles NSMutableDictionary maps popupmenu to Mac's popup button.
+        // JComboBox behavior currently relies on this.  However this is not the
+        // proper mapping for a JPopupMenu so fix that.
+        if ( [javaRole isEqualToString:@"popupmenu"] &&
+             ![[[self parent] javaRole] isEqualToString:@"combobox"] ) {
+             fNSRole = NSAccessibilityMenuRole;
+        }
+        if (fNSRole == nil) {
+            // this component has assigned itself a custom AccessibleRole not in the sRoles array
+            fNSRole = javaRole;
+        }
+        [fNSRole retain];
+    }
+    return fNSRole;
+}
+
+- (NSString *)accessibilityRoleDescription
+{
+    // first ask AppKit for its accessible role description for a given AXRole
+    NSString *value = NSAccessibilityRoleDescription([self accessibilityRole], nil);
+
+    if (value == nil) {
+        // query java if necessary
+        JNIEnv* env = [ThreadUtilities getJNIEnv];
+        GET_CACCESSIBILITY_CLASS_RETURN(nil);
+        DECLARE_STATIC_METHOD_RETURN(jm_getAccessibleRoleDisplayString, sjc_CAccessibility, "getAccessibleRoleDisplayString",
+                                     "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/String;", nil);
+
+        jobject axRole = (*env)->CallStaticObjectMethod(env, jm_getAccessibleRoleDisplayString, fAccessible, fComponent);
+        CHECK_EXCEPTION();
+        if (axRole != NULL) {
+            value = JavaStringToNSString(env, axRole);
+            (*env)->DeleteLocalRef(env, axRole);
+        } else {
+            value = @"unknown";
+        }
+    }
+
+    return value;
+}
+
+- (BOOL)isAccessibilityFocused
+{
+    JNIEnv* env = [ThreadUtilities getJNIEnv];
+    GET_CACCESSIBILITY_CLASS_RETURN(NO);
+    DECLARE_STATIC_METHOD_RETURN(sjm_isFocusTraversable, sjc_CAccessibility, "isFocusTraversable",
+                                 "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Z", NO);
+    // According to javadoc, a component that is focusable will return true from isFocusTraversable,
+    // as well as having AccessibleState.FOCUSABLE in its AccessibleStateSet.
+    // We use the former heuristic; if the component focus-traversable, add a focused attribute
+    // See also initializeAttributeNamesWithEnv:
+    if ((*env)->CallStaticBooleanMethod(env, sjc_CAccessibility, sjm_isFocusTraversable, fAccessible, fComponent)) {
+        return [self isEqual:[NSApp accessibilityFocusedUIElement]];
+    }
+    CHECK_EXCEPTION();
+
+    return NO;
+}
+
+- (void)setAccessibilityFocused:(BOOL)accessibilityFocused
+{
+    JNIEnv* env = [ThreadUtilities getJNIEnv];
+
+    GET_CACCESSIBILITY_CLASS();
+    DECLARE_STATIC_METHOD(jm_requestFocus, sjc_CAccessibility, "requestFocus", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)V");
+
+    if (accessibilityFocused)
+    {
+        (*env)->CallStaticVoidMethod(env, sjc_CAccessibility, jm_requestFocus, fAccessible, fComponent);
+        CHECK_EXCEPTION();
+    }
+}
+
+- (NSUInteger)accessibilityIndexOfChild:(id)child
+{
+    JNIEnv *env = [ThreadUtilities getJNIEnv];
+    GET_ACCESSIBLEINDEXINPARENT_STATIC_METHOD_RETURN(0);
+    jint returnValue =
+        (*env)->CallStaticIntMethod( env,
+                                sjc_CAccessibility,
+                                sjm_getAccessibleIndexInParent,
+                                ((CommonComponentAccessibility *)child)->fAccessible,
+                                ((CommonComponentAccessibility *)child)->fComponent );
+    CHECK_EXCEPTION();
+    return (returnValue == -1) ? NSNotFound : returnValue;
+}
+
+- (NSInteger)accessibilityIndex
+{
+    
+    int index = 0;
+    if (fParent != NULL) {
+        index = [fParent accessibilityIndexOfChild:self];
+    }
+    return index;
+}
+
+- (id)accessibilityMaxValue
+{
+    JNIEnv* env = [ThreadUtilities getJNIEnv];
+    GET_CACCESSIBILITY_CLASS_RETURN(nil);
+    DECLARE_STATIC_METHOD_RETURN(jm_getMaximumAccessibleValue, sjc_CAccessibility, "getMaximumAccessibleValue",
+                                  "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/Number;", nil);
+
+    jobject axValue = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getMaximumAccessibleValue, fAccessible, fComponent);
+    CHECK_EXCEPTION();
+    if (axValue == NULL) {
+        return [NSNumber numberWithInt:0];
+    }
+    NSNumber* num = JavaNumberToNSNumber(env, axValue);
+    (*env)->DeleteLocalRef(env, axValue);
+    return num;
+}
+
+- (id)accessibilityMinValue
+{
+    JNIEnv* env = [ThreadUtilities getJNIEnv];
+    GET_CACCESSIBILITY_CLASS_RETURN(nil);
+    DECLARE_STATIC_METHOD_RETURN(jm_getMinimumAccessibleValue, sjc_CAccessibility, "getMinimumAccessibleValue",
+                                  "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/Number;", nil);
+
+    jobject axValue = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getMinimumAccessibleValue, fAccessible, fComponent);
+    CHECK_EXCEPTION();
+    if (axValue == NULL) {
+        return [NSNumber numberWithInt:0];
+    }
+    NSNumber* num = JavaNumberToNSNumber(env, axValue);
+    (*env)->DeleteLocalRef(env, axValue);
+    return num;
+}
+
+- (NSAccessibilityOrientation)accessibilityOrientation
+{
+    JNIEnv* env = [ThreadUtilities getJNIEnv];
+    jobject axContext = [self axContextWithEnv:env];
+
+    // cmcnote - should batch these two calls into one that returns an array of two bools, one for vertical and one for horiz
+    if (isVertical(env, axContext, fComponent)) {
+        (*env)->DeleteLocalRef(env, axContext);
+        return NSAccessibilityOrientationVertical;
+    }
+    if (isHorizontal(env, axContext, fComponent)) {
+        (*env)->DeleteLocalRef(env, axContext);
+        return NSAccessibilityOrientationHorizontal;
+    }
+    return NSAccessibilityOrientationUnknown;
+}
+
+- (NSPoint)accessibilityActivationPoint
+{
+    JNIEnv* env = [ThreadUtilities getJNIEnv];
+    GET_ACCESSIBLECOMPONENT_STATIC_METHOD_RETURN(NSPointFromString(@""));
+    jobject axComponent = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, sjm_getAccessibleComponent,
+                           fAccessible, fComponent);
+    CHECK_EXCEPTION();
+
+    // NSAccessibility wants the bottom left point of the object in
+    // bottom left based screen coords
+
+    // Get the java screen coords, and make a NSPoint of the bottom left of the AxComponent.
+    NSSize size = getAxComponentSize(env, axComponent, fComponent);
+    NSPoint point = getAxComponentLocationOnScreen(env, axComponent, fComponent);
+    (*env)->DeleteLocalRef(env, axComponent);
+
+    point.y += size.height;
+
+    // Now make it into Cocoa screen coords.
+    point.y = [[[[self view] window] screen] frame].size.height - point.y;
+
+    return point;
+}
+
+- (BOOL)isAccessibilitySelected
+{
+    return [self isSelected:[ThreadUtilities getJNIEnv]];
+}
+
+- (void)setAccessibilitySelected:(BOOL)accessibilitySelected
+{
+   JNIEnv* env = [ThreadUtilities getJNIEnv];
+    GET_CACCESSIBILITY_CLASS();
+    DECLARE_STATIC_METHOD(jm_requestSelection,
+                          sjc_CAccessibility,
+                          "requestSelection",
+                          "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)V");
+
+    if (accessibilitySelected) {
+        (*env)->CallStaticVoidMethod(env, sjc_CAccessibility, jm_requestSelection, fAccessible, fComponent);
+        CHECK_EXCEPTION();
+    }
+}
+
+- (id)accessibilityValue
+{
+    JNIEnv* env = [ThreadUtilities getJNIEnv];
+
+    // Need to handle popupmenus differently.
+    //
+    // At least for now don't handle combo box menus.
+    // This may change when later fixing issues which currently
+    // exist for combo boxes, but for now the following is only
+    // for JPopupMenus, not for combobox menus.
+    id parent = [self parent];
+    if ( [[self javaRole] isEqualToString:@"popupmenu"] &&
+         ![[parent javaRole] isEqualToString:@"combobox"] ) {
+        NSArray *children =
+            [CommonComponentAccessibility childrenOfParent:self
+                                        withEnv:env
+                                        withChildrenCode:JAVA_AX_ALL_CHILDREN
+                                        allowIgnored:YES];
+        if ([children count] > 0) {
+            // handle case of AXMenuItem
+            // need to ask menu what is selected
+            NSArray *selectedChildrenOfMenu =
+                [self accessibilitySelectedChildren];
+            CommonComponentAccessibility *selectedMenuItem =
+                [selectedChildrenOfMenu objectAtIndex:0];
+            if (selectedMenuItem != nil) {
+                GET_CACCESSIBILITY_CLASS_RETURN(nil);
+                GET_ACCESSIBLENAME_METHOD_RETURN(nil);
+                jobject itemValue =
+                        (*env)->CallStaticObjectMethod( env,
+                                                   sjm_getAccessibleName,
+                                                   selectedMenuItem->fAccessible,
+                                                   selectedMenuItem->fComponent );
+                CHECK_EXCEPTION();
+                if (itemValue == NULL) {
+                    return nil;
+                }
+                NSString* itemString = JavaStringToNSString(env, itemValue);
+                (*env)->DeleteLocalRef(env, itemValue);
+                return itemString;
+            } else {
+                return nil;
+            }
+        }
+    }
+
+    // ask Java for the component's accessibleValue. In java, the "accessibleValue" just means a numerical value
+    // a text value is taken care of in JavaTextAccessibility
+
+    // cmcnote should coalesce these calls into one java call
+    NSNumber *num = nil;
+    GET_CACCESSIBILITY_CLASS_RETURN(nil);
+    DECLARE_STATIC_METHOD_RETURN(sjm_getAccessibleValue, sjc_CAccessibility, "getAccessibleValue",
+                "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/AccessibleValue;", nil);
+    jobject axValue = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, sjm_getAccessibleValue, fAccessible, fComponent);
+    CHECK_EXCEPTION();
+    if (axValue != NULL) {
+        DECLARE_STATIC_METHOD_RETURN(jm_getCurrentAccessibleValue, sjc_CAccessibility, "getCurrentAccessibleValue",
+                                     "(Ljavax/accessibility/AccessibleValue;Ljava/awt/Component;)Ljava/lang/Number;", nil);
+        jobject str = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getCurrentAccessibleValue, axValue, fComponent);
+        CHECK_EXCEPTION();
+        if (str != NULL) {
+            num = JavaNumberToNSNumber(env, str);
+            (*env)->DeleteLocalRef(env, str);
+        }
+        (*env)->DeleteLocalRef(env, axValue);
+    }
+    if (num == nil) {
+        num = [NSNumber numberWithInt:0];
+    }
+    return num;
+}
+
+- (id)accessibilityHitTest:(NSPoint)point
+{
+    JNIEnv* env = [ThreadUtilities getJNIEnv];
+
+    DECLARE_CLASS_RETURN(jc_Container, "java/awt/Container", nil);
+    DECLARE_STATIC_METHOD_RETURN(jm_accessibilityHitTest, sjc_CAccessibility, "accessibilityHitTest",
+                                 "(Ljava/awt/Container;FF)Ljavax/accessibility/Accessible;", nil);
+
+    // Make it into java screen coords
+    point.y = [[[[self view] window] screen] frame].size.height - point.y;
+
+    jobject jparent = fComponent;
+
+    id value = nil;
+    if ((*env)->IsInstanceOf(env, jparent, jc_Container)) {
+        jobject jaccessible = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_accessibilityHitTest,
+                               jparent, (jfloat)point.x, (jfloat)point.y);
+        CHECK_EXCEPTION();
+        if (jaccessible != NULL) {
+            value = [CommonComponentAccessibility createWithAccessible:jaccessible withEnv:env withView:fView];
+            (*env)->DeleteLocalRef(env, jaccessible);
+        }
+    }
+
+    if (value == nil) {
+        value = self;
+    }
+
+    if (![value isAccessibilityElement]) {
+        value = NSAccessibilityUnignoredAncestor(value);
+    }
+
+#ifdef JAVA_AX_DEBUG
+    NSLog(@"%s: %@", __FUNCTION__, value);
+#endif
+    return value;
+}
+
+- (id)accessibilityFocusedUIElement
+{
+    JNIEnv *env = [ThreadUtilities getJNIEnv];
+    GET_CACCESSIBILITY_CLASS_RETURN(nil);
+    DECLARE_STATIC_METHOD_RETURN(jm_getFocusOwner, sjc_CAccessibility, "getFocusOwner",
+                                  "(Ljava/awt/Component;)Ljavax/accessibility/Accessible;", nil);
+    id value = nil;
+
+    NSWindow* hostWindow = [[self->fView window] retain];
+    jobject focused = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getFocusOwner, fComponent);
+    [hostWindow release];
+    CHECK_EXCEPTION();
+
+    if (focused != NULL) {
+        DECLARE_CLASS_RETURN(sjc_Accessible, "javax/accessibility/Accessible", nil);
+        if ((*env)->IsInstanceOf(env, focused, sjc_Accessible)) {
+            value = [CommonComponentAccessibility createWithAccessible:focused withEnv:env withView:fView];
+        }
+        CHECK_EXCEPTION();
+        (*env)->DeleteLocalRef(env, focused);
+    }
+
+    if (value == nil) {
+        value = self;
+    }
+#ifdef JAVA_AX_DEBUG
+    NSLog(@"%s: %@", __FUNCTION__, value);
+#endif
+    return value;
+}
+
+- (id)accessibilityWindow {
+    return [self window];
 }
 
 // AccessibleAction support
+
 - (BOOL)performAccessibleAction:(int)index
 {
     AWT_ASSERT_APPKIT_THREAD;
@@ -186,8 +1071,34 @@ static jobject sAccessibilityClass = NULL;
     return TRUE;
 }
 
-- (BOOL)isAccessibilityElement {
-    return YES;
+// NSAccessibilityActions methods
+
+- (BOOL)isAccessibilitySelectorAllowed:(SEL)selector {
+    if ([sAllActionSelectors containsObject:NSStringFromSelector(selector)] &&
+        ![[self actionSelectors] containsObject:NSStringFromSelector(selector)]) {
+        return NO;
+    }
+    return [super isAccessibilitySelectorAllowed:selector];
+}
+
+- (BOOL)accessibilityPerformPick {
+    return [self accessiblePerformAction:NSAccessibilityPickAction];
+}
+
+- (BOOL)accessibilityPerformPress {
+    return [self accessiblePerformAction:NSAccessibilityPressAction];
+}
+
+- (BOOL)accessibilityPerformShowMenu {
+    return [self accessiblePerformAction:NSAccessibilityShowMenuAction];
+}
+
+- (BOOL)accessibilityPerformDecrement {
+    return [self accessiblePerformAction:NSAccessibilityDecrementAction];
+}
+
+- (BOOL)accessibilityPerformIncrement {
+    return [self accessiblePerformAction:NSAccessibilityIncrementAction];
 }
 
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonTextAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonTextAccessibility.m
@@ -70,7 +70,7 @@ static NSRange javaIntArrayToNSRange(JNIEnv* env, jintArray array) {
     GET_CACCESSIBILITY_CLASS_RETURN(nil);
     DECLARE_STATIC_METHOD_RETURN(sjm_getAccessibleName, sjc_CAccessibility, "getAccessibleName",
                           "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/String;", nil);
-    if ([[self accessibilityRoleAttribute] isEqualToString:NSAccessibilityStaticTextRole]) {
+    if ([[self accessibilityRole] isEqualToString:NSAccessibilityStaticTextRole]) {
         jobject axName = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility,
                            sjm_getAccessibleName, fAccessible, fComponent);
         CHECK_EXCEPTION();

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/GroupAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/GroupAccessibility.m
@@ -43,7 +43,7 @@
 - (NSArray *)accessibilityChildren {
     JNIEnv *env = [ThreadUtilities getJNIEnv];
 
-    NSArray *children = [JavaComponentAccessibility childrenOfParent:self
+    NSArray *children = [CommonComponentAccessibility childrenOfParent:self
                                                              withEnv:env
                                                     withChildrenCode:JAVA_AX_ALL_CHILDREN
                                                         allowIgnored:NO];
@@ -53,6 +53,16 @@
     } else {
         return children;
     }
+}
+
+- (NSRect)accessibilityFrame
+{
+    return [super accessibilityFrame];
+}
+
+- (id)accessibilityParent
+{
+    return [super accessibilityParent];
 }
 
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ImageAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ImageAccessibility.m
@@ -36,7 +36,17 @@
 
 - (NSString * _Nullable)accessibilityLabel
 {
-    return [self accessibilityTitleAttribute];
+    return [super accessibilityLabel];
+}
+
+- (NSRect)accessibilityFrame
+{
+    return [super accessibilityFrame];
+}
+
+- (id)accessibilityParent
+{
+    return [super accessibilityParent];
 }
 
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/RadiobuttonAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/RadiobuttonAccessibility.m
@@ -39,7 +39,7 @@
 - (id _Nonnull) accessibilityValue
 {
     AWT_ASSERT_APPKIT_THREAD;
-    return [self accessibilityValueAttribute];
+    return [super accessibilityValue];
 }
 
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollAreaAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollAreaAccessibility.m
@@ -35,16 +35,16 @@
 - (NSArray * _Nullable)accessibilityContentsAttribute
 {
     JNIEnv *env = [ThreadUtilities getJNIEnv];
-    NSArray *children = [JavaComponentAccessibility childrenOfParent:self withEnv:env withChildrenCode:JAVA_AX_ALL_CHILDREN allowIgnored:YES];
+    NSArray *children = [CommonComponentAccessibility childrenOfParent:self withEnv:env withChildrenCode:JAVA_AX_ALL_CHILDREN allowIgnored:YES];
 
     if ([children count] <= 0) return nil;
     NSArray *contents = [NSMutableArray arrayWithCapacity:[children count]];
 
     // The scroll bars are in the children. children less the scroll bars is the contents
     NSEnumerator *enumerator = [children objectEnumerator];
-    JavaComponentAccessibility *aElement;
-    while ((aElement = (JavaComponentAccessibility *)[enumerator nextObject])) {
-        if (![[aElement accessibilityRoleAttribute] isEqualToString:NSAccessibilityScrollBarRole]) {
+    CommonComponentAccessibility *aElement;
+    while ((aElement = (CommonComponentAccessibility *)[enumerator nextObject])) {
+        if (![[aElement accessibilityRole] isEqualToString:NSAccessibilityScrollBarRole]) {
             // no scroll bars in contents
             [(NSMutableArray *)contents addObject:aElement];
         }
@@ -56,14 +56,14 @@
 {
     JNIEnv *env = [ThreadUtilities getJNIEnv];
 
-    NSArray *children = [JavaComponentAccessibility childrenOfParent:self withEnv:env withChildrenCode:JAVA_AX_ALL_CHILDREN allowIgnored:YES];
+    NSArray *children = [CommonComponentAccessibility childrenOfParent:self withEnv:env withChildrenCode:JAVA_AX_ALL_CHILDREN allowIgnored:YES];
     if ([children count] <= 0) return nil;
 
     // The scroll bars are in the children.
-    JavaComponentAccessibility *aElement;
+    CommonComponentAccessibility *aElement;
     NSEnumerator *enumerator = [children objectEnumerator];
-    while ((aElement = (JavaComponentAccessibility *)[enumerator nextObject])) {
-        if ([[aElement accessibilityRoleAttribute] isEqualToString:NSAccessibilityScrollBarRole]) {
+    while ((aElement = (CommonComponentAccessibility *)[enumerator nextObject])) {
+        if ([[aElement accessibilityRole] isEqualToString:NSAccessibilityScrollBarRole]) {
             jobject elementAxContext = [aElement axContextWithEnv:env];
             if (orientation == NSAccessibilityOrientationHorizontal) {
                 if (isHorizontal(env, elementAxContext, fComponent)) {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SliderAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SliderAccessibility.m
@@ -39,12 +39,12 @@
 
 - (NSString * _Nullable)accessibilityLabel
 {
-    return [self accessibilityTitleAttribute];
+    return [super accessibilityLabel];
 }
 
 - (id _Nullable)accessibilityValue
 {
-    return [self accessibilityValueAttribute];
+    return [super accessibilityValue];
 }
 
 - (BOOL)accessibilityPerformIncrement
@@ -55,6 +55,16 @@
 - (BOOL)accessibilityPerformDecrement
 {
     return [self performAccessibleAction:DECREMENT];
+}
+
+- (NSRect)accessibilityFrame
+{
+    return [super accessibilityFrame];
+}
+
+- (id)accessibilityParent
+{
+    return [super accessibilityParent];
 }
 
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SpinboxAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SpinboxAccessibility.m
@@ -39,12 +39,12 @@
 
 - (NSString * _Nullable)accessibilityLabel
 {
-    return [self accessibilityTitleAttribute];
+    return [super accessibilityLabel];
 }
 
 - (id _Nullable)accessibilityValue
 {
-    return [self accessibilityValueAttribute];
+    return [super accessibilityValue];
 }
 
 - (BOOL)accessibilityPerformIncrement
@@ -56,6 +56,16 @@
 - (BOOL)accessibilityPerformDecrement
 {
     return [self performAccessibleAction:DECREMENT];
+}
+
+- (NSRect)accessibilityFrame
+{
+    return [super accessibilityFrame];
+}
+
+- (id)accessibilityParent
+{
+    return [super accessibilityParent];
 }
 
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.m
@@ -47,4 +47,14 @@
     return [self accessibilityVisibleCharacterRangeAttribute];
 }
 
+- (NSRect)accessibilityFrame
+{
+    return [super accessibilityFrame];
+}
+
+- (id)accessibilityParent
+{
+    return [super accessibilityParent];
+}
+
 @end

--- a/test/jdk/java/awt/a11y/AccessibleComponentTest.java
+++ b/test/jdk/java/awt/a11y/AccessibleComponentTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, JetBrains s.r.o.. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.*;
+import java.security.PublicKey;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CountDownLatch;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import javax.swing.*;
+import javax.swing.JPanel;
+
+public abstract class AccessibleComponentTest {
+
+    protected static volatile boolean testResult = true;
+    protected static volatile CountDownLatch countDownLatch;
+    protected static String INSTRUCTIONS;
+    protected static String exceptionString;
+    protected JFrame mainFrame;
+    protected static AccessibleComponentTest a11yTest;
+
+    public abstract CountDownLatch createCountDownLatch();
+
+    public void createUI(JPanel component, String testName) {
+        mainFrame = new JFrame(testName);
+        GridBagLayout layout = new GridBagLayout();
+        JPanel mainControlPanel = new JPanel(layout);
+        JPanel resultButtonPanel = new JPanel(layout);
+
+        GridBagConstraints gbc = new GridBagConstraints();
+
+        JTextArea instructionTextArea = new JTextArea();
+        instructionTextArea.setText(INSTRUCTIONS);
+        instructionTextArea.setEditable(false);
+        instructionTextArea.setBackground(Color.white);
+
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        mainControlPanel.add(instructionTextArea, gbc);
+        gbc.gridx = 0;
+        gbc.gridy = 1;
+        mainControlPanel.add(component);
+
+        JButton passButton = new JButton("Pass");
+        passButton.setActionCommand("Pass");
+        passButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                mainFrame.dispose();
+                countDownLatch.countDown();
+            }
+        });
+
+        JButton failButton = new JButton("Fail");
+        failButton.setActionCommand("Fail");
+        failButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                testResult = false;
+                mainFrame.dispose();
+                countDownLatch.countDown();
+            }
+        });
+
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        resultButtonPanel.add(passButton, gbc);
+
+        gbc.gridx = 1;
+        gbc.gridy = 0;
+        resultButtonPanel.add(failButton, gbc);
+
+        gbc.gridx = 0;
+        gbc.gridy = 2;
+        mainControlPanel.add(resultButtonPanel, gbc);
+
+        mainFrame.add(mainControlPanel);
+        mainFrame.pack();
+
+        mainFrame.addWindowListener(new WindowAdapter() {
+
+            @Override
+            public void windowClosing(WindowEvent e) {
+                mainFrame.dispose();
+                countDownLatch.countDown();
+            }
+        });
+        mainFrame.setVisible(true);
+    }
+}


### PR DESCRIPTION
This is the base change in the series of commits aimed at contributing to the task of transitioning to the new a11y protocol on macOS.

In this change we make the CommonComponentAccessibility class an independent root in the new a11y hierarchy. The class now implements NSAccessibilityElement and has no legacy a11y mixed in (which is not a viable construction based on out experiments). All the logic from JavaComponentAccessibility has been migrated to this class and translated to the new interface. Also, in case a control does not match any of the new a11y classes, the CommonComponentAccessibility object will represent the control as a generic a11y component.

The JavaComponentAccessibility class is left intact (except for some conflicting symbols) as a backup option.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8267385](https://bugs.openjdk.java.net/browse/JDK-8267385)

### Issue
 * [JDK-8267385](https://bugs.openjdk.java.net/browse/JDK-8267385): Create NSAccessibilityElement implementation for JavaComponentAccessibility ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4365/head:pull/4365` \
`$ git checkout pull/4365`

Update a local copy of the PR: \
`$ git checkout pull/4365` \
`$ git pull https://git.openjdk.java.net/jdk pull/4365/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4365`

View PR using the GUI difftool: \
`$ git pr show -t 4365`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4365.diff">https://git.openjdk.java.net/jdk/pull/4365.diff</a>

</details>
