### PR TITLE
8269074: (fs) Files.copy fails to copy from /proc on some linux kernel versions

### DIFF
--- a/src/java.base/unix/native/libnio/fs/UnixCopyFile.c
+++ b/src/java.base/unix/native/libnio/fs/UnixCopyFile.c
@@ -37,10 +37,6 @@
 #endif
 #include "sun_nio_fs_UnixCopyFile.h"
 
-#if ! defined(_ALLBSD_SOURCE)
-void transfer(JNIEnv* env, jint dst, jint src, volatile jint* cancel);
-#endif
-
 #define RESTARTABLE(_cmd, _result) do { \
   do { \
     _result = _cmd; \
@@ -72,64 +68,6 @@ int fcopyfile_callback(int what, int stage, copyfile_state_t state,
 }
 #endif
 
-/**
- * Transfer all bytes from src to dst within the kernel if possible (Linux),
- * otherwise via user-space buffers
- */
-JNIEXPORT void JNICALL
-Java_sun_nio_fs_UnixCopyFile_transfer
-    (JNIEnv* env, jclass this, jint dst, jint src, jlong cancelAddress)
-{
-    volatile jint* cancel = (jint*)jlong_to_ptr(cancelAddress);
-
-#if defined(__linux__)
-    // Transfer within the kernel
-    const size_t count = cancel != NULL ?
-        1048576 :   // 1 MB to give cancellation a chance
-        0x7ffff000; // maximum number of bytes that sendfile() can transfer
-    ssize_t bytes_sent;
-    do {
-        RESTARTABLE(sendfile64(dst, src, NULL, count), bytes_sent);
-        if (bytes_sent == -1) {
-            if (errno == EINVAL) {
-                // Fall back to copying via user-space buffers
-                break;
-            }
-            throwUnixException(env, errno);
-            return;
-        }
-        if (cancel != NULL && *cancel != 0) {
-            throwUnixException(env, ECANCELED);
-            return;
-        }
-    } while (bytes_sent > 0);
-
-    transfer(env, dst, src, cancel);
-#elif defined(_ALLBSD_SOURCE)
-    copyfile_state_t state;
-    if (cancel != NULL) {
-        state = copyfile_state_alloc();
-        copyfile_state_set(state, COPYFILE_STATE_STATUS_CB, fcopyfile_callback);
-        copyfile_state_set(state, COPYFILE_STATE_STATUS_CTX, (void*)cancel);
-    } else {
-        state = NULL;
-    }
-    if (fcopyfile(src, dst, state, COPYFILE_DATA) < 0) {
-        int errno_fcopyfile = errno;
-        if (state != NULL)
-            copyfile_state_free(state);
-        throwUnixException(env, errno_fcopyfile);
-        return;
-    }
-    if (state != NULL)
-        copyfile_state_free(state);
-#else
-    transfer(env, dst, src, cancel);
-#endif
-}
-
-
-#if ! defined(_ALLBSD_SOURCE)
 // Transfer via user-space buffers
 void transfer(JNIEnv* env, jint dst, jint src, volatile jint* cancel)
 {
@@ -162,4 +100,58 @@ void transfer(JNIEnv* env, jint dst, jint src, volatile jint* cancel)
         } while (len > 0);
     }
 }
+
+/**
+ * Transfer all bytes from src to dst within the kernel if possible (Linux),
+ * otherwise via user-space buffers
+ */
+JNIEXPORT void JNICALL
+Java_sun_nio_fs_UnixCopyFile_transfer
+    (JNIEnv* env, jclass this, jint dst, jint src, jlong cancelAddress)
+{
+    volatile jint* cancel = (jint*)jlong_to_ptr(cancelAddress);
+
+#if defined(__linux__)
+    // Transfer within the kernel
+    const size_t count = cancel != NULL ?
+        1048576 :   // 1 MB to give cancellation a chance
+        0x7ffff000; // maximum number of bytes that sendfile() can transfer
+    ssize_t bytes_sent;
+    do {
+        RESTARTABLE(sendfile64(dst, src, NULL, count), bytes_sent);
+        if (bytes_sent == -1) {
+            if (errno == EINVAL) {
+                // Fall back to copying via user-space buffers
+                transfer(env, dst, src, cancel);
+            } else {
+                throwUnixException(env, errno);
+            }
+            return;
+        }
+        if (cancel != NULL && *cancel != 0) {
+            throwUnixException(env, ECANCELED);
+            return;
+        }
+    } while (bytes_sent > 0);
+#elif defined(_ALLBSD_SOURCE)
+    copyfile_state_t state;
+    if (cancel != NULL) {
+        state = copyfile_state_alloc();
+        copyfile_state_set(state, COPYFILE_STATE_STATUS_CB, fcopyfile_callback);
+        copyfile_state_set(state, COPYFILE_STATE_STATUS_CTX, (void*)cancel);
+    } else {
+        state = NULL;
+    }
+    if (fcopyfile(src, dst, state, COPYFILE_DATA) < 0) {
+        int errno_fcopyfile = errno;
+        if (state != NULL)
+            copyfile_state_free(state);
+        throwUnixException(env, errno_fcopyfile);
+        return;
+    }
+    if (state != NULL)
+        copyfile_state_free(state);
+#else
+    transfer(env, dst, src, cancel);
 #endif
+}


### PR DESCRIPTION
On Linux, if while executing `java.nio.file.Files.copy(Path,Path,CopyOption...)` the native function `sendfile(2)` fails with `EINVAL`, fall back to transferring via user-space buffers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269074](https://bugs.openjdk.java.net/browse/JDK-8269074): (fs) Files.copy fails to copy from /proc on some linux kernel versions


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4543/head:pull/4543` \
`$ git checkout pull/4543`

Update a local copy of the PR: \
`$ git checkout pull/4543` \
`$ git pull https://git.openjdk.java.net/jdk pull/4543/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4543`

View PR using the GUI difftool: \
`$ git pr show -t 4543`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4543.diff">https://git.openjdk.java.net/jdk/pull/4543.diff</a>

</details>
