### PR TITLE
8269003: Update the java manpage for JDK 18 

### DIFF
--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -4022,96 +4022,24 @@ By default, this option is disabled.
 .RE
 .SH REMOVED JAVA OPTIONS
 .PP
-These \f[CB]java\f[R] options have been removed in JDK 17 and using them
-results in an error of:
-.RS
-.PP
-\f[CB]Unrecognized\ VM\ option\f[R] \f[I]option\-name\f[R]
-.RE
-.TP
-.B \f[CB]\-XX:+UseMembar\f[R]
-Enabled issuing membars on thread\-state transitions.
-This option was disabled by default on all platforms except ARM servers,
-where it was enabled.
-.RS
-.RE
-.TP
-.B \f[CB]\-XX:MaxPermSize=\f[R]\f[I]size\f[R]
-Sets the maximum permanent generation space size (in bytes).
-This option was deprecated in JDK 8 and superseded by the
-\f[CB]\-XX:MaxMetaspaceSize\f[R] option.
-.RS
-.RE
-.TP
-.B \f[CB]\-XX:PermSize=\f[R]\f[I]size\f[R]
-Sets the space (in bytes) allocated to the permanent generation that
-triggers a garbage collection if it\[aq]s exceeded.
-This option was deprecated in JDK 8 and superseded by the
-\f[CB]\-XX:MetaspaceSize\f[R] option.
-.RS
-.RE
-.TP
-.B \f[CB]\-XX:+TraceClassLoading\f[R]
-Enables tracing of classes as they are loaded.
-By default, this option is disabled and classes aren\[aq]t traced.
-.RS
-.PP
-The replacement Unified Logging syntax is
-\f[CB]\-Xlog:class+load=\f[R]\f[I]level\f[R].
-See \f[B]Enable Logging with the JVM Unified Logging Framework\f[R]
-.PP
-Use \f[I]level\f[R]=\f[CB]info\f[R] for regular information, or
-\f[I]level\f[R]=\f[CB]debug\f[R] for additional information.
-In Unified Logging syntax, \f[CB]\-verbose:class\f[R] equals
-\f[CB]\-Xlog:class+load=info,class+unload=info\f[R].
-.RE
-.TP
-.B \f[CB]\-XX:+TraceClassLoadingPreorder\f[R]
-Enables tracing of all loaded classes in the order in which they\[aq]re
-referenced.
-By default, this option is disabled and classes aren\[aq]t traced.
-.RS
-.PP
-The replacement Unified Logging syntax is
-\f[CB]\-Xlog:class+preorder=debug\f[R].
-See \f[B]Enable Logging with the JVM Unified Logging Framework\f[R].
-.RE
-.TP
-.B \f[CB]\-XX:+TraceClassResolution\f[R]
-Enables tracing of constant pool resolutions.
-By default, this option is disabled and constant pool resolutions
-aren\[aq]t traced.
-.RS
-.PP
-The replacement Unified Logging syntax is
-\f[CB]\-Xlog:class+resolve=debug\f[R].
-See \f[B]Enable Logging with the JVM Unified Logging Framework\f[R].
-.RE
-.TP
-.B \f[CB]\-XX:+TraceLoaderConstraints\f[R]
-Enables tracing of the loader constraints recording.
-By default, this option is disabled and loader constraints recording
-isn\[aq]t traced.
-.RS
-.PP
-The replacement Unified Logging syntax is
-\f[CB]\-Xlog:class+loader+constraints=info\f[R].
-See \f[B]Enable Logging with the JVM Unified Logging Framework\f[R].
-.RE
+No documented \f[CB]java\f[R] options have been removed in JDK 18.
 .PP
 For the lists and descriptions of options removed in previous releases
 see the \f[I]Removed Java Options\f[R] section in:
 .IP \[bu] 2
-\f[B]Java Platform, Standard Edition Tools Reference, Release 16\f[R]
+\f[B]The \f[BC]java\f[B] Command, Release 17\f[R]
+[https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html]
+.IP \[bu] 2
+\f[B]The \f[BC]java\f[B] Command, Release 16\f[R]
 [https://docs.oracle.com/en/java/javase/16/docs/specs/man/java.html]
 .IP \[bu] 2
-\f[B]Java Platform, Standard Edition Tools Reference, Release 15\f[R]
+\f[B]The \f[BC]java\f[B] Command, Release 15\f[R]
 [https://docs.oracle.com/en/java/javase/15/docs/specs/man/java.html]
 .IP \[bu] 2
-\f[B]Java Platform, Standard Edition Tools Reference, Release 14\f[R]
+\f[B]The \f[BC]java\f[B] Command, Release 14\f[R]
 [https://docs.oracle.com/en/java/javase/14/docs/specs/man/java.html]
 .IP \[bu] 2
-\f[B]Java Platform, Standard Edition Tools Reference, Release 13\f[R]
+\f[B]The \f[BC]java\f[B] Command, Release 13\f[R]
 [https://docs.oracle.com/en/java/javase/13/docs/specs/man/java.html]
 .IP \[bu] 2
 \f[B]Java Platform, Standard Edition Tools Reference, Release 12\f[R]


### PR DESCRIPTION
There are some start of release changes needed to the manpage that were overlooked:

- updated "removed options" section to get rid of things removed in 17 (nothing is removed in 18)
- update list of previous releases (corrected documentation title for JDK 13+)

The changes are easy to view in the nroff file so I didn't generate the html version.

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269003](https://bugs.openjdk.java.net/browse/JDK-8269003): Update the java manpage for JDK 18


### Reviewers
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4590/head:pull/4590` \
`$ git checkout pull/4590`

Update a local copy of the PR: \
`$ git checkout pull/4590` \
`$ git pull https://git.openjdk.java.net/jdk pull/4590/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4590`

View PR using the GUI difftool: \
`$ git pr show -t 4590`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4590.diff">https://git.openjdk.java.net/jdk/pull/4590.diff</a>

</details>
