### PR TITLE
8264866: Remove unneeded WorkArounds.isAutomaticModule

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/WorkArounds.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/WorkArounds.java
@@ -199,18 +199,6 @@ public class WorkArounds {
         return elementUtils.getTypeElement(className);
     }
 
-
-    // TODO: The following should be replaced by a new method such as Elements.isAutomaticModule
-    // see JDK-8261625
-    public boolean isAutomaticModule(ModuleElement me) {
-        if (me == null) {
-            return false;
-        } else {
-            ModuleSymbol msym = (ModuleSymbol) me;
-            return (msym.flags() & Flags.AUTOMATIC_MODULE) != 0;
-        }
-    }
-
     // TODO:  need to re-implement this using j.l.m. correctly!, this has
     //        implications on testInterface, the note here is that javac's supertype
     //        does the right thing returning Parameters in scope.

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Extern.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Extern.java
@@ -572,7 +572,7 @@ public class Extern {
                 return DocletConstants.DEFAULT_ELEMENT_NAME;
             } else if (moduleName == null) {
                 // suppress the warning message in the case of automatic modules
-                if (!configuration.workArounds.isAutomaticModule(me) && issueWarning) {
+                if (!utils.elementUtils.isAutomaticModule(me) && issueWarning) {
                     configuration.getReporter().print(Kind.WARNING,
                             resources.getText("doclet.linkMismatch_ModuleLinkedtoPackage", path));
                 }


### PR DESCRIPTION
Simple cleanup as a follow-on to JDK-8264865. Clean langtools test run.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264866](https://bugs.openjdk.java.net/browse/JDK-8264866): Remove unneeded WorkArounds.isAutomaticModule


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4417/head:pull/4417` \
`$ git checkout pull/4417`

Update a local copy of the PR: \
`$ git checkout pull/4417` \
`$ git pull https://git.openjdk.java.net/jdk pull/4417/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4417`

View PR using the GUI difftool: \
`$ git pr show -t 4417`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4417.diff">https://git.openjdk.java.net/jdk/pull/4417.diff</a>

</details>
