### PR TITLE
8267073: Race between Card Redirtying and Freeing Collection Set regions results in missing remembered set entries with G1

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1460,6 +1460,7 @@ G1CollectedHeap::G1CollectedHeap() :
   _cr(NULL),
   _task_queues(NULL),
   _num_regions_failed_evacuation(0),
+  _regions_failed_evacuation(NULL),
   _evacuation_failed_info_array(NULL),
   _preserved_marks_set(true /* in_c_heap */),
 #ifndef PRODUCT
@@ -1751,6 +1752,8 @@ jint G1CollectedHeap::initialize() {
   _preserved_marks_set.init(ParallelGCThreads);
 
   _collection_set.initialize(max_reserved_regions());
+
+  _regions_failed_evacuation = NEW_C_HEAP_ARRAY(volatile bool, max_regions(), mtGC);
 
   G1InitLogger::print();
 
@@ -3468,6 +3471,8 @@ void G1CollectedHeap::pre_evacuate_collection_set(G1EvacuationInfo& evacuation_i
 
   _expand_heap_after_alloc_failure = true;
   Atomic::store(&_num_regions_failed_evacuation, 0u);
+
+  memset((void*)_regions_failed_evacuation, false, sizeof(bool) * max_regions());
 
   // Disable the hot card cache.
   _hot_card_cache->reset_hot_cache_claimed_index();

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -867,6 +867,8 @@ public:
 
   // Number of regions evacuation failed in the current collection.
   volatile uint _num_regions_failed_evacuation;
+  // Records for every region on the heap whether evacuation failed for it.
+  volatile bool* _regions_failed_evacuation;
 
   EvacuationFailedInfo* _evacuation_failed_info_array;
 
@@ -1144,10 +1146,15 @@ public:
 
   // True iff an evacuation has failed in the most-recent collection.
   inline bool evacuation_failed() const;
+  // True iff the given region encountered an evacuation failure in the most-recent
+  // collection.
+  inline bool evacuation_failed(uint region_idx) const;
+
   inline uint num_regions_failed_evacuation() const;
-  // Notify that the garbage collection encountered an evacuation failure in a
-  // region. Should only be called once per region.
-  inline void notify_region_failed_evacuation();
+  // Notify that the garbage collection encountered an evacuation failure in the
+  // given region. Returns whether this has been the first occurrence of an evacuation
+  // failure in that region.
+  inline bool notify_region_failed_evacuation(uint const region_idx);
 
   void remove_from_old_gen_sets(const uint old_regions_removed,
                                 const uint archive_regions_removed,

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -194,12 +194,25 @@ bool G1CollectedHeap::evacuation_failed() const {
   return num_regions_failed_evacuation() > 0;
 }
 
+bool G1CollectedHeap::evacuation_failed(uint region_idx) const {
+  assert(region_idx < max_regions(), "Invalid region index %u", region_idx);
+
+  return Atomic::load(&_regions_failed_evacuation[region_idx]);
+}
+
 uint G1CollectedHeap::num_regions_failed_evacuation() const {
   return Atomic::load(&_num_regions_failed_evacuation);
 }
 
-void G1CollectedHeap::notify_region_failed_evacuation() {
-  Atomic::inc(&_num_regions_failed_evacuation, memory_order_relaxed);
+bool G1CollectedHeap::notify_region_failed_evacuation(uint const region_idx) {
+  assert(region_idx < max_regions(), "Invalid region index %u", region_idx);
+
+  volatile bool* region_failed_addr = &_regions_failed_evacuation[region_idx];
+  bool result = !Atomic::load(region_failed_addr) && !Atomic::cmpxchg(region_failed_addr, false, true, memory_order_relaxed);
+  if (result) {
+    Atomic::inc(&_num_regions_failed_evacuation, memory_order_relaxed);
+  }
+  return result;
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -237,7 +237,7 @@ public:
     assert(!hr->is_pinned(), "Unexpected pinned region at index %u", hr->hrm_index());
     assert(hr->in_collection_set(), "bad CS");
 
-    if (hr->evacuation_failed()) {
+    if (_g1h->evacuation_failed(hr->hrm_index())) {
       hr->clear_index_in_opt_cset();
 
       bool during_concurrent_start = _g1h->collector_state()->in_concurrent_start_gc();

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -605,8 +605,7 @@ oop G1ParScanThreadState::handle_evacuation_failure_par(oop old, markWord m) {
     // Forward-to-self succeeded. We are the "owner" of the object.
     HeapRegion* r = _g1h->heap_region_containing(old);
 
-    if (r->set_evacuation_failed()) {
-      _g1h->notify_region_failed_evacuation();
+    if (_g1h->notify_region_failed_evacuation(r->hrm_index())) {
       _g1h->hr_printer()->evac_failure(r);
     }
 

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -104,7 +104,6 @@ void HeapRegion::setup_heap_region_size(size_t max_heap_size) {
 void HeapRegion::handle_evacuation_failure() {
   uninstall_surv_rate_group();
   clear_young_index_in_cset();
-  reset_evacuation_failed();
   set_old();
   _next_marked_bytes = 0;
 }
@@ -118,8 +117,6 @@ void HeapRegion::unlink_from_list() {
 void HeapRegion::hr_clear(bool clear_space) {
   assert(_humongous_start_region == NULL,
          "we should have already filtered out humongous regions");
-  assert(!in_collection_set(),
-         "Should not clear heap region %u in the collection set", hrm_index());
 
   clear_young_index_in_cset();
   clear_index_in_opt_cset();
@@ -134,7 +131,6 @@ void HeapRegion::hr_clear(bool clear_space) {
   init_top_at_mark_start();
   if (clear_space) clear(SpaceDecorator::Mangle);
 
-  Atomic::store(&_evacuation_failed, false);
   _gc_efficiency = -1.0;
 }
 
@@ -242,7 +238,6 @@ HeapRegion::HeapRegion(uint hrm_index,
   _hrm_index(hrm_index),
   _type(),
   _humongous_start_region(NULL),
-  _evacuation_failed(false),
   _index_in_opt_cset(InvalidCSetIndex),
   _next(NULL), _prev(NULL),
 #ifdef ASSERT

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -210,9 +210,6 @@ private:
   // For a humongous region, region in which it starts.
   HeapRegion* _humongous_start_region;
 
-  // True iff an attempt to evacuate an object in the region failed.
-  volatile bool _evacuation_failed;
-
   static const uint InvalidCSetIndex = UINT_MAX;
 
   // The index in the optional regions array, if this region
@@ -497,15 +494,6 @@ public:
   void hr_clear(bool clear_space);
   // Clear the card table corresponding to this region.
   void clear_cardtable();
-
-  // Returns the "evacuation_failed" property of the region.
-  inline bool evacuation_failed() const;
-
-  // Sets the "evacuation_failed" property of the region, returning true if this
-  // has been the first call, false otherwise.
-  inline bool set_evacuation_failed();
-
-  inline void reset_evacuation_failed();
 
   // Notify the region that we are about to start processing
   // self-forwarded objects during evac failure handling.

--- a/src/hotspot/share/gc/g1/heapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.inline.hpp
@@ -452,16 +452,4 @@ inline void HeapRegion::record_surv_words_in_group(size_t words_survived) {
   _surv_rate_group->record_surviving_words(age_in_group, words_survived);
 }
 
-inline bool HeapRegion::evacuation_failed() const {
-  return Atomic::load(&_evacuation_failed);
-}
-
-inline bool HeapRegion::set_evacuation_failed() {
-  return !Atomic::load(&_evacuation_failed) && !Atomic::cmpxchg(&_evacuation_failed, false, true, memory_order_relaxed);
-}
-
-inline void HeapRegion::reset_evacuation_failed() {
-  Atomic::store(&_evacuation_failed, false);
-}
-
 #endif // SHARE_GC_G1_HEAPREGION_INLINE_HPP


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that fixes a race between card redirtying and collection set freeing?

So card redirtying tries to be clever about which cards to redirty by not keeping (redirtying) cards in regions that have been fully evacuated as they can't have any references. (We did collect them exactly in the case of evac failure of an old region X: if that region X fails evacuation it is kept and may still contain references to other old regions Y; if it is successfully evacuated, then obviously we keep these cards for nothing):

      bool RedirtyLoggedCardTableEntryClosure::will_become_free(HeapRegion* hr) const {
        // A region will be freed by during the FreeCollectionSet phase if the region is in the
        // collection set and has not had an evacuation failure.
        return _g1h->is_in_cset(hr) && !hr->evacuation_failed();
      }

At the same time, since [JDK-8214237](https://bugs.openjdk.java.net/browse/JDK-8214237), G1 frees the collection set which modifies both the is-in-cset field in the attribute table in `is_in_cset()` and the region's `_evacuation_failed` field which yields to returning the wrong value and so dropping cards from the dirty card queue (and in extension from the remembered sets).

The suggested fix consists of two parts:
  1) do not have the free collection set phase change the is-in-cset field in the attribute table
  2) do not have the free collection set phase change the `_evacuation_failed` field in the `HeapRegion`

The first item is fairly trivial, there is actually no need to clear that field at that point. Almost right after this phase the entire attribute table is reset again (in `start_new_collection_set()`).
The second is a bit trickier, as if we did not clear then, we would need to do it at a later point. So while this could be done, adding the clearing somewhere in the `pre_evacuate_collection_set_phase()`, the easier (and imo better solution) is to move that `_evacuation_failed` field for regions that is only necessary during young gc, out of `HeapRegion` and collecting it in a side table.
There are two reasons for this: first I want to in the future split out all transient, young-gc related data and code from `G1CollectedHeap` into a separate class like `G1FullCollector`, and we need that information available in such a side table for future improved pinned region support [JDK-8254167](https://bugs.openjdk.java.net/browse/JDK-8254167).

After this change a test where I could reproduce this failure fairly consistently with `-XX:+VerifyAfterGC` (rate ~1/100), did not fail in thousands of iterations. 

Testing: tier1-5

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267073](https://bugs.openjdk.java.net/browse/JDK-8267073): Race between Card Redirtying and Freeing Collection Set regions results in missing remembered set entries with G1


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4429/head:pull/4429` \
`$ git checkout pull/4429`

Update a local copy of the PR: \
`$ git checkout pull/4429` \
`$ git pull https://git.openjdk.java.net/jdk pull/4429/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4429`

View PR using the GUI difftool: \
`$ git pr show -t 4429`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4429.diff">https://git.openjdk.java.net/jdk/pull/4429.diff</a>

</details>
