### PR TITLE
8268425: Show decimal nid of OSThread instead of hex format one

### DIFF
--- a/src/hotspot/share/runtime/osThread.cpp
+++ b/src/hotspot/share/runtime/osThread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/osThread.cpp
+++ b/src/hotspot/share/runtime/osThread.cpp
@@ -38,7 +38,7 @@ OSThread::~OSThread() {
 
 // Printing
 void OSThread::print_on(outputStream *st) const {
-  st->print("nid=%d ", thread_id());
+  st->print("nid=" UINT64_FORMAT " ", (uint64_t)thread_id());
   switch (_state) {
     case ALLOCATED:               st->print("allocated ");                 break;
     case INITIALIZED:             st->print("initialized ");               break;

--- a/src/hotspot/share/runtime/osThread.cpp
+++ b/src/hotspot/share/runtime/osThread.cpp
@@ -46,10 +46,10 @@ void OSThread::print_on(outputStream *st) const {
     case MONITOR_WAIT:            st->print("waiting for monitor entry "); break;
     case CONDVAR_WAIT:            st->print("waiting on condition ");      break;
     case OBJECT_WAIT:             st->print("in Object.wait() ");          break;
-    case BREAKPOINTED:            st->print("at breakpoint ");             break;
-    case SLEEPING:                st->print("sleeping ");                  break;
-    case ZOMBIE:                  st->print("zombie ");                    break;
-    default:                      st->print("unknown state %d ", _state);  break;
+    case BREAKPOINTED:            st->print("at breakpoint");               break;
+    case SLEEPING:                st->print("sleeping");                    break;
+    case ZOMBIE:                  st->print("zombie");                      break;
+    default:                      st->print("unknown state %d", _state); break;
   }
 }
 

--- a/src/hotspot/share/runtime/osThread.cpp
+++ b/src/hotspot/share/runtime/osThread.cpp
@@ -38,7 +38,7 @@ OSThread::~OSThread() {
 
 // Printing
 void OSThread::print_on(outputStream *st) const {
-  st->print("nid=0x%x ", thread_id());
+  st->print("nid=%d ", thread_id());
   switch (_state) {
     case ALLOCATED:               st->print("allocated ");                 break;
     case INITIALIZED:             st->print("initialized ");               break;
@@ -46,10 +46,10 @@ void OSThread::print_on(outputStream *st) const {
     case MONITOR_WAIT:            st->print("waiting for monitor entry "); break;
     case CONDVAR_WAIT:            st->print("waiting on condition ");      break;
     case OBJECT_WAIT:             st->print("in Object.wait() ");          break;
-    case BREAKPOINTED:            st->print("at breakpoint");               break;
-    case SLEEPING:                st->print("sleeping");                    break;
-    case ZOMBIE:                  st->print("zombie");                      break;
-    default:                      st->print("unknown state %d", _state); break;
+    case BREAKPOINTED:            st->print("at breakpoint ");             break;
+    case SLEEPING:                st->print("sleeping ");                  break;
+    case ZOMBIE:                  st->print("zombie ");                    break;
+    default:                      st->print("unknown state %d ", _state);  break;
   }
 }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaThread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaThread.java
@@ -487,7 +487,7 @@ public class JavaThread extends Thread {
     out.print(" tid=");
     out.print(this.getAddress());
     out.print(" nid=");
-    out.print(String.format("0x%x ",this.getOSThread().threadId()));
+    out.print(String.format("%d ",this.getOSThread().threadId()));
     out.print(getOSThread().getThreadState().getPrintVal());
     out.print(" [");
     if(this.getLastJavaSP() == null){

--- a/test/hotspot/jtreg/serviceability/sa/JhsdbThreadInfoTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/JhsdbThreadInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/sa/JhsdbThreadInfoTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/JhsdbThreadInfoTest.java
@@ -60,8 +60,8 @@ public class JhsdbThreadInfoTest {
             System.out.println(out.getStdout());
             System.err.println(out.getStderr());
 
-            out.shouldMatch("\".+\" #\\d+ daemon prio=\\d+ tid=0x[0-9a-f]+ nid=0x[0-9a-f]+ .+ \\[0x[0-9a-f]+]");
-            out.shouldMatch("\"main\" #\\d+ prio=\\d+ tid=0x[0-9a-f]+ nid=0x[0-9a-f]+ .+ \\[0x[0-9a-f]+]");
+            out.shouldMatch("\".+\" #\\d+ daemon prio=\\d+ tid=0x[0-9a-f]+ nid=[0-9]+ .+ \\[0x[0-9a-f]+]");
+            out.shouldMatch("\"main\" #\\d+ prio=\\d+ tid=0x[0-9a-f]+ nid=[0-9]+ .+ \\[0x[0-9a-f]+]");
             out.shouldMatch("   java.lang.Thread.State: .+");
             out.shouldMatch("   JavaThread state: _thread_.+");
 

--- a/test/hotspot/jtreg/serviceability/sa/JhsdbThreadInfoTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/JhsdbThreadInfoTest.java
@@ -60,8 +60,9 @@ public class JhsdbThreadInfoTest {
             System.out.println(out.getStdout());
             System.err.println(out.getStderr());
 
-            out.shouldMatch("\".+\" #\\d+ daemon prio=\\d+ tid=0x[0-9a-f]+ nid=[0-9]+ .+ \\[0x[0-9a-f]+]");
-            out.shouldMatch("\"main\" #\\d+ prio=\\d+ tid=0x[0-9a-f]+ nid=[0-9]+ .+ \\[0x[0-9a-f]+]");
+            // The character class \p{XDigit} matches any hexadecimal character.
+            out.shouldMatch("\".+\" #\\d+ daemon prio=\\d+ tid=0x\\p{XDigit}+ nid=\\d+ .+ \\[0x\\p{XDigit}+]");
+            out.shouldMatch("\"main\" #\\d+ prio=\\d+ tid=0x\\p{XDigit}+ nid=\\d+ .+ \\[0x\\p{XDigit}+]");
             out.shouldMatch("   java.lang.Thread.State: .+");
             out.shouldMatch("   JavaThread state: _thread_.+");
 


### PR DESCRIPTION
From users' perspective, we can find corresponding os thread via top directly, otherwise, we must convert hex format based nid to an integer, and find that thread via `top -pid <pid>`. This slightly facilitates our debugging process, but would obviously break some existing jstack analysis tool.

Jstack Before:

"ParGC Thread#7" os_prio=0 cpu=103260.18ms elapsed=5255043.58s tid=0x00007f967000b000 nid=0x12e67 runnable

"ParGC Thread#8" os_prio=0 cpu=104818.76ms elapsed=5255043.58s tid=0x00007f967000c000 nid=0x12e68 runnable

"ParGC Thread#9" os_prio=0 cpu=102164.69ms elapsed=5255043.58s tid=0x00007f967000e000 nid=0x12e69 runnable

Jstack After:
"G1 Conc#0" os_prio=0 cpu=0.03ms elapsed=1295.27s tid=0x00007f99dc096490 nid=117707 runnable

"G1 Refine#0" os_prio=0 cpu=0.06ms elapsed=1295.22s tid=0x00007f99dc2cad20 nid=117708 runnable

"G1 Service" os_prio=0 cpu=87.05ms elapsed=1295.22s tid=0x00007f99dc2cc140 nid=117709 runnable

Top:
   PID USER PR NI VIRT RES SHR S %CPU %MEM TIME+ COMMAND
 49083 tianxia+ 20 0 32.8g 594148 10796 S 103.3 0.1 0:10.05 java
 71291 qingfen+ 20 0 39.3g 26.7g 18312 S 100.7 5.3 16861:35 jhsdb
 50407 tianxia+ 20 0 32.5g 32796 9768 S 100.3 0.0 0:05.80 java
107429 maolian+ 20 0 11.4g 1.1g 10956 S 100.3 0.2 20173:52 java
 99923 root 10 -10 288520 163228 5088 S 5.9 0.0 6463:53 AliYunDun

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268425](https://bugs.openjdk.java.net/browse/JDK-8268425): Show decimal nid of OSThread instead of hex format one


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to 6d3d0523cc1b2e904d537932c88e1d1b40c87e96
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to 0f23075510c1a653d4737b63d2b684d6d10aefa6


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4449/head:pull/4449` \
`$ git checkout pull/4449`

Update a local copy of the PR: \
`$ git checkout pull/4449` \
`$ git pull https://git.openjdk.java.net/jdk pull/4449/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4449`

View PR using the GUI difftool: \
`$ git pr show -t 4449`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4449.diff">https://git.openjdk.java.net/jdk/pull/4449.diff</a>

</details>
