### PR TITLE
8268427: Improve AlgorithmConstraints:checkAlgorithm performance

### DIFF
--- a/src/java.base/share/classes/sun/security/util/AbstractAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/AbstractAlgorithmConstraints.java
@@ -32,9 +32,8 @@ import java.security.Security;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.TreeSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -69,7 +68,7 @@ public abstract class AbstractAlgorithmConstraints
             }
             algorithmsInProperty = property.split(",");
             for (int i = 0; i < algorithmsInProperty.length; i++) {
-                algorithmsInProperty[i] = algorithmsInProperty[i].trim().toLowerCase(Locale.ENGLISH);
+                algorithmsInProperty[i] = algorithmsInProperty[i].trim();
             }
         }
 
@@ -77,7 +76,9 @@ public abstract class AbstractAlgorithmConstraints
         if (algorithmsInProperty == null) {
             return Collections.emptySet();
         }
-        return new HashSet<>(Arrays.asList(algorithmsInProperty));
+        Set<String> algorithmsInPropertySet = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        algorithmsInPropertySet.addAll(Arrays.asList(algorithmsInProperty));
+        return algorithmsInPropertySet;
     }
 
     static boolean checkAlgorithm(Set<String> algorithms, String algorithm,
@@ -87,7 +88,7 @@ public abstract class AbstractAlgorithmConstraints
         }
 
         Set<String> elements = null;
-        if (algorithms.contains(algorithm.toLowerCase())) {
+        if (algorithms.contains(algorithm)) {
             return false;
         }
 
@@ -97,9 +98,9 @@ public abstract class AbstractAlgorithmConstraints
         }
         // check the element of the elements
         for (String element : elements) {
-            if (algorithms.contains(element.toLowerCase())) {
-                 return false;
-             }
+            if (algorithms.contains(algorithm)) {
+                return false;
+            }
         }
 
         return true;

--- a/src/java.base/share/classes/sun/security/util/AbstractAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/AbstractAlgorithmConstraints.java
@@ -32,7 +32,9 @@ import java.security.Security;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -48,7 +50,7 @@ public abstract class AbstractAlgorithmConstraints
     }
 
     // Get algorithm constraints from the specified security property.
