### PR TITLE
6766844: ByteArrayInputStream#read with a byte array of length 0 not consistent with InputStream when at EOF

### DIFF
--- a/src/java.base/share/classes/java/io/ByteArrayInputStream.java
+++ b/src/java.base/share/classes/java/io/ByteArrayInputStream.java
@@ -159,7 +159,7 @@ public class ByteArrayInputStream extends InputStream {
      * This {@code read} method cannot block.
      *
      * @apiNote
-     * Unlike the {@link InputStream#read(byte[],int,int) equivalent method}
+     * Unlike the {@link InputStream#read(byte[],int,int) overridden method}
      * of {@code InputStream}, this method returns {@code -1} instead of zero
      * if the end of the stream has been reached and {@code len == 0}.
      *

--- a/src/java.base/share/classes/java/io/ByteArrayInputStream.java
+++ b/src/java.base/share/classes/java/io/ByteArrayInputStream.java
@@ -158,6 +158,11 @@ public class ByteArrayInputStream extends InputStream {
      * <p>
      * This {@code read} method cannot block.
      *
+     * @apiNote
+     * Unlike the {@link InputStream#read(byte[],int,int) equivalent method}
+     * of {@code InputStream}, this method returns {@code -1} instead of zero
+     * if the end of the stream has been reached and {@code len == 0}.
+     *
      * @param   b     the buffer into which the data is read.
      * @param   off   the start offset in the destination array {@code b}
      * @param   len   the maximum number of bytes read.
@@ -171,9 +176,6 @@ public class ByteArrayInputStream extends InputStream {
      */
     public synchronized int read(byte b[], int off, int len) {
         Objects.checkFromIndexSize(off, len, b.length);
-        if (len == 0) {
-            return 0;
-        }
 
         if (pos >= count) {
             return -1;

--- a/src/java.base/share/classes/java/io/ByteArrayInputStream.java
+++ b/src/java.base/share/classes/java/io/ByteArrayInputStream.java
@@ -156,12 +156,11 @@ public class ByteArrayInputStream extends InputStream {
      * {@code b[off+k-1]} in the manner performed by {@code System.arraycopy}.
      * The value {@code k} is added into {@code pos} and {@code k} is returned.
      * <p>
-     * This {@code read} method cannot block.
-     *
-     * @apiNote
      * Unlike the {@link InputStream#read(byte[],int,int) overridden method}
      * of {@code InputStream}, this method returns {@code -1} instead of zero
      * if the end of the stream has been reached and {@code len == 0}.
+     * <p>
+     * This {@code read} method cannot block.
      *
      * @param   b     the buffer into which the data is read.
      * @param   off   the start offset in the destination array {@code b}

--- a/src/java.base/share/classes/java/io/ByteArrayInputStream.java
+++ b/src/java.base/share/classes/java/io/ByteArrayInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -171,6 +171,9 @@ public class ByteArrayInputStream extends InputStream {
      */
     public synchronized int read(byte b[], int off, int len) {
         Objects.checkFromIndexSize(off, len, b.length);
+        if (len == 0) {
+            return 0;
+        }
 
         if (pos >= count) {
             return -1;

--- a/test/jdk/java/io/ByteArrayInputStream/ReadAllReadNTransferTo.java
+++ b/test/jdk/java/io/ByteArrayInputStream/ReadAllReadNTransferTo.java
@@ -50,10 +50,10 @@ public class ReadAllReadNTransferTo {
 
         ByteArrayInputStream bais = new ByteArrayInputStream(buf);
         bais.readAllBytes();
-        if (bais.read(new byte[0]) != 0) {
+        if (bais.read(new byte[0]) != -1) {
             throw new RuntimeException("read(byte[]) did not return 0");
         }
-        if (bais.read(new byte[1], 0, 0) != 0) {
+        if (bais.read(new byte[1], 0, 0) != -1) {
             throw new RuntimeException("read(byte[],int,int) did not return 0");
         }
 

--- a/test/jdk/java/io/ByteArrayInputStream/ReadAllReadNTransferTo.java
+++ b/test/jdk/java/io/ByteArrayInputStream/ReadAllReadNTransferTo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,8 +48,16 @@ public class ReadAllReadNTransferTo {
         int position = random.nextInt(SIZE/2);
         int size = random.nextInt(SIZE - position);
 
-        ByteArrayInputStream bais =
-            new ByteArrayInputStream(buf, position, size);
+        ByteArrayInputStream bais = new ByteArrayInputStream(buf);
+        bais.readAllBytes();
+        if (bais.read(new byte[0]) != 0) {
+            throw new RuntimeException("read(byte[]) did not return 0");
+        }
+        if (bais.read(new byte[1], 0, 0) != 0) {
+            throw new RuntimeException("read(byte[],int,int) did not return 0");
+        }
+
+        bais = new ByteArrayInputStream(buf, position, size);
         int off = size < 2 ? 0 : random.nextInt(size / 2);
         int len = size - off < 1 ? 0 : random.nextInt(size - off);
 
@@ -72,7 +80,6 @@ public class ReadAllReadNTransferTo {
             throw new RuntimeException("readAllBytes content");
         }
 
-        // XXX transferTo()
         bais = new ByteArrayInputStream(buf);
         ByteArrayOutputStream baos = new ByteArrayOutputStream(buf.length);
         if (bais.transferTo(baos) != buf.length) {

--- a/test/jdk/java/io/ByteArrayInputStream/ReadAllReadNTransferTo.java
+++ b/test/jdk/java/io/ByteArrayInputStream/ReadAllReadNTransferTo.java
@@ -33,7 +33,7 @@ import jdk.test.lib.RandomFactory;
  * @library /test/lib
  * @build jdk.test.lib.RandomFactory
  * @run main ReadAllReadNTransferTo
- * @bug 8180451
+ * @bug 6766844 8180451
  * @summary Verify ByteArrayInputStream readAllBytes, readNBytes, and transferTo
  * @key randomness
  */


### PR DESCRIPTION
Modify `java.io.ByteArrayInputStream` methods `read(byte[])` and `read(byte[],int,int)` to return zero per the `InputStream` specification when the byte array actual or specified length is zero.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-6766844](https://bugs.openjdk.java.net/browse/JDK-6766844): ByteArrayInputStream#read with a byte array of length 0 not consistent with InputStream when at EOF


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**) ⚠️ Review applies to 68b6f089bcf9cdd1edbac46519cd7f1867d4824d
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to a53849a26e51e44fb262809b0883e5c50cd4eaf7


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4591/head:pull/4591` \
`$ git checkout pull/4591`

Update a local copy of the PR: \
`$ git checkout pull/4591` \
`$ git pull https://git.openjdk.java.net/jdk pull/4591/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4591`

View PR using the GUI difftool: \
`$ git pr show -t 4591`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4591.diff">https://git.openjdk.java.net/jdk/pull/4591.diff</a>

</details>
