### PR TITLE
8269222: Incorrect number of workers reported for reference processing

### DIFF
--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -525,7 +525,7 @@ public:
                OopClosure* keep_alive,
                VoidClosure* complete_gc) override {
     ResourceMark rm;
-    RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::SoftRefSubPhase1, _phase_times, worker_id);
+    RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::SoftRefSubPhase1, _phase_times, tracker_id(worker_id));
     size_t const removed = _ref_processor.process_soft_ref_reconsider_work(_ref_processor._discoveredSoftRefs[worker_id],
                                                                            _policy,
                                                                            is_alive,
@@ -563,17 +563,17 @@ public:
                OopClosure* keep_alive,
                VoidClosure* complete_gc) override {
     ResourceMark rm;
-    RefProcWorkerTimeTracker t(_phase_times->phase2_worker_time_sec(), worker_id);
+    RefProcWorkerTimeTracker t(_phase_times->phase2_worker_time_sec(), tracker_id(worker_id));
     {
-      RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::SoftRefSubPhase2, _phase_times, worker_id);
+      RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::SoftRefSubPhase2, _phase_times, tracker_id(worker_id));
       run_phase2(worker_id, _ref_processor._discoveredSoftRefs, is_alive, keep_alive, true /* do_enqueue_and_clear */, REF_SOFT);
     }
     {
-      RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::WeakRefSubPhase2, _phase_times, worker_id);
+      RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::WeakRefSubPhase2, _phase_times, tracker_id(worker_id));
       run_phase2(worker_id, _ref_processor._discoveredWeakRefs, is_alive, keep_alive, true /* do_enqueue_and_clear */, REF_WEAK);
     }
     {
-      RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::FinalRefSubPhase2, _phase_times, worker_id);
+      RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::FinalRefSubPhase2, _phase_times, tracker_id(worker_id));
       run_phase2(worker_id, _ref_processor._discoveredFinalRefs, is_alive, keep_alive, false /* do_enqueue_and_clear */, REF_FINAL);
     }
     // Close the reachable set; needed for collectors which keep_alive_closure do
@@ -594,7 +594,7 @@ public:
                OopClosure* keep_alive,
                VoidClosure* complete_gc) override {
     ResourceMark rm;
-    RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::FinalRefSubPhase3, _phase_times, worker_id);
+    RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::FinalRefSubPhase3, _phase_times, tracker_id(worker_id));
     _ref_processor.process_final_keep_alive_work(_ref_processor._discoveredFinalRefs[worker_id], keep_alive, complete_gc);
   }
 };
