### PR TITLE
8268279: gc/shenandoah/compiler/TestLinkToNativeRBP.java fails after LibraryLookup is gone

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestLinkToNativeRBP.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestLinkToNativeRBP.java
@@ -39,7 +39,7 @@
 
 import jdk.incubator.foreign.CLinker;
 import jdk.incubator.foreign.FunctionDescriptor;
-import jdk.incubator.foreign.LibraryLookup;
+import jdk.incubator.foreign.SymbolLookup;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
@@ -47,8 +47,12 @@ import java.lang.invoke.MethodType;
 import static jdk.incubator.foreign.CLinker.C_INT;
 
 public class TestLinkToNativeRBP {
+    static {
+        System.loadLibrary("LinkToNativeRBP");
+    }
+
     final static CLinker abi = CLinker.getInstance();
-    static final LibraryLookup lookup = LibraryLookup.ofLibrary("LinkToNativeRBP");
+    static final SymbolLookup lookup = SymbolLookup.loaderLookup();
     final static MethodHandle foo = abi.downcallHandle(lookup.lookup("foo").get(),
             MethodType.methodType(int.class),
             FunctionDescriptor.of(C_INT));


### PR DESCRIPTION
LibraryLookup::lookup has been refactored in JDK-8268129. Replace it with SymbolLookup.loaderLookup.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268279](https://bugs.openjdk.java.net/browse/JDK-8268279): gc/shenandoah/compiler/TestLinkToNativeRBP.java fails after LibraryLookup is gone


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4370/head:pull/4370` \
`$ git checkout pull/4370`

Update a local copy of the PR: \
`$ git checkout pull/4370` \
`$ git pull https://git.openjdk.java.net/jdk pull/4370/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4370`

View PR using the GUI difftool: \
`$ git pr show -t 4370`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4370.diff">https://git.openjdk.java.net/jdk/pull/4370.diff</a>

</details>
