### PR TITLE
8268534: some serviceability/jvmti tests should be run in driver mode

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/GetObjectSizeClass.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetObjectSizeClass.java
@@ -39,7 +39,7 @@ import jdk.test.lib.process.ProcessTools;
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
  * @build GetObjectSizeClassAgent
  * @run driver jdk.test.lib.helpers.ClassFileInstaller GetObjectSizeClassAgent
- * @run main GetObjectSizeClass
+ * @run driver GetObjectSizeClass
  */
 public class GetObjectSizeClass {
     public static void main(String[] args) throws Exception  {

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeak.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeak.java
@@ -29,8 +29,8 @@
  * @modules java.base/jdk.internal.misc
  * @modules java.instrument
  *          jdk.jartool/sun.tools.jar
- * @run main RedefineLeak buildagent
- * @run main/othervm/timeout=6000  RedefineLeak runtest
+ * @run driver RedefineLeak buildagent
+ * @run driver/timeout=6000  RedefineLeak runtest
  */
 
 import java.io.FileNotFoundException;

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/TestLambdaFormRetransformation.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/TestLambdaFormRetransformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/TestLambdaFormRetransformation.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/TestLambdaFormRetransformation.java
@@ -32,7 +32,7 @@
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @compile -XDignore.symbol.file TestLambdaFormRetransformation.java
- * @run main TestLambdaFormRetransformation
+ * @run driver TestLambdaFormRetransformation
  */
 
 import java.io.IOException;

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/TestRedefineWithUnresolvedClass.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/TestRedefineWithUnresolvedClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/TestRedefineWithUnresolvedClass.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/TestRedefineWithUnresolvedClass.java
@@ -34,7 +34,7 @@
  *          jdk.jartool/sun.tools.jar
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
  * @build UnresolvedClassAgent
- * @run main TestRedefineWithUnresolvedClass
+ * @run driver TestRedefineWithUnresolvedClass
  */
 
 import java.io.File;


### PR DESCRIPTION
Hi all,

could you please review this small patch that switches execution mode in 4 `serviceability/jvmti` tests?
in all instances, the main test classes seem not to do actual testing and just orchestrate execution.

testing: `serviceability/jvmti`  on `{linux,windows,macosx}-x64`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268534](https://bugs.openjdk.java.net/browse/JDK-8268534): some serviceability/jvmti tests should be run in driver mode


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4454/head:pull/4454` \
`$ git checkout pull/4454`

Update a local copy of the PR: \
`$ git checkout pull/4454` \
`$ git pull https://git.openjdk.java.net/jdk pull/4454/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4454`

View PR using the GUI difftool: \
`$ git pr show -t 4454`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4454.diff">https://git.openjdk.java.net/jdk/pull/4454.diff</a>

</details>
