### PR TITLE
8269135: TestDifferentProtectionDomains runs into timeout in client VM

### DIFF
--- a/test/hotspot/jtreg/runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java
+++ b/test/hotspot/jtreg/runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java
@@ -29,7 +29,8 @@
  *          perform a nestmate access check.
  * @comment We use WB to force-compile a constructor to recreate the original
  *          failure scenario, so only run when we have "normal" compiler flags.
- * @requires vm.compMode=="Xmixed" &
+ * @requires vm.compMode == "Xmixed" &
+ *           vm.compiler2.enabled &
  *           (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
  * @library /test/lib /
  * @build sun.hotspot.WhiteBox
@@ -110,16 +111,11 @@ public class TestDifferentProtectionDomains {
 
         // Force the constructor to compile, which then triggers the nestmate
         // access check in the compiler thread, which leads to the original bug.
-        int optimizationLevel = CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION;
-        if (!wb.isC2OrJVMCIIncluded()) {
-            optimizationLevel = CompilerWhiteBoxTest.COMP_LEVEL_SIMPLE;
+        if (!wb.enqueueMethodForCompilation(cons, CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION)) {
+            throw new RuntimeException("Failed to queue constructor for compilation");
         }
-        wb.enqueueMethodForCompilation(cons,  optimizationLevel);
-        for (int i = 0; i < 300 && !wb.isMethodCompiled(cons); ++i) {
+        while (!wb.isMethodCompiled(cons)) {
             Thread.sleep(100);
-        }
-        if (!wb.isMethodCompiled(cons)) {
-            throw new RuntimeException("Timeout");
         }
 
         // Just for good measure call the compiled constructor.

--- a/test/hotspot/jtreg/runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java
+++ b/test/hotspot/jtreg/runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java
@@ -110,9 +110,16 @@ public class TestDifferentProtectionDomains {
 
         // Force the constructor to compile, which then triggers the nestmate
         // access check in the compiler thread, which leads to the original bug.
-        wb.enqueueMethodForCompilation(cons,  CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION);
-        while (!wb.isMethodCompiled(cons)) {
+        int optimizationLevel = CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION;
+        if (!wb.isC2OrJVMCIIncluded()) {
+            optimizationLevel = CompilerWhiteBoxTest.COMP_LEVEL_SIMPLE;
+        }
+        wb.enqueueMethodForCompilation(cons,  optimizationLevel);
+        for (int i = 0; i < 300 && !wb.isMethodCompiled(cons); ++i) {
             Thread.sleep(100);
+        }
+        if (!wb.isMethodCompiled(cons)) {
+            throw new RuntimeException("Timeout");
         }
 
         // Just for good measure call the compiled constructor.


### PR DESCRIPTION
The test tries to compile a method using the WhiteBox with optimization level 4, which is not available in client VMs. The WhiteBox only prints out a warning, and the call to enqueueMethodForCompilation succeeds. After that, the test case goes into an endless loop to wait for the compilation to finish, which never happens, because the method is not enqueued for compilation.

I fixed this by choosing a different compilation level, if C2 is not included in the JVM. I think this test should be enough, since there is already an `@requires` which checks, that we are in mixed mode and that C2 should be used.

In addition, I bound the loop in order to fail with a timeout more early, if the compilation does not happen (or takes too long because of platform restrictions).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269135](https://bugs.openjdk.java.net/browse/JDK-8269135): TestDifferentProtectionDomains runs into timeout in client VM


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4558/head:pull/4558` \
`$ git checkout pull/4558`

Update a local copy of the PR: \
`$ git checkout pull/4558` \
`$ git pull https://git.openjdk.java.net/jdk pull/4558/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4558`

View PR using the GUI difftool: \
`$ git pr show -t 4558`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4558.diff">https://git.openjdk.java.net/jdk/pull/4558.diff</a>

</details>
