### PR TITLE
8268303: Incorrect casts in JfrWriterHost::write for Ticks and Tickspan

### DIFF
--- a/src/hotspot/share/jfr/writers/jfrWriterHost.inline.hpp
+++ b/src/hotspot/share/jfr/writers/jfrWriterHost.inline.hpp
@@ -274,22 +274,22 @@ void WriterHost<BE, IE, WriterPolicyImpl>::write(const Symbol* symbol) {
 
 template <typename BE, typename IE, typename WriterPolicyImpl>
 void WriterHost<BE, IE, WriterPolicyImpl>::write(const Ticks& time) {
-  write((uintptr_t)JfrTime::is_ft_enabled() ? time.ft_value() : time.value());
+  write(JfrTime::is_ft_enabled() ? time.ft_value() : time.value());
 }
 
 template <typename BE, typename IE, typename WriterPolicyImpl>
 void WriterHost<BE, IE, WriterPolicyImpl>::write(const Tickspan& time) {
-  write((uintptr_t)JfrTime::is_ft_enabled() ? time.ft_value() : time.value());
+  write(JfrTime::is_ft_enabled() ? time.ft_value() : time.value());
 }
 
 template <typename BE, typename IE, typename WriterPolicyImpl>
 void WriterHost<BE, IE, WriterPolicyImpl>::write(const JfrTicks& time) {
-  write((uintptr_t)time.value());
+  write(time.value());
 }
 
 template <typename BE, typename IE, typename WriterPolicyImpl>
 void WriterHost<BE, IE, WriterPolicyImpl>::write(const JfrTickspan& time) {
-  write((uintptr_t)time.value());
+  write(time.value());
 }
 
 template <typename BE, typename IE, typename WriterPolicyImpl>


### PR DESCRIPTION
Greetings,

please help review this change to remove a couple of incorrect casts.

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268303](https://bugs.openjdk.java.net/browse/JDK-8268303): Incorrect casts in JfrWriterHost::write for Ticks and Tickspan


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4411/head:pull/4411` \
`$ git checkout pull/4411`

Update a local copy of the PR: \
`$ git checkout pull/4411` \
`$ git pull https://git.openjdk.java.net/jdk pull/4411/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4411`

View PR using the GUI difftool: \
`$ git pr show -t 4411`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4411.diff">https://git.openjdk.java.net/jdk/pull/4411.diff</a>

</details>
