### PR TITLE
8268318: Missing comma in copyright header 

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testSerializedForm/SerializedForm.java
+++ b/test/langtools/jdk/javadoc/doclet/testSerializedForm/SerializedForm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Please review this trivial fix to a copyright line.

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268318](https://bugs.openjdk.java.net/browse/JDK-8268318): Missing comma in copyright header


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4385/head:pull/4385` \
`$ git checkout pull/4385`

Update a local copy of the PR: \
`$ git checkout pull/4385` \
`$ git pull https://git.openjdk.java.net/jdk pull/4385/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4385`

View PR using the GUI difftool: \
`$ git pr show -t 4385`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4385.diff">https://git.openjdk.java.net/jdk/pull/4385.diff</a>

</details>
