### PR TITLE
8266082: AssertionError in Annotate.fromAnnotations with -Xdoclint

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/ReferenceParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/ReferenceParser.java
@@ -25,6 +25,9 @@
 
 package com.sun.tools.javac.parser;
 
+import com.sun.source.tree.AnnotatedTypeTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.util.TreeScanner;
 import com.sun.tools.javac.parser.Tokens.TokenKind;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.util.List;
@@ -193,6 +196,21 @@ public class ReferenceParser {
         if (p.token().kind != TokenKind.EOF)
             throw new ParseException("dc.ref.unexpected.input");
 
+        if (new TypeAnnotationFinder().scan(paramTypes, null) != null)
+            throw new ParseException("dc.ref.annotations.not.allowed");
+
         return paramTypes.toList();
+    }
+
+    static class TypeAnnotationFinder extends TreeScanner<Tree, Void> {
+        @Override
+        public Tree visitAnnotatedType(AnnotatedTypeTree t, Void ignore) {
+            return t;
+        }
+
+        @Override
+        public Tree reduce(Tree t1, Tree t2) {
+            return t1 != null ? t1 : t2;
+        }
     }
 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -3266,6 +3266,9 @@ compiler.err.dc.unterminated.signature=\
 compiler.err.dc.unterminated.string=\
     unterminated string
 
+compiler.err.dc.ref.annotations.not.allowed=\
+    annotations not allowed
+
 ###
 # errors related to modules
 

--- a/test/langtools/tools/doclint/CrashInAnnotateTest.java
+++ b/test/langtools/tools/doclint/CrashInAnnotateTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8266082
+ * @summary javac should not crash when seeing type annotations in links
+ * @compile/fail/ref=CrashInAnnotateTest.out -Xdoclint -XDrawDiagnostics CrashInAnnotateTest.java
+ */
+
+/** {@link #equals(@Deprecated Object)} */
+class CrashInAnnotateTest {
+}
+
+/** {@link #compare(Object, @Deprecated Object)} */
+class CrashInAnnotateTest2 {
+}
+
+/** {@link #compare(Object, List<List<@Deprecated Object>>)} */
+class CrashInAnnotateTest3 {
+}

--- a/test/langtools/tools/doclint/CrashInAnnotateTest.java
+++ b/test/langtools/tools/doclint/CrashInAnnotateTest.java
@@ -1,41 +1,27 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
- *
- * This code is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
- *
- * This code is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- * version 2 for more details (a copy is included in the LICENSE file that
- * accompanied this code).
- *
- * You should have received a copy of the GNU General Public License version
- * 2 along with this work; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- *
- * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
- * or visit www.oracle.com if you need additional information or have any
- * questions.
- */
-
-/*
- * @test
+ * @test /nodynamiccopyright/
  * @bug 8266082
  * @summary javac should not crash when seeing type annotations in links
  * @compile/fail/ref=CrashInAnnotateTest.out -Xdoclint -XDrawDiagnostics CrashInAnnotateTest.java
  */
 
+import java.util.List;
+
 /** {@link #equals(@Deprecated Object)} */
 class CrashInAnnotateTest {
 }
 
-/** {@link #compare(Object, @Deprecated Object)} */
+/** {@link #compare(Object, List<List<@Deprecated Object>>)} */
 class CrashInAnnotateTest2 {
+    void compare(Object o, List<List<Object>> l) {}
 }
 
