### PR TITLE
8268902: Testing for threadObj != NULL is unnecessary in suspend handshake

### DIFF
--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -624,8 +624,8 @@ class ThreadSelfSuspensionHandshake : public AsyncHandshakeClosure {
 };
 
 bool HandshakeState::suspend_with_handshake() {
-  if (_handshakee->is_exiting() ||
-     _handshakee->threadObj() == NULL) {
+  assert(_handshakee->threadObj() != NULL, "cannot suspend with a NULL threadObj");
+  if (_handshakee->is_exiting()) {
     log_trace(thread, suspend)("JavaThread:" INTPTR_FORMAT " exiting", p2i(_handshakee));
     return false;
   }


### PR DESCRIPTION
In the last pull request on this topic, I was making more general (mis)statements, but this null threadObj check is only for the case where we're suspending a thread which already has a threadObj.  This null check is unnecessary.
Tested already with tier1-6 (rerun tier1).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268902](https://bugs.openjdk.java.net/browse/JDK-8268902): Testing for threadObj != NULL is unnecessary in suspend handshake


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.java.net/census#pchilanomate) (@pchilano - Committer)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4598/head:pull/4598` \
`$ git checkout pull/4598`

Update a local copy of the PR: \
`$ git checkout pull/4598` \
`$ git pull https://git.openjdk.java.net/jdk pull/4598/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4598`

View PR using the GUI difftool: \
`$ git pr show -t 4598`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4598.diff">https://git.openjdk.java.net/jdk/pull/4598.diff</a>

</details>
