### PR TITLE
8268093: Manual Testcase: "sun/security/krb5/config/native/TestDynamicStore.java" Fails with NPE

### DIFF
--- a/test/jdk/sun/security/krb5/config/native/TestDynamicStore.java
+++ b/test/jdk/sun/security/krb5/config/native/TestDynamicStore.java
@@ -34,6 +34,13 @@
 import jdk.test.lib.Asserts;
 import sun.security.krb5.Config;
 
+// =================== Attention ===================
+// This test calls a native method implemented in libTestDynamicStore.m
+// to modify system-level Kerberos 5 settings stored in the dynamic store.
+// It must be launched by a user with enough privilege or with "sudo".
+// If launched with sudo, remember to remove the report and working
+// directories with sudo as well after executing the test.
+
 public class TestDynamicStore {
 
     native static int actionInternal(char what, char whom);
@@ -59,7 +66,10 @@ public class TestDynamicStore {
 
         try {
             System.out.println("Fill in dynamic store");
-            action('a', 'a');
+            if (action('a', 'a') == 0) {
+                throw new Exception("Cannot write native Kerberos settings. " +
+                        "Please make sure the test runs with enough privilege.");
+            }
             Asserts.assertTrue(Config.getInstance().get("libdefaults", "default_realm").equals("A.COM"));
             Asserts.assertTrue(Config.getInstance().exists("domain_realm"));
 

--- a/test/jdk/sun/security/krb5/config/native/libTestDynamicStore.m
+++ b/test/jdk/sun/security/krb5/config/native/libTestDynamicStore.m
@@ -62,7 +62,9 @@ int addMapping(SCDynamicStoreRef store) {
 
 int addAll(SCDynamicStoreRef store) {
     NSArray *keys = [NSArray arrayWithObjects:@"A.COM", @"B.COM", nil];
-    fprintf(stderr, "%d\n", SCDynamicStoreSetValue(store, (CFStringRef) KERBEROS_DEFAULT_REALMS, keys));
+    Boolean b = SCDynamicStoreSetValue(store, (CFStringRef) KERBEROS_DEFAULT_REALMS, keys);
+    fprintf(stderr, "%d\n", b);
+    if (!b) return 0;
 
     NSDictionary *k1 = [NSDictionary dictionaryWithObjectsAndKeys:
         @"kdc1.a.com", @"host", nil];


### PR DESCRIPTION
The test must run with sudo but I forgot to mention it. New comment and a better error message is added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8268093](https://bugs.openjdk.java.net/browse/JDK-8268093): Manual Testcase: "sun/security/krb5/config/native/TestDynamicStore.java" Fails with NPE


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4401/head:pull/4401` \
`$ git checkout pull/4401`

Update a local copy of the PR: \
`$ git checkout pull/4401` \
`$ git pull https://git.openjdk.java.net/jdk pull/4401/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4401`

View PR using the GUI difftool: \
`$ git pr show -t 4401`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4401.diff">https://git.openjdk.java.net/jdk/pull/4401.diff</a>

</details>
