### PR TITLE
8268906: gc/g1/mixedgc/TestOldGenCollectionUsage.java assumes that GCs take 1ms minimum

### DIFF
--- a/test/hotspot/jtreg/gc/g1/mixedgc/TestOldGenCollectionUsage.java
+++ b/test/hotspot/jtreg/gc/g1/mixedgc/TestOldGenCollectionUsage.java
@@ -139,8 +139,8 @@ public class TestOldGenCollectionUsage {
         if (newCollectionCount <= collectionCount) {
             throw new RuntimeException("No new collection");
         }
-        if (newCollectionTime <= collectionTime) {
-            throw new RuntimeException("Collector has not run some more");
+        if (newCollectionTime < collectionTime) {
+            throw new RuntimeException("Collection time ran backwards");
         }
 
         System.out.println("Test passed.");


### PR DESCRIPTION
Hi,

  can I have reviews for this change to a test that incorrectly assumed that GCs take 1ms minimum?

At the end of the test, MXBeans' `getCollectionTime()` is compared against one taken two gcs earlier. If these two gcs are very short, `getCollectionTime()` returns the same value as before because its resolution is 1ms.

The `getCollectionTime()` documentation states:

> Returns the approximate accumulated collection elapsed time in milliseconds. This method returns -1 if the collection elapsed time is undefined for this collector.
> 
> The Java virtual machine implementation may use a high resolution timer to measure the elapsed time. **This method may return the same value even if the collection count has been incremented if the collection elapsed time is very short.**
> 

Which is what the test tested

Testing: test does not fail any more after some VM hack so that `getCollectionTime()` returns very low values.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268906](https://bugs.openjdk.java.net/browse/JDK-8268906): gc/g1/mixedgc/TestOldGenCollectionUsage.java assumes that GCs take 1ms minimum


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Committer)
 * [Leo Korinth](https://openjdk.java.net/census#lkorinth) (@lkorinth - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4531/head:pull/4531` \
`$ git checkout pull/4531`

Update a local copy of the PR: \
`$ git checkout pull/4531` \
`$ git pull https://git.openjdk.java.net/jdk pull/4531/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4531`

View PR using the GUI difftool: \
`$ git pr show -t 4531`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4531.diff">https://git.openjdk.java.net/jdk/pull/4531.diff</a>

</details>
