### PR TITLE
8268283: serviceability/sa/TestJmapCore.java failed with zgc on linux-aarch64 after JDK-8266957

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -32,4 +32,4 @@ serviceability/sa/CDSJMapClstats.java                         8220624   generic-
 serviceability/sa/ClhsdbJhisto.java                           8220624   generic-all
 serviceability/sa/TestHeapDumpForLargeArray.java              8220624   generic-all
 vmTestbase/jit/escape/AdaptiveBlocking/AdaptiveBlocking001/AdaptiveBlocking001.java 8260303 windows-x64
-serviceability/sa/TestJmapCore.java                           8268283   linux-aarch64
+serviceability/sa/TestJmapCore.java                           8220624   linux-aarch64

--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -32,3 +32,4 @@ serviceability/sa/CDSJMapClstats.java                         8220624   generic-
 serviceability/sa/ClhsdbJhisto.java                           8220624   generic-all
 serviceability/sa/TestHeapDumpForLargeArray.java              8220624   generic-all
 vmTestbase/jit/escape/AdaptiveBlocking/AdaptiveBlocking001/AdaptiveBlocking001.java 8260303 windows-x64
+serviceability/sa/TestJmapCore.java                           8268283   linux-aarch64


### PR DESCRIPTION
We still see the problem in TestJmapCore.java even though [JDK-8266957 was fixed](https://github.com/openjdk/jdk/commit/7e41ca3da820650e16d9ca7f5b188628cd666419).

According to JBS, the problem suffers on linux-aarch64 only, and I've not yet reproduce it on Linux x64, so it is difficult to fix quickly. So I added it to ProblemList-zgc.txt .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8268283](https://bugs.openjdk.java.net/browse/JDK-8268283): serviceability/sa/TestJmapCore.java failed with zgc on linux-aarch64 after JDK-8266957


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4372/head:pull/4372` \
`$ git checkout pull/4372`

Update a local copy of the PR: \
`$ git checkout pull/4372` \
`$ git pull https://git.openjdk.java.net/jdk pull/4372/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4372`

View PR using the GUI difftool: \
`$ git pr show -t 4372`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4372.diff">https://git.openjdk.java.net/jdk/pull/4372.diff</a>

</details>
