### PR TITLE
8269384: Determine native byte order for StringUTF16 via ByteOrder

### DIFF
--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -38,6 +38,9 @@ import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 
 import static java.lang.String.UTF16;
+
+import java.nio.ByteOrder;
+
 import static java.lang.String.LATIN1;
 
 final class StringUTF16 {
@@ -1502,12 +1505,10 @@ final class StringUTF16 {
 
     ////////////////////////////////////////////////////////////////
 
-    private static native boolean isBigEndian();
-
     static final int HI_BYTE_SHIFT;
     static final int LO_BYTE_SHIFT;
     static {
-        if (isBigEndian()) {
+        if (ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN) {
             HI_BYTE_SHIFT = 8;
             LO_BYTE_SHIFT = 0;
         } else {

--- a/src/java.base/share/native/libjava/String.c
+++ b/src/java.base/share/native/libjava/String.c
@@ -31,14 +31,3 @@ Java_java_lang_String_intern(JNIEnv *env, jobject this)
 {
     return JVM_InternString(env, this);
 }
-
-JNIEXPORT jboolean JNICALL
-Java_java_lang_StringUTF16_isBigEndian(JNIEnv *env, jclass cls)
-{
-  unsigned int endianTest = 0xff000000;
-  if (((char*)(&endianTest))[0] != 0) {
-    return JNI_TRUE;
-  } else {
-    return JNI_FALSE;
-  }
-}


### PR DESCRIPTION
Prefer using ByteOrder to compute byte order for StringUTF16 to determining byte order by native method StringUTF16.isBigEndian.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8269384](https://bugs.openjdk.java.net/browse/JDK-8269384): Determine native byte order for StringUTF16 via ByteOrder


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4596/head:pull/4596` \
`$ git checkout pull/4596`

Update a local copy of the PR: \
`$ git checkout pull/4596` \
`$ git pull https://git.openjdk.java.net/jdk pull/4596/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4596`

View PR using the GUI difftool: \
`$ git pr show -t 4596`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4596.diff">https://git.openjdk.java.net/jdk/pull/4596.diff</a>

</details>
