### PR TITLE
8268565: runtime/records/RedefineRecord.java should be run in driver mode

### DIFF
--- a/test/hotspot/jtreg/runtime/records/RedefineRecord.java
+++ b/test/hotspot/jtreg/runtime/records/RedefineRecord.java
@@ -29,8 +29,8 @@
  * @modules java.base/jdk.internal.misc
  * @modules java.instrument
  * @requires vm.jvmti
- * @run main RedefineRecord buildagent
- * @run main/othervm/timeout=6000 RedefineRecord runtest
+ * @run driver RedefineRecord buildagent
+ * @run driver/timeout=6000 RedefineRecord runtest
  */
 
 import java.io.FileNotFoundException;


### PR DESCRIPTION
Hi all,

could you please review this small and trivial patch that changes the execution mode to `driver` in `runtime/records/RedefineRecord.java` test?

testing: `runtime/records` on `{linux,windows,macosx}-x64`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268565](https://bugs.openjdk.java.net/browse/JDK-8268565): runtime/records/RedefineRecord.java should be run in driver mode


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4468/head:pull/4468` \
`$ git checkout pull/4468`

Update a local copy of the PR: \
`$ git checkout pull/4468` \
`$ git pull https://git.openjdk.java.net/jdk pull/4468/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4468`

View PR using the GUI difftool: \
`$ git pr show -t 4468`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4468.diff">https://git.openjdk.java.net/jdk/pull/4468.diff</a>

</details>
