### PR TITLE
8269138: Move typeArrayOop.inline.hpp include to vectorSupport.cpp

### DIFF
--- a/src/hotspot/share/prims/vectorSupport.cpp
+++ b/src/hotspot/share/prims/vectorSupport.cpp
@@ -30,6 +30,7 @@
 #include "classfile/vmSymbols.hpp"
 #include "code/location.hpp"
 #include "oops/klass.inline.hpp"
+#include "oops/typeArrayOop.inline.hpp"
 #include "prims/vectorSupport.hpp"
 #include "runtime/fieldDescriptor.inline.hpp"
 #include "runtime/frame.inline.hpp"

--- a/src/hotspot/share/prims/vectorSupport.hpp
+++ b/src/hotspot/share/prims/vectorSupport.hpp
@@ -28,7 +28,7 @@
 #include "jni.h"
 #include "code/debugInfo.hpp"
 #include "memory/allocation.hpp"
-#include "oops/typeArrayOop.inline.hpp"
+#include "oops/typeArrayOop.hpp"
 #include "runtime/registerMap.hpp"
 #include "utilities/exceptions.hpp"
 


### PR DESCRIPTION
See the bug report for inclusion circularity that breaks current Loom workspace. Including stuff properly, `.hpp` in `.hpp`, and `.inline.hpp` in `.cpp` resolves this.

Additional testing:
 - [x] Linux x86_64 builds
 - [x] Loom repository builds Linux x86_64 with this patch cherry-picked

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269138](https://bugs.openjdk.java.net/browse/JDK-8269138): Move typeArrayOop.inline.hpp include to vectorSupport.cpp


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4559/head:pull/4559` \
`$ git checkout pull/4559`

Update a local copy of the PR: \
`$ git checkout pull/4559` \
`$ git pull https://git.openjdk.java.net/jdk pull/4559/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4559`

View PR using the GUI difftool: \
`$ git pr show -t 4559`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4559.diff">https://git.openjdk.java.net/jdk/pull/4559.diff</a>

</details>
