### PR TITLE
8268542: serviceability/logging/TestFullNames.java tests only 1st test case

### DIFF
--- a/test/hotspot/jtreg/serviceability/logging/TestFullNames.java
+++ b/test/hotspot/jtreg/serviceability/logging/TestFullNames.java
@@ -61,6 +61,7 @@ public class TestFullNames {
             fileName
         };
         for (String logOutput : validOutputs) {
+            Asserts.assertFalse(file.exists());
             // Run with logging=trace on stdout so that we can verify the log configuration afterwards.
             ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xlog:logging=trace",
                                                                       "-Xlog:all=trace:" + logOutput,
@@ -68,7 +69,7 @@ public class TestFullNames {
             OutputAnalyzer output = new OutputAnalyzer(pb.start());
             output.shouldHaveExitValue(0);
             Asserts.assertTrue(file.exists());
-            file.deleteOnExit(); // Clean up after test
+            file.delete();
             output.shouldMatch("\\[logging *\\].*" + baseName); // Expect to see the log output listed
         }
     }


### PR DESCRIPTION
Hi all,

could you please review this small fix for `serviceability/logging/TestFullNames.java` test?
from JBS:
> serviceability/logging/TestFullNames.java test contains two test cases: specifying filename w/ and w/o "file=" prefix. yet, the test doesn't remove the file, hence its 2nd test case doesn't really test much.

the patch simply calls `File::delete` inside the loop and verifies that the file doesn't exist at the beginning of each iteration.

testing: `serviceability/logging/TestFullNames.java` on `{linux,windows,macosx}-x64`

Thanks,
-- Igor

/cc hotspot-runtime serviceability

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268542](https://bugs.openjdk.java.net/browse/JDK-8268542): serviceability/logging/TestFullNames.java tests only 1st test case


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4461/head:pull/4461` \
`$ git checkout pull/4461`

Update a local copy of the PR: \
`$ git checkout pull/4461` \
`$ git pull https://git.openjdk.java.net/jdk pull/4461/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4461`

View PR using the GUI difftool: \
`$ git pr show -t 4461`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4461.diff">https://git.openjdk.java.net/jdk/pull/4461.diff</a>

</details>
