### PR TITLE
8268530: resourcehogs/serviceability/jvmti/GetObjectSizeOverflow.java should be run in driver mode

### DIFF
--- a/test/hotspot/jtreg/resourcehogs/serviceability/jvmti/GetObjectSizeOverflow.java
+++ b/test/hotspot/jtreg/resourcehogs/serviceability/jvmti/GetObjectSizeOverflow.java
@@ -43,10 +43,8 @@
 import java.io.PrintWriter;
 
 import jdk.test.lib.JDKToolFinder;
-import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
-import jtreg.SkippedException;
 
 public class GetObjectSizeOverflow {
     public static void main(String[] args) throws Exception  {

--- a/test/hotspot/jtreg/resourcehogs/serviceability/jvmti/GetObjectSizeOverflow.java
+++ b/test/hotspot/jtreg/resourcehogs/serviceability/jvmti/GetObjectSizeOverflow.java
@@ -37,7 +37,7 @@
  * @requires os.maxMemory > 6G
  * @build GetObjectSizeOverflowAgent
  * @run driver jdk.test.lib.helpers.ClassFileInstaller GetObjectSizeOverflowAgent
- * @run main GetObjectSizeOverflow
+ * @run driver GetObjectSizeOverflow
  */
 
 import java.io.PrintWriter;

--- a/test/hotspot/jtreg/resourcehogs/serviceability/jvmti/GetObjectSizeOverflow.java
+++ b/test/hotspot/jtreg/resourcehogs/serviceability/jvmti/GetObjectSizeOverflow.java
@@ -51,9 +51,9 @@ import jtreg.SkippedException;
 public class GetObjectSizeOverflow {
     public static void main(String[] args) throws Exception  {
 
-        PrintWriter pw = new PrintWriter("MANIFEST.MF");
-        pw.println("Premain-Class: GetObjectSizeOverflowAgent");
-        pw.close();
+        try (var pw = new PrintWriter("MANIFEST.MF")) {
+            pw.println("Premain-Class: GetObjectSizeOverflowAgent");
+        }
 
         ProcessBuilder pb = new ProcessBuilder();
         pb.command(new String[] { JDKToolFinder.getJDKTool("jar"), "cmf", "MANIFEST.MF", "agent.jar", "GetObjectSizeOverflowAgent.class"});

--- a/test/hotspot/jtreg/resourcehogs/serviceability/jvmti/GetObjectSizeOverflow.java
+++ b/test/hotspot/jtreg/resourcehogs/serviceability/jvmti/GetObjectSizeOverflow.java
@@ -54,11 +54,11 @@ public class GetObjectSizeOverflow {
         }
 
         var jar = new ProcessBuilder(JDKToolFinder.getJDKTool("jar"), "cmf", "MANIFEST.MF", "agent.jar", "GetObjectSizeOverflowAgent.class");
-        jar.start().waitFor();
+        new OutputAnalyzer(jar.start()).shouldHaveExitValue(0);
 
         ProcessBuilder pt = ProcessTools.createTestJvm("-Xmx4000m", "-javaagent:agent.jar",  "GetObjectSizeOverflowAgent");
         OutputAnalyzer output = new OutputAnalyzer(pt.start());
-
         output.stdoutShouldContain("GetObjectSizeOverflow passed");
+        output.shouldHaveExitValue(0);
     }
 }

--- a/test/hotspot/jtreg/resourcehogs/serviceability/jvmti/GetObjectSizeOverflow.java
+++ b/test/hotspot/jtreg/resourcehogs/serviceability/jvmti/GetObjectSizeOverflow.java
@@ -53,9 +53,8 @@ public class GetObjectSizeOverflow {
             pw.println("Premain-Class: GetObjectSizeOverflowAgent");
         }
 
-        ProcessBuilder pb = new ProcessBuilder();
-        pb.command(new String[] { JDKToolFinder.getJDKTool("jar"), "cmf", "MANIFEST.MF", "agent.jar", "GetObjectSizeOverflowAgent.class"});
-        pb.start().waitFor();
+        var jar = new ProcessBuilder(JDKToolFinder.getJDKTool("jar"), "cmf", "MANIFEST.MF", "agent.jar", "GetObjectSizeOverflowAgent.class");
+        jar.start().waitFor();
 
         ProcessBuilder pt = ProcessTools.createTestJvm("-Xmx4000m", "-javaagent:agent.jar",  "GetObjectSizeOverflowAgent");
         OutputAnalyzer output = new OutputAnalyzer(pt.start());


### PR DESCRIPTION
Hi all,

could you please review this small and test-only change for `resourcehogs/serviceability/jvmti/GetObjectSizeOverflow.java` test?

the test's main class just orchestrates execution and hence should be run in a driver mode, the patch also makes small refactoring of the test code: removes redundant imports, simplifies process creation, and adds checks of the exit code.

testing: `resourcehogs/serviceability` tests on `{linux,windows,macosx}-x64`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268530](https://bugs.openjdk.java.net/browse/JDK-8268530): resourcehogs/serviceability/jvmti/GetObjectSizeOverflow.java should be run in driver mode


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4452/head:pull/4452` \
`$ git checkout pull/4452`

Update a local copy of the PR: \
`$ git checkout pull/4452` \
`$ git pull https://git.openjdk.java.net/jdk pull/4452/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4452`

View PR using the GUI difftool: \
`$ git pr show -t 4452`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4452.diff">https://git.openjdk.java.net/jdk/pull/4452.diff</a>

</details>
