### PR TITLE
8268543: some runtime/verifier tests should be run in driver mode

### DIFF
--- a/test/hotspot/jtreg/runtime/verifier/OverriderMsg.java
+++ b/test/hotspot/jtreg/runtime/verifier/OverriderMsg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/verifier/OverriderMsg.java
+++ b/test/hotspot/jtreg/runtime/verifier/OverriderMsg.java
@@ -37,7 +37,7 @@ import jdk.test.lib.process.OutputAnalyzer;
  *          java.base/jdk.internal.misc
  *          java.management
  * @compile -XDignore.symbol.file OverriderMsg.java
- * @run main/othervm OverriderMsg
+ * @run driver OverriderMsg
  */
 
 // This test checks that the super class name is included in the message when

--- a/test/hotspot/jtreg/runtime/verifier/TestANewArray.java
+++ b/test/hotspot/jtreg/runtime/verifier/TestANewArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/verifier/TestANewArray.java
+++ b/test/hotspot/jtreg/runtime/verifier/TestANewArray.java
@@ -38,8 +38,8 @@ import jdk.test.lib.process.OutputAnalyzer;
  * @library /test/lib
  * @modules java.base/jdk.internal.org.objectweb.asm
  * @compile -XDignore.symbol.file TestANewArray.java
- * @run main/othervm TestANewArray 49
- * @run main/othervm TestANewArray 52
+ * @run driver TestANewArray 49
+ * @run driver TestANewArray 52
  */
 
 /*

--- a/test/hotspot/jtreg/runtime/verifier/TestMultiANewArray.java
+++ b/test/hotspot/jtreg/runtime/verifier/TestMultiANewArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/verifier/TestMultiANewArray.java
+++ b/test/hotspot/jtreg/runtime/verifier/TestMultiANewArray.java
@@ -37,10 +37,10 @@ import jdk.test.lib.process.OutputAnalyzer;
  *          java.base/jdk.internal.misc
  *          java.management
  * @compile -XDignore.symbol.file TestMultiANewArray.java
- * @run main/othervm TestMultiANewArray 49
- * @run main/othervm TestMultiANewArray 50
- * @run main/othervm TestMultiANewArray 51
- * @run main/othervm TestMultiANewArray 52
+ * @run driver TestMultiANewArray 49
+ * @run driver TestMultiANewArray 50
+ * @run driver TestMultiANewArray 51
+ * @run driver TestMultiANewArray 52
  */
 
 public class TestMultiANewArray {


### PR DESCRIPTION
Hi all,

could you please review the patch that switches the execution mode in a few `runtime/verifier` tests to `driver`?

testing: `runtime/verifier` on `{linux,windows,macosx}-x64`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268543](https://bugs.openjdk.java.net/browse/JDK-8268543): some runtime/verifier tests should be run in driver mode


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4462/head:pull/4462` \
`$ git checkout pull/4462`

Update a local copy of the PR: \
`$ git checkout pull/4462` \
`$ git pull https://git.openjdk.java.net/jdk pull/4462/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4462`

View PR using the GUI difftool: \
`$ git pr show -t 4462`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4462.diff">https://git.openjdk.java.net/jdk/pull/4462.diff</a>

</details>
