### PR TITLE
8269122: The use of "extern const" for Register definitions generates poor code

### DIFF
--- a/src/hotspot/share/asm/register.hpp
+++ b/src/hotspot/share/asm/register.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/asm/register.hpp
+++ b/src/hotspot/share/asm/register.hpp
@@ -47,16 +47,6 @@ class AbstractRegisterImpl {
 
 #define AS_REGISTER(type,name)         ((type)name##_##type##EnumValue)
 
-#ifndef USE_EXTERN_CONST_FOR_REGISTER_DEFINITIONS
-
-// JDK-8269122: The use of "extern const" for Register definitions
-// generates poor code.
-//
-// The use of "extern const" for Register definitions is a historical
-// artefact that leads to excessive code size for class Assembler. The
-// old definitions for CONSTANT_REGISTER_DECLARATION et al are left
-// here in case some platform needs them.
-
 #define CONSTANT_REGISTER_DECLARATION(type, name, value)        \
 const type name = ((type)value);                                \
 enum { name##_##type##EnumValue = (value) }
@@ -65,56 +55,6 @@ enum { name##_##type##EnumValue = (value) }
 const type name = ((type)value)
 
 #define REGISTER_DEFINITION(type, name)
-
-#else
-
-// Macros for use in defining Register instances.  We'd like to be
-// able to simply define const instances of the RegisterImpl* for each
-// of the registers needed on a system in a header file.  However many
-// compilers don't handle this very well and end up producing a
-// private definition in every file which includes the header file.
-// Along with the static constructors necessary for initialization it
-// can consume a significant amount of space in the result library.
-//
-// The following macros allow us to declare the instance in a .hpp and
-// produce an enumeration value which has the same number.  Then in a
-// .cpp the the register instance can be defined using the enumeration
-// value.  This avoids the use of static constructors and multiple
-// definitions per .cpp.  In addition #defines for the register can be
-// produced so that the constant registers can be inlined.  These
-// macros should not be used inside other macros, because you may get
-// multiple evaluations of the macros which can give bad results.
-//
-// Here are some example uses and expansions.  Note that the macro
-// invocation is terminated with a ;.
-//
-// CONSTANT_REGISTER_DECLARATION(Register, G0, 0);
-//
-// extern const Register G0 ;
-// enum { G0_RegisterEnumValue = 0 } ;
-//
-// REGISTER_DECLARATION(Register, Gmethod, G5);
-//
-// extern const Register Gmethod ;
-// enum { Gmethod_RegisterEnumValue = G5_RegisterEnumValue } ;
-//
-// REGISTER_DEFINITION(Register, G0);
-//
-// const Register G0 = ( ( Register ) G0_RegisterEnumValue ) ;
-//
-
-#define CONSTANT_REGISTER_DECLARATION(type, name, value) \
-extern const type name;                                  \
-enum { name##_##type##EnumValue = (value) }
-
-#define REGISTER_DECLARATION(type, name, value) \
-extern const type name;                         \
-enum { name##_##type##EnumValue = value##_##type##EnumValue }
-
-#define REGISTER_DEFINITION(type, name) \
-const type name = ((type)name##_##type##EnumValue)
-
-#endif // USE_EXTERN_CONST_FOR_REGISTER_DEFINITIONS
 
 #include CPU_HEADER(register)
 

--- a/src/hotspot/share/asm/register.hpp
+++ b/src/hotspot/share/asm/register.hpp
@@ -58,7 +58,8 @@ class AbstractRegisterImpl {
 // here in case some platform needs them.
 
 #define CONSTANT_REGISTER_DECLARATION(type, name, value)        \
-const type name = ((type)value)
+const type name = ((type)value);                                \
+enum { name##_##type##EnumValue = (value) }
 
 #define REGISTER_DECLARATION(type, name, value)                 \
 const type name = ((type)value)

--- a/src/hotspot/share/asm/register.hpp
+++ b/src/hotspot/share/asm/register.hpp
@@ -45,8 +45,28 @@ class AbstractRegisterImpl {
   int value() const                              { return (int)(intx)this; }
 };
 
+#define AS_REGISTER(type,name)         ((type)name##_##type##EnumValue)
 
+#ifndef USE_EXTERN_CONST_FOR_REGISTER_DEFINITIONS
+
+// JDK-8269122: The use of "extern const" for Register definitions
+// generates poor code.
 //
+// The use of "extern const" for Register definitions is a historical
+// artefact that leads to excessive code size for class Assembler. The
+// old definitions for CONSTANT_REGISTER_DECLARATION et al are left
+// here in case some platform needs them.
+
+#define CONSTANT_REGISTER_DECLARATION(type, name, value)        \
+const type name = ((type)value)
+
+#define REGISTER_DECLARATION(type, name, value)                 \
+const type name = ((type)value)
+
+#define REGISTER_DEFINITION(type, name)
+
+#else
+
 // Macros for use in defining Register instances.  We'd like to be
 // able to simply define const instances of the RegisterImpl* for each
 // of the registers needed on a system in a header file.  However many
@@ -82,8 +102,6 @@ class AbstractRegisterImpl {
 // const Register G0 = ( ( Register ) G0_RegisterEnumValue ) ;
 //
 
-#define AS_REGISTER(type,name)         ((type)name##_##type##EnumValue)
-
 #define CONSTANT_REGISTER_DECLARATION(type, name, value) \
 extern const type name;                                  \
 enum { name##_##type##EnumValue = (value) }
@@ -94,6 +112,8 @@ enum { name##_##type##EnumValue = value##_##type##EnumValue }
 
 #define REGISTER_DEFINITION(type, name) \
 const type name = ((type)name##_##type##EnumValue)
+
+#endif // USE_EXTERN_CONST_FOR_REGISTER_DEFINITIONS
 
 #include CPU_HEADER(register)
 


### PR DESCRIPTION
Register definitions in HotSpot are declared as "extern const"
for ancient-historical reasons. We should stop doing that: it would
make the assembler significantly faster and smaller, improving both
bootstrap time and compilation speed.

This change shaves 2% off the size of the text section of libjvm.so on AArch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269122](https://bugs.openjdk.java.net/browse/JDK-8269122): The use of "extern const" for Register definitions generates poor code


### Reviewers
 * [Andrew Dinn](https://openjdk.java.net/census#adinn) (@adinn - **Reviewer**) ⚠️ Review applies to 0f6396c09d4a781583e30855001533022fae6ce9
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 621c25be92acd73984d37d952af3442e2159488f


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4554/head:pull/4554` \
`$ git checkout pull/4554`

Update a local copy of the PR: \
`$ git checkout pull/4554` \
`$ git pull https://git.openjdk.java.net/jdk pull/4554/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4554`

View PR using the GUI difftool: \
`$ git pr show -t 4554`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4554.diff">https://git.openjdk.java.net/jdk/pull/4554.diff</a>

</details>
