### PR TITLE
8268289: build failure due to missing signed flag in x86 evcmpb instruction

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -2144,19 +2144,19 @@ void C2_MacroAssembler::evpcmp(BasicType typ, KRegister kdmask, KRegister ksmask
   switch(typ) {
     case T_BYTE:
     case T_BOOLEAN:
-      evpcmpb(kdmask, ksmask, src1, src2, comparison, vector_len);
+      evpcmpb(kdmask, ksmask, src1, src2, comparison, /*signed*/ true, vector_len);
       break;
     case T_SHORT:
     case T_CHAR:
-      evpcmpw(kdmask, ksmask, src1, src2, comparison, vector_len);
+      evpcmpw(kdmask, ksmask, src1, src2, comparison, /*signed*/ true, vector_len);
       break;
     case T_INT:
     case T_FLOAT:
-      evpcmpd(kdmask, ksmask, src1, src2, comparison, vector_len);
+      evpcmpd(kdmask, ksmask, src1, src2, comparison, /*signed*/ true, vector_len);
       break;
     case T_LONG:
     case T_DOUBLE:
-      evpcmpq(kdmask, ksmask, src1, src2, comparison, vector_len);
+      evpcmpq(kdmask, ksmask, src1, src2, comparison, /*signed*/ true, vector_len);
       break;
     default:
       assert(false,"Should not reach here.");


### PR DESCRIPTION
Code introduced with PR/3999

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268289](https://bugs.openjdk.java.net/browse/JDK-8268289): build failure due to missing signed flag in x86 evcmpb instruction


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4375/head:pull/4375` \
`$ git checkout pull/4375`

Update a local copy of the PR: \
`$ git checkout pull/4375` \
`$ git pull https://git.openjdk.java.net/jdk pull/4375/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4375`

View PR using the GUI difftool: \
`$ git pr show -t 4375`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4375.diff">https://git.openjdk.java.net/jdk/pull/4375.diff</a>

</details>
