### PR TITLE
8269268: JDWP: Properly fix thread lookup assert in findThread()

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
@@ -1239,6 +1239,10 @@ cbVMDeath(jvmtiEnv *jvmti_env, JNIEnv *env)
         EXIT_ERROR(error,"Can't clear event callbacks on vm death");
     }
 
+    /* Setting this flag is needed for a very special case. See the reference in findThread(). */
+    gdata->handlingVMDeath = JNI_TRUE;
+
+
     /* Now that no new callbacks will be made, we need to wait for the ones
      *   that are still active to complete.
      *   The BEGIN_CALLBACK/END_CALLBACK macros implement the VM_DEATH
@@ -1292,6 +1296,8 @@ cbVMDeath(jvmtiEnv *jvmti_env, JNIEnv *env)
      */
     commandLoop_sync();
     debugLoop_sync();
+
+    gdata->handlingVMDeath = JNI_FALSE;
 
     LOG_MISC(("END cbVMDeath"));
 }

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
@@ -1230,6 +1230,10 @@ cbVMDeath(jvmtiEnv *jvmti_env, JNIEnv *env)
     EventInfo info;
     LOG_CB(("cbVMDeath"));
 
+    /* Setting this flag is needed by findThread(). It's ok to set it before
+       the callbacks are cleared.*/
+    gdata->jvmtiCallBacksCleared = JNI_TRUE;
+
     /* Clear out ALL callbacks at this time, we don't want any more. */
     /*    This should prevent any new BEGIN_CALLBACK() calls. */
     (void)memset(&(gdata->callbacks),0,sizeof(gdata->callbacks));
@@ -1238,10 +1242,6 @@ cbVMDeath(jvmtiEnv *jvmti_env, JNIEnv *env)
     if (error != JVMTI_ERROR_NONE) {
         EXIT_ERROR(error,"Can't clear event callbacks on vm death");
     }
-
-    /* Setting this flag is needed for a very special case. See the reference in findThread(). */
-    gdata->handlingVMDeath = JNI_TRUE;
-
 
     /* Now that no new callbacks will be made, we need to wait for the ones
      *   that are still active to complete.
@@ -1296,8 +1296,6 @@ cbVMDeath(jvmtiEnv *jvmti_env, JNIEnv *env)
      */
     commandLoop_sync();
     debugLoop_sync();
-
-    gdata->handlingVMDeath = JNI_FALSE;
 
     LOG_MISC(("END cbVMDeath"));
 }

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -262,7 +262,7 @@ findThread(ThreadList *list, jthread thread)
          * avoid this situation of having a thread in runningThreads, but with no TLS.
          *
          * However... there is one exception to this. While handling VM_DEATH, the first thing
-         * the debug agent does is clear all the callbacks. This means we will no long
+         * the debug agent does is clear all the callbacks. This means we will no longer
          * get THREAD_END events as threads exit. This means we might find threads on
          * runningThreads with no TLS during VM_DEATH. Essentially the THREAD_END that
          * would normally have resulted in removing the thread from runningThreads is

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -268,11 +268,12 @@ findThread(ThreadList *list, jthread thread)
          * would normally have resulted in removing the thread from runningThreads is
          * missed, so the thread remains on runningThreads.
          *
-         * The end result of all this is that if the TLS lookup failed, we still need to
-         * check if the thread is on runningThreads, but only if we are handling VM_DEATH.
+         * The end result of all this is that if the TLS lookup failed, we still need to check
+         * if the thread is on runningThreads, but only if JVMTI callbacks have been cleared.
+         * Otherwise the thread should not be on the runningThreads.
          */
-        if ( !gdata->handlingVMDeath ) {
-            /* The thread better not be on runningThreads is the TLS lookup failed. */
+        if ( !gdata->jvmtiCallBacksCleared ) {
+            /* The thread better not be on runningThreads if the TLS lookup failed. */
             JDI_ASSERT(!nonTlsSearch(getEnv(), &runningThreads, thread));
         } else {
             /*

--- a/src/jdk.jdwp.agent/share/native/libjdwp/util.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/util.h
@@ -136,8 +136,8 @@ typedef struct {
     /* Indication that the agent has been loaded */
     jboolean isLoaded;
 
-    /* Indication that we are currently handling VM_DEATH event. */
-    jboolean handlingVMDeath;
+    /* Indication that VM_DEATH has been recieved and the JVMTI callbacks have been cleared. */
+    volatile jboolean jvmtiCallBacksCleared;
 
 } BackendGlobalData;
 

--- a/src/jdk.jdwp.agent/share/native/libjdwp/util.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/util.h
@@ -133,8 +133,11 @@ typedef struct {
     int           objectsByIDsize;
     int           objectsByIDcount;
 
-     /* Indication that the agent has been loaded */
-     jboolean isLoaded;
+    /* Indication that the agent has been loaded */
+    jboolean isLoaded;
+
+    /* Indication that we are currently handling VM_DEATH event. */
+    jboolean handlingVMDeath;
 
 } BackendGlobalData;
 


### PR DESCRIPTION
Re-enable the assert that was disabled (with some overhead) by [JDK-8265683](https://bugs.openjdk.java.net/browse/JDK-8265683). Explanation is in the CR and also in comments included with the changes.

I tested by running `vmTestbase/nsk/jdb/suspend/suspend001/suspend001.java` and `vmTestbase/nsk/jdb/wherei/wherei001/wherei001.java` 100's of times, and did not see any failures. I also verified the original issue was still reproducible by temporarily not setting `gdata->handlingVMDeath = JNI_TRUE`, which did trigger the assert as expected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269268](https://bugs.openjdk.java.net/browse/JDK-8269268): JDWP: Properly fix thread lookup assert in findThread()


### Reviewers
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4580/head:pull/4580` \
`$ git checkout pull/4580`

Update a local copy of the PR: \
`$ git checkout pull/4580` \
`$ git pull https://git.openjdk.java.net/jdk pull/4580/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4580`

View PR using the GUI difftool: \
`$ git pr show -t 4580`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4580.diff">https://git.openjdk.java.net/jdk/pull/4580.diff</a>

</details>
