### PR TITLE
8268536: mark hotspot serviceability/dcmd tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/compiler/CodeHeapAnalyticsParams.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/compiler/CodeHeapAnalyticsParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/dcmd/compiler/CodeHeapAnalyticsParams.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/compiler/CodeHeapAnalyticsParams.java
@@ -26,6 +26,7 @@ import jdk.test.lib.dcmd.PidJcmdExecutor;
 /*
  * @test CodeHeapAnalyticsParams
  * @summary Test the Compiler.CodeHeap_Analytics command
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/serviceability/dcmd/gc/RunFinalizationTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/RunFinalizationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/dcmd/gc/RunFinalizationTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/RunFinalizationTest.java
@@ -30,6 +30,7 @@ import jdk.test.lib.process.ProcessTools;
 /*
  * @test
  * @summary Test of diagnostic command GC.run_finalization
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.compiler


### PR DESCRIPTION
Hi all,

could you please review the patch which adds `@requires vm.flagless` to `serviceability/dcmd/gc/RunFinalizationTest.java` and `serviceability/dcmd/compiler/CodeHeapAnalyticsParams.java` tests as they completely ignore external vm flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268536](https://bugs.openjdk.java.net/browse/JDK-8268536): mark hotspot serviceability/dcmd tests which ignore external VM flags


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4457/head:pull/4457` \
`$ git checkout pull/4457`

Update a local copy of the PR: \
`$ git checkout pull/4457` \
`$ git pull https://git.openjdk.java.net/jdk pull/4457/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4457`

View PR using the GUI difftool: \
`$ git pr show -t 4457`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4457.diff">https://git.openjdk.java.net/jdk/pull/4457.diff</a>

</details>
