### PR TITLE
8268328: Upstream: 8267989: Exceptions thrown during upcalls should be handled (Pt. 1)

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -2118,15 +2118,16 @@ abstract class MethodHandleImpl {
 
     // Indexes into constant method handles:
     static final int
-            MH_cast                  = 0,
-            MH_selectAlternative     = 1,
-            MH_countedLoopPred       = 2,
-            MH_countedLoopStep       = 3,
-            MH_initIterator          = 4,
-            MH_iteratePred           = 5,
-            MH_iterateNext           = 6,
-            MH_Array_newInstance     = 7,
-            MH_LIMIT                 = 8;
+            MH_cast                               = 0,
+            MH_selectAlternative                  = 1,
+            MH_countedLoopPred                    = 2,
+            MH_countedLoopStep                    = 3,
+            MH_initIterator                       = 4,
+            MH_iteratePred                        = 5,
+            MH_iterateNext                        = 6,
+            MH_Array_newInstance                  = 7,
+            MH_VarHandles_handleCheckedExceptions = 8,
+            MH_LIMIT                              = 9;
 
     static MethodHandle getConstantHandle(int idx) {
         MethodHandle handle = HANDLES[idx];
@@ -2176,6 +2177,9 @@ abstract class MethodHandleImpl {
                 case MH_Array_newInstance:
                     return IMPL_LOOKUP.findStatic(Array.class, "newInstance",
                             MethodType.methodType(Object.class, Class.class, int.class));
+                case MH_VarHandles_handleCheckedExceptions:
+                    return IMPL_LOOKUP.findStatic(VarHandles.class, "handleCheckedExceptions",
+                            MethodType.methodType(void.class, Throwable.class));
             }
         } catch (ReflectiveOperationException ex) {
             throw newInternalError(ex);

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -31,12 +31,9 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.lang.reflect.Parameter;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -45,8 +42,6 @@ import java.util.stream.Stream;
 import static java.lang.invoke.MethodHandleStatics.UNSAFE;
 import static java.lang.invoke.MethodHandleStatics.VAR_HANDLE_IDENTITY_ADAPT;
 import static java.lang.invoke.MethodHandleStatics.newIllegalArgumentException;
-import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
 
 final class VarHandles {
 
@@ -359,13 +354,13 @@ final class VarHandles {
         return target;
     }
 
-    public static VarHandle filterValue(VarHandle target, MethodHandle filterToTarget, MethodHandle filterFromTarget) {
+    public static VarHandle filterValue(VarHandle target, MethodHandle pFilterToTarget, MethodHandle pFilterFromTarget) {
         Objects.requireNonNull(target);
-        Objects.requireNonNull(filterToTarget);
-        Objects.requireNonNull(filterFromTarget);
+        Objects.requireNonNull(pFilterToTarget);
+        Objects.requireNonNull(pFilterFromTarget);
         //check that from/to filters do not throw checked exceptions
-        noCheckedExceptions(filterToTarget);
-        noCheckedExceptions(filterFromTarget);
+        MethodHandle filterToTarget = adaptForCheckedExceptions(pFilterToTarget);
+        MethodHandle filterFromTarget = adaptForCheckedExceptions(pFilterFromTarget);
 
         List<Class<?>> newCoordinates = new ArrayList<>();
         List<Class<?>> additionalCoordinates = new ArrayList<>();
@@ -473,8 +468,9 @@ final class VarHandles {
 
         List<Class<?>> newCoordinates = new ArrayList<>(targetCoordinates);
         for (int i = 0 ; i < filters.length ; i++) {
-            noCheckedExceptions(filters[i]);
-            MethodType filterType = filters[i].type();
+            MethodHandle filter = Objects.requireNonNull(filters[i]);
+            filter = adaptForCheckedExceptions(filter);
+            MethodType filterType = filter.type();
             if (filterType.parameterCount() != 1) {
                 throw newIllegalArgumentException("Invalid filter type " + filterType);
             } else if (newCoordinates.get(pos + i) != filterType.returnType()) {
@@ -564,10 +560,10 @@ final class VarHandles {
         return adjustedType;
     }
 
-    public static VarHandle collectCoordinates(VarHandle target, int pos, MethodHandle filter) {
+    public static VarHandle collectCoordinates(VarHandle target, int pos, MethodHandle pFilter) {
         Objects.requireNonNull(target);
-        Objects.requireNonNull(filter);
-        noCheckedExceptions(filter);
+        Objects.requireNonNull(pFilter);
+        MethodHandle filter = adaptForCheckedExceptions(pFilter);
 
         List<Class<?>> targetCoordinates = target.coordinateTypes();
         if (pos < 0 || pos >= targetCoordinates.size()) {
@@ -604,42 +600,55 @@ final class VarHandles {
                 (mode, modeHandle) -> MethodHandles.dropArguments(modeHandle, 1 + pos, valueTypes));
     }
 
-    private static void noCheckedExceptions(MethodHandle handle) {
+    private static MethodHandle adaptForCheckedExceptions(MethodHandle target) {
+        Class<?>[] exceptionTypes = exceptionTypes(target);
+        if (exceptionTypes != null) { // exceptions known
+            if (Stream.of(exceptionTypes).anyMatch(VarHandles::isCheckedException)) {
+                throw newIllegalArgumentException("Cannot adapt a var handle with a method handle which throws checked exceptions");
+            }
+            return target; // no adaptation needed
+        } else {
+            MethodHandle handler = MethodHandleImpl.getConstantHandle(MethodHandleImpl.MH_VarHandles_handleCheckedExceptions);
+            MethodHandle zero = MethodHandles.zero(target.type().returnType()); // dead branch
+            handler = MethodHandles.collectArguments(zero, 0, handler);
+            return MethodHandles.catchException(target, Throwable.class, handler);
+        }
+    }
+
+    static void handleCheckedExceptions(Throwable throwable) throws Throwable {
+        if (isCheckedException(throwable.getClass())) {
+            throw new IllegalStateException("Adapter handle threw checked exception", throwable);
+        }
+        throw throwable;
+    }
+
+    private static Class<?>[] exceptionTypes(MethodHandle handle) {
         if (handle instanceof DirectMethodHandle directHandle) {
             byte refKind = directHandle.member.getReferenceKind();
             MethodHandleInfo info = new InfoFromMemberName(
                     MethodHandles.Lookup.IMPL_LOOKUP,
                     directHandle.member,
                     refKind);
-            final Class<?>[] exceptionTypes;
             if (MethodHandleNatives.refKindIsMethod(refKind)) {
-                exceptionTypes = info.reflectAs(Method.class, MethodHandles.Lookup.IMPL_LOOKUP)
+                return info.reflectAs(Method.class, MethodHandles.Lookup.IMPL_LOOKUP)
                         .getExceptionTypes();
             } else if (MethodHandleNatives.refKindIsField(refKind)) {
-                exceptionTypes = null;
+                return new Class<?>[0];
             } else if (MethodHandleNatives.refKindIsConstructor(refKind)) {
-                exceptionTypes = info.reflectAs(Constructor.class, MethodHandles.Lookup.IMPL_LOOKUP)
+                return info.reflectAs(Constructor.class, MethodHandles.Lookup.IMPL_LOOKUP)
                         .getExceptionTypes();
             } else {
                 throw new AssertionError("Cannot get here");
             }
-            if (exceptionTypes != null) {
-                if (Stream.of(exceptionTypes).anyMatch(VarHandles::isCheckedException)) {
-                    throw newIllegalArgumentException("Cannot adapt a var handle with a method handle which throws checked exceptions");
-                }
-            }
         } else if (handle instanceof DelegatingMethodHandle) {
-            noCheckedExceptions(((DelegatingMethodHandle)handle).getTarget());
-        } else {
-            //bound
-            BoundMethodHandle boundHandle = (BoundMethodHandle)handle;
-            for (int i = 0 ; i < boundHandle.fieldCount() ; i++) {
-                Object arg = boundHandle.arg(i);
-                if (arg instanceof MethodHandle){
-                    noCheckedExceptions((MethodHandle) arg);
-                }
-            }
+            return exceptionTypes(((DelegatingMethodHandle)handle).getTarget());
+        } else if (handle instanceof NativeMethodHandle) {
+            return new Class<?>[0];
         }
+
+        assert handle instanceof BoundMethodHandle : "Unexpected handle type: " + handle;
+        // unknown
+        return null;
     }
 
     private static boolean isCheckedException(Class<?> clazz) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryHandles.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryHandles.java
@@ -329,6 +329,9 @@ public final class MemoryHandles {
      * the resulting var handle will have type {@code S} and will feature the additional coordinates {@code A...} (which
      * will be appended to the coordinates of the target var handle).
      * <p>
+     * If the boxing and unboxing filters throw any checked exceptions when invoked, the resulting var handle will
+     * throw an {@link IllegalStateException}.
+     * <p>
      * The resulting var handle will feature the same access modes (see {@link java.lang.invoke.VarHandle.AccessMode} and
      * atomic access guarantees as those featured by the target var handle.
      *
@@ -338,7 +341,7 @@ public final class MemoryHandles {
      * @return an adapter var handle which accepts a new type, performing the provided boxing/unboxing conversions.
      * @throws IllegalArgumentException if {@code filterFromTarget} and {@code filterToTarget} are not well-formed, that is, they have types
      * other than {@code (A... , S) -> T} and {@code (A... , T) -> S}, respectively, where {@code T} is the type of the target var handle,
-     * or if either {@code filterFromTarget} or {@code filterToTarget} throws any checked exceptions.
+     * or if it's determined that either {@code filterFromTarget} or {@code filterToTarget} throws any checked exceptions.
      */
     public static VarHandle filterValue(VarHandle target, MethodHandle filterToTarget, MethodHandle filterFromTarget) {
         return JLI.filterValue(target, filterToTarget, filterFromTarget);
@@ -356,6 +359,9 @@ public final class MemoryHandles {
      * For the coordinate filters to be well formed, their types must be of the form {@code S1 -> T1, S2 -> T1 ... Sn -> Tn},
      * where {@code T1, T2 ... Tn} are the coordinate types starting at position {@code pos} of the target var handle.
      * <p>
+     * If any of the filters throws a checked exception when invoked, the resulting var handle will
+     * throw an {@link IllegalStateException}.
+     * <p>
      * The resulting var handle will feature the same access modes (see {@link java.lang.invoke.VarHandle.AccessMode}) and
      * atomic access guarantees as those featured by the target var handle.
      *
@@ -368,7 +374,7 @@ public final class MemoryHandles {
      * other than {@code S1 -> T1, S2 -> T2, ... Sn -> Tn} where {@code T1, T2 ... Tn} are the coordinate types starting
      * at position {@code pos} of the target var handle, if {@code pos} is not between 0 and the target var handle coordinate arity, inclusive,
      * or if more filters are provided than the actual number of coordinate types available starting at {@code pos},
-     * or if any of the filters throws any checked exceptions.
+     * or if it's determined that any of the filters throws any checked exceptions.
      */
     public static VarHandle filterCoordinates(VarHandle target, int pos, MethodHandle... filters) {
         return JLI.filterCoordinates(target, pos, filters);
@@ -464,6 +470,9 @@ public final class MemoryHandles {
      * coordinate type of the target var handle at position {@code pos}, and that target var handle
      * coordinate is supplied by the return value of the filter.
      * <p>
+     * If any of the filters throws a checked exception when invoked, the resulting var handle will
+     * throw an {@link IllegalStateException}.
+     * <p>
      * The resulting var handle will feature the same access modes (see {@link java.lang.invoke.VarHandle.AccessMode}) and
      * atomic access guarantees as those featured by the target var handle.
      *
@@ -476,7 +485,7 @@ public final class MemoryHandles {
      * is void, or it is not the same as the {@code pos} coordinate of the target var handle,
      * if {@code pos} is not between 0 and the target var handle coordinate arity, inclusive,
      * if the resulting var handle's type would have <a href="MethodHandle.html#maxarity">too many coordinates</a>,
-     * or if {@code filter} throws any checked exceptions.
+     * or if it's determined that {@code filter} throws any checked exceptions.
      */
     public static VarHandle collectCoordinates(VarHandle target, int pos, MethodHandle filter) {
         return JLI.collectCoordinates(target, pos, filter);

--- a/test/jdk/java/foreign/TestAdaptVarHandles.java
+++ b/test/jdk/java/foreign/TestAdaptVarHandles.java
@@ -189,16 +189,25 @@ public class TestAdaptVarHandles {
         MemoryHandles.filterValue(intHandle, S2L_EX, I2S);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalStateException.class)
     public void testBadFilterBoxHandleException() {
         VarHandle intHandle = MemoryLayouts.JAVA_INT.varHandle(int.class);
-        MemoryHandles.filterValue(intHandle, S2I, I2S_EX);
+        VarHandle vh = MemoryHandles.filterValue(intHandle, S2I, I2S_EX);
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+            MemorySegment seg = MemorySegment.allocateNative(MemoryLayouts.JAVA_INT, scope);
+            vh.set(seg, "42");
+            String x = (String) vh.get(seg); // should throw
+        }
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalStateException.class)
     public void testBadFilterUnboxHandleException() {
         VarHandle intHandle = MemoryLayouts.JAVA_INT.varHandle(int.class);
-        MemoryHandles.filterValue(intHandle, S2I_EX, I2S);
+        VarHandle vh = MemoryHandles.filterValue(intHandle, S2I_EX, I2S);
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+            MemorySegment seg = MemorySegment.allocateNative(MemoryLayouts.JAVA_INT, scope);
+            vh.set(seg, "42"); // should throw
+        }
     }
 
     @Test


### PR DESCRIPTION
Hi,

This is part 1 of a two part upstreaming process of the patch mentioned in the subject line. The patch was split into 2 in order to document 2 separate specification changes that arose from a change in the implementation, with 2 separate CSRs.

This patch changes the handling of method handles that might throw checked exceptions, by the var handle combinators found in `jdk.incubator.foreign.MemoryHandles`. Particularly, it makes the check more lenient towards `BoundMethodHandle`s that have fields that are method handles that might themselves throw exceptions, since it is not known whether the enclosing method handle catches such exceptions. For instance, if a target method handle is wrapped using the `catchException` combinator, which handles all exceptions thrown by that target, the current code will still reject such method handles, even though no checked exceptions can be thrown.

The patch fixes this by instead wrapping method handles for which it is not possible to eagerly determine whether they throw exception using the `catchException` combinator, with an exception handler that catches checked exceptions and instead throws an `IllegalStateException` with the original exception as the cause. (See also the CSR).

The main motivation for doing this is having the ability to share the implementation with the `CLinker::upcallStub` API, which also wants to eagerly reject method handles that are determined to throw exceptions.

See also the original review for the panama-foreign repo: https://github.com/openjdk/panama-foreign/pull/543

Thanks,
Jorn

Testing: `jdk_foreign` test suite.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ The change requires a CSR request to be approved.

### Issue
 * [JDK-8268328](https://bugs.openjdk.java.net/browse/JDK-8268328): Upstream: 8267989: Exceptions thrown during upcalls should be handled (Pt. 1)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4395/head:pull/4395` \
`$ git checkout pull/4395`

Update a local copy of the PR: \
`$ git checkout pull/4395` \
`$ git pull https://git.openjdk.java.net/jdk pull/4395/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4395`

View PR using the GUI difftool: \
`$ git pr show -t 4395`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4395.diff">https://git.openjdk.java.net/jdk/pull/4395.diff</a>

</details>
