### PR TITLE
8268083: JDK-8267706 breaks bin/idea.sh on a Mac

### DIFF
--- a/make/common/Utils.gmk
+++ b/make/common/Utils.gmk
@@ -92,40 +92,58 @@ SetIfEmpty = \
 #     foo/bar/baz, /foo/bar -> <empty>
 #
 # The x prefix is used to preserve the presence of the initial slash
+# On Windows paths are treated as case-insensitive
 #
 # $1 - Path to compare
 # $2 - Other path to compare
 FindCommonPathPrefix = \
-    $(patsubst x%,%,$(subst $(SPACE),/,$(strip \
-        $(call FindCommonPathPrefixHelper, \
-            $(subst /,$(SPACE),x$(strip $1)), $(subst /,$(SPACE),x$(strip $2))) \
-    )))
+    $(call DecodeSpace,$(patsubst x%,%,$(subst $(SPACE),/,$(strip \
+        $(call FindCommonPathPrefixHelper1, \
+            $(subst /,$(SPACE),x$(call EncodeSpace,$(strip $1))), \
+            $(subst /,$(SPACE),x$(call EncodeSpace,$(strip $2)))) \
+    ))))
 
-FindCommonPathPrefixHelper = \
+FindCommonPathPrefixHelper1 = \
+    $(if $(filter $(OPENJDK_TARGET_OS), windows), \
+        $(call FindCommonPathPrefixHelper2,$(call uppercase,$1),$(call uppercase,$2),$1), \
+        $(call FindCommonPathPrefixHelper2,$1,$2,$1))
+
+FindCommonPathPrefixHelper2 = \
     $(if $(call equals, $(firstword $1), $(firstword $2)), \
-      $(firstword $1) \
-      $(call FindCommonPathPrefixHelper, \
-          $(wordlist 2, $(words $1), $1), $(wordlist 2, $(words $2), $2) \
+      $(if $(call equals, $(firstword $1),),, \
+        $(firstword $3) \
+        $(call FindCommonPathPrefixHelper2, \
+            $(wordlist 2, $(words $1), $1), \
+            $(wordlist 2, $(words $2), $2), \
+            $(wordlist 2, $(words $3), $3) \
+        ) \
       ) \
     )
-
-# Convert a partial path into as many directory levels of ../, removing
-# leading and following /.
-# Ex: foo/bar/baz/ -> ../../..
-#     foo/bar -> ../..
-#     /foo -> ..
-DirToDotDot = \
-    $(subst $(SPACE),/,$(foreach d, $(subst /,$(SPACE),$1),..))
 
 # Computes the relative path from a directory to a file
 # $1 - File to compute the relative path to
 # $2 - Directory to compute the relative path from
 RelativePath = \
-    $(eval $1_prefix := $(call FindCommonPathPrefix, $1, $2)) \
-    $(eval $1_dotdots := $(call DirToDotDot, $(patsubst $($(strip $1)_prefix)%, %, $2))) \
-    $(eval $1_dotdots := $(if $($(strip $1)_dotdots),$($(strip $1)_dotdots),.)) \
-    $(eval $1_suffix := $(patsubst $($(strip $1)_prefix)/%, %, $1)) \
-    $($(strip $1)_dotdots)/$($(strip $1)_suffix)
+    $(call DecodeSpace,$(strip $(call RelativePathHelper,$(call EncodeSpace \
+        ,$(strip $1)),$(call EncodeSpace \
+        ,$(strip $2)),$(call EncodeSpace \
+        ,$(call FindCommonPathPrefix,$1,$2)))))
+
+RelativePathHelper = \
+    $(eval $3_prefix_length := $(words $(subst /,$(SPACE),$3))) \
+    $(eval $1_words := $(subst /,$(SPACE),$1)) \
+    $(eval $2_words := $(subst /,$(SPACE),$2)) \
+    $(if $(call equals,$($3_prefix_length),0),, \
+        $(eval $1_words := $(wordlist 2,$(words $($1_words)),$(wordlist \
+            $($3_prefix_length),$(words $($1_words)),$($1_words)))) \
+        $(eval $2_words := $(wordlist 2,$(words $($2_words)),$(wordlist \
+            $($3_prefix_length),$(words $($2_words)),$($2_words)))) \
+    ) \
+    $(eval $1_suffix := $(subst $(SPACE),/,$($1_words))) \
+    $(eval $2_dotdots := $(subst $(SPACE),/,$(foreach d,$($2_words),..))) \
+    $(if $($1_suffix), \
+        $(if $($2_dotdots), $($2_dotdots)/$($1_suffix), $($1_suffix)), \
+        $(if $($2_dotdots), $($2_dotdots), .))
 
 ################################################################################
 # Filter out duplicate sub strings while preserving order. Keeps the first occurance.

--- a/make/ide/idea/jdk/idea.gmk
+++ b/make/ide/idea/jdk/idea.gmk
@@ -46,17 +46,15 @@ else #with SPEC
   endif
 
   idea:
-	$(ECHO) "SUPPORT=$(SUPPORT_OUTPUTDIR)" > $(OUT)
 	$(ECHO) "MODULES=\"$(foreach mod, $(SEL_MODULES), \
 	          module='$(mod)' \
-	          moduleSrcDirs='$(call FindModuleSrcDirs,$(mod))' \
+	          moduleSrcDirs='$(foreach m,$(call FindModuleSrcDirs,$(mod)),$(call RelativePath,$m,$(topdir)))' \
 	          moduleDependencies='$(call FindTransitiveDepsForModule,$(mod))' \
-	        #)\"" >> $(OUT)
+	        #)\"" > $(OUT)
 	$(ECHO) "MODULE_NAMES=\"$(strip $(foreach mod, $(SEL_MODULES), $(mod)))\"" >> $(OUT)
-	$(ECHO) "SEL_MODULES=\"$(SEL_MODULES)\"" >> $(OUT)
-	$(ECHO) "BOOT_JDK=\"$(BOOT_JDK)\"" >> $(OUT)
+	$(ECHO) "RELATIVE_PROJECT_DIR=\"$(call RelativePath,$(topdir),$(IDEA_OUTPUT_PARENT))\"" >> $(OUT)
+	$(ECHO) "RELATIVE_BUILD_DIR=\"$(call RelativePath,$(OUTPUTDIR),$(IDEA_OUTPUT_PARENT))\"" >> $(OUT)
 	$(ECHO) "PATHTOOL=\"$(PATHTOOL)\"" >> $(OUT)
-	$(ECHO) "SPEC=\"$(SPEC)\"" >> $(OUT)
 	$(ECHO) "JT_HOME=\"$(JT_HOME)\"" >> $(OUT)
 	$(ECHO) "WINENV_ROOT=\"$(WINENV_ROOT)\"" >> $(OUT)
 

--- a/make/ide/idea/jdk/template/compiler.xml
+++ b/make/ide/idea/jdk/template/compiler.xml
@@ -3,10 +3,10 @@
   <component name="CompilerConfiguration">
     <option name="DEFAULT_COMPILER" value="Javac" />
     <excludeFromCompile>
-      <directory url="file://$PROJECT_DIR$/src" includeSubdirectories="true" />
-      <directory url="file://$PROJECT_DIR$/build" includeSubdirectories="true" />
-      <directory url="file://$PROJECT_DIR$/make" includeSubdirectories="true" />
-      <directory url="file://$PROJECT_DIR$/test" includeSubdirectories="false" />
+      <directory url="file://###PROJECT_DIR###/src" includeSubdirectories="true" />
+      <directory url="file://###PROJECT_DIR###/build" includeSubdirectories="true" />
+      <directory url="file://###PROJECT_DIR###/make" includeSubdirectories="true" />
+      <directory url="file://###PROJECT_DIR###/test" includeSubdirectories="false" />
     </excludeFromCompile>
     <resourceExtensions />
     <wildcardResourcePatterns>

--- a/make/ide/idea/jdk/template/jdk.iml
+++ b/make/ide/idea/jdk/template/jdk.iml
@@ -2,9 +2,9 @@
 <module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
-    <content url="file://$MODULE_DIR$">
-      <excludeFolder url="file://$MODULE_DIR$/build" />
-      <excludeFolder url="file://$MODULE_DIR$/make" />
+    <content url="file://###MODULE_DIR###">
+      <excludeFolder url="file://###MODULE_DIR###/build" />
+      <excludeFolder url="file://###MODULE_DIR###/make" />
     </content>
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="inheritedJdk" />

--- a/make/ide/idea/jdk/template/misc.xml
+++ b/make/ide/idea/jdk/template/misc.xml
@@ -5,14 +5,11 @@
   </component>
   <component name="JTRegService">
     <path>###JTREG_HOME###</path>
-    <workDir>$PROJECT_DIR$/###BUILD_DIR###</workDir>
-    <jre alt="true" value="$PROJECT_DIR$/###IMAGES_DIR###" />
+    <workDir>###BUILD_DIR###</workDir>
+    <jre alt="true" value="###BUILD_DIR###/images/jdk" />
     <options></options>
-    <ant>
-      <target file="file://$PROJECT_DIR$/make/ide/idea/jdk/build.xml" name="images" />
-    </ant>
   </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_16" assert-keyword="true" jdk-15="true">
-    <output url="file://$PROJECT_DIR$/###BUILD_DIR###/idea" />
+    <output url="file://###BUILD_DIR###/idea" />
   </component>
 </project>

--- a/make/ide/idea/jdk/template/module.iml
+++ b/make/ide/idea/jdk/template/module.iml
@@ -2,7 +2,7 @@
 <module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
-    <content url="file://$MODULE_DIR$/###MODULE_DIR###">
+    <content url="file://###MODULE_DIR###/###MODULE_CONTENT###">
       ###SOURCE_DIRS###
     </content>
     <orderEntry type="sourceFolder" forTests="false" />

--- a/make/ide/idea/jdk/template/test.iml
+++ b/make/ide/idea/jdk/template/test.iml
@@ -2,7 +2,7 @@
 <module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
-    <content url="file://$MODULE_DIR$/test/jdk"></content>
+    <content url="file://###MODULE_DIR###/test/jdk"></content>
     <orderEntry type="sourceFolder" forTests="true" />
     ###TEST_MODULE_DEPENDENCIES###
     <orderEntry type="inheritedJdk" />

--- a/make/ide/idea/jdk/template/vcs.xml
+++ b/make/ide/idea/jdk/template/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="###VCS_TYPE###" />
+    <mapping directory="###PROJECT_DIR###" vcs="###VCS_TYPE###" />
   </component>
 </project>

--- a/make/ide/idea/jdk/template/workspace.xml
+++ b/make/ide/idea/jdk/template/workspace.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ChangeListManager">
     <ignored path="jdk.iws" />
-    <ignored path="$PROJECT_DIR$/build/idea/out/" />
+    <ignored path="###PROJECT_DIR###/build/idea/out/" />
     <ignored path=".idea/" />
   </component>
   <component name="StructureViewFactory">
@@ -15,7 +15,7 @@
       <option name="SCRIPT_PATH" value="" />
       <option name="SCRIPT_OPTIONS" value="" />
       <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
-      <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+      <option name="SCRIPT_WORKING_DIRECTORY" value="###PROJECT_DIR###" />
       <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
       <option name="INTERPRETER_PATH" value="" />
       <option name="INTERPRETER_OPTIONS" value="" />
@@ -30,7 +30,7 @@
       <option name="SCRIPT_PATH" value="" />
       <option name="SCRIPT_OPTIONS" value="" />
       <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
-      <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+      <option name="SCRIPT_WORKING_DIRECTORY" value="###PROJECT_DIR###" />
       <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
       <option name="INTERPRETER_PATH" value="" />
       <option name="INTERPRETER_OPTIONS" value="" />
@@ -45,7 +45,7 @@
       <option name="SCRIPT_PATH" value="" />
       <option name="SCRIPT_OPTIONS" value="" />
       <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
-      <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+      <option name="SCRIPT_WORKING_DIRECTORY" value="###PROJECT_DIR###" />
       <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
       <option name="INTERPRETER_PATH" value="" />
       <option name="INTERPRETER_OPTIONS" value="" />

--- a/test/make/TestMakeBase.gmk
+++ b/test/make/TestMakeBase.gmk
@@ -344,25 +344,16 @@ $(call AssertEquals, \
     FindCommonPathPrefix, \
 )
 
-################################################################################
-# DirToDotDot
-
 $(call AssertEquals, \
-    $(call DirToDotDot, foo/bar/baz/), \
-    ../../.., \
-    DirToDotDot, \
+    $(call FindCommonPathPrefix, /foo/bar/, /foo/bar), \
+    /foo/bar, \
+    FindCommonPathPrefix, \
 )
 
 $(call AssertEquals, \
-    $(call DirToDotDot, foo/bar), \
-    ../.., \
-    DirToDotDot, \
-)
-
-$(call AssertEquals, \
-    $(call DirToDotDot, /foo), \
-    .., \
-    DirToDotDot, \
+    $(call FindCommonPathPrefix, /fo oo/bar1/, /fo oo/bar2), \
+    /fo oo, \
+    FindCommonPathPrefix, \
 )
 
 ################################################################################
@@ -388,13 +379,43 @@ $(call AssertEquals, \
 
 $(call AssertEquals, \
     $(call RelativePath, /foo/bar/baz/banan/kung, /foo/bar/baz), \
-    ./banan/kung, \
+    banan/kung, \
     RelativePath, \
 )
 
 $(call AssertEquals, \
     $(call RelativePath, /foo/bar/baz/banan/kung, /foo/bar/baz/), \
-    ./banan/kung, \
+    banan/kung, \
+    RelativePath, \
+)
+
+$(call AssertEquals, \
+    $(call RelativePath, /foo/bar, /foo/bar/baz), \
+    .., \
+    RelativePath, \
+)
+
+$(call AssertEquals, \
+    $(call RelativePath, /foo/bar/baz/, /foo/bar/baz), \
+    ., \
+    RelativePath, \
+)
+
+$(call AssertEquals, \
+    $(call RelativePath, /fo oo/bar/baz/ban an, /fo oo/bar/), \
+    baz/ban an, \
+    RelativePath, \
+)
+
+$(call AssertEquals, \
+    $(call RelativePath, /foo/ba rr/ba zz, /foo/ba rr/banan), \
+    ../ba zz, \
+    RelativePath, \
+)
+
+$(call AssertEquals, \
+    $(call RelativePath, /foo, /bar), \
+    ../foo, \
     RelativePath, \
 )
 


### PR DESCRIPTION
I got rid of `realpath` usage as discussed in https://github.com/openjdk/jdk/pull/4190 and used `RelativePath` macro instead, however there were quite a few problems with this macro, here's the example:
```
$(call RelativePath,/foo/bar,/foo/bar/baz) -> "    ..//foo/bar"
$(call RelativePath,/foo/bar/baz/,/foo/bar/baz) -> SEGFAULT
$(call RelativePath,/foo/bar/baz/banan,/foo/bar/) -> "    ./baz/banan"
$(call RelativePath,/foo/bar/baz,/foo/bar/banan) -> "    ../baz"
```
As you can see, 1st case is just plain wrong, 2nd crashes make because of infinite loop, 3rd can be simplified and all of them have leading whitespaces
First commit in this PR fixes all these issues and adds corresponding test cases and second commit replaces usage of `realpath` in idea.sh with `RelativePath` macro in idea.gmk and fixes problems, when paths are incorrectly treated by IDEA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268083](https://bugs.openjdk.java.net/browse/JDK-8268083): JDK-8267706 breaks bin/idea.sh on a Mac


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4369/head:pull/4369` \
`$ git checkout pull/4369`

Update a local copy of the PR: \
`$ git checkout pull/4369` \
`$ git pull https://git.openjdk.java.net/jdk pull/4369/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4369`

View PR using the GUI difftool: \
`$ git pr show -t 4369`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4369.diff">https://git.openjdk.java.net/jdk/pull/4369.diff</a>

</details>
