### PR TITLE
8269225: JFR.stop misses the written info when the filename is only specified by JFR.start

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStop.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStop.java
@@ -26,10 +26,13 @@ package jdk.jfr.internal.dcmd;
 
 import java.io.IOException;
 import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import jdk.jfr.Recording;
+import jdk.jfr.internal.PrivateAccess;
 import jdk.jfr.internal.SecuritySupport.SafePath;
+import jdk.jfr.internal.WriteableUserPath;
 
 /**
  * JFR.stop
@@ -44,8 +47,9 @@ final class DCmdStop extends AbstractDCmd {
         String name = parser.getOption("name");
         String filename = parser.getOption("filename");
         try {
-            SafePath safePath = null;
             Recording recording = findRecording(name);
+            WriteableUserPath path = PrivateAccess.getInstance().getPlatformRecording(recording).getDestination();
+            SafePath safePath = path == null ? null : new SafePath(path.getRealPathText());
             if (filename != null) {
                 try {
                     // Ensure path is valid. Don't generate safePath if filename == null, as a user may

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStop.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStop.java
@@ -26,7 +26,6 @@ package jdk.jfr.internal.dcmd;
 
 import java.io.IOException;
 import java.nio.file.InvalidPathException;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import jdk.jfr.Recording;

--- a/test/jdk/jdk/jfr/jcmd/TestJcmdStopWithoutFilename.java
+++ b/test/jdk/jdk/jfr/jcmd/TestJcmdStopWithoutFilename.java
@@ -39,9 +39,14 @@ import jdk.test.lib.process.OutputAnalyzer;
 public class TestJcmdStopWithoutFilename {
 
     public static void main(String[] args) throws Exception {
+
+        JcmdHelper.jcmd("JFR.start name=test");
+        OutputAnalyzer output = JcmdHelper.jcmd("JFR.stop name=test");
+        output.shouldNotContain("written to");
+
         String filename = "output.jfr";
         JcmdHelper.jcmd("JFR.start name=test filename=" + filename);
-        OutputAnalyzer output = JcmdHelper.jcmd("JFR.stop name=test");
+        output = JcmdHelper.jcmd("JFR.stop name=test");
         output.shouldContain("written to").shouldContain(filename);
     }
 }

--- a/test/jdk/jdk/jfr/jcmd/TestJcmdStopWithoutFilename.java
+++ b/test/jdk/jdk/jfr/jcmd/TestJcmdStopWithoutFilename.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.jcmd;
+
+import java.io.File;
+
+import jdk.test.lib.jfr.FileHelper;
+import jdk.test.lib.process.OutputAnalyzer;
+
+/**
+ * @test
+ * @summary The test verifies JFR.stop
+ * @key jfr
+ * @requires vm.hasJFR
+ * @library /test/lib /test/jdk
+ * @run main/othervm jdk.jfr.jcmd.TestJcmdStopWithoutFilename
+ */
+public class TestJcmdStopWithoutFilename {
+
+    public static void main(String[] args) throws Exception {
+        String filename = "output.jfr";
+        JcmdHelper.jcmd("JFR.start name=test filename=" + filename);
+        OutputAnalyzer output = JcmdHelper.jcmd("JFR.stop name=test");
+        output.shouldContain("written to").shouldContain(filename);
+    }
+}
+

--- a/test/jdk/jdk/jfr/jcmd/TestJcmdStopWithoutFilename.java
+++ b/test/jdk/jdk/jfr/jcmd/TestJcmdStopWithoutFilename.java
@@ -23,9 +23,6 @@
 
 package jdk.jfr.jcmd;
 
-import java.io.File;
-
-import jdk.test.lib.jfr.FileHelper;
 import jdk.test.lib.process.OutputAnalyzer;
 
 /**


### PR DESCRIPTION
Hi,

Could I have a review of this small fix?

JFR.stop misses the written info when the filename is only specified by JFR.start, for example:
```
$jcmd 87802 JFR.start name=test filename=2.jfr
87802:
Started recording 1. No limit specified, using maxsize=250MB as default.

Use jcmd 87802 JFR.dump name=test to copy recording data to file.

$jcmd 87802 JFR.stop name=test
87802:
Stopped recording "test".
```

The 'JFR.stop' didn't print written info, but actually, 2.jfr was generated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269225](https://bugs.openjdk.java.net/browse/JDK-8269225): JFR.stop misses the written info when the filename is only specified by JFR.start


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**) ⚠️ Review applies to c1950b96c3b7ef698c31c55e342bcda5fb6cf807


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4573/head:pull/4573` \
`$ git checkout pull/4573`

Update a local copy of the PR: \
`$ git checkout pull/4573` \
`$ git pull https://git.openjdk.java.net/jdk pull/4573/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4573`

View PR using the GUI difftool: \
`$ git pr show -t 4573`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4573.diff">https://git.openjdk.java.net/jdk/pull/4573.diff</a>

</details>
