### PR TITLE
8268078: ClassListParser::_interfaces should be freed

### DIFF
--- a/src/hotspot/share/cds/classListParser.cpp
+++ b/src/hotspot/share/cds/classListParser.cpp
@@ -91,13 +91,7 @@ ClassListParser::~ClassListParser() {
   Atomic::store(&_parsing_thread, (Thread*)NULL);
   delete _indy_items;
   delete _interfaces;
-  cleanup_table();
   _instance = NULL;
-}
-
-void ClassListParser::cleanup_table() {
-  ID2KlassTableCleaner cleaner;
-  _id2klass_table.iterate(&cleaner);
 }
 
 int ClassListParser::parse(TRAPS) {

--- a/src/hotspot/share/cds/classListParser.cpp
+++ b/src/hotspot/share/cds/classListParser.cpp
@@ -85,11 +85,19 @@ bool ClassListParser::is_parsing_thread() {
 }
 
 ClassListParser::~ClassListParser() {
-  if (_file) {
+  if (_file != NULL) {
     fclose(_file);
   }
   Atomic::store(&_parsing_thread, (Thread*)NULL);
+  delete _indy_items;
+  delete _interfaces;
+  cleanup_table();
   _instance = NULL;
+}
+
+void ClassListParser::cleanup_table() {
+  ID2KlassTableCleaner cleaner;
+  _id2klass_table.iterate(&cleaner);
 }
 
 int ClassListParser::parse(TRAPS) {

--- a/src/hotspot/share/cds/classListParser.hpp
+++ b/src/hotspot/share/cds/classListParser.hpp
@@ -25,6 +25,7 @@
 #ifndef SHARE_CDS_CLASSLISTPARSER_HPP
 #define SHARE_CDS_CLASSLISTPARSER_HPP
 
+#include "oops/instanceKlass.hpp"
 #include "utilities/exceptions.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/growableArray.hpp"
@@ -118,6 +119,15 @@ class ClassListParser : public StackObj {
   void resolve_indy_impl(Symbol* class_name_symbol, TRAPS);
   bool parse_one_line();
   Klass* load_current_class(Symbol* class_name_symbol, TRAPS);
+  void cleanup_table();
+
+  class ID2KlassTableCleaner {
+  public:
+    bool do_entry(int key, InstanceKlass** value) {
+      (*value)->release_C_heap_structures();
+      return true;
+    }
+  };
 
 public:
   ClassListParser(const char* file);

--- a/src/hotspot/share/cds/classListParser.hpp
+++ b/src/hotspot/share/cds/classListParser.hpp
@@ -25,7 +25,6 @@
 #ifndef SHARE_CDS_CLASSLISTPARSER_HPP
 #define SHARE_CDS_CLASSLISTPARSER_HPP
 
-#include "oops/instanceKlass.hpp"
 #include "utilities/exceptions.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/growableArray.hpp"
@@ -119,15 +118,6 @@ class ClassListParser : public StackObj {
   void resolve_indy_impl(Symbol* class_name_symbol, TRAPS);
   bool parse_one_line();
   Klass* load_current_class(Symbol* class_name_symbol, TRAPS);
-  void cleanup_table();
-
-  class ID2KlassTableCleaner {
-  public:
-    bool do_entry(int key, InstanceKlass** value) {
-      (*value)->release_C_heap_structures();
-      return true;
-    }
-  };
 
 public:
   ClassListParser(const char* file);


### PR DESCRIPTION
This patch frees the `_interfaces`, `_indy_items`, and `_id2klass_table` of `ClassListParser` in its destructor.
It also fixes the non-NULL check at line 88.

- [x] mach5 tiers 1, 2 tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268078](https://bugs.openjdk.java.net/browse/JDK-8268078): ClassListParser::_interfaces should be freed


### Reviewers
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**) ⚠️ Review applies to 58f7c03ee17975ccec8d77390c69a261a858dc43
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4498/head:pull/4498` \
`$ git checkout pull/4498`

Update a local copy of the PR: \
`$ git checkout pull/4498` \
`$ git pull https://git.openjdk.java.net/jdk pull/4498/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4498`

View PR using the GUI difftool: \
`$ git pr show -t 4498`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4498.diff">https://git.openjdk.java.net/jdk/pull/4498.diff</a>

</details>
