### PR TITLE
8268361: Fix the infinite loop in next_line

### DIFF
--- a/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
@@ -63,11 +63,13 @@ static struct perfbuf {
 #define DEC_64 "%"SCNd64
 #define NS_PER_SEC 1000000000
 
-static void next_line(FILE *f) {
+static int next_line(FILE *f) {
     int c;
     do {
         c = fgetc(f);
     } while (c != '\n' && c != EOF);
+
+    return c;
 }
 
 /**
@@ -96,7 +98,10 @@ static int get_totalticks(int which, ticks *pticks) {
            &iowTicks, &irqTicks, &sirqTicks);
 
     // Move to next line
-    next_line(fh);
+    if (next_line(fh) == EOF) {
+        fclose(fh);
+        return -2;
+    }
 
     //find the line for requested cpu faster to just iterate linefeeds?
     if (which != -1) {
@@ -109,7 +114,10 @@ static int get_totalticks(int which, ticks *pticks) {
                 fclose(fh);
                 return -2;
             }
-            next_line(fh);
+            if (next_line(fh) == EOF) {
+                fclose(fh);
+                return -2;
+            }
         }
         n = fscanf(fh, "cpu%*d " DEC_64 " " DEC_64 " " DEC_64 " " DEC_64 " "
                        DEC_64 " " DEC_64 " " DEC_64 "\n",

--- a/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
@@ -64,7 +64,10 @@ static struct perfbuf {
 #define NS_PER_SEC 1000000000
 
 static void next_line(FILE *f) {
-    while (fgetc(f) != '\n');
+    int c;
+    do {
+        c = fgetc(f);
+    } while(c != '\n' && c != EOF);
 }
 
 /**

--- a/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
@@ -67,7 +67,7 @@ static void next_line(FILE *f) {
     int c;
     do {
         c = fgetc(f);
-    } while(c != '\n' && c != EOF);
+    } while (c != '\n' && c != EOF);
 }
 
 /**


### PR DESCRIPTION
If the /proc/stat mount point is changed in container environment, the while loop may lead to 100% cpu usage.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268361](https://bugs.openjdk.java.net/browse/JDK-8268361): Fix the infinite loop in next_line


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to e4f90ebda68f576c35c1f24e35bb9cecf8c561da
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4378/head:pull/4378` \
`$ git checkout pull/4378`

Update a local copy of the PR: \
`$ git checkout pull/4378` \
`$ git pull https://git.openjdk.java.net/jdk pull/4378/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4378`

View PR using the GUI difftool: \
`$ git pr show -t 4378`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4378.diff">https://git.openjdk.java.net/jdk/pull/4378.diff</a>

</details>
