### PR TITLE
Fix the consumed event example in the InputEvent javadoc

### DIFF
--- a/src/java.desktop/share/classes/java/awt/event/InputEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/InputEvent.java
@@ -43,9 +43,9 @@ import sun.util.logging.PlatformLogger;
  * processed normally by the source where they originated.
  * This allows listeners and component subclasses to "consume"
  * the event so that the source will not process them in their
- * default manner.  For example, consuming mousePressed events
- * on a Button component will prevent the Button from being
- * activated.
+ * default manner.  For example, consuming keyTyped events
+ * on a TextField component will prevent the TextField from being
+ * updated.
  *
  * @author Carl Quinn
  *


### PR DESCRIPTION
The InputEvent javadoc states that:

> For example, consuming mousePressed events on a Button component will prevent the Button from being activated.

But this is not the case, as demonstrated by this simple example:

    public static void main(String[] args) {
        Frame frame = new Frame("TEST");
        frame.setSize(200, 200);
        frame.setVisible(true);
        
        Button button = new Button("CLICK ME");
        button.addActionListener(event -> System.out.println("Button activated"));
        button.addMouseListener(new MouseAdapter() {
            public void mousePressed(MouseEvent e) {
                e.consume();
            }
        });
        
        frame.add(button);
    }

Here the mouse pressed event is consumed by the listener, but the action listener is still triggered. The behavior is the same with the Swing components.

I suggest to change the example to mention the TextField component and the key pressed event. In this case, if a listener consumes the event the component doesn't process it and the field remains unchanged.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4389/head:pull/4389` \
`$ git checkout pull/4389`

Update a local copy of the PR: \
`$ git checkout pull/4389` \
`$ git pull https://git.openjdk.java.net/jdk pull/4389/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4389`

View PR using the GUI difftool: \
`$ git pr show -t 4389`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4389.diff">https://git.openjdk.java.net/jdk/pull/4389.diff</a>

</details>
