### PR TITLE
8268229: Aarch64: Use Neon in intrinsics for String.equals

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -16673,7 +16673,7 @@ instruct string_equalsL(iRegP_R1 str1, iRegP_R3 str2, iRegI_R4 cnt,
 
   format %{ "String Equals $str1,$str2,$cnt -> $result" %}
   ins_encode %{
-    // Count is in 8-bit bytes; non-Compact chars are 16 bits.
+    // Count is in 8-bit bytes; non-Compact chars are 8 bits.
     __ string_equals($str1$$Register, $str2$$Register,
                      $result$$Register, $cnt$$Register, 1);
   %}

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -16673,7 +16673,7 @@ instruct string_equalsL(iRegP_R1 str1, iRegP_R3 str2, iRegI_R4 cnt,
 
   format %{ "String Equals $str1,$str2,$cnt -> $result" %}
   ins_encode %{
-    // Count is in 8-bit bytes; non-Compact chars are 8 bits.
+    // Count is in 8-bit bytes.
     __ string_equals($str1$$Register, $str2$$Register,
                      $result$$Register, $cnt$$Register, 1);
   %}
@@ -16689,7 +16689,7 @@ instruct string_equalsU(iRegP_R1 str1, iRegP_R3 str2, iRegI_R4 cnt,
 
   format %{ "String Equals $str1,$str2,$cnt -> $result" %}
   ins_encode %{
-    // Count is in 8-bit bytes; non-Compact chars are 16 bits.
+    // Count is in 8-bit bytes.
     __ string_equals($str1$$Register, $str2$$Register,
                      $result$$Register, $cnt$$Register, 2);
   %}

--- a/src/hotspot/cpu/aarch64/globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globals_aarch64.hpp
@@ -93,6 +93,8 @@ define_pd_global(intx, InlineSmallCode,          1000);
           "Use SIMD instructions in generated array equals code")       \
   product(bool, UseSimpleArrayEquals, false,                            \
           "Use simpliest and shortest implementation for array equals") \
+  product(bool, UseSimpleStringEquals, true,                            \
+          "Use simpliest and shortest implementation for string equals")\
   product(bool, UseSIMDForBigIntegerShiftIntrinsics, true,              \
           "Use SIMD instructions for left/right shift of BigInteger")   \
   product(bool, AvoidUnalignedAccesses, false,                          \

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -4637,12 +4637,11 @@ class StubGenerator: public StubCodeGenerator {
   // result = r0 - return value. Already contains "false"
   // cnt1 = r4 - amount of elements left to check
   address generate_long_string_equals() {
-    Register a1 = r1, a2 = r3, result = r0, cnt1 = r4, tmp1 = rscratch1,
-        tmp2 = rscratch2;
-    Label TAIL, NOT_EQUAL, EQUAL, LOOP, SMALL_LOOP, POST_LOOP;
-    int loopThreshold = 4 * 2 * wordSize;
+    Register a1 = r1, a2 = r3, result = r0, cnt1 = r4;
+    Label NOT_EQUAL, EQUAL, LOOP, SMALL_LOOP, POST_LOOP;
+    int loopThreshold = 4 * wordSize;
 
-    assert_different_registers(a1, a2, result, cnt1, tmp1, tmp2);
+    assert_different_registers(a1, a2, result, cnt1);
 
     __ align(CodeEntryAlignment);
 
@@ -4651,61 +4650,40 @@ class StubGenerator: public StubCodeGenerator {
     address entry = __ pc();
     __ enter();
 
-    // cnt1 minus wordSize outside of stub
-    __ add(cnt1, cnt1, wordSize);
+    // reset cnt1
+    __ add(cnt1, cnt1, loopThreshold);
 
+    // Main 32 byte comparison loop.
     __ bind(LOOP);
-      __ ldr(v0, __ Q, Address(__ post(a1, wordSize * 2)));
-      __ ldr(v1, __ Q, Address(__ post(a2, wordSize * 2)));
-      __ eor(v0, __ T16B, v0, v1);
-      __ umov(tmp1, v0, __ D, 0);
-      __ umov(tmp2, v0, __ D, 1);
-      __ orr(tmp1, tmp1, tmp2);
-      __ cbnz(tmp1, NOT_EQUAL);
-
-      __ ldr(v2, __ Q, Address(__ post(a1, wordSize * 2)));
-      __ ldr(v3, __ Q, Address(__ post(a2, wordSize * 2)));
-      __ eor(v2, __ T16B, v2, v3);
-      __ umov(tmp1, v2, __ D, 0);
-      __ umov(tmp2, v2, __ D, 1);
-      __ orr(tmp1, tmp1, tmp2);
-      __ cbnz(tmp1, NOT_EQUAL);
-
-      __ ldr(v4, __ Q, Address(__ post(a1, wordSize * 2)));
-      __ ldr(v5, __ Q, Address(__ post(a2, wordSize * 2)));
-      __ eor(v4, __ T16B, v4, v5);
-      __ umov(tmp1, v4, __ D, 0);
-      __ umov(tmp2, v4, __ D, 1);
-      __ orr(tmp1, tmp1, tmp2);
-      __ cbnz(tmp1, NOT_EQUAL);
-
-      __ ldr(v6, __ Q, Address(__ post(a1, wordSize * 2)));
+      __ ld1(v0, v1, __ T2D, Address(__ post(a1, loopThreshold)));
       __ sub(cnt1, cnt1, loopThreshold);
-      __ ldr(v7, __ Q, Address(__ post(a2, wordSize * 2)));
-      __ subs(tmp1, cnt1, loopThreshold);
-      __ eor(v6, __ T16B, v6, v7);
-      __ umov(tmp1, v6, __ D, 0);
-      __ umov(tmp2, v6, __ D, 1);
-      __ orr(tmp1, tmp1, tmp2);
-      __ cbnz(tmp1, NOT_EQUAL);
+      __ ld1(v2, v3, __ T2D, Address(__ post(a2, loopThreshold)));
+      __ subs(zr, cnt1, loopThreshold);
+      __ eor(v0, __ T16B, v0, v2);
+      __ eor(v1, __ T16B, v1, v3);
+      __ orr(v0, __ T16B, v0, v1);
+      __ umov(rscratch1, v0, __ D, 0);
+      __ umov(rscratch2, v0, __ D, 1);
+      __ orr(rscratch1, rscratch1, rscratch2);
+      __ cbnz(rscratch1, NOT_EQUAL);
       __ br(__ GE, LOOP);
 
-    __ bind(TAIL);
-      __ cbz(cnt1, EQUAL);
-      __ subs(cnt1, cnt1, wordSize);
-      __ br(__ LE, POST_LOOP);
+    __ cbz(cnt1, EQUAL);
+    __ subs(cnt1, cnt1, wordSize);
+    __ br(__ LE, POST_LOOP);
+
     __ bind(SMALL_LOOP);
-      __ ldr(tmp1, Address(__ post(a1, wordSize)));
-      __ ldr(tmp2, Address(__ post(a2, wordSize)));
+      __ ldr(rscratch1, Address(__ post(a1, wordSize)));
+      __ ldr(rscratch2, Address(__ post(a2, wordSize)));
       __ subs(cnt1, cnt1, wordSize);
-      __ eor(tmp1, tmp1, tmp2);
-      __ cbnz(tmp1, NOT_EQUAL);
+      __ eor(rscratch1, rscratch1, rscratch2);
+      __ cbnz(rscratch1, NOT_EQUAL);
       __ br(__ GT, SMALL_LOOP);
     __ bind(POST_LOOP);
-      __ ldr(tmp1, Address(a1, cnt1));
-      __ ldr(tmp2, Address(a2, cnt1));
-      __ eor(tmp1, tmp1, tmp2);
-      __ cbnz(tmp1, NOT_EQUAL);
+      __ ldr(rscratch1, Address(a1, cnt1));
+      __ ldr(rscratch2, Address(a2, cnt1));
+      __ eor(rscratch1, rscratch1, rscratch2);
+      __ cbnz(rscratch1, NOT_EQUAL);
 
     __ bind(EQUAL);
       __ mov(result, true);

--- a/src/hotspot/cpu/aarch64/stubRoutines_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubRoutines_aarch64.cpp
@@ -48,6 +48,7 @@ address StubRoutines::aarch64::_zero_blocks = NULL;
 address StubRoutines::aarch64::_has_negatives = NULL;
 address StubRoutines::aarch64::_has_negatives_long = NULL;
 address StubRoutines::aarch64::_large_array_equals = NULL;
+address StubRoutines::aarch64::_long_string_equals = NULL;
 address StubRoutines::aarch64::_compare_long_string_LL = NULL;
 address StubRoutines::aarch64::_compare_long_string_UU = NULL;
 address StubRoutines::aarch64::_compare_long_string_LU = NULL;

--- a/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
@@ -61,6 +61,7 @@ class aarch64 {
   static address _has_negatives;
   static address _has_negatives_long;
   static address _large_array_equals;
+  static address _long_string_equals;
   static address _compare_long_string_LL;
   static address _compare_long_string_LU;
   static address _compare_long_string_UL;
@@ -139,6 +140,10 @@ class aarch64 {
 
   static address large_array_equals() {
       return _large_array_equals;
+  }
+
+  static address long_string_equals() {
+      return _long_string_equals;
   }
 
   static address compare_long_string_LL() {

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -156,6 +156,9 @@ void VM_Version::initialize() {
     if (FLAG_IS_DEFAULT(UseSIMDForMemoryOps)) {
       FLAG_SET_DEFAULT(UseSIMDForMemoryOps, true);
     }
+    if (FLAG_IS_DEFAULT(UseSimpleStringEquals)) {
+      FLAG_SET_DEFAULT(UseSimpleStringEquals, false);
+    }
   }
 
   // Cortex A53

--- a/test/micro/org/openjdk/bench/java/lang/StringEquals.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringEquals.java
@@ -31,10 +31,13 @@ import java.util.concurrent.TimeUnit;
  * This benchmark naively explores String::equals performance
  */
 @BenchmarkMode(Mode.AverageTime)
-@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations=3, time=1)
+@Measurement(iterations=5, time=1)
 @State(Scope.Benchmark)
+@Fork(value=1)
 public class StringEquals {
-    @Param({"8", "16", "32", "64", "128"})
+    @Param({"8", "11", "16", "22", "32", "45", "64", "91", "121", "181", "256", "512", "1024"})
     int size;
 
     public String test = new String("0123456789");
@@ -48,12 +51,14 @@ public class StringEquals {
     public String str;
     public String strh;
     public String strt;
+    public String strDup;
 
     @Setup()
     public void init() {
         str = newString(size, 'c', -1, 'a');
         strh = newString(size, 'c', size / 3, 'a');
         strt = newString(size, 'c', size - 1 - size / 3, 'a');
+        strDup = new String (str.toCharArray());
     }
 
     public String newString(int size, char charToFill, int pos, char charDiff) {
@@ -68,79 +73,70 @@ public class StringEquals {
         return "";
     }
 
-    @Fork(jvmArgsAppend = {"-XX:+UseSimpleStringEquals"})
-    public boolean different_simple() {
-        return test.equals(test2);
-    }
-
     public boolean different() {
-        return test.equals(test2);
-    }
-
-    @Fork(jvmArgsAppend = {"-XX:+UseSimpleStringEquals"})
-    public boolean equal_simple() {
-        return test.equals(test3);
-    }
-
-    public boolean equal() {
-        return test.equals(test3);
-    }
-
-    @Fork(jvmArgsAppend = {"-XX:+UseSimpleStringEquals"})
-    public boolean almostEqual_simple() {
-        return test.equals(test6);
+        boolean result = false;
+        for (int i = 0; i < 1000; i++) {
+            result ^= test.equals(test2);
+        }
+        return result;
     }
 
     public boolean almostEqual() {
-        return test.equals(test6);
-    }
-
-    @Fork(jvmArgsAppend = {"-XX:+UseSimpleStringEquals"})
-    public boolean almostEqualUTF16_simple() {
-        return test4.equals(test7);
+        boolean result = false;
+        for (int i = 0; i < 1000; i++) {
+            result ^= test.equals(test6);
+        }
+        return result;
     }
 
     public boolean almostEqualUTF16() {
-        return test4.equals(test7);
-    }
-
-    @Fork(jvmArgsAppend = {"-XX:+UseSimpleStringEquals"})
-    public boolean differentCoders_simple() {
-        return test.equals(test4);
+        boolean result = false;
+        for (int i = 0; i < 1000; i++) {
+            result ^= test4.equals(test7);
+        }
+        return result;
     }
 
     public boolean differentCoders() {
-        return test.equals(test4);
+        boolean result = false;
+        for (int i = 0; i < 1000; i++) {
+            result ^= test.equals(test4);
+        }
+        return result;
     }
 
-    @Fork(jvmArgsAppend = {"-XX:+UseSimpleStringEquals"})
-    public boolean equalsUTF16_simple() {
-        return test5.equals(test4);
+    public boolean equalUTF16() {
+        boolean result = false;
+        for (int i = 0; i < 1000; i++) {
+            result ^= test5.equals(test4);
+        }
+        return result;
     }
 
-    public boolean equalsUTF16() {
-        return test5.equals(test4);
+    public boolean equalDiffAtHead() {
+        boolean result = false;
+        for (int i = 0; i < 1000; i++) {
+            result ^= str.equals(strh);
+        }
+        return result;
+    }
+
+    public boolean equalDiffAtTail() {
+        boolean result = false;
+        for (int i = 0; i < 1000; i++) {
+            result ^= str.equals(strt);
+        }
+        return result;
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend = {"-XX:+UseSimpleStringEquals"})
-    public boolean equalsLenH_simple() {
-        return str.equals(strh);
-    }
-
-    @Benchmark
-    public boolean equalsLenH() {
-        return str.equals(strh);
-    }
-
-    @Benchmark
-    @Fork(jvmArgsAppend = {"-XX:+UseSimpleStringEquals"})
-    public boolean equalsLenT_simple() {
-        return str.equals(strt);
-    }
-
-    @Benchmark
-    public boolean equalsLenT() {
-        return str.equals(strt);
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public boolean equal() {
+        boolean result = false;
+        for (int i = 0; i < 1000; i++) {
+            result ^= str.equals(strDup);
+        }
+        return result;
     }
 }
+


### PR DESCRIPTION
Dear all, 
     Could you give me a favor to review this patch? It improves the performance of the intrinsic of `String.equals` on Neon backend of Aarch64.
     We profile the performance by using this JMH case:
 

   ```java
    package com.huawei.string;
    import java.util.*;
    import java.util.concurrent.TimeUnit;
    
    import org.openjdk.jmh.annotations.CompilerControl;
    import org.openjdk.jmh.annotations.Benchmark;
    import org.openjdk.jmh.annotations.Level;
    import org.openjdk.jmh.annotations.OutputTimeUnit;
    import org.openjdk.jmh.annotations.Param;
    import org.openjdk.jmh.annotations.Scope;
    import org.openjdk.jmh.annotations.Setup;
    import org.openjdk.jmh.annotations.State;
    import org.openjdk.jmh.annotations.Fork;
    import org.openjdk.jmh.infra.Blackhole;
    
    @State(Scope.Thread)
    @OutputTimeUnit(TimeUnit.MILLISECONDS)
    public class StringEqual {
        @Param({"8", "64", "4096"})
        int size;
    
        String str1;
        String str2;
    
        @Setup(Level.Trial)
        public void init() {
            str1 = newString(size, 'c', '1');
            str2 = newString(size, 'c', '2');
        }
    
        public String newString(int length, char charToFill, char lastChar) {
            if (length > 0) {
                char[] array = new char[length];
                Arrays.fill(array, charToFill);
                array[length - 1] = lastChar;
                return new String(array);
            }
            return "";
        }
    
        @Benchmark
        @CompilerControl(CompilerControl.Mode.DONT_INLINE)
        public boolean EqualString() {
            return str1.equals(str2);
        }
    }

   ```
The result is list as following:（Linux aarch64 with 128cores）

Benchmark                       | (size) |  Mode | Cnt  |     Score |     Error |  Units
----------------------------------|-------|---------|-------|------------|------------|----------
StringEqual.EqualString      |         8 | thrpt  | 10 | 123971.994 | ± 1462.131 | ops/ms
StringEqual.EqualString       |       64 | thrpt |  10  | 56009.960  | ±  999.734 | ops/ms
StringEqual.EqualString        |    4096 | thrpt |  10 |   1943.852 | ±  8.159 | ops/ms
StringEqual.EqualStringWithNEON    |   8 | thrpt |  10 | 120319.271  | ± 1392.185 | ops/ms
StringEqual.EqualStringWithNEON    |  64 | thrpt |  10 |  72914.767 | ± 1814.173 | ops/ms
StringEqual.EqualStringWithNEON  |  4096 | thrpt  | 10  |  2579.155 | ± 15.589 | ops/ms

Yours, 
WANG Huang

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8268229](https://bugs.openjdk.java.net/browse/JDK-8268229): Aarch64: Use Neon in intrinsics for String.equals


### Contributors
 * Wang Huang `<whuang@openjdk.org>`
 * Miao Zhuojun `<mouzhuojun@huawei.com>`
 * Ai Jiaming `<aijiaming1@huawei.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4423/head:pull/4423` \
`$ git checkout pull/4423`

Update a local copy of the PR: \
`$ git checkout pull/4423` \
`$ git pull https://git.openjdk.java.net/jdk pull/4423/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4423`

View PR using the GUI difftool: \
`$ git pr show -t 4423`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4423.diff">https://git.openjdk.java.net/jdk/pull/4423.diff</a>

</details>
