### PR TITLE
8230797: ARM32-softfp: assertion in InterpreterRuntime::resolve_ldc

### DIFF
--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -190,7 +190,7 @@ JRT_ENTRY(void, InterpreterRuntime::resolve_ldc(JavaThread* current, Bytecodes::
     // The bytecode wrappers aren't GC-safe so construct a new one
     Bytecode_loadconstant ldc2(m, last_frame.bci());
     int rindex = ldc2.cache_index();
-    if (rindex < 0 && m->constants()->resolved_references() != NULL)
+    if (rindex < 0 && m->constants()->resolved_references_or_null() != NULL)
       rindex = m->constants()->cp_to_object_index(ldc2.pool_index());
     if (rindex >= 0) {
       oop coop = m->constants()->resolved_references()->obj_at(rindex);

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -190,7 +190,7 @@ JRT_ENTRY(void, InterpreterRuntime::resolve_ldc(JavaThread* current, Bytecodes::
     // The bytecode wrappers aren't GC-safe so construct a new one
     Bytecode_loadconstant ldc2(m, last_frame.bci());
     int rindex = ldc2.cache_index();
-    if (rindex < 0)
+    if (rindex < 0 && m->constants()->resolved_references() != NULL)
       rindex = m->constants()->cp_to_object_index(ldc2.pool_index());
     if (rindex >= 0) {
       oop coop = m->constants()->resolved_references()->obj_at(rindex);


### PR DESCRIPTION
Hi,

please review the following change, which was way too long on my chest. It fixes an assertion in the template interpreter for ARM32-softfp.

For ARM32-softfp, the template interpreter calls into the runtime to load a double constant using the ldc bytecode. After the interpreter loaded the constants, the assert block does some sanity checks on the cached constants. But if the double constant is the first constant to be loaded, the cache is not yet initialized and the check results in a SIGSEGV.

I guarded the usage of `ConstantPool::cp_to_object_index` by another check, which tests if there are any resolved references and if that's the case, the cache has already been initialized and the sanity checks can be performed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8230797](https://bugs.openjdk.java.net/browse/JDK-8230797): ARM32-softfp: assertion in InterpreterRuntime::resolve_ldc


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4582/head:pull/4582` \
`$ git checkout pull/4582`

Update a local copy of the PR: \
`$ git checkout pull/4582` \
`$ git pull https://git.openjdk.java.net/jdk pull/4582/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4582`

View PR using the GUI difftool: \
`$ git pr show -t 4582`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4582.diff">https://git.openjdk.java.net/jdk/pull/4582.diff</a>

</details>
