### PR TITLE
8269383: (bf) ByteOrder should expose methods to test if platform is big or little endian

### DIFF
--- a/src/java.base/share/classes/java/nio/ByteOrder.java
+++ b/src/java.base/share/classes/java/nio/ByteOrder.java
@@ -80,6 +80,26 @@ public final class ByteOrder {
     }
 
     /**
+     * Check if the byte order of underlying platform is big endian.
+     *
+     * @return {@code true} if the byte order of underlying platform is
+     * big endian otherwise {@code false}
+     */
+    public static boolean isBigEndian() {
+        return NATIVE_ORDER == BIG_ENDIAN;
+    }
+
+    /**
+     * Check if the byte order of underlying platform is little endian.
+     *
+     * @return {@code true} if the byte order of underlying platform is
+     * little endian otherwise {@code false}
+     */
+    public static boolean isLittleEndian() {
+        return NATIVE_ORDER == LITTLE_ENDIAN;
+    }
+
+    /**
      * Constructs a string describing this object.
      *
      * <p> This method returns the string


### PR DESCRIPTION
Hi, can I have a review of this change that adds two new utility methods for java.nio.ByteOrder? Looking through the whole JDK codebase, most calls of ByteOrder.nativeOrder() is to check if the underlying platform is little-endian/big-endian(e.g. #4596 ). There is no reason to only provide ByteOrder.nativeOrder while leaving big-endian/little-endian checking methods blank. For most cases(in JDK or in user code), we want a checking(byte order) rather than retrieving(byte order).

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8269383](https://bugs.openjdk.java.net/browse/JDK-8269383): (bf) ByteOrder should expose methods to test if platform is big or little endian


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4595/head:pull/4595` \
`$ git checkout pull/4595`

Update a local copy of the PR: \
`$ git checkout pull/4595` \
`$ git pull https://git.openjdk.java.net/jdk pull/4595/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4595`

View PR using the GUI difftool: \
`$ git pr show -t 4595`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4595.diff">https://git.openjdk.java.net/jdk/pull/4595.diff</a>

</details>
