### PR TITLE
8268664: The documentation of the Scanner.hasNextLine is incorrect

### DIFF
--- a/src/java.base/share/classes/java/util/Scanner.java
+++ b/src/java.base/share/classes/java/util/Scanner.java
@@ -1600,7 +1600,8 @@ public final class Scanner implements Iterator<String>, Closeable {
      * This method may block while waiting for input. The scanner does not
      * advance past any input.
      *
-     * @return true if and only if this scanner has another line of input
+     * @return true if there is a line separator in the remaining input
+     * or if the input has other remaining characters
      * @throws IllegalStateException if this scanner is closed
      */
     public boolean hasNextLine() {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268664](https://bugs.openjdk.java.net/browse/JDK-8268664): The documentation of the Scanner.hasNextLine is incorrect


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4547/head:pull/4547` \
`$ git checkout pull/4547`

Update a local copy of the PR: \
`$ git checkout pull/4547` \
`$ git pull https://git.openjdk.java.net/jdk pull/4547/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4547`

View PR using the GUI difftool: \
`$ git pr show -t 4547`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4547.diff">https://git.openjdk.java.net/jdk/pull/4547.diff</a>

</details>
