### PR TITLE
8259338: Add expiry exception for identrustdstx3 alias to VerifyCACerts.java test

### DIFF
--- a/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
+++ b/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
@@ -268,6 +268,8 @@ public class VerifyCACerts {
             add("luxtrustglobalrootca [jdk]");
             // Valid until: Wed Mar 17 11:33:33 PDT 2021
             add("quovadisrootca [jdk]");
+            // Valid until: Thu Sep 30 14:01:15 GMT 2021
+            add("identrustdstx3 [jdk]");
         }
     };
 


### PR DESCRIPTION
Test is updated to add expiry exception for "identrustdstx3 [jdk]" alias.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * ⚠️ Failed to retrieve information on issue `8259338`.


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4500/head:pull/4500` \
`$ git checkout pull/4500`

Update a local copy of the PR: \
`$ git checkout pull/4500` \
`$ git pull https://git.openjdk.java.net/jdk pull/4500/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4500`

View PR using the GUI difftool: \
`$ git pr show -t 4500`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4500.diff">https://git.openjdk.java.net/jdk/pull/4500.diff</a>

</details>
