### PR TITLE
8268390: G1 concurrent gc upgrade to full gc not working

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1915,16 +1915,6 @@ bool G1CollectedHeap::should_do_concurrent_full_gc(GCCause::Cause cause) {
   }
 }
 
-bool G1CollectedHeap::should_upgrade_to_full_gc(GCCause::Cause cause) {
-  if (should_do_concurrent_full_gc(_gc_cause)) {
-    return false;
-  } else if (has_regions_left_for_allocation()) {
-    return false;
-  } else {
-    return true;
-  }
-}
-
 #ifndef PRODUCT
 void G1CollectedHeap::allocate_dummy_regions() {
   // Let's fill up most of the region

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -285,9 +285,6 @@ private:
                                 uint gc_counter,
                                 uint old_marking_started_before);
 
-  // Return true if should upgrade to full gc after an incremental one.
-  bool should_upgrade_to_full_gc(GCCause::Cause cause);
-
   // indicates whether we are in young or mixed GC mode
   G1CollectorState _collector_state;
 
@@ -1089,9 +1086,10 @@ public:
     return _hrm.available() == 0;
   }
 
-  // Returns whether there are any regions left in the heap for allocation.
-  bool has_regions_left_for_allocation() const {
-    return !is_maximal_no_gc() || num_free_regions() != 0;
+  // Returns true if an incremental GC should be upgrade to a full gc. This
+  // is done when there are no free regions and the heap can't be expanded.
+  bool should_upgrade_to_full_gc() const {
+    return is_maximal_no_gc() && num_free_regions() == 0;
   }
 
   // The current number of regions in the heap.

--- a/src/hotspot/share/gc/g1/g1VMOperations.cpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.cpp
@@ -100,7 +100,7 @@ void VM_G1TryInitiateConcMark::doit() {
     // makes a later _gc_locker collection needed.  (Else we would have hit
     // the GCLocker check in the prologue.)
     _transient_failure = true;
-  } else if (g1h->should_upgrade_to_full_gc(_gc_cause)) {
+  } else if (g1h->should_upgrade_to_full_gc()) {
     _gc_succeeded = g1h->upgrade_to_full_collection();
   } else {
     _gc_succeeded = true;
@@ -150,7 +150,7 @@ void VM_G1CollectForAllocation::doit() {
       // An allocation had been requested. Do it, eventually trying a stronger
       // kind of GC.
       _result = g1h->satisfy_failed_allocation(_word_size, &_gc_succeeded);
-    } else if (g1h->should_upgrade_to_full_gc(_gc_cause)) {
+    } else if (g1h->should_upgrade_to_full_gc()) {
       // There has been a request to perform a GC to free some space. We have no
       // information on how much memory has been asked for. In case there are
       // absolutely no regions left to allocate into, do a full compaction.


### PR DESCRIPTION
Please review this small change to enable concurrent GCs to be upgraded to Full collections when there are no free regions.

**Summary** 
During the review of PR #4342 it was noted that we currently never upgrade concurrent GCs (from `VM_G1TryInitiateConcMark::doit()`) to full collections. In `should_upgrade_to_full_gc()` there was a check to always return false for "concurrent" GC-causes. There is no obviously good reason for this, and this change will enable concurrent GCs to be upgraded.

This could not be included in PR #4342 because that would make us hit the same problem as reported in [JDK-8195158](https://bugs.openjdk.java.net/browse/JDK-8195158). The fix back then was to not upgrade concurrent GCs. The approach used now, which was added by PR #4357, is to use another GC cause for upgraded GCs. 

What this change does is basically just removing the `should_do_concurrent_full_gc()` check from `should_upgrade_to_full_gc()` and once that is done `has_regions_left_for_allocation()` might as well be folded into `should_upgrade_to_full_gc()`

**Testing**
Manual testing to verify this does not cause the assertion failure from JDK-8195158. Currently running Mach5 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268390](https://bugs.openjdk.java.net/browse/JDK-8268390): G1 concurrent gc upgrade to full gc not working


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4435/head:pull/4435` \
`$ git checkout pull/4435`

Update a local copy of the PR: \
`$ git checkout pull/4435` \
`$ git pull https://git.openjdk.java.net/jdk pull/4435/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4435`

View PR using the GUI difftool: \
`$ git pr show -t 4435`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4435.diff">https://git.openjdk.java.net/jdk/pull/4435.diff</a>

</details>
