### PR TITLE
8261441: JFR: Filename expansion

### DIFF
--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -1747,6 +1747,9 @@ written when the recording is stopped, for example:
 \f[CB]/home/user/recordings/recording.jfr\f[R]
 .IP \[bu] 2
 \f[CB]c:\\recordings\\recording.jfr\f[R]
+.PP
+If \f[CB]%p\f[R] and/or \f[CB]%t\f[R] is specified in the filename, it expands to the JVM\[aq]s
+PID and the current timestamp, respectively.
 .RE
 .TP
 .B \f[CB]name=\f[R]\f[I]identifier\f[R]

--- a/src/jdk.jcmd/share/man/jcmd.1
+++ b/src/jdk.jcmd/share/man/jcmd.1
@@ -441,6 +441,8 @@ If no filename is given, a filename is generated from the PID and the
 current date.
 The filename may also be a directory in which case, the filename is
 generated from the PID and the current date in the specified directory.
+If \f[CB]%p\f[R] and/or \f[CB]%t\f[R] is specified in the filename, it
+expands to the JVM\[aq]s PID and the current timestamp, respectively.
 (STRING, no default value)
 .IP \[bu] 2
 \f[CB]maxage\f[R]: (Optional) Length of time for dumping the flight
@@ -509,6 +511,8 @@ current date and is placed in the directory where the process was
 started.
 The filename may also be a directory in which case, the filename is
 generated from the PID and the current date in the specified directory.
+If \f[CB]%p\f[R] and/or \f[CB]%t\f[R] is specified in the filename, it
+expands to the JVM\[aq]s PID and the current timestamp, respectively.
 (STRING, no default value)
 .IP \[bu] 2
 \f[CB]maxage\f[R]: (Optional) Maximum time to keep the recorded data on
@@ -596,6 +600,8 @@ If no parameters are entered, then no recording is stopped.
 .IP \[bu] 2
 \f[CB]filename\f[R]: (Optional) Name of the file to which the recording is
 written when the recording is stopped.
+If \f[CB]%p\f[R] and/or \f[CB]%t\f[R] is specified in the filename, it
+expands to the JVM\[aq]s PID and the current timestamp, respectively.
 If no path is provided, the data from the recording is discarded.
 (STRING, no default value)
 .IP \[bu] 2

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
@@ -192,7 +192,7 @@ abstract class AbstractDCmd {
     }
 
     protected final void print(String s, Object... args) {
-        currentLine.append(args != null && args.length > 0 ? String.format(s, args) : s);
+        currentLine.append(args.length > 0 ? String.format(s, args) : s);
     }
 
     protected final void println(String s, Object... args) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
@@ -191,7 +191,7 @@ abstract class AbstractDCmd {
     }
 
     protected final void print(String s, Object... args) {
-        currentLine.append(String.format(s, args));
+        currentLine.append(args.length > 0 ? String.format(s, args) : s);
     }
 
     protected final void println(String s, Object... args) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
@@ -29,10 +29,12 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.List;
 
 import jdk.jfr.FlightRecorder;
