### PR TITLE
8268320: Better error recovery for broken patterns in switch

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -1189,6 +1189,9 @@ compiler.err.static.imp.only.classes.and.interfaces=\
 compiler.err.string.const.req=\
     constant string expression required
 
+compiler.err.pattern.expected=\
+    type pattern expected
+
 # 0: symbol, 1: fragment
 compiler.err.cannot.generate.class=\
     error while generating class {0}\n\

--- a/test/langtools/tools/javac/diags/examples/PatternExpected.java
+++ b/test/langtools/tools/javac/diags/examples/PatternExpected.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.err.pattern.expected
+// key: compiler.note.preview.filename
+// key: compiler.note.preview.recompile
+// options: --enable-preview -source ${jdk.version}
+
+class PatternSwitch {
+    private void doSwitch(Object o) {
+        switch (o) {
+            case String: break;
+            default: break;
+        }
+    }
+}

--- a/test/langtools/tools/javac/patterns/SwitchErrors-no-preview.out
+++ b/test/langtools/tools/javac/patterns/SwitchErrors-no-preview.out
@@ -1,18 +1,17 @@
+SwitchErrors.java:35:31: compiler.err.preview.feature.disabled.plural: (compiler.misc.feature.pattern.switch)
 SwitchErrors.java:34:18: compiler.err.constant.label.not.compatible: java.lang.String, java.lang.Object
 SwitchErrors.java:40:18: compiler.err.constant.label.not.compatible: int, java.lang.Object
 SwitchErrors.java:46:18: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.String, java.lang.Integer)
 SwitchErrors.java:47:18: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Integer, java.lang.CharSequence)
-SwitchErrors.java:52:18: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: compiler.misc.type.null, int)
+SwitchErrors.java:52:18: compiler.err.preview.feature.disabled: (compiler.misc.feature.case.null)
 SwitchErrors.java:53:18: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.String, int)
 SwitchErrors.java:54:18: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: int, java.lang.CharSequence)
 SwitchErrors.java:60:20: compiler.err.total.pattern.and.default
 SwitchErrors.java:66:13: compiler.err.pattern.dominated
-SwitchErrors.java:66:24: compiler.err.total.pattern.and.default
 SwitchErrors.java:72:18: compiler.err.total.pattern.and.default
 SwitchErrors.java:78:18: compiler.err.duplicate.total.pattern
 SwitchErrors.java:84:20: compiler.err.duplicate.default.label
 SwitchErrors.java:90:20: compiler.err.duplicate.default.label
-SwitchErrors.java:95:27: compiler.err.duplicate.default.label
 SwitchErrors.java:101:13: compiler.err.duplicate.case.label
 SwitchErrors.java:106:13: compiler.err.duplicate.case.label
 SwitchErrors.java:111:28: compiler.err.flows.through.to.pattern
