### PR TITLE
8269216: Useless initialization in com/sun/crypto/provider/PBES2Parameters.java

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/PBES2Parameters.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBES2Parameters.java
@@ -174,7 +174,6 @@ abstract class PBES2Parameters extends AlgorithmParametersSpi {
         }
 
         if (cipherAlgo.equals("AES")) {
-            this.keysize = keysize;
             switch (keysize) {
             case 128:
                 cipherAlgo_OID = aes128CBC_OID;


### PR DESCRIPTION
SonarCloud reports:
"Remove or correct this useless self-assignment."

```
        if (cipherAlgo.equals("AES")) {
            this.keysize = keysize; // <---- here
            switch (keysize) {
            case 128:
                cipherAlgo_OID = aes128CBC_OID;
```

Seems to be here since initial addition in JDK-6383200.

Additional testing:
 - [x] `jdk_security` pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269216](https://bugs.openjdk.java.net/browse/JDK-8269216): Useless initialization in com/sun/crypto/provider/PBES2Parameters.java


### Reviewers
 * [Valerie Peng](https://openjdk.java.net/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4570/head:pull/4570` \
`$ git checkout pull/4570`

Update a local copy of the PR: \
`$ git checkout pull/4570` \
`$ git pull https://git.openjdk.java.net/jdk pull/4570/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4570`

View PR using the GUI difftool: \
`$ git pr show -t 4570`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4570.diff">https://git.openjdk.java.net/jdk/pull/4570.diff</a>

</details>
