### PR TITLE
8268428: Test java/foreign/TestResourceScope.java fails: expected [M] but found [N]

### DIFF
--- a/test/jdk/java/foreign/TestResourceScope.java
+++ b/test/jdk/java/foreign/TestResourceScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This tests fails intermittently but very rarely, on Windows it seems. The subtest in question is `testLockSharedMultiThread`. This test is spawning a number of threads, each of which:

* increments a counter atomically
* acquire scope
* waits some time
* release scope
* decrement counter (in finally block)

The main test thread tries (while the counter value is > 0) to repeatedly close the scope, and asserts that if the scope closes successfully, then the counter value should be exactly zero.

Looking at the test closely, I realized there's an issue: the order in which counter is incremented and scope is acquired is wrong. As such it is possible for counter to be increased, but then for subsequent acquire to fail (e.g. if segment is already closed). This would lead to the main test thread to fail, as it would appear as if the segment has been closed successfully, but the counter value is not zero.

The fix is to only increment the counter after a successful acquire. I have also tweaked the test so that it keeps trying closing the scope, even if the counter value reaches zero permanently (e.g. all other threads have completed).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268428](https://bugs.openjdk.java.net/browse/JDK-8268428): Test java/foreign/TestResourceScope.java fails: expected [M] but found [N]


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4427/head:pull/4427` \
`$ git checkout pull/4427`

Update a local copy of the PR: \
`$ git checkout pull/4427` \
`$ git pull https://git.openjdk.java.net/jdk pull/4427/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4427`

View PR using the GUI difftool: \
`$ git pr show -t 4427`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4427.diff">https://git.openjdk.java.net/jdk/pull/4427.diff</a>

</details>
