### PR TITLE
8268330: [BACKOUT] JDK-8267924: Misleading G1 eager reclaim detail logging

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3391,16 +3391,6 @@ class G1PrepareEvacuationTask : public AbstractGangTask {
         _g1h->set_humongous_reclaim_candidate(index, false);
         _g1h->register_region_with_region_attr(hr);
       }
-      log_debug(gc, humongous)("Humongous region %u (object size " SIZE_FORMAT " @ " PTR_FORMAT ") remset " SIZE_FORMAT " code roots " SIZE_FORMAT " marked %d reclaim candidate %d type array %d",
-                               index,
-                               (size_t)cast_to_oop(hr->bottom())->size() * HeapWordSize,
-                               p2i(hr->bottom()),
-                               hr->rem_set()->occupied(),
-                               hr->rem_set()->strong_code_roots_list_length(),
-                               _g1h->concurrent_mark()->next_mark_bitmap()->is_marked(hr->bottom()),
-                               _g1h->is_humongous_reclaim_candidate(index),
-                               cast_to_oop(hr->bottom())->is_typeArray()
-                              );
       _worker_humongous_total++;
 
       return false;

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -91,43 +91,8 @@ class G1FreeHumongousRegionClosure : public HeapRegionClosure {
   uint _humongous_objects_reclaimed;
   uint _humongous_regions_reclaimed;
   size_t _freed_bytes;
-
-  // Returns whether the given humongous object defined by the start region index
-  // is reclaimable.
-  //
-  // At this point in the garbage collection, checking whether the humongous object
-  // is still a candidate is sufficient because:
-  //
-  // - if it has not been a candidate at the start of collection, it will never
-  // changed to be a candidate during the gc (and live).
-  // - any found outstanding (i.e. in the DCQ, or in its remembered set)
-  // references will set the candidate state to false.
-  // - there can be no references from within humongous starts regions referencing
-  // the object because we never allocate other objects into them.
-  // (I.e. there can be no intra-region references)
-  //
-  // It is not required to check whether the object has been found dead by marking
-  // or not, in fact it would prevent reclamation within a concurrent cycle, as
-  // all objects allocated during that time are considered live.
-  // SATB marking is even more conservative than the remembered set.
-  // So if at this point in the collection we did not find a reference during gc
-  // (or it had enough references to not be a candidate, having many remembered
-  // set entries), nobody has a reference to it.
-  // At the start of collection we flush all refinement logs, and remembered sets
-  // are completely up-to-date wrt to references to the humongous object.
-  //
-  // So there is no need to re-check remembered set size of the humongous region.
-  //
-  // Other implementation considerations:
-  // - never consider object arrays at this time because they would pose
-  // considerable effort for cleaning up the the remembered sets. This is
-  // required because stale remembered sets might reference locations that
-  // are currently allocated into.
-  bool is_reclaimable(uint region_idx) const {
-    return G1CollectedHeap::heap()->is_humongous_reclaim_candidate(region_idx);
-  }
-
 public:
+
   G1FreeHumongousRegionClosure() :
     _humongous_objects_reclaimed(0),
     _humongous_regions_reclaimed(0),
@@ -139,17 +104,70 @@ public:
       return false;
     }
 
+    G1CollectedHeap* g1h = G1CollectedHeap::heap();
+
+    oop obj = cast_to_oop(r->bottom());
+    G1CMBitMap* next_bitmap = g1h->concurrent_mark()->next_mark_bitmap();
+
+    // The following checks whether the humongous object is live are sufficient.
+    // The main additional check (in addition to having a reference from the roots
+    // or the young gen) is whether the humongous object has a remembered set entry.
+    //
+    // A humongous object cannot be live if there is no remembered set for it
+    // because:
+    // - there can be no references from within humongous starts regions referencing
+    // the object because we never allocate other objects into them.
+    // (I.e. there are no intra-region references that may be missed by the
+    // remembered set)
+    // - as soon there is a remembered set entry to the humongous starts region
+    // (i.e. it has "escaped" to an old object) this remembered set entry will stay
+    // until the end of a concurrent mark.
+    //
+    // It is not required to check whether the object has been found dead by marking
+    // or not, in fact it would prevent reclamation within a concurrent cycle, as
+    // all objects allocated during that time are considered live.
+    // SATB marking is even more conservative than the remembered set.
+    // So if at this point in the collection there is no remembered set entry,
+    // nobody has a reference to it.
+    // At the start of collection we flush all refinement logs, and remembered sets
+    // are completely up-to-date wrt to references to the humongous object.
+    //
+    // Other implementation considerations:
+    // - never consider object arrays at this time because they would pose
+    // considerable effort for cleaning up the the remembered sets. This is
+    // required because stale remembered sets might reference locations that
+    // are currently allocated into.
     uint region_idx = r->hrm_index();
