### PR TITLE
8267075: jcmd VM.cds should print directory of the output files

### DIFF
--- a/src/java.base/share/classes/jdk/internal/misc/CDS.java
+++ b/src/java.base/share/classes/jdk/internal/misc/CDS.java
@@ -256,6 +256,7 @@ public class CDS {
     * @param fileName user input archive name, can be null.
     */
     private static void dumpSharedArchive(boolean isStatic, String fileName) throws Exception {
+        String cwd = new File("").getAbsolutePath(); // current dir used for printing message.
         String currentPid = String.valueOf(ProcessHandle.current().pid());
         String archiveFileName =  fileName != null ? fileName :
             "java_pid" + currentPid + (isStatic ? "_static.jsa" : "_dynamic.jsa");
@@ -299,8 +300,8 @@ public class CDS {
             Process proc = Runtime.getRuntime().exec(cmds.toArray(new String[0]));
 
             // Drain stdout/stderr to files in new threads.
-            String stdOutFile = drainOutput(proc.getInputStream(), proc.pid(), "stdout", cmds);
-            String stdErrFile = drainOutput(proc.getErrorStream(), proc.pid(), "stderr", cmds);
+            String stdOutFileName = drainOutput(proc.getInputStream(), proc.pid(), "stdout", cmds);
+            String stdErrFileName = drainOutput(proc.getErrorStream(), proc.pid(), "stderr", cmds);
 
             proc.waitFor();
             // done, delete classlist file.
@@ -311,14 +312,15 @@ public class CDS {
             if (!tempArchiveFile.exists()) {
                 throw new RuntimeException("Archive file " + tempArchiveFileName +
                                            " is not created, please check stdout file " +
-                                            stdOutFile + " or stderr file " +
-                                            stdErrFile + " for more detail");
+                                            cwd + File.separator + stdOutFileName + " or stderr file " +
+                                            cwd + File.separator + stdErrFileName + " for more detail");
             }
         } else {
             dumpDynamicArchive(tempArchiveFileName);
             if (!tempArchiveFile.exists()) {
                 throw new RuntimeException("Archive file " + tempArchiveFileName +
-                                           " is not created, please check process " +
+                                           " is not created, please check current working directory " +
+                                           cwd  + " for process " +
                                            currentPid + " output for more detail");
             }
         }
@@ -331,6 +333,6 @@ public class CDS {
             throw new RuntimeException("Cannot rename temp file " + tempArchiveFileName + " to archive file" + archiveFileName);
         }
         // Everyting goes well, print out the file name.
-        System.out.println((isStatic ? "Static" : " Dynamic") + " dump to file " + archiveFileName);
+        System.out.println((isStatic ? "Static" : " Dynamic") + " dump to file " + cwd + File.separator + archiveFileName);
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDumpBase.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDumpBase.java
@@ -172,7 +172,7 @@ public abstract class JCmdTestDumpBase {
         }
     }
 
-    protected static void test(String fileName, long pid,
+    protected static OutputAnalyzer test(String fileName, long pid,
                              boolean useBoot, boolean expectOK, String... messages) throws Exception {
         System.out.println("Expected: " + (expectOK ? "SUCCESS" : "FAIL"));
         String archiveFileName = fileName != null ? fileName :
@@ -200,6 +200,7 @@ public abstract class JCmdTestDumpBase {
                 checkFileExistence(archiveFileName, false);
             }
         }
+        return output;
     }
 
     protected static void print2ln(String arg) {

--- a/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestFileSafety.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestFileSafety.java
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @bug 8265465
+ * @bug 8265465 8267075
  * @summary Test jcmd to dump static shared archive.
  * @requires vm.cds
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
@@ -44,16 +44,16 @@ import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 
 public class JCmdTestFileSafety extends JCmdTestDumpBase {
-    static final String promtStdout = "please check stdout file";
-    static final String promtStderr = "or stderr file";
+    static final String promptStdout = "please check stdout file";
+    static final String promptStderr = "or stderr file";
 
     static void checkContainAbsoluteLogPath(OutputAnalyzer output) throws Exception {
        String stdText = output.getOutput();
-       if (stdText.contains(promtStdout) &&
-           stdText.contains(promtStderr)) {
-           int a = stdText.indexOf(promtStdout);
-           int b = stdText.indexOf(promtStderr);
-           String stdOutFileName = stdText.substring(a + promtStdout.length() + 1, b - 1).trim();
+       if (stdText.contains(promptStdout) &&
+           stdText.contains(promptStderr)) {
+           int a = stdText.indexOf(promptStdout);
+           int b = stdText.indexOf(promptStderr);
+           String stdOutFileName = stdText.substring(a + promptStdout.length() + 1, b - 1).trim();
            File   stdOutFile = new File(stdOutFileName);
            if (!stdOutFile.isAbsolute()) {
                throw new RuntimeException("Failed to set file name in absolute for prompting message");


### PR DESCRIPTION
Hi, Please review the simple change for jcmd VM.cds to print directory of output file.
The printout will print out absolute file path, also a test scenario added.

Tests: tier1,tier2,tier3,tier4

Thanks
Yumin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267075](https://bugs.openjdk.java.net/browse/JDK-8267075): jcmd VM.cds should print directory of the output files


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4576/head:pull/4576` \
`$ git checkout pull/4576`

Update a local copy of the PR: \
`$ git checkout pull/4576` \
`$ git pull https://git.openjdk.java.net/jdk pull/4576/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4576`

View PR using the GUI difftool: \
`$ git pr show -t 4576`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4576.diff">https://git.openjdk.java.net/jdk/pull/4576.diff</a>

</details>
