### PR TITLE
8268952: Automatically update heap sizes in G1MonitoringScope

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3061,12 +3061,6 @@ void G1CollectedHeap::do_collection_pause_at_safepoint_helper(double target_paus
     print_heap_regions();
     trace_heap_after_gc(_gc_tracer_stw);
 
-    // We must call G1MonitoringSupport::update_sizes() in the same scoping level
-    // as an active TraceMemoryManagerStats object (i.e. before the destructor for the
-    // TraceMemoryManagerStats is called) so that the G1 memory pools are updated
-    // before any GC notifications are raised.
-    g1mm()->update_sizes();
-
     gc_tracer_report_gc_end(concurrent_operation_is_full_mark, evacuation_info);
   }
   // It should now be safe to tell the concurrent mark thread to start

--- a/src/hotspot/share/gc/g1/g1FullGCScope.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCScope.cpp
@@ -51,11 +51,6 @@ G1FullGCScope::G1FullGCScope(G1MonitoringSupport* monitoring_support,
 }
 
 G1FullGCScope::~G1FullGCScope() {
-  // We must call G1MonitoringSupport::update_sizes() in the same scoping level
-  // as an active TraceMemoryManagerStats object (i.e. before the destructor for the
-  // TraceMemoryManagerStats is called) so that the G1 memory pools are updated
-  // before any GC notifications are raised.
-  _g1h->g1mm()->update_sizes();
   _g1h->trace_heap_after_gc(&_tracer);
   _g1h->post_full_gc_dump(&_timer);
   _timer.register_gc_end();

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
@@ -343,7 +343,12 @@ MemoryUsage G1MonitoringSupport::old_gen_memory_usage(size_t initial_size, size_
 }
 
 G1MonitoringScope::G1MonitoringScope(G1MonitoringSupport* g1mm, bool full_gc, bool all_memory_pools_affected) :
+  _g1mm(g1mm),
   _tcs(full_gc ? g1mm->_full_collection_counters : g1mm->_incremental_collection_counters),
   _tms(full_gc ? &g1mm->_full_gc_memory_manager : &g1mm->_incremental_memory_manager,
        G1CollectedHeap::heap()->gc_cause(), all_memory_pools_affected) {
+}
+
+G1MonitoringScope::~G1MonitoringScope() {
+  _g1mm->update_sizes();
 }

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
@@ -238,10 +238,12 @@ public:
 
 // Scope object for java.lang.management support.
 class G1MonitoringScope : public StackObj {
+  G1MonitoringSupport* _g1mm;
   TraceCollectorStats _tcs;
   TraceMemoryManagerStats _tms;
 public:
   G1MonitoringScope(G1MonitoringSupport* g1mm, bool full_gc, bool all_memory_pools_affected);
+  ~G1MonitoringScope();
 };
 
 #endif // SHARE_GC_G1_G1MONITORINGSUPPORT_HPP


### PR DESCRIPTION
Hi,

  can I have reviews to factor out the call to `G1MonitoringScope::update_sizes()` into the destructor of that class? Currently all users seem to call this manually close to the end of the scope `G1MonitoringScope` is in.

Testing: tier1-5

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268952](https://bugs.openjdk.java.net/browse/JDK-8268952): Automatically update heap sizes in G1MonitoringScope


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4529/head:pull/4529` \
`$ git checkout pull/4529`

Update a local copy of the PR: \
`$ git checkout pull/4529` \
`$ git pull https://git.openjdk.java.net/jdk pull/4529/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4529`

View PR using the GUI difftool: \
`$ git pr show -t 4529`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4529.diff">https://git.openjdk.java.net/jdk/pull/4529.diff</a>

</details>
