### PR TITLE
8240349: jlink should not leave partial image output directory on failure

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImageFileCreator.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImageFileCreator.java
@@ -158,8 +158,10 @@ public final class ImageFileCreator {
         BasicImageWriter writer = new BasicImageWriter(byteOrder);
         ResourcePoolManager allContent = createPoolManager(archives,
                 entriesForModule, byteOrder, writer);
-        ResourcePool result = generateJImage(allContent,
-             writer, plugins, plugins.getJImageFileOutputStream());
+        ResourcePool result;
+        try (DataOutputStream out = plugins.getJImageFileOutputStream()) {
+            result = generateJImage(allContent, writer, plugins, out);
+        }
 
         //Handle files.
         try {

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/TaskHelper.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/TaskHelper.java
@@ -420,7 +420,7 @@ public final class TaskHelper {
                     ) throws IOException, BadArgs {
             if (output != null) {
                 if (Files.exists(output)) {
-                    throw new PluginException(PluginsResourceBundle.
+                    throw new IllegalArgumentException(PluginsResourceBundle.
                             getMessage("err.dir.already.exits", output));
                 }
             }

--- a/test/jdk/tools/jlink/JLinkNegativeTest.java
+++ b/test/jdk/tools/jlink/JLinkNegativeTest.java
@@ -130,6 +130,9 @@ public class JLinkNegativeTest {
                 .output(image)
                 .addMods("leaf1")
                 .call().assertFailure("Error: directory already exists: .*failure4.image(\n|\r|.)*");
+        if (Files.notExists(image)) {
+            throw new RuntimeException("output directory should not have been deleted");
+        }
     }
 
     public void testModuleNotFound() {

--- a/test/jdk/tools/jlink/JLinkTest.java
+++ b/test/jdk/tools/jlink/JLinkTest.java
@@ -376,7 +376,7 @@ public class JLinkTest {
                     .addMods("java.base")
                     .option("--vm=client")
                     .call().assertFailure("Error: Selected VM client doesn't exist");
-            if (Files.isDirectory(imagePath)) {
+            if (!Files.notExists(imagePath)) {
                 throw new RuntimeException("bug8240349 directory not deleted");
             }
         }

--- a/test/jdk/tools/jlink/JLinkTest.java
+++ b/test/jdk/tools/jlink/JLinkTest.java
@@ -47,6 +47,7 @@ import tests.JImageGenerator;
  * @bug 8189777
  * @bug 8194922
  * @bug 8206962
+ * @bug 8240349
  * @author Jean-Francois Denise
  * @requires (vm.compMode != "Xcomp" & os.maxMemory >= 2g)
  * @library ../lib
@@ -365,6 +366,19 @@ public class JLinkTest {
                     .addMods("java.base")
                     .option("--release-info=del")
                     .call().assertFailure("Error: No key specified for delete");
+        }
+        {
+            String imageDir = "bug8240349";
+            Path imagePath = helper.createNewImageDir(imageDir);
+            JImageGenerator.getJLinkTask()
+                    .modulePath(helper.defaultModulePath())
+                    .output(imagePath)
+                    .addMods("java.base")
+                    .option("--vm=client")
+                    .call().assertFailure("Error: Selected VM client doesn't exist");
+            if (Files.isDirectory(imagePath)) {
+                throw new RuntimeException("bug8240349 directory not deleted");
+            }
         }
     }
 


### PR DESCRIPTION
jlink should clean up output directory on any failure. should not leave partially filled output.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8240349](https://bugs.openjdk.java.net/browse/JDK-8240349): jlink should not leave partial image output directory on failure


### Reviewers
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4386/head:pull/4386` \
`$ git checkout pull/4386`

Update a local copy of the PR: \
`$ git checkout pull/4386` \
`$ git pull https://git.openjdk.java.net/jdk pull/4386/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4386`

View PR using the GUI difftool: \
`$ git pr show -t 4386`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4386.diff">https://git.openjdk.java.net/jdk/pull/4386.diff</a>

</details>
