### PR TITLE
8228343: JCMD and attach fail to work across Linux Container boundary

### DIFF
--- a/src/jdk.attach/aix/classes/sun/tools/attach/VirtualMachineImpl.java
+++ b/src/jdk.attach/aix/classes/sun/tools/attach/VirtualMachineImpl.java
@@ -71,9 +71,8 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
         File socket_file = new File(tmpdir, ".java_pid" + pid);
         socket_path = socket_file.getPath();
         if (!socket_file.exists()) {
-            File f = createAttachFile(pid);
-            // Keep a canonical version of File, to delete, in case target process ends and /proc link has gone:
-            File f2 = f.getCanonicalFile();
+            // Keep canonical version of File, to delete, in case target process ends and /proc link has gone:
+            File f = createAttachFile(pid).getCanonicalFile();
             try {
                 sendQuitTo(pid);
 
@@ -103,7 +102,7 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
                                       time_spend));
                 }
             } finally {
-                f2.delete();
+                f.delete();
             }
         }
 

--- a/src/jdk.attach/aix/classes/sun/tools/attach/VirtualMachineImpl.java
+++ b/src/jdk.attach/aix/classes/sun/tools/attach/VirtualMachineImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2015, 2019 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -72,6 +72,8 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
         socket_path = socket_file.getPath();
         if (!socket_file.exists()) {
             File f = createAttachFile(pid);
+            // Keep a canonical version of File, to delete, in case target process ends and /proc link has gone:
+            File f2 = f.getCanonicalFile();
             try {
                 sendQuitTo(pid);
 
@@ -101,7 +103,7 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
                                       time_spend));
                 }
             } finally {
-                f.delete();
+                f2.delete();
             }
         }
 
@@ -275,7 +277,6 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
         String path = "/proc/" + pid + "/cwd/" + fn;
         File f = new File(path);
         try {
-            f = f.getCanonicalFile();
             f.createNewFile();
         } catch (IOException x) {
             f = new File(tmpdir, fn);

--- a/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java
+++ b/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java
+++ b/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java
@@ -77,6 +77,8 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
         socket_path = socket_file.getPath();
         if (!socket_file.exists()) {
             File f = createAttachFile(pid, ns_pid);
+            // Keep a canonical version of File, to delete, in case target process ends and /proc link has gone:
+            File f2 = f.getCanonicalFile();
             try {
                 sendQuitTo(pid);
 
@@ -106,7 +108,7 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
                                       time_spend));
                 }
             } finally {
-                f.delete();
+                f2.delete();
             }
         }
 
@@ -290,7 +292,7 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
         String path = "/proc/" + pid + "/cwd/" + fn;
         File f = new File(path);
         try {
-            f = f.getCanonicalFile();
+            // Do not canonicalize the file path, or we will fail to attach to a VM in a container.
             f.createNewFile();
         } catch (IOException x) {
             String root;
@@ -303,7 +305,6 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
                 root = tmpdir;
             }
             f = new File(root, fn);
-            f = f.getCanonicalFile();
             f.createNewFile();
         }
         return f;

--- a/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java
+++ b/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java
@@ -76,9 +76,8 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
         File socket_file = findSocketFile(pid, ns_pid);
         socket_path = socket_file.getPath();
         if (!socket_file.exists()) {
-            File f = createAttachFile(pid, ns_pid);
-            // Keep a canonical version of File, to delete, in case target process ends and /proc link has gone:
-            File f2 = f.getCanonicalFile();
+            // Keep canonical version of File, to delete, in case target process ends and /proc link has gone:
+            File f = createAttachFile(pid, ns_pid).getCanonicalFile();
             try {
                 sendQuitTo(pid);
 
@@ -108,7 +107,7 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
                                       time_spend));
                 }
             } finally {
-                f2.delete();
+                f.delete();
             }
         }
 


### PR DESCRIPTION
Since 8214300, jcmd cannot attach to a Java process in a docker container.

That change started using a canonicalized File to create the .attach_pidXXX file.  For a target process in a container, it will follow a symlink that is likely not the same as for the target process.  e.g. follow a symlink to a cwd of / which is not the same directory for the container host, as it is within the container.  Containerized VM never sees the file, never creates the socket file, the attach times out and fails.

To keep the 8214300 change working for non-container situations, we can keep a canonical version of the attach File to use for deleting.

For containers there will remain the problem 8214300 describes, although it is unlikely: if you start the attach to a containerized VM,  and it then exits, we can't delete the .attach_pidXXX file.  Neither the /proc/PID/cwd or canonical form are any use.

(Possibly leaving a .attach_pidXXX file if the target dies in that small window is better than the current situation.)

Here I'm suggesting the same change on AIX, although I can't build/test that.  I'm expecting it has the same problem, as /proc/pid/cwd is still a symlink.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8228343](https://bugs.openjdk.java.net/browse/JDK-8228343): JCMD and attach fail to work across Linux Container boundary


### Reviewers
 * [Yasumasa Suenaga](https://openjdk.java.net/census#ysuenaga) (@YaSuenag - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4418/head:pull/4418` \
`$ git checkout pull/4418`

Update a local copy of the PR: \
`$ git checkout pull/4418` \
`$ git pull https://git.openjdk.java.net/jdk pull/4418/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4418`

View PR using the GUI difftool: \
`$ git pr show -t 4418`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4418.diff">https://git.openjdk.java.net/jdk/pull/4418.diff</a>

</details>
