### PR TITLE
8264766: ClassCastException during template compilation (Variable cannot be cast to Param)

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/SymbolTable.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/SymbolTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -35,7 +35,7 @@ import java.util.StringTokenizer;
  * @author Jacek Ambroziak
  * @author Santiago Pericas-Geertsen
  * @author Morten Jorgensen
- * @LastModified: Oct 2017
+ * @LastModified: June 2021
  */
 final class SymbolTable {
 
@@ -94,14 +94,14 @@ final class SymbolTable {
 
     public Variable addVariable(Variable variable) {
         if (_variables == null) _variables = new HashMap<>();
-        final String name = variable.getName().getStringRep();
-        return (Variable)_variables.put(name, variable);
+        VariableBase v = _variables.put(variable.getName().getStringRep(), variable);
+        return v instanceof Variable ? (Variable)v : null;
     }
 
     public Param addParam(Param parameter) {
         if (_variables == null) _variables = new HashMap<>();
-        final String name = parameter.getName().getStringRep();
-        return (Param)_variables.put(name, parameter);
+        VariableBase v = _variables.put(parameter.getName().getStringRep(), parameter);
+        return v instanceof Param ? (Param)v : null;
     }
 
     public Variable lookupVariable(QName qname) {

--- a/test/jaxp/javax/xml/jaxp/unittest/transform/SymbolTableTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/transform/SymbolTableTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package transform;
+
+import java.io.StringReader;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamSource;
+import org.testng.annotations.Test;
+
+/*
+ * @test
+ * @bug 8264766
+ * @run testng transform.SymbolTableTest
+ * @summary Tests SymbolTable
+ */
+public class SymbolTableTest {
+    /**
+     * Verifies that the SymbolTable processes (adds) variables and params
+     * properly. The SymbolTable holds variables and params in a map, it shall
+     * therefore perform a type check before cast, or else result in a
+     * ClassCastException when variables and/or params have the same name (in
+     * which case the later ones shadow the previous ones).
+     *
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void test() throws Exception {
+        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        String stylesheet = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<xsl:stylesheet xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" version=\"1.0\">\n" +
+                " <xsl:variable name=\"background-color\">#f4f4f4</xsl:variable>\n" +
+                " <xsl:param name=\"background-color\">pp</xsl:param>\n" +
+                " <xsl:template name=\"tName\"><xsl:param name=\"background-color\">black</xsl:param>\n" +
+                " OK <xsl:value-of select=\"$background-color\"/>\n" +
+                " </xsl:template>\n" +
+                " <xsl:template match=\"/root\">\n" +
+                " <xsl:call-template name=\"tName\">\n" +
+                " <xsl:with-param name=\"background-color\" select=\"$background-color\"/>\n" +
+                " </xsl:call-template>\n" +
+                " </xsl:template>\n" +
+                "</xsl:stylesheet>\n";
+        transformerFactory.newTransformer(new StreamSource(new StringReader(stylesheet)));
+    }
+}


### PR DESCRIPTION
Fixes the addVariable/addParam methods in the SymbolTable to check types before casting.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264766](https://bugs.openjdk.java.net/browse/JDK-8264766): ClassCastException during template compilation (Variable cannot be cast to Param)


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4398/head:pull/4398` \
`$ git checkout pull/4398`

Update a local copy of the PR: \
`$ git checkout pull/4398` \
`$ git pull https://git.openjdk.java.net/jdk pull/4398/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4398`

View PR using the GUI difftool: \
`$ git pr show -t 4398`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4398.diff">https://git.openjdk.java.net/jdk/pull/4398.diff</a>

</details>
