### PR TITLE
8236212: CompiledMethodLoad and CompiledMethodUnload events can be posted in START phase

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/CompiledMethodLoad/compmethload001/compmethload001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/CompiledMethodLoad/compmethload001/compmethload001.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,13 +76,13 @@ CompiledMethodLoad(jvmtiEnv *jvmti_env, jmethodID method, jint code_size,
         return;
     }
 
-    if (phase != JVMTI_PHASE_LIVE) {
+    if (phase != JVMTI_PHASE_START && phase != JVMTI_PHASE_LIVE) {
         result = STATUS_FAILED;
-        NSK_COMPLAIN1("TEST FAILED: CompiledMethodLoad event received during non-live phase %s\n",
+        NSK_COMPLAIN1("TEST FAILED: CompiledMethodLoad event received during wrong phase %s\n",
             TranslatePhase(phase));
     }
     else
-        NSK_DISPLAY0("CHECK PASSED: CompiledMethodLoad event received during the live phase as expected\n\n");
+        NSK_DISPLAY0("CHECK PASSED: CompiledMethodLoad event received during the start or live phase as expected\n\n");
 }
 /************************/
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/CompiledMethodUnload/compmethunload001/compmethunload001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/CompiledMethodUnload/compmethunload001/compmethunload001.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,13 +108,13 @@ CompiledMethodUnload(jvmtiEnv *jvmti_env, jmethodID method,
         return;
     }
 
-    if (phase != JVMTI_PHASE_LIVE) {
+    if (phase != JVMTI_PHASE_START && phase != JVMTI_PHASE_LIVE) {
         result = STATUS_FAILED;
-        NSK_COMPLAIN1("TEST FAILED: CompiledMethodUnload event received during non-live phase %s\n",
+        NSK_COMPLAIN1("TEST FAILED: CompiledMethodUnload event received during wrong phase %s\n",
             TranslatePhase(phase));
     }
     else
-        NSK_DISPLAY0("CHECK PASSED: CompiledMethodUnload event received during the live phase as expected\n\n");
+        NSK_DISPLAY0("CHECK PASSED: CompiledMethodUnload event received during the start or live phase as expected\n\n");
 }
 /************************/
 


### PR DESCRIPTION
Accordingly the spec CompiledMethodLoad/CompiledMethodUnload events may be sent in the start and live phases.
VM implementation send them only in the live phase, but tests should expect them in the start phase too

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8236212](https://bugs.openjdk.java.net/browse/JDK-8236212): CompiledMethodLoad and CompiledMethodUnload events can be posted in START phase


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4535/head:pull/4535` \
`$ git checkout pull/4535`

Update a local copy of the PR: \
`$ git checkout pull/4535` \
`$ git pull https://git.openjdk.java.net/jdk pull/4535/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4535`

View PR using the GUI difftool: \
`$ git pr show -t 4535`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4535.diff">https://git.openjdk.java.net/jdk/pull/4535.diff</a>

</details>
