### PR TITLE
8269223: -Xcheck:jni WARNINGs working with fonts on Linux

### DIFF
--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DRenderQueue.cpp
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DRenderQueue.cpp
@@ -866,7 +866,8 @@ void D3DRQ_FlushBuffer(void *pParam)
 
     if (!JNU_IsNull(env, pFlush->runnable)) {
         J2dTraceLn(J2D_TRACE_VERBOSE, "  executing runnable");
-        JNU_CallMethodByName(env, NULL, pFlush->runnable, "run", "()V");
+        jboolean ignoreException;
+        JNU_CallMethodByName(env, &ignoreException, pFlush->runnable, "run", "()V");
     }
 }
 

--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DRenderQueue.cpp
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DRenderQueue.cpp
@@ -866,8 +866,11 @@ void D3DRQ_FlushBuffer(void *pParam)
 
     if (!JNU_IsNull(env, pFlush->runnable)) {
         J2dTraceLn(J2D_TRACE_VERBOSE, "  executing runnable");
-        jboolean ignoreException;
-        JNU_CallMethodByName(env, &ignoreException, pFlush->runnable, "run", "()V");
+        jboolean hasException;
+        JNU_CallMethodByName(env, &hasException, pFlush->runnable, "run", "()V");
+        if (hasException) {
+            J2dTraceLn(J2D_TRACE_ERROR, "  exception occurred while executing runnable");
+        }
     }
 }
 

--- a/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
@@ -6573,7 +6573,7 @@ Java_java_awt_Component_initIDs(JNIEnv *env, jclass cls)
     jintArray obj = (jintArray)JNU_CallStaticMethodByName(env, &ignoreException,
                                                           "java/awt/event/InputEvent",
                                                           "getButtonDownMasks", "()[I").l;
-
+    CHECK_NULL(obj);
     jint * tmp = env->GetIntArrayElements(obj, JNI_FALSE);
     CHECK_NULL(tmp);
     jsize len = env->GetArrayLength(obj);

--- a/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
@@ -6569,11 +6569,11 @@ JNIEXPORT void JNICALL
 Java_java_awt_Component_initIDs(JNIEnv *env, jclass cls)
 {
     TRY;
-    jclass inputEventClazz = env->FindClass("java/awt/event/InputEvent");
-    CHECK_NULL(inputEventClazz);
-    jmethodID getButtonDownMasksID = env->GetStaticMethodID(inputEventClazz, "getButtonDownMasks", "()[I");
-    CHECK_NULL(getButtonDownMasksID);
-    jintArray obj = (jintArray)env->CallStaticObjectMethod(inputEventClazz, getButtonDownMasksID);
+    jboolean ignoreException;
+    jintArray obj = (jintArray)JNU_CallStaticMethodByName(env, &ignoreException,
+                                                          "java/awt/event/InputEvent",
+                                                          "getButtonDownMasks", "()[I").l;
+
     jint * tmp = env->GetIntArrayElements(obj, JNI_FALSE);
     CHECK_NULL(tmp);
     jsize len = env->GetArrayLength(obj);

--- a/src/java.desktop/windows/native/libawt/windows/awt_DesktopProperties.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_DesktopProperties.cpp
@@ -752,6 +752,7 @@ void AwtDesktopProperties::SetStringProperty(LPCTSTR propName, LPTSTR value) {
                              key, jValue);
     GetEnv()->DeleteLocalRef(jValue);
     GetEnv()->DeleteLocalRef(key);
+    (void)safe_ExceptionOccurred(GetEnv());
 }
 
 void AwtDesktopProperties::SetIntegerProperty(LPCTSTR propName, int value) {
@@ -764,6 +765,7 @@ void AwtDesktopProperties::SetIntegerProperty(LPCTSTR propName, int value) {
                              AwtDesktopProperties::setIntegerPropertyID,
                              key, (jint)value);
     GetEnv()->DeleteLocalRef(key);
+    (void)safe_ExceptionOccurred(GetEnv());
 }
 
 void AwtDesktopProperties::SetBooleanProperty(LPCTSTR propName, BOOL value) {
@@ -775,6 +777,7 @@ void AwtDesktopProperties::SetBooleanProperty(LPCTSTR propName, BOOL value) {
                              AwtDesktopProperties::setBooleanPropertyID,
                              key, value ? JNI_TRUE : JNI_FALSE);
     GetEnv()->DeleteLocalRef(key);
+    (void)safe_ExceptionOccurred(GetEnv());
 }
 
 void AwtDesktopProperties::SetColorProperty(LPCTSTR propName, DWORD value) {
@@ -787,6 +790,7 @@ void AwtDesktopProperties::SetColorProperty(LPCTSTR propName, DWORD value) {
                              key, GetRValue(value), GetGValue(value),
                              GetBValue(value));
     GetEnv()->DeleteLocalRef(key);
+    (void)safe_ExceptionOccurred(GetEnv());
 }
 
 void AwtDesktopProperties::SetFontProperty(HDC dc, int fontID,
@@ -849,6 +853,7 @@ void AwtDesktopProperties::SetFontProperty(HDC dc, int fontID,
                               key, fontName, style, pointSize);
                     GetEnv()->DeleteLocalRef(key);
                     GetEnv()->DeleteLocalRef(fontName);
+                    (void)safe_ExceptionOccurred(GetEnv());
                 }
             }
             delete[] face;