@@ -611,7 +611,7 @@ public:
                OopClosure* keep_alive,
                VoidClosure* complete_gc) override {
     ResourceMark rm;
-    RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::PhantomRefSubPhase4, _phase_times, worker_id);
+    RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::PhantomRefSubPhase4, _phase_times, tracker_id(worker_id));
     size_t const removed = _ref_processor.process_phantom_refs_work(_ref_processor._discoveredPhantomRefs[worker_id],
                                                                     is_alive,
                                                                     keep_alive,

--- a/src/hotspot/share/gc/shared/referenceProcessor.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.hpp
@@ -573,6 +573,10 @@ protected:
   ReferenceProcessor& _ref_processor;
   ReferenceProcessorPhaseTimes* _phase_times;
 
+  // Used for tracking how much time a worker spends in a (sub)phase.
+  uint tracker_id(uint worker_id) const {
+    return _ref_processor.processing_is_mt() ? worker_id : 0;
+  }
 public:
   RefProcTask(ReferenceProcessor& ref_processor,
               ReferenceProcessorPhaseTimes* phase_times)

--- a/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
@@ -98,7 +98,7 @@ RefProcWorkerTimeTracker::RefProcWorkerTimeTracker(WorkerDataArray<double>* work
 
 RefProcWorkerTimeTracker::~RefProcWorkerTimeTracker() {
   double result = os::elapsedTime() - _start_time;
-  _worker_time->set(_worker_id, result);
+  _worker_time->set_or_add(_worker_id, result);
 }
 
 RefProcSubPhasesWorkerTimeTracker::RefProcSubPhasesWorkerTimeTracker(ReferenceProcessor::RefProcSubPhases phase,

--- a/src/hotspot/share/gc/shared/workerDataArray.hpp
+++ b/src/hotspot/share/gc/shared/workerDataArray.hpp
@@ -67,6 +67,7 @@ private:
   static T uninitialized();
 
   void set(uint worker_i, T value);
+  void set_or_add(uint worker_i, T value);
   T get(uint worker_i) const;
 
   void add(uint worker_i, T value);

--- a/src/hotspot/share/gc/shared/workerDataArray.inline.hpp
+++ b/src/hotspot/share/gc/shared/workerDataArray.inline.hpp
@@ -54,6 +54,16 @@ void WorkerDataArray<T>::set(uint worker_i, T value) {
 }
 
 template <typename T>
+void WorkerDataArray<T>::set_or_add(uint worker_i, T value) {
+  assert(worker_i < _length, "Worker %d is greater than max: %d", worker_i, _length);
+  if (_data[worker_i] == uninitialized()) {
+    _data[worker_i] = value;
+  } else {
+    _data[worker_i] += value;
+  }
+}
+
+template <typename T>
 T WorkerDataArray<T>::get(uint worker_i) const {
   assert(worker_i < _length, "Worker %d is greater than max: %d", worker_i, _length);
   return _data[worker_i];


### PR DESCRIPTION
Override the `worker_id` used by worker time trackers to `0` in sequential ref-processing.

With this patch, `java -XX:+UseParallelGC -Xms2g -Xmx2g -XX:+ParallelRefProcEnabled -Xlog:gc,gc+phases+ref=debug:gc.log::filecount=0 -jar dacapo-9.12-MR1-bach.jar h2 -n 1` prints

```
[2.159s][debug][gc,phases,ref] GC(0)   Reconsider SoftReferences: 0.0ms
[2.159s][debug][gc,phases,ref] GC(0)     SoftRef (ms):                  skipped
[2.159s][debug][gc,phases,ref] GC(0)   Notify Soft/WeakReferences: 0.1ms
[2.159s][debug][gc,phases,ref] GC(0)     SoftRef (ms):                  Min:  0.0, Avg:  0.0, Max:  0.0, Diff:  0.0, Sum:  0.0, Workers: 1
[2.159s][debug][gc,phases,ref] GC(0)     WeakRef (ms):                  Min:  0.0, Avg:  0.0, Max:  0.0, Diff:  0.0, Sum:  0.0, Workers: 1
[2.159s][debug][gc,phases,ref] GC(0)     FinalRef (ms):                 Min:  0.0, Avg:  0.0, Max:  0.0, Diff:  0.0, Sum:  0.0, Workers: 1
[2.159s][debug][gc,phases,ref] GC(0)     Total (ms):                    Min:  0.0, Avg:  0.0, Max:  0.0, Diff:  0.0, Sum:  0.0, Workers: 1
[2.159s][debug][gc,phases,ref] GC(0)   Notify and keep alive finalizable: 0.0ms
[2.159s][debug][gc,phases,ref] GC(0)     FinalRef (ms):                 skipped
[2.159s][debug][gc,phases,ref] GC(0)   Notify PhantomReferences: 0.0ms
[2.159s][debug][gc,phases,ref] GC(0)     PhantomRef (ms):               Min:  0.0, Avg:  0.0, Max:  0.0, Diff:  0.0, Sum:  0.0, Workers: 1
[2.159s][debug][gc,phases,ref] GC(0)   SoftReference:
[2.159s][debug][gc,phases,ref] GC(0)     Discovered: 0
[2.159s][debug][gc,phases,ref] GC(0)     Cleared: 0
[2.159s][debug][gc,phases,ref] GC(0)   WeakReference:
[2.159s][debug][gc,phases,ref] GC(0)     Discovered: 316
[2.159s][debug][gc,phases,ref] GC(0)     Cleared: 188
[2.159s][debug][gc,phases,ref] GC(0)   FinalReference:
[2.159s][debug][gc,phases,ref] GC(0)     Discovered: 4
[2.159s][debug][gc,phases,ref] GC(0)     Cleared: 4
[2.159s][debug][gc,phases,ref] GC(0)   PhantomReference:
[2.159s][debug][gc,phases,ref] GC(0)     Discovered: 156
[2.159s][debug][gc,phases,ref] GC(0)     Cleared: 67
```

It's "Workers: 1" since #refs < 1000.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269222](https://bugs.openjdk.java.net/browse/JDK-8269222): Incorrect number of workers reported for reference processing


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Sangheon Kim](https://openjdk.java.net/census#sangheki) (@sangheon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4588/head:pull/4588` \
`$ git checkout pull/4588`

Update a local copy of the PR: \
`$ git checkout pull/4588` \
`$ git pull https://git.openjdk.java.net/jdk pull/4588/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4588`

View PR using the GUI difftool: \
`$ git pr show -t 4588`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4588.diff">https://git.openjdk.java.net/jdk/pull/4588.diff</a>

</details>
