### PR TITLE
8268857: Merge VM_PrintJNI and VM_PrintThreads and remove the unused field 'is_deadlock' of DeadlockCycle

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -399,12 +399,8 @@ static void signal_thread_entry(JavaThread* thread, TRAPS) {
         // Any SIGBREAK operations added here should make sure to flush
         // the output stream (e.g. tty->flush()) after output.  See 4803766.
         // Each module also prints an extra carriage return after its output.
-        VM_PrintThreads op;
+        VM_ExtendedPrintThreads op;
         VMThread::execute(&op);
-        VM_PrintJNI jni_op;
-        VMThread::execute(&jni_op);
-        VM_FindDeadlocks op1(tty);
-        VMThread::execute(&op1);
         Universe::print_heap_at_SIGBREAK();
         if (PrintClassHistogram) {
           VM_GC_HeapInspection op1(tty, true /* force full GC before heap inspection */);

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -401,6 +401,8 @@ static void signal_thread_entry(JavaThread* thread, TRAPS) {
         // Each module also prints an extra carriage return after its output.
         VM_ExtendedPrintThreads op;
         VMThread::execute(&op);
+        VM_FindDeadlocks op1(tty);
+        VMThread::execute(&op1);
         Universe::print_heap_at_SIGBREAK();
         if (PrintClassHistogram) {
           VM_GC_HeapInspection op1(tty, true /* force full GC before heap inspection */);

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -399,7 +399,7 @@ static void signal_thread_entry(JavaThread* thread, TRAPS) {
         // Any SIGBREAK operations added here should make sure to flush
         // the output stream (e.g. tty->flush()) after output.  See 4803766.
         // Each module also prints an extra carriage return after its output.
-        VM_PrintThreads op(tty, PrintConcurrentLocks, false, true);
+        VM_PrintThreads op(tty, PrintConcurrentLocks, false /* no extended info */, true /* print JNI handle info */);
         VMThread::execute(&op);
         VM_FindDeadlocks op1(tty);
         VMThread::execute(&op1);

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -399,7 +399,7 @@ static void signal_thread_entry(JavaThread* thread, TRAPS) {
         // Any SIGBREAK operations added here should make sure to flush
         // the output stream (e.g. tty->flush()) after output.  See 4803766.
         // Each module also prints an extra carriage return after its output.
-        VM_ExtendedPrintThreads op;
+        VM_PrintThreads op(tty, PrintConcurrentLocks, false, true);
         VMThread::execute(&op);
         VM_FindDeadlocks op1(tty);
         VMThread::execute(&op1);

--- a/src/hotspot/share/runtime/vmOperation.hpp
+++ b/src/hotspot/share/runtime/vmOperation.hpp
@@ -47,7 +47,6 @@
   template(DeoptimizeAll)                         \
   template(ZombieAll)                             \
   template(Verify)                                \
-  template(PrintJNI)                              \
   template(HeapDumper)                            \
   template(DeoptimizeTheWorld)                    \
   template(CollectForMetadataAllocation)          \

--- a/src/hotspot/share/runtime/vmOperation.hpp
+++ b/src/hotspot/share/runtime/vmOperation.hpp
@@ -109,7 +109,8 @@
   template(PrintMetadata)                         \
   template(GTestExecuteAtSafepoint)               \
   template(JFROldObject)                          \
-  template(JvmtiPostObjectFree)
+  template(JvmtiPostObjectFree)                   \
+  template(ExtendedPrintThreads)
 
 class Thread;
 class outputStream;

--- a/src/hotspot/share/runtime/vmOperation.hpp
+++ b/src/hotspot/share/runtime/vmOperation.hpp
@@ -108,8 +108,7 @@
   template(PrintMetadata)                         \
   template(GTestExecuteAtSafepoint)               \
   template(JFROldObject)                          \
-  template(JvmtiPostObjectFree)                   \
-  template(ExtendedPrintThreads)
+  template(JvmtiPostObjectFree)
 
 class Thread;
 class outputStream;

--- a/src/hotspot/share/runtime/vmOperations.cpp
+++ b/src/hotspot/share/runtime/vmOperations.cpp
@@ -494,8 +494,6 @@ void VM_ExtendedPrintThreads::doit() {
   VM_PrintThreads::doit();
   // JNI global handles
   JNIHandles::print_on(_out);
-  // Deadlock detection
-  _find_dead_locks.doit();
 }
 
 #if INCLUDE_SERVICES

--- a/src/hotspot/share/runtime/vmOperations.cpp
+++ b/src/hotspot/share/runtime/vmOperations.cpp
@@ -493,6 +493,12 @@ void VM_PrintCompileQueue::doit() {
   CompileBroker::print_compile_queues(_out);
 }
 
+void VM_ExtendedPrintThreads::doit() {
+  VM_PrintThreads::doit();
+  _print_jni.doit();
+  _find_dead_locks.doit();
+}
+
 #if INCLUDE_SERVICES
 void VM_PrintClassHierarchy::doit() {
   KlassHierarchy::print_class_hierarchy(_out, _print_interfaces, _print_subclasses, _classname);

--- a/src/hotspot/share/runtime/vmOperations.cpp
+++ b/src/hotspot/share/runtime/vmOperations.cpp
@@ -168,7 +168,7 @@ bool VM_PrintThreads::doit_prologue() {
 
 void VM_PrintThreads::doit() {
   Threads::print_on(_out, true, false, _print_concurrent_locks, _print_extended_info);
-  if (_print_jni) {
+  if (_print_jni_handle_info) {
     JNIHandles::print_on(_out);
   }
 }

--- a/src/hotspot/share/runtime/vmOperations.cpp
+++ b/src/hotspot/share/runtime/vmOperations.cpp
@@ -177,10 +177,6 @@ void VM_PrintThreads::doit_epilogue() {
   }
 }
 
-void VM_PrintJNI::doit() {
-  JNIHandles::print_on(_out);
-}
-
 void VM_PrintMetadata::doit() {
   metaspace::MetaspaceReporter::print_report(_out, _scale, _flags);
 }
@@ -494,8 +490,11 @@ void VM_PrintCompileQueue::doit() {
 }
 
 void VM_ExtendedPrintThreads::doit() {
+  // thread stacks
   VM_PrintThreads::doit();
-  _print_jni.doit();
+  // JNI global handles
+  JNIHandles::print_on(_out);
+  // Deadlock detection
   _find_dead_locks.doit();
 }
 

--- a/src/hotspot/share/runtime/vmOperations.cpp
+++ b/src/hotspot/share/runtime/vmOperations.cpp
@@ -168,6 +168,9 @@ bool VM_PrintThreads::doit_prologue() {
 
 void VM_PrintThreads::doit() {
   Threads::print_on(_out, true, false, _print_concurrent_locks, _print_extended_info);
+  if (_print_jni) {
+    JNIHandles::print_on(_out);
+  }
 }
 
 void VM_PrintThreads::doit_epilogue() {
@@ -487,13 +490,6 @@ void VM_Exit::wait_if_vm_exited() {
 
 void VM_PrintCompileQueue::doit() {
   CompileBroker::print_compile_queues(_out);
-}
-
-void VM_ExtendedPrintThreads::doit() {
-  // thread stacks
-  VM_PrintThreads::doit();
-  // JNI global handles
-  JNIHandles::print_on(_out);
 }
 
 #if INCLUDE_SERVICES

--- a/src/hotspot/share/runtime/vmOperations.hpp
+++ b/src/hotspot/share/runtime/vmOperations.hpp
@@ -148,7 +148,7 @@ class VM_PrintThreads: public VM_Operation {
   VM_PrintThreads()
     : _out(tty), _print_concurrent_locks(PrintConcurrentLocks), _print_extended_info(false), _print_jni_handle_info(false)
   {}
-  VM_PrintThreads(outputStream* out, bool print_concurrent_locks, bool print_extended_info, bool print_jni_handle_info = false)
+  VM_PrintThreads(outputStream* out, bool print_concurrent_locks, bool print_extended_info, bool print_jni_handle_info)
     : _out(out), _print_concurrent_locks(print_concurrent_locks), _print_extended_info(print_extended_info),
       _print_jni_handle_info(print_jni_handle_info)
   {}

--- a/src/hotspot/share/runtime/vmOperations.hpp
+++ b/src/hotspot/share/runtime/vmOperations.hpp
@@ -270,6 +270,23 @@ class VM_PrintCompileQueue: public VM_Operation {
   void doit();
 };
 
+class VM_ExtendedPrintThreads: public VM_PrintThreads {
+ private:
+   VM_PrintJNI _print_jni;
+   VM_FindDeadlocks _find_dead_locks;
+
+ public:
+  VM_ExtendedPrintThreads() : VM_PrintThreads(), _print_jni(), _find_dead_locks(tty) {}
+  VM_ExtendedPrintThreads(outputStream* out, bool print_concurrent_locks, bool print_extended_info)
+    : VM_PrintThreads(out, print_concurrent_locks, print_extended_info),
+      _print_jni(out), _find_dead_locks(out) {}
+
+  VMOp_Type type() const {
+    return VMOp_ExtendedPrintThreads;
+  }
+  void doit();
+};
+
 #if INCLUDE_SERVICES
 class VM_PrintClassHierarchy: public VM_Operation {
  private:

--- a/src/hotspot/share/runtime/vmOperations.hpp
+++ b/src/hotspot/share/runtime/vmOperations.hpp
@@ -139,8 +139,9 @@ class VM_ZombieAll: public VM_Operation {
 #endif // PRODUCT
 
 class VM_PrintThreads: public VM_Operation {
- private:
+ protected:
   outputStream* _out;
+ private:
   bool _print_concurrent_locks;
   bool _print_extended_info;
  public:
@@ -156,16 +157,6 @@ class VM_PrintThreads: public VM_Operation {
   void doit();
   bool doit_prologue();
   void doit_epilogue();
-};
-
-class VM_PrintJNI: public VM_Operation {
- private:
-  outputStream* _out;
- public:
-  VM_PrintJNI()                         { _out = tty; }
-  VM_PrintJNI(outputStream* out)        { _out = out; }
-  VMOp_Type type() const                { return VMOp_PrintJNI; }
-  void doit();
 };
 
 class VM_PrintMetadata : public VM_Operation {
@@ -272,14 +263,13 @@ class VM_PrintCompileQueue: public VM_Operation {
 
 class VM_ExtendedPrintThreads: public VM_PrintThreads {
  private:
-   VM_PrintJNI _print_jni;
    VM_FindDeadlocks _find_dead_locks;
 
  public:
-  VM_ExtendedPrintThreads() : VM_PrintThreads(), _print_jni(), _find_dead_locks(tty) {}
+  VM_ExtendedPrintThreads() : VM_PrintThreads(), _find_dead_locks(tty) {}
   VM_ExtendedPrintThreads(outputStream* out, bool print_concurrent_locks, bool print_extended_info)
     : VM_PrintThreads(out, print_concurrent_locks, print_extended_info),
-      _print_jni(out), _find_dead_locks(out) {}
+      _find_dead_locks(out) {}
 
   VMOp_Type type() const {
     return VMOp_ExtendedPrintThreads;

--- a/src/hotspot/share/runtime/vmOperations.hpp
+++ b/src/hotspot/share/runtime/vmOperations.hpp
@@ -262,14 +262,10 @@ class VM_PrintCompileQueue: public VM_Operation {
 };
 
 class VM_ExtendedPrintThreads: public VM_PrintThreads {
- private:
-   VM_FindDeadlocks _find_dead_locks;
-
  public:
-  VM_ExtendedPrintThreads() : VM_PrintThreads(), _find_dead_locks(tty) {}
+  VM_ExtendedPrintThreads() : VM_PrintThreads() {}
   VM_ExtendedPrintThreads(outputStream* out, bool print_concurrent_locks, bool print_extended_info)
-    : VM_PrintThreads(out, print_concurrent_locks, print_extended_info),
-      _find_dead_locks(out) {}
+    : VM_PrintThreads(out, print_concurrent_locks, print_extended_info) {}
 
   VMOp_Type type() const {
     return VMOp_ExtendedPrintThreads;

--- a/src/hotspot/share/runtime/vmOperations.hpp
+++ b/src/hotspot/share/runtime/vmOperations.hpp
@@ -139,17 +139,18 @@ class VM_ZombieAll: public VM_Operation {
 #endif // PRODUCT
 
 class VM_PrintThreads: public VM_Operation {
- protected:
-  outputStream* _out;
  private:
+  outputStream* _out;
   bool _print_concurrent_locks;
   bool _print_extended_info;
+  bool _print_jni;
  public:
   VM_PrintThreads()
-    : _out(tty), _print_concurrent_locks(PrintConcurrentLocks), _print_extended_info(false)
+    : _out(tty), _print_concurrent_locks(PrintConcurrentLocks), _print_extended_info(false), _print_jni(false)
   {}
-  VM_PrintThreads(outputStream* out, bool print_concurrent_locks, bool print_extended_info)
-    : _out(out), _print_concurrent_locks(print_concurrent_locks), _print_extended_info(print_extended_info)
+  VM_PrintThreads(outputStream* out, bool print_concurrent_locks, bool print_extended_info, bool print_jni = false)
+    : _out(out), _print_concurrent_locks(print_concurrent_locks), _print_extended_info(print_extended_info),
+      _print_jni(print_jni)
   {}
   VMOp_Type type() const {
     return VMOp_PrintThreads;
@@ -258,18 +259,6 @@ class VM_PrintCompileQueue: public VM_Operation {
  public:
   VM_PrintCompileQueue(outputStream* st) : _out(st) {}
   VMOp_Type type() const { return VMOp_PrintCompileQueue; }
-  void doit();
-};
-
-class VM_ExtendedPrintThreads: public VM_PrintThreads {
- public:
-  VM_ExtendedPrintThreads() : VM_PrintThreads() {}
-  VM_ExtendedPrintThreads(outputStream* out, bool print_concurrent_locks, bool print_extended_info)
-    : VM_PrintThreads(out, print_concurrent_locks, print_extended_info) {}
-
-  VMOp_Type type() const {
-    return VMOp_ExtendedPrintThreads;
-  }
   void doit();
 };
 

--- a/src/hotspot/share/runtime/vmOperations.hpp
+++ b/src/hotspot/share/runtime/vmOperations.hpp
@@ -143,14 +143,14 @@ class VM_PrintThreads: public VM_Operation {
   outputStream* _out;
   bool _print_concurrent_locks;
   bool _print_extended_info;
-  bool _print_jni;
+  bool _print_jni_handle_info;
  public:
   VM_PrintThreads()
-    : _out(tty), _print_concurrent_locks(PrintConcurrentLocks), _print_extended_info(false), _print_jni(false)
+    : _out(tty), _print_concurrent_locks(PrintConcurrentLocks), _print_extended_info(false), _print_jni_handle_info(false)
   {}
-  VM_PrintThreads(outputStream* out, bool print_concurrent_locks, bool print_extended_info, bool print_jni = false)
+  VM_PrintThreads(outputStream* out, bool print_concurrent_locks, bool print_extended_info, bool print_jni_handle_info = false)
     : _out(out), _print_concurrent_locks(print_concurrent_locks), _print_extended_info(print_extended_info),
-      _print_jni(print_jni)
+      _print_jni_handle_info(print_jni_handle_info)
   {}
   VMOp_Type type() const {
     return VMOp_PrintThreads;

--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -184,7 +184,7 @@ static jint thread_dump(AttachOperation* op, outputStream* out) {
   }
 
   // thread stacks and JNI global handles
-  VM_PrintThreads op1(out, print_concurrent_locks, print_extended_info, true);
+  VM_PrintThreads op1(out, print_concurrent_locks, print_extended_info, true /* print JNI handle info */);
   VMThread::execute(&op1);
 
   // Deadlock detection

--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -183,9 +183,6 @@ static jint thread_dump(AttachOperation* op, outputStream* out) {
     }
   }
 
-  // thread stacks
-  // JNI global handles
-  // Deadlock detection
   VM_ExtendedPrintThreads vm_op(out, print_concurrent_locks, print_extended_info);
   VMThread::execute(&vm_op);
 

--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -183,8 +183,13 @@ static jint thread_dump(AttachOperation* op, outputStream* out) {
     }
   }
 
-  VM_ExtendedPrintThreads vm_op(out, print_concurrent_locks, print_extended_info);
-  VMThread::execute(&vm_op);
+  // thread stacks and JNI global handles
+  VM_ExtendedPrintThreads op1(out, print_concurrent_locks, print_extended_info);
+  VMThread::execute(&op1);
+
+  // Deadlock detection
+  VM_FindDeadlocks op2(out);
+  VMThread::execute(&op2);
 
   return JNI_OK;
 }

--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -184,7 +184,7 @@ static jint thread_dump(AttachOperation* op, outputStream* out) {
   }
 
   // thread stacks and JNI global handles
-  VM_ExtendedPrintThreads op1(out, print_concurrent_locks, print_extended_info);
+  VM_PrintThreads op1(out, print_concurrent_locks, print_extended_info, true);
   VMThread::execute(&op1);
 
   // Deadlock detection

--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -184,16 +184,10 @@ static jint thread_dump(AttachOperation* op, outputStream* out) {
   }
 
   // thread stacks
-  VM_PrintThreads op1(out, print_concurrent_locks, print_extended_info);
-  VMThread::execute(&op1);
-
   // JNI global handles
-  VM_PrintJNI op2(out);
-  VMThread::execute(&op2);
-
   // Deadlock detection
-  VM_FindDeadlocks op3(out);
-  VMThread::execute(&op3);
+  VM_ExtendedPrintThreads vm_op(out, print_concurrent_locks, print_extended_info);
+  VMThread::execute(&vm_op);
 
   return JNI_OK;
 }

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -534,8 +534,13 @@ ThreadDumpDCmd::ThreadDumpDCmd(outputStream* output, bool heap) :
 }
 
 void ThreadDumpDCmd::execute(DCmdSource source, TRAPS) {
-  VM_ExtendedPrintThreads op(output(), _locks.value(), _extended.value());
-  VMThread::execute(&op);
+  // thread stacks and JNI global handles
+  VM_ExtendedPrintThreads op1(output(), _locks.value(), _extended.value());
+  VMThread::execute(&op1);
+
+  // Deadlock detection
+  VM_FindDeadlocks op2(output());
+  VMThread::execute(&op2);
 }
 
 // Enhanced JMX Agent support

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -534,17 +534,8 @@ ThreadDumpDCmd::ThreadDumpDCmd(outputStream* output, bool heap) :
 }
 
 void ThreadDumpDCmd::execute(DCmdSource source, TRAPS) {
-  // thread stacks
-  VM_PrintThreads op1(output(), _locks.value(), _extended.value());
-  VMThread::execute(&op1);
-
-  // JNI global handles
-  VM_PrintJNI op2(output());
-  VMThread::execute(&op2);
-
-  // Deadlock detection
-  VM_FindDeadlocks op3(output());
-  VMThread::execute(&op3);
+  VM_ExtendedPrintThreads op(output(), _locks.value(), _extended.value());
+  VMThread::execute(&op);
 }
 
 // Enhanced JMX Agent support

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -535,7 +535,7 @@ ThreadDumpDCmd::ThreadDumpDCmd(outputStream* output, bool heap) :
 
 void ThreadDumpDCmd::execute(DCmdSource source, TRAPS) {
   // thread stacks and JNI global handles
-  VM_ExtendedPrintThreads op1(output(), _locks.value(), _extended.value());
+  VM_PrintThreads op1(output(), _locks.value(), _extended.value(), true);
   VMThread::execute(&op1);
 
   // Deadlock detection

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -535,7 +535,7 @@ ThreadDumpDCmd::ThreadDumpDCmd(outputStream* output, bool heap) :
 
 void ThreadDumpDCmd::execute(DCmdSource source, TRAPS) {
   // thread stacks and JNI global handles
-  VM_PrintThreads op1(output(), _locks.value(), _extended.value(), true);
+  VM_PrintThreads op1(output(), _locks.value(), _extended.value(), true /* print JNI handle info */);
   VMThread::execute(&op1);
 
   // Deadlock detection

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -441,8 +441,6 @@ DeadlockCycle* ThreadService::find_deadlocks_at_safepoint(ThreadsList * t_list, 
             // blocked permanently. We record this as a deadlock.
             num_deadlocks++;
 
-            cycle->set_deadlock(true);
-
             // add this cycle to the deadlocks list
             if (deadlocks == NULL) {
               deadlocks = cycle;
@@ -483,8 +481,6 @@ DeadlockCycle* ThreadService::find_deadlocks_at_safepoint(ThreadsList * t_list, 
       } else {
         // We have a (new) cycle
         num_deadlocks++;
-
-        cycle->set_deadlock(true);
 
         // add this cycle to the deadlocks list
         if (deadlocks == NULL) {
@@ -955,7 +951,6 @@ void ThreadSnapshot::metadata_do(void f(Metadata*)) {
 
 
 DeadlockCycle::DeadlockCycle() {
-  _is_deadlock = false;
   _threads = new (ResourceObj::C_HEAP, mtServiceability) GrowableArray<JavaThread*>(INITIAL_ARRAY_SIZE, mtServiceability);
   _next = NULL;
 }

--- a/src/hotspot/share/services/threadService.hpp
+++ b/src/hotspot/share/services/threadService.hpp
@@ -384,7 +384,6 @@ class ThreadDumpResult : public StackObj {
 
 class DeadlockCycle : public CHeapObj<mtInternal> {
  private:
-  bool _is_deadlock;
   GrowableArray<JavaThread*>* _threads;
   DeadlockCycle*              _next;
  public:
@@ -394,9 +393,7 @@ class DeadlockCycle : public CHeapObj<mtInternal> {
   DeadlockCycle* next()                     { return _next; }
   void           set_next(DeadlockCycle* d) { _next = d; }
   void           add_thread(JavaThread* t)  { _threads->append(t); }
-  void           reset()                    { _is_deadlock = false; _threads->clear(); }
-  void           set_deadlock(bool value)   { _is_deadlock = value; }
-  bool           is_deadlock()              { return _is_deadlock; }
+  void           reset()                    { _threads->clear(); }
   int            num_threads()              { return _threads->length(); }
   GrowableArray<JavaThread*>* threads()     { return _threads; }
   void           print_on_with(ThreadsList * t_list, outputStream* st) const;


### PR DESCRIPTION
Hi,

Could I have a review of this change that merges three vm operations(VM_PrintThreads, VM_PrintJNI, VM_FindDeadlocks) in thread_dump and signal_thread_entry.

`jstack` is a very common command, even in the production environment.

In addition to reduce the cost of entering safepoint, I think this patch also could ensure the consistency of the results of VM_PrintThreads and VM_FindDeadlocks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268857](https://bugs.openjdk.java.net/browse/JDK-8268857): Merge VM_PrintJNI and VM_PrintThreads and remove the unused field 'is_deadlock' of DeadlockCycle


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4504/head:pull/4504` \
`$ git checkout pull/4504`

Update a local copy of the PR: \
`$ git checkout pull/4504` \
`$ git pull https://git.openjdk.java.net/jdk pull/4504/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4504`

View PR using the GUI difftool: \
`$ git pr show -t 4504`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4504.diff">https://git.openjdk.java.net/jdk/pull/4504.diff</a>

</details>
