### PR TITLE
8267908: linux: thread_native_entry can scribble on stack frame 

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -672,7 +672,8 @@ static void *thread_native_entry(Thread *thread) {
   // and we did not see any degradation in performance without `alloca()`.
   static int counter = 0;
   int pid = os::current_process_id();
-  void *stackmem = alloca(((pid ^ counter++) & 7) * 128);
+  int random = ((pid ^ counter++) & 7) * 128;
+  void *stackmem = alloca(random != 0 ? random : 1); // ensure we allocate > 0
   // Ensure the alloca result is used in a way that prevents the compiler from eliding it.
   *(char *)stackmem = 1;
 #endif


### PR DESCRIPTION
Please review this trivial fix to ensure we do not try to alloca zero bytes.

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267908](https://bugs.openjdk.java.net/browse/JDK-8267908): linux: thread_native_entry can scribble on stack frame


### Reviewers
 * [Yasumasa Suenaga](https://openjdk.java.net/census#ysuenaga) (@YaSuenag - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4407/head:pull/4407` \
`$ git checkout pull/4407`

Update a local copy of the PR: \
`$ git checkout pull/4407` \
`$ git pull https://git.openjdk.java.net/jdk pull/4407/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4407`

View PR using the GUI difftool: \
`$ git pr show -t 4407`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4407.diff">https://git.openjdk.java.net/jdk/pull/4407.diff</a>

</details>
