### PR TITLE
JDK-8269202: Support %p in jfr dump file name

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/ArgumentParser.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/ArgumentParser.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import jdk.jfr.internal.JVM;
+
 final class ArgumentParser {
     private final Map<String, Object> options = new HashMap<>();
     private final Map<String, Object> extendedOptions = new HashMap<>();
@@ -60,6 +62,9 @@ final class ArgumentParser {
             }
             if (!atEnd() && !accept(delimiter)) { // must be followed by delimiter
                 throw new IllegalArgumentException("Expected delimiter, but found " + currentChar());
+            }
+            if (key.equals("filename") && value != null && value.contains("%p")) {
+                value = value.replaceFirst("%p", "pid" + JVM.getJVM().getPid());
             }
             addOption(key, value);
             eatDelimiter();


### PR DESCRIPTION
Currently, jfr supports 2 ways to name dump file.
1. dump without a file name, it will generate a name automatically with pid.
2. specify a file name explicitly, but without support for pid(%p)
It will be helpful to support %p in file name.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8269202](https://bugs.openjdk.java.net/browse/JDK-8269202): Support %p in jfr dump file name


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4564/head:pull/4564` \
`$ git checkout pull/4564`

Update a local copy of the PR: \
`$ git checkout pull/4564` \
`$ git pull https://git.openjdk.java.net/jdk pull/4564/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4564`

View PR using the GUI difftool: \
`$ git pr show -t 4564`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4564.diff">https://git.openjdk.java.net/jdk/pull/4564.diff</a>

</details>
