### PR TITLE
8003216: Add JFR event indicating explicit System.gc() call

### DIFF
--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -278,6 +278,10 @@
     <Field type="Tickspan" name="longestPause" label="Longest Pause" description="Longest individual pause during the garbage collection" />
   </Event>
 
+  <Event name="SystemGC" category="Java Virtual Machine, GC, Collector" label="System GC" stackTrace="true" startTime="true" thread="true">
+    <Field type="boolean" name="invokedConcurrent" label="Invoked Concurrent" />
+  </Event>
+
   <Event name="ParallelOldGarbageCollection" category="Java Virtual Machine, GC, Collector" label="Parallel Old Garbage Collection"
     description="Extra information specific to Parallel Old Garbage Collections">
     <Field type="uint" name="gcId" label="GC Identifier" relation="GcId" />

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -443,7 +443,10 @@ JVM_END
 
 JVM_ENTRY_NO_ENV(void, JVM_GC(void))
   if (!DisableExplicitGC) {
+    EventSystemGC event;
+    event.set_invokedConcurrent(ExplicitGCInvokesConcurrent);
     Universe::heap()->collect(GCCause::_java_lang_system_gc);
+    event.commit();
   }
 JVM_END
 

--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -346,6 +346,12 @@
       <setting name="threshold">0 ms</setting>
     </event>
 
+    <event name="jdk.SystemGC">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
     <event name="jdk.ParallelOldGarbageCollection">
       <setting name="enabled" control="gc-enabled-normal">true</setting>
       <setting name="threshold">0 ms</setting>

--- a/src/jdk.jfr/share/conf/jfr/profile.jfc
+++ b/src/jdk.jfr/share/conf/jfr/profile.jfc
@@ -346,6 +346,12 @@
       <setting name="threshold">0 ms</setting>
     </event>
 
+    <event name="jdk.SystemGC">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+      <setting name="stackTrace">true</setting> 
+    </event>
+
     <event name="jdk.ParallelOldGarbageCollection">
       <setting name="enabled" control="gc-enabled-normal">true</setting>
       <setting name="threshold">0 ms</setting>

--- a/test/jdk/jdk/jfr/event/gc/collection/TestSystemGc.java
+++ b/test/jdk/jdk/jfr/event/gc/collection/TestSystemGc.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.event.gc.collection;
+
+import java.lang.management.ManagementFactory;
+import java.util.List;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.jfr.EventNames;
+import jdk.test.lib.jfr.Events;
+
+/**
+ * @test
+ * @key jfr
+ * @requires vm.hasJFR
+ * @library /test/lib /test/jdk
+ * @run main/othervm -XX:+ExplicitGCInvokesConcurrent jdk.jfr.event.gc.collection.TestSystemGC true
+ * @run main/othervm -XX:-ExplicitGCInvokesConcurrent jdk.jfr.event.gc.collection.TestSystemGC false
+ */
+public class TestSystemGC {
+    public static void main(String[] args) throws Exception {
+        boolean concurrent = Boolean.valueOf(args[0]);
+        try (Recording recording = new Recording()) {
+            recording.enable(EventNames.SystemGC);
+            recording.start();
+
+            // Trigger 3 System GC
+            System.gc();
+            ManagementFactory.getMemoryMXBean().gc();
+            Runtime.getRuntime().gc();
+
+            recording.stop();
+            List<RecordedEvent> events = Events.fromRecording(recording);
+            System.out.println(events);
+
+            Asserts.assertEquals(3, events.size(), "Expected 3 SystemGC events");
+
+            RecordedEvent event1 = events.get(0);
+            Events.assertFrame(event1, System.class, "gc");
+            Events.assertEventThread(event1, Thread.currentThread());
+            Events.assertField(event1, "invokedConcurrent").isEqual(concurrent);
+
+            RecordedEvent event2 = events.get(1);
+            Events.assertFrame(event2, Runtime.class, "gc");
+            Events.assertEventThread(event2, Thread.currentThread());
+            Events.assertField(event1, "invokedConcurrent").isEqual(concurrent);
+
+            RecordedEvent event3 = events.get(2);
+            // MemoryMXBean.class is an interface so can't assertFrame on it
+            Events.assertEventThread(event3, Thread.currentThread());
+            Events.assertField(event1, "invokedConcurrent").isEqual(concurrent);
+        }
+     }
+}

--- a/test/lib/jdk/test/lib/jfr/EventNames.java
+++ b/test/lib/jdk/test/lib/jfr/EventNames.java
@@ -150,6 +150,7 @@ public class EventNames {
     public final static String ZUncommit = PREFIX + "ZUncommit";
     public final static String ZUnmap = PREFIX + "ZUnmap";
     public final static String GCLocker = PREFIX + "GCLocker";
+    public static final String SystemGC = PREFIX + "SystemGC";
 
     // Compiler
     public final static String Compilation = PREFIX + "Compilation";


### PR DESCRIPTION
Hi,

This is a continuation of a review that started before the pandemic. 

In an offline discussion with Stefan Johansson, we looked into adding GC id to the SystemGC event, but it was not trivial. Still, it would make sense to have this event to see the stack trace of the System GC call. GC id can always be added as another enhancement. I added a field that indicates the status of -XX:+ExplicitGCInvokesConcurrent, to hint to users that the duration of the event may not be the time the GC took. 

I only emit the event if a GC is triggered, so there is no need for a field -XX:+DisableExplicitGC which we talked about back then. The reason is that it could potentially create many events in the default configuration, for example if called every rendered frame. I also think users want to track calls that actually led to a GC. If there is a need for a second field, it could be added as another enhancement later.

Testing: tier1/tier2 + test/jdk/jdk/jfr 

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8003216](https://bugs.openjdk.java.net/browse/JDK-8003216): Add JFR event indicating explicit System.gc() call


### Reviewers
 * [Jaroslav Bachorik](https://openjdk.java.net/census#jbachorik) (@jbachorik - **Reviewer**)
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4456/head:pull/4456` \
`$ git checkout pull/4456`

Update a local copy of the PR: \
`$ git checkout pull/4456` \
`$ git pull https://git.openjdk.java.net/jdk pull/4456/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4456`

View PR using the GUI difftool: \
`$ git pr show -t 4456`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4456.diff">https://git.openjdk.java.net/jdk/pull/4456.diff</a>

</details>
