### PR TITLE
8269302: serviceability/dcmd/framework/InvalidCommandTest.java still fails after JDK-8268433

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/SocketIOPipe.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/SocketIOPipe.java
@@ -234,7 +234,7 @@ public class SocketIOPipe extends Log.Logger implements Finalizable {
 
         public SocketConnection getConnection() {
             synchronized (this) {
-                while (!connection.isConnected() && error != null) {
+                while (!connection.isConnected() && error == null) {
                     try {
                         wait();
                     } catch (InterruptedException e) {


### PR DESCRIPTION
Please review this trivial fix in the cycle condition.

The cycle should run until connection is established (connection.isConnected() returns true) or error occurred (error != null)
This wrong condition causes test error if ListenerThread.getConnection() reaches "synchronized (this)" section earlier than ListenerThread.run()

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8269302](https://bugs.openjdk.java.net/browse/JDK-8269302): serviceability/dcmd/framework/InvalidCommandTest.java still fails after JDK-8268433


### Reviewers
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4593/head:pull/4593` \
`$ git checkout pull/4593`

Update a local copy of the PR: \
`$ git checkout pull/4593` \
`$ git pull https://git.openjdk.java.net/jdk pull/4593/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4593`

View PR using the GUI difftool: \
`$ git pr show -t 4593`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4593.diff">https://git.openjdk.java.net/jdk/pull/4593.diff</a>

</details>
