### PR TITLE
8268592: JDK-8262891 causes an NPE in Lint.augment

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -1577,6 +1577,10 @@ public class Flow {
         public void visitClassDef(JCClassDecl tree) {
             //skip
         }
+        @Override
+        public void visitLambda(JCLambda tree) {
+            //skip
+        }
         public boolean isAlive() {
             return super.alive != Liveness.DEAD;
         }

--- a/test/langtools/tools/javac/T8268592/T8268592.java
+++ b/test/langtools/tools/javac/T8268592/T8268592.java
@@ -24,8 +24,6 @@
 /* @test
  * @bug 8268592
  * @summary JDK-8262891 causes an NPE in Lint.augment
- * @modules java.compiler
- *          jdk.compiler
  * @compile T8268592.java
  */
 

--- a/test/langtools/tools/javac/T8268592/T8268592.java
+++ b/test/langtools/tools/javac/T8268592/T8268592.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021, Alphabet LLC. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8268592
+ * @summary JDK-8262891 causes an NPE in Lint.augment
+ * @modules java.compiler
+ *          jdk.compiler
+ * @compile T8268592.java
+ */
+
+import java.util.Collection;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+abstract class T {
+
+    abstract <T> T r(Function<String, Supplier<T>> x);
+
+    enum E {
+        ONE
+    }
+
+    abstract <T> Supplier<T> f(Function<T, Supplier<T>> x);
+
+    public void updateAcl(E e, Supplier<Void> v) {
+        r(
+                (String t) -> {
+                    switch (e) {
+                        case ONE:
+                            return f(
+                                    a -> {
+                                        Collection<String> m = null;
+                                        return v;
+                                    });
+                        default:
+                            return v;
+                    }
+                });
+    }
+}


### PR DESCRIPTION
Avoid descending into lambdas in `Flow.aliveAfter`, since the lambda won't affect the result,
and to avoid descending into lambda bodies that haven't been attributed yet when `aliveAfter`
is used while attributing switches.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268592](https://bugs.openjdk.java.net/browse/JDK-8268592): JDK-8262891 causes an NPE in Lint.augment


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**) ⚠️ Review applies to b5b2d54d1010b13ab0056d2b4cfa001aa4b89480


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4502/head:pull/4502` \
`$ git checkout pull/4502`

Update a local copy of the PR: \
`$ git checkout pull/4502` \
`$ git pull https://git.openjdk.java.net/jdk pull/4502/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4502`

View PR using the GUI difftool: \
`$ git pr show -t 4502`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4502.diff">https://git.openjdk.java.net/jdk/pull/4502.diff</a>

</details>
