### PR TITLE
8268353: Test libsvml.so is and is not present in jdk image

### DIFF
--- a/test/jdk/jdk/incubator/vector/ImageTest.java
+++ b/test/jdk/jdk/incubator/vector/ImageTest.java
@@ -42,6 +42,9 @@ public class ImageTest {
                     new RuntimeException("jlink tool not found")
             );
 
+    static final Path SVML_LIBRARY_PATH = System.getProperty("os.name").startsWith("Windows")
+            ? Path.of("bin/svml.dll")    // Path on windows
+            : Path.of("lib/libsvml.so"); // Path on linux
 
     static void link(String module, Path output) {
         int e = JLINK_TOOL.run(System.out, System.err,
@@ -54,13 +57,13 @@ public class ImageTest {
     }
 
     static void checkSVML(Path image, boolean shouldBepresent) {
-        Path libsvml = image.resolve("lib/libsvml.so");
+        Path libsvml = image.resolve(SVML_LIBRARY_PATH);
 
         boolean exists = Files.exists(libsvml);
         if (shouldBepresent) {
-            Assert.assertTrue(exists, "lib/libsvml.so should be present");
+            Assert.assertTrue(exists, SVML_LIBRARY_PATH + " should be present");
         } else {
-            Assert.assertFalse(exists, "lib/libsvml.so should be absent");
+            Assert.assertFalse(exists, SVML_LIBRARY_PATH + "should be absent");
         }
     }
 

--- a/test/jdk/jdk/incubator/vector/ImageTest.java
+++ b/test/jdk/jdk/incubator/vector/ImageTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.spi.ToolProvider;
+
+/**
+ * @test
+ * @summary Tests that lib/libsvml.so is present in an image only when jdk.incubator.vector is present
+ * @requires os.arch == "x86_64" & (os.family == "linux" | os.family == "windows")
+ * @modules jdk.incubator.vector jdk.jlink
+ * @run testng ImageTest
+ */
+
+public class ImageTest {
+    static final ToolProvider JLINK_TOOL = ToolProvider.findFirst("jlink")
+            .orElseThrow(() ->
+                    new RuntimeException("jlink tool not found")
+            );
+
+
+    static void link(String module, Path output) {
+        int e = JLINK_TOOL.run(System.out, System.err,
+                "--add-modules", module,
+                "--output", output.toString()
+        );
+        if (e != 0) {
+            throw new RuntimeException("Error running jlink");
+        }
+    }
+
+    static void checkSVML(Path image, boolean shouldBepresent) {
+        Path libsvml = image.resolve("lib/libsvml.so");
+
+        boolean exists = Files.exists(libsvml);
+        if (shouldBepresent) {
+            Assert.assertTrue(exists, "lib/libsvml.so should be present");
+        } else {
+            Assert.assertFalse(exists, "lib/libsvml.so should be absent");
+        }
+    }
+
+
+    @Test
+    public void withVectorModule() {
+        Path output = Path.of("withVectorModule");
+        link("jdk.incubator.vector", output);
+        checkSVML(output, true);
+    }
+
+    @Test
+    public void withoutVectorModule() {
+        Path output = Path.of("withoutVectorModule");
+        link("java.base", output);
+        checkSVML(output, false);
+    }
+}

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -333,11 +333,20 @@ public class Platform {
      * Returns absolute path to directory containing shared libraries in the tested JDK.
      */
     public static Path libDir() {
-        Path dir = Paths.get(testJdk);
+        return libDir(Paths.get(testJdk)).toAbsolutePath();
+    }
+
+    /**
+     * Resolves a given path, to a JDK image, to the directory containing shared libraries.
+     *
+     * @param image the path to a JDK image
+     * @return the resolved path to the directory containing shared libraries
+     */
+    public static Path libDir(Path image) {
         if (Platform.isWindows()) {
-            return dir.resolve("bin").toAbsolutePath();
+            return image.resolve("bin");
         } else {
-            return dir.resolve("lib").toAbsolutePath();
+            return image.resolve("lib");
         }
     }
 


### PR DESCRIPTION
Test that when the jdk.incubator.vector module is present that libsvml.so is present, and test the opposite case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8268353](https://bugs.openjdk.java.net/browse/JDK-8268353): Test libsvml.so is and is not present in jdk image


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4421/head:pull/4421` \
`$ git checkout pull/4421`

Update a local copy of the PR: \
`$ git checkout pull/4421` \
`$ git pull https://git.openjdk.java.net/jdk pull/4421/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4421`

View PR using the GUI difftool: \
`$ git pr show -t 4421`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4421.diff">https://git.openjdk.java.net/jdk/pull/4421.diff</a>

</details>
