### PR TITLE
8268285: vmTestbase/nsk/jvmti/GetThreadState/thrstat002 failed with "Wrong thread "thr1" (...) state after SuspendThread"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadState/thrstat002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadState/thrstat002.java
@@ -160,6 +160,9 @@ class thrstat002a extends Thread {
 
             System.out.println("thrstat002a.run before runningBarrier unlock");
             thrstat002.runningBarrier.unlock();
+
+            // Don't do println's from this point until we have exited the loop,
+            // else we can suspend in the println in an unexpected state.
             int i = 0;
             int n = 1000;
             while (flag) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadState/thrstat002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadState/thrstat002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -158,8 +158,8 @@ class thrstat002a extends Thread {
             }
             System.out.println("thrstat002a.run after blockingMonitor lock");
 
+            System.out.println("thrstat002a.run before runningBarrier unlock");
             thrstat002.runningBarrier.unlock();
-            System.out.println("thrstat002a.run after runningBarrier unlock");
             int i = 0;
             int n = 1000;
             while (flag) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadState/thrstat002/thrstat002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadState/thrstat002/thrstat002.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -355,6 +355,7 @@ Java_nsk_jvmti_GetThreadState_thrstat002_checkStatus(JNIEnv *env, jclass cls,
             result = STATUS_FAILED;
         }
     }
+    fflush(0);
 }
 
 JNIEXPORT jint JNICALL


### PR DESCRIPTION
The test is intermittently failing because the tested thread thrstat002a is blocked on a monitor in the PrintStream.println(String) when it is expected to be in the RUNNABLE state:
  thrstat002.runningBarrier.unlock(); <= now the thrstat002 state can be checked and suspend issued
  System.out.println("thrstat002a.run after runningBarrier unlock"); <= blocked on the monitor in here

The fix is to move println line to the point before thrstat002.runningBarrier.unlock();
Also, a fflush(0) statement is added to the agent *_checkStatus() function to get output better sync'ed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268285](https://bugs.openjdk.java.net/browse/JDK-8268285): vmTestbase/nsk/jvmti/GetThreadState/thrstat002 failed with "Wrong thread "thr1" (...) state after SuspendThread"


### Reviewers
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - Committer) ⚠️ Review applies to 9d7ed6e515f1951c2a5e13cbf259e300f9999090
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**) ⚠️ Review applies to 9d7ed6e515f1951c2a5e13cbf259e300f9999090
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 07bdb421e56525b5beb5ed07416877c0d00fad59


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4447/head:pull/4447` \
`$ git checkout pull/4447`

Update a local copy of the PR: \
`$ git checkout pull/4447` \
`$ git pull https://git.openjdk.java.net/jdk pull/4447/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4447`

View PR using the GUI difftool: \
`$ git pr show -t 4447`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4447.diff">https://git.openjdk.java.net/jdk/pull/4447.diff</a>

</details>
