### PR TITLE
8266407: remove jdk.internal.javac.PreviewFeature.Feature.SEALED_CLASSES

### DIFF
--- a/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
@@ -54,10 +54,6 @@ public @interface PreviewFeature {
     public boolean reflective() default false;
 
     public enum Feature {
-        /*
-         * This one can only be removed after JDK 17
-         */
-        SEALED_CLASSES,
         SWITCH_PATTERN_MATCHING,
         /**
          * A key for testing.


### PR DESCRIPTION
Enum constant: jdk.internal.javac.PreviewFeature.Feature.SEALED_CLASSES was not removed when Sealed Classes were made final because the build was failing without it. Now that the feature is final we should be able to safely removed it. This is the intention of this patch.

TIA,
Vicente

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266407](https://bugs.openjdk.java.net/browse/JDK-8266407): remove jdk.internal.javac.PreviewFeature.Feature.SEALED_CLASSES


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4578/head:pull/4578` \
`$ git checkout pull/4578`

Update a local copy of the PR: \
`$ git checkout pull/4578` \
`$ git pull https://git.openjdk.java.net/jdk pull/4578/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4578`

View PR using the GUI difftool: \
`$ git pr show -t 4578`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4578.diff">https://git.openjdk.java.net/jdk/pull/4578.diff</a>

</details>