-    if (!is_reclaimable(region_idx)) {
+    if (!g1h->is_humongous_reclaim_candidate(region_idx) ||
+        !r->rem_set()->is_empty()) {
+      log_debug(gc, humongous)("Live humongous region %u object size " SIZE_FORMAT " start " PTR_FORMAT "  with remset " SIZE_FORMAT " code roots " SIZE_FORMAT " is marked %d reclaim candidate %d type array %d",
+                               region_idx,
+                               (size_t)obj->size() * HeapWordSize,
+                               p2i(r->bottom()),
+                               r->rem_set()->occupied(),
+                               r->rem_set()->strong_code_roots_list_length(),
+                               next_bitmap->is_marked(r->bottom()),
+                               g1h->is_humongous_reclaim_candidate(region_idx),
+                               obj->is_typeArray()
+                              );
       return false;
     }
 
-    oop obj = cast_to_oop(r->bottom());
     guarantee(obj->is_typeArray(),
               "Only eagerly reclaiming type arrays is supported, but the object "
               PTR_FORMAT " is not.", p2i(r->bottom()));
 
-    G1CollectedHeap* g1h = G1CollectedHeap::heap();
+    log_debug(gc, humongous)("Dead humongous region %u object size " SIZE_FORMAT " start " PTR_FORMAT " with remset " SIZE_FORMAT " code roots " SIZE_FORMAT " is marked %d reclaim candidate %d type array %d",
+                             region_idx,
+                             (size_t)obj->size() * HeapWordSize,
+                             p2i(r->bottom()),
+                             r->rem_set()->occupied(),
+                             r->rem_set()->strong_code_roots_list_length(),
+                             next_bitmap->is_marked(r->bottom()),
+                             g1h->is_humongous_reclaim_candidate(region_idx),
+                             obj->is_typeArray()
+                            );
+
     G1ConcurrentMark* const cm = g1h->concurrent_mark();
     cm->humongous_object_eagerly_reclaimed(r);
     assert(!cm->is_marked_in_prev_bitmap(obj) && !cm->is_marked_in_next_bitmap(obj),
@@ -168,11 +186,6 @@ public:
       r = next;
     } while (r != nullptr);
 
-    log_debug(gc, humongous)("Reclaimed humongous region %u (object size " SIZE_FORMAT " @ " PTR_FORMAT ")",
-                             region_idx,
-                             (size_t)obj->size() * HeapWordSize,
-                             p2i(r->bottom())
-                            );
     return false;
   }
 

--- a/test/hotspot/jtreg/gc/g1/TestG1TraceEagerReclaimHumongousObjects.java
+++ b/test/hotspot/jtreg/gc/g1/TestG1TraceEagerReclaimHumongousObjects.java
@@ -52,7 +52,6 @@ public class TestG1TraceEagerReclaimHumongousObjects {
 
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
-    System.out.println(output.getStdout());
     // As G1ReclaimDeadHumongousObjectsAtYoungGC is set(default), below logs should be displayed.
     output.shouldContain("Humongous Reclaim");
     output.shouldContain("Humongous Total");
@@ -61,8 +60,8 @@ public class TestG1TraceEagerReclaimHumongousObjects {
 
     // As G1TraceReclaimDeadHumongousObjectsAtYoungGC is set and GCWithHumongousObjectTest has humongous objects,
     // these logs should be displayed.
-    output.shouldContain("Humongous region");
-    output.shouldContain("Reclaimed humongous region");
+    output.shouldContain("Live humongous");
+    output.shouldContain("Dead humongous region");
     output.shouldHaveExitValue(0);
   }
 


### PR DESCRIPTION
Hi all,

  can I have reviews for this revert of commit 15715a8984e3e346c2a65e5a0c7b48c4dee21d3e because it causes some tier1 failures.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268330](https://bugs.openjdk.java.net/browse/JDK-8268330): [BACKOUT] JDK-8267924: Misleading G1 eager reclaim detail logging


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4391/head:pull/4391` \
`$ git checkout pull/4391`

Update a local copy of the PR: \
`$ git checkout pull/4391` \
`$ git pull https://git.openjdk.java.net/jdk pull/4391/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4391`

View PR using the GUI difftool: \
`$ git pr show -t 4391`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4391.diff">https://git.openjdk.java.net/jdk/pull/4391.diff</a>

</details>
