### PR TITLE
8268720: Unspecified checks on NameAndType constants should not be performed

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -694,13 +694,14 @@ void ClassFileParser::parse_constant_pool(const ClassFileStream* const stream,
           }
         } else {
           if (_need_verify) {
-            // Method name and signature are verified above, when iterating NameAndType_info.
-            // Need only to be sure signature is non-zero length and the right type.
+            // Method name and signature are individually verified above, when iterating
+            // NameAndType_info.  Need to check here that signature is non-zero length and
+            // the right type.
             if (!Signature::is_method(signature)) {
               throwIllegalSignature("Method", name, signature, CHECK);
             }
           }
-          // 4509014: If a class method name begins with '<', it must be "<init>"
+          // If a class method name begins with '<', it must be "<init>" and have void signature.
           const unsigned int name_len = name->utf8_length();
           if (tag == JVM_CONSTANT_Methodref && name_len != 0 &&
               name->char_at(0) == JVM_SIGNATURE_SPECIAL) {
@@ -709,9 +710,8 @@ void ClassFileParser::parse_constant_pool(const ClassFileStream* const stream,
                 "Bad method name at constant pool index %u in class file %s",
                 name_ref_index, THREAD);
               return;
-            } else if (!Signature::is_void_method(signature)) { // must have void return
+            } else if (!Signature::is_void_method(signature)) { // must have void signature.
               throwIllegalSignature("Method", name, signature, CHECK);
-              return;
             }
           }
         }

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -5053,8 +5053,6 @@ void ClassFileParser::verify_legal_name_with_signature(const Symbol* name,
                                                        const Symbol* signature,
                                                        TRAPS) const {
   if (!_need_verify) {
-    // make sure caller's args_size will be less than 0 even for non-static
-    // method so it will be recomputed in compute_size_of_parameters().
     return;
   }
 

--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -461,6 +461,7 @@ class ClassFileParser {
                                     TRAPS) const;
   int  verify_legal_method_signature(const Symbol* methodname,
                                      const Symbol* signature,
+                                     bool check_compatibility,
                                      TRAPS) const;
 
   void verify_class_version(u2 major, u2 minor, Symbol* class_name, TRAPS);

--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -461,8 +461,10 @@ class ClassFileParser {
                                     TRAPS) const;
   int  verify_legal_method_signature(const Symbol* methodname,
                                      const Symbol* signature,
-                                     bool check_compatibility,
                                      TRAPS) const;
+  void verify_legal_name_with_signature(const Symbol* name,
+                                        const Symbol* signature,
+                                        TRAPS) const;
 
   void verify_class_version(u2 major, u2 minor, Symbol* class_name, TRAPS);
 

--- a/test/hotspot/jtreg/runtime/classFileParserBug/NameAndTypeSig.java
+++ b/test/hotspot/jtreg/runtime/classFileParserBug/NameAndTypeSig.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8268720
+ * @summary Constant pool NameAndType entries with valid but incompatible method
+ *          name and signature shouldn't cause an exception until referenced by
+ *          a method_ref.
+ * @compile nonVoidInitSig.jcod
+ * @run main/othervm -Xverify:remote NameAndTypeSig
+ */
+
+// Test constant pool NameAndType descriptors with valid but incompatible method
+// names and signatures.
+public class NameAndTypeSig {
+    public static void main(String args[]) throws Throwable {
+
+        // Test that an unreferenced NameAndType with a valid name and signature
+        // is allowed even for name and signature pairs such as <init>()D.
+        Class newClass = Class.forName("nonVoidInitSig");
+
+        // Test that a NameAndType with a valid name and signature is allowed for
+        // name and signature pairs such as <init>()D, but not allowed by a cp
+        // Method_ref.
+        try {
+            Class newClass2 = Class.forName("nonVoidInitSigCFE");
+            throw new RuntimeException("Expected ClassFormatError exception not thrown");
+        } catch (java.lang.ClassFormatError e) {
+            if (!e.getMessage().contains("Method \"<init>\" in class nonVoidInitSigCFE has illegal signature")) {
+                throw new RuntimeException("Wrong ClassFormatError exception: " + e.getMessage());
+            }
+        }
+        System.out.println("Test NameAndTypeSig passed.");
+    }
+}

--- a/test/hotspot/jtreg/runtime/classFileParserBug/NameAndTypeSig.java
+++ b/test/hotspot/jtreg/runtime/classFileParserBug/NameAndTypeSig.java
@@ -51,6 +51,18 @@ public class NameAndTypeSig {
                 throw new RuntimeException("Wrong ClassFormatError exception: " + e.getMessage());
             }
         }
