### PR TITLE
StringBuffer - appendValue() only appends the object if it's not null

### DIFF
--- a/src/java.base/share/classes/java/lang/StringBuffer.java
+++ b/src/java.base/share/classes/java/lang/StringBuffer.java
@@ -428,6 +428,18 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
         super.append(i);
         return this;
     }
+    
+     /**
+      * Only append the given object if it is not NULL. Else just return the current StringBuffer instance.
+      * @since 18
+      */
+    public synchronized StringBuffer appendValue(Object obj) {
+        if(obj != null) {
+            return append(obj);
+        } else {
+            return this;
+        }
+    }
 
     /**
      * @since 1.5


### PR DESCRIPTION
Improve StringBuffer by adding a appendValue() method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4475/head:pull/4475` \
`$ git checkout pull/4475`

Update a local copy of the PR: \
`$ git checkout pull/4475` \
`$ git pull https://git.openjdk.java.net/jdk pull/4475/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4475`

View PR using the GUI difftool: \
`$ git pr show -t 4475`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4475.diff">https://git.openjdk.java.net/jdk/pull/4475.diff</a>

</details>
