### PR TITLE
8209092: Remove outdated wording from RC5ParameterSpec

### DIFF
--- a/src/java.base/share/classes/javax/crypto/spec/RC5ParameterSpec.java
+++ b/src/java.base/share/classes/javax/crypto/spec/RC5ParameterSpec.java
@@ -36,7 +36,8 @@ import java.security.spec.AlgorithmParameterSpec;
  * size, and optionally an initialization vector (IV) (only in feedback mode).
  *
  * <p> This class can be used to initialize a {@code Cipher} object that
- * implements the <i>RC5</i> algorithm as specified in <a href="https://datatracker.ietf.org/doc/html/rfc2040">RFC 2040</a>.
+ * implements the <i>RC5</i> algorithm as specified in
+ * <a href="https://datatracker.ietf.org/doc/html/rfc2040">RFC 2040</a>.
  *
  * @author Jan Luehe
  *

--- a/src/java.base/share/classes/javax/crypto/spec/RC5ParameterSpec.java
+++ b/src/java.base/share/classes/javax/crypto/spec/RC5ParameterSpec.java
@@ -36,8 +36,7 @@ import java.security.spec.AlgorithmParameterSpec;
  * size, and optionally an initialization vector (IV) (only in feedback mode).
  *
  * <p> This class can be used to initialize a {@code Cipher} object that
- * implements the <i>RC5</i> algorithm as specified in 
- * <a href="https://datatracker.ietf.org/doc/html/rfc2040">RFC 2040</a>.
+ * implements the <i>RC5</i> algorithm as specified in <a href="https://datatracker.ietf.org/doc/html/rfc2040">RFC 2040</a>.
  *
  * @author Jan Luehe
  *

--- a/src/java.base/share/classes/javax/crypto/spec/RC5ParameterSpec.java
+++ b/src/java.base/share/classes/javax/crypto/spec/RC5ParameterSpec.java
@@ -36,8 +36,7 @@ import java.security.spec.AlgorithmParameterSpec;
  * size, and optionally an initialization vector (IV) (only in feedback mode).
  *
  * <p> This class can be used to initialize a {@code Cipher} object that
- * implements the <i>RC5</i> algorithm as specified in
- * <a href="https://datatracker.ietf.org/doc/html/rfc2040">RFC 2040</a>.
+ * implements the <i>RC5</i> algorithm.
  *
  * @author Jan Luehe
  *

--- a/src/java.base/share/classes/javax/crypto/spec/RC5ParameterSpec.java
+++ b/src/java.base/share/classes/javax/crypto/spec/RC5ParameterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,9 +36,8 @@ import java.security.spec.AlgorithmParameterSpec;
  * size, and optionally an initialization vector (IV) (only in feedback mode).
  *
  * <p> This class can be used to initialize a {@code Cipher} object that
- * implements the <i>RC5</i> algorithm as supplied by
- * <a href="http://www.rsa.com">RSA Security LLC</a>,
- * or any parties authorized by RSA Security.
+ * implements the <i>RC5</i> algorithm as specified in 
+ * <a href="https://datatracker.ietf.org/doc/html/rfc2040">RFC 2040</a>.
  *
  * @author Jan Luehe
  *


### PR DESCRIPTION
The RC5ParameterSpec class description contains the following sentence: "This class can be used to initialize a Cipher object that implements the RC5 algorithm as supplied by RSA Security LLC, or any parties authorized by RSA Security."

The part "as supplied by RSA Security LLC, or any parties authorized by RSA Security." should be removed. We don't generally include information about 3rd-party JCA providers in the standard javadocs. Also the "authorized" part was probably referring to the RC5 patent but that has since expired.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8209092](https://bugs.openjdk.java.net/browse/JDK-8209092): Remove outdated wording from RC5ParameterSpec


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**) ⚠️ Review applies to ee75475e1c0b1550c137beab63751fbffa21f5f0
 * [Bradford Wetmore](https://openjdk.java.net/census#wetmore) (@bradfordwetmore - **Reviewer**) ⚠️ Review applies to ee75475e1c0b1550c137beab63751fbffa21f5f0


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4443/head:pull/4443` \
`$ git checkout pull/4443`

Update a local copy of the PR: \
`$ git checkout pull/4443` \
`$ git pull https://git.openjdk.java.net/jdk pull/4443/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4443`

View PR using the GUI difftool: \
`$ git pr show -t 4443`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4443.diff">https://git.openjdk.java.net/jdk/pull/4443.diff</a>

</details>
