### PR TITLE
8269417: Minor clarification on NonblockingQueue utility

### DIFF
--- a/src/hotspot/share/utilities/nonblockingQueue.hpp
+++ b/src/hotspot/share/utilities/nonblockingQueue.hpp
@@ -29,10 +29,8 @@
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/pair.hpp"
 
-// The NonblockingQueue template provides a non-blocking FIFO. It provides a
-// try_pop() function for the client to implement pop() according to its
-// need (e.g., whether or not to retry or prevent ABA problem). It has inner
-// padding of one cache line between its two internal pointer fields.
+// The NonblockingQueue template provides a non-blocking FIFO.
+// It has inner padding of one cache line between its two internal pointers.
 //
 // The queue is internally represented by a linked list of elements, with
 // the link to the next element provided by a member of each element.

--- a/src/hotspot/share/utilities/nonblockingQueue.inline.hpp
+++ b/src/hotspot/share/utilities/nonblockingQueue.inline.hpp
@@ -85,10 +85,8 @@ size_t NonblockingQueue<T, next_ptr>::length() const {
 
 // An append operation atomically exchanges the new tail with the queue tail.
 // It then sets the "next" value of the old tail to the head of the list being
-// appended; it is an invariant that the old tail's "next" value is NULL.
-// But if the old tail is NULL then the queue was empty.  In this case the
-// head of the list being appended is instead stored in the queue head; it is
-// an invariant that the queue head is NULL in this case.
+// appended. If the old tail is NULL then the queue was empty, then the head
+// of the list being appended is instead stored in the queue head.
 //
 // This means there is a period between the exchange and the old tail update
 // where the queue sequence is split into two parts, the list from the queue
@@ -105,12 +103,23 @@ void NonblockingQueue<T, next_ptr>::append(T& first, T& last) {
   assert(next(last) == NULL, "precondition");
   set_next(last, end_marker());
   T* old_tail = Atomic::xchg(&_tail, &last);
-  if ((old_tail == NULL) ||
+  bool is_old_tail_null = (old_tail == NULL);
+  if (is_old_tail_null ||
       // Try to install first as old_tail's next.
       !is_end(Atomic::cmpxchg(next_ptr(*old_tail), end_marker(), &first))) {
     // Install first as the new head if either
     // (1) the list was empty, or
     // (2) a concurrent try_pop claimed old_tail, so it is no longer in the list.
+    // Note that multiple concurrent push/append operations cannot modify
+    // _head simultaneously, because the Atomic::xchg() above orders these
+    // push/append operations so they perform Atomic::cmpxchg() on different
+    // old_tail. Thus, at most one Atomic::cmpxchg() can fail.
+    DEBUG_ONLY(T* old_head = Atomic::load(&_head);)
+    // If old_tail is NULL, old_head could be NULL, or an unseen object
+    // that is being popped.  Otherwise, old_head must be either NULL
+    // or the same as old_tail.
+    assert(is_old_tail_null ||
+           old_head == NULL || old_head == old_tail, "invariant");
     Atomic::store(&_head, &first);
   }
 }
@@ -179,10 +188,13 @@ bool NonblockingQueue<T, next_ptr>::try_pop(T** node_ptr) {
 template<typename T, T* volatile* (*next_ptr)(T&)>
 T* NonblockingQueue<T, next_ptr>::pop() {
   T* result = NULL;
+  // Typically try_pop() will succeed without retrying many times, thus we
+  // omit SpinPause in the loop body.  SpinPause or yield may be worthwhile
+  // in rare, highly contended cases, and client code could implement such
+  // with try_pop().
   while (!try_pop(&result)) {}
   return result;
 }
-
 
 template<typename T, T* volatile* (*next_ptr)(T&)>
 Pair<T*, T*> NonblockingQueue<T, next_ptr>::take_all() {

--- a/src/hotspot/share/utilities/nonblockingQueue.inline.hpp
+++ b/src/hotspot/share/utilities/nonblockingQueue.inline.hpp
@@ -113,7 +113,7 @@ void NonblockingQueue<T, next_ptr>::append(T& first, T& last) {
     // Note that multiple concurrent push/append operations cannot modify
     // _head simultaneously, because the Atomic::xchg() above orders these
     // push/append operations so they perform Atomic::cmpxchg() on different
-    // old_tail. Thus, at most one Atomic::cmpxchg() can fail.
+    // old_tail. Thus, the cmpxchg can only fail because of a concurrent try_pop.
     DEBUG_ONLY(T* old_head = Atomic::load(&_head);)
     // If old_tail is NULL, old_head could be NULL, or an unseen object
     // that is being popped.  Otherwise, old_head must be either NULL


### PR DESCRIPTION
Hi,

Could you review this change mainly based on the comments in https://github.com/openjdk/jdk/pull/4379?
I also added an assertion to ensure and better understand why the Atomic::store() in append() is correct.

Stress tested with fastdebug build with:
$ make test TEST="gtest:NonblockingQueueTestBasics gtest:NonblockingQueueTest" GTEST="REPEAT=-1"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269417](https://bugs.openjdk.java.net/browse/JDK-8269417): Minor clarification on NonblockingQueue utility


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to e7890729ee284fd69bc86689868251d9a9f2f59e
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4600/head:pull/4600` \
`$ git checkout pull/4600`

Update a local copy of the PR: \
`$ git checkout pull/4600` \
`$ git pull https://git.openjdk.java.net/jdk pull/4600/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4600`

View PR using the GUI difftool: \
`$ git pr show -t 4600`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4600.diff">https://git.openjdk.java.net/jdk/pull/4600.diff</a>

</details>
