### PR TITLE
8268433: serviceability/dcmd/framework/VMVersionTest.java fails with Unable to send object throw not established PipeIO Listener Thread connection

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -40,7 +40,3 @@ serviceability/sa/ClhsdbPmap.java#id1                         8268722   macosx-x
 serviceability/sa/ClhsdbPstack.java#id1                       8268722   macosx-x64
 serviceability/sa/TestJmapCore.java                           8268722,8268283   macosx-x64,linux-aarch64
 serviceability/sa/TestJmapCoreMetaspace.java                  8268722,8268636   macosx-x64,linux-x64
-
-serviceability/dcmd/framework/HelpTest.java                   8268433 windows-x64
-serviceability/dcmd/framework/InvalidCommandTest.java         8268433 windows-x64
-serviceability/dcmd/framework/VMVersionTest.java              8268433 windows-x64

--- a/test/hotspot/jtreg/serviceability/dcmd/framework/TestProcessLauncher.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/framework/TestProcessLauncher.java
@@ -77,7 +77,11 @@ public class TestProcessLauncher {
 
     public void quit() {
         if (pipe != null) {
-            pipe.println("quit");
+            if (pipe.isConnected()) {
+                pipe.println("quit");
+            } else {
+                System.out.println("WARNING: IOPipe is not connected");
+            }
         }
     }
 


### PR DESCRIPTION
Main logic of the tests is:

TestProcessLauncher t = ...;
try {
    t.launch();
    .. perform testing ...
} finally {
   t.quit();
}

We have some problem with the tests, but the exception from TestProcessLauncher.quit() masks it.
The failures are very intermittent, so need to fix this excption to get more information about real error.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268433](https://bugs.openjdk.java.net/browse/JDK-8268433): serviceability/dcmd/framework/VMVersionTest.java fails with Unable to send object throw not established PipeIO Listener Thread connection


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4532/head:pull/4532` \
`$ git checkout pull/4532`

Update a local copy of the PR: \
`$ git checkout pull/4532` \
`$ git pull https://git.openjdk.java.net/jdk pull/4532/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4532`

View PR using the GUI difftool: \
`$ git pr show -t 4532`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4532.diff">https://git.openjdk.java.net/jdk/pull/4532.diff</a>

</details>
