### PR TITLE
8269064: Dropped messages of AsyncLogWriter cause memleak

### DIFF
--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -46,6 +46,10 @@ void AsyncLogWriter::enqueue_locked(const AsyncLogMessage& msg) {
     uint32_t* counter = _stats.add_if_absent(msg.output(), 0, &p_created);
     *counter = *counter + 1;
     // drop the enqueueing message.
+    char* s = msg.message();
+    if (s != nullptr) {
+      os::free(s);
+    }
     return;
   }
 

--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -159,6 +159,11 @@ void AsyncLogWriter::run() {
   }
 }
 
+void AsyncLogWriter::remove(LogOutput* output) {
+  AsyncLogLocker locker;
+  _stats.remove(static_cast<LogFileOutput* >(output));
+}
+
 AsyncLogWriter* AsyncLogWriter::_instance = nullptr;
 
 void AsyncLogWriter::initialize() {

--- a/src/hotspot/share/logging/logAsyncWriter.hpp
+++ b/src/hotspot/share/logging/logAsyncWriter.hpp
@@ -170,6 +170,7 @@ class AsyncLogWriter : public NonJavaThread {
  public:
   void enqueue(LogFileOutput& output, const LogDecorations& decorations, const char* msg);
   void enqueue(LogFileOutput& output, LogMessageBuffer::Iterator msg_iterator);
+  void remove(LogOutput* output);
 
   static AsyncLogWriter* instance();
   static void initialize();

--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -205,6 +205,12 @@ void LogConfiguration::delete_output(size_t idx) {
          "idx must be in range 1 < idx < _n_outputs, but idx = " SIZE_FORMAT
          " and _n_outputs = " SIZE_FORMAT, idx, _n_outputs);
   LogOutput* output = _outputs[idx];
+
+  AsyncLogWriter* asynclog = AsyncLogWriter::instance();
+  if (asynclog!= nullptr) {
+    asynclog->remove(output);
+  }
+
   // Swap places with the last output and shrink the array
   _outputs[idx] = _outputs[--_n_outputs];
   _outputs = REALLOC_C_HEAP_ARRAY(LogOutput*, _outputs, _n_outputs, mtLogging);

--- a/src/hotspot/share/utilities/hashtable.cpp
+++ b/src/hotspot/share/utilities/hashtable.cpp
@@ -278,6 +278,7 @@ template class BasicHashtable<mtInternal>;
 template class BasicHashtable<mtModule>;
 template class BasicHashtable<mtCompiler>;
 template class BasicHashtable<mtTracing>;
+template class BasicHashtable<mtTest>;
 template class BasicHashtable<mtServiceability>;
 template class BasicHashtable<mtLogging>;
 

--- a/src/hotspot/share/utilities/hashtable.hpp
+++ b/src/hotspot/share/utilities/hashtable.hpp
@@ -311,11 +311,36 @@ public:
     return &(entry->_value);
   }
 
+  bool remove(K key) {
+    unsigned int hash = HASH(key);
+    int index = BasicHashtable<F>::hash_to_index(hash);
+    BasicHashtableEntry<F>* p = NULL;
+    KVHashtableEntry* e = bucket(index);
+
+    for (; e != NULL; p = e, e = e->next()) {
+      if (e->hash() == hash && EQUALS(e->_key, key)) {
+        break;
+      }
+    }
+
+    if (e != NULL) {
+      if (p == NULL) {
+        *(bucket_addr(index)) = e->next();
+      } else {
+        *(p->next_addr()) = e->next();
+      }
+      free_entry(e);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
   int table_size() const {
     return BasicHashtable<F>::table_size();
   }
 
-  // ITER contains bool do_entry(K, V const&), which will be
+  // ITER contains bool do_entry(K, V*), which will be
   // called for each entry in the table.  If do_entry() returns false,
   // the iteration is cancelled.
   template<class ITER>

--- a/test/hotspot/gtest/utilities/test_hashtable.cpp
+++ b/test/hotspot/gtest/utilities/test_hashtable.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "precompiled.hpp"
+#include "unittest.hpp"
+#include "utilities/hashtable.hpp"
+
+// Count how many keys in KVHashtable
+template <class K, class V>
+class CountIterator {
+  int _sz = {0};
+
+ public:
+  bool do_entry(K key, V* val) {
+    _sz++;
+    return true;
+  }
+
+  int size() const {
+    return _sz;
+  }
+};
+
+TEST_VM(Hashtable, kvhashtable_remove) {
+  KVHashtable<int, int, mtTest> map(137/*table_size*/);
+  typedef CountIterator<int, int> Iter;
+  const int SZ = 1000;
+
+  for (int i = 0; i < SZ; ++i) {
+    int* v = map.add(i, i);
+    EXPECT_EQ(i, *v);
+  }
+
+  for (int i = 0; i < SZ; ++i) {
+    EXPECT_TRUE(map.remove(i));
+    EXPECT_FALSE(map.remove(i));
+    EXPECT_EQ(NULL, map.lookup(i));
+
+    Iter it;
+    map.iterate(&it);
+    EXPECT_EQ(SZ - (i + 1), it.size());
+  }
+
+  for (int i = 0; i < SZ; ++i) {
+    int* v = map.add(i, i);
+    EXPECT_EQ(i, *v);
+  }
+  // 2nd round: reverse order
+  for (int i = SZ - 1; i >= 0; --i) {
+    EXPECT_TRUE(map.remove(i));
+    EXPECT_FALSE(map.remove(i));
+    EXPECT_EQ(NULL, map.lookup(i));
+
+    Iter it;
+    map.iterate(&it);
+    EXPECT_EQ(i, it.size());
+  }
+
+  for (int i = 0; i < SZ; ++i) {
+    int* v = map.add(i, i);
+    EXPECT_EQ(i, *v);
+  }
+
+  // 3rd round: start in middle
+  int Mid = SZ / 2;
+  for (int i = 0; i < SZ; ++i) {
+    int j = i + Mid;
+    if (j >= SZ) {
+      j -= SZ;
+    }
+    //fprintf(stderr, "executing: %d %d \n", i, j);
+    ASSERT_TRUE(map.remove(j));
+    ASSERT_FALSE(map.remove(j));
+    EXPECT_EQ(NULL, map.lookup(j));
+
+    Iter it;
+    map.iterate(&it);
+    EXPECT_EQ(SZ - (i + 1), it.size());
+  }
+}


### PR DESCRIPTION
free c-strings of the dropped messages.

This patch added KVHashtable::remove(K), which allows user to remove the 
useless entries from the hashtable. Remove the corresponding entry from
AsyncLogWriter::_stats when the output is about to delete.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8269064](https://bugs.openjdk.java.net/browse/JDK-8269064): Dropped messages of AsyncLogWriter cause memleak


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4537/head:pull/4537` \
`$ git checkout pull/4537`

Update a local copy of the PR: \
`$ git checkout pull/4537` \
`$ git pull https://git.openjdk.java.net/jdk pull/4537/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4537`

View PR using the GUI difftool: \
`$ git pr show -t 4537`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4537.diff">https://git.openjdk.java.net/jdk/pull/4537.diff</a>

</details>
