### PR TITLE
8269029: compiler/codegen/TestCharVect2.java fails for client VMs

### DIFF
--- a/test/hotspot/jtreg/compiler/codegen/TestCharVect2.java
+++ b/test/hotspot/jtreg/compiler/codegen/TestCharVect2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/codegen/TestCharVect2.java
+++ b/test/hotspot/jtreg/compiler/codegen/TestCharVect2.java
@@ -27,6 +27,14 @@
  * @summary incorrect results of char vectors right shift operation
  *
  * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m compiler.codegen.TestCharVect2
+ */
+
+/**
+ * @test
+ * @bug 8001183
+ * @summary incorrect results of char vectors right shift operation
+ * @requires vm.compiler2.enabled | vm.graal.enabled
+ *
  * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=8 compiler.codegen.TestCharVect2
  * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=16 compiler.codegen.TestCharVect2
  * @run main/othervm -Xbatch -XX:CompileCommand=exclude,*::test() -Xmx128m -XX:MaxVectorSize=32 compiler.codegen.TestCharVect2


### PR DESCRIPTION
This reverts parts of the changes done by 7320e051eade3f22d28f11aef9c5effe324f0b79.

The introduced `CompileCommand` is still present, but the test case is again split up into two parts, one generic (without the `MaxVectorSize` flag), and one C2 specific with that flag. This fixes the test case for C1.

We could also keep the current test structure and add `IgnoreUnrecognizedVMOptions` for the later three `run`s, but this would execute the same test case multiple times if a client VM is tested.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269029](https://bugs.openjdk.java.net/browse/JDK-8269029): compiler/codegen/TestCharVect2.java fails for client VMs


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to b6fa971dcc8a8a4b62e4323cce0e43ee921495a6
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4530/head:pull/4530` \
`$ git checkout pull/4530`

Update a local copy of the PR: \
`$ git checkout pull/4530` \
`$ git pull https://git.openjdk.java.net/jdk pull/4530/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4530`

View PR using the GUI difftool: \
`$ git pr show -t 4530`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4530.diff">https://git.openjdk.java.net/jdk/pull/4530.diff</a>

</details>
