### PR TITLE
8268272: Remove JDK-8264874 changes because Graal was removed.

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -92,11 +92,8 @@ $(eval $(call SetupTarget, buildtools-modules, \
     MAKEFILE := CompileModuleTools, \
 ))
 
-# interim-langtools is needed by hotspot only when $(INCLUDE_GRAAL) is true
-GRAAL_INTERIM_LANGTOOLS_true = interim-langtools
 $(eval $(call SetupTarget, buildtools-hotspot, \
     MAKEFILE := CompileToolsHotspot, \
-    DEPS := $(GRAAL_INTERIM_LANGTOOLS_$(INCLUDE_GRAAL)), \
 ))
 
 ################################################################################


### PR DESCRIPTION
JDK-8264806 removed Graal sources from JDK and INCLUDE_GRAAL is not defined anymore. We can now remove code added by JDK-8264874: 
https://github.com/openjdk/jdk/commit/951f277a

Tested Tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268272](https://bugs.openjdk.java.net/browse/JDK-8268272): Remove JDK-8264874 changes because Graal was removed.


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4367/head:pull/4367` \
`$ git checkout pull/4367`

Update a local copy of the PR: \
`$ git checkout pull/4367` \
`$ git pull https://git.openjdk.java.net/jdk pull/4367/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4367`

View PR using the GUI difftool: \
`$ git pr show -t 4367`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4367.diff">https://git.openjdk.java.net/jdk/pull/4367.diff</a>

</details>
