### PR TITLE
8268458: Add verification type for evacuation failures

### DIFF
--- a/src/hotspot/share/gc/g1/g1Arguments.cpp
+++ b/src/hotspot/share/gc/g1/g1Arguments.cpp
@@ -90,6 +90,8 @@ void G1Arguments::parse_verification_type(const char* type) {
     G1HeapVerifier::enable_verification_type(G1HeapVerifier::G1VerifyConcurrentStart);
   } else if (strcmp(type, "mixed") == 0) {
     G1HeapVerifier::enable_verification_type(G1HeapVerifier::G1VerifyMixed);
+  } else if (strcmp(type, "young-evac-fail") == 0) {
+    G1HeapVerifier::enable_verification_type(G1HeapVerifier::G1VerifyYoungEvacFail);
   } else if (strcmp(type, "remark") == 0) {
     G1HeapVerifier::enable_verification_type(G1HeapVerifier::G1VerifyRemark);
   } else if (strcmp(type, "cleanup") == 0) {
@@ -98,7 +100,7 @@ void G1Arguments::parse_verification_type(const char* type) {
     G1HeapVerifier::enable_verification_type(G1HeapVerifier::G1VerifyFull);
   } else {
     log_warning(gc, verify)("VerifyGCType: '%s' is unknown. Available types are: "
-                            "young-normal, concurrent-start, mixed, remark, cleanup and full", type);
+                            "young-normal, young-evac-fail, concurrent-start, mixed, remark, cleanup and full", type);
   }
 }
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2842,6 +2842,9 @@ void G1CollectedHeap::verify_before_young_collection(G1HeapVerifier::G1VerifyTyp
 }
 
 void G1CollectedHeap::verify_after_young_collection(G1HeapVerifier::G1VerifyType type) {
+  if (evacuation_failed()) {
+    type = (G1HeapVerifier::G1VerifyType)(type | G1HeapVerifier::G1VerifyYoungEvacFail);
+  }
   if (VerifyRememberedSets) {
     log_info(gc, verify)("[Verifying RemSets after GC]");
     VerifyRegionRemSetClosure v_cl;

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -467,7 +467,7 @@ void G1HeapVerifier::enable_verification_type(G1VerifyType type) {
 }
 
 bool G1HeapVerifier::should_verify(G1VerifyType type) {
-  return (_enabled_verification_types & type) == type;
+  return (_enabled_verification_types & type) != 0;
 }
 
 void G1HeapVerifier::verify(VerifyOption vo) {

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.hpp
@@ -45,9 +45,10 @@ public:
     G1VerifyYoungNormal     =  1, // -XX:VerifyGCType=young-normal
     G1VerifyConcurrentStart =  2, // -XX:VerifyGCType=concurrent-start
     G1VerifyMixed           =  4, // -XX:VerifyGCType=mixed
-    G1VerifyRemark          =  8, // -XX:VerifyGCType=remark
-    G1VerifyCleanup         = 16, // -XX:VerifyGCType=cleanup
-    G1VerifyFull            = 32, // -XX:VerifyGCType=full
+    G1VerifyYoungEvacFail   =  8, // -XX:VerifyGCType=young-evac-fail
+    G1VerifyRemark          = 16, // -XX:VerifyGCType=remark
+    G1VerifyCleanup         = 32, // -XX:VerifyGCType=cleanup
+    G1VerifyFull            = 64, // -XX:VerifyGCType=full
     G1VerifyAll             = -1
   };
 

--- a/test/hotspot/gtest/gc/g1/test_g1HeapVerifier.cpp
+++ b/test/hotspot/gtest/gc/g1/test_g1HeapVerifier.cpp
@@ -41,20 +41,20 @@ TEST_VM_F(G1HeapVerifierTest, parse) {
   LogConfiguration::configure_stdout(LogLevel::Off, true, LOG_TAGS(gc, verify));
 
   // Default is to verify everything.
-  ASSERT_TRUE(G1HeapVerifier::should_verify(G1HeapVerifier::G1VerifyAll));
   ASSERT_TRUE(G1HeapVerifier::should_verify(G1HeapVerifier::G1VerifyYoungNormal));
   ASSERT_TRUE(G1HeapVerifier::should_verify(G1HeapVerifier::G1VerifyConcurrentStart));
   ASSERT_TRUE(G1HeapVerifier::should_verify(G1HeapVerifier::G1VerifyMixed));
+  ASSERT_TRUE(G1HeapVerifier::should_verify(G1HeapVerifier::G1VerifyYoungEvacFail));
   ASSERT_TRUE(G1HeapVerifier::should_verify(G1HeapVerifier::G1VerifyRemark));
   ASSERT_TRUE(G1HeapVerifier::should_verify(G1HeapVerifier::G1VerifyCleanup));
   ASSERT_TRUE(G1HeapVerifier::should_verify(G1HeapVerifier::G1VerifyFull));
 
   // Setting one will disable all other.
   G1HeapVerifierTest::parse_verification_type("full");
-  ASSERT_FALSE(G1HeapVerifier::should_verify(G1HeapVerifier::G1VerifyAll));
   ASSERT_FALSE(G1HeapVerifier::should_verify(G1HeapVerifier::G1VerifyYoungNormal));
   ASSERT_FALSE(G1HeapVerifier::should_verify(G1HeapVerifier::G1VerifyConcurrentStart));
   ASSERT_FALSE(G1HeapVerifier::should_verify(G1HeapVerifier::G1VerifyMixed));
+  ASSERT_FALSE(G1HeapVerifier::should_verify(G1HeapVerifier::G1VerifyYoungEvacFail));
   ASSERT_FALSE(G1HeapVerifier::should_verify(G1HeapVerifier::G1VerifyRemark));
   ASSERT_FALSE(G1HeapVerifier::should_verify(G1HeapVerifier::G1VerifyCleanup));
   ASSERT_TRUE(G1HeapVerifier::should_verify(G1HeapVerifier::G1VerifyFull));
@@ -79,7 +79,4 @@ TEST_VM_F(G1HeapVerifierTest, parse) {
   G1HeapVerifierTest::parse_verification_type("cleanup");
   ASSERT_TRUE(G1HeapVerifier::should_verify(G1HeapVerifier::G1VerifyRemark));
   ASSERT_TRUE(G1HeapVerifier::should_verify(G1HeapVerifier::G1VerifyCleanup));
-
-  // Enabling all is not the same as G1VerifyAll
-  ASSERT_FALSE(G1HeapVerifier::should_verify(G1HeapVerifier::G1VerifyAll));
 }


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that adds a new verification type (argument for `-XX:VerifyGCType` for G1) that only enables verification after an evacuation failure?

The reasons is that time and time again we have issues with evacuation failure as it's by far not tested as much as regular collection, and reproducing issues then is often hampered by that there is no way to just verify after verification failure. Enabling it just for all young collections is possible, but typically does not help much.

Fwiw, this change requires a small semantics change in how the current `VerifyGCType` is compared to the one stored as active (i.e. in `G1HeapVerifier::_enabled_verification_types`). Since the situations that can be enabled are not distinct any more (any young gc can have an evacuation failure), the existing check for a given set bit in `G1HeapVerifier::should_verify()` does not work any more.

This also means that the previous assumption that `G1VerifyType::G1VerifyAll` is not the same as all flags enabled can not be checked any more. I do not think this is any loss in functionality (see the gtests for removed checks).

The same functionality could also have been implemented by injecting all of the young gen type bits into the existing `type` on evacuation failure at the cost of remembering that the user selected evacuation failures for evacuation somewhere else. Not sure if that would be simpler. 

Testing: tier1-2 (still running), updated test

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268458](https://bugs.openjdk.java.net/browse/JDK-8268458): Add verification type for evacuation failures


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4473/head:pull/4473` \
`$ git checkout pull/4473`

Update a local copy of the PR: \
`$ git checkout pull/4473` \
`$ git pull https://git.openjdk.java.net/jdk pull/4473/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4473`

View PR using the GUI difftool: \
`$ git pr show -t 4473`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4473.diff">https://git.openjdk.java.net/jdk/pull/4473.diff</a>

</details>