@@ -896,6 +901,7 @@ void AwtDesktopProperties::SetFontProperty(LPCTSTR propName, const LOGFONT & fon
                              key, fontName, style, pointSize);
     GetEnv()->DeleteLocalRef(key);
     GetEnv()->DeleteLocalRef(fontName);
+    (void)safe_ExceptionOccurred(GetEnv());
 }
 
 void AwtDesktopProperties::SetSoundProperty(LPCTSTR propName, LPCTSTR winEventName) {
@@ -913,6 +919,7 @@ void AwtDesktopProperties::SetSoundProperty(LPCTSTR propName, LPCTSTR winEventNa
                              key, event);
     GetEnv()->DeleteLocalRef(event);
     GetEnv()->DeleteLocalRef(key);
+    (void)safe_ExceptionOccurred(GetEnv());
 }
 
 void AwtDesktopProperties::PlayWindowsSound(LPCTSTR event) {

--- a/test/jdk/java/awt/font/JNICheck/FreeTypeScalerJNICheck.java
+++ b/test/jdk/java/awt/font/JNICheck/FreeTypeScalerJNICheck.java
@@ -26,6 +26,7 @@
  * @bug 8269223
  * @summary Verifies that -Xcheck:jni issues no warnings from freetypeScaler.c
  * @library /test/lib
+ * @key headful
  * @run main FreeTypeScalerJNICheck
  */
 import javax.swing.*;

--- a/test/jdk/java/awt/font/JNICheck/FreeTypeScalerJNICheck.java
+++ b/test/jdk/java/awt/font/JNICheck/FreeTypeScalerJNICheck.java
@@ -29,11 +29,13 @@
  * @key headful
  * @run main FreeTypeScalerJNICheck
  */
-import javax.swing.*;
-import java.awt.*;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.GraphicsEnvironment;
+import java.awt.Graphics2D;
 import java.awt.geom.Rectangle2D;
-import java.awt.image.*;
-import java.io.*;
+import java.awt.image.BufferedImage;
+import javax.swing.JFrame;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 
@@ -56,7 +58,7 @@ public class FreeTypeScalerJNICheck {
 
         for (String ff : families)
         {
-            Font font = Font.decode(ff);
+            Font font = new Font(ff, Font.PLAIN, 12);
             Rectangle2D bounds = font.getStringBounds("test", g2d.getFontRenderContext());
             FontMetrics metrics = frame.getFontMetrics(font);
             System.out.println(bounds.getHeight() + metrics.getHeight()); // use bounds and metrics

--- a/test/jdk/java/awt/font/JNICheck/FreeTypeScalerJNICheck.java
+++ b/test/jdk/java/awt/font/JNICheck/FreeTypeScalerJNICheck.java
@@ -25,7 +25,6 @@
 /* @test
  * @bug 8269223
  * @summary Verifies that -Xcheck:jni issues no warnings from freetypeScaler.c
- * @requires os.family == "linux"
  * @library /test/lib
  * @run main FreeTypeScalerJNICheck
  */

--- a/test/jdk/java/awt/font/JNICheck/FreeTypeScalerJNICheck.java
+++ b/test/jdk/java/awt/font/JNICheck/FreeTypeScalerJNICheck.java
@@ -26,7 +26,6 @@
  * @bug 8269223
  * @summary Verifies that -Xcheck:jni issues no warnings from freetypeScaler.c
  * @library /test/lib
- * @key headful
  * @run main FreeTypeScalerJNICheck
  */
 import java.awt.Font;
@@ -52,7 +51,6 @@ public class FreeTypeScalerJNICheck {
 
     public static void runTest() {
         String families[] = GraphicsEnvironment.getLocalGraphicsEnvironment().getAvailableFontFamilyNames();
-        JFrame frame = new JFrame("test");
         BufferedImage bi = new BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB);
         Graphics2D g2d = bi.createGraphics();
 
@@ -60,7 +58,8 @@ public class FreeTypeScalerJNICheck {
         {
             Font font = new Font(ff, Font.PLAIN, 12);
             Rectangle2D bounds = font.getStringBounds("test", g2d.getFontRenderContext());
-            FontMetrics metrics = frame.getFontMetrics(font);
+            g2d.setFont(font);
+            FontMetrics metrics = g2d.getFontMetrics(font);
             System.out.println(bounds.getHeight() + metrics.getHeight()); // use bounds and metrics
         }
 

--- a/test/jdk/java/awt/font/JNICheck/FreeTypeScalerJNICheck.java
+++ b/test/jdk/java/awt/font/JNICheck/FreeTypeScalerJNICheck.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, JetBrains s.r.o.. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8269223
+ * @summary Verifies that -Xcheck:jni issues no warnings from freetypeScaler.c
+ * @requires os.family == "linux"
+ * @library /test/lib
+ * @run main FreeTypeScalerJNICheck
+ */
+import javax.swing.*;
+import java.awt.*;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.*;
+import java.io.*;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class FreeTypeScalerJNICheck {
+    public static void main(String[] args) throws Exception {
+        if (args.length > 0 && args[0].equals("runtest")) {
+            runTest();
+        } else {
+            ProcessBuilder pb = ProcessTools.createTestJvm("-Xcheck:jni", FreeTypeScalerJNICheck.class.getName(), "runtest");
+            OutputAnalyzer oa = ProcessTools.executeProcess(pb);
+            oa.shouldContain("Done").shouldNotContain("WARNING").shouldHaveExitValue(0);
+        }
+    }
+
+    public static void runTest() {
+        String families[] = GraphicsEnvironment.getLocalGraphicsEnvironment().getAvailableFontFamilyNames();
+        JFrame frame = new JFrame("test");
+        BufferedImage bi = new BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g2d = bi.createGraphics();
+
+        for (String ff : families)
+        {
+            Font font = Font.decode(ff);
+            Rectangle2D bounds = font.getStringBounds("test", g2d.getFontRenderContext());
+            FontMetrics metrics = frame.getFontMetrics(font);
+            System.out.println(bounds.getHeight() + metrics.getHeight()); // use bounds and metrics
+        }
+
+        System.out.println("Done");
+    }
+}
+


### PR DESCRIPTION
Added an `ExceptionCheck()` followed by `ExceptionDescribe()` and `ExceptionClear()` immediately after the Java calls made from the callback function `ReadTTFontFileFunc()` in `freetypeScaler.c`. 

The exception(s) need to be cleared because we're not returning immediately to Java that would've been able to handle them gracefully. And in order not to loose the exception entirely (even though the return value would also indicate an error condition), print out the exception with `ExceptionDescribe()` to aid in debugging.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269223](https://bugs.openjdk.java.net/browse/JDK-8269223): -Xcheck:jni WARNINGs working with fonts on Linux


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to 13b086860601d2ea6601306973828a2c6ea1f4aa
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4572/head:pull/4572` \
`$ git checkout pull/4572`

Update a local copy of the PR: \
`$ git checkout pull/4572` \
`$ git pull https://git.openjdk.java.net/jdk pull/4572/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4572`

View PR using the GUI difftool: \
`$ git pr show -t 4572`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4572.diff">https://git.openjdk.java.net/jdk/pull/4572.diff</a>

</details>
