### PR TITLE
8268339: Upstream: 8267989: Exceptions thrown during upcalls should be handled

### DIFF
--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2398,6 +2398,11 @@ public final class System {
             public long findNative(ClassLoader loader, String entry) {
                 return ClassLoader.findNative(loader, entry);
             }
+
+            @Override
+            public void exit(int statusCode) {
+                Shutdown.exit(statusCode);
+            }
         });
     }
 }

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -395,4 +395,10 @@ public interface JavaLangAccess {
     Object classData(Class<?> c);
 
     long findNative(ClassLoader loader, String entry);
+
+    /**
+     * Direct access to Shutdown.exit to avoid security manager checks
+     * @param statusCode the status code
+     */
+    void exit(int statusCode);
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
@@ -214,8 +214,12 @@ public sealed interface CLinker permits AbstractCLinker {
      * Allocates a native stub with given scope which can be passed to other foreign functions (as a function pointer);
      * calling such a function pointer from native code will result in the execution of the provided method handle.
      *
-     * <p>The returned memory address is associated with the provided scope. When such scope is closed,
+     * <p>
+     * The returned memory address is associated with the provided scope. When such scope is closed,
      * the corresponding native stub will be deallocated.
+     * <p>
+     * The target method handle should not throw any exceptions. If the target method handle does throw an exception,
+     * the VM will exit with a non-zero exit code.
      *
      * @param target   the target method handle.
      * @param function the function descriptor.

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
@@ -219,7 +219,10 @@ public sealed interface CLinker permits AbstractCLinker {
      * the corresponding native stub will be deallocated.
      * <p>
      * The target method handle should not throw any exceptions. If the target method handle does throw an exception,
-     * the VM will exit with a non-zero exit code.
+     * the VM will exit with a non-zero exit code. To avoid the VM aborting due to an uncaught exception, clients
+     * could wrap all code in the target method handle in a try/catch block that catches any {@link Throwable}, for
+     * instance by using the {@link java.lang.invoke.MethodHandles#catchException(MethodHandle, Class, MethodHandle)}
+     * method handle combinator, and handle exceptions as desired in the corresponding catch block.
      *
      * @param target   the target method handle.
      * @param function the function descriptor.

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/CABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/CABI.java
@@ -25,9 +25,10 @@
  */
 package jdk.internal.foreign;
 
-import jdk.internal.foreign.abi.SharedUtils;
+import sun.security.action.GetPropertyAction;
 
 import static jdk.incubator.foreign.MemoryLayouts.ADDRESS;
+import static sun.security.action.GetPropertyAction.privilegedGetProperty;
 
 public enum CABI {
     SysV,
@@ -38,8 +39,8 @@ public enum CABI {
     private static final CABI current;
 
     static {
-        String arch = System.getProperty("os.arch");
-        String os = System.getProperty("os.name");
+        String arch = privilegedGetProperty("os.arch");
+        String os = privilegedGetProperty("os.name");
         long addressSize = ADDRESS.bitSize();
         // might be running in a 32-bit VM on a 64-bit platform.
         // addressSize will be correctly 32

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
@@ -295,6 +295,9 @@ public class ProgrammableUpcallHandler {
             } else {
                 return returnMoves;
             }
+        } catch(Throwable t) {
+            SharedUtils.handleUncaughtException(t);
+            return null;
         }
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -38,7 +38,6 @@ import jdk.incubator.foreign.SequenceLayout;
 import jdk.incubator.foreign.CLinker;
 import jdk.incubator.foreign.ValueLayout;
 import jdk.internal.access.JavaLangAccess;
-import jdk.internal.access.JavaLangInvokeAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.CABI;
 import jdk.internal.foreign.MemoryAddressImpl;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -53,7 +53,6 @@ import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
 import java.lang.ref.Reference;
 import java.nio.charset.Charset;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -37,6 +37,9 @@ import jdk.incubator.foreign.SegmentAllocator;
 import jdk.incubator.foreign.SequenceLayout;
 import jdk.incubator.foreign.CLinker;
 import jdk.incubator.foreign.ValueLayout;
+import jdk.internal.access.JavaLangAccess;
+import jdk.internal.access.JavaLangInvokeAccess;
+import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.CABI;
 import jdk.internal.foreign.MemoryAddressImpl;
 import jdk.internal.foreign.Utils;
@@ -51,6 +54,7 @@ import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
 import java.lang.ref.Reference;
 import java.nio.charset.Charset;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -73,6 +77,8 @@ import static jdk.incubator.foreign.CLinker.*;
 
 public class SharedUtils {
 
+    private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
+
     private static final MethodHandle MH_ALLOC_BUFFER;
     private static final MethodHandle MH_BASEADDRESS;
     private static final MethodHandle MH_BUFFER_COPY;
@@ -80,6 +86,7 @@ public class SharedUtils {
     private static final MethodHandle MH_MAKE_CONTEXT_BOUNDED_ALLOCATOR;
     private static final MethodHandle MH_CLOSE_CONTEXT;
     private static final MethodHandle MH_REACHBILITY_FENCE;
+    private static final MethodHandle MH_HANDLE_UNCAUGHT_EXCEPTION;
 
     static {
         try {
@@ -98,6 +105,8 @@ public class SharedUtils {
                     methodType(void.class));
             MH_REACHBILITY_FENCE = lookup.findStatic(Reference.class, "reachabilityFence",
                     methodType(void.class, Object.class));
+            MH_HANDLE_UNCAUGHT_EXCEPTION = lookup.findStatic(SharedUtils.class, "handleUncaughtException",
+                    methodType(void.class, Throwable.class));
         } catch (ReflectiveOperationException e) {
             throw new BootstrapMethodError(e);
         }
@@ -361,6 +370,13 @@ public class SharedUtils {
         return MH_REACHBILITY_FENCE.asType(MethodType.methodType(void.class, type));
     }
 
+    static void handleUncaughtException(Throwable t) {
+        if (t != null) {
+            t.printStackTrace();
+            JLA.exit(1);
+        }
+    }
+
     static MethodHandle wrapWithAllocator(MethodHandle specializedHandle,
                                           int allocatorPos, long bufferCopySize,
                                           boolean upcall) {
@@ -368,7 +384,11 @@ public class SharedUtils {
         MethodHandle closer;
         int insertPos;
         if (specializedHandle.type().returnType() == void.class) {
-            closer = empty(methodType(void.class, Throwable.class)); // (Throwable) -> void
+            if (!upcall) {
+                closer = empty(methodType(void.class, Throwable.class)); // (Throwable) -> void
+            } else {
+                closer = MH_HANDLE_UNCAUGHT_EXCEPTION;
+            }
             insertPos = 1;
         } else {
             closer = identity(specializedHandle.type().returnType()); // (V) -> V

--- a/test/jdk/java/foreign/TestUpcallException.java
+++ b/test/jdk/java/foreign/TestUpcallException.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @library /test/lib
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build ThrowingUpcall TestUpcallException
+ *
+ * @run testng/othervm/native
+ *   --enable-native-access=ALL-UNNAMED
+ *   TestUpcallException
+ */
+
+import jdk.incubator.foreign.CLinker;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.ResourceScope;
+import jdk.test.lib.Utils;
+import org.testng.annotations.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestUpcallException {
+
+    @Test
+    public void testExceptionInterpreted() throws InterruptedException, IOException {
+        boolean useSpec = false;
+        run(useSpec);
+    }
+
+    @Test
+    public void testExceptionSpecialized() throws IOException, InterruptedException {
+        boolean useSpec = true;
+        run(useSpec);
+    }
+
+    private void run(boolean useSpec) throws IOException, InterruptedException {
+        Process process = new ProcessBuilder()
+            .command(
+                Paths.get(Utils.TEST_JDK)
+                     .resolve("bin")
+                     .resolve("java")
+                     .toAbsolutePath()
+                     .toString(),
+                "--add-modules", "jdk.incubator.foreign",
+                "--enable-native-access=ALL-UNNAMED",
+                "-Djava.library.path=" + System.getProperty("java.library.path"),
+                "-Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=" + useSpec,
+                "-cp", Utils.TEST_CLASS_PATH,
+                "ThrowingUpcall")
+            .start();
+
+        int result = process.waitFor();
+        assertNotEquals(result, 0);
+
+        List<String> outLines = linesFromStream(process.getInputStream());
+        outLines.forEach(System.out::println);
+        List<String> errLines = linesFromStream(process.getErrorStream());
+        errLines.forEach(System.err::println);
+
+        // Exception message would be found in stack trace
+        String shouldInclude = "Testing upcall exceptions";
+        assertTrue(linesContain(errLines, shouldInclude), "Did not find '" + shouldInclude + "' in stderr");
+    }
+
+    private boolean linesContain(List<String> errLines, String shouldInclude) {
+        return errLines.stream().anyMatch(line -> line.contains(shouldInclude));
+    }
+
+    private static List<String> linesFromStream(InputStream stream) throws IOException {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream))) {
+            return reader.lines().toList();
+        }
+    }
+}

--- a/test/jdk/java/foreign/ThrowingUpcall.java
+++ b/test/jdk/java/foreign/ThrowingUpcall.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.incubator.foreign.CLinker;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.ResourceScope;
+import jdk.incubator.foreign.SymbolLookup;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.security.Permission;
+
+import static jdk.incubator.foreign.CLinker.C_POINTER;
+
+public class ThrowingUpcall {
+
+    private static final MethodHandle downcall;
+    public static final MethodHandle MH_throwException;
+
+    static {
+        System.loadLibrary("TestUpcall");
+        SymbolLookup lookup = SymbolLookup.loaderLookup();
+        downcall = CLinker.getInstance().downcallHandle(
+            lookup.lookup("f0_V__").orElseThrow(),
+            MethodType.methodType(void.class, MemoryAddress.class),
+            FunctionDescriptor.ofVoid(C_POINTER)
+        );
+
+        try {
+            MH_throwException = MethodHandles.lookup().findStatic(ThrowingUpcall.class, "throwException",
+                    MethodType.methodType(void.class));
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    public static void throwException() throws Throwable {
+        throw new Throwable("Testing upcall exceptions");
+    }
+
+    public static void main(String[] args) throws Throwable {
+        test();
+    }
+
+    public static void test() throws Throwable {
+        MethodHandle handle = MH_throwException;
+        MethodHandle invoker = MethodHandles.exactInvoker(MethodType.methodType(void.class));
+        handle = MethodHandles.insertArguments(invoker, 0, handle);
+
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+            MemoryAddress stub = CLinker.getInstance().upcallStub(handle, FunctionDescriptor.ofVoid(), scope);
+
+            downcall.invokeExact(stub); // should call Shutdown.exit(1);
+        }
+    }
+
+}


### PR DESCRIPTION
Hi,

~This is part 2 of a two part upstreaming process of the patch mentioned in the subject line. The patch was split into 2 in order to document 2 separate specification changes that arose from a change in the implementation, with 2 separate CSRs. The first patch can be found here: https://github.com/openjdk/jdk/pull/4395~

This patch adds uniform exception handling for exceptions thrown during FLA upcalls. Currently, these exceptions are either handled similarly to the VMs `CATCH` macro, or ignored after which control returns to unsuspecting native code, until control returns to Java, which will then handle the exception. The handling depends on the invocation mode.

Both of these are bad. The former because a stack trace is not printed and instead the VM exits with a fatal error. The latter is bad because an upcall completing abruptly and returning to native code which has no idea an exception occurred is unsafe, in the sense that invariants about the state of the program that the native code depends on might no longer hold.

This patch adds uniform exception handling that replaces both of these cases (see `SharedUtils::handleUncaughtException`), which prints the exception stack trace, and then unconditionally exits the VM, which is the only safe course of action at that point.

Exceptions thrown by upcalls should instead be handled during the upcall itself, for instance by translating the exception into an error code that is then returned to the native caller, which can deal with it appropriately.

See also the original review for panama-foreign: https://github.com/openjdk/panama-foreign/pull/543

Thanks,
Jorn

Testing: `jdk_foreign` test suite.

Thanks,
Jorn

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268339](https://bugs.openjdk.java.net/browse/JDK-8268339): Upstream: 8267989: Exceptions thrown during upcalls should be handled


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4396/head:pull/4396` \
`$ git checkout pull/4396`

Update a local copy of the PR: \
`$ git checkout pull/4396` \
`$ git pull https://git.openjdk.java.net/jdk pull/4396/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4396`

View PR using the GUI difftool: \
`$ git pr show -t 4396`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4396.diff">https://git.openjdk.java.net/jdk/pull/4396.diff</a>

</details>
