### PR TITLE
8268286: ProblemList serviceability/sa/TestJmapCore.java on linux-aarch64 with ZGC

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -32,3 +32,4 @@ serviceability/sa/CDSJMapClstats.java                         8220624   generic-
 serviceability/sa/ClhsdbJhisto.java                           8220624   generic-all
 serviceability/sa/TestHeapDumpForLargeArray.java              8220624   generic-all
 vmTestbase/jit/escape/AdaptiveBlocking/AdaptiveBlocking001/AdaptiveBlocking001.java 8260303 windows-x64
+serviceability/sa/TestJmapCore.java                           8268283 linux-aarch64


### PR DESCRIPTION
A trivial fix to ProblemList serviceability/sa/TestJmapCore.java on linux-aarch64 with ZGC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268286](https://bugs.openjdk.java.net/browse/JDK-8268286): ProblemList serviceability/sa/TestJmapCore.java on linux-aarch64 with ZGC


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4374/head:pull/4374` \
`$ git checkout pull/4374`

Update a local copy of the PR: \
`$ git checkout pull/4374` \
`$ git pull https://git.openjdk.java.net/jdk pull/4374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4374`

View PR using the GUI difftool: \
`$ git pr show -t 4374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4374.diff">https://git.openjdk.java.net/jdk/pull/4374.diff</a>

</details>
