### PR TITLE
8268780: Use 'print_cr' instead of 'print' for the message 'eliminated <owner is scalar replaced>'

### DIFF
--- a/src/hotspot/share/runtime/vframe.cpp
+++ b/src/hotspot/share/runtime/vframe.cpp
@@ -235,7 +235,7 @@ void javaVFrame::print_lock_info_on(outputStream* st, int frame_count) {
       if (monitor->eliminated() && is_compiled_frame()) { // Eliminated in compiled code
         if (monitor->owner_is_scalar_replaced()) {
           Klass* k = java_lang_Class::as_Klass(monitor->owner_klass());
-          st->print("\t- eliminated <owner is scalar replaced> (a %s)", k->external_name());
+          st->print_cr("\t- eliminated <owner is scalar replaced> (a %s)", k->external_name());
         } else {
           Handle obj(current, monitor->owner());
           if (obj() != NULL) {


### PR DESCRIPTION
Hi,

Cound I have a review of this small fix that adds a line feed for the message 'eliminated <owner is scalar replaced>'.

When we run the following code and run `jstack <pid>`

```
    public static void main(String[] args) {
        for (int i = 0; i < 200000000; i++) {
            try {
                test();
            } catch (Exception e) {
            }
        }
    }

    private static void test() throws Exception {
        Object obj = new Object();
        synchronized (obj) {
            throw new Exception();
        }
    }
```

We could find that a frame that does not wrap properly.
```
"main" #1 prio=5 os_prio=0 cpu=53202.88ms elapsed=54.10s tid=0x00007f8c2c022550 nid=0x4743 runnable  [0x00007f8c35ac2000]
   java.lang.Thread.State: RUNNABLE
        at java.lang.Throwable.fillInStackTrace(java.base@17-internal/Native Method)
        at java.lang.Throwable.fillInStackTrace(java.base@17-internal/Throwable.java:798)
        - locked <0x00000000f3b00340> (a java.lang.Exception)
        at java.lang.Throwable.<init>(java.base@17-internal/Throwable.java:256)
        at java.lang.Exception.<init>(java.base@17-internal/Exception.java:55)
        at Test.test(Test.java:14)
        - eliminated <owner is scalar replaced> (a java.lang.Object)    at Test.main(Test.java:5)
```

Also, I noticed that this message has a correct line feed in the implementation of JavaVFrame.java.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268780](https://bugs.openjdk.java.net/browse/JDK-8268780): Use 'print_cr' instead of 'print' for the message 'eliminated <owner is scalar replaced>'


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4495/head:pull/4495` \
`$ git checkout pull/4495`

Update a local copy of the PR: \
`$ git checkout pull/4495` \
`$ git pull https://git.openjdk.java.net/jdk pull/4495/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4495`

View PR using the GUI difftool: \
`$ git pr show -t 4495`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4495.diff">https://git.openjdk.java.net/jdk/pull/4495.diff</a>

</details>
