### PR TITLE
8268417: Add test from JDK-8268360

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/TestInfLoopNearUsePlacement.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestInfLoopNearUsePlacement.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8268360
+ * @summary Test node placement when its use is inside infinite loop.
+ * @library /test/lib
+ * @run main/othervm -XX:CompileCommand=compileonly,compiler.loopopts.TestInfLoopNearUsePlacement::test
+ *                   compiler.loopopts.TestInfLoopNearUsePlacement
+ */
+
+package compiler.loopopts;
+
+import jdk.test.lib.Utils;
+
+public class TestInfLoopNearUsePlacement {
+
+    static void test() {
+        long loa[] = new long[42];
+
+        try {
+            for (int i = 0; i < 42; i++) {
+                Thread.sleep(1);
+                loa[i] = 42L;
+            }
+        } catch (InterruptedException e) {}
+
+        loa[0] = 1L;
+        // Infinite loop: loop's variable is reset on each iteration
+        for (int i = 0; i < 21; i++) {
+            loa[0] += 1L;
+            i = 1;
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        // Execute test in own thread because it contains an infinite loop
+        Thread thread = new Thread() {
+            public void run() {
+                for (int i = 0; i < 100; ++i) {
+                    test();
+                }
+            }
+        };
+        thread.setDaemon(true);
+        thread.start();
+        // Give thread some time to trigger compilation
+        Thread.sleep(Utils.adjustTimeout(5000));
+    }
+}


### PR DESCRIPTION
The fix from JDK-8268360 is not applied to JDK 17 sources anymore because JDK-8252372 changes rewrote affected code and the test does not fail with JDK 17.  Even so the fix is not needed in JDK 17, I want to add the test from JDK-8268360.

Tested tier1 (where the test runs).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268417](https://bugs.openjdk.java.net/browse/JDK-8268417): Add test from JDK-8268360


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4420/head:pull/4420` \
`$ git checkout pull/4420`

Update a local copy of the PR: \
`$ git checkout pull/4420` \
`$ git pull https://git.openjdk.java.net/jdk pull/4420/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4420`

View PR using the GUI difftool: \
`$ git pr show -t 4420`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4420.diff">https://git.openjdk.java.net/jdk/pull/4420.diff</a>

</details>
