### PR TITLE
8269130: Replace usages of Collection.toArray() with Collection.toArray(T[]) to avoid redundant array copying

### DIFF
--- a/src/java.base/share/classes/java/security/Security.java
+++ b/src/java.base/share/classes/java/security/Security.java
@@ -653,14 +653,7 @@ public final class Security {
         if (candidates == null || candidates.isEmpty())
             return null;
 
-        Object[] candidatesArray = candidates.toArray();
-        Provider[] result = new Provider[candidatesArray.length];
-
-        for (int i = 0; i < result.length; i++) {
-            result[i] = (Provider)candidatesArray[i];
-        }
-
-        return result;
+        return candidates.toArray(new Provider[0]);
     }
 
     // Map containing cached Spi Class objects of the specified type

--- a/src/java.base/share/classes/sun/security/pkcs/PKCS9Attributes.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS9Attributes.java
@@ -241,10 +241,8 @@ public class PKCS9Attributes {
 
     private byte[] generateDerEncoding() throws IOException {
         DerOutputStream out = new DerOutputStream();
-        Object[] attribVals = attributes.values().toArray();
-
-        out.putOrderedSetOf(DerValue.tag_SetOf,
-                            castToDerEncoder(attribVals));
+        DerEncoder[] attribVals = attributes.values().toArray(new DerEncoder[0]);
+        out.putOrderedSetOf(DerValue.tag_SetOf, attribVals);
         return out.toByteArray();
     }
 
@@ -348,17 +346,4 @@ public class PKCS9Attributes {
         return sb.toString();
     }
 
-    /**
-     * Cast an object array whose components are
-     * <code>DerEncoder</code>s to <code>DerEncoder[]</code>.
-     */
-    static DerEncoder[] castToDerEncoder(Object[] objs) {
-
-        DerEncoder[] encoders = new DerEncoder[objs.length];
-
-        for (int i=0; i < encoders.length; i++)
-            encoders[i] = (DerEncoder) objs[i];
-
-        return encoders;
-    }
 }

--- a/src/java.base/share/classes/sun/security/pkcs/PKCS9Attributes.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS9Attributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/sun/font/SunFontManager.java
+++ b/src/java.desktop/share/classes/sun/font/SunFontManager.java
@@ -3352,14 +3352,7 @@ public abstract class SunFontManager implements FontSupport, FontManagerForSGE {
                 }
             }
 
-            String[] fontNames = null;
-            if (fontMapNames.size() > 0) {
-                fontNames = new String[fontMapNames.size()];
-                Object [] keyNames = fontMapNames.keySet().toArray();
-                for (int i=0; i < keyNames.length; i++) {
-                    fontNames[i] = (String)keyNames[i];
-                }
-            }
+            String[] fontNames = fontMapNames.keySet().toArray(new String[0]);
             Font[] fonts = new Font[fontNames.length];
             for (int i=0; i < fontNames.length; i++) {
                 fonts[i] = new Font(fontNames[i], Font.PLAIN, 1);
@@ -3428,11 +3421,7 @@ public abstract class SunFontManager implements FontSupport, FontManagerForSGE {
         // Add any native font family names here
         addNativeFontFamilyNames(familyNames, requestedLocale);
 
-        String[] retval =  new String[familyNames.size()];
-        Object [] keyNames = familyNames.keySet().toArray();
-        for (int i=0; i < keyNames.length; i++) {
-            retval[i] = familyNames.get(keyNames[i]);
-        }
+        String[] retval = familyNames.values().toArray(new String[0]);
         if (requestedLocale.equals(Locale.getDefault())) {
             lastDefaultLocale = requestedLocale;
             allFamilies = new String[retval.length];

--- a/src/java.desktop/share/classes/sun/java2d/SunGraphicsEnvironment.java
+++ b/src/java.desktop/share/classes/sun/java2d/SunGraphicsEnvironment.java
@@ -188,7 +188,7 @@ public abstract class SunGraphicsEnvironment extends GraphicsEnvironment
                 map.put(installed[i].toLowerCase(requestedLocale),
                         installed[i]);
             }
-            String[] retval = map.keySet().toArray(new String[0]);
+            String[] retval = map.values().toArray(new String[0]);
             return retval;
         }
     }

--- a/src/java.desktop/share/classes/sun/java2d/SunGraphicsEnvironment.java
+++ b/src/java.desktop/share/classes/sun/java2d/SunGraphicsEnvironment.java
@@ -188,11 +188,7 @@ public abstract class SunGraphicsEnvironment extends GraphicsEnvironment
                 map.put(installed[i].toLowerCase(requestedLocale),
                         installed[i]);
             }
