### PR TITLE
8268544: some runtime/sealedClasses tests should be run in driver mode

### DIFF
--- a/test/hotspot/jtreg/runtime/sealedClasses/RedefinePermittedSubclass.java
+++ b/test/hotspot/jtreg/runtime/sealedClasses/RedefinePermittedSubclass.java
@@ -31,8 +31,8 @@
  * @modules java.instrument
  * @requires vm.jvmti
  * @compile RedefinePermittedSubclass.java
- * @run main/othervm RedefinePermittedSubclass buildagent
- * @run main/othervm/timeout=6000 RedefinePermittedSubclass runtest
+ * @run driver RedefinePermittedSubclass buildagent
+ * @run driver/timeout=6000 RedefinePermittedSubclass runtest
  */
 
 import java.io.FileNotFoundException;
@@ -128,6 +128,7 @@ public class RedefinePermittedSubclass {
             ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(javaArgs1);
             OutputAnalyzer output = new OutputAnalyzer(pb.start());
             output.shouldNotContain("processing of -javaagent failed");
+            output.shouldHaveExitValue(0);
         }
     }
 }

--- a/test/hotspot/jtreg/runtime/sealedClasses/RedefineSealedClass.java
+++ b/test/hotspot/jtreg/runtime/sealedClasses/RedefineSealedClass.java
@@ -30,8 +30,8 @@
  * @modules java.instrument
  * @requires vm.jvmti
  * @compile RedefineSealedClass.java
- * @run main/othervm RedefineSealedClass buildagent
- * @run main/othervm/timeout=6000 RedefineSealedClass runtest
+ * @run driver RedefineSealedClass buildagent
+ * @run driver/timeout=6000 RedefineSealedClass runtest
  */
 
 import java.io.FileNotFoundException;
@@ -110,6 +110,7 @@ public class RedefineSealedClass {
             ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(javaArgs1);
             OutputAnalyzer output = new OutputAnalyzer(pb.start());
             output.shouldNotContain("processing of -javaagent failed");
+            output.shouldHaveExitValue(0);
         }
     }
 }


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch that changes the execution mode to `driver` in two `runtime/sealedClasses` tests?

testing:  `runtime/sealedClasses` on `{linux,windows,macosx}-x64`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268544](https://bugs.openjdk.java.net/browse/JDK-8268544): some runtime/sealedClasses tests should be run in driver mode


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4463/head:pull/4463` \
`$ git checkout pull/4463`

Update a local copy of the PR: \
`$ git checkout pull/4463` \
`$ git pull https://git.openjdk.java.net/jdk pull/4463/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4463`

View PR using the GUI difftool: \
`$ git pr show -t 4463`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4463.diff">https://git.openjdk.java.net/jdk/pull/4463.diff</a>

</details>
