### PR TITLE
8268638: semaphores of AsyncLogWriter may be broken when JVM is exiting.

### DIFF
--- a/src/hotspot/share/logging/logAsyncWriter.hpp
+++ b/src/hotspot/share/logging/logAsyncWriter.hpp
@@ -133,6 +133,8 @@ typedef KVHashtable<LogFileOutput*, uint32_t, mtLogging> AsyncLogMap;
 // times. It is no-op if async logging is not established.
 //
 class AsyncLogWriter : public NonJavaThread {
+  class AsyncLogLocker;
+
   static AsyncLogWriter* _instance;
   // _lock(1) denotes a critional region.
   Semaphore _lock;

--- a/src/hotspot/share/logging/logAsyncWriter.hpp
+++ b/src/hotspot/share/logging/logAsyncWriter.hpp
@@ -134,11 +134,13 @@ typedef KVHashtable<LogFileOutput*, uint32_t, mtLogging> AsyncLogMap;
 //
 class AsyncLogWriter : public NonJavaThread {
   static AsyncLogWriter* _instance;
+  // _lock(1) denotes a critional region.
+  Semaphore _lock;
   // _sem is a semaphore whose value denotes how many messages have been enqueued.
   // It decreases in AsyncLogWriter::run()
-  static Semaphore _sem;
+  Semaphore _sem;
   // A lock of IO
-  static Semaphore _io_sem;
+  Semaphore _io_sem;
 
   volatile bool _initialized;
   AsyncLogMap _stats; // statistics for dropped messages

--- a/src/hotspot/share/runtime/semaphore.hpp
+++ b/src/hotspot/share/runtime/semaphore.hpp
@@ -42,6 +42,8 @@ class JavaThread;
 
 // Implements the limited, platform independent Semaphore API.
 class Semaphore : public CHeapObj<mtSynchronizer> {
+  friend class SemaphoreLocker;
+
   SemaphoreImpl _impl;
   DEBUG_ONLY(const uint _value;)
 
@@ -58,10 +60,6 @@ class Semaphore : public CHeapObj<mtSynchronizer> {
   bool trywait()              { return _impl.trywait(); }
 
   void wait_with_safepoint_check(JavaThread* thread);
-
-#ifdef ASSERT
-  uint value() const { return _value; }
-#endif
 };
 
 #endif // SHARE_RUNTIME_SEMAPHORE_HPP

--- a/src/hotspot/share/runtime/semaphore.hpp
+++ b/src/hotspot/share/runtime/semaphore.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,11 +43,12 @@ class JavaThread;
 // Implements the limited, platform independent Semaphore API.
 class Semaphore : public CHeapObj<mtSynchronizer> {
   SemaphoreImpl _impl;
+  DEBUG_ONLY(const uint _value;)
 
   NONCOPYABLE(Semaphore);
 
  public:
-  Semaphore(uint value = 0) : _impl(value) {}
+  Semaphore(uint value = 0) : _impl(value) DEBUG_ONLY(COMMA _value(value)) {}
   ~Semaphore() {}
 
   void signal(uint count = 1) { _impl.signal(count); }
@@ -57,6 +58,10 @@ class Semaphore : public CHeapObj<mtSynchronizer> {
   bool trywait()              { return _impl.trywait(); }
 
   void wait_with_safepoint_check(JavaThread* thread);
+
+#ifndef PRODUCT
+  uint value() const { return _value; }
+#endif
 };
 
 #endif // SHARE_RUNTIME_SEMAPHORE_HPP

--- a/src/hotspot/share/runtime/semaphore.hpp
+++ b/src/hotspot/share/runtime/semaphore.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,15 +42,12 @@ class JavaThread;
 
 // Implements the limited, platform independent Semaphore API.
 class Semaphore : public CHeapObj<mtSynchronizer> {
-  friend class SemaphoreLocker;
-
   SemaphoreImpl _impl;
-  DEBUG_ONLY(const uint _value;)
 
   NONCOPYABLE(Semaphore);
 
  public:
-  Semaphore(uint value = 0) : _impl(value) DEBUG_ONLY(COMMA _value(value)) {}
+  Semaphore(uint value = 0) : _impl(value) {}
   ~Semaphore() {}
 
   void signal(uint count = 1) { _impl.signal(count); }

--- a/src/hotspot/share/runtime/semaphore.hpp
+++ b/src/hotspot/share/runtime/semaphore.hpp
@@ -59,7 +59,7 @@ class Semaphore : public CHeapObj<mtSynchronizer> {
 
   void wait_with_safepoint_check(JavaThread* thread);
 
-#ifndef PRODUCT
+#ifdef ASSERT
   uint value() const { return _value; }
 #endif
 };


### PR DESCRIPTION
All 3 semaphores used by AsyncLogWriter are static member data. CRT(`libsystem_c.dylib __cxa_finalize_ranges`) deletes them on MacOS. Currently, AsyncLog Thread doesn't exit at all. As a result, semaphore_wait/signal
returns with KERN_INVALID_NAME(15) After those semaphore are destroyed. 

This patch change those to regular data members. This prevents from deleting.
This patch also provides a general RAII class AsyncLogLocker which is analogous MutexLocker.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268638](https://bugs.openjdk.java.net/browse/JDK-8268638): semaphores of AsyncLogWriter may be broken when JVM is exiting.


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4479/head:pull/4479` \
`$ git checkout pull/4479`

Update a local copy of the PR: \
`$ git checkout pull/4479` \
`$ git pull https://git.openjdk.java.net/jdk pull/4479/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4479`

View PR using the GUI difftool: \
`$ git pr show -t 4479`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4479.diff">https://git.openjdk.java.net/jdk/pull/4479.diff</a>

</details>
