### PR TITLE
8269077: TestSystemGC uses "require vm.gc.G1" for large pages subtest

### DIFF
--- a/test/hotspot/jtreg/gc/TestSystemGC.java
+++ b/test/hotspot/jtreg/gc/TestSystemGC.java
@@ -43,8 +43,7 @@ package gc;
  * @summary Runs System.gc() with different flags.
  * @run main/othervm -XX:+UseG1GC gc.TestSystemGC
  * @run main/othervm -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent gc.TestSystemGC
- * @run main/othervm -XX:+UseLargePages gc.TestSystemGC
-  */
+ */
 
 /*
  * @test TestSystemGCShenandoah
@@ -53,6 +52,13 @@ package gc;
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC gc.TestSystemGC
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:+ExplicitGCInvokesConcurrent gc.TestSystemGC
  */
+
+/*
+ * @test TestSystemGCLargePages
+ * @summary Runs System.gc() with different flags.
+ * @run main/othervm -XX:+UseLargePages gc.TestSystemGC
+ */
+
 public class TestSystemGC {
   public static void main(String args[]) throws Exception {
     System.gc();


### PR DESCRIPTION
The invocation that runs with large pages are guarded with `@require vm.gc.G1` and doesn't explicitly state that G1 should be used.

This means two things:
1) We are not running the large pages subtest when other GCs are specified
2) Under some circumstances another GC is ergonomically selected and we run the test with that GC even though the test was guarded by `@require vm.gc.G1`.

I propose that we move the subtest to its own run section, without any requirement about the used GC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269077](https://bugs.openjdk.java.net/browse/JDK-8269077): TestSystemGC uses "require vm.gc.G1" for large pages subtest


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4538/head:pull/4538` \
`$ git checkout pull/4538`

Update a local copy of the PR: \
`$ git checkout pull/4538` \
`$ git pull https://git.openjdk.java.net/jdk pull/4538/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4538`

View PR using the GUI difftool: \
`$ git pr show -t 4538`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4538.diff">https://git.openjdk.java.net/jdk/pull/4538.diff</a>

</details>
