### PR TITLE
8238197: JFR: Rework setting and getting EventHandler

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
@@ -445,23 +445,17 @@ public final class Utils {
 
     public static synchronized EventHandler getHandler(Class<? extends jdk.internal.event.Event> eventClass) {
         Utils.ensureValidEventSubclass(eventClass);
-        try {
-            Field f = eventClass.getDeclaredField(EventInstrumentation.FIELD_EVENT_HANDLER);
-            SecuritySupport.setAccessible(f);
-            return (EventHandler) f.get(null);
-        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException e) {
-            throw new InternalError("Could not access event handler");
+        Object handler = JVM.getJVM().getHandler(eventClass);
+        if (handler == null || handler instanceof EventHandler) {
+            return (EventHandler) handler;
         }
+        throw new InternalError("Could not access event handler");
     }
 
     static synchronized void setHandler(Class<? extends jdk.internal.event.Event> eventClass, EventHandler handler) {
         Utils.ensureValidEventSubclass(eventClass);
-        try {
-            Field field = eventClass.getDeclaredField(EventInstrumentation.FIELD_EVENT_HANDLER);
-            SecuritySupport.setAccessible(field);
-            field.set(null, handler);
-        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException e) {
-            throw new InternalError("Could not access event handler");
+        if (!JVM.getJVM().setHandler(eventClass, handler)) {
+            throw new InternalError("Could not set event handler");
         }
     }
 


### PR DESCRIPTION
Greetings,

please help review this changeset which moves the setting and getting of event handlers to native to avoid allocations.

Testing: jdk_jfr, stress

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8238197](https://bugs.openjdk.java.net/browse/JDK-8238197): JFR: Rework setting and getting EventHandler


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)
 * [Jaroslav Bachorik](https://openjdk.java.net/census#jbachorik) (@jbachorik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4445/head:pull/4445` \
`$ git checkout pull/4445`

Update a local copy of the PR: \
`$ git checkout pull/4445` \
`$ git pull https://git.openjdk.java.net/jdk pull/4445/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4445`

View PR using the GUI difftool: \
`$ git pr show -t 4445`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4445.diff">https://git.openjdk.java.net/jdk/pull/4445.diff</a>

</details>
