### PR TITLE
JDK-8269206 A small typo in comment in test/lib/sun/hotspot/WhiteBox.java

### DIFF
--- a/test/lib/sun/hotspot/WhiteBox.java
+++ b/test/lib/sun/hotspot/WhiteBox.java
@@ -310,7 +310,7 @@ public class WhiteBox {
     makeMethodNotCompilable0(method, compLevel, isOsr);
   }
   public        int     getMethodCompilationLevel(Executable method) {
-    return getMethodCompilationLevel(method, false /*not ost*/);
+    return getMethodCompilationLevel(method, false /*not osr*/);
   }
   private native int     getMethodCompilationLevel0(Executable method, boolean isOsr);
   public         int     getMethodCompilationLevel(Executable method, boolean isOsr) {


### PR DESCRIPTION
return getMethodCompilationLevel(method, false /*not ost*/); 

"ost" should be "osr"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269206](https://bugs.openjdk.java.net/browse/JDK-8269206): A small typo in comment in test/lib/sun/hotspot/WhiteBox.java


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4566/head:pull/4566` \
`$ git checkout pull/4566`

Update a local copy of the PR: \
`$ git checkout pull/4566` \
`$ git pull https://git.openjdk.java.net/jdk pull/4566/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4566`

View PR using the GUI difftool: \
`$ git pr show -t 4566`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4566.diff">https://git.openjdk.java.net/jdk/pull/4566.diff</a>

</details>