@@ -271,22 +273,32 @@ abstract class AbstractDCmd {
     }
 
     static String expandFilename(String filename) {
-        if (filename == null) {
-            return null;
+        if (filename == null || filename.indexOf('%') == -1) {
+            return filename;
         }
 
-        String pid = JVM.getJVM().getPid();
+        String pid = null;
+        String time = null;
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < filename.length(); i++) {
             char c = filename.charAt(i);
             if (c == '%' && i < filename.length() - 1) {
                 char nc = filename.charAt(i + 1);
                 if (nc == '%') { // %% ==> %
-                    sb.append(c);
+                    sb.append('%');
                     i++;
                 } else if (nc == 'p') {
+                    if (pid == null) {
+                      pid = JVM.getJVM().getPid();
+                    }
                     sb.append(pid);
                     i++;
+                } else if (nc == 't') {
+                   if (time == null) {
+                       time = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss").format(new Date());
+                   }
+                   sb.append(time);
+                   i++;
                 } else {
                     sb.append('%');
                 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
@@ -191,7 +191,7 @@ abstract class AbstractDCmd {
     }
 
     protected final void print(String s, Object... args) {
-        currentLine.append(args.length > 0 ? String.format(s, args) : s);
+        currentLine.append(args != null && args.length > 0 ? String.format(s, args) : s);
     }
 
     protected final void println(String s, Object... args) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
@@ -31,6 +31,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -295,7 +296,7 @@ abstract class AbstractDCmd {
                     i++;
                 } else if (nc == 't') {
                     if (time == null) {
-                        time = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss").format(new Date());
+                        time = Utils.formatDateTime(LocalDateTime.now());
                     }
                     sb.append(time);
                     i++;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
@@ -289,16 +289,16 @@ abstract class AbstractDCmd {
                     i++;
                 } else if (nc == 'p') {
                     if (pid == null) {
-                      pid = JVM.getJVM().getPid();
+                        pid = JVM.getJVM().getPid();
                     }
                     sb.append(pid);
                     i++;
                 } else if (nc == 't') {
-                   if (time == null) {
-                       time = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss").format(new Date());
-                   }
-                   sb.append(time);
-                   i++;
+                    if (time == null) {
+                        time = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss").format(new Date());
+                    }
+                    sb.append(time);
+                    i++;
                 } else {
                     sb.append('%');
                 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
@@ -29,13 +29,11 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.List;
 
 import jdk.jfr.FlightRecorder;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
@@ -269,4 +269,31 @@ abstract class AbstractDCmd {
             return "/directory/recordings";
         }
     }
+
+    static String expandFilename(String filename) {
+        if (filename == null) {
+            return null;
+        }
+
+        String pid = JVM.getJVM().getPid();
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < filename.length(); i++) {
+            char c = filename.charAt(i);
+            if (c == '%' && i < filename.length() - 1) {
+                char nc = filename.charAt(i + 1);
+                if (nc == '%') { // %% ==> %
+                    sb.append(c);
+                    i++;
+                } else if (nc == 'p') {
+                    sb.append(pid);
+                    i++;
+                } else {
+                    sb.append('%');
+                }
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdDump.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdDump.java
@@ -227,11 +227,14 @@ final class DCmdDump extends AbstractDCmd {
                                  For example, "-12h", "-15m" or "-30s"
 
                  filename        (Optional) Name of the file to which the flight recording data is
-                                 dumped. The string '%%p' in the filename will be replaced with the
-                                 PID. If no filename is given, a filename is generated from the PID
+                                 dumped. If no filename is given, a filename is generated from the PID
                                  and the current date. The filename may also be a directory in which
                                  case, the filename is generated from the PID and the current date in
                                  the specified directory. (STRING, no default value)
+
+                                 Note: If a filename is given, '%%p' in the filename will be
+                                 replaced by the PID, and '%%t' will be replaced by the time in
+                                 'yyyy-MM-dd_HH-mm-ss' format.
 
                  maxage          (Optional) Length of time for dumping the flight recording data to a
                                  file. (INTEGER followed by 's' for seconds 'm' for minutes or 'h' for

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdDump.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdDump.java
@@ -234,7 +234,7 @@ final class DCmdDump extends AbstractDCmd {
 
                                  Note: If a filename is given, '%%p' in the filename will be
                                  replaced by the PID, and '%%t' will be replaced by the time in
-                                 'yyyy-MM-dd_HH-mm-ss' format.
+                                 'yyyy_MM_dd_HH_mm_ss' format.
 
                  maxage          (Optional) Length of time for dumping the flight recording data to a
                                  file. (INTEGER followed by 's' for seconds 'm' for minutes or 'h' for

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdDump.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdDump.java
@@ -55,7 +55,7 @@ final class DCmdDump extends AbstractDCmd {
     public void execute(ArgumentParser parser) throws DCmdException {
         parser.checkUnknownArguments();
         String name = parser.getOption("name");
-        String filename = parser.getOption("filename");
+        String filename = expandFilename(parser.getOption("filename"));
         Long maxAge = parser.getOption("maxage");
         Long maxSize = parser.getOption("maxsize");
         String begin = parser.getOption("begin");
@@ -227,7 +227,8 @@ final class DCmdDump extends AbstractDCmd {
                                  For example, "-12h", "-15m" or "-30s"
 
                  filename        (Optional) Name of the file to which the flight recording data is
-                                 dumped. If no filename is given, a filename is generated from the PID
+                                 dumped. The string '%p' in the filename will be replaced with the
+                                 PID. If no filename is given, a filename is generated from the PID
                                  and the current date. The filename may also be a directory in which
                                  case, the filename is generated from the PID and the current date in
                                  the specified directory. (STRING, no default value)

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdDump.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdDump.java
@@ -227,7 +227,7 @@ final class DCmdDump extends AbstractDCmd {
                                  For example, "-12h", "-15m" or "-30s"
 
                  filename        (Optional) Name of the file to which the flight recording data is
-                                 dumped. The string '%p' in the filename will be replaced with the
+                                 dumped. The string '%%p' in the filename will be replaced with the
                                  PID. If no filename is given, a filename is generated from the PID
                                  and the current date. The filename may also be a directory in which
                                  case, the filename is generated from the PID and the current date in

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -332,7 +332,7 @@ final class DCmdStart extends AbstractDCmd {
                                  hours, 0s)
 
                  filename        (Optional) Name of the file to which the flight recording data is
-                                 written when the recording is stopped. The string '%p' in the
+                                 written when the recording is stopped. The string '%%p' in the
                                  filename will be replaced with the PID. If no filename is given,
                                  a filename is generated from the PID and the current date and is
                                  placed in the directory where the process was started. The

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -76,7 +76,7 @@ final class DCmdStart extends AbstractDCmd {
         Long delay = parser.getOption("delay");
         Long duration = parser.getOption("duration");
         Boolean disk = parser.getOption("disk");
-        String path = parser.getOption("filename");
+        String path = expandFilename(parser.getOption("filename"));
         Long maxAge = parser.getOption("maxage");
         Long maxSize = parser.getOption("maxsize");
         Long flush = parser.getOption("flush-interval");
@@ -332,8 +332,9 @@ final class DCmdStart extends AbstractDCmd {
                                  hours, 0s)
 
                  filename        (Optional) Name of the file to which the flight recording data is
-                                 written when the recording is stopped. If no filename is given, a
-                                 filename is generated from the PID and the current date and is
+                                 written when the recording is stopped. The string '%p' in the
+                                 filename will be replaced with the PID. If no filename is given,
+                                 a filename is generated from the PID and the current date and is
                                  placed in the directory where the process was started. The
                                  filename may also be a directory in which case, the filename is
                                  generated from the PID and the current date in the specified

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -332,13 +332,16 @@ final class DCmdStart extends AbstractDCmd {
                                  hours, 0s)
 
                  filename        (Optional) Name of the file to which the flight recording data is
-                                 written when the recording is stopped. The string '%%p' in the
-                                 filename will be replaced with the PID. If no filename is given,
-                                 a filename is generated from the PID and the current date and is
+                                 written when the recording is stopped. If no filename is given, a
+                                 filename is generated from the PID and the current date and is
                                  placed in the directory where the process was started. The
                                  filename may also be a directory in which case, the filename is
                                  generated from the PID and the current date in the specified
                                  directory. (STRING, no default value)
+
+                                 Note: If a filename is given, '%%p' in the filename will be
+                                 replaced by the PID, and '%%t' will be replaced by the time in
+                                 'yyyy-MM-dd_HH-mm-ss' format.
 
                  maxage          (Optional) Maximum time to keep the recorded data on disk. This
                                  parameter is valid only when the disk parameter is set to true.

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -341,7 +341,7 @@ final class DCmdStart extends AbstractDCmd {
 
                                  Note: If a filename is given, '%%p' in the filename will be
                                  replaced by the PID, and '%%t' will be replaced by the time in
-                                 'yyyy-MM-dd_HH-mm-ss' format.
+                                 'yyyy_MM_dd_HH_mm_ss' format.
 
                  maxage          (Optional) Maximum time to keep the recorded data on disk. This
                                  parameter is valid only when the disk parameter is set to true.

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStop.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStop.java
@@ -76,7 +76,7 @@ final class DCmdStop extends AbstractDCmd {
                Options:
 
                  filename  (Optional) Name of the file to which the recording is written when the
-                           recording is stopped. The string '%p' in the filename will be replaced
+                           recording is stopped. The string '%%p' in the filename will be replaced
                            with the PID. If no path is provided, the data from the recording is
                            discarded. (STRING, no default value)
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStop.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStop.java
@@ -80,7 +80,7 @@ final class DCmdStop extends AbstractDCmd {
                            is discarded. (STRING, no default value)
 
                            Note: If a path is given, '%%p' in the path will be replaced by the PID,
-                           and '%%t' will be replaced by the time in 'yyyy-MM-dd_HH-mm-ss' format.
+                           and '%%t' will be replaced by the time in 'yyyy_MM_dd_HH_mm_ss' format.
 
                  name      Name of the recording (STRING, no default value)
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStop.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStop.java
@@ -76,9 +76,11 @@ final class DCmdStop extends AbstractDCmd {
                Options:
 
                  filename  (Optional) Name of the file to which the recording is written when the
-                           recording is stopped. The string '%%p' in the filename will be replaced
-                           with the PID. If no path is provided, the data from the recording is
-                           discarded. (STRING, no default value)
+                           recording is stopped. If no path is provided, the data from the recording
+                           is discarded. (STRING, no default value)
+
+                           Note: If a path is given, '%%p' in the path will be replaced by the PID,
+                           and '%%t' will be replaced by the time in 'yyyy-MM-dd_HH-mm-ss' format.
 
                  name      Name of the recording (STRING, no default value)
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStop.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStop.java
@@ -42,7 +42,7 @@ final class DCmdStop extends AbstractDCmd {
     protected void execute(ArgumentParser parser)  throws DCmdException {
         parser.checkUnknownArguments();
         String name = parser.getOption("name");
-        String filename = parser.getOption("filename");
+        String filename = expandFilename(parser.getOption("filename"));
         try {
             SafePath safePath = null;
             Recording recording = findRecording(name);
@@ -76,8 +76,9 @@ final class DCmdStop extends AbstractDCmd {
                Options:
 
                  filename  (Optional) Name of the file to which the recording is written when the
-                           recording is stopped. If no path is provided, the data from the recording
-                           is discarded. (STRING, no default value)
+                           recording is stopped. The string '%p' in the filename will be replaced
+                           with the PID. If no path is provided, the data from the recording is
+                           discarded. (STRING, no default value)
 
                  name      Name of the recording (STRING, no default value)
 

--- a/test/jdk/jdk/jfr/jcmd/JcmdHelper.java
+++ b/test/jdk/jdk/jfr/jcmd/JcmdHelper.java
@@ -25,6 +25,7 @@ package jdk.jfr.jcmd;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.stream.Collectors;
 
 import jdk.test.lib.Asserts;
@@ -117,5 +118,17 @@ public class JcmdHelper {
 
     public static OutputAnalyzer jcmdCheck(String recordingName, boolean verbose) {
         return jcmd("JFR.check", "name=" + recordingName, "verbose=" + verbose);
+    }
+
+    public static String readFilename(OutputAnalyzer output) throws Exception {
+        Iterator<String> it = output.asLines().iterator();
+        while (it.hasNext()) {
+            String line = it.next();
+            if (line.contains("written to")) {
+                line = it.next(); // blank line
+                return it.next();
+            }
+        }
+        throw new Exception("Could not find filename of dumped recording.");
     }
 }

--- a/test/jdk/jdk/jfr/jcmd/TestFilenameExpansion.java
+++ b/test/jdk/jdk/jfr/jcmd/TestFilenameExpansion.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.jcmd;
+
+import java.io.File;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.jfr.FileHelper;
+
+/**
+ * @test
+ * @summary The test verifies JFR.start/dump/stop commands
+ * @key jfr
+ * @requires vm.hasJFR
+ * @library /test/lib /test/jdk
+ * @run main/othervm jdk.jfr.jcmd.TestFilenameExpansion
+ */
+public class TestFilenameExpansion {
+
+    public static void main(String[] args) throws Exception {
+        String pid = Long.toString(ProcessHandle.current().pid());
+        test("output.jfr", "output.jfr");
+        test("output_%p.jfr", "output_" + pid + ".jfr");
+        test("%p_output_%p.jfr", pid + "_output_" + pid + ".jfr");
+        test("%%_output_%p.jfr", "%_output_" + pid + ".jfr");
+        test("%a_output_%%", "%a_output_%");
+    }
+
+    private static void test(String name, String finalName) throws Exception {
+        File file = new File(finalName);
+
+        // set when JFR.start
+        JcmdHelper.jcmd("JFR.start name=test filename=" + name);
+        JcmdHelper.jcmd("JFR.dump name=test");
+        checkFileAndDelete(file);
+
+        // set when JFR.dump
+        JcmdHelper.jcmd("JFR.start name=test");
+        JcmdHelper.jcmd("JFR.dump name=test filename=" + name);
+        checkFileAndDelete(file);
+
+        // set when JFR.stop
+        JcmdHelper.jcmd("JFR.start name=test");
+        JcmdHelper.jcmd("JFR.stop name=test filename=" + name);
+        checkFileAndDelete(file);
+    }
+
+    private static void checkFileAndDelete(File file) {
+        Asserts.assertTrue(file.exists(), file.getAbsolutePath() + " does not exist");
+        Asserts.assertTrue(file.isFile(), file.getAbsolutePath() + " is not a file");
+        Asserts.assertTrue(file.delete(), "Delete " + file.getAbsolutePath() + " failed");
+        Asserts.assertFalse(file.exists(), file.getAbsolutePath() + " should be deleted");
+    }
+}

--- a/test/jdk/jdk/jfr/jcmd/TestFilenameExpansion.java
+++ b/test/jdk/jdk/jfr/jcmd/TestFilenameExpansion.java
@@ -44,7 +44,7 @@ public class TestFilenameExpansion {
     public static void main(String[] args) throws Exception {
         String pid = Long.toString(ProcessHandle.current().pid());
         String name = "output_%p_%t_%%.jfr";
-        String pattern = "output_" + pid + "_" + "\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}" + "_%\\.jfr";
+        String pattern = "output_" + pid + "_" + "\\d{4}_\\d{2}_\\d{2}_\\d{2}_\\d{2}_\\d{2}" + "_%\\.jfr";
 
         JcmdHelper.jcmd("JFR.start name=test");
         String filename = JcmdHelper.readFilename(JcmdHelper.jcmd("JFR.dump name=test filename=" + name));

--- a/test/jdk/jdk/jfr/jcmd/TestJcmdDumpGeneratedFilename.java
+++ b/test/jdk/jdk/jfr/jcmd/TestJcmdDumpGeneratedFilename.java
@@ -26,7 +26,6 @@ package jdk.jfr.jcmd;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Iterator;
 
 import jdk.jfr.Configuration;
 import jdk.jfr.Recording;
@@ -60,18 +59,18 @@ public class TestJcmdDumpGeneratedFilename {
 
     private static void testDumpFilename() throws Exception {
         OutputAnalyzer output = JcmdHelper.jcmd("JFR.dump");
-        verifyFile(readFilename(output), null);
+        verifyFile(JcmdHelper.readFilename(output), null);
     }
 
     private static void testDumpFilename(Recording r) throws Exception {
         OutputAnalyzer output = JcmdHelper.jcmd("JFR.dump", "name=" + r.getId());
-        verifyFile(readFilename(output), r.getId());
+        verifyFile(JcmdHelper.readFilename(output), r.getId());
     }
 
     private static void testDumpDiectory() throws Exception {
         Path directory = Paths.get(".").toAbsolutePath().normalize();
         OutputAnalyzer output = JcmdHelper.jcmd("JFR.dump", "filename=" + directory);
-        String filename = readFilename(output);
+        String filename = JcmdHelper.readFilename(output);
         verifyFile(filename, null);
         verifyDirectory(filename, directory);
     }
@@ -79,7 +78,7 @@ public class TestJcmdDumpGeneratedFilename {
     private static void testDumpDiectory(Recording r) throws Exception {
         Path directory = Paths.get(".").toAbsolutePath().normalize();
         OutputAnalyzer output = JcmdHelper.jcmd("JFR.dump", "name=" + r.getId(), "filename=" + directory);
-        String filename = readFilename(output);
+        String filename = JcmdHelper.readFilename(output);
         verifyFile(filename, r.getId());
         verifyDirectory(filename, directory);
     }
@@ -97,17 +96,5 @@ public class TestJcmdDumpGeneratedFilename {
             throw new Exception("Expected filename to contain " + expectedName);
         }
         FileHelper.verifyRecording(new File(filename));
-    }
-
-    private static String readFilename(OutputAnalyzer output) throws Exception {
-        Iterator<String> it = output.asLines().iterator();
-        while (it.hasNext()) {
-            String line = it.next();
-            if (line.contains("written to")) {
-                line = it.next(); // blank line
-                return it.next();
-            }
-        }
-        throw new Exception("Could not find filename of dumped recording.");
     }
 }


### PR DESCRIPTION
Hi,
Could I have a review of this change that let the users could use `%p` in the filename to represent the PID  when JFR.start/stop/dump.

~~I haven't implemented `%t` described in the issue, because I don't think it's very useful.~~

Best,
Denghui Dong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261441](https://bugs.openjdk.java.net/browse/JDK-8261441): JFR: Filename expansion


### Reviewers
 * [Jaroslav Bachorik](https://openjdk.java.net/census#jbachorik) (@jbachorik - **Reviewer**) ⚠️ Review applies to a9f62c740dfb6687cccdeacadb342fd387adcfd1
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4550/head:pull/4550` \
`$ git checkout pull/4550`

Update a local copy of the PR: \
`$ git checkout pull/4550` \
`$ git pull https://git.openjdk.java.net/jdk pull/4550/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4550`

View PR using the GUI difftool: \
`$ git pr show -t 4550`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4550.diff">https://git.openjdk.java.net/jdk/pull/4550.diff</a>

</details>
