### PR TITLE
JDK-8269031: linux x86_64 check for binutils 2.25 or higher after 8265783

### DIFF
--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -222,6 +222,7 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETERMINE_TOOLCHAIN_TYPE],
       [the toolchain type (or family) to use, use '--help' to show possible values @<:@platform dependent@:>@])])
 
   # Linux x86_64 needs higher binutils after 8265783
+  # (this really is a dependency on as version, but we take ld as a check for a general binutils version)
   if test "x$OPENJDK_TARGET_CPU" = "xx86_64"; then
     TOOLCHAIN_MINIMUM_LD_VERSION_gcc="2.25"
   fi

--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -221,6 +221,11 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETERMINE_TOOLCHAIN_TYPE],
   AC_ARG_WITH(toolchain-type, [AS_HELP_STRING([--with-toolchain-type],
       [the toolchain type (or family) to use, use '--help' to show possible values @<:@platform dependent@:>@])])
 
+  # Linux x86_64 needs higher binutils after 8265783
+  if test "x$OPENJDK_TARGET_CPU" = "xx86_64"; then
+    TOOLCHAIN_MINIMUM_LD_VERSION_gcc="2.25"
+  fi
+
   # Use indirect variable referencing
   toolchain_var_name=VALID_TOOLCHAINS_$OPENJDK_BUILD_OS
   VALID_TOOLCHAINS=${!toolchain_var_name}
@@ -677,9 +682,10 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETECT_TOOLCHAIN_CORE],
   TOOLCHAIN_PREPARE_FOR_LD_VERSION_COMPARISONS
 
   if test "x$TOOLCHAIN_MINIMUM_LD_VERSION" != x; then
+    AC_MSG_NOTICE([comparing linker version to minimum version $TOOLCHAIN_MINIMUM_LD_VERSION])
     TOOLCHAIN_CHECK_LINKER_VERSION(VERSION: $TOOLCHAIN_MINIMUM_LD_VERSION,
         IF_OLDER_THAN: [
-          AC_MSG_WARN([You are using a linker older than $TOOLCHAIN_MINIMUM_LD_VERSION. This is not a supported configuration.])
+          AC_MSG_ERROR([You are using a linker older than $TOOLCHAIN_MINIMUM_LD_VERSION. This is not a supported configuration.])
         ]
     )
   fi


### PR DESCRIPTION
This change adds a check for binutils 2.25 or higher after 8265783. The change 8265783 introduced on linux x86_64 a minimum requirement for binutils : "Minimum required would be binutils 2.25 where AVX512 support was added for Skylake."  (see https://bugs.openjdk.java.net/browse/JDK-8265783 )
I adjusted the existing check that already checked the binutils version by looking at the linker output (we do not look at the assembler version and it seems to me we do not really invoke the assembler directly, just indirectly via gcc).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269031](https://bugs.openjdk.java.net/browse/JDK-8269031): linux x86_64 check for binutils 2.25 or higher after 8265783


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to b52c324e0b4d3d5f703c69195872b02f75e3948e
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4548/head:pull/4548` \
`$ git checkout pull/4548`

Update a local copy of the PR: \
`$ git checkout pull/4548` \
`$ git pull https://git.openjdk.java.net/jdk pull/4548/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4548`

View PR using the GUI difftool: \
`$ git pr show -t 4548`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4548.diff">https://git.openjdk.java.net/jdk/pull/4548.diff</a>

</details>
