### PR TITLE
8269034: AccessControlException for SunPKCS11 daemon threads

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -199,6 +199,7 @@ module java.base {
         jdk.attach,
         jdk.charsets,
         jdk.compiler,
+        jdk.crypto.cryptoki,
         jdk.incubator.vector,
         jdk.jfr,
         jdk.jshell,

--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -126,10 +126,9 @@ grant codeBase "jrt:/jdk.crypto.ec" {
 };
 
 grant codeBase "jrt:/jdk.crypto.cryptoki" {
-    permission java.lang.RuntimePermission
-                   "accessClassInPackage.com.sun.crypto.provider";
-    permission java.lang.RuntimePermission
-                   "accessClassInPackage.sun.security.*";
+    permission java.lang.RuntimePermission "accessClassInPackage.com.sun.crypto.provider";
+    permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.misc";
+    permission java.lang.RuntimePermission "accessClassInPackage.sun.security.*";
     permission java.lang.RuntimePermission "accessClassInPackage.sun.nio.ch";
     permission java.lang.RuntimePermission "loadLibrary.j2pkcs11";
     permission java.util.PropertyPermission "sun.security.pkcs11.allowSingleThreadedModules", "read";
@@ -140,8 +139,7 @@ grant codeBase "jrt:/jdk.crypto.cryptoki" {
     permission java.security.SecurityPermission "putProviderProperty.*";
     permission java.security.SecurityPermission "clearProviderProperties.*";
     permission java.security.SecurityPermission "removeProviderProperty.*";
-    permission java.security.SecurityPermission
-                   "getProperty.auth.login.defaultCallbackHandler";
+    permission java.security.SecurityPermission "getProperty.auth.login.defaultCallbackHandler";
     permission java.security.SecurityPermission "authProvider.*";
     // Needed for reading PKCS11 config file and NSS library check
     permission java.io.FilePermission "<<ALL FILES>>", "read";

--- a/test/jdk/sun/security/pkcs11/Provider/MultipleLogins.java
+++ b/test/jdk/sun/security/pkcs11/Provider/MultipleLogins.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,10 +31,9 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.LoginException;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
-import java.security.KeyStore;
-import java.security.Provider;
-import java.security.Security;
+import java.security.*;
 import java.util.Iterator;
+import java.util.PropertyPermission;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 
@@ -44,19 +43,27 @@ public class MultipleLogins {
     private static final String KS_TYPE = "PKCS11";
     private static final int NUM_PROVIDERS = 20;
     private static final SunPKCS11[] providers = new SunPKCS11[NUM_PROVIDERS];
-
+    static final Policy DEFAULT_POLICY = Policy.getPolicy();
 
     public static void main(String[] args) throws Exception {
+        String nssConfig = PKCS11Test.getNssConfig();
         for (int i =0; i < NUM_PROVIDERS; i++) {
-            String nssConfig = PKCS11Test.getNssConfig();
+            // loop to set up test without security manger
             if (nssConfig == null) {
                 // No test framework support yet. Ignore
                 System.out.println("No NSS config found. Skipping.");
                 return;
             }
-            providers[i] =
-                    (SunPKCS11)PKCS11Test.newPKCS11Provider()
-                    .configure(nssConfig);
+            providers[i] = (SunPKCS11)PKCS11Test.newPKCS11Provider();
+        }
+
+        if (args.length > 0) {
+            Policy.setPolicy(new SimplePolicy());
+            System.setSecurityManager(new SecurityManager());
+        }
+
+        for (int i =0; i < NUM_PROVIDERS; i++) {
+            providers[i] = (SunPKCS11)providers[i].configure(nssConfig);
             Security.addProvider(providers[i]);
             test(providers[i]);
         }
@@ -92,7 +99,6 @@ public class MultipleLogins {
 
     private static void test(SunPKCS11 p) throws Exception {
         KeyStore ks = KeyStore.getInstance(KS_TYPE, p);
-
         p.setCallbackHandler(new PasswordCallbackHandler());
         try {
             ks.load(null, (char[]) null);
@@ -115,6 +121,27 @@ public class MultipleLogins {
                 throw new RuntimeException("Token was present", e);
             }
         }
+    }
+
+    static final class SimplePolicy extends Policy {
+
+        final Permissions perms = new Permissions();
+        SimplePolicy() {
+            perms.add(new PropertyPermission("*", "read, write"));
+            perms.add(new RuntimePermission("accessClassInPackage.sun.*"));
+            perms.add(new RuntimePermission("accessClassInPackage.sun.security.pkcs11.*"));
+            perms.add(new SecurityPermission("authProvider.*"));
+            perms.add(new SecurityPermission("clearProviderProperties.*"));
+            perms.add(new SecurityPermission("insertProvider.*"));
+            perms.add(new SecurityPermission("removeProvider.*"));
+        }
+
+        @Override
+        public boolean implies(ProtectionDomain domain, Permission permission) {
+            return perms.implies(permission) ||
+                    DEFAULT_POLICY.implies(domain, permission);
+        }
+
     }
 
     public static class PasswordCallbackHandler implements CallbackHandler {

--- a/test/jdk/sun/security/pkcs11/Provider/MultipleLogins.sh
+++ b/test/jdk/sun/security/pkcs11/Provider/MultipleLogins.sh
@@ -22,7 +22,7 @@
 #
 
 # @test
-# @bug 7777777
+# @bug 8240256 8269034
 # @summary
 # @library /test/lib/
 # @build jdk.test.lib.util.ForceGC
@@ -114,7 +114,7 @@ ${COMPILEJAVA}${FS}bin${FS}javac ${TESTJAVACOPTS} ${TESTTOOLVMOPTS} \
         ${TESTSRC}${FS}MultipleLogins.java \
         ${TESTSRC}${FS}..${FS}PKCS11Test.java
 
-# run test
+# run test without security manager
 ${TESTJAVA}${FS}bin${FS}java ${TESTVMOPTS} \
         -classpath ${TESTCLASSPATH} \
         --add-modules jdk.crypto.cryptoki \
@@ -126,10 +126,21 @@ ${TESTJAVA}${FS}bin${FS}java ${TESTVMOPTS} \
         -Dtest.src=${TESTSRC} \
         -Dtest.classes=${TESTCLASSES} \
         -Djava.security.debug=${DEBUG} \
-        MultipleLogins
+        MultipleLogins || exit 10
 
-# save error status
-status=$?
+# run test with security manager
+${TESTJAVA}${FS}bin${FS}java ${TESTVMOPTS} \
+        -classpath ${TESTCLASSPATH} \
+        --add-modules jdk.crypto.cryptoki \
+        --add-exports jdk.crypto.cryptoki/sun.security.pkcs11=ALL-UNNAMED \
+        -DCUSTOM_DB_DIR=${TESTCLASSES} \
+        -DCUSTOM_P11_CONFIG=${TESTSRC}${FS}MultipleLogins-nss.txt \
+        -DNO_DEFAULT=true \
+        -DNO_DEIMOS=true \
+        -Dtest.src=${TESTSRC} \
+        -Dtest.classes=${TESTCLASSES} \
+        -Djava.security.debug=${DEBUG} \
+        MultipleLogins ${TESTSRC}${FS}MultipleLogins.policy || exit 11
 
-# return
-exit $status
+echo Done
+exit 0


### PR DESCRIPTION
Sufficient permissions missing if this code was ever to run with SecurityManager. 

Cleanest approach appears to be use of InnocuousThread to create the cleaner/poller threads.
Test case coverage extended to cover the SecurityManager scenario.

Reviewer request: @valeriepeng

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8269034](https://bugs.openjdk.java.net/browse/JDK-8269034): AccessControlException for SunPKCS11 daemon threads


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4555/head:pull/4555` \
`$ git checkout pull/4555`

Update a local copy of the PR: \
`$ git checkout pull/4555` \
`$ git pull https://git.openjdk.java.net/jdk pull/4555/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4555`

View PR using the GUI difftool: \
`$ git pr show -t 4555`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4555.diff">https://git.openjdk.java.net/jdk/pull/4555.diff</a>

</details>
