### PR TITLE
8268764: Use Long.hashCode() instead of int-cast where applicable

### DIFF
--- a/src/java.desktop/share/classes/com/sun/media/sound/DLSSoundbank.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/DLSSoundbank.java
@@ -103,7 +103,7 @@ public final class DLSSoundbank implements Soundbank {
 
         @Override
         public int hashCode() {
-            return (int)i1;
+            return Long.hashCode(i1);
         }
 
         @Override

--- a/src/java.desktop/share/classes/com/sun/media/sound/WaveExtensibleFileReader.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/WaveExtensibleFileReader.java
@@ -91,7 +91,7 @@ public final class WaveExtensibleFileReader extends SunFileReader {
 
         @Override
         public int hashCode() {
-            return (int) i1;
+            return Long.hashCode(i1);
         }
 
         @Override

--- a/src/java.rmi/share/classes/java/rmi/server/ObjID.java
+++ b/src/java.rmi/share/classes/java/rmi/server/ObjID.java
@@ -199,8 +199,9 @@ public final class ObjID implements Serializable {
      *
      * @return  the hash code value for this object identifier
      */
+    @Override
     public int hashCode() {
-        return (int) objNum;
+        return Long.hashCode(objNum);
     }
 
     /**

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethodImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethodImpl.java
@@ -175,7 +175,7 @@ final class HotSpotResolvedJavaMethodImpl extends HotSpotMethod implements HotSp
 
     @Override
     public int hashCode() {
-        return (int) getMetaspaceMethod();
+        return Long.hashCode(getMetaspaceMethod());
     }
 
     /**

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/FieldImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/FieldImpl.java
@@ -51,8 +51,9 @@ public class FieldImpl extends TypeComponentImpl
         }
     }
 
+    @Override
     public int hashCode() {
-        return (int)ref();
+        return Long.hashCode(ref());
     }
 
     public int compareTo(Field field) {

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/MethodImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/MethodImpl.java
@@ -95,8 +95,9 @@ public abstract class MethodImpl extends TypeComponentImpl
         }
     }
 
+    @Override
     public int hashCode() {
-        return (int)ref();
+        return Long.hashCode(ref());
     }
 
     public final List<Location> allLineLocations()

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/ObjectReferenceImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/ObjectReferenceImpl.java
@@ -155,8 +155,9 @@ public class ObjectReferenceImpl extends ValueImpl
         }
     }
 
+    @Override
     public int hashCode() {
-        return(int)ref();
+        return Long.hashCode(ref());
     }
 
     public Type type() {

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/ReferenceTypeImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/ReferenceTypeImpl.java
@@ -152,8 +152,9 @@ public abstract class ReferenceTypeImpl extends TypeImpl implements ReferenceTyp
         }
     }
 
+    @Override
     public int hashCode() {
-        return(int)ref();
+        return Long.hashCode(ref());
     }
 
     public int compareTo(ReferenceType object) {

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/NTNumericCredential.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/NTNumericCredential.java
@@ -100,7 +100,8 @@ public class NTNumericCredential {
      *
      * @return a hash code for this {@code NTNumericCredential}.
      */
+    @Override
     public int hashCode() {
-        return (int)this.impersonationToken;
+        return Long.hashCode(this.impersonationToken);
     }
 }


### PR DESCRIPTION
In some JDK classes there's still the following hashCode() implementation:
```java
long objNum;

public int hashCode() {
    return (int) objNum;
}
```
This outdated expression should be replaced with Long.hashCode(long) as it

- uses all bits of the original value, does not discard any information upfront. For example, depending on how you are generating the IDs, the upper bits could change more frequently (or the opposite).

- does not introduce any bias towards values with more ones (zeros), as it would be the case if the two halves were combined with an OR (AND) operation.

See https://stackoverflow.com/a/4045083

This is related to https://github.com/openjdk/jdk/pull/4309