### PR TITLE
JDK-8268461: ARM32: vector intrinsics reaches ShouldNotReachHere

### DIFF
--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -979,7 +979,7 @@ const bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType 
   // e.g. Op_ vector nodes and other intrinsics while guarding with vlen
   bool ret_value = match_rule_supported(opcode) && vector_size_supported(bt, vlen);
   // Add rules here.
- 
+
   return ret_value;  // Per default match rules are supported.
 }
 

--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -977,9 +977,9 @@ const bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType 
   // TODO
   // identify extra cases that we might want to provide match rules for
   // e.g. Op_ vector nodes and other intrinsics while guarding with vlen
-  bool ret_value = match_rule_supported(opcode);
+  bool ret_value = match_rule_supported(opcode) && vector_size_supported(bt, vlen);
   // Add rules here.
-
+ 
   return ret_value;  // Per default match rules are supported.
 }
 


### PR DESCRIPTION
This fixes C2 vector intrinsics for 32-bit ARM.
Since the problem exists in mainline, I guess it should be fixed here first and will later be merged into the panama repository.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268461](https://bugs.openjdk.java.net/browse/JDK-8268461): ARM32: vector intrinsics reaches ShouldNotReachHere


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)
 * [Ningsheng Jian](https://openjdk.java.net/census#njian) (@nsjian - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4430/head:pull/4430` \
`$ git checkout pull/4430`

Update a local copy of the PR: \
`$ git checkout pull/4430` \
`$ git pull https://git.openjdk.java.net/jdk pull/4430/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4430`

View PR using the GUI difftool: \
`$ git pr show -t 4430`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4430.diff">https://git.openjdk.java.net/jdk/pull/4430.diff</a>

</details>
