### PR TITLE
8268539: several serviceability/sa tests should be run in driver mode

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/CDSJMapClstats.java
+++ b/test/hotspot/jtreg/serviceability/sa/CDSJMapClstats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/sa/CDSJMapClstats.java
+++ b/test/hotspot/jtreg/serviceability/sa/CDSJMapClstats.java
@@ -27,7 +27,7 @@
  * @summary Test the jhsdb jmap -clstats command with CDS enabled
  * @requires vm.hasSA & vm.cds
  * @library /test/lib
- * @run main/othervm/timeout=2400 CDSJMapClstats
+ * @run driver/timeout=2400 CDSJMapClstats
  */
 
 import java.util.stream.Collectors;

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpclass.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpclass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpclass.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpclass.java
@@ -70,8 +70,8 @@ public class ClhsdbDumpclass {
             // Run javap on the generated class file to make sure it's valid.
             JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("javap");
             launcher.addVMArgs(Utils.getTestJavaOpts());
-            launcher.addToolArg(APP_DOT_CLASSNAME);
-            System.out.println("> javap " + APP_DOT_CLASSNAME);
+            launcher.addToolArg(classFile.toString());
+            System.out.println("> javap " + classFile.toString());
             List<String> cmdStringList = Arrays.asList(launcher.getCommand());
             ProcessBuilder pb = new ProcessBuilder(cmdStringList);
             Process javap = pb.start();

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpclass.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpclass.java
@@ -39,7 +39,7 @@ import jtreg.SkippedException;
  * @summary Test clhsdb dumpclass command
  * @requires vm.hasSA
  * @library /test/lib
- * @run main/othervm ClhsdbDumpclass
+ * @run driver ClhsdbDumpclass
  */
 
 public class ClhsdbDumpclass {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbFlags.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbFlags.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbFlags.java
@@ -37,7 +37,7 @@ import jtreg.SkippedException;
  * @summary Test clhsdb flags command
  * @requires vm.hasSA
  * @library /test/lib
- * @run main/othervm ClhsdbFlags
+ * @run driver ClhsdbFlags
  */
 
 public class ClhsdbFlags {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbJstackXcompStress.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbJstackXcompStress.java
@@ -38,7 +38,7 @@ import jdk.test.lib.process.OutputAnalyzer;
  * @requires vm.hasSA
  * @requires vm.opt.DeoptimizeALot != true
  * @library /test/lib
- * @run main/othervm ClhsdbJstackXcompStress
+ * @run driver ClhsdbJstackXcompStress
  */
 public class ClhsdbJstackXcompStress {
 

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbJstackXcompStress.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbJstackXcompStress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/hotspot/jtreg/serviceability/sa/DeadlockDetectionTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/DeadlockDetectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/sa/DeadlockDetectionTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/DeadlockDetectionTest.java
@@ -28,7 +28,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @modules java.management
- * @run main DeadlockDetectionTest
+ * @run driver DeadlockDetectionTest
  */
 
 import java.util.stream.Collectors;

--- a/test/hotspot/jtreg/serviceability/sa/JhsdbThreadInfoTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/JhsdbThreadInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/sa/JhsdbThreadInfoTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/JhsdbThreadInfoTest.java
@@ -31,7 +31,7 @@ import jdk.test.lib.Utils;
  * @test
  * @requires vm.hasSA
  * @library /test/lib
- * @run main JhsdbThreadInfoTest
+ * @run driver JhsdbThreadInfoTest
  */
 public class JhsdbThreadInfoTest {
 

--- a/test/hotspot/jtreg/serviceability/sa/TestCpoolForInvokeDynamic.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestCpoolForInvokeDynamic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/sa/TestCpoolForInvokeDynamic.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestCpoolForInvokeDynamic.java
@@ -52,7 +52,7 @@ import jdk.test.lib.Utils;
  *          jdk.hotspot.agent/sun.jvm.hotspot.oops
  *          jdk.hotspot.agent/sun.jvm.hotspot.debugger
  *          jdk.hotspot.agent/sun.jvm.hotspot.ui.classbrowser
- * @run main TestCpoolForInvokeDynamic
+ * @run driver TestCpoolForInvokeDynamic
  */
 
 public class TestCpoolForInvokeDynamic {

--- a/test/hotspot/jtreg/serviceability/sa/TestDefaultMethods.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestDefaultMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/sa/TestDefaultMethods.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestDefaultMethods.java
@@ -50,7 +50,7 @@ import jdk.test.lib.Utils;
  *          jdk.hotspot.agent/sun.jvm.hotspot.utilities
  *          jdk.hotspot.agent/sun.jvm.hotspot.oops
  *          jdk.hotspot.agent/sun.jvm.hotspot.debugger
- * @run main TestDefaultMethods
+ * @run driver TestDefaultMethods
  */
 
 public class TestDefaultMethods {

--- a/test/hotspot/jtreg/serviceability/sa/TestHeapDumpForInvokeDynamic.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestHeapDumpForInvokeDynamic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/sa/TestHeapDumpForInvokeDynamic.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestHeapDumpForInvokeDynamic.java
@@ -48,7 +48,7 @@ import jdk.test.lib.hprof.model.Snapshot;
  *          jdk.hotspot.agent/sun.jvm.hotspot.utilities
  *          jdk.hotspot.agent/sun.jvm.hotspot.oops
  *          jdk.hotspot.agent/sun.jvm.hotspot.debugger
- * @run main/othervm TestHeapDumpForInvokeDynamic
+ * @run driver TestHeapDumpForInvokeDynamic
  */
 
 public class TestHeapDumpForInvokeDynamic {

--- a/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackLineNumbers.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackLineNumbers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackLineNumbers.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackLineNumbers.java
@@ -39,7 +39,7 @@ import jdk.test.lib.SA.SATestUtils;
  * @requires os.arch=="amd64" | os.arch=="x86_64"
  * @requires os.family=="windows" | os.family == "linux" | os.family == "mac"
  * @library /test/lib
- * @run main/othervm TestJhsdbJstackLineNumbers
+ * @run driver TestJhsdbJstackLineNumbers
  */
 
 /*

--- a/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackLock.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackLock.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackLock.java
@@ -31,7 +31,7 @@ import jdk.test.lib.Utils;
  * @test
  * @requires vm.hasSA
  * @library /test/lib
- * @run main/othervm TestJhsdbJstackLock
+ * @run driver TestJhsdbJstackLock
  */
 
 public class TestJhsdbJstackLock {

--- a/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackMixed.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackMixed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackMixed.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackMixed.java
@@ -38,7 +38,7 @@ import jdk.test.lib.process.OutputAnalyzer;
  * @bug 8208091
  * @requires (os.family == "linux") & (vm.hasSA)
  * @library /test/lib
- * @run main/othervm TestJhsdbJstackMixed
+ * @run driver TestJhsdbJstackMixed
  */
 public class TestJhsdbJstackMixed {
 

--- a/test/hotspot/jtreg/serviceability/sa/TestObjectMonitorIterate.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestObjectMonitorIterate.java
@@ -41,7 +41,7 @@ import jdk.test.lib.SA.SATestUtils;
  * @modules jdk.hotspot.agent/sun.jvm.hotspot
  *          jdk.hotspot.agent/sun.jvm.hotspot.oops
  *          jdk.hotspot.agent/sun.jvm.hotspot.runtime
- * @run main TestObjectMonitorIterate
+ * @run driver TestObjectMonitorIterate
  */
 
 public class TestObjectMonitorIterate {

--- a/test/hotspot/jtreg/serviceability/sa/TestRevPtrsForInvokeDynamic.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestRevPtrsForInvokeDynamic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/sa/TestRevPtrsForInvokeDynamic.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestRevPtrsForInvokeDynamic.java
@@ -44,7 +44,7 @@ import jdk.test.lib.Utils;
  * @modules java.base/jdk.internal.misc
  *          jdk.hotspot.agent/sun.jvm.hotspot
  *          jdk.hotspot.agent/sun.jvm.hotspot.utilities
- * @run main/othervm TestRevPtrsForInvokeDynamic
+ * @run driver TestRevPtrsForInvokeDynamic
  */
 
 public class TestRevPtrsForInvokeDynamic {

--- a/test/hotspot/jtreg/serviceability/sa/TestSysProps.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestSysProps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/sa/TestSysProps.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestSysProps.java
@@ -38,7 +38,7 @@ import jdk.test.lib.SA.SATestUtils;
  * @summary Test "jhsdb jinfo --sysprops", "jinfo -sysprops", and clhsdb "sysprops" commands
  * @requires vm.hasSA
  * @library /test/lib
- * @run main/othervm TestSysProps
+ * @run driver TestSysProps
  */
 
 public class TestSysProps {

--- a/test/hotspot/jtreg/serviceability/sa/jmap-hprof/JMapHProfLargeHeapTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/jmap-hprof/JMapHProfLargeHeapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/sa/jmap-hprof/JMapHProfLargeHeapTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/jmap-hprof/JMapHProfLargeHeapTest.java
@@ -49,7 +49,7 @@ import jdk.test.lib.SA.SATestUtils;
  *          java.management/sun.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
  * @build JMapHProfLargeHeapProc
- * @run main JMapHProfLargeHeapTest
+ * @run driver JMapHProfLargeHeapTest
  */
 
 public class JMapHProfLargeHeapTest {

--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/ClhsdbAttachToDebugServer.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/ClhsdbAttachToDebugServer.java
@@ -38,7 +38,7 @@ import jtreg.SkippedException;
  * @requires vm.hasSA
  * @requires os.family != "windows"
  * @library /test/lib
- * @run main/othervm ClhsdbAttachToDebugServer
+ * @run driver ClhsdbAttachToDebugServer
  */
 
 public class ClhsdbAttachToDebugServer {

--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/ClhsdbTestConnectArgument.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/ClhsdbTestConnectArgument.java
@@ -37,7 +37,7 @@ import jtreg.SkippedException;
  * @requires vm.hasSA
  * @requires os.family != "windows"
  * @library /test/lib
- * @run main/othervm ClhsdbTestConnectArgument
+ * @run driver ClhsdbTestConnectArgument
  */
 
 public class ClhsdbTestConnectArgument {

--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/DebugdConnectTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/DebugdConnectTest.java
@@ -30,7 +30,7 @@
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  *
- * @run main/othervm DebugdConnectTest
+ * @run driver DebugdConnectTest
  */
 
 import java.io.IOException;

--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/DisableRegistryTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/DisableRegistryTest.java
@@ -38,7 +38,7 @@ import jtreg.SkippedException;
  * @requires vm.hasSA
  * @requires os.family != "windows"
  * @library /test/lib
- * @run main/othervm DisableRegistryTest
+ * @run driver DisableRegistryTest
  */
 
 public class DisableRegistryTest {

--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/PmapOnDebugdTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/PmapOnDebugdTest.java
@@ -35,7 +35,7 @@ import jtreg.SkippedException;
  * @requires vm.hasSA
  * @requires (os.family != "windows") & (os.family != "mac")
  * @library /test/lib
- * @run main/othervm PmapOnDebugdTest
+ * @run driver PmapOnDebugdTest
  */
 
 public class PmapOnDebugdTest {

--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/RunCommandOnServerTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/RunCommandOnServerTest.java
@@ -38,7 +38,7 @@ import jtreg.SkippedException;
  * @requires vm.hasSA
  * @requires os.family != "windows"
  * @library /test/lib
- * @run main/othervm RunCommandOnServerTest
+ * @run driver RunCommandOnServerTest
  */
 
 public class RunCommandOnServerTest {

--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/SADebugDTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/SADebugDTest.java
@@ -31,7 +31,7 @@
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  *
- * @run main/othervm SADebugDTest
+ * @run driver SADebugDTest
  */
 
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
Hi all,

could you please review this _test-only_ patch that switches the execution mode of several `serviceability/sa` tests to `driver`? all these tests seem not to perform actual testing, and just organize other JDK executions and validates their outputs.

`ClhsdbDumpclass.java` had to be updated to have access to `./jdk/test/lib/apps/LingeredApp.class` file. Although this also can be fixed by propagating the classpath setting to `javap`, using the path to `.class` file is more clear and relable, and I actually suspect that before `javap` read not the dumped `.class` file, but the one from the test's classpath.

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268539](https://bugs.openjdk.java.net/browse/JDK-8268539): several serviceability/sa tests should be run in driver mode


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4460/head:pull/4460` \
`$ git checkout pull/4460`

Update a local copy of the PR: \
`$ git checkout pull/4460` \
`$ git pull https://git.openjdk.java.net/jdk pull/4460/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4460`

View PR using the GUI difftool: \
`$ git pr show -t 4460`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4460.diff">https://git.openjdk.java.net/jdk/pull/4460.diff</a>

</details>