+
+        // Test that a NameAndType with a valid name and invalid signature throws a
+        // ClassFormatError exception with a message containing the name <init> and
+        // the bad signature.
+        try {
+            Class newClass2 = Class.forName("voidInitBadSig");
+            throw new RuntimeException("Expected ClassFormatError exception not thrown");
+        } catch (java.lang.ClassFormatError e) {
+            if (!e.getMessage().contains("Method \"<init>\" in class voidInitBadSig has illegal signature \"()))V\"")) {
+                throw new RuntimeException("Wrong ClassFormatError exception: " + e.getMessage());
+            }
+        }
         System.out.println("Test NameAndTypeSig passed.");
     }
 }

--- a/test/hotspot/jtreg/runtime/classFileParserBug/nonVoidInitSig.jcod
+++ b/test/hotspot/jtreg/runtime/classFileParserBug/nonVoidInitSig.jcod
@@ -129,11 +129,11 @@ class nonVoidInitSig {
 
 
 
-// The constant pool in this class contains a cp NameAndType entry (#20) that
+// The constant pool in this class contains a cp NameAndType entry (#3) that
 // points to method <init> and signature ()D.  This is a valid NameAndType
 // because <init> is a valid method name and ()D is a valid method signature.
-// But, a cp Methodref that points to NameAndType with a method named <init>,
-// and a non-void return type, is invalid.
+// But, a cp Methodref (#1) that points to NameAndType with a method named
+// <init> and a non-void return type, is invalid.
 class nonVoidInitSigCFE {
   0xCAFEBABE;
   0; // minor version
@@ -237,3 +237,110 @@ class nonVoidInitSigCFE {
 } // end class nonVoidInitSigCFE
 
 
+// The constant pool in this class contains a cp NameAndType entry (#20) that
+// points to method <init> and signature ()))V.  This is an invalid NameAndType
+// entry and should throw a ClassFormatError exception, with a message containing
+// the name <init> and the bad signature, even thought the NameAndType is not
+// referenced by a cp Methodref.
+class voidInitBadSig {
+  0xCAFEBABE;
+  0; // minor version
+  62; // version
+  [21] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    class #8; // #7     at 0x39
+    Utf8 "voidInitBadSig"; // #8     at 0x3C
+    Method #7 #3; // #9     at 0x47
+    Utf8 "Code"; // #10     at 0x4C
+    Utf8 "LineNumberTable"; // #11     at 0x53
+    Utf8 "func"; // #12     at 0x65
+    Utf8 "([Ljava/lang/String;)V"; // #13     at 0x6C
+    Utf8 "Exceptions"; // #14     at 0x85
+    class #16; // #15     at 0x92
+    Utf8 "java/lang/Throwable"; // #16     at 0x95
+    Utf8 "SourceFile"; // #17     at 0xAB
+    Utf8 "voidInitBadSig.java"; // #18     at 0xB8
+    Utf8 "()))V"; // #19
+    NameAndType #5 #19; // #20 // Unused, points to <init>()))V.
+  } // Constant Pool
+
+  0x0021; // access [ ACC_PUBLIC ACC_SUPER ]
+  #7;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [0] { // Fields
+  } // Fields
+
+  [2] { // Methods
+    {  // method at 0xD4
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#10, 29) { // Code at 0xDC
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB70001B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#11, 6) { // LineNumberTable at 0xF3
+              [1] { // line_number_table
+                0  1; //  at 0xFF
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0xFF
+      0x0009; // access
+      #12; // name_index       : func
+      #13; // descriptor_index : ([Ljava/lang/String;)V
+      [2] { // Attributes
+        Attr(#10, 37) { // Code at 0x0107
+          2; // max_stack
+          2; // max_locals
+          Bytes[9]{
+            0xBB000759B700094C;
+            0xB1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#11, 10) { // LineNumberTable at 0x0122
+              [2] { // line_number_table
+                0  4; //  at 0x012E
+                8  5; //  at 0x0132
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+        ;
+        Attr(#14, 4) { // Exceptions at 0x0132
+          [1] { // Exceptions
+            #15; //  at 0x013C
+          }
+        } // end Exceptions
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#17, 2) { // SourceFile at 0x013E
+      #18;
+    } // end SourceFile
+  } // Attributes
+} // end class voidInitBadSig

--- a/test/hotspot/jtreg/runtime/classFileParserBug/nonVoidInitSig.jcod
+++ b/test/hotspot/jtreg/runtime/classFileParserBug/nonVoidInitSig.jcod
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// The constant pool in this class contains an unused NameAndType entry (#20)
+// that points to method <init> and signature ()D.  This is a valid NameAndType
+// because <init> is a valid method name and ()D is a valid method signature.
+class nonVoidInitSig {
+  0xCAFEBABE;
+  0; // minor version
+  62; // version
+  [21] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    class #8; // #7     at 0x39
+    Utf8 "nonVoidInitSig"; // #8     at 0x3C
+    Method #7 #3; // #9     at 0x47
+    Utf8 "Code"; // #10     at 0x4C
+    Utf8 "LineNumberTable"; // #11     at 0x53
+    Utf8 "func"; // #12     at 0x65
+    Utf8 "([Ljava/lang/String;)V"; // #13     at 0x6C
+    Utf8 "Exceptions"; // #14     at 0x85
+    class #16; // #15     at 0x92
+    Utf8 "java/lang/Throwable"; // #16     at 0x95
+    Utf8 "SourceFile"; // #17     at 0xAB
+    Utf8 "nonVoidInitSig.java"; // #18     at 0xB8
+    Utf8 "()D"; // #19
+    NameAndType #5 #19; // #20 // Unused, points to <init>()D.
+  } // Constant Pool
+
+  0x0021; // access [ ACC_PUBLIC ACC_SUPER ]
+  #7;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [0] { // Fields
+  } // Fields
+
+  [2] { // Methods
+    {  // method at 0xD4
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#10, 29) { // Code at 0xDC
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB70001B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#11, 6) { // LineNumberTable at 0xF3
+              [1] { // line_number_table
+                0  1; //  at 0xFF
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0xFF
+      0x0009; // access
+      #12; // name_index       : func
+      #13; // descriptor_index : ([Ljava/lang/String;)V
+      [2] { // Attributes
+        Attr(#10, 37) { // Code at 0x0107
+          2; // max_stack
+          2; // max_locals
+          Bytes[9]{
+            0xBB000759B700094C;
+            0xB1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#11, 10) { // LineNumberTable at 0x0122
+              [2] { // line_number_table
+                0  4; //  at 0x012E
+                8  5; //  at 0x0132
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+        ;
+        Attr(#14, 4) { // Exceptions at 0x0132
+          [1] { // Exceptions
+            #15; //  at 0x013C
+          }
+        } // end Exceptions
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#17, 2) { // SourceFile at 0x013E
+      #18;
+    } // end SourceFile
+  } // Attributes
+} // end class nonVoidInitSig
+
+
+
+// The constant pool in this class contains a cp NameAndType entry (#20) that
+// points to method <init> and signature ()D.  This is a valid NameAndType
+// because <init> is a valid method name and ()D is a valid method signature.
+// But, a cp Methodref that points to NameAndType with a method named <init>,
+// and a non-void return type, is invalid.
+class nonVoidInitSigCFE {
+  0xCAFEBABE;
+  0; // minor version
+  62; // version
+  [20] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #19; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    class #8; // #7     at 0x39
+    Utf8 "nonVoidInitSigCFE"; // #8     at 0x3C
+    Method #7 #3; // #9     at 0x47
+    Utf8 "Code"; // #10     at 0x4C
+    Utf8 "LineNumberTable"; // #11     at 0x53
+    Utf8 "func"; // #12     at 0x65
+    Utf8 "([Ljava/lang/String;)V"; // #13     at 0x6C
+    Utf8 "Exceptions"; // #14     at 0x85
+    class #16; // #15     at 0x92
+    Utf8 "java/lang/Throwable"; // #16     at 0x95
+    Utf8 "SourceFile"; // #17     at 0xAB
+    Utf8 "nonVoidInitSigCFE.java"; // #18     at 0xB8
+    Utf8 "()D"; // #19
+  } // Constant Pool
+
+  0x0021; // access [ ACC_PUBLIC ACC_SUPER ]
+  #7;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [0] { // Fields
+  } // Fields
+
+  [2] { // Methods
+    {  // method at 0xD4
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#10, 29) { // Code at 0xDC
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB70001B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#11, 6) { // LineNumberTable at 0xF3
+              [1] { // line_number_table
+                0  1; //  at 0xFF
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0xFF
+      0x0009; // access
+      #12; // name_index       : func
+      #13; // descriptor_index : ([Ljava/lang/String;)V
+      [2] { // Attributes
+        Attr(#10, 37) { // Code at 0x0107
+          2; // max_stack
+          2; // max_locals
+          Bytes[9]{
+            0xBB000759B700094C;
+            0xB1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#11, 10) { // LineNumberTable at 0x0122
+              [2] { // line_number_table
+                0  4; //  at 0x012E
+                8  5; //  at 0x0132
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+        ;
+        Attr(#14, 4) { // Exceptions at 0x0132
+          [1] { // Exceptions
+            #15; //  at 0x013C
+          }
+        } // end Exceptions
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#17, 2) { // SourceFile at 0x013E
+      #18;
+    } // end SourceFile
+  } // Attributes
+} // end class nonVoidInitSigCFE
+
+


### PR DESCRIPTION
Please review this small fix for JDK-8268720.  The fix changes the JVM to no longer throw a ClassFormatError exception for a constant pool NameAndType that has a name and descriptor that are both valid, but are incompatible together, such as "<init>()D".

Note that if the CONSTANT_NameAndType_info for a CONSTANT_Methodref_info contained the name "<init>"and descriptor such as "()D" then a ClassFormatError exception would get thrown because the CONSTANT_Methodref_info would be invalid. JVM Spec section 4.4.2 says:

If the name of the method in a CONSTANT_Methodref_info structure begins with a '<' ('\u003c'), then the name must be the special name <init>, representing an instance initialization method (§2.9.1). The return type of such a method must be void.

The fix was tested with Mach5 tiers 1 and 2 on Linux, Mac OS, and Windows, Mach5 tiers 3-5 on Linux x64, and JCK Lang and VM tests on Linux x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268720](https://bugs.openjdk.java.net/browse/JDK-8268720): Unspecified checks on NameAndType constants should not be performed


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to b42efc40fdf824806ab7a96d48d5cc92afe90895
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4497/head:pull/4497` \
`$ git checkout pull/4497`

Update a local copy of the PR: \
`$ git checkout pull/4497` \
`$ git pull https://git.openjdk.java.net/jdk pull/4497/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4497`

View PR using the GUI difftool: \
`$ git pr show -t 4497`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4497.diff">https://git.openjdk.java.net/jdk/pull/4497.diff</a>

</details>
