### PR TITLE
8267430: GraphicsDevice.setDisplayMode(REFRESH_RATE_UNKNOWN) throws IAE: Unable to set display mode!

### DIFF
--- a/src/java.desktop/macosx/classes/sun/awt/CGraphicsDevice.java
+++ b/src/java.desktop/macosx/classes/sun/awt/CGraphicsDevice.java
@@ -34,6 +34,7 @@ import java.awt.Rectangle;
 import java.awt.Window;
 import java.awt.geom.Rectangle2D;
 import java.awt.peer.WindowPeer;
+import java.util.Arrays;
 import java.util.Objects;
 
 import sun.java2d.SunGraphicsEnvironment;
@@ -203,6 +204,7 @@ public final class CGraphicsDevice extends GraphicsDevice
     public void invalidate(CGraphicsDevice device) {
         //TODO do we need to restore the full-screen window/modes on old device?
         displayID = device.displayID;
+        initialMode = device.initialMode;
     }
 
     @Override
@@ -359,7 +361,22 @@ public final class CGraphicsDevice extends GraphicsDevice
 
     @Override
     public DisplayMode[] getDisplayModes() {
-        return nativeGetDisplayModes(displayID);
+        DisplayMode[] nativeModes = nativeGetDisplayModes(displayID);
+        boolean match = false;
+        for (DisplayMode mode : nativeModes) {
+            if (initialMode.equals(mode)) {
+                match = true;
+                break;
+            }
+        }
+        if (match) {
+            return nativeModes;
+        } else {
+          int len = nativeModes.length;
+          DisplayMode[] modes = Arrays.copyOf(nativeModes, len+1, DisplayMode[].class);
+          modes[len] = initialMode;
+          return modes; 
+        }
     }
 
     public static boolean usingMetalPipeline() {

--- a/src/java.desktop/macosx/classes/sun/awt/CGraphicsDevice.java
+++ b/src/java.desktop/macosx/classes/sun/awt/CGraphicsDevice.java
@@ -375,7 +375,7 @@ public final class CGraphicsDevice extends GraphicsDevice
           int len = nativeModes.length;
           DisplayMode[] modes = Arrays.copyOf(nativeModes, len+1, DisplayMode[].class);
           modes[len] = initialMode;
-          return modes; 
+          return modes;
         }
     }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m
@@ -263,7 +263,7 @@ JNI_COCOA_EXIT(env);
 
 /*
  * Class:     sun_awt_CGraphicsDevice
- * Method:    nativeSetDisplayMode
+ * Method:    nativeResetDisplayMode
  * Signature: ()V
  */
 JNIEXPORT void JNICALL

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m
@@ -264,6 +264,18 @@ JNI_COCOA_EXIT(env);
 /*
  * Class:     sun_awt_CGraphicsDevice
  * Method:    nativeSetDisplayMode
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL
+Java_sun_awt_CGraphicsDevice_nativeResetDisplayMode
+(JNIEnv *env, jclass class)
+{
+    CGRestorePermanentDisplayConfiguration();
+}
+
+/*
+ * Class:     sun_awt_CGraphicsDevice
+ * Method:    nativeSetDisplayMode
  * Signature: (IIIII)V
  */
 JNIEXPORT void JNICALL

--- a/test/jdk/java/awt/GraphicsDevice/DisplayModes/UnknownRefrshRateTest.java
+++ b/test/jdk/java/awt/GraphicsDevice/DisplayModes/UnknownRefrshRateTest.java
@@ -65,6 +65,7 @@ public class UnknownRefrshRateTest {
              } finally {
                  System.out.println("restoring original mode"+odm);
                  d.setDisplayMode(odm);
+                 Thread.sleep(10000);
              }
        }
     }

--- a/test/jdk/java/awt/GraphicsDevice/DisplayModes/UnknownRefrshRateTest.java
+++ b/test/jdk/java/awt/GraphicsDevice/DisplayModes/UnknownRefrshRateTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8267430
+ * @key headful
+ * @summary verify setting a display mode with unknow refresh rate works
+ */
+
+import java.awt.DisplayMode;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+
+public class UnknownRefrshRateTest {
+
+    public static void main(String[] args) throws Exception {
+
+        GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
+        GraphicsDevice[] devices = ge.getScreenDevices();
+
+        for (GraphicsDevice d : devices) {
+
+            if (!d.isDisplayChangeSupported()) {
+                continue;
+            }
+            DisplayMode odm = d.getDisplayMode();
+            System.out.println("device=" + d + " original mode=" + odm);
+
+            DisplayMode[] modes = d.getDisplayModes();
+            System.out.println("There are " + modes.length + " modes.");
+            try {
+                for (int i=0; i<modes.length; i++) {
+                    DisplayMode mode = modes[i];
+                    System.out.println("copying from mode " + i + " : " + mode);
+                    int w = mode.getWidth();
+                    int h = mode.getHeight();
+                    int bpp = mode.getBitDepth();
+                    int refRate = DisplayMode.REFRESH_RATE_UNKNOWN;
+                    DisplayMode newMode = new DisplayMode(w, h, bpp, refRate);
+                    d.setDisplayMode(newMode);
+                    Thread.sleep(2000);
+                    System.out.println("set " + d.getDisplayMode());
+                 }
+             } finally {
+                 System.out.println("restoring original mode"+odm);
+                 d.setDisplayMode(odm);
+             }
+       }
+    }
+}


### PR DESCRIPTION
There are two issues here, both macOS specific.
First the original reported one that occurs when running on a shared remote VNC type desktop on macOS.
Only a single supported display mode is returned and it is also the current mode.
A program that simply enumerates the reported modes and tries to set them, if it reaches the native layer,
will fail because macOS reports the same display mode it returned as valid as now being illegal.
It does not appear to be as simple as a user's permission level since it occurs with an admin user as well
so it probably is the case that macOS simply does not allow this shared desktop to be changed although
there's no docs I can find
Ordinarily we would not have tried this since we test if the requested display mode is the same as the native
one and skip it, but the provided test used REFRESH_RATE_UNKNOWN which is allowed as meaning match
any mode that satisfies W,H,BPP. But this caused it to fail the equals test so the code is enhanced to check for that

Second, when creating a test it was discovered that *at least* on the built-in retina display of a 16" macbook pro,
the system default contig is never in the list of available modes and can be discovered only by querying the *current* mode
before any modes are changed. This beheaviour is 100% consistent no matter if the system was just rebooted, has
an external monitor attached as well, or not, activates the discrete card, or not.

Since we've had code since at least 2013 that added the default mode I suspect this has been seen before but nowhere
can I find an explanation.

It has odd consequences like after you change the display mode, you will no longer see the default display mode reported,
so the list of available modes is reduced by one.
But for a typical use case which doesn't re-query or more typically caches the original display mode in order to restore it, it presents a bigger problem that trying to restore will always fail. 

So the other thing this fix does is detect when we fail to restore the initial mode and try again in a different way.
Only if that fails do we then throw an exception.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267430](https://bugs.openjdk.java.net/browse/JDK-8267430): GraphicsDevice.setDisplayMode(REFRESH_RATE_UNKNOWN) throws IAE: Unable to set display mode!


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4373/head:pull/4373` \
`$ git checkout pull/4373`

Update a local copy of the PR: \
`$ git checkout pull/4373` \
`$ git pull https://git.openjdk.java.net/jdk pull/4373/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4373`

View PR using the GUI difftool: \
`$ git pr show -t 4373`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4373.diff">https://git.openjdk.java.net/jdk/pull/4373.diff</a>

</details>
