### PR TITLE
8268556: Use bitmap for storing regions that failed evacuation

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1477,7 +1477,7 @@ G1CollectedHeap::G1CollectedHeap() :
   _cr(NULL),
   _task_queues(NULL),
   _num_regions_failed_evacuation(0),
-  _regions_failed_evacuation(NULL),
+  _regions_failed_evacuation(mtGC),
   _evacuation_failed_info_array(NULL),
   _preserved_marks_set(true /* in_c_heap */),
 #ifndef PRODUCT
@@ -1770,7 +1770,7 @@ jint G1CollectedHeap::initialize() {
 
   _collection_set.initialize(max_reserved_regions());
 
-  _regions_failed_evacuation = NEW_C_HEAP_ARRAY(volatile bool, max_regions(), mtGC);
+  _regions_failed_evacuation.resize(max_regions());
 
   G1InitLogger::print();
 
@@ -3470,7 +3470,7 @@ void G1CollectedHeap::pre_evacuate_collection_set(G1EvacuationInfo& evacuation_i
   _expand_heap_after_alloc_failure = true;
   Atomic::store(&_num_regions_failed_evacuation, 0u);
 
-  memset((void*)_regions_failed_evacuation, false, sizeof(bool) * max_regions());
+  _regions_failed_evacuation.clear();
 
   // Disable the hot card cache.
   _hot_card_cache->reset_hot_cache_claimed_index();

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -55,6 +55,7 @@
 #include "gc/shared/softRefPolicy.hpp"
 #include "gc/shared/taskqueue.hpp"
 #include "memory/memRegion.hpp"
+#include "utilities/bitMap.hpp"
 #include "utilities/stack.hpp"
 
 // A "G1CollectedHeap" is an implementation of a java heap for HotSpot.
@@ -868,7 +869,7 @@ public:
   // Number of regions evacuation failed in the current collection.
   volatile uint _num_regions_failed_evacuation;
   // Records for every region on the heap whether evacuation failed for it.
-  volatile bool* _regions_failed_evacuation;
+  CHeapBitMap _regions_failed_evacuation;
 
   EvacuationFailedInfo* _evacuation_failed_info_array;
 


### PR DESCRIPTION
Hi all,

  can I have reviews for this follow-up cleanup of the earlier JDK-8267073? It introduced a byte-map for storing information about regions that have already been experienced an evacuation failure.

During review the improvement to use a bitmap instead came up - uses less space and there are existing setters/getters that can be used.

Testing: tier1-4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268556](https://bugs.openjdk.java.net/browse/JDK-8268556): Use bitmap for storing regions that failed evacuation


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4471/head:pull/4471` \
`$ git checkout pull/4471`

Update a local copy of the PR: \
`$ git checkout pull/4471` \
`$ git pull https://git.openjdk.java.net/jdk pull/4471/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4471`

View PR using the GUI difftool: \
`$ git pr show -t 4471`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4471.diff">https://git.openjdk.java.net/jdk/pull/4471.diff</a>

</details>
