### PR TITLE
8268927: Windows: link error: unresolved external symbol "int __cdecl convert_to_unicode(char const *,wchar_t * *)"

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -892,7 +892,7 @@ static SetThreadDescriptionFnPtr _SetThreadDescription = NULL;
 DEBUG_ONLY(static GetThreadDescriptionFnPtr _GetThreadDescription = NULL;)
 
 // forward decl.
-errno_t convert_to_unicode(char const* char_path, LPWSTR* unicode_path);
+static errno_t convert_to_unicode(char const* char_path, LPWSTR* unicode_path);
 
 void os::set_native_thread_name(const char *name) {
 


### PR DESCRIPTION
Please review this trivial fix to add a missing "static" to a function prototype. For some reason VS 16.9.3+ doesn't treat this as an error but earlier versions do (and gcc/g++ confirms).

Tested our CI builds remain okay with this change.

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268927](https://bugs.openjdk.java.net/browse/JDK-8268927): Windows: link error: unresolved external symbol "int __cdecl convert_to_unicode(char const *,wchar_t * *)"


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4516/head:pull/4516` \
`$ git checkout pull/4516`

Update a local copy of the PR: \
`$ git checkout pull/4516` \
`$ git pull https://git.openjdk.java.net/jdk pull/4516/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4516`

View PR using the GUI difftool: \
`$ git pr show -t 4516`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4516.diff">https://git.openjdk.java.net/jdk/pull/4516.diff</a>

</details>
