### PR TITLE
8268299: jvms tag produces incorrect URL

### DIFF
--- a/make/jdk/src/classes/build/tools/taglet/JSpec.java
+++ b/make/jdk/src/classes/build/tools/taglet/JSpec.java
@@ -114,7 +114,7 @@ public class JSpec implements Taglet  {
         return EnumSet.allOf(jdk.javadoc.doclet.Taglet.Location.class);
     }
 
-    //@Override // uncomment when JDK 15 is the boot JDK
+    @Override
     public boolean isBlockTag() {
         return true;
     }
@@ -163,7 +163,7 @@ public class JSpec implements Taglet  {
                 String chapter = m.group("chapter");
                 String section = m.group("section");
 
-                String url = String.format("%1$s/%2$s-%3$s.html#jls-%3$s%4$s",
+                String url = String.format("%1$s/%2$s-%3$s.html#%2$s-%3$s%4$s",
                         baseURL, idPrefix, chapter, section);
 
                 sb.append("<a href=\"")


### PR DESCRIPTION
The @jls and @jvms taglet share most of their functionality.  A  JLS URL looks like

    https://docs.oracle.com/javase/specs/jls/se16/html/**jls**-8.html#jls-8.1

and a JVMS URL looks like

    https://docs.oracle.com/javase/specs/jvms/se16/html/**jvms**-4.html#jvms-4.3.2

The current taglet incorrectly uses "jls" in from the chapter for both JLS and JVMS URLs. The patch corrects this to use "jvms" for JVMS URLs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268299](https://bugs.openjdk.java.net/browse/JDK-8268299): jvms tag produces incorrect URL


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4381/head:pull/4381` \
`$ git checkout pull/4381`

Update a local copy of the PR: \
`$ git checkout pull/4381` \
`$ git pull https://git.openjdk.java.net/jdk pull/4381/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4381`

View PR using the GUI difftool: \
`$ git pr show -t 4381`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4381.diff">https://git.openjdk.java.net/jdk/pull/4381.diff</a>

</details>
