### PR TITLE
8268241: deprecate JVM TI Heap functions 1.0

### DIFF
--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -4963,7 +4963,9 @@ class C2 extends C1 implements I2 {
     <intro>
       <b>
         These functions and data types were introduced in the original
-        <jvmti/> version 1.0 and have been superseded by more
+        <jvmti/> version 1.0. They are deprecated and will be changed 
+        to return an error in a future release. They were superseded in
+        <jvmti/> version 1.2 (Java SE6) by more 
       </b>
       <internallink id="Heap"><b>powerful and flexible versions</b></internallink>
       <b>

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <?xml-stylesheet type="text/xsl" href="jvmti.xsl"?>
 <!--
- Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -15035,6 +15035,9 @@ typedef void (JNICALL *jvmtiEventVMInit)
       Minor update for new class file PermittedSubclasses attribute:
         - Specify that RedefineClasses and RetransformClasses are not allowed
           to change the class file PermittedSubclasses attribute.
+  </change>
+  <change date="8 June 2021" version="17.0.0">
+      Minor update to deprecate Heap functions 1.0.
   </change>
 </changehistory>
 

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -4965,7 +4965,7 @@ class C2 extends C1 implements I2 {
         These functions and data types were introduced in the original
         <jvmti/> version 1.0. They are deprecated and will be changed 
         to return an error in a future release. They were superseded in
-        <jvmti/> version 1.2 (Java SE6) by more 
+        <jvmti/> version 1.2 (Java SE 6) by more 
       </b>
       <internallink id="Heap"><b>powerful and flexible versions</b></internallink>
       <b>


### PR DESCRIPTION
The JVM TI Heap functions 1.0 were superseded by newer functions in JVM TI 1.2 (Java 6) and should be deprecated so they can be removed in a future release.

We need to replace this sentence:
"These functions and data types were introduced in the original JVM TI
version 1.0 and have been superseded by more powerful and flexible
versions which:"
with:
"These functions and data types were introduced in the original JVM TI
version 1.0. They are deprecated and will be changed to return an error
in a future release. They were superseded in JVM TI version 1.2 (Java 6) by more powerful and flexible versions which:" 

The CSR has been approved:
  https://bugs.openjdk.java.net/browse/JDK-8268242

The JVM TI Heap functions reflect the requirements of tool vendors during JSR-163. They pre-date concurrent collectors, the built-in heap dump support, and JFR. They are a maintenance burden and there is little evidence that they are used by modern tools (they involve stop-the-world operations and so are not suitable for production systems).

The JVM TI functions to deprecate are:
    IterateOverObjectsReachableFromObject
    IterateOverReachableObjects
    IterateOverHeap
    IterateOverInstancesOfClass

The "Heap 1.0" section of the JVM TI spec has existing wording in bold to say that the functions have been superseded. The proposal is to change this to say that the functions are deprecated and will be degraded in a future release.
A release note is planned. The release note will detail how to use -Xlog:jvmti=trace and -XX:TraceJVMTI= to identify any residual usages of these functions.

A future CSR will likely degrade these functions so that they return an error to indicate that they are no longer implemented/supported. We also plan to re-examine the newer Heap functions with a view to deprecate them in the future too (this requires a bit more work to understand if there is any real usage, also some adjustments to the JDWP and JDI specs).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268241](https://bugs.openjdk.java.net/browse/JDK-8268241): deprecate JVM TI Heap functions 1.0


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to 2cd78dfdd94e0a409a197a07e7154003b07f0b38
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to 2cd78dfdd94e0a409a197a07e7154003b07f0b38
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4406/head:pull/4406` \
`$ git checkout pull/4406`

Update a local copy of the PR: \
`$ git checkout pull/4406` \
`$ git pull https://git.openjdk.java.net/jdk pull/4406/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4406`

View PR using the GUI difftool: \
`$ git pr show -t 4406`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4406.diff">https://git.openjdk.java.net/jdk/pull/4406.diff</a>

</details>
