### PR TITLE
JDK-8268352: Rename javadoc Messager class to JavadocLog

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ElementsTable.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ElementsTable.java
@@ -165,7 +165,7 @@ public class ElementsTable {
     private final List<Location> locations;
     private final Modules modules;
     private final ToolOptions options;
-    private final Messager messager;
+    private final JavadocLog log;
     private final JavaCompiler compiler;
 
     private final Map<String, Entry> entries = new LinkedHashMap<>();
@@ -210,7 +210,7 @@ public class ElementsTable {
         this.fm = toolEnv.fileManager;
         this.modules = Modules.instance(context);
         this.options = options;
-        this.messager = Messager.instance0(context);
+        this.log = JavadocLog.instance0(context);
         this.compiler = JavaCompiler.instance(context);
         Source source = Source.instance(context);
 
@@ -370,19 +370,19 @@ public class ElementsTable {
             return;
 
         if (moduleNames.size() > 1) {
-            String text = messager.getText("main.cannot_use_sourcepath_for_modules",
+            String text = log.getText("main.cannot_use_sourcepath_for_modules",
                     String.join(", ", moduleNames));
             throw new ToolException(CMDERR, text);
         }
 
         String foundModule = getModuleName(StandardLocation.SOURCE_PATH);
         if (foundModule == null) {
-            String text = messager.getText("main.module_not_found_on_sourcepath", moduleNames.get(0));
+            String text = log.getText("main.module_not_found_on_sourcepath", moduleNames.get(0));
             throw new ToolException(CMDERR, text);
         }
 
         if (!moduleNames.get(0).equals(foundModule)) {
-            String text = messager.getText("main.sourcepath_does_not_contain_module", moduleNames.get(0));
+            String text = log.getText("main.sourcepath_does_not_contain_module", moduleNames.get(0));
             throw new ToolException(CMDERR, text);
         }
     }
@@ -399,7 +399,7 @@ public class ElementsTable {
                 }
             }
         } catch (IOException ioe) {
-            String text = messager.getText("main.file.manager.list", location);
+            String text = log.getText("main.file.manager.list", location);
             throw new ToolException(SYSERR, text, ioe);
         }
         return null;
@@ -413,7 +413,7 @@ public class ElementsTable {
         for (String m : modules) {
             List<Location> moduleLocations = getModuleLocation(locations, m);
             if (moduleLocations.isEmpty()) {
-                String text = messager.getText("main.module_not_found", m);
+                String text = log.getText("main.module_not_found", m);
                 throw new ToolException(CMDERR, text);
             }
             if (moduleLocations.contains(StandardLocation.SOURCE_PATH)) {
@@ -520,7 +520,7 @@ public class ElementsTable {
         try {
             return fm.list(location, packagename, kinds, recurse);
         } catch (IOException ioe) {
-            String text = messager.getText("main.file.manager.list", packagename);
+            String text = log.getText("main.file.manager.list", packagename);
             throw new ToolException(SYSERR, text, ioe);
         }
     }
@@ -567,7 +567,7 @@ public class ElementsTable {
             if (!isMandated(mdle, rd) && onlyTransitive == rd.isTransitive()) {
                 if (!haveModuleSources(dep)) {
                     if (!warnedNoSources.contains(dep)) {
-                        messager.printWarningUsingKey(dep, "main.module_source_not_found", dep.getQualifiedName());
+                        log.printWarningUsingKey(dep, "main.module_source_not_found", dep.getQualifiedName());
                         warnedNoSources.add(dep);
                     }
                 }
@@ -759,7 +759,7 @@ public class ElementsTable {
             if (pkg != null) {
                 packlist.add(pkg);
             } else {
-                messager.printWarningUsingKey("main.package_not_found", modpkg.toString());
+                log.printWarningUsingKey("main.package_not_found", modpkg.toString());
             }
         });
         specifiedPackageElements = Collections.unmodifiableSet(packlist);
@@ -780,7 +780,7 @@ public class ElementsTable {
         for (String className : classArgList) {
             TypeElement te = toolEnv.loadClass(className);
             if (te == null) {
-                String text = messager.getText("javadoc.class_not_found", className);
+                String text = log.getText("javadoc.class_not_found", className);
                 throw new ToolException(CMDERR, text);
             } else {
                 addAllClasses(classes, te, true);
@@ -796,7 +796,7 @@ public class ElementsTable {
             toolEnv.notice("main.Loading_source_files_for_package", modpkg.toString());
             List<JavaFileObject> files = getFiles(modpkg, recurse);
             if (files.isEmpty()) {
-                String text = messager.getText("main.no_source_files_for_package",
+                String text = log.getText("main.no_source_files_for_package",
                         modpkg.toString());
                 throw new ToolException(CMDERR, text);
             } else {
@@ -909,7 +909,7 @@ public class ElementsTable {
         try {
             return fm.getLocationForModule(location, msymName);
         } catch (IOException ioe) {
-            String text = messager.getText("main.doclet_could_not_get_location", msymName);
+            String text = log.getText("main.doclet_could_not_get_location", msymName);
             throw new ToolException(ERROR, text, ioe);
         }
     }
@@ -956,9 +956,9 @@ public class ElementsTable {
             }
         } catch (CompletionFailure e) {
             if (e.getMessage() != null)
-                messager.printWarning(e.getMessage());
+                log.printWarning(e.getMessage());
             else
-                messager.printWarningUsingKey("main.unexpected.exception", e);
+                log.printWarningUsingKey("main.unexpected.exception", e);
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/JavadocEnter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/JavadocEnter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/JavadocEnter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/JavadocEnter.java
@@ -61,24 +61,24 @@ public class JavadocEnter extends Enter {
 
     protected JavadocEnter(Context context) {
         super(context);
-        messager = Messager.instance0(context);
+        log = JavadocLog.instance0(context);
         toolEnv = ToolEnvironment.instance(context);
         compiler = JavaCompiler.instance(context);
     }
 
-    final Messager messager;
+    final JavadocLog log;
     final ToolEnvironment toolEnv;
     final JavaCompiler compiler;
 
     @Override
     public void main(List<JCCompilationUnit> trees) {
         // cache the error count if we need to convert Enter errors as warnings.
-        int nerrors = messager.nerrors;
+        int nerrors = log.nerrors;
         super.main(trees);
         compiler.enterDone();
         if (toolEnv.ignoreSourceErrors) {
-            messager.nwarnings += (messager.nerrors - nerrors);
-            messager.nerrors = nerrors;
+            log.nwarnings += (log.nerrors - nerrors);
+            log.nerrors = nerrors;
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/JavadocLog.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/JavadocLog.java
@@ -123,7 +123,7 @@ import com.sun.tools.javac.util.Log;
  * @see java.util.ResourceBundle
  * @see java.text.MessageFormat
  */
-public class Messager extends Log implements Reporter {
+public class JavadocLog extends Log implements Reporter {
     /** The overall context for the documentation run. */
     private final Context context;
 
@@ -138,22 +138,22 @@ public class Messager extends Log implements Reporter {
      */
     private final LinkedHashMap<JavaFileObject, SoftReference<DiagnosticSource>> diagSourceCache;
 
-    /** Get the current messager, which is also the compiler log. */
-    public static Messager instance0(Context context) {
+    /** Get the current javadoc log, which is also the compiler log. */
+    public static JavadocLog instance0(Context context) {
         Log instance = context.get(logKey);
-        if (!(instance instanceof Messager m))
-            throw new InternalError("no messager instance!");
-        return m;
+        if (!(instance instanceof JavadocLog l))
+            throw new InternalError("no JavadocLog instance!");
+        return l;
     }
 
     public static void preRegister(Context context,
                                    final String programName) {
-        context.put(logKey, (Factory<Log>)c -> new Messager(c, programName));
+        context.put(logKey, (Factory<Log>)c -> new JavadocLog(c, programName));
     }
 
     public static void preRegister(Context context, final String programName,
             final PrintWriter outWriter, final PrintWriter errWriter) {
-        context.put(logKey, (Factory<Log>)c -> new Messager(c, programName, outWriter, errWriter));
+        context.put(logKey, (Factory<Log>)c -> new JavadocLog(c, programName, outWriter, errWriter));
     }
 
     final String programName;
@@ -176,7 +176,7 @@ public class Messager extends Log implements Reporter {
      * Constructor
      * @param programName  Name of the program (for error messages).
      */
-    public Messager(Context context, String programName) {
+    public JavadocLog(Context context, String programName) {
         // use the current values of System.out, System.err, in case they have been redirected
         this(context, programName,
                 createPrintWriter(System.out, false),
@@ -189,7 +189,7 @@ public class Messager extends Log implements Reporter {
      * @param outWriter    Stream for notices etc.
      * @param errWriter    Stream for errors and warnings
      */
-    public Messager(Context context, String programName, PrintWriter outWriter, PrintWriter errWriter) {
+    public JavadocLog(Context context, String programName, PrintWriter outWriter, PrintWriter errWriter) {
         super(context, outWriter, errWriter);
         messages = JavacMessages.instance(context);
         messages.add(locale -> ResourceBundle.getBundle("jdk.javadoc.internal.tool.resources.javadoc",

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/JavadocTool.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/JavadocTool.java
@@ -70,7 +70,7 @@ import static jdk.javadoc.internal.tool.Main.Result.*;
 public class JavadocTool extends com.sun.tools.javac.main.JavaCompiler {
     ToolEnvironment toolEnv;
 
-    final Messager messager;
+    final JavadocLog log;
     final ClassFinder javadocFinder;
     final DeferredCompletionFailureHandler dcfh;
     final Enter javadocEnter;
@@ -82,7 +82,7 @@ public class JavadocTool extends com.sun.tools.javac.main.JavaCompiler {
      */
     protected JavadocTool(Context context) {
         super(context);
-        messager = Messager.instance0(context);
+        log = JavadocLog.instance0(context);
         javadocFinder = JavadocClassFinder.instance(context);
         dcfh = DeferredCompletionFailureHandler.instance(context);
         javadocEnter = JavadocEnter.instance(context);
@@ -101,7 +101,7 @@ public class JavadocTool extends com.sun.tools.javac.main.JavaCompiler {
      *  Construct a new javadoc tool.
      */
     public static JavadocTool make0(Context context) {
-        Messager messager = null;
+        JavadocLog log = null;
         try {
             // force the use of Javadoc's class finder
             JavadocClassFinder.preRegister(context);
@@ -115,13 +115,13 @@ public class JavadocTool extends com.sun.tools.javac.main.JavaCompiler {
             // force the use of Javadoc's own todo phase
             JavadocTodo.preRegister(context);
 
-            // force the use of Messager as a Log
-            messager = Messager.instance0(context);
+            // force the use of Javadoc's subtype of Log
+            log = JavadocLog.instance0(context);
 
             return new JavadocTool(context);
         } catch (CompletionFailure ex) {
-            assert messager != null;
-            messager.error(Position.NOPOS, ex.getMessage());
+            assert log != null;
+            log.error(Position.NOPOS, ex.getMessage());
             return null;
         }
     }
@@ -142,11 +142,11 @@ public class JavadocTool extends com.sun.tools.javac.main.JavaCompiler {
             // If -Xclasses is set, the args should be a list of class names
             for (String arg: javaNames) {
                 if (!isValidPackageName(arg)) { // checks
-                    String text = messager.getText("main.illegal_class_name", arg);
+                    String text = log.getText("main.illegal_class_name", arg);
                     throw new ToolException(CMDERR, text);
                 }
             }
-            if (messager.hasErrors()) {
+            if (log.hasErrors()) {
                 return null;
             }
             etable.setClassArgList(javaNames);
@@ -171,14 +171,14 @@ public class JavadocTool extends com.sun.tools.javac.main.JavaCompiler {
                     packageNames.add(arg);
                 } else if (arg.endsWith(".java")) {
                     if (fm == null) {
-                        String text = messager.getText("main.assertion.error", "fm == null");
+                        String text = log.getText("main.assertion.error", "fm == null");
                         throw new ToolException(ABNORMAL, text);
                     } else {
-                        String text = messager.getText("main.file_not_found", arg);
+                        String text = log.getText("main.file_not_found", arg);
                         throw new ToolException(ERROR, text);
                     }
                 } else {
-                    String text = messager.getText("main.illegal_package_name", arg);
+                    String text = log.getText("main.illegal_package_name", arg);
                     throw new ToolException(CMDERR, text);
                 }
             }
@@ -191,7 +191,7 @@ public class JavadocTool extends com.sun.tools.javac.main.JavaCompiler {
                     .scanSpecifiedItems();
 
             // abort, if errors were encountered during modules initialization
-            if (messager.hasErrors()) {
+            if (log.hasErrors()) {
                 return null;
             }
 
@@ -202,7 +202,7 @@ public class JavadocTool extends com.sun.tools.javac.main.JavaCompiler {
             modules.newRound();
             modules.initModules(allTrees.toList());
 
-            if (messager.hasErrors()) {
+            if (log.hasErrors()) {
                 return null;
             }
 
@@ -210,7 +210,7 @@ public class JavadocTool extends com.sun.tools.javac.main.JavaCompiler {
             toolEnv.notice("main.Building_tree");
             javadocEnter.main(allTrees.toList());
 
-            if (messager.hasErrors()) {
+            if (log.hasErrors()) {
                 return null;
             }
 
@@ -232,17 +232,17 @@ public class JavadocTool extends com.sun.tools.javac.main.JavaCompiler {
         } catch (CompletionFailure cf) {
             throw new ToolException(ABNORMAL, cf.getMessage(), cf);
         } catch (Abort abort) {
-            if (messager.hasErrors()) {
+            if (log.hasErrors()) {
                 // presumably a message has been emitted, keep silent
                 throw new ToolException(ABNORMAL, "", abort);
             } else {
-                String text = messager.getText("main.internal.error");
+                String text = log.getText("main.internal.error");
                 Throwable t = abort.getCause() == null ? abort : abort.getCause();
                 throw new ToolException(ABNORMAL, text, t);
             }
         }
 
-        if (messager.hasErrors())
+        if (log.hasErrors())
             return null;
 
         toolEnv.docEnv = new DocEnvImpl(toolEnv, etable);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ToolEnvironment.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ToolEnvironment.java
@@ -83,7 +83,7 @@ public class ToolEnvironment {
         return instance;
     }
 
-    final Messager messager;
+    final JavadocLog log;
 
     /** Predefined symbols known to the compiler. */
     public final Symtab syms;
@@ -137,7 +137,7 @@ public class ToolEnvironment {
         context.put(ToolEnvKey, this);
         this.context = context;
 
-        messager = Messager.instance0(context);
+        log = JavadocLog.instance0(context);
         syms = Symtab.instance(context);
         finder = JavadocClassFinder.instance(context);
         enter = JavadocEnter.instance(context);
@@ -199,7 +199,7 @@ public class ToolEnvironment {
         if (quiet) {
             return;
         }
-        messager.noticeUsingKey(key);
+        log.noticeUsingKey(key);
     }
 
     /**
@@ -212,7 +212,7 @@ public class ToolEnvironment {
         if (quiet) {
             return;
         }
-        messager.noticeUsingKey(key, a1);
+        log.noticeUsingKey(key, a1);
     }
 
     TreePath getTreePath(JCCompilationUnit tree) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ToolOptions.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ToolOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ToolOptions.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ToolOptions.java
@@ -168,9 +168,9 @@ public class ToolOptions {
     private final OptionHelper compilerOptionHelper;
 
     /**
-     * The messager to be used to report diagnostics..
+     * The log to be used to report diagnostics..
      */
-    private final Messager messager;
+    private final JavadocLog log;
 
     /**
      * The helper for help and version options
@@ -181,10 +181,10 @@ public class ToolOptions {
      * Creates an object to handle tool options.
      *
      * @param context the context used to find other tool-related components
-     * @param messager the messager to be used to report diagnostics
+     * @param log the log to be used to report diagnostics
      */
-    ToolOptions(Context context, Messager messager, ShowHelper showHelper) {
-        this.messager = messager;
+    ToolOptions(Context context, JavadocLog log, ShowHelper showHelper) {
+        this.log = log;
         this.showHelper = showHelper;
         compOpts = Options.instance(context);
         fileManagerOpts = new LinkedHashMap<>();
@@ -200,7 +200,7 @@ public class ToolOptions {
         compOpts = null;
         compilerOptionHelper = null;
         fileManagerOpts = null;
-        messager = null;
+        log = null;
         showHelper = null;
     }
 
@@ -646,14 +646,14 @@ public class ToolOptions {
             return names;
         }
 
-        String getParameters(Messager messager) {
+        String getParameters(JavadocLog log) {
             return (hasArg || primaryName.endsWith(":"))
-                    ? messager.getText(getKey(primaryName, ".arg"))
+                    ? log.getText(getKey(primaryName, ".arg"))
                     : null;
         }
 
-        String getDescription(Messager messager) {
-            return messager.getText(getKey(primaryName, ".desc"));
+        String getDescription(JavadocLog log) {
+            return log.getText(getKey(primaryName, ".desc"));
         }
 
         private String getKey(String optionName, String suffix) {
@@ -833,7 +833,7 @@ public class ToolOptions {
      * @return the exception
      */
     private IllegalOptionValue illegalOptionValue(String arg) {
-        return new IllegalOptionValue(showHelper::usage, messager.getText("main.illegal_option_value", arg));
+        return new IllegalOptionValue(showHelper::usage, log.getText("main.illegal_option_value", arg));
     }
 
     /**
@@ -864,7 +864,7 @@ public class ToolOptions {
      * @return the helper
      */
     private OptionHelper getOptionHelper() {
-        return new OptionHelper.GrumpyHelper(messager) {
+        return new OptionHelper.GrumpyHelper(log) {
             @Override
             public String get(com.sun.tools.javac.main.Option option) {
                 return compOpts.get(option);

--- a/test/langtools/jdk/javadoc/tool/CheckResourceKeys.java
+++ b/test/langtools/jdk/javadoc/tool/CheckResourceKeys.java
@@ -227,7 +227,7 @@ public class CheckResourceKeys {
             }
 
             // special handling for code strings synthesized in
-            // jdk.javadoc.internal.tool.Messager
+            // jdk.javadoc.internal.tool.JavadocLog
             results.add("javadoc.error.msg");
             results.add("javadoc.note.msg");
             results.add("javadoc.note.pos.msg");

--- a/test/langtools/jdk/javadoc/tool/api/basic/JavadocTaskImplTest.java
+++ b/test/langtools/jdk/javadoc/tool/api/basic/JavadocTaskImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/tool/api/basic/JavadocTaskImplTest.java
+++ b/test/langtools/jdk/javadoc/tool/api/basic/JavadocTaskImplTest.java
@@ -46,7 +46,7 @@ import javax.tools.ToolProvider;
 import com.sun.tools.javac.file.JavacFileManager;
 import com.sun.tools.javac.util.Context;
 import jdk.javadoc.internal.api.JavadocTaskImpl;
-import jdk.javadoc.internal.tool.Messager;
+import jdk.javadoc.internal.tool.JavadocLog;
 
 /**
  *  Misc tests for JavacTaskImpl.
@@ -81,7 +81,7 @@ public class JavadocTaskImplTest extends APITest {
         JavaFileObject srcFile = createSimpleJavaFileObject();
         Iterable<? extends JavaFileObject> files = Arrays.asList(srcFile);
         Context c = new Context();
-        Messager.preRegister(c, "javadoc");
+        JavadocLog.preRegister(c, "javadoc");
         try (StandardJavaFileManager fm = new JavacFileManager(c, true, null)) {
             File outDir = getOutDir();
             fm.setLocation(DocumentationTool.Location.DOCUMENTATION_OUTPUT, Arrays.asList(outDir));
@@ -99,7 +99,7 @@ public class JavadocTaskImplTest extends APITest {
         JavaFileObject srcFile = null; // error, provokes NPE
         Iterable<? extends JavaFileObject> files = Arrays.asList(srcFile);
         Context c = new Context();
-        Messager.preRegister(c, "javadoc");
+        JavadocLog.preRegister(c, "javadoc");
         try (StandardJavaFileManager fm = new JavacFileManager(c, true, null)) {
             File outDir = getOutDir();
             fm.setLocation(DocumentationTool.Location.DOCUMENTATION_OUTPUT, Arrays.asList(outDir));


### PR DESCRIPTION
Please review a simple cleanup, to rename the javadoc Messager class to the more explicit, less-confusing name of JavadocLog, since it is the javadoc subtype of the javac Log class.

The new name is in line with other javadoc subtypes of javac classes.

The change only affects the javadoc.tool package; it does not affect any doclet packages, which use the `Reporter` interface, provided by `JavadocLog`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268352](https://bugs.openjdk.java.net/browse/JDK-8268352): Rename javadoc Messager class to JavadocLog


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4405/head:pull/4405` \
`$ git checkout pull/4405`

Update a local copy of the PR: \
`$ git checkout pull/4405` \
`$ git pull https://git.openjdk.java.net/jdk pull/4405/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4405`

View PR using the GUI difftool: \
`$ git pr show -t 4405`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4405.diff">https://git.openjdk.java.net/jdk/pull/4405.diff</a>

</details>
