### PR TITLE
JDK-8269092: Add OldObjectSampleEvent.allocationSize field

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/eventEmitter.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/eventEmitter.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Datadog, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -159,6 +160,7 @@ void EventEmitter::write_event(const ObjectSample* sample, EdgeStore* edge_store
   e.set_starttime(_start_time);
   e.set_endtime(_end_time);
   e.set_allocationTime(sample->allocation_time());
+  e.set_allocationSize(sample->allocated());
   e.set_objectAge(object_age);
   e.set_lastKnownHeapUsage(sample->heap_used_at_last_gc());
   e.set_object(object_id);

--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/eventEmitter.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/eventEmitter.cpp
@@ -160,7 +160,7 @@ void EventEmitter::write_event(const ObjectSample* sample, EdgeStore* edge_store
   e.set_starttime(_start_time);
   e.set_endtime(_end_time);
   e.set_allocationTime(sample->allocation_time());
-  e.set_allocationSize(sample->allocated());
+  e.set_objectSize(sample->allocated());
   e.set_objectAge(object_age);
   e.set_lastKnownHeapUsage(sample->heap_used_at_last_gc());
   e.set_object(object_id);

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -627,6 +627,7 @@
   <Event name="OldObjectSample" category="Java Virtual Machine, Profiling" label="Old Object Sample" description="A potential memory leak" stackTrace="true" thread="true"
     startTime="false" cutoff="true">
     <Field type="Ticks" name="allocationTime" label="Allocation Time" />
+    <Field type="ulong" contentType="bytes" name="allocationSize" label="Allocation Size" />
     <Field type="Tickspan" name="objectAge" label="Object Age" />
     <Field type="ulong" contentType="bytes" name="lastKnownHeapUsage" label="Last Known Heap Usage" />
     <Field type="OldObject" name="object" label="Object" />

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -627,7 +627,7 @@
   <Event name="OldObjectSample" category="Java Virtual Machine, Profiling" label="Old Object Sample" description="A potential memory leak" stackTrace="true" thread="true"
     startTime="false" cutoff="true">
     <Field type="Ticks" name="allocationTime" label="Allocation Time" />
-    <Field type="ulong" contentType="bytes" name="allocationSize" label="Allocation Size" />
+    <Field type="ulong" contentType="bytes" name="objectSize" label="Object Size" />
     <Field type="Tickspan" name="objectAge" label="Object Age" />
     <Field type="ulong" contentType="bytes" name="lastKnownHeapUsage" label="Last Known Heap Usage" />
     <Field type="OldObject" name="object" label="Object" />

--- a/test/jdk/jdk/jfr/event/oldobject/TestAllocationSize.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestAllocationSize.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.event.oldobject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jdk.jfr.Event;
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedClass;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedObject;
+import jdk.jfr.internal.test.WhiteBox;
+import jdk.test.lib.jfr.EventNames;
+import jdk.test.lib.jfr.Events;
+
+/**
+ * @test
+ * @key jfr
+ * @requires vm.hasJFR
+ * @library /test/lib /test/jdk
+ * @modules jdk.jfr/jdk.jfr.internal.test
+ * @run main/othervm  -XX:TLABSize=2k jdk.jfr.event.oldobject.TestAllocationSize
+ */
+public class TestAllocationSize {
+
+    private interface Leak {
+    }
+    private static class Leak1 implements Leak {
+        private byte field1;
+    }
+    private static class Leak2 implements Leak {
+        private int field2;
+    }
+    private static class Leak3 implements Leak {
+        private long field3;
+    }
+
+    public static List<Object> leak = new ArrayList<>(OldObjects.MIN_SIZE);
+
+    public static void main(String[] args) throws Exception {
+        WhiteBox.setWriteAllObjectSamples(true);
+
+        try (Recording recording = new Recording()) {
+            leak.clear();
+            recording.enable(EventNames.OldObjectSample).withStackTrace().with("cutoff", "infinity");
+            recording.start();
+
+            for (int i = 0; i < 300; i++) {
+                leak.add(new Leak1());
+                leak.add(new Leak2());
+                leak.add(new Leak3());
+            }
+
+            recording.stop();
+
+            List<RecordedEvent> events = Events.fromRecording(recording);
+            Events.hasEvents(events);
+            for (RecordedEvent e : events) {
+                if (e.getEventType().getName().equals(EventNames.OldObjectSample)) {
+                    RecordedObject object = e.getValue("object");
+                    RecordedClass type = object.getValue("type");
+                    if ((long)e.getValue("allocationSize") <= 0) {
+                        throw new Exception("Allocation size for " + type.getName() + " is lower or equal to 0");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/jdk/jdk/jfr/event/oldobject/TestObjectSize.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestObjectSize.java
@@ -25,6 +25,7 @@ package jdk.jfr.event.oldobject;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 import jdk.jfr.Event;
 import jdk.jfr.Recording;
@@ -41,9 +42,9 @@ import jdk.test.lib.jfr.Events;
  * @requires vm.hasJFR
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
- * @run main/othervm  -XX:TLABSize=2k jdk.jfr.event.oldobject.TestAllocationSize
+ * @run main/othervm  -XX:TLABSize=2k jdk.jfr.event.oldobject.TestObjectSize
  */
-public class TestAllocationSize {
+public class TestObjectSize {
 
     private interface Leak {
     }
@@ -78,12 +79,10 @@ public class TestAllocationSize {
             List<RecordedEvent> events = Events.fromRecording(recording);
             Events.hasEvents(events);
             for (RecordedEvent e : events) {
-                if (e.getEventType().getName().equals(EventNames.OldObjectSample)) {
-                    RecordedObject object = e.getValue("object");
-                    RecordedClass type = object.getValue("type");
-                    if ((long)e.getValue("allocationSize") <= 0) {
-                        throw new Exception("Allocation size for " + type.getName() + " is lower or equal to 0");
-                    }
+                RecordedObject object = e.getValue("object");
+                RecordedClass type = object.getValue("type");
+                if (e.getLong("objectSize") <= 0) {
+                    throw new Exception("Object size for " + type.getName() + " is lower or equal to 0");
                 }
             }
         }


### PR DESCRIPTION
The data is already available in ObjectSample.allocated and getting this data
in another way is complicated (via Instrumentation for example). Having the
size of the objects also allows to augment the memory leak analysis based on
the object size impact on top of based on the object count impact.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269092](https://bugs.openjdk.java.net/browse/JDK-8269092): Add OldObjectSampleEvent.allocationSize field


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)
 * [Jaroslav Bachorik](https://openjdk.java.net/census#jbachorik) (@jbachorik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4549/head:pull/4549` \
`$ git checkout pull/4549`

Update a local copy of the PR: \
`$ git checkout pull/4549` \
`$ git pull https://git.openjdk.java.net/jdk pull/4549/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4549`

View PR using the GUI difftool: \
`$ git pr show -t 4549`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4549.diff">https://git.openjdk.java.net/jdk/pull/4549.diff</a>

</details>