-/** {@link #compare(Object, List<List<@Deprecated Object>>)} */
-class CrashInAnnotateTest3 {
+/** {@link java.lang.@Deprecated Object#hashCode()} */
+class CrashInAnnotateTest3 { }
+
+/** {@link CrashInAnnotateTest4.@Deprecated Inner#aField} */
+class CrashInAnnotateTest4 {
+    class Inner {
+        Object aField;
+    }
 }

--- a/test/langtools/tools/doclint/CrashInAnnotateTest.java
+++ b/test/langtools/tools/doclint/CrashInAnnotateTest.java
@@ -7,7 +7,9 @@
 
 import java.util.List;
 
-/** {@link #equals(@Deprecated Object)} */
+/** {@link #equals(@Deprecated Object)}
+ *  {@link Map.@Deprecated Entry#getKey()}
+ */
 class CrashInAnnotateTest {
 }
 
@@ -16,10 +18,10 @@ class CrashInAnnotateTest2 {
     void compare(Object o, List<List<Object>> l) {}
 }
 
-/** {@link java.lang.@Deprecated Object#hashCode()} */
+/** {@link @Deprecated java.lang.Object#hashCode()} */
 class CrashInAnnotateTest3 { }
 
-/** {@link CrashInAnnotateTest4.@Deprecated Inner#aField} */
+/** {@link CrashInAnnotateTest4.@java.lang.Deprecated Inner#aField} */
 class CrashInAnnotateTest4 {
     class Inner {
         Object aField;

--- a/test/langtools/tools/doclint/CrashInAnnotateTest.java
+++ b/test/langtools/tools/doclint/CrashInAnnotateTest.java
@@ -8,7 +8,7 @@
 import java.util.List;
 
 /** {@link #equals(@Deprecated Object)}
- *  {@link Map.@Deprecated Entry#getKey()}
+ *  {@link java.util.Map.@Deprecated Entry#getKey()}
  */
 class CrashInAnnotateTest {
 }
@@ -21,7 +21,9 @@ class CrashInAnnotateTest2 {
 /** {@link @Deprecated java.lang.Object#hashCode()} */
 class CrashInAnnotateTest3 { }
 
-/** {@link CrashInAnnotateTest4.@java.lang.Deprecated Inner#aField} */
+/** {@link CrashInAnnotateTest4.@java.lang.Deprecated Inner#aField}
+ *  {@link java.util.Map.@Deprecated#getKey()}
+ */
 class CrashInAnnotateTest4 {
     class Inner {
         Object aField;

--- a/test/langtools/tools/doclint/CrashInAnnotateTest.out
+++ b/test/langtools/tools/doclint/CrashInAnnotateTest.out
@@ -1,4 +1,9 @@
-CrashInAnnotateTest.java:31:5: compiler.err.proc.messager: annotations not allowed
-CrashInAnnotateTest.java:35:5: compiler.err.proc.messager: annotations not allowed
-CrashInAnnotateTest.java:39:5: compiler.err.proc.messager: annotations not allowed
-3 errors
+CrashInAnnotateTest.java:10:5: compiler.err.proc.messager: annotations not allowed
+CrashInAnnotateTest.java:14:5: compiler.err.proc.messager: annotations not allowed
+CrashInAnnotateTest.java:16:10: compiler.warn.proc.messager: no comment
+CrashInAnnotateTest.java:19:5: compiler.err.proc.messager: syntax error in reference
+CrashInAnnotateTest.java:22:5: compiler.err.proc.messager: syntax error in reference
+CrashInAnnotateTest.java:24:5: compiler.warn.proc.messager: no comment
+CrashInAnnotateTest.java:25:16: compiler.warn.proc.messager: no comment
+4 errors
+3 warnings

--- a/test/langtools/tools/doclint/CrashInAnnotateTest.out
+++ b/test/langtools/tools/doclint/CrashInAnnotateTest.out
@@ -1,9 +1,10 @@
 CrashInAnnotateTest.java:10:5: compiler.err.proc.messager: annotations not allowed
-CrashInAnnotateTest.java:14:5: compiler.err.proc.messager: annotations not allowed
-CrashInAnnotateTest.java:16:10: compiler.warn.proc.messager: no comment
-CrashInAnnotateTest.java:19:5: compiler.err.proc.messager: syntax error in reference
-CrashInAnnotateTest.java:22:5: compiler.err.proc.messager: syntax error in reference
-CrashInAnnotateTest.java:24:5: compiler.warn.proc.messager: no comment
-CrashInAnnotateTest.java:25:16: compiler.warn.proc.messager: no comment
-4 errors
+CrashInAnnotateTest.java:11:5: compiler.err.proc.messager: syntax error in reference
+CrashInAnnotateTest.java:16:5: compiler.err.proc.messager: annotations not allowed
+CrashInAnnotateTest.java:18:10: compiler.warn.proc.messager: no comment
+CrashInAnnotateTest.java:21:5: compiler.err.proc.messager: syntax error in reference
+CrashInAnnotateTest.java:24:5: compiler.err.proc.messager: syntax error in reference
+CrashInAnnotateTest.java:26:5: compiler.warn.proc.messager: no comment
+CrashInAnnotateTest.java:27:16: compiler.warn.proc.messager: no comment
+5 errors
 3 warnings

--- a/test/langtools/tools/doclint/CrashInAnnotateTest.out
+++ b/test/langtools/tools/doclint/CrashInAnnotateTest.out
@@ -1,0 +1,4 @@
+CrashInAnnotateTest.java:31:5: compiler.err.proc.messager: annotations not allowed
+CrashInAnnotateTest.java:35:5: compiler.err.proc.messager: annotations not allowed
+CrashInAnnotateTest.java:39:5: compiler.err.proc.messager: annotations not allowed
+3 errors

--- a/test/langtools/tools/doclint/CrashInAnnotateTest.out
+++ b/test/langtools/tools/doclint/CrashInAnnotateTest.out
@@ -4,7 +4,8 @@ CrashInAnnotateTest.java:16:5: compiler.err.proc.messager: annotations not allow
 CrashInAnnotateTest.java:18:10: compiler.warn.proc.messager: no comment
 CrashInAnnotateTest.java:21:5: compiler.err.proc.messager: syntax error in reference
 CrashInAnnotateTest.java:24:5: compiler.err.proc.messager: syntax error in reference
-CrashInAnnotateTest.java:26:5: compiler.warn.proc.messager: no comment
-CrashInAnnotateTest.java:27:16: compiler.warn.proc.messager: no comment
-5 errors
+CrashInAnnotateTest.java:25:5: compiler.err.proc.messager: syntax error in reference
+CrashInAnnotateTest.java:28:5: compiler.warn.proc.messager: no comment
+CrashInAnnotateTest.java:29:16: compiler.warn.proc.messager: no comment
+6 errors
 3 warnings

--- a/test/langtools/tools/javac/diags/examples/NoAnnotationsInLink.java
+++ b/test/langtools/tools/javac/diags/examples/NoAnnotationsInLink.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.err.dc.ref.annotations.not.allowed
+// key: compiler.note.note
+// key: compiler.note.proc.messager
+// run: backdoor
+// options: -processor DocCommentProcessor -proc:only
+
+/** {@link #equals(@Deprecated Object)} */
+class NoAnnotationsInLink {
+}


### PR DESCRIPTION
Javac crashes in Annotate when a javadoc reference contains an annotated type, since attribType expects type annotations to have been attributed.

This proposed fix checks references at parse time to disallow annotated types instead of crashing later on.

Since the exact type of error is known I opted for a new error message to make it easier for the developer to see what is wrong.

Since this affects javac at least as far back as jdk 11 and we are past RDP1 I targeted this for 18.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266082](https://bugs.openjdk.java.net/browse/JDK-8266082): AssertionError in Annotate.fromAnnotations with -Xdoclint


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4483/head:pull/4483` \
`$ git checkout pull/4483`

Update a local copy of the PR: \
`$ git checkout pull/4483` \
`$ git pull https://git.openjdk.java.net/jdk pull/4483/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4483`

View PR using the GUI difftool: \
`$ git pr show -t 4483`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4483.diff">https://git.openjdk.java.net/jdk/pull/4483.diff</a>

</details>
