### PR TITLE
8269261: The PlaceHolder code uses Thread everywhere but is always dealing with JavaThreads

### DIFF
--- a/src/hotspot/share/classfile/placeholders.cpp
+++ b/src/hotspot/share/classfile/placeholders.cpp
@@ -52,10 +52,10 @@ public:
        _stnext = NULL;
        _stprev = NULL;
    }
-   JavaThread* thread()                const { return _thread;}
+   JavaThread* thread()          const { return _thread;}
    void set_thread(JavaThread* thread) { _thread = thread; }
 
-   SeenThread* next()              const { return _stnext;}
+   SeenThread* next()        const { return _stnext;}
    void set_next(SeenThread* seen) { _stnext = seen; }
    void set_prev(SeenThread* seen) { _stprev = seen; }
 

--- a/src/hotspot/share/classfile/placeholders.cpp
+++ b/src/hotspot/share/classfile/placeholders.cpp
@@ -43,21 +43,21 @@
 // result the first thread gets.
 class SeenThread: public CHeapObj<mtInternal> {
 private:
-   Thread *_thread;
+   JavaThread* _thread;
    SeenThread* _stnext;
    SeenThread* _stprev;
 public:
-   SeenThread(Thread *thread) {
+   SeenThread(JavaThread* thread) {
        _thread = thread;
        _stnext = NULL;
        _stprev = NULL;
    }
-   Thread* thread()                const { return _thread;}
-   void set_thread(Thread *thread) { _thread = thread; }
+   JavaThread* thread()                const { return _thread;}
+   void set_thread(JavaThread* thread) { _thread = thread; }
 
    SeenThread* next()              const { return _stnext;}
-   void set_next(SeenThread *seen) { _stnext = seen; }
-   void set_prev(SeenThread *seen) { _stprev = seen; }
+   void set_next(SeenThread* seen) { _stnext = seen; }
+   void set_prev(SeenThread* seen) { _stprev = seen; }
 
   void print_action_queue(outputStream* st) {
     SeenThread* seen = this;
@@ -107,7 +107,7 @@ void PlaceholderEntry::set_threadQ(SeenThread* seenthread, PlaceholderTable::cla
 // bootstrap loader support:  links in a thread before load_instance_class
 // definers: use as queue of define requestors, including owner of
 // define token. Appends for debugging of requestor order
-void PlaceholderEntry::add_seen_thread(Thread* thread, PlaceholderTable::classloadAction action) {
+void PlaceholderEntry::add_seen_thread(JavaThread* thread, PlaceholderTable::classloadAction action) {
   assert_lock_strong(SystemDictionary_lock);
   SeenThread* threadEntry = new SeenThread(thread);
   SeenThread* seen = actionToQueue(action);
@@ -128,7 +128,7 @@ void PlaceholderEntry::add_seen_thread(Thread* thread, PlaceholderTable::classlo
   return;
 }
 
-bool PlaceholderEntry::check_seen_thread(Thread* thread, PlaceholderTable::classloadAction action) {
+bool PlaceholderEntry::check_seen_thread(JavaThread* thread, PlaceholderTable::classloadAction action) {
   assert_lock_strong(SystemDictionary_lock);
   SeenThread* threadQ = actionToQueue(action);
   SeenThread* seen = threadQ;
@@ -146,7 +146,7 @@ bool PlaceholderEntry::check_seen_thread(Thread* thread, PlaceholderTable::class
 // SystemDictionary_lock
 // ignores if cleanup has already been done
 // if found, deletes SeenThread
-bool PlaceholderEntry::remove_seen_thread(Thread* thread, PlaceholderTable::classloadAction action) {
+bool PlaceholderEntry::remove_seen_thread(JavaThread* thread, PlaceholderTable::classloadAction action) {
   assert_lock_strong(SystemDictionary_lock);
   SeenThread* threadQ = actionToQueue(action);
   SeenThread* seen = threadQ;
@@ -288,7 +288,7 @@ PlaceholderEntry* PlaceholderTable::find_and_add(unsigned int hash,
                                                  ClassLoaderData* loader_data,
                                                  classloadAction action,
                                                  Symbol* supername,
-                                                 Thread* thread) {
+                                                 JavaThread* thread) {
   assert(action != LOAD_SUPER || supername != NULL, "must have a super class name");
   PlaceholderEntry* probe = get_entry(hash, name, loader_data);
   if (probe == NULL) {
@@ -321,7 +321,7 @@ PlaceholderEntry* PlaceholderTable::find_and_add(unsigned int hash,
 void PlaceholderTable::find_and_remove(unsigned int hash,
                                        Symbol* name, ClassLoaderData* loader_data,
                                        classloadAction action,
-                                       Thread* thread) {
+                                       JavaThread* thread) {
     assert_locked_or_safepoint(SystemDictionary_lock);
     PlaceholderEntry *probe = get_entry(hash, name, loader_data);
     if (probe != NULL) {

--- a/src/hotspot/share/classfile/placeholders.hpp
+++ b/src/hotspot/share/classfile/placeholders.hpp
@@ -116,7 +116,7 @@ class PlaceholderEntry : public HashtableEntry<Symbol*, mtClass> {
  private:
   ClassLoaderData*  _loader_data;   // initiating loader
   Symbol*           _supername;
-  JavaThread*           _definer;       // owner of define token
+  JavaThread*       _definer;       // owner of define token
   InstanceKlass*    _instanceKlass; // InstanceKlass from successful define
   SeenThread*       _superThreadQ;  // doubly-linked queue of Threads loading a superclass for this class
   SeenThread*       _loadInstanceThreadQ;  // loadInstance thread

--- a/src/hotspot/share/classfile/placeholders.hpp
+++ b/src/hotspot/share/classfile/placeholders.hpp
@@ -85,7 +85,7 @@ public:
   PlaceholderEntry* find_and_add(unsigned int hash,
                                  Symbol* name, ClassLoaderData* loader_data,
                                  classloadAction action, Symbol* supername,
-                                 Thread* thread);
+                                 JavaThread* thread);
 
   void remove_entry(unsigned int hash,
                     Symbol* name, ClassLoaderData* loader_data);
@@ -94,7 +94,7 @@ public:
   // If all queues are empty and definer is null, remove the PlacheholderEntry completely
   void find_and_remove(unsigned int hash,
                        Symbol* name, ClassLoaderData* loader_data,
-                       classloadAction action, Thread* thread);
+                       classloadAction action, JavaThread* thread);
 
   void print_on(outputStream* st) const;
   void print() const;
@@ -116,7 +116,7 @@ class PlaceholderEntry : public HashtableEntry<Symbol*, mtClass> {
  private:
   ClassLoaderData*  _loader_data;   // initiating loader
   Symbol*           _supername;
-  Thread*           _definer;       // owner of define token
+  JavaThread*           _definer;       // owner of define token
   InstanceKlass*    _instanceKlass; // InstanceKlass from successful define
   SeenThread*       _superThreadQ;  // doubly-linked queue of Threads loading a superclass for this class
   SeenThread*       _loadInstanceThreadQ;  // loadInstance thread
@@ -130,8 +130,8 @@ class PlaceholderEntry : public HashtableEntry<Symbol*, mtClass> {
 
   SeenThread* actionToQueue(PlaceholderTable::classloadAction action);
   void set_threadQ(SeenThread* seenthread, PlaceholderTable::classloadAction action);
-  void add_seen_thread(Thread* thread, PlaceholderTable::classloadAction action);
-  bool remove_seen_thread(Thread* thread, PlaceholderTable::classloadAction action);
+  void add_seen_thread(JavaThread* thread, PlaceholderTable::classloadAction action);
+  bool remove_seen_thread(JavaThread* thread, PlaceholderTable::classloadAction action);
 
  public:
   // Simple accessors, used only by SystemDictionary
@@ -146,8 +146,8 @@ class PlaceholderEntry : public HashtableEntry<Symbol*, mtClass> {
     if (_supername != NULL) _supername->increment_refcount();
   }
 
-  Thread*            definer()             const {return _definer; }
-  void               set_definer(Thread* definer) { _definer = definer; }
+  JavaThread*        definer()             const {return _definer; }
+  void               set_definer(JavaThread* definer) { _definer = definer; }
 
   InstanceKlass*     instance_klass()      const {return _instanceKlass; }
   void               set_instance_klass(InstanceKlass* ik) { _instanceKlass = ik; }
@@ -158,7 +158,7 @@ class PlaceholderEntry : public HashtableEntry<Symbol*, mtClass> {
   SeenThread*        loadInstanceThreadQ() const { return _loadInstanceThreadQ; }
   void               set_loadInstanceThreadQ(SeenThread* SeenThread) { _loadInstanceThreadQ = SeenThread; }
 
-  SeenThread*        defineThreadQ()        const { return _defineThreadQ; }
+  SeenThread*        defineThreadQ()       const { return _defineThreadQ; }
   void               set_defineThreadQ(SeenThread* SeenThread) { _defineThreadQ = SeenThread; }
 
   PlaceholderEntry* next() const {
@@ -188,7 +188,7 @@ class PlaceholderEntry : public HashtableEntry<Symbol*, mtClass> {
   }
 
   // Used for ClassCircularityError checking
-  bool check_seen_thread(Thread* thread, PlaceholderTable::classloadAction action);
+  bool check_seen_thread(JavaThread* thread, PlaceholderTable::classloadAction action);
 
   // Print method doesn't append a cr
   void print_entry(outputStream* st) const;


### PR DESCRIPTION
Please review this trivial cleanup to change Thread to JavaThread.

Testing (in progress):
  - tiers 1-3 sanity check
  - GHA

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269261](https://bugs.openjdk.java.net/browse/JDK-8269261): The PlaceHolder code uses Thread everywhere but is always dealing with JavaThreads


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**) ⚠️ Review applies to 42a5484495631c6346f7819b684be675b1abe17e
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to d84e386d5fc726535db5503ee034571ae3bd2c8b


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4592/head:pull/4592` \
`$ git checkout pull/4592`

Update a local copy of the PR: \
`$ git checkout pull/4592` \
`$ git pull https://git.openjdk.java.net/jdk pull/4592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4592`

View PR using the GUI difftool: \
`$ git pr show -t 4592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4592.diff">https://git.openjdk.java.net/jdk/pull/4592.diff</a>

</details>
