### PR TITLE
8268349: Provide more detail in JEP 411 warning messages

### DIFF
--- a/test/jdk/java/lang/System/LoggerFinder/internal/LoggerFinderLoaderTest/LoggerFinderLoaderTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/internal/LoggerFinderLoaderTest/LoggerFinderLoaderTest.java
@@ -36,6 +36,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.ResourceBundle;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -44,15 +45,11 @@ import java.util.function.Supplier;
 import java.lang.System.LoggerFinder;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.Locale;
-import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.concurrent.atomic.AtomicReference;
-import jdk.internal.logger.SimpleConsoleLogger;
 
 /**
  * @test
@@ -202,6 +199,10 @@ public class LoggerFinderLoaderTest {
         }
     }
 
+    private static String withoutWarning(String in) {
+        return in.lines().filter(s -> !s.startsWith("WARNING:")).collect(Collectors.joining());
+    }
+
     static LoggerFinder getLoggerFinder(Class<?> expectedClass,
             String errorPolicy, boolean singleton) {
         LoggerFinder provider = null;
@@ -235,12 +236,7 @@ public class LoggerFinderLoaderTest {
                     }
                 } else if ("QUIET".equals(errorPolicy.toUpperCase(Locale.ROOT))) {
                     String warning = ErrorStream.errorStream.peek();
-                    String smDeprecationWarning
-                            = "WARNING: java.lang.System::setSecurityManager is deprecated and will be removed in a future release."
-                            + System.getProperty("line.separator");
-                    if (warning.startsWith(smDeprecationWarning)) {
-                        warning = warning.substring(smDeprecationWarning.length());
-                    }
+                    warning = withoutWarning(warning);
                     if (!warning.isEmpty()) {
                         throw new RuntimeException("Unexpected error message found: "
                                 + ErrorStream.errorStream.peek());

--- a/test/jdk/java/lang/invoke/lambda/LogGeneratedClassesTest.java
+++ b/test/jdk/java/lang/invoke/lambda/LogGeneratedClassesTest.java
@@ -147,9 +147,8 @@ public class LogGeneratedClassesTest extends LUtils {
                                "-Djdk.internal.lambda.dumpProxyClasses=notExist",
                                "com.example.TestLambda");
         assertEquals(tr.testOutput.stream()
-                                  .filter(s -> !s.contains("setSecurityManager is deprecated"))
                                   .filter(s -> s.startsWith("WARNING"))
-                                  .peek(s -> assertTrue(s.contains("does not exist")))
+                                  .filter(s -> s.contains("does not exist"))
                                   .count(),
                      1, "only show error once");
         tr.assertZero("Should still return 0");
@@ -164,9 +163,8 @@ public class LogGeneratedClassesTest extends LUtils {
                                "-Djdk.internal.lambda.dumpProxyClasses=file",
                                "com.example.TestLambda");
         assertEquals(tr.testOutput.stream()
-                                  .filter(s -> !s.contains("setSecurityManager is deprecated"))
                                   .filter(s -> s.startsWith("WARNING"))
-                                  .peek(s -> assertTrue(s.contains("not a directory")))
+                                  .filter(s -> s.contains("not a directory"))
                                   .count(),
                      1, "only show error once");
         tr.assertZero("Should still return 0");
@@ -224,9 +222,8 @@ public class LogGeneratedClassesTest extends LUtils {
                                    "-Djdk.internal.lambda.dumpProxyClasses=readOnly",
                                    "com.example.TestLambda");
             assertEquals(tr.testOutput.stream()
-                                      .filter(s -> !s.contains("setSecurityManager is deprecated"))
                                       .filter(s -> s.startsWith("WARNING"))
-                                      .peek(s -> assertTrue(s.contains("not writable")))
+                                      .filter(s -> s.contains("not writable"))
                                       .count(),
                          1, "only show error once");
             tr.assertZero("Should still return 0");

--- a/test/jdk/java/net/spi/URLStreamHandlerProvider/Basic.java
+++ b/test/jdk/java/net/spi/URLStreamHandlerProvider/Basic.java
@@ -86,10 +86,14 @@ public class Basic {
     static final String SECURITY_MANAGER_DEPRECATED
             = "WARNING: The Security Manager is deprecated and will be removed in a future release."
                     + System.getProperty("line.separator");
+
+    private static String withoutWarning(String in) {
+        return in.lines().filter(s -> !s.startsWith("WARNING:")).collect(Collectors.joining());
+    }
+
     static final Consumer<Result> KNOWN = r -> {
-        if (r.exitValue != 0 ||
-                (!r.output.isEmpty() && !r.output.equals(SECURITY_MANAGER_DEPRECATED)))
-            throw new RuntimeException(r.output);
+        if (r.exitValue != 0 || !withoutWarning(r.output).isEmpty())
+            throw new RuntimeException("[" + r.output + "]");
     };
     static final Consumer<Result> UNKNOWN = r -> {
         if (r.exitValue == 0 ||


### PR DESCRIPTION
More loudly and precise warning messages when a security manager is either enabled at startup or installed at runtime.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ The change requires a CSR request to be approved.

### Issue
 * [JDK-8268349](https://bugs.openjdk.java.net/browse/JDK-8268349): Provide more detail in JEP 411 warning messages


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4400/head:pull/4400` \
`$ git checkout pull/4400`

Update a local copy of the PR: \
`$ git checkout pull/4400` \
`$ git pull https://git.openjdk.java.net/jdk pull/4400/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4400`

View PR using the GUI difftool: \
`$ git pr show -t 4400`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4400.diff">https://git.openjdk.java.net/jdk/pull/4400.diff</a>

</details>
