### PR TITLE
8268538: mark hotspot serviceability/logging tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/serviceability/logging/TestBasicLogOutput.java
+++ b/test/hotspot/jtreg/serviceability/logging/TestBasicLogOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/logging/TestBasicLogOutput.java
+++ b/test/hotspot/jtreg/serviceability/logging/TestBasicLogOutput.java
@@ -24,6 +24,7 @@
 /*
  * @test TestBasicLogOutput
  * @summary Ensure logging can be enabled and successfully prints to stdout.
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver TestBasicLogOutput

--- a/test/hotspot/jtreg/serviceability/logging/TestDefaultLogOutput.java
+++ b/test/hotspot/jtreg/serviceability/logging/TestDefaultLogOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/logging/TestDefaultLogOutput.java
+++ b/test/hotspot/jtreg/serviceability/logging/TestDefaultLogOutput.java
@@ -24,6 +24,7 @@
 /*
  * @test TestDefaultLogOutput
  * @summary Ensure logging is default on stdout.
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver TestDefaultLogOutput

--- a/test/hotspot/jtreg/serviceability/logging/TestFullNames.java
+++ b/test/hotspot/jtreg/serviceability/logging/TestFullNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/logging/TestFullNames.java
+++ b/test/hotspot/jtreg/serviceability/logging/TestFullNames.java
@@ -23,8 +23,9 @@
 
 /*
  * @test TestFullNames
- * @summary Ensure proper parsing of unquoted full output names for -Xlog arguments.
  * @bug 8215398
+ * @summary Ensure proper parsing of unquoted full output names for -Xlog arguments.
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver TestFullNames

--- a/test/hotspot/jtreg/serviceability/logging/TestMultipleXlogArgs.java
+++ b/test/hotspot/jtreg/serviceability/logging/TestMultipleXlogArgs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/logging/TestMultipleXlogArgs.java
+++ b/test/hotspot/jtreg/serviceability/logging/TestMultipleXlogArgs.java
@@ -24,6 +24,7 @@
 /*
  * @test TestMultipleXlogArgs
  * @summary Ensure multiple -Xlog arguments aggregate the logging options.
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver TestMultipleXlogArgs

--- a/test/hotspot/jtreg/serviceability/logging/TestQuotedLogOutputs.java
+++ b/test/hotspot/jtreg/serviceability/logging/TestQuotedLogOutputs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/logging/TestQuotedLogOutputs.java
+++ b/test/hotspot/jtreg/serviceability/logging/TestQuotedLogOutputs.java
@@ -24,6 +24,7 @@
 /*
  * @test TestQuotedLogOutputs
  * @summary Ensure proper parsing of quoted output names for -Xlog arguments.
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @comment after JDK-8224505, this has to be run in othervm mode


### PR DESCRIPTION
Hi all,

could you please review the patch which adds `@requires vm.flagless` to serviceability/logging` tests that ignore external VM flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268538](https://bugs.openjdk.java.net/browse/JDK-8268538): mark hotspot serviceability/logging tests which ignore external VM flags


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4458/head:pull/4458` \
`$ git checkout pull/4458`

Update a local copy of the PR: \
`$ git checkout pull/4458` \
`$ git pull https://git.openjdk.java.net/jdk pull/4458/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4458`

View PR using the GUI difftool: \
`$ git pr show -t 4458`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4458.diff">https://git.openjdk.java.net/jdk/pull/4458.diff</a>

</details>
