### PR TITLE
8268292: compiler/intrinsics/VectorizedMismatchTest.java fails with release VMs

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/VectorizedMismatchTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/VectorizedMismatchTest.java
@@ -36,7 +36,7 @@ package compiler.intrinsics;
  *
  *  @run main/othervm -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,*::test*
  *                    -Xbatch -XX:-TieredCompilation
- *                    -XX:UseAVX=3 -XX:AVX3Threshold=0
+ *                    -XX:+UnlockDiagnosticVMOptions -XX:UseAVX=3 -XX:AVX3Threshold=0
  *                     compiler.intrinsics.VectorizedMismatchTest
  */
 


### PR DESCRIPTION
Please review this trivial change.
Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268292](https://bugs.openjdk.java.net/browse/JDK-8268292): compiler/intrinsics/VectorizedMismatchTest.java fails with release VMs


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4377/head:pull/4377` \
`$ git checkout pull/4377`

Update a local copy of the PR: \
`$ git checkout pull/4377` \
`$ git pull https://git.openjdk.java.net/jdk pull/4377/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4377`

View PR using the GUI difftool: \
`$ git pr show -t 4377`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4377.diff">https://git.openjdk.java.net/jdk/pull/4377.diff</a>

</details>
