### PR TITLE
8268778: CDS check_excluded_classes needs DumpTimeTable_lock

### DIFF
--- a/src/hotspot/share/cds/dynamicArchive.cpp
+++ b/src/hotspot/share/cds/dynamicArchive.cpp
@@ -107,9 +107,11 @@ public:
 
     verify_universe("Before CDS dynamic dump");
     DEBUG_ONLY(SystemDictionaryShared::NoClassLoadingMark nclm);
+
+    // Block concurrent class unloading from changing the _dumptime_table
+    MutexLocker ml(DumpTimeTable_lock, Mutex::_no_safepoint_check_flag);
     SystemDictionaryShared::check_excluded_classes();
 
-    MutexLocker ml(DumpTimeTable_lock, Mutex::_no_safepoint_check_flag);
     init_header();
     gather_source_objs();
     reserve_buffer();

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -484,12 +484,10 @@ void VM_PopulateDumpSharedSpace::doit() {
 
   NOT_PRODUCT(SystemDictionary::verify();)
 
-  // At this point, many classes have been loaded.
-  // Gather systemDictionary classes in a global array and do everything to
-  // that so we don't have to walk the SystemDictionary again.
+  // Block concurrent class unloading from changing the _dumptime_table
+  MutexLocker ml(DumpTimeTable_lock, Mutex::_no_safepoint_check_flag);
   SystemDictionaryShared::check_excluded_classes();
 
-  MutexLocker ml(DumpTimeTable_lock, Mutex::_no_safepoint_check_flag);
   StaticArchiveBuilder builder;
   builder.gather_source_objs();
   builder.reserve_buffer();

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -1485,6 +1485,8 @@ public:
 };
 
 void SystemDictionaryShared::check_excluded_classes() {
+  assert(no_class_loading_should_happen(), "sanity");
+  assert_lock_strong(DumpTimeTable_lock);
   ExcludeDumpTimeSharedClasses excl;
   _dumptime_table->iterate(&excl);
   _dumptime_table->update_counts();


### PR DESCRIPTION
Fixing a mistake in https://git.openjdk.java.net/jdk/pull/4322

`SystemDictionaryShared::check_excluded_classes()` iterates over `_dumptime_table`, so we must hold the `DumpTimeTable_lock` first. Otherwise concurrent class unloading may be modifying the `_dumptime_table` while we are still iterating it.

I also removed an outdated comment.

(This fix should be backported to JDK 17, but I want to have some mileage on it in the JDK 18 repo first.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268778](https://bugs.openjdk.java.net/browse/JDK-8268778): CDS check_excluded_classes needs DumpTimeTable_lock


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4494/head:pull/4494` \
`$ git checkout pull/4494`

Update a local copy of the PR: \
`$ git checkout pull/4494` \
`$ git pull https://git.openjdk.java.net/jdk pull/4494/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4494`

View PR using the GUI difftool: \
`$ git pr show -t 4494`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4494.diff">https://git.openjdk.java.net/jdk/pull/4494.diff</a>

</details>
