### PR TITLE
8267399: C2: java/text/Normalizer/ConformanceTest.java test failed with assertion

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2851,6 +2851,13 @@ int PhaseIdealLoop::do_range_check(IdealLoopTree *loop, Node_List &old_new) {
     register_new_node(main_cmp, main_cle->in(0));
     _igvn.replace_input_of(main_bol, 1, main_cmp);
   }
+  assert(main_limit == cl->limit() || get_ctrl(main_limit) == pre_ctrl, "wrong control for added limit");
+  const TypeInt* orig_limit_t = _igvn.type(orig_limit)->is_int();
+  bool upward = cl->stride_con() > 0;
+  main_limit = new CastIINode(main_limit, TypeInt::make(upward ? min_jint : orig_limit_t->_lo,
+                                                        upward ? orig_limit_t->_hi : max_jint, Type::WidenMax));
+  main_limit->init_req(0, pre_ctrl);
+  register_new_node(main_limit, pre_ctrl);
   // Hack the now-private loop bounds
   _igvn.replace_input_of(main_cmp, 2, main_limit);
   // The OpaqueNode is unshared by design

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2854,6 +2854,9 @@ int PhaseIdealLoop::do_range_check(IdealLoopTree *loop, Node_List &old_new) {
   assert(main_limit == cl->limit() || get_ctrl(main_limit) == pre_ctrl, "wrong control for added limit");
   const TypeInt* orig_limit_t = _igvn.type(orig_limit)->is_int();
   bool upward = cl->stride_con() > 0;
+  // The new loop limit is <= (for an upward loop) >= (for a downward loop) than the orig limit.
+  // The expression that computes the new limit may be too complicated and the computed type of the new limit
+  // may be too pessimistic. A CastII here guarantees it's not lost.
   main_limit = new CastIINode(main_limit, TypeInt::make(upward ? min_jint : orig_limit_t->_lo,
                                                         upward ? orig_limit_t->_hi : max_jint, Type::WidenMax));
   main_limit->init_req(0, pre_ctrl);

--- a/test/hotspot/jtreg/compiler/loopopts/TestDeadCountedLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestDeadCountedLoop.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8267399
+ * @summary C2: java/text/Normalizer/ConformanceTest.java test failed with assertion
+ *
+ * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation TestDeadCountedLoop
+ *
+ */
+
+public class TestDeadCountedLoop {
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            test(true, new int[10], false, 0, 1);
+            test(false, new int[10], false, 0, 1);
+        }
+    }
+
+    private static int test(boolean flag, int[] array2, boolean flag2, int start, int stop) {
+        if (array2 == null) {
+        }
+        int[] array;
+        if (flag) {
+            array = new int[1];
+        } else {
+            array = new int[2];
+        }
+        int len = array.length;
+        int v = 1;
+        for (int j = start; j < stop; j++) {
+            for (int i = 0; i < len; i++) {
+                if (i > 0) {
+                    if (flag2) {
+                        break;
+                    }
+                    v *= array2[i + j];
+                }
+            }
+        }
+
+        return v;
+    }
+}


### PR DESCRIPTION
This was found with Shenandoah but has nothing specific to Shenandoah.

For the inner loop of the test case:

- the loop limit, len, is known to be either 1 or 2. As a consequence
  the type of the iv phi is set to [0..2].

- range check elimination is applied which causes the pre/main/post
  loops to be added and the limit of the main loop to be adjusted. C2
  computes the limit of the main loop as TypeINT:INT.

- the main loop is peeled. So now the type of the iv phi is 2 and it
  constant folds. Because the main loop limit has type TypeInt::INT,
  the exit condition of the loop doesn't constant fold. But the loop
  no longer has the shape of a counted loop because the iv phi doesn't
  exist anymore.

The crash then occurs when some other loop opts is attempted and loop
strip mining verification code checks that the shape of the main loop
is that of a counted loop.

The fix I propose is to add a CastII at range elimination time that
captures the bounds of the limit before RC is applied. This way the
type of the limit is not lost and the main loop backbranch can be
properly eliminated in the chain of events above.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267399](https://bugs.openjdk.java.net/browse/JDK-8267399): C2: java/text/Normalizer/ConformanceTest.java test failed with assertion


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4388/head:pull/4388` \
`$ git checkout pull/4388`

Update a local copy of the PR: \
`$ git checkout pull/4388` \
`$ git pull https://git.openjdk.java.net/jdk pull/4388/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4388`

View PR using the GUI difftool: \
`$ git pr show -t 4388`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4388.diff">https://git.openjdk.java.net/jdk/pull/4388.diff</a>

</details>
