### PR TITLE
8268574: ProblemList tests failing due to UseBiasedLocking going away

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -102,7 +102,11 @@ runtime/os/TestTracePageSizes.java#with-Serial 8267460 linux-aarch64
 
 # :hotspot_serviceability
 
-serviceability/sa/sadebugd/DebugdConnectTest.java 8239062 macosx-x64
+serviceability/sa/sadebugd/DebugdConnectTest.java 8239062,8268570 generic-all
+serviceability/attach/RemovingUnixDomainSocketTest.java 8268570 generic-all
+serviceability/sa/TestJhsdbJstackLock.java 8268570 generic-all
+serviceability/sa/JhsdbThreadInfoTest.java 8268570 generic-all
+
 serviceability/sa/TestRevPtrsForInvokeDynamic.java 8241235 generic-all
 resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java 8262386 generic-all
 


### PR DESCRIPTION
A trivial fix to ProblemList tests failing due to UseBiasedLocking going away

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268574](https://bugs.openjdk.java.net/browse/JDK-8268574): ProblemList tests failing due to UseBiasedLocking going away


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4469/head:pull/4469` \
`$ git checkout pull/4469`

Update a local copy of the PR: \
`$ git checkout pull/4469` \
`$ git pull https://git.openjdk.java.net/jdk pull/4469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4469`

View PR using the GUI difftool: \
`$ git pr show -t 4469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4469.diff">https://git.openjdk.java.net/jdk/pull/4469.diff</a>

</details>
