### PR TITLE
8268902: Testing for threadObj != NULL is unnecessary in handshake

### DIFF
--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -624,8 +624,9 @@ class ThreadSelfSuspensionHandshake : public AsyncHandshakeClosure {
 };
 
 bool HandshakeState::suspend_with_handshake() {
-  if (_handshakee->is_exiting() ||
-     _handshakee->threadObj() == NULL) {
+  assert(_handshakee->threadObj() != NULL,
+         "null threadobj is impossible because we're handshaking while the thread is being created");
+  if (_handshakee->is_exiting()) {
     log_trace(thread, suspend)("JavaThread:" INTPTR_FORMAT " exiting", p2i(_handshakee));
     return false;
   }


### PR DESCRIPTION
The handshake code tests if the JavaThread->is_exiting or that the threadObj() is null. Ever since JDK-8244997, once the JavaThread is running, the _threadObj won't be null until JavaThread is destroyed. So testing is_exiting is all you need to do.
In gtest, the test JavaThread doesn't create a _threadObj JDK-8215948 so removing this unnecessary test allows writing gtests for handshakes.

Tested with tier1-6.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268902](https://bugs.openjdk.java.net/browse/JDK-8268902): Testing for threadObj != NULL is unnecessary in handshake


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4512/head:pull/4512` \
`$ git checkout pull/4512`

Update a local copy of the PR: \
`$ git checkout pull/4512` \
`$ git pull https://git.openjdk.java.net/jdk pull/4512/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4512`

View PR using the GUI difftool: \
`$ git pr show -t 4512`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4512.diff">https://git.openjdk.java.net/jdk/pull/4512.diff</a>

</details>
