### PR TITLE
8268852: AsyncLogWriter should not overide is_Named_thread()

### DIFF
--- a/src/hotspot/share/logging/logAsyncWriter.hpp
+++ b/src/hotspot/share/logging/logAsyncWriter.hpp
@@ -157,7 +157,6 @@ class AsyncLogWriter : public NonJavaThread {
     log_debug(logging, thread)("starting AsyncLog Thread tid = " INTX_FORMAT, os::current_thread_id());
   }
   char* name() const override { return (char*)"AsyncLog Thread"; }
-  bool is_Named_thread() const override { return true; }
   void print_on(outputStream* st) const override {
     st->print("\"%s\" ", name());
     Thread::print_on(st);

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -646,7 +646,9 @@ void Thread::print_on_error(outputStream* st, char* buf, int buflen) const {
   else if (is_GC_task_thread())       { st->print("GCTaskThread"); }
   else if (is_Watcher_thread())       { st->print("WatcherThread"); }
   else if (is_ConcurrentGC_thread())  { st->print("ConcurrentGCThread"); }
-  else                                { st->print("Thread"); }
+  else if (this == AsyncLogWriter::instance()) {
+    st->print("%s", this->name());
+  } else                                { st->print("Thread"); }
 
   if (is_Named_thread()) {
     st->print(" \"%s\"", name());


### PR DESCRIPTION
AsyncLogWriter is a subclass of NonJavaThread but not NamedThread. Therefore, 
is_Named_thread() must not return true.

Testing: 

1. hardcrash scenario:
...
Other Threads:
  0x00007f2870391f70 VMThread "VM Thread" [stack: 0x00007f2809d7d000,0x00007f2809e7d000] [id=76015]
  0x00007f28706a1d70 WatcherThread [stack: 0x00007f28082f0000,0x00007f28083f0000] [id=76033]
  0x00007f28702499b0 AsyncLog Thread [stack: 0x00007f2809e7f000,0x00007f2809f7f000] [id=76014]
...

2. jcmd $pid Thread.print
...
"AsyncLog Thread" os_prio=0 cpu=1015.24ms elapsed=181.04s tid=0x00007f7b14c57fb0 nid=0x12ed8 runnable
...

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268852](https://bugs.openjdk.java.net/browse/JDK-8268852): AsyncLogWriter should not overide is_Named_thread()


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Yasumasa Suenaga](https://openjdk.java.net/census#ysuenaga) (@YaSuenag - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4503/head:pull/4503` \
`$ git checkout pull/4503`

Update a local copy of the PR: \
`$ git checkout pull/4503` \
`$ git pull https://git.openjdk.java.net/jdk pull/4503/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4503`

View PR using the GUI difftool: \
`$ git pr show -t 4503`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4503.diff">https://git.openjdk.java.net/jdk/pull/4503.diff</a>

</details>
