### PR TITLE
8268647: Generation::expand_and_allocate has unused "parallel" argument

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -495,7 +495,7 @@ HeapWord* DefNewGeneration::allocate_from_space(size_t size) {
   return result;
 }
 
-HeapWord* DefNewGeneration::expand_and_allocate(size_t size, bool   is_tlab) {
+HeapWord* DefNewGeneration::expand_and_allocate(size_t size, bool is_tlab) {
   // We don't attempt to expand the young generation (but perhaps we should.)
   return allocate(size, is_tlab);
 }

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -495,9 +495,7 @@ HeapWord* DefNewGeneration::allocate_from_space(size_t size) {
   return result;
 }
 
-HeapWord* DefNewGeneration::expand_and_allocate(size_t size,
-                                                bool   is_tlab,
-                                                bool   parallel) {
+HeapWord* DefNewGeneration::expand_and_allocate(size_t size, bool   is_tlab) {
   // We don't attempt to expand the young generation (but perhaps we should.)
   return allocate(size, is_tlab);
 }

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -308,9 +308,8 @@ protected:
                        bool   clear_all_soft_refs,
                        size_t size,
                        bool   is_tlab);
-  HeapWord* expand_and_allocate(size_t size,
-                                bool is_tlab,
-                                bool parallel = false);
+
+  HeapWord* expand_and_allocate(size_t size, bool is_tlab);
 
   oop copy_to_survivor_space(oop old);
   uint tenuring_threshold() { return _tenuring_threshold; }

--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -188,34 +188,10 @@ void TenuredGeneration::collect(bool   full,
 }
 
 HeapWord*
-TenuredGeneration::expand_and_allocate(size_t word_size,
-                                       bool is_tlab,
-                                       bool parallel) {
+TenuredGeneration::expand_and_allocate(size_t word_size, bool is_tlab) {
   assert(!is_tlab, "TenuredGeneration does not support TLAB allocation");
-  if (parallel) {
-    MutexLocker x(ParGCRareEvent_lock);
-    HeapWord* result = NULL;
-    size_t byte_size = word_size * HeapWordSize;
-    while (true) {
-      expand(byte_size, _min_heap_delta_bytes);
-      if (GCExpandToAllocateDelayMillis > 0) {
-        os::naked_sleep(GCExpandToAllocateDelayMillis);
-      }
-      result = _the_space->par_allocate(word_size);
-      if ( result != NULL) {
-        return result;
-      } else {
-        // If there's not enough expansion space available, give up.
-        if (_virtual_space.uncommitted_size() < byte_size) {
-          return NULL;
-        }
-        // else try again
-      }
-    }
-  } else {
-    expand(word_size*HeapWordSize, _min_heap_delta_bytes);
-    return _the_space->allocate(word_size);
-  }
+  expand(word_size*HeapWordSize, _min_heap_delta_bytes);
+  return _the_space->allocate(word_size);
 }
 
 bool TenuredGeneration::expand(size_t bytes, size_t expand_bytes) {

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,9 +93,7 @@ class TenuredGeneration: public CardGeneration {
                        size_t size,
                        bool is_tlab);
 
-  HeapWord* expand_and_allocate(size_t size,
-                                bool is_tlab,
-                                bool parallel = false);
+  HeapWord* expand_and_allocate(size_t size, bool is_tlab);
 
   virtual void prepare_for_verify();
 

--- a/src/hotspot/share/gc/shared/generation.hpp
+++ b/src/hotspot/share/gc/shared/generation.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -333,9 +333,7 @@ class Generation: public CHeapObj<mtGC> {
   // successful, perform the allocation and return the resulting
   // "oop" (initializing the allocated block). If the allocation is
   // still unsuccessful, return "NULL".
-  virtual HeapWord* expand_and_allocate(size_t word_size,
-                                        bool is_tlab,
-                                        bool parallel = false) = 0;
+  virtual HeapWord* expand_and_allocate(size_t word_size, bool is_tlab) = 0;
 
   // Some generations may require some cleanup or preparation actions before
   // allowing a collection.  The default is to do nothing.


### PR DESCRIPTION
Please review this simplification of the Generation class and the classes
derived from it.  There are no callers of expand_and_allocate that pass the
third argument explicitly, so its value is always the default (false) value.

This change removes the argument and updates the two implementations of this
virtual function accordingly.

[The "parallel" argument is probably a leftover from CMS support.]

Testing:
mach5 tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268647](https://bugs.openjdk.java.net/browse/JDK-8268647): Generation::expand_and_allocate has unused "parallel" argument


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Committer) ⚠️ Review applies to 9de6004aa5f28c740350baa9bc44675fa815caf5
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 9de6004aa5f28c740350baa9bc44675fa815caf5


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4485/head:pull/4485` \
`$ git checkout pull/4485`

Update a local copy of the PR: \
`$ git checkout pull/4485` \
`$ git pull https://git.openjdk.java.net/jdk pull/4485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4485`

View PR using the GUI difftool: \
`$ git pr show -t 4485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4485.diff">https://git.openjdk.java.net/jdk/pull/4485.diff</a>

</details>
