### PR TITLE
8269126: Rename G1AllowPreventiveGC option to G1UsePreventiveGC 

### DIFF
--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1416,7 +1416,7 @@ static size_t get_num_regions_adjust_for_plab_waste(size_t byte_count) {
 }
 
 bool G1Policy::preventive_collection_required(uint alloc_region_count) {
-  if (!G1AllowPreventiveGC || !Universe::is_fully_initialized()) {
+  if (!G1UsePreventiveGC || !Universe::is_fully_initialized()) {
     // Don't attempt any preventive GC's if the feature is disabled,
     // or before initialization is complete.
     return false;

--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -340,7 +340,7 @@
           "percentage of the currently used memory.")                       \
           range(0.0, 1.0)                                                   \
                                                                             \
-  product(bool, G1AllowPreventiveGC, true, DIAGNOSTIC,                      \
+  product(bool, G1UsePreventiveGC, true, DIAGNOSTIC,                        \
           "Allows collections to be triggered proactively based on the      \
            number of free regions and the expected survival rates in each   \
            section of the heap.")

--- a/test/hotspot/jtreg/gc/g1/TestGCLogMessages.java
+++ b/test/hotspot/jtreg/gc/g1/TestGCLogMessages.java
@@ -248,7 +248,7 @@ public class TestGCLogMessages {
                                                                   "-XX:G1EvacuationFailureALotCount=100",
                                                                   "-XX:G1EvacuationFailureALotInterval=1",
                                                                   "-XX:+UnlockDiagnosticVMOptions",
-                                                                  "-XX:-G1AllowPreventiveGC",
+                                                                  "-XX:-G1UsePreventiveGC",
                                                                   "-Xlog:gc+phases=debug",
                                                                   GCTestWithEvacuationFailure.class.getName());
 
@@ -261,7 +261,7 @@ public class TestGCLogMessages {
                                                    "-Xmn16M",
                                                    "-Xms32M",
                                                    "-XX:+UnlockDiagnosticVMOptions",
-                                                   "-XX:-G1AllowPreventiveGC",
+                                                   "-XX:-G1UsePreventiveGC",
                                                    "-Xlog:gc+phases=trace",
                                                    GCTestWithEvacuationFailure.class.getName());
 

--- a/test/hotspot/jtreg/gc/g1/TestVerifyGCType.java
+++ b/test/hotspot/jtreg/gc/g1/TestVerifyGCType.java
@@ -126,7 +126,7 @@ public class TestVerifyGCType {
                                                         "-XX:G1EvacuationFailureALotCount=100",
                                                         "-XX:G1EvacuationFailureALotInterval=1",
                                                         "-XX:+UnlockDiagnosticVMOptions",
-                                                        "-XX:-G1AllowPreventiveGC"});
+                                                        "-XX:-G1UsePreventiveGC"});
         output.shouldHaveExitValue(0);
 
         verifyCollection("Pause Young (Normal)", false, false, true, output.getStdout());


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that as the title suggest only changes the name of the `G1AllowPreventiveGC` option to `G1UsePreventiveGC` to better conform to other G1 options which all use `Use`.

Since this is a diagnostic flag, no further process is required.

Testing: tier1-5

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8269126](https://bugs.openjdk.java.net/browse/JDK-8269126): Rename G1AllowPreventiveGC option to G1UsePreventiveGC


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4571/head:pull/4571` \
`$ git checkout pull/4571`

Update a local copy of the PR: \
`$ git checkout pull/4571` \
`$ git pull https://git.openjdk.java.net/jdk pull/4571/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4571`

View PR using the GUI difftool: \
`$ git pr show -t 4571`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4571.diff">https://git.openjdk.java.net/jdk/pull/4571.diff</a>

</details>
