### PR TITLE
8269087: CheckSegmentedCodeCache test fails in an emulated-client VM

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/CheckSegmentedCodeCache.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckSegmentedCodeCache.java
@@ -58,7 +58,7 @@ public class CheckSegmentedCodeCache {
                 out.shouldContain(NON_METHOD);
             } catch (RuntimeException e) {
                 // Check if TieredCompilation is disabled (in a client VM)
-                if (!out.getOutput().contains("-XX:+TieredCompilation not supported in this VM")) {
+                if (WHITE_BOX.isC2OrJVMCIIncluded() && !out.getOutput().contains("-XX:+TieredCompilation not supported in this VM")) {
                     // Code cache is not segmented
                     throw new RuntimeException("No code cache segmentation.");
                 }

--- a/test/hotspot/jtreg/compiler/codecache/CheckSegmentedCodeCache.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckSegmentedCodeCache.java
@@ -58,7 +58,7 @@ public class CheckSegmentedCodeCache {
                 out.shouldContain(NON_METHOD);
             } catch (RuntimeException e) {
                 // Check if TieredCompilation is disabled (in a client VM)
-                if (WHITE_BOX.isC2OrJVMCIIncluded() && !out.getOutput().contains("-XX:+TieredCompilation not supported in this VM")) {
+                if (Platform.isTieredSupported()) {
                     // Code cache is not segmented
                     throw new RuntimeException("No code cache segmentation.");
                 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269087](https://bugs.openjdk.java.net/browse/JDK-8269087): CheckSegmentedCodeCache test fails in an emulated-client VM


### Reviewers
 * [Igor Veresov](https://openjdk.java.net/census#iveresov) (@veresov - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4540/head:pull/4540` \
`$ git checkout pull/4540`

Update a local copy of the PR: \
`$ git checkout pull/4540` \
`$ git pull https://git.openjdk.java.net/jdk pull/4540/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4540`

View PR using the GUI difftool: \
`$ git pr show -t 4540`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4540.diff">https://git.openjdk.java.net/jdk/pull/4540.diff</a>

</details>
