### PR TITLE
8268285: vmTestbase/nsk/jvmti/GetThreadState/thrstat002 failed with "Wrong thread "thr1" (...) state after SuspendThread"

### DIFF
--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -4963,7 +4963,9 @@ class C2 extends C1 implements I2 {
     <intro>
       <b>
         These functions and data types were introduced in the original
-        <jvmti/> version 1.0 and have been superseded by more
+        <jvmti/> version 1.0. They are deprecated and will be changed 
+        to return an error in a future release. They were superseded in
+        <jvmti/> version 1.2 (Java SE6) by more 
       </b>
       <internallink id="Heap"><b>powerful and flexible versions</b></internallink>
       <b>

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <?xml-stylesheet type="text/xsl" href="jvmti.xsl"?>
 <!--
- Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -15035,6 +15035,9 @@ typedef void (JNICALL *jvmtiEventVMInit)
       Minor update for new class file PermittedSubclasses attribute:
         - Specify that RedefineClasses and RetransformClasses are not allowed
           to change the class file PermittedSubclasses attribute.
+  </change>
+  <change date="8 June 2021" version="17.0.0">
+      Minor update to deprecate Heap functions 1.0.
   </change>
 </changehistory>
 

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -4965,7 +4965,7 @@ class C2 extends C1 implements I2 {
         These functions and data types were introduced in the original
         <jvmti/> version 1.0. They are deprecated and will be changed 
         to return an error in a future release. They were superseded in
-        <jvmti/> version 1.2 (Java SE6) by more 
+        <jvmti/> version 1.2 (Java SE 6) by more 
       </b>
       <internallink id="Heap"><b>powerful and flexible versions</b></internallink>
       <b>

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadState/thrstat002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadState/thrstat002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -158,8 +158,8 @@ class thrstat002a extends Thread {
             }
             System.out.println("thrstat002a.run after blockingMonitor lock");
 
+            System.out.println("thrstat002a.run before runningBarrier unlock");
             thrstat002.runningBarrier.unlock();
-            System.out.println("thrstat002a.run after runningBarrier unlock");
             int i = 0;
             int n = 1000;
             while (flag) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadState/thrstat002/thrstat002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadState/thrstat002/thrstat002.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -355,6 +355,7 @@ Java_nsk_jvmti_GetThreadState_thrstat002_checkStatus(JNIEnv *env, jclass cls,
             result = STATUS_FAILED;
         }
     }
+    fflush(0);
 }
 
 JNIEXPORT jint JNICALL


### PR DESCRIPTION
The test failure is that the tested thread thrstat002a is blocked on a monitor when it is expect to be in a RUNNABLE state. The only chance for thrstat002a.run() be blocked on a monitor in this context is a synchronized statement in implementation of the PrintStream.println(String):
  thrstat002.runningBarrier.unlock(); <= now suspend can be issued
  System.out.println("thrstat002a.run after runningBarrier unlock"); <= we block on monitor in here

The fix is to move the println() line above the thrstat002.runningBarrier.unlock() line.
Also, a fflush() is added to the agent in one spot to get the agent output synced and aligned with the Java app.