### PR TITLE
8268532: several serviceability/attach tests should be run in driver mode

### DIFF
--- a/test/hotspot/jtreg/serviceability/attach/AttachNegativePidTest.java
+++ b/test/hotspot/jtreg/serviceability/attach/AttachNegativePidTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @requires os.family != "windows"
  * @library /test/lib
  * @modules jdk.attach/com.sun.tools.attach
- * @run main AttachNegativePidTest
+ * @run driver AttachNegativePidTest
  */
 
 import java.io.IOException;

--- a/test/hotspot/jtreg/serviceability/attach/AttachSetGetFlag.java
+++ b/test/hotspot/jtreg/serviceability/attach/AttachSetGetFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/attach/AttachSetGetFlag.java
+++ b/test/hotspot/jtreg/serviceability/attach/AttachSetGetFlag.java
@@ -31,7 +31,7 @@
  *          java.management
  *          jdk.attach/sun.tools.attach
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
- * @run main AttachSetGetFlag
+ * @run driver AttachSetGetFlag
  */
 
 import java.io.BufferedReader;

--- a/test/hotspot/jtreg/serviceability/attach/AttachWithStalePidFile.java
+++ b/test/hotspot/jtreg/serviceability/attach/AttachWithStalePidFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/attach/AttachWithStalePidFile.java
+++ b/test/hotspot/jtreg/serviceability/attach/AttachWithStalePidFile.java
@@ -30,7 +30,7 @@
  * @modules jdk.attach/sun.tools.attach
  * @library /test/lib
  * @requires os.family != "windows"
- * @run main AttachWithStalePidFile
+ * @run driver AttachWithStalePidFile
  */
 
 import jdk.test.lib.Platform;

--- a/test/hotspot/jtreg/serviceability/attach/RemovingUnixDomainSocketTest.java
+++ b/test/hotspot/jtreg/serviceability/attach/RemovingUnixDomainSocketTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/attach/RemovingUnixDomainSocketTest.java
+++ b/test/hotspot/jtreg/serviceability/attach/RemovingUnixDomainSocketTest.java
@@ -26,7 +26,7 @@
  * @bug 8225193
  * @requires os.family != "windows"
  * @library /test/lib
- * @run main RemovingUnixDomainSocketTest
+ * @run driver RemovingUnixDomainSocketTest
  */
 
 import java.io.File;


### PR DESCRIPTION
Hi all,

could you please review this small patch that switches execution mode in 4 `serviceability/attach` tests?
in all instances, the main test classes seem not to do actual testing and just orchestrate execution.

testing: `serviceability/attach` on `{linux,windows,macosx}-x64`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268532](https://bugs.openjdk.java.net/browse/JDK-8268532): several serviceability/attach tests should be run in driver mode


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4455/head:pull/4455` \
`$ git checkout pull/4455`

Update a local copy of the PR: \
`$ git checkout pull/4455` \
`$ git pull https://git.openjdk.java.net/jdk pull/4455/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4455`

View PR using the GUI difftool: \
`$ git pr show -t 4455`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4455.diff">https://git.openjdk.java.net/jdk/pull/4455.diff</a>

</details>
