### PR TITLE
8268362: [REDO] C2 crash when compile negative Arrays.copyOf length after loop

### DIFF
--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -1758,7 +1758,7 @@ Node *AllocateArrayNode::make_ideal_length(const TypeOopPtr* oop_type, PhaseTran
       InitializeNode* init = initialization();
       assert(init != NULL, "initialization not found");
       length = new CastIINode(length, narrow_length_type);
-      length->set_req(0, init->proj_out_or_null(0));
+      length->set_req(TypeFunc::Control, init->proj_out_or_null(TypeFunc::Control));
     }
   }
 

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1187,7 +1187,9 @@ Node* GraphKit::load_array_length(Node* array) {
     alen = alloc->Ideal_length();
     Node* ccast = alloc->make_ideal_length(_gvn.type(array)->is_oopptr(), &_gvn);
     if (ccast != alen) {
-      alen = _gvn.transform(ccast);
+      _gvn.set_type_bottom(ccast);
+      record_for_igvn(ccast);
+      alen = ccast;
     }
   }
   return alen;

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4443,6 +4443,33 @@ void LibraryCallKit::arraycopy_move_allocation_here(AllocateArrayNode* alloc, No
     Node* alloc_mem = alloc->in(TypeFunc::Memory);
     C->gvn_replace_by(callprojs.fallthrough_ioproj, alloc->in(TypeFunc::I_O));
     C->gvn_replace_by(init->proj_out(TypeFunc::Memory), alloc_mem);
+
+    // The CastIINode created in GraphKit::new_array (in AllocateArrayNode::make_ideal_length) must stay below
+    // the allocation (i.e. is only valid if the allocation succeeds):
+    // 1) replace CastIINode with AllocateArrayNode's length here
+    // 2) Create CastIINode again once allocation has moved (see below) at the end of this method
+    Node* init_control = init->proj_out(TypeFunc::Control);
+    Node* alloc_length = alloc->Ideal_length();
+#ifdef ASSERT
+    Node* prev_cast = NULL;
+#endif
+    for (uint i = 0; i < init_control->outcnt(); i++) {
+      Node *init_out = init_control->raw_out(i);
+      if (init_out->is_CastII() && init_out->in(0) == init_control && init_out->in(1) == alloc_length) {
+#ifdef ASSERT
+        if (prev_cast == NULL) {
+          prev_cast = init_out;
+        } else {
+          if (prev_cast->cmp(*init_out) == false) {
+            prev_cast->dump();
+            init_out->dump();
+            assert(false, "not equal CastIINode");
+          }
+        }
+#endif
+        C->gvn_replace_by(init_out, alloc_length);
+      }
+    }
     C->gvn_replace_by(init->proj_out(TypeFunc::Control), alloc->in(0));
 
     // move the allocation here (after the guards)
@@ -4474,6 +4501,19 @@ void LibraryCallKit::arraycopy_move_allocation_here(AllocateArrayNode* alloc, No
     dest->set_req(0, control());
     Node* destx = _gvn.transform(dest);
     assert(destx == dest, "where has the allocation result gone?");
+
+    // Cast length on remaining path to be as narrow as possible
+    // previous CastNode inserted when creating AllocateArrayNode
+    // is removed in early step in LibraryCallKit::inline_arraycopy
+    Node* length = alloc->in(AllocateNode::ALength);
+    if (map()->find_edge(length) >= 0) {
+      Node* ccast = alloc->make_ideal_length(ary_type, &_gvn);
+      if (ccast != length) {
+        _gvn.set_type_bottom(ccast);
+        record_for_igvn(ccast);
+        replace_in_map(length, ccast);
+      }
+    }
   }
 }
 

