### PR TITLE
8268443: ParallelGC Full GC should use parallel WeakProcessor

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -2114,7 +2114,10 @@ void PSParallelCompact::marking_phase(ParCompactionManager* cm,
 
   {
     GCTraceTime(Debug, gc, phases) tm("Weak Processing", &_gc_timer);
-    WeakProcessor::weak_oops_do(is_alive_closure(), &do_nothing_cl);
+    WeakProcessor::weak_oops_do(&ParallelScavengeHeap::heap()->workers(),
+                                is_alive_closure(),
+                                &do_nothing_cl,
+                                1);
   }
 
   {


### PR DESCRIPTION
Simple change of making weak oops processing in Full GC cycles parallel for Parallel collector.

Tested: running benchmarks with `gc+phases=debug` and confirm the `Weak Processing` time in Full GCs becomes shorter.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268443](https://bugs.openjdk.java.net/browse/JDK-8268443): ParallelGC Full GC should use parallel WeakProcessor


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Contributors
 * Kim Barrett `<kbarrett@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4444/head:pull/4444` \
`$ git checkout pull/4444`

Update a local copy of the PR: \
`$ git checkout pull/4444` \
`$ git pull https://git.openjdk.java.net/jdk pull/4444/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4444`

View PR using the GUI difftool: \
`$ git pr show -t 4444`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4444.diff">https://git.openjdk.java.net/jdk/pull/4444.diff</a>

</details>
