### PR TITLE
8268537: (Temporary) Disable ParallelRefProcEnabled for Parallel GC

### DIFF
--- a/src/hotspot/share/gc/parallel/parallelArguments.cpp
+++ b/src/hotspot/share/gc/parallel/parallelArguments.cpp
@@ -87,7 +87,7 @@ void ParallelArguments::initialize() {
   }
 
   if (FLAG_IS_DEFAULT(ParallelRefProcEnabled) && ParallelGCThreads > 1) {
-    FLAG_SET_DEFAULT(ParallelRefProcEnabled, true);
+    //FLAG_SET_DEFAULT(ParallelRefProcEnabled, true);
   }
 }
 

--- a/test/hotspot/jtreg/gc/arguments/TestParallelRefProc.java
+++ b/test/hotspot/jtreg/gc/arguments/TestParallelRefProc.java
@@ -51,7 +51,7 @@ public class TestParallelRefProc {
         }
         if (GC.Parallel.isSupported()) {
             noneGCSupported = false;
-            testFlag(new String[] { "-XX:+UseParallelGC" }, true);
+            testFlag(new String[] { "-XX:+UseParallelGC" }, false);
         }
         if (GC.G1.isSupported()) {
             noneGCSupported = false;


### PR DESCRIPTION
(Temporary) Disable ParallelRefProcEnabled for Parallel GC, will make Kitchensink pass.

Tier3 running, will wait for it before integrating.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268537](https://bugs.openjdk.java.net/browse/JDK-8268537): (Temporary) Disable ParallelRefProcEnabled for Parallel GC


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4464/head:pull/4464` \
`$ git checkout pull/4464`

Update a local copy of the PR: \
`$ git checkout pull/4464` \
`$ git pull https://git.openjdk.java.net/jdk pull/4464/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4464`

View PR using the GUI difftool: \
`$ git pr show -t 4464`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4464.diff">https://git.openjdk.java.net/jdk/pull/4464.diff</a>

</details>