--- a/test/hotspot/jtreg/compiler/c2/TestNegArrayLengthAsIndex1.java
+++ b/test/hotspot/jtreg/compiler/c2/TestNegArrayLengthAsIndex1.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8268362
+ * @requires vm.compiler2.enabled & vm.debug
+ * @summary C2 using negative array length as index, using a.length.
+ *          AllocateArrayNode::make_ideal_length create CastIINode to not negative range.
+ *          Apply transform in GraphKit::load_array_length will covert array load index type to top.
+ *          This cause assert in Parse::array_addressing, it expect index type is int.
+ * @run main/othervm -XX:-PrintCompilation compiler.c2.TestNegArrayLengthAsIndex1
+ */
+
+package compiler.c2;
+public class TestNegArrayLengthAsIndex1 {
+
+    public static void main(String[] args) throws Exception {
+        for (int i = 0; i < 10000; i++) {
+            foo();
+        }
+    }
+
+    static int foo() {
+        int minusOne = -1;
+        int[] a = null;
+        try {
+            a = new int[minusOne];
+        } catch (NegativeArraySizeException e) {
+           return 0;
+        }
+        return a[a.length - 1];
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/TestNegArrayLengthAsIndex2.java
+++ b/test/hotspot/jtreg/compiler/c2/TestNegArrayLengthAsIndex2.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8268362
+ * @requires vm.compiler2.enabled & vm.debug
+ * @summary C2 using negative array length as index, using array allocation length.
+ *          This assertion is triggered by 8267904.
+ * @run main/othervm compiler.c2.TestNegArrayLengthAsIndex2
+ */
+
+package compiler.c2;
+public class TestNegArrayLengthAsIndex2 {
+
+    public static void main(String[] args) throws Exception {
+        for (int i = 0; i < 10000; i++) {
+            foo();
+        }
+    }
+
+    static int foo() {
+        int minusOne = -1;
+        int[] a = null;
+        try {
+            a = new int[minusOne];
+        } catch (NegativeArraySizeException e) {
+           return 0;
+        }
+        return a[minusOne - 1];
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/TestNegativeArrayCopyAfterLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/TestNegativeArrayCopyAfterLoop.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8267904
+ * @requires vm.compiler2.enabled
+ * @summary C2 inline array_copy move CastIINode(Array Length) before allocation cause crash.
+ * @run main/othervm compiler.c2.TestNegativeArrayCopyAfterLoop
+ */
+
+package compiler.c2;
+import java.util.Arrays;
+
+class test {
+    public static int exp_count = 0;
+    public int in1 = -4096;
+    test (){
+        try {
+            short sha4[] = new short[1012];
+            for (int i = 0; i < sha4.length; i++) {
+              sha4[i] = 9;
+            }
+            Arrays.copyOf(sha4, in1);
+        } catch (Exception ex) {
+            exp_count++;
+        }
+    }
+}
+
+public class TestNegativeArrayCopyAfterLoop {
+    public static void main(String[] args) {
+        for (int i = 0; i < 20000; i++) {
+            new test();
+        }
+        if (test.exp_count == 20000) {
+            System.out.println("TEST PASSED");
+        }
+    }
+}


### PR DESCRIPTION
This redos PR https://github.com/openjdk/jdk/pull/4238

Some closed tests fail due to original PR, the main reasons are:
- 8268325/8268345
  - CastIINode created in AllocateArrayNode::make_ideal_length apply on a negative array length.  GVN transform converts these  CastIINode to top. This breaks assumptions, eg., array index node type is TypeInt.
- 8268345
  - Some CastIINode is created in LoadRange::Ideal, which doesn't apply GVN transform. CastIINode can not be found in GVN hashtable and cause assertion failure.

Based on previous PR https://github.com/openjdk/jdk/pull/4238, this PR unifies CastIINode processing post AllocateArrayNode::make_ideal_length. Setup type and add into igvn worklist. Avoid apply GVN transform to break different assumptions in parser.

Based on closed test failrue message, two new tests are added
1. TestNegArrayLengthAsIndex1 : fail in debug build even without previous PR https://github.com/openjdk/jdk/pull/4238, it loads a negative array length and apply GVN transform (In GraphKit::load_array_length) which covert length to top node. It also assert in Parse::array_addressing.

2. TestNegArrayLengthAsIndex2 : similar with failrue in https://bugs.openjdk.java.net/browse/JDK-8268301

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8268362](https://bugs.openjdk.java.net/browse/JDK-8268362): [REDO] C2 crash when compile negative Arrays.copyOf length after loop


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4480/head:pull/4480` \
`$ git checkout pull/4480`

Update a local copy of the PR: \
`$ git checkout pull/4480` \
`$ git pull https://git.openjdk.java.net/jdk pull/4480/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4480`

View PR using the GUI difftool: \
`$ git pr show -t 4480`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4480.diff">https://git.openjdk.java.net/jdk/pull/4480.diff</a>

</details>