-            String[] retval =  new String[map.size()];
-            Object [] keyNames = map.keySet().toArray();
-            for (int i=0; i < keyNames.length; i++) {
-                retval[i] = map.get(keyNames[i]);
-            }
+            String[] retval = map.keySet().toArray(new String[0]);
             return retval;
         }
     }

--- a/src/java.desktop/windows/classes/sun/awt/windows/WDesktopProperties.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WDesktopProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/windows/classes/sun/awt/windows/WDesktopProperties.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WDesktopProperties.java
@@ -89,12 +89,7 @@ final class WDesktopProperties {
      * Returns String[] containing available property names
      */
     private String [] getKeyNames() {
-        Object[]  keys = map.keySet().toArray();
-        String[]  sortedKeys = new String[keys.length];
-
-        for ( int nkey = 0; nkey < keys.length; nkey++ ) {
-            sortedKeys[nkey] = keys[nkey].toString();
-        }
+        String[] sortedKeys = map.keySet().toArray(new String[0]);
         Arrays.sort(sortedKeys);
         return sortedKeys;
     }

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/JoinRowSetImpl.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/JoinRowSetImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/JoinRowSetImpl.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/JoinRowSetImpl.java
@@ -427,13 +427,7 @@ public class JoinRowSetImpl extends WebRowSetImpl implements JoinRowSet {
      * @see CachedRowSet#setTableName
      */
     public String[] getRowSetNames() throws SQLException {
-        Object [] arr = vecTableNames.toArray();
-        String []strArr = new String[arr.length];
-
-        for( int i = 0;i < arr.length; i++) {
-           strArr[i] = arr[i].toString();
-        }
-
+        String[] strArr = vecTableNames.toArray(new String[0]);
         return strArr;
     }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PStack.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PStack.java
@@ -234,8 +234,7 @@ public class PStack extends Tool {
             // after printing stack trace.
             exp.printStackTrace();
          }
-         JavaVFrame[] jvframes = new JavaVFrame[tmp.size()];
-         System.arraycopy(tmp.toArray(), 0, jvframes, 0, jvframes.length);
+         JavaVFrame[] jvframes = tmp.toArray(new JavaVFrame[0]);
          jframeCache.put(cur.getThreadProxy(), jvframes);
          proxyToThread.put(cur.getThreadProxy(), cur);
       }
@@ -286,8 +285,7 @@ public class PStack extends Tool {
             names.add(sb.toString());
          }
       }
-      String[] res = new String[names.size()];
-      System.arraycopy(names.toArray(), 0, res, 0, res.length);
+      String[] res = names.toArray(new String[0]);
       return res;
    }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/SystemDictionaryHelper.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/SystemDictionaryHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/SystemDictionaryHelper.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/SystemDictionaryHelper.java
@@ -65,9 +65,7 @@ public class SystemDictionaryHelper {
                         }
                      });
 
-      Object[] tmpArray = tmp.toArray();
-      klasses = new InstanceKlass[tmpArray.length];
-      System.arraycopy(tmpArray, 0, klasses, 0, tmpArray.length);
+      klasses = tmp.toArray(new InstanceKlass[0]);
       Arrays.sort(klasses, new Comparator<>() {
                           public int compare(InstanceKlass k1, InstanceKlass k2) {
                              Symbol s1 = k1.getName();
@@ -91,9 +89,7 @@ public class SystemDictionaryHelper {
          }
       }
 
-      Object[] tmpArray = tmp.toArray();
-      InstanceKlass[] searchResult = new InstanceKlass[tmpArray.length];
-      System.arraycopy(tmpArray, 0, searchResult, 0, tmpArray.length);
+      InstanceKlass[] searchResult = tmp.toArray(new InstanceKlass[0]);
       return searchResult;
    }
 


### PR DESCRIPTION
I found few places, where code initially perform `Object[] Colleciton.toArray()` call and then manually copy array into another array with required type.
This PR cleanups such places to more shorter call `T[] Collection.toArray(T[])`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269130](https://bugs.openjdk.java.net/browse/JDK-8269130): Replace usages of Collection.toArray() with Collection.toArray(T[]) to avoid redundant array copying


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4487/head:pull/4487` \
`$ git checkout pull/4487`

Update a local copy of the PR: \
`$ git checkout pull/4487` \
`$ git pull https://git.openjdk.java.net/jdk pull/4487/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4487`

View PR using the GUI difftool: \
`$ git pr show -t 4487`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4487.diff">https://git.openjdk.java.net/jdk/pull/4487.diff</a>

</details>