-    static List<String> getAlgorithms(String propertyName) {
+    static Set<String> getAlgorithms(String propertyName) {
         @SuppressWarnings("removal")
         String property = AccessController.doPrivileged(
                 new PrivilegedAction<String>() {
@@ -67,15 +69,15 @@ public abstract class AbstractAlgorithmConstraints
             }
             algorithmsInProperty = property.split(",");
             for (int i = 0; i < algorithmsInProperty.length; i++) {
-                algorithmsInProperty[i] = algorithmsInProperty[i].trim();
+                algorithmsInProperty[i] = algorithmsInProperty[i].trim().toLowerCase(Locale.ENGLISH);
             }
         }
 
         // map the disabled algorithms
         if (algorithmsInProperty == null) {
-            return Collections.emptyList();
+            return Collections.emptySet();
         }
-        return new ArrayList<>(Arrays.asList(algorithmsInProperty));
+        return new HashSet<>(Arrays.asList(algorithmsInProperty));
     }
 
     static boolean checkAlgorithm(Set<String> algorithms, String algorithm,

--- a/src/java.base/share/classes/sun/security/util/AbstractAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/AbstractAlgorithmConstraints.java
@@ -87,18 +87,16 @@ public abstract class AbstractAlgorithmConstraints
             throw new IllegalArgumentException("No algorithm name specified");
         }
 
-        Set<String> elements = null;
         if (algorithms.contains(algorithm)) {
             return false;
         }
 
         // decompose the algorithm into sub-elements
-        if (elements == null) {
-            elements = decomposer.decompose(algorithm);
-        }
+        Set<String> elements = decomposer.decompose(algorithm);
+
         // check the element of the elements
         for (String element : elements) {
-            if (algorithms.contains(algorithm)) {
+            if (algorithms.contains(element)) {
                 return false;
             }
         }

--- a/src/java.base/share/classes/sun/security/util/AbstractAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/AbstractAlgorithmConstraints.java
@@ -78,34 +78,26 @@ public abstract class AbstractAlgorithmConstraints
         return new ArrayList<>(Arrays.asList(algorithmsInProperty));
     }
 
-    static boolean checkAlgorithm(List<String> algorithms, String algorithm,
+    static boolean checkAlgorithm(Set<String> algorithms, String algorithm,
             AlgorithmDecomposer decomposer) {
         if (algorithm == null || algorithm.isEmpty()) {
             throw new IllegalArgumentException("No algorithm name specified");
         }
 
         Set<String> elements = null;
-        for (String item : algorithms) {
-            if (item == null || item.isEmpty()) {
-                continue;
-            }
+        if (algorithms.contains(algorithm.toLowerCase())) {
+            return false;
+        }
 
-            // check the full name
-            if (item.equalsIgnoreCase(algorithm)) {
-                return false;
-            }
-
-            // decompose the algorithm into sub-elements
-            if (elements == null) {
-                elements = decomposer.decompose(algorithm);
-            }
-
-            // check the items of the algorithm
-            for (String element : elements) {
-                if (item.equalsIgnoreCase(element)) {
-                    return false;
-                }
-            }
+        // decompose the algorithm into sub-elements
+        if (elements == null) {
+            elements = decomposer.decompose(algorithm);
+        }
+        // check the element of the elements
+        for (String element : elements) {
+            if (algorithms.contains(element.toLowerCase())) {
+                 return false;
+             }
         }
 
         return true;

--- a/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
@@ -130,9 +130,10 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
         disabledAlgorithms = getAlgorithms(propertyName);
 
         // Check for alias
-        Pattern INCLUDE_PATTERN = Pattern.compile("include " + PROPERTY_DISABLED_EC_CURVES, Pattern.CASE_INSENSITIVE);
-        Matcher matcher;
+        Pattern INCLUDE_PATTERN = Pattern.compile(
+                "include " + PROPERTY_DISABLED_EC_CURVES);
         for (String s : disabledAlgorithms) {
+            Matcher matcher;
             if ((matcher = INCLUDE_PATTERN.matcher(s)).matches()) {
                 disabledAlgorithms.remove(matcher.group());
                 disabledAlgorithms.addAll(getAlgorithms(PROPERTY_DISABLED_EC_CURVES));

--- a/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
@@ -322,11 +322,11 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
 
         private static class Holder {
             private static final Pattern DENY_AFTER_PATTERN = Pattern.compile(
-                    "denyAfter\\s+(\\d{4})-(\\d{2})-(\\d{2})", Pattern.CASE_INSENSITIVE);
+                    "denyAfter\\s+(\\d{4})-(\\d{2})-(\\d{2})");
         }
 
-        public Constraints(String propertyName, Set<String> constraintArray) {
-            for (String constraintEntry : constraintArray) {
+        public Constraints(String propertyName, Set<String> constraintSet) {
+            for (String constraintEntry : constraintSet) {
                 if (constraintEntry == null || constraintEntry.isEmpty()) {
                     continue;
                 }
@@ -373,13 +373,13 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
                     entry = entry.trim();
 
                     Matcher matcher;
-                    if (entry.regionMatches(true, 0, "keySize", 0, 7)) {
+                    if (entry.startsWith("keySize")) {
                         if (debug != null) {
                             debug.println("Constraints set to keySize: " +
                                     entry);
                         }
                         StringTokenizer tokens = new StringTokenizer(entry);
-                        if (!"keySize".equalsIgnoreCase(tokens.nextToken())) {
+                        if (!"keySize".equals(tokens.nextToken())) {
                             throw new IllegalArgumentException("Error in " +
                                     "security property. Constraint unknown: " +
                                     entry);
@@ -400,7 +400,7 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
                         c = new jdkCAConstraint(algorithm);
                         jdkCALimit = true;
 
-                    } else if (entry.regionMatches(true, 0, "denyAfter", 0, 8) &&
+                    } else if (entry.startsWith("denyAfter") &&
                             (matcher = Holder.DENY_AFTER_PATTERN.matcher(entry))
                                     .matches()) {
                         if (debug != null) {
@@ -417,7 +417,7 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
                         c = new DenyAfterConstraint(algorithm, year, month,
                                 day);
                         denyAfterLimit = true;
-                    } else if (entry.regionMatches(true, 0, "usage", 0, 5)) {
+                    } else if (entry.startsWith("usage")) {
                         String s[] = (entry.substring(5)).trim().split(" ");
                         c = new UsageConstraint(algorithm, s);
                         if (debug != null) {

--- a/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
@@ -85,6 +85,9 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
     private static final String PROPERTY_DISABLED_EC_CURVES =
             "jdk.disabled.namedCurves";
 
+    private static final Pattern INCLUDE_PATTERN = Pattern.compile("include " +
+            PROPERTY_DISABLED_EC_CURVES, Pattern.CASE_INSENSITIVE);
+
     private static class CertPathHolder {
         static final DisabledAlgorithmConstraints CONSTRAINTS =
             new DisabledAlgorithmConstraints(PROPERTY_CERTPATH_DISABLED_ALGS);
@@ -130,13 +133,12 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
         disabledAlgorithms = getAlgorithms(propertyName);
 
         // Check for alias
-        Pattern INCLUDE_PATTERN = Pattern.compile(
-                "include " + PROPERTY_DISABLED_EC_CURVES);
         for (String s : disabledAlgorithms) {
-            Matcher matcher;
-            if ((matcher = INCLUDE_PATTERN.matcher(s)).matches()) {
+            Matcher matcher = INCLUDE_PATTERN.matcher(s);
+            if (matcher.matches()) {
                 disabledAlgorithms.remove(matcher.group());
-                disabledAlgorithms.addAll(getAlgorithms(PROPERTY_DISABLED_EC_CURVES));
+                disabledAlgorithms.addAll(
+                        getAlgorithms(PROPERTY_DISABLED_EC_CURVES));
                 break;
             }
         }

--- a/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
@@ -95,7 +95,7 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
             new DisabledAlgorithmConstraints(PROPERTY_JAR_DISABLED_ALGS);
     }
 
-    private final List<String> disabledAlgorithms;
+    private final Set<String> disabledAlgorithms;
     private final Constraints algorithmConstraints;
 
     public static DisabledAlgorithmConstraints certPathConstraints() {
@@ -127,11 +127,11 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
     public DisabledAlgorithmConstraints(String propertyName,
             AlgorithmDecomposer decomposer) {
         super(decomposer);
-        disabledAlgorithms = getAlgorithms(propertyName);
+        List<String> disabledAlgorithmsList = getAlgorithms(propertyName);
 
         // Check for alias
         int ecindex = -1, i = 0;
-        for (String s : disabledAlgorithms) {
+        for (String s : disabledAlgorithmsList) {
             if (s.regionMatches(true, 0,"include ", 0, 8)) {
                 if (s.regionMatches(true, 8, PROPERTY_DISABLED_EC_CURVES, 0,
                         PROPERTY_DISABLED_EC_CURVES.length())) {
@@ -142,11 +142,19 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
             i++;
         }
         if (ecindex > -1) {
-            disabledAlgorithms.remove(ecindex);
-            disabledAlgorithms.addAll(ecindex,
+            disabledAlgorithmsList.remove(ecindex);
+            disabledAlgorithmsList.addAll(ecindex,
                     getAlgorithms(PROPERTY_DISABLED_EC_CURVES));
         }
-        algorithmConstraints = new Constraints(propertyName, disabledAlgorithms);
+        algorithmConstraints = new Constraints(propertyName, disabledAlgorithmsList);
+
+        disabledAlgorithms = new HashSet<String>();
+        for (String algorithm : disabledAlgorithmsList) {
+            if (algorithm == null || algorithm.isEmpty()) {
+                continue;
+            }
+            disabledAlgorithms.add(algorithm.toLowerCase());
+        }
     }
 
     /*

--- a/src/java.base/share/classes/sun/security/util/LegacyAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/LegacyAlgorithmConstraints.java
@@ -46,14 +46,7 @@ public class LegacyAlgorithmConstraints extends AbstractAlgorithmConstraints {
     public LegacyAlgorithmConstraints(String propertyName,
             AlgorithmDecomposer decomposer) {
         super(decomposer);
-        List<String> legacyAlgorithmsList = getAlgorithms(propertyName);
-        legacyAlgorithms = new HashSet<String>();
-        for (String algorithm : legacyAlgorithmsList) {
-            if (algorithm == null || algorithm.isEmpty()) {
-                continue;
-            }
-            legacyAlgorithms.add(algorithm.toLowerCase());
-        }
+        legacyAlgorithms = getAlgorithms(propertyName);
     }
 
     @Override

--- a/src/java.base/share/classes/sun/security/util/LegacyAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/LegacyAlgorithmConstraints.java
@@ -28,7 +28,6 @@ package sun.security.util;
 import java.security.AlgorithmParameters;
 import java.security.CryptoPrimitive;
 import java.security.Key;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 

--- a/src/java.base/share/classes/sun/security/util/LegacyAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/LegacyAlgorithmConstraints.java
@@ -28,6 +28,7 @@ package sun.security.util;
 import java.security.AlgorithmParameters;
 import java.security.CryptoPrimitive;
 import java.security.Key;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -40,12 +41,19 @@ public class LegacyAlgorithmConstraints extends AbstractAlgorithmConstraints {
     public static final String PROPERTY_TLS_LEGACY_ALGS =
             "jdk.tls.legacyAlgorithms";
 
-    private final List<String> legacyAlgorithms;
+    private final Set<String> legacyAlgorithms;
 
     public LegacyAlgorithmConstraints(String propertyName,
             AlgorithmDecomposer decomposer) {
         super(decomposer);
-        legacyAlgorithms = getAlgorithms(propertyName);
+        List<String> legacyAlgorithmsList = getAlgorithms(propertyName);
+        legacyAlgorithms = new HashSet<String>();
+        for (String algorithm : legacyAlgorithmsList) {
+            if (algorithm == null || algorithm.isEmpty()) {
+                continue;
+            }
+            legacyAlgorithms.add(algorithm.toLowerCase());
+        }
     }
 
     @Override

--- a/test/micro/org/openjdk/bench/java/security/AlgorithmConstraintsPermits.java
+++ b/test/micro/org/openjdk/bench/java/security/AlgorithmConstraintsPermits.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.security;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import sun.security.util.DisabledAlgorithmConstraints;
+
+import java.security.AlgorithmConstraints;
+import java.security.CryptoPrimitive;
+import java.util.concurrent.TimeUnit;
+import java.util.EnumSet;
+import java.util.Set;
+
+import static sun.security.util.DisabledAlgorithmConstraints.PROPERTY_TLS_DISABLED_ALGS;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(jvmArgsAppend = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED"})
+@State(Scope.Thread)
+public class AlgorithmConstraintsPermits {
+
+    AlgorithmConstraints tlsDisabledAlgConstraints;
+    Set<CryptoPrimitive> primitives = EnumSet.of(CryptoPrimitive.KEY_AGREEMENT);
+
+    @Param({"SSLv3", "DES", "NULL", "TLS1.3"})
+    String algorithm;
+
+    @Setup
+    public void setup() {
+        tlsDisabledAlgConstraints = new DisabledAlgorithmConstraints(PROPERTY_TLS_DISABLED_ALGS);
+    }
+
+    @Benchmark
+    public boolean permits() {
+        return tlsDisabledAlgConstraints.permits(primitives, algorithm, null);
+    }
+}
+


### PR DESCRIPTION
Now AlgorithmConstraints:checkAlgorithm uses List to check if an algorithm has been disabled. It is less efficient when there are more disabled elements in the list, we can use Set instead of List to speed up the search.

Patch contains a benchmark that can be run with `make test TEST="micro:java.security.AlgorithmConstraintsPermits"`.
Baseline results before patch:
```java
Benchmark                            (algorithm)  Mode  Cnt    Score     Error  Units
AlgorithmConstraintsPermits.permits        SSLv3  avgt    5   21.687 ?   1.118  ns/op
AlgorithmConstraintsPermits.permits          DES  avgt    5  324.216 ?   6.233  ns/op
AlgorithmConstraintsPermits.permits         NULL  avgt    5  709.462 ?  51.259  ns/op
AlgorithmConstraintsPermits.permits       TLS1.3  avgt    5  687.497 ? 170.181  ns/op
```
Benchmark results after patch:
```java
Benchmark                            (algorithm)  Mode  Cnt    Score    Error  Units
AlgorithmConstraintsPermits.permits        SSLv3  avgt    5   46.407 ?  1.057  ns/op
AlgorithmConstraintsPermits.permits          DES  avgt    5   65.722 ?  0.578  ns/op
AlgorithmConstraintsPermits.permits         NULL  avgt    5   43.988 ?  1.264  ns/op
AlgorithmConstraintsPermits.permits       TLS1.3  avgt    5  399.546 ? 11.194  ns/op
```
SSLv3, DES, NULL are the first, middle and last element in `jdk.tls.disabledAlgorithms` from `conf/security/java.security`.

Tomcat(maxKeepAliveRequests=1, which will disable HTTP/1.0 keep-alive)+Jmeter:
Before patch:
```java
summary +  50349 in 00:00:30 = 1678.4/s Avg:   238 Min:   188 Max:   298 Err:     0 (0.00%) Active: 400 Started: 400 Finished: 0
summary = 135183 in 00:01:22 = 1654.5/s Avg:   226 Min:    16 Max:  1281 Err:     0 (0.00%)
summary +  50240 in 00:00:30 = 1674.1/s Avg:   238 Min:   200 Max:   308 Err:     0 (0.00%) Active: 400 Started: 400 Finished: 0
summary = 185423 in 00:01:52 = 1659.7/s Avg:   229 Min:    16 Max:  1281 Err:     0 (0.00%)
summary +  50351 in 00:00:30 = 1678.4/s Avg:   238 Min:   191 Max:   306 Err:     0 (0.00%) Active: 400 Started: 400 Finished: 0
summary = 235774 in 00:02:22 = 1663.7/s Avg:   231 Min:    16 Max:  1281 Err:     0 (0.00%)
summary +  50461 in 00:00:30 = 1681.9/s Avg:   237 Min:   174 Max:   303 Err:     0 (0.00%) Active: 400 Started: 400 Finished: 0
```
After patch:
```java
summary +  59003 in 00:00:30 = 1966.6/s Avg:   203 Min:   158 Max:   272 Err:     0 (0.00%) Active: 400 Started: 400 Finished: 0
summary = 146675 in 00:01:18 = 1884.6/s Avg:   198 Min:    26 Max:   697 Err:     0 (0.00%)
summary +  58965 in 00:00:30 = 1965.9/s Avg:   203 Min:   166 Max:   257 Err:     0 (0.00%) Active: 400 Started: 400 Finished: 0
summary = 205640 in 00:01:48 = 1907.2/s Avg:   199 Min:    26 Max:   697 Err:     0 (0.00%)
summary +  59104 in 00:00:30 = 1969.1/s Avg:   203 Min:   157 Max:   266 Err:     0 (0.00%) Active: 400 Started: 400 Finished: 0
summary = 264744 in 00:02:18 = 1920.7/s Avg:   200 Min:    26 Max:   697 Err:     0 (0.00%)
summary +  59323 in 00:00:30 = 1977.6/s Avg:   202 Min:   158 Max:   256 Err:     0 (0.00%) Active: 400 Started: 400 Finished: 0
```

Testing: tier1, tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268427](https://bugs.openjdk.java.net/browse/JDK-8268427): Improve AlgorithmConstraints:checkAlgorithm performance


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)
 * [Anthony Scarpino](https://openjdk.java.net/census#ascarpino) (@ascarpino - **Reviewer**) ⚠️ Review applies to 0253fdb28210df66052ea80a9d1d381203a21fe6


### Contributors
 * GaofengZhang `<zhanggaofeng9@huawei.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4424/head:pull/4424` \
`$ git checkout pull/4424`

Update a local copy of the PR: \
`$ git checkout pull/4424` \
`$ git pull https://git.openjdk.java.net/jdk pull/4424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4424`

View PR using the GUI difftool: \
`$ git pr show -t 4424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4424.diff">https://git.openjdk.java.net/jdk/pull/4424.diff</a>

</details>
