### PR TITLE
8269188: [BACKOUT] Remove CodeCache::mark_for_evol_deoptimization() method

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1077,6 +1077,12 @@ void CodeCache::old_nmethods_do(MetadataClosure* f) {
   log_debug(redefine, class, nmethod)("Walked %d nmethods for mark_on_stack", length);
 }
 
+// Just marks the methods in this class as needing deoptimization
+void CodeCache::mark_for_evol_deoptimization(InstanceKlass* dependee) {
+  assert(SafepointSynchronize::is_at_safepoint(), "Can only do this at a safepoint!");
+}
+
+
 // Walk compiled methods and mark dependent methods for deoptimization.
 int CodeCache::mark_dependents_for_evol_deoptimization() {
   assert(SafepointSynchronize::is_at_safepoint(), "Can only do this at a safepoint!");

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -271,6 +271,7 @@ class CodeCache : AllStatic {
 
   // RedefineClasses support
   // Flushing and deoptimization in case of evolution
+  static void mark_for_evol_deoptimization(InstanceKlass* dependee);
   static int  mark_dependents_for_evol_deoptimization();
   static void mark_all_nmethods_for_evol_deoptimization();
   static void flush_evol_dependents();

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -312,6 +312,7 @@ bool              JvmtiExport::_can_modify_any_class                      = fals
 bool              JvmtiExport::_can_walk_any_space                        = false;
 
 uint64_t          JvmtiExport::_redefinition_count                        = 0;
+bool              JvmtiExport::_all_dependencies_are_recorded             = false;
 
 //
 // field access management

--- a/src/hotspot/share/prims/jvmtiExport.hpp
+++ b/src/hotspot/share/prims/jvmtiExport.hpp
@@ -187,6 +187,13 @@ class JvmtiExport : public AllStatic {
   inline static void increment_redefinition_count() {
     JVMTI_ONLY(_redefinition_count++;)
   }
+  // Flag to indicate if the compiler has recorded all dependencies. When the
+  // can_redefine_classes capability is enabled in the OnLoad phase then the compiler
+  // records all dependencies from startup. However if the capability is first
+  // enabled some time later then the dependencies recorded by the compiler
+  // are incomplete. This flag is used by RedefineClasses to know if the
+  // dependency information is complete or not.
+  static bool _all_dependencies_are_recorded;
 
   static void post_method_exit_inner(JavaThread* thread,
                                      methodHandle& mh,
@@ -205,6 +212,14 @@ class JvmtiExport : public AllStatic {
   inline static uint64_t redefinition_count() {
     JVMTI_ONLY(return _redefinition_count);
     NOT_JVMTI(return 0);
+  }
+
+  inline static bool all_dependencies_are_recorded() {
+    return _all_dependencies_are_recorded;
+  }
+
+  inline static void set_all_dependencies_are_recorded(bool on) {
+    _all_dependencies_are_recorded = (on != 0);
   }
 
   // Add read edges to the unnamed modules of the bootstrap and app class loaders

--- a/src/hotspot/share/prims/jvmtiManageCapabilities.cpp
+++ b/src/hotspot/share/prims/jvmtiManageCapabilities.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -326,6 +326,13 @@ void JvmtiManageCapabilities::update() {
        || avail.can_generate_field_modification_events)
   {
     RewriteFrequentPairs = false;
+  }
+
+  // If can_redefine_classes is enabled in the onload phase then we know that the
+  // dependency information recorded by the compiler is complete.
+  if ((avail.can_redefine_classes || avail.can_retransform_classes) &&
+      JvmtiEnv::get_phase() == JVMTI_PHASE_ONLOAD) {
+    JvmtiExport::set_all_dependencies_are_recorded(true);
   }
 
   JvmtiExport::set_can_get_source_debug_extension(avail.can_get_source_debug_extension);

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -4068,17 +4068,56 @@ void VM_RedefineClasses::transfer_old_native_function_registrations(InstanceKlas
   transfer.transfer_registrations(_matching_old_methods, _matching_methods_length);
 }
 
-// Deoptimize all compiled code that depends on the classes redefined.
+// Deoptimize all compiled code that depends on this class.
+//
+// If the can_redefine_classes capability is obtained in the onload
+// phase then the compiler has recorded all dependencies from startup.
+// In that case we need only deoptimize and throw away all compiled code
+// that depends on the class.
+//
+// If can_redefine_classes is obtained sometime after the onload
+// phase then the dependency information may be incomplete. In that case
+// the first call to RedefineClasses causes all compiled code to be
+// thrown away. As can_redefine_classes has been obtained then
+// all future compilations will record dependencies so second and
+// subsequent calls to RedefineClasses need only throw away code
+// that depends on the class.
+//
+
+// First step is to walk the code cache for each class redefined and mark
+// dependent methods.  Wait until all classes are processed to deoptimize everything.
+void VM_RedefineClasses::mark_dependent_code(InstanceKlass* ik) {
+  assert_locked_or_safepoint(Compile_lock);
+
+  // All dependencies have been recorded from startup or this is a second or
+  // subsequent use of RedefineClasses
+  if (JvmtiExport::all_dependencies_are_recorded()) {
+    CodeCache::mark_for_evol_deoptimization(ik);
+  }
+}
 
 void VM_RedefineClasses::flush_dependent_code() {
   assert(SafepointSynchronize::is_at_safepoint(), "sanity check");
 
-  int deopt = CodeCache::mark_dependents_for_evol_deoptimization();
-  log_debug(redefine, class, nmethod)("Marked %d dependent nmethods for deopt", deopt);
+  bool deopt_needed;
 
-  if (deopt != 0) {
+  // This is the first redefinition, mark all the nmethods for deoptimization
+  if (!JvmtiExport::all_dependencies_are_recorded()) {
+    log_debug(redefine, class, nmethod)("Marked all nmethods for deopt");
+    CodeCache::mark_all_nmethods_for_evol_deoptimization();
+    deopt_needed = true;
+  } else {
+    int deopt = CodeCache::mark_dependents_for_evol_deoptimization();
+    log_debug(redefine, class, nmethod)("Marked %d dependent nmethods for deopt", deopt);
+    deopt_needed = (deopt != 0);
+  }
+
+  if (deopt_needed) {
     CodeCache::flush_evol_dependents();
   }
+
+  // From now on we know that the dependency information is complete
+  JvmtiExport::set_all_dependencies_are_recorded(true);
 }
 
 void VM_RedefineClasses::compute_added_deleted_matching_methods() {
@@ -4181,6 +4220,9 @@ void VM_RedefineClasses::redefine_single_class(Thread* current, jclass the_jclas
   // Remove all breakpoints in methods of this class
   JvmtiBreakpoints& jvmti_breakpoints = JvmtiCurrentBreakpoints::get_jvmti_breakpoints();
   jvmti_breakpoints.clearall_in_class_at_safepoint(the_class);
+
+  // Mark all compiled code that depends on this class
+  mark_dependent_code(the_class);
 
   _old_methods = the_class->methods();
   _new_methods = scratch_class->methods();

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
@@ -493,6 +493,7 @@ class VM_RedefineClasses: public VM_Operation {
          constantPoolHandle scratch_cp, int scratch_cp_length, TRAPS);
 
   void flush_dependent_code();
+  void mark_dependent_code(InstanceKlass* ik);
 
   // lock classes to redefine since constant pool merging isn't thread safe.
   void lock_classes();


### PR DESCRIPTION
This reverts commit 33c23a1cf2aa81551eee4a2acf271edf573558aa.

Built locally linux-x64-debug and ran vmTestbase/nsk/jvmti tests.

See bug for details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269188](https://bugs.openjdk.java.net/browse/JDK-8269188): [BACKOUT] Remove CodeCache::mark_for_evol_deoptimization() method


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4563/head:pull/4563` \
`$ git checkout pull/4563`

Update a local copy of the PR: \
`$ git checkout pull/4563` \
`$ git pull https://git.openjdk.java.net/jdk pull/4563/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4563`

View PR using the GUI difftool: \
`$ git pr show -t 4563`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4563.diff">https://git.openjdk.java.net/jdk/pull/4563.diff</a>

</details>
