### PR TITLE
8245877: assert(_value != __null) failed: resolving NULL _value in JvmtiExport::post_compiled_method_load

### DIFF
--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1608,39 +1608,41 @@ void nmethod::post_compiled_method_load_event(JvmtiThreadState* state) {
     if (is_not_entrant() && can_convert_to_zombie()) {
       return;
     }
+    mark_as_seen_on_stack();
+  }
+
+  // This is a bad time for a safepoint.  We don't want
+  // this nmethod to get unloaded while we're queueing the event.
+  NoSafepointVerifier nsv;
 
 
-    // This is a bad time for a safepoint.  We don't want
-    // this nmethod to get unloaded while we're queueing the event.
-    NoSafepointVerifier nsv;
+  Method *m = method();
+  HOTSPOT_COMPILED_METHOD_LOAD(
+      (char *) m->klass_name()->bytes(),
+      m->klass_name()->utf8_length(),
+      (char *) m->name()->bytes(),
+      m->name()->utf8_length(),
+      (char *) m->signature()->bytes(),
+      m->signature()->utf8_length(),
+      insts_begin(), insts_size());
 
-    Method *m = method();
-    HOTSPOT_COMPILED_METHOD_LOAD(
-        (char *) m->klass_name()->bytes(),
-        m->klass_name()->utf8_length(),
-        (char *) m->name()->bytes(),
-        m->name()->utf8_length(),
-        (char *) m->signature()->bytes(),
-        m->signature()->utf8_length(),
-        insts_begin(), insts_size());
-
-    if (JvmtiExport::should_post_compiled_method_load()) {
-      // Only post unload events if load events are found.
-      set_load_reported();
-      // If a JavaThread hasn't been passed in, let the Service thread
-      // (which is a real Java thread) post the event
-      JvmtiDeferredEvent event = JvmtiDeferredEvent::compiled_method_load_event(this);
-      if (state == NULL) {
-        // Execute any barrier code for this nmethod as if it's called, since
-        // keeping it alive looks like stack walking.
-        run_nmethod_entry_barrier();
-        ServiceThread::enqueue_deferred_event(&event);
-      } else {
-        // This enters the nmethod barrier outside in the caller.
-        state->enqueue_event(&event);
-      }
+  if (JvmtiExport::should_post_compiled_method_load()) {
+    // Only post unload events if load events are found.
+    set_load_reported();
+    // If a JavaThread hasn't been passed in, let the Service thread
+    // (which is a real Java thread) post the event
+    JvmtiDeferredEvent event = JvmtiDeferredEvent::compiled_method_load_event(this);
+    if (state == NULL) {
+      // Execute any barrier code for this nmethod as if it's called, since
+      // keeping it alive looks like stack walking.
+      run_nmethod_entry_barrier();
+      ServiceThread::enqueue_deferred_event(&event);
+    } else {
+      // This enters the nmethod barrier outside in the caller.
+      state->enqueue_event(&event);
     }
   }
+
 }
 
 void nmethod::post_compiled_method_unload() {

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1608,37 +1608,37 @@ void nmethod::post_compiled_method_load_event(JvmtiThreadState* state) {
     if (is_not_entrant() && can_convert_to_zombie()) {
       return;
     }
-  }
-
-  // This is a bad time for a safepoint.  We don't want
-  // this nmethod to get unloaded while we're queueing the event.
-  NoSafepointVerifier nsv;
-
-  Method* m = method();
-  HOTSPOT_COMPILED_METHOD_LOAD(
-      (char *) m->klass_name()->bytes(),
-      m->klass_name()->utf8_length(),
-      (char *) m->name()->bytes(),
-      m->name()->utf8_length(),
-      (char *) m->signature()->bytes(),
-      m->signature()->utf8_length(),
-      insts_begin(), insts_size());
 
 
-  if (JvmtiExport::should_post_compiled_method_load()) {
-    // Only post unload events if load events are found.
-    set_load_reported();
-    // If a JavaThread hasn't been passed in, let the Service thread
-    // (which is a real Java thread) post the event
-    JvmtiDeferredEvent event = JvmtiDeferredEvent::compiled_method_load_event(this);
-    if (state == NULL) {
-      // Execute any barrier code for this nmethod as if it's called, since
-      // keeping it alive looks like stack walking.
-      run_nmethod_entry_barrier();
-      ServiceThread::enqueue_deferred_event(&event);
-    } else {
-      // This enters the nmethod barrier outside in the caller.
-      state->enqueue_event(&event);
+    // This is a bad time for a safepoint.  We don't want
+    // this nmethod to get unloaded while we're queueing the event.
+    NoSafepointVerifier nsv;
+
+    Method *m = method();
+    HOTSPOT_COMPILED_METHOD_LOAD(
+        (char *) m->klass_name()->bytes(),
+        m->klass_name()->utf8_length(),
+        (char *) m->name()->bytes(),
+        m->name()->utf8_length(),
+        (char *) m->signature()->bytes(),
+        m->signature()->utf8_length(),
+        insts_begin(), insts_size());
+
+    if (JvmtiExport::should_post_compiled_method_load()) {
+      // Only post unload events if load events are found.
+      set_load_reported();
+      // If a JavaThread hasn't been passed in, let the Service thread
+      // (which is a real Java thread) post the event
+      JvmtiDeferredEvent event = JvmtiDeferredEvent::compiled_method_load_event(this);
+      if (state == NULL) {
+        // Execute any barrier code for this nmethod as if it's called, since
+        // keeping it alive looks like stack walking.
+        run_nmethod_entry_barrier();
+        ServiceThread::enqueue_deferred_event(&event);
+      } else {
+        // This enters the nmethod barrier outside in the caller.
+        state->enqueue_event(&event);
+      }
     }
   }
 }

--- a/src/hotspot/share/prims/jvmtiCodeBlobEvents.cpp
+++ b/src/hotspot/share/prims/jvmtiCodeBlobEvents.cpp
@@ -245,6 +245,7 @@ jvmtiError JvmtiCodeBlobEvents::generate_compiled_method_load_events(JvmtiEnv* e
     state->run_nmethod_entry_barriers();
   }
 
+  state->verify_nmethods();
   // Now post all the events outside the CodeCache_lock.
   // If there's a safepoint, the queued events will be kept alive.
   // Adding these events to the service thread to post is something that

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -2196,6 +2196,8 @@ void JvmtiExport::post_compiled_method_load(JvmtiEnv* env, nmethod *nm) {
   if (callback == NULL) {
     return;
   }
+  assert(nm != NULL, "zombie in post_compiled_method_load");
+  assert(!nm->is_zombie(), "zombie in post_compiled_method_load");
   JavaThread* thread = JavaThread::current();
 
   EVT_TRACE(JVMTI_EVENT_COMPILED_METHOD_LOAD,
@@ -2205,6 +2207,10 @@ void JvmtiExport::post_compiled_method_load(JvmtiEnv* env, nmethod *nm) {
             (nm->method() == NULL) ? "NULL" : nm->method()->name()->as_C_string()));
   ResourceMark rm(thread);
   HandleMark hm(thread);
+
+
+  assert(nm != NULL, "zombie in post_compiled_method_load2");
+  assert(!nm->is_zombie(), "zombie in post_compiled_method_load2");
 
   // Add inlining information
   jvmtiCompiledMethodLoadInlineRecord* inlinerecord = create_inline_record(nm);

--- a/src/hotspot/share/prims/jvmtiImpl.hpp
+++ b/src/hotspot/share/prims/jvmtiImpl.hpp
@@ -450,6 +450,8 @@ class JvmtiDeferredEvent {
   void post() NOT_JVMTI_RETURN;
   void post_compiled_method_load_event(JvmtiEnv* env) NOT_JVMTI_RETURN;
   void run_nmethod_entry_barriers() NOT_JVMTI_RETURN;
+  void verify() NOT_JVMTI_RETURN;
+
   // Sweeper support to keep nmethods from being zombied while in the queue.
   void nmethods_do(CodeBlobClosure* cf) NOT_JVMTI_RETURN;
   // GC support to keep nmethod from being unloaded while in the queue.
@@ -492,6 +494,7 @@ class JvmtiDeferredEventQueue : public CHeapObj<mtInternal> {
   void post(JvmtiEnv* env) NOT_JVMTI_RETURN;
   void enqueue(JvmtiDeferredEvent event) NOT_JVMTI_RETURN;
   void run_nmethod_entry_barriers();
+  void verify();
 
   // Sweeper support to keep nmethods from being zombied while in the queue.
   void nmethods_do(CodeBlobClosure* cf) NOT_JVMTI_RETURN;

--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -445,3 +445,9 @@ void JvmtiThreadState::run_nmethod_entry_barriers() {
     _jvmti_event_queue->run_nmethod_entry_barriers();
   }
 }
+
+void JvmtiThreadState::verify_nmethods() {
+  if (_jvmti_event_queue != NULL) {
+    _jvmti_event_queue->run_nmethod_entry_barriers();
+  }
+}

--- a/src/hotspot/share/prims/jvmtiThreadState.hpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.hpp
@@ -397,6 +397,7 @@ public:
   void enqueue_event(JvmtiDeferredEvent* event) NOT_JVMTI_RETURN;
   void post_events(JvmtiEnv* env);
   void run_nmethod_entry_barriers();
+  void verify_nmethods();
 };
 
 #endif // SHARE_PRIMS_JVMTITHREADSTATE_HPP


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ 8245877 is used in problem lists: [test/hotspot/jtreg/ProblemList.txt]

### Issue
 * [JDK-8245877](https://bugs.openjdk.java.net/browse/JDK-8245877): assert(_value != __null) failed: resolving NULL _value in JvmtiExport::post_compiled_method_load


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4599/head:pull/4599` \
`$ git checkout pull/4599`

Update a local copy of the PR: \
`$ git checkout pull/4599` \
`$ git pull https://git.openjdk.java.net/jdk pull/4599/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4599`

View PR using the GUI difftool: \
`$ git pr show -t 4599`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4599.diff">https://git.openjdk.java.net/jdk/pull/4599.diff</a>

</details>
