### PR TITLE
8268873: Unnecessary Vector usage in java.base

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/jar/JarIndex.java
+++ b/src/java.base/share/classes/jdk/internal/util/jar/JarIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -284,11 +284,11 @@ public class JarIndex {
     public void read(InputStream is) throws IOException {
         BufferedReader br = new BufferedReader
             (new InputStreamReader(is, UTF_8.INSTANCE));
-        String line = null;
+        String line;
         String currentJar = null;
 
         /* an ordered list of jar file names */
-        Vector<String> jars = new Vector<>();
+        ArrayList<String> jars = new ArrayList<>();
 
         /* read until we see a .jar line */
         while((line = br.readLine()) != null && !line.endsWith(".jar"));

--- a/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
@@ -39,12 +39,10 @@ import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.security.Principal;
 import java.security.cert.*;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.StringTokenizer;
-import java.util.Vector;
-
-import javax.security.auth.x500.X500Principal;
 
 import javax.net.ssl.*;
 import sun.net.www.http.HttpClient;
@@ -148,14 +146,14 @@ final class HttpsClient extends HttpClient
             ciphers = null;
         } else {
             StringTokenizer     tokenizer;
-            Vector<String>      v = new Vector<String>();
+            ArrayList<String>   v = new ArrayList<>();
 
             tokenizer = new StringTokenizer(cipherString, ",");
             while (tokenizer.hasMoreTokens())
-                v.addElement(tokenizer.nextToken());
+                v.add(tokenizer.nextToken());
             ciphers = new String [v.size()];
             for (int i = 0; i < ciphers.length; i++)
-                ciphers [i] = v.elementAt(i);
+                ciphers [i] = v.get(i);
         }
         return ciphers;
     }
@@ -172,14 +170,14 @@ final class HttpsClient extends HttpClient
             protocols = null;
         } else {
             StringTokenizer     tokenizer;
-            Vector<String>      v = new Vector<String>();
+            ArrayList<String>   v = new ArrayList<>();
 
             tokenizer = new StringTokenizer(protocolString, ",");
             while (tokenizer.hasMoreTokens())
-                v.addElement(tokenizer.nextToken());
+                v.add(tokenizer.nextToken());
             protocols = new String [v.size()];
             for (int i = 0; i < protocols.length; i++) {
-                protocols [i] = v.elementAt(i);
+                protocols [i] = v.get(i);
             }
         }
         return protocols;

--- a/src/java.base/share/classes/sun/security/pkcs/PKCS7.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -578,19 +578,18 @@ public class PKCS7 {
     public SignerInfo[] verify(byte[] bytes)
     throws NoSuchAlgorithmException, SignatureException {
 
-        Vector<SignerInfo> intResult = new Vector<>();
+        ArrayList<SignerInfo> intResult = new ArrayList<>();
         for (int i = 0; i < signerInfos.length; i++) {
 
             SignerInfo signerInfo = verify(signerInfos[i], bytes);
             if (signerInfo != null) {
-                intResult.addElement(signerInfo);
+                intResult.add(signerInfo);
             }
         }
         if (!intResult.isEmpty()) {
 
             SignerInfo[] result = new SignerInfo[intResult.size()];
-            intResult.copyInto(result);
-            return result;
+            return intResult.toArray(result);
         }
         return null;
     }


### PR DESCRIPTION
Usage of thread-safe collection `Vector` is unnecessary. It's recommended to use `ArrayList` if a thread-safe implementation is not needed. In post-BiasedLocking times, this is gets worse, as every access is synchronized.
I checked only places where `Vector` was used as local variable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268873](https://bugs.openjdk.java.net/browse/JDK-8268873): Unnecessary Vector usage in java.base


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)
 * @stsypanov (no known github.com user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4482/head:pull/4482` \
`$ git checkout pull/4482`

Update a local copy of the PR: \
`$ git checkout pull/4482` \
`$ git pull https://git.openjdk.java.net/jdk pull/4482/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4482`

View PR using the GUI difftool: \
`$ git pr show -t 4482`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4482.diff">https://git.openjdk.java.net/jdk/pull/4482.diff</a>

</details>
