### PR TITLE
JDK-8268463: Windows 32bit build fails in DynamicCodeGenerated\libDynamicCodeGenerated.cpp

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/DynamicCodeGenerated/libDynamicCodeGenerated.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/DynamicCodeGenerated/libDynamicCodeGenerated.cpp
@@ -46,7 +46,8 @@ void JNICALL DynamicCodeGenerated(jvmtiEnv* jvmti, const char* name, const void*
 
 }
 
-jint Agent_OnLoad(JavaVM* vm, char* options, void* reserved) {
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM* vm, char* options, void* reserved) {
     vm->GetEnv((void**)&jvmti, JVMTI_VERSION_1_0);
     jvmtiEventCallbacks callbacks;
     memset(&callbacks, 0, sizeof(callbacks));


### PR DESCRIPTION
Hello, please review this small fix for a build error on 32bit Windows.
Currently we run into 
d:\test\hotspot\jtreg\serviceability\jvmti\DynamicCodeGenerated\libDynamicCodeGenerated.cpp(49): error C2373: 'Agent_OnLoad': redefinition; different type modifiers
d:\jdk-dev-build\support\modules_include\java.base\jvmti.h(51): note: see declaration of 'Agent_OnLoad'

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268463](https://bugs.openjdk.java.net/browse/JDK-8268463): Windows 32bit build fails in DynamicCodeGenerated\libDynamicCodeGenerated.cpp


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4450/head:pull/4450` \
`$ git checkout pull/4450`

Update a local copy of the PR: \
`$ git checkout pull/4450` \
`$ git pull https://git.openjdk.java.net/jdk pull/4450/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4450`

View PR using the GUI difftool: \
`$ git pr show -t 4450`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4450.diff">https://git.openjdk.java.net/jdk/pull/4450.diff</a>

</details>
