### PR TITLE
8267421: j.l.constant.DirectMethodHandleDesc.Kind.valueOf(int) implementation doesn't conform to the spec regarding REF_invokeInterface handling

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/DirectMethodHandleDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/DirectMethodHandleDesc.java
@@ -105,7 +105,7 @@ public sealed interface DirectMethodHandleDesc
          * @throws IllegalArgumentException if there is no such member
          */
         public static Kind valueOf(int refKind) {
-            return valueOf(refKind, false);
+            return valueOf(refKind, refKind == REF_invokeInterface);
         }
 
         /**

--- a/src/java.base/share/classes/java/lang/constant/DirectMethodHandleDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/DirectMethodHandleDesc.java
@@ -137,13 +137,14 @@ public sealed interface DirectMethodHandleDesc
             if (i >= 0 && i < TABLE.length) {
                 Kind kind = TABLE[i];
                 if (kind == null) {
-                    throw new IllegalArgumentException(String.format("refKind=%d", refKind));
+                    throw new IllegalArgumentException(String.format("refKind=%d isInterface=%s", refKind, isInterface));
                 }
-                if (kind.refKind == refKind && kind.isInterface == isInterface) {
+                if (kind.refKind == refKind &&
+                        (refKind != REF_invokeStatic || refKind != REF_invokeSpecial || kind.isInterface == isInterface)){
                     return kind;
                 }
             }
-            throw new IllegalArgumentException(String.format("refKind=%d", refKind));
+            throw new IllegalArgumentException(String.format("refKind=%d isInterface=%s", refKind, isInterface));
         }
 
         private static int tableIndex(int refKind, boolean isInterface) {

--- a/test/jdk/java/lang/constant/MethodHandleDescTest.java
+++ b/test/jdk/java/lang/constant/MethodHandleDescTest.java
@@ -53,7 +53,9 @@ import static java.lang.constant.ConstantDescs.CD_Object;
 import static java.lang.constant.ConstantDescs.CD_String;
 import static java.lang.constant.ConstantDescs.CD_int;
 import static java.lang.constant.ConstantDescs.CD_void;
+import static java.lang.invoke.MethodHandleInfo.*;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
@@ -361,6 +363,19 @@ public class MethodHandleDescTest extends SymbolicDescTest {
         for (Kind k : Kind.values()) {
             assertEquals(Kind.valueOf(k.refKind), Kind.valueOf(k.refKind, k.refKind == MethodHandleInfo.REF_invokeInterface));
             assertEquals(Kind.valueOf(k.refKind, k.isInterface), k);
+        }
+        // let's now verify those cases for which the value of the isInterface parameter is ignored
+        int[] isInterfaceIgnored = new int[] {
+                REF_getField,
+                REF_getStatic,
+                REF_putField,
+                REF_putStatic,
+                REF_newInvokeSpecial,
+                REF_invokeInterface
+        };
+
+        for (int refKind : isInterfaceIgnored) {
+            assertEquals(Kind.valueOf(refKind, false), Kind.valueOf(refKind, true));
         }
     }
 }

--- a/test/jdk/java/lang/constant/MethodHandleDescTest.java
+++ b/test/jdk/java/lang/constant/MethodHandleDescTest.java
@@ -359,6 +359,7 @@ public class MethodHandleDescTest extends SymbolicDescTest {
 
     public void testKind() {
         for (Kind k : Kind.values()) {
+            assertEquals(Kind.valueOf(k.refKind), Kind.valueOf(k.refKind, k.refKind == MethodHandleInfo.REF_invokeInterface));
             assertEquals(Kind.valueOf(k.refKind, k.isInterface), k);
         }
     }


### PR DESCRIPTION
Please review this PR which is just syncing the implementation of DirectMethodHandleDesc.Kind.valueOf(int) with its spec. My reading of the method's spec is that if the value of the `refKind` parameter is: MethodHandleInfo.REF_invokeInterface, then DirectMethodHandleDesc.Kind.valueOf(int, boolean) should be called with a value of `true` for its second argument, currently it is invoked with `false` regardless of the value of the `refKind` parameter

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267421](https://bugs.openjdk.java.net/browse/JDK-8267421): j.l.constant.DirectMethodHandleDesc.Kind.valueOf(int) implementation doesn't conform to the spec regarding REF_invokeInterface handling


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - **Reviewer**) ⚠️ Review applies to ea47769d7c21507e8dc5c2a142375485658455c7


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4416/head:pull/4416` \
`$ git checkout pull/4416`

Update a local copy of the PR: \
`$ git checkout pull/4416` \
`$ git pull https://git.openjdk.java.net/jdk pull/4416/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4416`

View PR using the GUI difftool: \
`$ git pr show -t 4416`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4416.diff">https://git.openjdk.java.net/jdk/pull/4416.diff</a>

</details>
