### PR TITLE
8268727: Remove unused slowpath locking method in OptoRuntime

### DIFF
--- a/src/hotspot/share/opto/runtime.hpp
+++ b/src/hotspot/share/opto/runtime.hpp
@@ -170,10 +170,6 @@ class OptoRuntime : public AllStatic {
   static void multianewarrayN_C(Klass* klass, arrayOopDesc* dims, JavaThread* current);
 
 public:
-  // Slow-path Locking and Unlocking
-  static void complete_monitor_locking_C(oopDesc* obj, BasicLock* lock, JavaThread* thread);
-  static void complete_monitor_unlocking_C(oopDesc* obj, BasicLock* lock, JavaThread* thread);
-
   static void monitor_notify_C(oopDesc* obj, JavaThread* current);
   static void monitor_notifyAll_C(oopDesc* obj, JavaThread* current);
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268727](https://bugs.openjdk.java.net/browse/JDK-8268727): Remove unused slowpath locking method in OptoRuntime


### Reviewers
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4490/head:pull/4490` \
`$ git checkout pull/4490`

Update a local copy of the PR: \
`$ git checkout pull/4490` \
`$ git pull https://git.openjdk.java.net/jdk pull/4490/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4490`

View PR using the GUI difftool: \
`$ git pr show -t 4490`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4490.diff">https://git.openjdk.java.net/jdk/pull/4490.diff</a>

</details>
