### PR TITLE
8268520: VirtualSpace::print_on() should be const

### DIFF
--- a/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
@@ -293,8 +293,7 @@ void EpsilonHeap::object_iterate(ObjectClosure *cl) {
 void EpsilonHeap::print_on(outputStream *st) const {
   st->print_cr("Epsilon Heap");
 
-  // Cast away constness:
-  ((VirtualSpace)_virtual_space).print_on(st);
+  _virtual_space.print_on(st);
 
   if (_space != NULL) {
     st->print_cr("Allocation space:");

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -1036,7 +1036,7 @@ void VirtualSpace::check_for_contiguity() {
   assert(high() <= upper_high(), "upper high");
 }
 
-void VirtualSpace::print_on(outputStream* out) {
+void VirtualSpace::print_on(outputStream* out) const {
   out->print   ("Virtual space:");
   if (special()) out->print(" (pinned in memory)");
   out->cr();
@@ -1046,7 +1046,7 @@ void VirtualSpace::print_on(outputStream* out) {
   out->print_cr(" - [low_b, high_b]: [" INTPTR_FORMAT ", " INTPTR_FORMAT "]",  p2i(low_boundary()), p2i(high_boundary()));
 }
 
-void VirtualSpace::print() {
+void VirtualSpace::print() const {
   print_on(tty);
 }
 

--- a/src/hotspot/share/memory/virtualspace.hpp
+++ b/src/hotspot/share/memory/virtualspace.hpp
@@ -240,8 +240,8 @@ class VirtualSpace {
   void check_for_contiguity() PRODUCT_RETURN;
 
   // Debugging
-  void print_on(outputStream* out) PRODUCT_RETURN;
-  void print();
+  void print_on(outputStream* out) const PRODUCT_RETURN;
+  void print() const;
 };
 
 #endif // SHARE_MEMORY_VIRTUALSPACE_HPP


### PR DESCRIPTION
Please review this trivial patch. VirtualSpace::print_on() should be const so we can avoid the weird casting in epsilonHeap.cpp

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268520](https://bugs.openjdk.java.net/browse/JDK-8268520): VirtualSpace::print_on() should be const


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4448/head:pull/4448` \
`$ git checkout pull/4448`

Update a local copy of the PR: \
`$ git checkout pull/4448` \
`$ git pull https://git.openjdk.java.net/jdk pull/4448/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4448`

View PR using the GUI difftool: \
`$ git pr show -t 4448`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4448.diff">https://git.openjdk.java.net/jdk/pull/4448.diff</a>

</details>