@@ -23,12 +22,10 @@ SwitchErrors.java:136:18: compiler.err.prob.found.req: (compiler.misc.inconverti
 SwitchErrors.java:142:18: compiler.err.instanceof.reifiable.not.safe: java.util.List, java.util.List<java.lang.Integer>
 SwitchErrors.java:148:18: compiler.err.cant.resolve.location: kindname.class, Undefined, , , (compiler.misc.location: kindname.class, SwitchErrors, null)
 SwitchErrors.java:155:18: compiler.err.type.found.req: int, (compiler.misc.type.req.class.array)
-SwitchErrors.java:161:28: compiler.err.flows.through.from.pattern
-SwitchErrors.java:167:18: compiler.err.flows.through.from.pattern
 SwitchErrors.java:172:27: compiler.err.flows.through.to.pattern
 SwitchErrors.java:178:18: compiler.err.flows.through.to.pattern
 SwitchErrors.java:184:13: compiler.err.pattern.dominated
-SwitchErrors.java:196:18: compiler.err.pattern.expected
+SwitchErrors.java:196:18: compiler.err.const.expr.req
 SwitchErrors.java:33:9: compiler.err.not.exhaustive.statement
 SwitchErrors.java:39:9: compiler.err.not.exhaustive.statement
 SwitchErrors.java:45:9: compiler.err.not.exhaustive.statement
@@ -40,6 +37,4 @@ SwitchErrors.java:115:9: compiler.err.not.exhaustive.statement
 SwitchErrors.java:121:9: compiler.err.not.exhaustive.statement
 SwitchErrors.java:128:9: compiler.err.not.exhaustive.statement
 SwitchErrors.java:188:9: compiler.err.not.exhaustive.statement
-- compiler.note.preview.filename: SwitchErrors.java, DEFAULT
-- compiler.note.preview.recompile
-42 errors
+39 errors

--- a/test/langtools/tools/javac/patterns/SwitchErrors.java
+++ b/test/langtools/tools/javac/patterns/SwitchErrors.java
@@ -26,6 +26,7 @@
  * @bug 8262891
  * @summary Verify errors related to pattern switches.
  * @compile/fail/ref=SwitchErrors.out --enable-preview -source ${jdk.version} -XDrawDiagnostics -XDshould-stop.at=FLOW SwitchErrors.java
+ * @compile/fail/ref=SwitchErrors-no-preview.out -XDrawDiagnostics -XDshould-stop.at=FLOW SwitchErrors.java
  */
 public class SwitchErrors {
     void incompatibleSelectorObjectString(Object o) {
@@ -190,4 +191,10 @@ public class SwitchErrors {
     }
     sealed class SealedNonAbstract permits A {}
     final class A extends SealedNonAbstract {}
+    void errorRecoveryNoPattern1(Object o) {
+        switch (o) {
+            case String: break;
+            case Object obj: break;
+        }
+    }
 }

--- a/test/langtools/tools/javac/patterns/Switches.java
+++ b/test/langtools/tools/javac/patterns/Switches.java
@@ -247,7 +247,7 @@ public class Switches {
     String testStringWithGuards1(E e) {
         switch (e != null ? e.name() : null) {
             case "A": return "a";
-            case "B": return "b";
+            case Switches.ConstantClassClash: return "b";
             case String x && "C".equals(x): return "C";
             case "C": return "broken";
             case null, String x: return String.valueOf(x);
@@ -257,7 +257,7 @@ public class Switches {
     String testStringWithGuardsExpression1(E e) {
         return switch (e != null ? e.name() : null) {
             case "A" -> "a";
-            case "B" -> "b";
+            case ConstantClassClash -> "b";
             case String x && "C".equals(x) -> "C";
             case "C" -> "broken";
             case null, String x -> String.valueOf(x);
@@ -309,6 +309,12 @@ public class Switches {
             case Object obj, null:; //no break intentionally - should not fall through to any possible default
         }
     }
+
+    //verify that for cases like:
+    //case ConstantClassClash ->
+    //ConstantClassClash is interpreted as a field, not as a class
+    private static final String ConstantClassClash = "B";
+    private static class ConstantClassClash {}
 
     sealed interface I {}
     final class A implements I {}


### PR DESCRIPTION
Trying to improve error recovery in case the user wanted to use a type-pattern in the switch construct, but didn't put a binding variable name after the type name. E.g.:
```
$ cat test/langtools/tools/javac/diags/examples/PatternExpected.java
[snip]
class PatternSwitch {
    private void doSwitch(Object o) {
        switch (o) {
            case String: break;
            default: break;
        }
    }
}
$ javac --enable-preview -source 17  test/langtools/tools/javac/diags/examples/PatternExpected.java
test/langtools/tools/javac/diags/examples/PatternExpected.java:32: error: type pattern expected
            case String: break;
                 ^
Note: test/langtools/tools/javac/diags/examples/PatternExpected.java uses preview features of Java SE 17.
Note: Recompile with -Xlint:preview for details.
1 error
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8268320](https://bugs.openjdk.java.net/browse/JDK-8268320): Better error recovery for broken patterns in switch


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4441/head:pull/4441` \
`$ git checkout pull/4441`

Update a local copy of the PR: \
`$ git checkout pull/4441` \
`$ git pull https://git.openjdk.java.net/jdk pull/4441/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4441`

View PR using the GUI difftool: \
`$ git pr show -t 4441`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4441.diff">https://git.openjdk.java.net/jdk/pull/4441.diff</a>

</details>
