### PR TITLE
8268644: ProblemList serviceability/sa/ClhsdbJstackXcompStress.java in -Xcomp mode

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -32,3 +32,5 @@ compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java 8268033 generic-x64
 vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java 8205957 generic-all
 
 vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java 8265295 windows-x64
+
+serviceability/sa/ClhsdbJstackXcompStress.java 8268570 generic-all


### PR DESCRIPTION
A trivial fix to ProblemList serviceability/sa/ClhsdbJstackXcompStress.java in -Xcomp mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268644](https://bugs.openjdk.java.net/browse/JDK-8268644): ProblemList serviceability/sa/ClhsdbJstackXcompStress.java in -Xcomp mode


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4478/head:pull/4478` \
`$ git checkout pull/4478`

Update a local copy of the PR: \
`$ git checkout pull/4478` \
`$ git pull https://git.openjdk.java.net/jdk pull/4478/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4478`

View PR using the GUI difftool: \
`$ git pr show -t 4478`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4478.diff">https://git.openjdk.java.net/jdk/pull/4478.diff</a>

</details>
