### PR TITLE
8269404: Base64 Encoding optimization enhancements for x86 using AVX-512

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -3762,7 +3762,7 @@ void Assembler::vpermb(XMMRegister dst, XMMRegister nds, Address src, int vector
   InstructionAttr attributes(vector_len, /* rex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
   attributes.set_is_evex_instruction();
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
-  emit_int8(0x8D);
+  emit_int8((unsigned char)0x8D);
   emit_operand(dst, src);
 }
 
@@ -3851,7 +3851,7 @@ void Assembler::evpmultishiftqb(XMMRegister dst, XMMRegister ctl, XMMRegister sr
   InstructionAttr attributes(vector_len, /* vex_w */ true, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
   attributes.set_is_evex_instruction();
   int encode = vex_prefix_and_encode(dst->encoding(), ctl->encoding(), src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
-  emit_int16(0x83, (0xC0 | encode));
+  emit_int16((unsigned char)0x83, (unsigned char)(0xC0 | encode));
 }
 
 void Assembler::pause() {
@@ -4157,7 +4157,7 @@ void Assembler::vpmaskmovd(XMMRegister dst, XMMRegister nds, Address src, int ve
   InstructionMark im(this);
   InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ false, /* uses_vl */ true);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
-  emit_int8(0x8C);
+  emit_int8((unsigned char)0x8C);
   emit_operand(dst, src);
 }
 

--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -4155,7 +4155,7 @@ void Assembler::vpmovmskb(Register dst, XMMRegister src, int vec_enc) {
 void Assembler::vpmaskmovd(XMMRegister dst, XMMRegister nds, Address src, int vector_len) {
   assert((VM_Version::supports_avx2() && vector_len == AVX_256bit), "");
   InstructionMark im(this);
-  InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ false, /* uses_vl */ true);
+  InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ false, /* uses_vl */ true);
   vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int8((unsigned char)0x8C);
   emit_operand(dst, src);
@@ -6690,8 +6690,9 @@ void Assembler::pmuludq(XMMRegister dst, XMMRegister src) {
 
 void Assembler::vpmulhuw(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
   assert((vector_len == AVX_128bit && VM_Version::supports_avx()) ||
-         (vector_len == AVX_256bit && VM_Version::supports_avx2()), "");
-  InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
+         (vector_len == AVX_256bit && VM_Version::supports_avx2()) ||
+         (vector_len == AVX_512bit && VM_Version::supports_avx512bw()), "");
+  InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ _legacy_mode_bw, /* no_mask_reg */ true, /* uses_vl */ true);
   int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int16((unsigned char)0xE4, (0xC0 | encode));
 }

--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -3837,6 +3837,14 @@ void Assembler::evpermt2b(XMMRegister dst, XMMRegister nds, XMMRegister src, int
   emit_int16(0x7D, (0xC0 | encode));
 }
 
+void Assembler::evpmultishiftqb(XMMRegister dst, XMMRegister ctl, XMMRegister src, int vector_len) {
+  assert(VM_Version::supports_avx512_vbmi(), "");
+  InstructionAttr attributes(vector_len, /* vex_w */ true, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
+  attributes.set_is_evex_instruction();
+  int encode = vex_prefix_and_encode(dst->encoding(), ctl->encoding(), src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
+  emit_int16(0x83, (0xC0 | encode));
+}
+
 void Assembler::pause() {
   emit_int16((unsigned char)0xF3, (unsigned char)0x90);
 }

--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -3757,6 +3757,15 @@ void Assembler::vpermb(XMMRegister dst, XMMRegister nds, XMMRegister src, int ve
   emit_int16((unsigned char)0x8D, (0xC0 | encode));
 }
 
+void Assembler::vpermb(XMMRegister dst, XMMRegister nds, Address src, int vector_len) {
+  assert(VM_Version::supports_avx512_vbmi(), "");
+  InstructionAttr attributes(vector_len, /* rex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
+  attributes.set_is_evex_instruction();
+  vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
+  emit_int8(0x8D);
+  emit_operand(dst, src);
+}
+
 void Assembler::vpermw(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
   assert(vector_len == AVX_128bit ? VM_Version::supports_avx512vlbw() :
          vector_len == AVX_256bit ? VM_Version::supports_avx512vlbw() :
@@ -4141,6 +4150,15 @@ void Assembler::vpmovmskb(Register dst, XMMRegister src, int vec_enc) {
   InstructionAttr attributes(vec_enc, /* rex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
   int encode = vex_prefix_and_encode(dst->encoding(), 0, src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int16((unsigned char)0xD7, (0xC0 | encode));
+}
+
+void Assembler::vpmaskmovd(XMMRegister dst, XMMRegister nds, Address src, int vector_len) {
+  assert((VM_Version::supports_avx2() && vector_len == AVX_256bit), "");
+  InstructionMark im(this);
+  InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ false, /* uses_vl */ true);
+  vex_prefix(src, nds->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
+  emit_int8(0x8C);
+  emit_operand(dst, src);
 }
 
 void Assembler::pextrd(Register dst, XMMRegister src, int imm8) {
@@ -6572,6 +6590,13 @@ void Assembler::psubq(XMMRegister dst, XMMRegister src) {
   emit_int8((0xC0 | encode));
 }
 
+void Assembler::vpsubusb(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
+  assert(UseAVX > 0, "requires some form of AVX");
+  InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ _legacy_mode_bw, /* no_mask_reg */ true, /* uses_vl */ true);
+  int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
+  emit_int16((unsigned char)0xD8, (0xC0 | encode));
+}
+
 void Assembler::vpsubb(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
   assert(UseAVX > 0, "requires some form of AVX");
   InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ _legacy_mode_bw, /* no_mask_reg */ true, /* uses_vl */ true);
@@ -6661,6 +6686,14 @@ void Assembler::pmuludq(XMMRegister dst, XMMRegister src) {
   InstructionAttr attributes(AVX_128bit, /* rex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
   int encode = simd_prefix_and_encode(dst, dst, src, VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int16((unsigned char)0xF4, (0xC0 | encode));
+}
+
+void Assembler::vpmulhuw(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
+  assert((vector_len == AVX_128bit && VM_Version::supports_avx()) ||
+         (vector_len == AVX_256bit && VM_Version::supports_avx2()), "");
+  InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
+  int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
+  emit_int16((unsigned char)0xE4, (0xC0 | encode));
 }
 
 void Assembler::vpmullw(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -1688,6 +1688,7 @@ private:
   void vpermq(XMMRegister dst, XMMRegister src, int imm8);
   void vpermq(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
   void vpermb(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
+  void vpermb(XMMRegister dst, XMMRegister nds, Address src, int vector_len);
   void vpermw(XMMRegister dst,  XMMRegister nds, XMMRegister src, int vector_len);
   void vpermd(XMMRegister dst,  XMMRegister nds, Address src, int vector_len);
   void vpermd(XMMRegister dst,  XMMRegister nds, XMMRegister src, int vector_len);

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -1698,6 +1698,7 @@ private:
   void vpermpd(XMMRegister dst, XMMRegister src, int imm8, int vector_len);
   void evpermi2q(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
   void evpermt2b(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
+  void evpmultishiftqb(XMMRegister dst, XMMRegister ctl, XMMRegister src, int vector_len);
 
   void pause();
 
@@ -1746,6 +1747,7 @@ private:
 
   void pmovmskb(Register dst, XMMRegister src);
   void vpmovmskb(Register dst, XMMRegister src, int vec_enc);
+  void vpmaskmovd(XMMRegister dst, XMMRegister nds, Address src, int vector_len);
 
   // SSE 4.1 extract
   void pextrd(Register dst, XMMRegister src, int imm8);
@@ -2268,6 +2270,7 @@ private:
   void vpmullw(XMMRegister dst, XMMRegister nds, Address src, int vector_len);
   void vpmulld(XMMRegister dst, XMMRegister nds, Address src, int vector_len);
   void vpmullq(XMMRegister dst, XMMRegister nds, Address src, int vector_len);
+  void vpmulhuw(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
 
   // Minimum of packed integers
   void pminsb(XMMRegister dst, XMMRegister src);

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -2251,6 +2251,7 @@ private:
   void psubw(XMMRegister dst, XMMRegister src);
   void psubd(XMMRegister dst, XMMRegister src);
   void psubq(XMMRegister dst, XMMRegister src);
+  void vpsubusb(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
   void vpsubb(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
   void vpsubw(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
   void vpsubd(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -5286,400 +5286,495 @@ address generate_avx_ghash_processBlocks() {
     return start;
   }
 
-  //base64 character set
-  address base64_charset_addr() {
-    __ align(CodeEntryAlignment);
-    StubCodeMark mark(this, "StubRoutines", "base64_charset");
-    address start = __ pc();
-    __ emit_data64(0x0000004200000041, relocInfo::none);
-    __ emit_data64(0x0000004400000043, relocInfo::none);
-    __ emit_data64(0x0000004600000045, relocInfo::none);
-    __ emit_data64(0x0000004800000047, relocInfo::none);
-    __ emit_data64(0x0000004a00000049, relocInfo::none);
-    __ emit_data64(0x0000004c0000004b, relocInfo::none);
-    __ emit_data64(0x0000004e0000004d, relocInfo::none);
-    __ emit_data64(0x000000500000004f, relocInfo::none);
-    __ emit_data64(0x0000005200000051, relocInfo::none);
-    __ emit_data64(0x0000005400000053, relocInfo::none);
-    __ emit_data64(0x0000005600000055, relocInfo::none);
-    __ emit_data64(0x0000005800000057, relocInfo::none);
-    __ emit_data64(0x0000005a00000059, relocInfo::none);
-    __ emit_data64(0x0000006200000061, relocInfo::none);
-    __ emit_data64(0x0000006400000063, relocInfo::none);
-    __ emit_data64(0x0000006600000065, relocInfo::none);
-    __ emit_data64(0x0000006800000067, relocInfo::none);
-    __ emit_data64(0x0000006a00000069, relocInfo::none);
-    __ emit_data64(0x0000006c0000006b, relocInfo::none);
-    __ emit_data64(0x0000006e0000006d, relocInfo::none);
-    __ emit_data64(0x000000700000006f, relocInfo::none);
-    __ emit_data64(0x0000007200000071, relocInfo::none);
-    __ emit_data64(0x0000007400000073, relocInfo::none);
-    __ emit_data64(0x0000007600000075, relocInfo::none);
-    __ emit_data64(0x0000007800000077, relocInfo::none);
-    __ emit_data64(0x0000007a00000079, relocInfo::none);
-    __ emit_data64(0x0000003100000030, relocInfo::none);
-    __ emit_data64(0x0000003300000032, relocInfo::none);
-    __ emit_data64(0x0000003500000034, relocInfo::none);
-    __ emit_data64(0x0000003700000036, relocInfo::none);
-    __ emit_data64(0x0000003900000038, relocInfo::none);
-    __ emit_data64(0x0000002f0000002b, relocInfo::none);
-    return start;
+  address base64_shuffle_addr()
+  {
+	  __ align(64, (unsigned long)__ pc());
+	  StubCodeMark mark(this, "StubRoutines", "shuffle_base64");
+	  address start = __ pc();
+	  assert(((unsigned long)start & 0x3f) == 0,
+		 "Alignment problem (0x%08lx)", (unsigned long)start);
+	  __ emit_data64(0x0405030401020001, relocInfo::none);
+	  __ emit_data64(0x0a0b090a07080607, relocInfo::none);
+	  __ emit_data64(0x10110f100d0e0c0d, relocInfo::none);
+	  __ emit_data64(0x1617151613141213, relocInfo::none);
+	  __ emit_data64(0x1c1d1b1c191a1819, relocInfo::none);
+	  __ emit_data64(0x222321221f201e1f, relocInfo::none);
+	  __ emit_data64(0x2829272825262425, relocInfo::none);
+	  __ emit_data64(0x2e2f2d2e2b2c2a2b, relocInfo::none);
+	  return start;
   }
 
-  //base64 url character set
-  address base64url_charset_addr() {
-    __ align(CodeEntryAlignment);
-    StubCodeMark mark(this, "StubRoutines", "base64url_charset");
-    address start = __ pc();
-    __ emit_data64(0x0000004200000041, relocInfo::none);
-    __ emit_data64(0x0000004400000043, relocInfo::none);
-    __ emit_data64(0x0000004600000045, relocInfo::none);
-    __ emit_data64(0x0000004800000047, relocInfo::none);
-    __ emit_data64(0x0000004a00000049, relocInfo::none);
-    __ emit_data64(0x0000004c0000004b, relocInfo::none);
-    __ emit_data64(0x0000004e0000004d, relocInfo::none);
-    __ emit_data64(0x000000500000004f, relocInfo::none);
-    __ emit_data64(0x0000005200000051, relocInfo::none);
-    __ emit_data64(0x0000005400000053, relocInfo::none);
-    __ emit_data64(0x0000005600000055, relocInfo::none);
-    __ emit_data64(0x0000005800000057, relocInfo::none);
-    __ emit_data64(0x0000005a00000059, relocInfo::none);
-    __ emit_data64(0x0000006200000061, relocInfo::none);
-    __ emit_data64(0x0000006400000063, relocInfo::none);
-    __ emit_data64(0x0000006600000065, relocInfo::none);
-    __ emit_data64(0x0000006800000067, relocInfo::none);
-    __ emit_data64(0x0000006a00000069, relocInfo::none);
-    __ emit_data64(0x0000006c0000006b, relocInfo::none);
-    __ emit_data64(0x0000006e0000006d, relocInfo::none);
-    __ emit_data64(0x000000700000006f, relocInfo::none);
-    __ emit_data64(0x0000007200000071, relocInfo::none);
-    __ emit_data64(0x0000007400000073, relocInfo::none);
-    __ emit_data64(0x0000007600000075, relocInfo::none);
-    __ emit_data64(0x0000007800000077, relocInfo::none);
-    __ emit_data64(0x0000007a00000079, relocInfo::none);
-    __ emit_data64(0x0000003100000030, relocInfo::none);
-    __ emit_data64(0x0000003300000032, relocInfo::none);
-    __ emit_data64(0x0000003500000034, relocInfo::none);
-    __ emit_data64(0x0000003700000036, relocInfo::none);
-    __ emit_data64(0x0000003900000038, relocInfo::none);
-    __ emit_data64(0x0000005f0000002d, relocInfo::none);
-
-    return start;
+  address base64_avx2_shuffle_addr()
+  {
+	  __ align(32);
+	  StubCodeMark mark(this, "StubRoutines", "avx2_shuffle_base64");
+	  address start = __ pc();
+	  __ emit_data64(0x0809070805060405, relocInfo::none);
+	  __ emit_data64(0x0e0f0d0e0b0c0a0b, relocInfo::none);
+	  __ emit_data64(0x0405030401020001, relocInfo::none);
+	  __ emit_data64(0x0a0b090a07080607, relocInfo::none);
+	  return start;
   }
 
-  address base64_bswap_mask_addr() {
-    __ align(CodeEntryAlignment);
-    StubCodeMark mark(this, "StubRoutines", "bswap_mask_base64");
-    address start = __ pc();
-    __ emit_data64(0x0504038002010080, relocInfo::none);
-    __ emit_data64(0x0b0a098008070680, relocInfo::none);
-    __ emit_data64(0x0908078006050480, relocInfo::none);
-    __ emit_data64(0x0f0e0d800c0b0a80, relocInfo::none);
-    __ emit_data64(0x0605048003020180, relocInfo::none);
-    __ emit_data64(0x0c0b0a8009080780, relocInfo::none);
-    __ emit_data64(0x0504038002010080, relocInfo::none);
-    __ emit_data64(0x0b0a098008070680, relocInfo::none);
-
-    return start;
+  address base64_avx2_input_mask_addr()
+  {
+	  __ align(32);
+	  StubCodeMark mark(this, "StubRoutines", "avx2_input_mask_base64");
+	  address start = __ pc();
+	  __ emit_data64(0x8000000000000000, relocInfo::none);
+	  __ emit_data64(0x8000000080000000, relocInfo::none);
+	  __ emit_data64(0x8000000080000000, relocInfo::none);
+	  __ emit_data64(0x8000000080000000, relocInfo::none);
+	  return start;
   }
 
-  address base64_right_shift_mask_addr() {
-    __ align(CodeEntryAlignment);
-    StubCodeMark mark(this, "StubRoutines", "right_shift_mask");
-    address start = __ pc();
-    __ emit_data64(0x0006000400020000, relocInfo::none);
-    __ emit_data64(0x0006000400020000, relocInfo::none);
-    __ emit_data64(0x0006000400020000, relocInfo::none);
-    __ emit_data64(0x0006000400020000, relocInfo::none);
-    __ emit_data64(0x0006000400020000, relocInfo::none);
-    __ emit_data64(0x0006000400020000, relocInfo::none);
-    __ emit_data64(0x0006000400020000, relocInfo::none);
-    __ emit_data64(0x0006000400020000, relocInfo::none);
+  address base64_avx2_lut_addr()
+  {
+	  __ align(32);
+	  StubCodeMark mark(this, "StubRoutines", "avx2_lut_base64");
+	  address start = __ pc();
+	  __ emit_data64(0xfcfcfcfcfcfc4741, relocInfo::none);
+	  __ emit_data64(0x0000f0edfcfcfcfc, relocInfo::none);
+	  __ emit_data64(0xfcfcfcfcfcfc4741, relocInfo::none);
+	  __ emit_data64(0x0000f0edfcfcfcfc, relocInfo::none);
 
-    return start;
+	  // URL LUT
+	  __ emit_data64(0xfcfcfcfcfcfc4741, relocInfo::none);
+	  __ emit_data64(0x000020effcfcfcfc, relocInfo::none);
+	  __ emit_data64(0xfcfcfcfcfcfc4741, relocInfo::none);
+	  __ emit_data64(0x000020effcfcfcfc, relocInfo::none);
+	  return start;
   }
 
-  address base64_left_shift_mask_addr() {
-    __ align(CodeEntryAlignment);
-    StubCodeMark mark(this, "StubRoutines", "left_shift_mask");
-    address start = __ pc();
-    __ emit_data64(0x0000000200040000, relocInfo::none);
-    __ emit_data64(0x0000000200040000, relocInfo::none);
-    __ emit_data64(0x0000000200040000, relocInfo::none);
-    __ emit_data64(0x0000000200040000, relocInfo::none);
-    __ emit_data64(0x0000000200040000, relocInfo::none);
-    __ emit_data64(0x0000000200040000, relocInfo::none);
-    __ emit_data64(0x0000000200040000, relocInfo::none);
-    __ emit_data64(0x0000000200040000, relocInfo::none);
+  address base64_encoding_table_addr()
+  {
+	  __ align(64, (unsigned long)__ pc());
+	  StubCodeMark mark(this, "StubRoutines", "encoding_table_base64");
+	  address start = __ pc();
+	  assert(((unsigned long)start & 0x3f) == 0,
+		 "Alignment problem (0x%08lx)", (unsigned long)start);
+	  __ emit_data64(0x4847464544434241, relocInfo::none);
+	  __ emit_data64(0x504f4e4d4c4b4a49, relocInfo::none);
+	  __ emit_data64(0x5857565554535251, relocInfo::none);
+	  __ emit_data64(0x6665646362615a59, relocInfo::none);
+	  __ emit_data64(0x6e6d6c6b6a696867, relocInfo::none);
+	  __ emit_data64(0x767574737271706f, relocInfo::none);
+	  __ emit_data64(0x333231307a797877, relocInfo::none);
+	  __ emit_data64(0x2f2b393837363534, relocInfo::none);
 
-    return start;
+	  // URL table
+	  __ emit_data64(0x4847464544434241, relocInfo::none);
+	  __ emit_data64(0x504f4e4d4c4b4a49, relocInfo::none);
+	  __ emit_data64(0x5857565554535251, relocInfo::none);
+	  __ emit_data64(0x6665646362615a59, relocInfo::none);
+	  __ emit_data64(0x6e6d6c6b6a696867, relocInfo::none);
+	  __ emit_data64(0x767574737271706f, relocInfo::none);
+	  __ emit_data64(0x333231307a797877, relocInfo::none);
+	  __ emit_data64(0x5f2d393837363534, relocInfo::none);
+	  return start;
   }
 
-  address base64_and_mask_addr() {
-    __ align(CodeEntryAlignment);
-    StubCodeMark mark(this, "StubRoutines", "and_mask");
-    address start = __ pc();
-    __ emit_data64(0x3f003f003f000000, relocInfo::none);
-    __ emit_data64(0x3f003f003f000000, relocInfo::none);
-    __ emit_data64(0x3f003f003f000000, relocInfo::none);
-    __ emit_data64(0x3f003f003f000000, relocInfo::none);
-    __ emit_data64(0x3f003f003f000000, relocInfo::none);
-    __ emit_data64(0x3f003f003f000000, relocInfo::none);
-    __ emit_data64(0x3f003f003f000000, relocInfo::none);
-    __ emit_data64(0x3f003f003f000000, relocInfo::none);
-    return start;
-  }
+  // Code for generating Base64 encoding.
+  // Intrinsic function prototype in Base64.java:
+  // private void encodeBlock(byte[] src, int sp, int sl, byte[] dst, int dp,
+  // boolean isURL) {
+  address generate_base64_encodeBlock()
+  {
+	  __ align(CodeEntryAlignment);
+	  StubCodeMark mark(this, "StubRoutines", "implEncode");
+	  address start = __ pc();
+	  __ enter();
 
-  address base64_gather_mask_addr() {
-    __ align(CodeEntryAlignment);
-    StubCodeMark mark(this, "StubRoutines", "gather_mask");
-    address start = __ pc();
-    __ emit_data64(0xffffffffffffffff, relocInfo::none);
-    return start;
-  }
+	  // Save callee-saved registers before using them
+	  __ push(r12);
+	  __ push(r13);
+	  __ push(r14);
+	  __ push(r15);
 
-// Code for generating Base64 encoding.
-// Intrinsic function prototype in Base64.java:
-// private void encodeBlock(byte[] src, int sp, int sl, byte[] dst, int dp, boolean isURL) {
-  address generate_base64_encodeBlock() {
-    __ align(CodeEntryAlignment);
-    StubCodeMark mark(this, "StubRoutines", "implEncode");
-    address start = __ pc();
-    __ enter();
-
-    // Save callee-saved registers before using them
-    __ push(r12);
-    __ push(r13);
-    __ push(r14);
-    __ push(r15);
-
-    // arguments
-    const Register source = c_rarg0; // Source Array
-    const Register start_offset = c_rarg1; // start offset
-    const Register end_offset = c_rarg2; // end offset
-    const Register dest = c_rarg3; // destination array
+	  // arguments
+	  const Register source = c_rarg0;       // Source Array
+	  const Register start_offset = c_rarg1; // start offset
+	  const Register end_offset = c_rarg2;   // end offset
+	  const Register dest = c_rarg3;	 // destination array
 
 #ifndef _WIN64
-    const Register dp = c_rarg4;  // Position for writing to dest array
-    const Register isURL = c_rarg5;// Base64 or URL character set
+	  const Register dp = c_rarg4;    // Position for writing to dest array
+	  const Register isURL = c_rarg5; // Base64 or URL character set
 #else
-    const Address  dp_mem(rbp, 6 * wordSize);  // length is on stack on Win64
-    const Address isURL_mem(rbp, 7 * wordSize);
-    const Register isURL = r10;      // pick the volatile windows register
-    const Register dp = r12;
-    __ movl(dp, dp_mem);
-    __ movl(isURL, isURL_mem);
+	  const Address dp_mem(rbp,
+			       6 * wordSize); // length is on stack on Win64
+	  const Address isURL_mem(rbp, 7 * wordSize);
+	  const Register isURL = r10; // pick the volatile windows register
+	  const Register dp = r12;
+	  __ movl(dp, dp_mem);
+	  __ movl(isURL, isURL_mem);
 #endif
 
-    const Register length = r14;
-    Label L_process80, L_process32, L_process3, L_exit, L_processdata;
+	  const Register length = r14;
+	  const Register encode_table = r13;
+	  Label L_process3, L_exit, L_processdata, L_vbmiLoop, L_not512,
+		  L_32byteLoop;
 
-    // calculate length from offsets
-    __ movl(length, end_offset);
-    __ subl(length, start_offset);
-    __ cmpl(length, 0);
-    __ jcc(Assembler::lessEqual, L_exit);
+	  // calculate length from offsets
+	  __ movl(length, end_offset);
+	  __ subl(length, start_offset);
+	  __ cmpl(length, 0);
+	  __ jcc(Assembler::lessEqual, L_exit);
 
-    __ lea(r11, ExternalAddress(StubRoutines::x86::base64_charset_addr()));
-    // check if base64 charset(isURL=0) or base64 url charset(isURL=1) needs to be loaded
-    __ cmpl(isURL, 0);
-    __ jcc(Assembler::equal, L_processdata);
-    __ lea(r11, ExternalAddress(StubRoutines::x86::base64url_charset_addr()));
+	  // Code for 512-bit VBMI encoding.  Encodes 48 input bytes into 64
+	  // output bytes. We read 64 input bytes and ignore the last 16, so be
+	  // sure not to read past the end of the input buffer.
+	  if (VM_Version::supports_avx512_vbmi()) {
+		  __ cmpl(length, 64); // Do not overrun input buffer.
+		  __ jcc(Assembler::below, L_not512);
 
-    // load masks required for encoding data
-    __ BIND(L_processdata);
-    __ movdqu(xmm16, ExternalAddress(StubRoutines::x86::base64_gather_mask_addr()));
-    // Set 64 bits of K register.
-    __ evpcmpeqb(k3, xmm16, xmm16, Assembler::AVX_512bit);
-    __ evmovdquq(xmm12, ExternalAddress(StubRoutines::x86::base64_bswap_mask_addr()), Assembler::AVX_256bit, r13);
-    __ evmovdquq(xmm13, ExternalAddress(StubRoutines::x86::base64_right_shift_mask_addr()), Assembler::AVX_512bit, r13);
-    __ evmovdquq(xmm14, ExternalAddress(StubRoutines::x86::base64_left_shift_mask_addr()), Assembler::AVX_512bit, r13);
-    __ evmovdquq(xmm15, ExternalAddress(StubRoutines::x86::base64_and_mask_addr()), Assembler::AVX_512bit, r13);
+		  __ shll(isURL, 6); // index into decode table based on isURL
+		  __ lea(encode_table,
+			 ExternalAddress(StubRoutines::x86::
+						 base64_encoding_table_addr()));
+		  __ addptr(encode_table, isURL);
+		  __ shrl(isURL, 6); // restore isURL
 
-    // Vector Base64 implementation, producing 96 bytes of encoded data
-    __ BIND(L_process80);
-    __ cmpl(length, 80);
-    __ jcc(Assembler::below, L_process32);
-    __ evmovdquq(xmm0, Address(source, start_offset, Address::times_1, 0), Assembler::AVX_256bit);
-    __ evmovdquq(xmm1, Address(source, start_offset, Address::times_1, 24), Assembler::AVX_256bit);
-    __ evmovdquq(xmm2, Address(source, start_offset, Address::times_1, 48), Assembler::AVX_256bit);
+		  __ mov64(rax, 0x3036242a1016040a); // Shifts
+		  __ evmovdquq(
+			  xmm3,
+			  ExternalAddress(
+				  StubRoutines::x86::base64_shuffle_addr()),
+			  Assembler::AVX_512bit, r15);
+		  __ evmovdquq(xmm2, Address(encode_table, 0),
+			       Assembler::AVX_512bit);
+		  __ evpbroadcastq(xmm1, rax, Assembler::AVX_512bit);
 
-    //permute the input data in such a manner that we have continuity of the source
-    __ vpermq(xmm3, xmm0, 148, Assembler::AVX_256bit);
-    __ vpermq(xmm4, xmm1, 148, Assembler::AVX_256bit);
-    __ vpermq(xmm5, xmm2, 148, Assembler::AVX_256bit);
+		  __ align(32);
+		  __ BIND(L_vbmiLoop);
 
-    //shuffle input and group 3 bytes of data and to it add 0 as the 4th byte.
-    //we can deal with 12 bytes at a time in a 128 bit register
-    __ vpshufb(xmm3, xmm3, xmm12, Assembler::AVX_256bit);
-    __ vpshufb(xmm4, xmm4, xmm12, Assembler::AVX_256bit);
-    __ vpshufb(xmm5, xmm5, xmm12, Assembler::AVX_256bit);
+		  __ vpermb(xmm0, xmm3, Address(source, start_offset),
+			    Assembler::AVX_512bit);
+		  __ subl(length, 48);
 
-    //convert byte to word. Each 128 bit register will have 6 bytes for processing
-    __ vpmovzxbw(xmm3, xmm3, Assembler::AVX_512bit);
-    __ vpmovzxbw(xmm4, xmm4, Assembler::AVX_512bit);
-    __ vpmovzxbw(xmm5, xmm5, Assembler::AVX_512bit);
+		  // Put the input bytes into the proper lanes for writing, then
+		  // encode them.
+		  __ evpmultishiftqb(xmm0, xmm1, xmm0, Assembler::AVX_512bit);
+		  __ vpermb(xmm0, xmm0, xmm2, Assembler::AVX_512bit);
 
-    // Extract bits in the following pattern 6, 4+2, 2+4, 6 to convert 3, 8 bit numbers to 4, 6 bit numbers
-    __ evpsrlvw(xmm0, xmm3, xmm13,  Assembler::AVX_512bit);
-    __ evpsrlvw(xmm1, xmm4, xmm13, Assembler::AVX_512bit);
-    __ evpsrlvw(xmm2, xmm5, xmm13, Assembler::AVX_512bit);
+		  // Write to destination
+		  __ evmovdquq(Address(dest, dp), xmm0, Assembler::AVX_512bit);
 
-    __ evpsllvw(xmm3, xmm3, xmm14, Assembler::AVX_512bit);
-    __ evpsllvw(xmm4, xmm4, xmm14, Assembler::AVX_512bit);
-    __ evpsllvw(xmm5, xmm5, xmm14, Assembler::AVX_512bit);
+		  __ addptr(dest, 64);
+		  __ addptr(source, 48);
+		  __ cmpl(length, 64);
+		  __ jcc(Assembler::aboveEqual, L_vbmiLoop);
 
-    __ vpsrlq(xmm0, xmm0, 8, Assembler::AVX_512bit);
-    __ vpsrlq(xmm1, xmm1, 8, Assembler::AVX_512bit);
-    __ vpsrlq(xmm2, xmm2, 8, Assembler::AVX_512bit);
+		  __ vzeroupper();
+	  }
 
-    __ vpsllq(xmm3, xmm3, 8, Assembler::AVX_512bit);
-    __ vpsllq(xmm4, xmm4, 8, Assembler::AVX_512bit);
-    __ vpsllq(xmm5, xmm5, 8, Assembler::AVX_512bit);
+	  __ BIND(L_not512);
+	  if (VM_Version::supports_avx2()
+	      && VM_Version::supports_avx512vlbw()) {
+		  /*
+		  ** This AVX2 encoder is based off the paper at:
+		  **      https://dl.acm.org/doi/10.1145/3132709
+		  **
+		  ** We use AVX2 SIMD instructions to encode 24 bytes into 32
+		  *output bytes.
+		  **
+		  */
+		  // Lengths under 32 bytes are done with scalar routine
+		  __ cmpl(length, 31);
+		  __ jcc(Assembler::belowEqual, L_process3);
 
-    __ vpandq(xmm3, xmm3, xmm15, Assembler::AVX_512bit);
-    __ vpandq(xmm4, xmm4, xmm15, Assembler::AVX_512bit);
-    __ vpandq(xmm5, xmm5, xmm15, Assembler::AVX_512bit);
+		  // Set up supporting constant table data
+		  __ vmovdqu(xmm9, ExternalAddress(
+					   StubRoutines::x86::
+						   base64_avx2_shuffle_addr()));
+		  // 6-bit mask for 2nd and 4th (and multiples) 6-bit values
+		  __ movl(rax, 0x0fc0fc00);
+		  __ vmovdqu(xmm1,
+			     ExternalAddress(
+				     StubRoutines::x86::
+					     base64_avx2_input_mask_addr()));
+		  __ evpbroadcastd(xmm8, rax, Assembler::AVX_256bit);
 
-    // Get the final 4*6 bits base64 encoding
-    __ vporq(xmm3, xmm3, xmm0, Assembler::AVX_512bit);
-    __ vporq(xmm4, xmm4, xmm1, Assembler::AVX_512bit);
-    __ vporq(xmm5, xmm5, xmm2, Assembler::AVX_512bit);
+		  // Multiplication constant for "shifting" right by 6 and 10
+		  // bits
+		  __ movl(rax, 0x04000040);
 
-    // Shift
-    __ vpsrlq(xmm3, xmm3, 8, Assembler::AVX_512bit);
-    __ vpsrlq(xmm4, xmm4, 8, Assembler::AVX_512bit);
-    __ vpsrlq(xmm5, xmm5, 8, Assembler::AVX_512bit);
+		  __ subl(length, 24);
+		  __ evpbroadcastd(xmm7, rax, Assembler::AVX_256bit);
 
-    // look up 6 bits in the base64 character set to fetch the encoding
-    // we are converting word to dword as gather instructions need dword indices for looking up encoding
-    __ vextracti64x4(xmm6, xmm3, 0);
-    __ vpmovzxwd(xmm0, xmm6, Assembler::AVX_512bit);
-    __ vextracti64x4(xmm6, xmm3, 1);
-    __ vpmovzxwd(xmm1, xmm6, Assembler::AVX_512bit);
+		  // For the first load, we mask off reading of the first 4
+		  // bytes into the register. This is so we can get 4 3-byte
+		  // chunks into each lane of the register, avoiding having to
+		  // handle end conditions.  We then shuffle these bytes into a
+		  // specific order so that manipulation is easier.
+		  //
+		  // The initial read loads the XMM register like this:
+		  //
+		  // Lower 128-bit lane:
+		  // +----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
+		  // | XX | XX | XX | XX | A0 | A1 | A2 | B0 | B1 | B2 | C0 | C1
+		  // | C2 | D0 | D1 | D2 |
+		  // +----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
+		  //
+		  // Upper 128-bit lane:
+		  // +----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
+		  // | E0 | E1 | E2 | F0 | F1 | F2 | G0 | G1 | G2 | H0 | H1 | H2
+		  // | XX | XX | XX | XX |
+		  // +----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
+		  //
+		  // Where A0 is the first input byte, B0 is the fourth, etc.
+		  // The alphabetical significance denotes the 3 bytes to be
+		  // consumed and encoded into 4 bytes.
+		  //
+		  // We then shuffle the register so each 32-bit word contains
+		  // the sequence:
+		  //    A1 A0 A2 A1, B1, B0, B2, B1, etc.
+		  // Each of these byte sequences are then manipulated into 4
+		  // 6-bit values ready for encoding.
+		  //
+		  // If we focus on one set of 3-byte chunks, changing the
+		  // nomenclature such that A0 => a, A1 => b, and A2 => c, we
+		  // shuffle such that each 24-bit chunk contains:
+		  //
+		  // b7 b6 b5 b4 b3 b2 b1 b0 | a7 a6 a5 a4 a3 a2 a1 a0 | c7 c6
+		  // c5 c4 c3 c2 c1 c0 | b7 b6 b5 b4 b3 b2 b1 b0
+		  // Explain this step.
+		  // b3 b2 b1 b0 c5 c4 c3 c2 | c1 c0 d5 d4 d3 d2 d1 d0 | a5 a4
+		  // a3 a2 a1 a0 b5 b4 | b3 b2 b1 b0 c5 c4 c3 c2
+		  //
+		  // W first and off all but bits 4-9 and 16-21 (c5..c0 and
+		  // a5..a0) and shift them using a vector multiplication
+		  // operation (vpmulhuw) which effectively shifts c right by 6
+		  // bits and a right by 10 bits.  We similarly mask bits 10-15
+		  // (d5..d0) and 22-27 (b5..b0) and shift them left by 8 and 4
+		  // bits respecively.  This is done using vpmullw.  We end up
+		  // with 4 6-bit values, thus splitting the 3 input bytes,
+		  // ready for encoding:
+		  //    0 0 d5..d0 0 0 c5..c0 0 0 b5..b0 0 0 a5..a0
+		  //
+		  // For translation, we recognize that there are 5 distinct
+		  // ranges of legal Base64 characters as below:
+		  //
+		  //   +-------------+-------------+------------+
+		  //   | 6-bit value | ASCII range |   offset   |
+		  //   +-------------+-------------+------------+
+		  //   |    0..25    |    A..Z     |     65     |
+		  //   |   26..51    |    a..z     |     71     |
+		  //   |   52..61    |    0..9     |     -4     |
+		  //   |     62      |   + or -    | -19 or -17 |
+		  //   |     63      |   / or _    | -16 or 32  |
+		  //   +-------------+-------------+------------+
+		  //
+		  // We note that vpshufb does a parallel lookup in a
+		  // destination register using the lower 4 bits of bytes from a
+		  // source register.  If we use a saturated subtraction and
+		  // subtract 51 from each 6-bit value, bytes from [0,51]
+		  // saturate to 0, and [52,63] map to a range of [1,12].  We
+		  // distinguish the [0,25] and [26,51] ranges by assigning a
+		  // value of 13 for all 6-bit values less than 26.  We end up
+		  // with:
+		  //
+		  //   +-------------+-------------+------------+
+		  //   | 6-bit value |   Reduced   |   offset   |
+		  //   +-------------+-------------+------------+
+		  //   |    0..25    |     13      |     65     |
+		  //   |   26..51    |      0      |     71     |
+		  //   |   52..61    |    0..9     |     -4     |
+		  //   |     62      |     11      | -19 or -17 |
+		  //   |     63      |     12      | -16 or 32  |
+		  //   +-------------+-------------+------------+
+		  //
+		  // We then use a final vpshufb to add the appropriate offset,
+		  // translating the bytes.
+		  //
+		  // Load input bytes - only 28 bytes.  Mask the first load to
+		  // not load into the full register.
+		  __ vpmaskmovd(
+			  xmm1, xmm1,
+			  Address(source, start_offset, Address::times_1, -4),
+			  Assembler::AVX_256bit);
 
-    __ vextracti64x4(xmm6, xmm4, 0);
-    __ vpmovzxwd(xmm2, xmm6, Assembler::AVX_512bit);
-    __ vextracti64x4(xmm6, xmm4, 1);
-    __ vpmovzxwd(xmm3, xmm6, Assembler::AVX_512bit);
+		  // Move 3-byte chunks of input (12 bytes) into 16 bytes,
+		  // ordering by:
+		  //   1, 0, 2, 1; 4, 3, 5, 4; etc.  This groups 6-bit chunks
+		  //   for easy masking
+		  __ vpshufb(xmm1, xmm1, xmm9, Assembler::AVX_256bit);
 
-    __ vextracti64x4(xmm4, xmm5, 0);
-    __ vpmovzxwd(xmm6, xmm4, Assembler::AVX_512bit);
+		  __ addl(start_offset, 24);
 
-    __ vextracti64x4(xmm4, xmm5, 1);
-    __ vpmovzxwd(xmm7, xmm4, Assembler::AVX_512bit);
+		  // Load masking register for first and third (and multiples)
+		  // 6-bit values.
+		  __ movl(rax, 0x003f03f0);
+		  __ evpbroadcastd(xmm6, rax, Assembler::AVX_256bit);
+		  // Multiplication constant for "shifting" left by 4 and 8 bits
+		  __ movl(rax, 0x01000010);
+		  __ evpbroadcastd(xmm5, rax, Assembler::AVX_256bit);
 
-    __ kmovql(k2, k3);
-    __ evpgatherdd(xmm4, k2, Address(r11, xmm0, Address::times_4, 0), Assembler::AVX_512bit);
-    __ kmovql(k2, k3);
-    __ evpgatherdd(xmm5, k2, Address(r11, xmm1, Address::times_4, 0), Assembler::AVX_512bit);
-    __ kmovql(k2, k3);
-    __ evpgatherdd(xmm8, k2, Address(r11, xmm2, Address::times_4, 0), Assembler::AVX_512bit);
-    __ kmovql(k2, k3);
-    __ evpgatherdd(xmm9, k2, Address(r11, xmm3, Address::times_4, 0), Assembler::AVX_512bit);
-    __ kmovql(k2, k3);
-    __ evpgatherdd(xmm10, k2, Address(r11, xmm6, Address::times_4, 0), Assembler::AVX_512bit);
-    __ kmovql(k2, k3);
-    __ evpgatherdd(xmm11, k2, Address(r11, xmm7, Address::times_4, 0), Assembler::AVX_512bit);
+		  // Isolate 6-bit chunks of interest
+		  __ vpand(xmm0, xmm8, xmm1, Assembler::AVX_256bit);
 
-    //Down convert dword to byte. Final output is 16*6 = 96 bytes long
-    __ evpmovdb(Address(dest, dp, Address::times_1, 0), xmm4, Assembler::AVX_512bit);
-    __ evpmovdb(Address(dest, dp, Address::times_1, 16), xmm5, Assembler::AVX_512bit);
-    __ evpmovdb(Address(dest, dp, Address::times_1, 32), xmm8, Assembler::AVX_512bit);
-    __ evpmovdb(Address(dest, dp, Address::times_1, 48), xmm9, Assembler::AVX_512bit);
-    __ evpmovdb(Address(dest, dp, Address::times_1, 64), xmm10, Assembler::AVX_512bit);
-    __ evpmovdb(Address(dest, dp, Address::times_1, 80), xmm11, Assembler::AVX_512bit);
+		  // Load constants for encoding
+		  __ movl(rax, 0x19191919);
+		  __ evpbroadcastd(xmm3, rax, Assembler::AVX_256bit);
+		  __ movl(rax, 0x33333333);
+		  __ evpbroadcastd(xmm4, rax, Assembler::AVX_256bit);
 
-    __ addq(dest, 96);
-    __ addq(source, 72);
-    __ subq(length, 72);
-    __ jmp(L_process80);
+		  // Shift output bytes 0 and 2 into proper lanes
+		  __ vpmulhuw(xmm2, xmm0, xmm7, Assembler::AVX_256bit);
 
-    // Vector Base64 implementation generating 32 bytes of encoded data
-    __ BIND(L_process32);
-    __ cmpl(length, 32);
-    __ jcc(Assembler::below, L_process3);
-    __ evmovdquq(xmm0, Address(source, start_offset), Assembler::AVX_256bit);
-    __ vpermq(xmm0, xmm0, 148, Assembler::AVX_256bit);
-    __ vpshufb(xmm6, xmm0, xmm12, Assembler::AVX_256bit);
-    __ vpmovzxbw(xmm6, xmm6, Assembler::AVX_512bit);
-    __ evpsrlvw(xmm2, xmm6, xmm13, Assembler::AVX_512bit);
-    __ evpsllvw(xmm3, xmm6, xmm14, Assembler::AVX_512bit);
+		  // Mask and shift output bytes 1 and 3 into proper lanes and
+		  // combine
+		  __ vpand(xmm0, xmm6, xmm1, Assembler::AVX_256bit);
+		  __ vpmullw(xmm0, xmm5, xmm0, Assembler::AVX_256bit);
+		  __ vpor(xmm0, xmm0, xmm2, Assembler::AVX_256bit);
 
-    __ vpsrlq(xmm2, xmm2, 8, Assembler::AVX_512bit);
-    __ vpsllq(xmm3, xmm3, 8, Assembler::AVX_512bit);
-    __ vpandq(xmm3, xmm3, xmm15, Assembler::AVX_512bit);
-    __ vporq(xmm1, xmm2, xmm3, Assembler::AVX_512bit);
-    __ vpsrlq(xmm1, xmm1, 8, Assembler::AVX_512bit);
-    __ vextracti64x4(xmm9, xmm1, 0);
-    __ vpmovzxwd(xmm6, xmm9, Assembler::AVX_512bit);
-    __ vextracti64x4(xmm9, xmm1, 1);
-    __ vpmovzxwd(xmm5, xmm9,  Assembler::AVX_512bit);
-    __ kmovql(k2, k3);
-    __ evpgatherdd(xmm8, k2, Address(r11, xmm6, Address::times_4, 0), Assembler::AVX_512bit);
-    __ kmovql(k2, k3);
-    __ evpgatherdd(xmm10, k2, Address(r11, xmm5, Address::times_4, 0), Assembler::AVX_512bit);
-    __ evpmovdb(Address(dest, dp, Address::times_1, 0), xmm8, Assembler::AVX_512bit);
-    __ evpmovdb(Address(dest, dp, Address::times_1, 16), xmm10, Assembler::AVX_512bit);
-    __ subq(length, 24);
-    __ addq(dest, 32);
-    __ addq(source, 24);
-    __ jmp(L_process32);
+		  // Find out which are 0..25.  This indicates which input
+		  // values fall in the range of 'A'-'Z', which require an
+		  // additional offset (see comments above)
+		  __ vpcmpgtb(xmm2, xmm0, xmm3, Assembler::AVX_256bit);
+		  __ vpsubusb(xmm1, xmm0, xmm4, Assembler::AVX_256bit);
+		  __ vpsubb(xmm1, xmm1, xmm2, Assembler::AVX_256bit);
 
-    // Scalar data processing takes 3 bytes at a time and produces 4 bytes of encoded data
-    /* This code corresponds to the scalar version of the following snippet in Base64.java
-    ** int bits = (src[sp0++] & 0xff) << 16 |(src[sp0++] & 0xff) << 8 |(src[sp0++] & 0xff);
-    ** dst[dp0++] = (byte)base64[(bits >> > 18) & 0x3f];
-    ** dst[dp0++] = (byte)base64[(bits >> > 12) & 0x3f];
-    ** dst[dp0++] = (byte)base64[(bits >> > 6) & 0x3f];
-    ** dst[dp0++] = (byte)base64[bits & 0x3f];*/
-    __ BIND(L_process3);
-    __ cmpl(length, 3);
-    __ jcc(Assembler::below, L_exit);
-    // Read 1 byte at a time
-    __ movzbl(rax, Address(source, start_offset));
-    __ shll(rax, 0x10);
-    __ movl(r15, rax);
-    __ movzbl(rax, Address(source, start_offset, Address::times_1, 1));
-    __ shll(rax, 0x8);
-    __ movzwl(rax, rax);
-    __ orl(r15, rax);
-    __ movzbl(rax, Address(source, start_offset, Address::times_1, 2));
-    __ orl(rax, r15);
-    // Save 3 bytes read in r15
-    __ movl(r15, rax);
-    __ shrl(rax, 0x12);
-    __ andl(rax, 0x3f);
-    // rax contains the index, r11 contains base64 lookup table
-    __ movb(rax, Address(r11, rax, Address::times_4));
-    // Write the encoded byte to destination
-    __ movb(Address(dest, dp, Address::times_1, 0), rax);
-    __ movl(rax, r15);
-    __ shrl(rax, 0xc);
-    __ andl(rax, 0x3f);
-    __ movb(rax, Address(r11, rax, Address::times_4));
-    __ movb(Address(dest, dp, Address::times_1, 1), rax);
-    __ movl(rax, r15);
-    __ shrl(rax, 0x6);
-    __ andl(rax, 0x3f);
-    __ movb(rax, Address(r11, rax, Address::times_4));
-    __ movb(Address(dest, dp, Address::times_1, 2), rax);
-    __ movl(rax, r15);
-    __ andl(rax, 0x3f);
-    __ movb(rax, Address(r11, rax, Address::times_4));
-    __ movb(Address(dest, dp, Address::times_1, 3), rax);
-    __ subl(length, 3);
-    __ addq(dest, 4);
-    __ addq(source, 3);
-    __ jmp(L_process3);
-    __ BIND(L_exit);
-    __ pop(r15);
-    __ pop(r14);
-    __ pop(r13);
-    __ pop(r12);
-    __ leave();
-    __ ret(0);
-    return start;
+		  // Load the proper lookup table
+		  __ lea(r11,
+			 ExternalAddress(
+				 StubRoutines::x86::base64_avx2_lut_addr()));
+		  __ movl(r15, isURL);
+		  __ shll(r15, 5);
+		  __ vmovdqu(xmm2, Address(r11, r15));
+
+		  // Shuffle the offsets based on the range calculation done
+		  // above. This allows us to add the correct offset to the
+		  // 6-bit value corresponding to the range documented above.
+		  __ vpshufb(xmm1, xmm2, xmm1, Assembler::AVX_256bit);
+		  __ vpaddb(xmm0, xmm1, xmm0, Assembler::AVX_256bit);
+
+		  // Store the encoded bytes
+		  __ vmovdqu(Address(dest, dp), xmm0);
+		  __ addl(dp, 32);
+
+		  __ cmpl(length, 31);
+		  __ jcc(Assembler::belowEqual, L_process3);
+
+		  __ align(32);
+		  __ BIND(L_32byteLoop);
+
+		  // Get next 32 bytes
+		  __ vmovdqu(xmm1, Address(source, start_offset,
+					   Address::times_1, -4));
+
+		  __ subl(length, 24);
+		  __ addl(start_offset, 24);
+
+		  // This logic is identical to the above, with only constant
+		  // register loads removed.  Shuffle the input, mask off 6-bit
+		  // chunks, shift them into place, then add the offset to
+		  // encode.
+		  __ vpshufb(xmm1, xmm1, xmm9, Assembler::AVX_256bit);
+
+		  __ vpand(xmm0, xmm8, xmm1, Assembler::AVX_256bit);
+		  __ vpmulhuw(xmm10, xmm0, xmm7, Assembler::AVX_256bit);
+		  __ vpand(xmm0, xmm6, xmm1, Assembler::AVX_256bit);
+		  __ vpmullw(xmm0, xmm5, xmm0, Assembler::AVX_256bit);
+		  __ vpor(xmm0, xmm0, xmm10, Assembler::AVX_256bit);
+		  __ vpcmpgtb(xmm10, xmm0, xmm3, Assembler::AVX_256bit);
+		  __ vpsubusb(xmm1, xmm0, xmm4, Assembler::AVX_256bit);
+		  __ vpsubb(xmm1, xmm1, xmm10, Assembler::AVX_256bit);
+		  __ vpshufb(xmm1, xmm2, xmm1, Assembler::AVX_256bit);
+		  __ vpaddb(xmm0, xmm1, xmm0, Assembler::AVX_256bit);
+
+		  // Store the encoded bytes
+		  __ vmovdqu(Address(dest, dp), xmm0);
+		  __ addl(dp, 32);
+
+		  __ cmpl(length, 31);
+		  __ jcc(Assembler::above, L_32byteLoop);
+
+		  __ vzeroupper();
+		  __ addl(dp, 32);
+	  }
+
+	  __ BIND(L_process3);
+	  __ cmpl(length, 3);
+	  __ jcc(Assembler::below, L_exit);
+
+	  // Load the encoding table based on isURL
+	  __ lea(r11, ExternalAddress(
+			      StubRoutines::x86::base64_encoding_table_addr()));
+	  __ movl(r15, isURL);
+	  __ shll(r15, 5);
+	  __ addptr(r11, r15);
+
+	  __ BIND(L_processdata);
+
+	  // Load 3 bytes
+	  __ load_unsigned_byte(r15, Address(source, start_offset));
+	  __ load_unsigned_byte(
+		  r10, Address(source, start_offset, Address::times_1, 1));
+	  __ load_unsigned_byte(
+		  r13, Address(source, start_offset, Address::times_1, 2));
+
+	  // Build a 32-bit word with bytes 1, 2, 0, 1
+	  __ movl(rax, r10);
+	  __ shll(r10, 24);
+	  __ orl(rax, r10);
+
+	  __ subl(length, 3);
+
+	  __ shll(r15, 8);
+	  __ shll(r13, 16);
+	  __ orl(rax, r15);
+
+	  __ addl(start_offset, 3);
+
+	  __ orl(rax, r13);
+	  // At this point, rax contains | byte1 | byte2 | byte0 | byte1
+	  // r13 has byte2 << 16 - need low-order 6 bits to translate.
+	  // This translated byte is the fourth output byte.
+	  __ shrl(r13, 16);
+	  __ andl(r13, 0x3f);
+
+	  // The high-order 6 bits of r15 (byte0) is translated.
+	  // The translated byte is the first output byte.
+	  __ shrl(r15, 10);
+
+	  __ load_unsigned_byte(r13, Address(r11, r13));
+	  __ load_unsigned_byte(r15, Address(r11, r15));
+
+	  __ movb(Address(dest, dp, Address::times_1, 3), r13);
+
+	  // Extract high-order 4 bits of byte1 and low-order 2 bits of byte0.
+	  // This translated byte is the second output byte.
+	  __ shrl(rax, 4);
+	  __ movl(r10, rax);
+	  __ andl(rax, 0x3f);
+
+	  __ movb(Address(dest, dp, Address::times_1, 0), r15);
+
+	  __ load_unsigned_byte(rax, Address(r11, rax));
+
+	  // Extract low-order 2 bits of byte1 and high-order 4 bits of byte2.
+	  // This translated byte is the third output byte.
+	  __ shrl(r10, 18);
+	  __ andl(r10, 0x3f);
+
+	  __ load_unsigned_byte(r10, Address(r11, r10));
+
+	  __ movb(Address(dest, dp, Address::times_1, 1), rax);
+	  __ movb(Address(dest, dp, Address::times_1, 2), r10);
+
+	  __ addl(dp, 4);
+	  __ cmpl(length, 3);
+	  __ jcc(Assembler::aboveEqual, L_processdata);
+
+	  __ BIND(L_exit);
+	  __ pop(r15);
+	  __ pop(r14);
+	  __ pop(r13);
+	  __ pop(r12);
+	  __ leave();
+	  __ ret(0);
+	  return start;
   }
 
   // base64 AVX512vbmi tables
@@ -7603,27 +7698,29 @@ address generate_avx_ghash_processBlocks() {
       }
     }
 
+
     if (UseBASE64Intrinsics) {
-      StubRoutines::x86::_and_mask = base64_and_mask_addr();
-      StubRoutines::x86::_bswap_mask = base64_bswap_mask_addr();
-      StubRoutines::x86::_base64_charset = base64_charset_addr();
-      StubRoutines::x86::_url_charset = base64url_charset_addr();
-      StubRoutines::x86::_gather_mask = base64_gather_mask_addr();
-      StubRoutines::x86::_left_shift_mask = base64_left_shift_mask_addr();
-      StubRoutines::x86::_right_shift_mask = base64_right_shift_mask_addr();
-      StubRoutines::_base64_encodeBlock = generate_base64_encodeBlock();
-      if(VM_Version::supports_avx512_vbmi() &&
-         VM_Version::supports_avx512bw()) {
-        StubRoutines::x86::_lookup_lo_base64 = base64_vbmi_lookup_lo_addr();
-        StubRoutines::x86::_lookup_hi_base64 = base64_vbmi_lookup_hi_addr();
-        StubRoutines::x86::_lookup_lo_base64url = base64_vbmi_lookup_lo_url_addr();
-        StubRoutines::x86::_lookup_hi_base64url = base64_vbmi_lookup_hi_url_addr();
-        StubRoutines::x86::_pack_vec_base64 = base64_vbmi_pack_vec_addr();
-        StubRoutines::x86::_join_0_1_base64 = base64_vbmi_join_0_1_addr();
-        StubRoutines::x86::_join_1_2_base64 = base64_vbmi_join_1_2_addr();
-        StubRoutines::x86::_join_2_3_base64 = base64_vbmi_join_2_3_addr();
+      if(VM_Version::supports_avx2() &&
+         VM_Version::supports_avx512bw() &&
+         VM_Version::supports_avx512vl()) {
+        StubRoutines::x86::_avx2_shuffle_base64 = base64_avx2_shuffle_addr();
+        StubRoutines::x86::_avx2_input_mask_base64 = base64_avx2_input_mask_addr();
+        StubRoutines::x86::_avx2_lut_base64 = base64_avx2_lut_addr();
       }
-      StubRoutines::x86::_decoding_table_base64 = base64_decoding_table_addr();
+      StubRoutines::x86::_encoding_table_base64 = base64_encoding_table_addr();
+      if (VM_Version::supports_avx512_vbmi()) {
+        StubRoutines::x86::_shuffle_base64 = base64_shuffle_addr();
+        StubRoutines::x86::_lookup_lo = base64_vbmi_lookup_lo_addr();
+        StubRoutines::x86::_lookup_hi = base64_vbmi_lookup_hi_addr();
+        StubRoutines::x86::_lookup_lo_url = base64_vbmi_lookup_lo_url_addr();
+        StubRoutines::x86::_lookup_hi_url = base64_vbmi_lookup_hi_url_addr();
+        StubRoutines::x86::_pack_vec = base64_vbmi_pack_vec_addr();
+        StubRoutines::x86::_join_0_1 = base64_vbmi_join_0_1_addr();
+        StubRoutines::x86::_join_1_2 = base64_vbmi_join_1_2_addr();
+        StubRoutines::x86::_join_2_3 = base64_vbmi_join_2_3_addr();
+      }
+      StubRoutines::x86::_decoding_table = base64_decoding_table_addr();
+      StubRoutines::_base64_encodeBlock = generate_base64_encodeBlock();
       StubRoutines::_base64_decodeBlock = generate_base64_decodeBlock();
     }
 

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -5292,7 +5292,7 @@ address generate_avx_ghash_processBlocks() {
     StubCodeMark mark(this, "StubRoutines", "shuffle_base64");
     address start = __ pc();
     assert(((unsigned long long)start & 0x3f) == 0,
-           "Alignment problem (0x%08lx)", (unsigned long long)start);
+           "Alignment problem (0x%08llx)", (unsigned long long)start);
     __ emit_data64(0x0405030401020001, relocInfo::none);
     __ emit_data64(0x0a0b090a07080607, relocInfo::none);
     __ emit_data64(0x10110f100d0e0c0d, relocInfo::none);
@@ -5352,7 +5352,7 @@ address generate_avx_ghash_processBlocks() {
     StubCodeMark mark(this, "StubRoutines", "encoding_table_base64");
     address start = __ pc();
     assert(((unsigned long long)start & 0x3f) == 0,
-           "Alignment problem (0x%08lx)", (unsigned long long)start);
+           "Alignment problem (0x%08llx)", (unsigned long long)start);
     __ emit_data64(0x4847464544434241, relocInfo::none);
     __ emit_data64(0x504f4e4d4c4b4a49, relocInfo::none);
     __ emit_data64(0x5857565554535251, relocInfo::none);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -5288,90 +5288,90 @@ address generate_avx_ghash_processBlocks() {
 
   address base64_shuffle_addr()
   {
-	  __ align(64, (unsigned long long)__ pc());
-	  StubCodeMark mark(this, "StubRoutines", "shuffle_base64");
-	  address start = __ pc();
-	  assert(((unsigned long long)start & 0x3f) == 0,
-		       "Alignment problem (0x%08lx)", (unsigned long long)start);
-	  __ emit_data64(0x0405030401020001, relocInfo::none);
-	  __ emit_data64(0x0a0b090a07080607, relocInfo::none);
-	  __ emit_data64(0x10110f100d0e0c0d, relocInfo::none);
-	  __ emit_data64(0x1617151613141213, relocInfo::none);
-	  __ emit_data64(0x1c1d1b1c191a1819, relocInfo::none);
-	  __ emit_data64(0x222321221f201e1f, relocInfo::none);
-	  __ emit_data64(0x2829272825262425, relocInfo::none);
-	  __ emit_data64(0x2e2f2d2e2b2c2a2b, relocInfo::none);
-	  return start;
+    __ align(64, (unsigned long long)__ pc());
+    StubCodeMark mark(this, "StubRoutines", "shuffle_base64");
+    address start = __ pc();
+    assert(((unsigned long long)start & 0x3f) == 0,
+           "Alignment problem (0x%08lx)", (unsigned long long)start);
+    __ emit_data64(0x0405030401020001, relocInfo::none);
+    __ emit_data64(0x0a0b090a07080607, relocInfo::none);
+    __ emit_data64(0x10110f100d0e0c0d, relocInfo::none);
+    __ emit_data64(0x1617151613141213, relocInfo::none);
+    __ emit_data64(0x1c1d1b1c191a1819, relocInfo::none);
+    __ emit_data64(0x222321221f201e1f, relocInfo::none);
+    __ emit_data64(0x2829272825262425, relocInfo::none);
+    __ emit_data64(0x2e2f2d2e2b2c2a2b, relocInfo::none);
+    return start;
   }
 
   address base64_avx2_shuffle_addr()
   {
-	  __ align(32);
-	  StubCodeMark mark(this, "StubRoutines", "avx2_shuffle_base64");
-	  address start = __ pc();
-	  __ emit_data64(0x0809070805060405, relocInfo::none);
-	  __ emit_data64(0x0e0f0d0e0b0c0a0b, relocInfo::none);
-	  __ emit_data64(0x0405030401020001, relocInfo::none);
-	  __ emit_data64(0x0a0b090a07080607, relocInfo::none);
-	  return start;
+    __ align(32);
+    StubCodeMark mark(this, "StubRoutines", "avx2_shuffle_base64");
+    address start = __ pc();
+    __ emit_data64(0x0809070805060405, relocInfo::none);
+    __ emit_data64(0x0e0f0d0e0b0c0a0b, relocInfo::none);
+    __ emit_data64(0x0405030401020001, relocInfo::none);
+    __ emit_data64(0x0a0b090a07080607, relocInfo::none);
+    return start;
   }
 
   address base64_avx2_input_mask_addr()
   {
-	  __ align(32);
-	  StubCodeMark mark(this, "StubRoutines", "avx2_input_mask_base64");
-	  address start = __ pc();
-	  __ emit_data64(0x8000000000000000, relocInfo::none);
-	  __ emit_data64(0x8000000080000000, relocInfo::none);
-	  __ emit_data64(0x8000000080000000, relocInfo::none);
-	  __ emit_data64(0x8000000080000000, relocInfo::none);
-	  return start;
+    __ align(32);
+    StubCodeMark mark(this, "StubRoutines", "avx2_input_mask_base64");
+    address start = __ pc();
+    __ emit_data64(0x8000000000000000, relocInfo::none);
+    __ emit_data64(0x8000000080000000, relocInfo::none);
+    __ emit_data64(0x8000000080000000, relocInfo::none);
+    __ emit_data64(0x8000000080000000, relocInfo::none);
+    return start;
   }
 
   address base64_avx2_lut_addr()
   {
-	  __ align(32);
-	  StubCodeMark mark(this, "StubRoutines", "avx2_lut_base64");
-	  address start = __ pc();
-	  __ emit_data64(0xfcfcfcfcfcfc4741, relocInfo::none);
-	  __ emit_data64(0x0000f0edfcfcfcfc, relocInfo::none);
-	  __ emit_data64(0xfcfcfcfcfcfc4741, relocInfo::none);
-	  __ emit_data64(0x0000f0edfcfcfcfc, relocInfo::none);
+    __ align(32);
+    StubCodeMark mark(this, "StubRoutines", "avx2_lut_base64");
+    address start = __ pc();
+    __ emit_data64(0xfcfcfcfcfcfc4741, relocInfo::none);
+    __ emit_data64(0x0000f0edfcfcfcfc, relocInfo::none);
+    __ emit_data64(0xfcfcfcfcfcfc4741, relocInfo::none);
+    __ emit_data64(0x0000f0edfcfcfcfc, relocInfo::none);
 
-	  // URL LUT
-	  __ emit_data64(0xfcfcfcfcfcfc4741, relocInfo::none);
-	  __ emit_data64(0x000020effcfcfcfc, relocInfo::none);
-	  __ emit_data64(0xfcfcfcfcfcfc4741, relocInfo::none);
-	  __ emit_data64(0x000020effcfcfcfc, relocInfo::none);
-	  return start;
+    // URL LUT
+    __ emit_data64(0xfcfcfcfcfcfc4741, relocInfo::none);
+    __ emit_data64(0x000020effcfcfcfc, relocInfo::none);
+    __ emit_data64(0xfcfcfcfcfcfc4741, relocInfo::none);
+    __ emit_data64(0x000020effcfcfcfc, relocInfo::none);
+    return start;
   }
 
   address base64_encoding_table_addr()
   {
-	  __ align(64, (unsigned long long)__ pc());
-	  StubCodeMark mark(this, "StubRoutines", "encoding_table_base64");
-	  address start = __ pc();
-	  assert(((unsigned long long)start & 0x3f) == 0,
-		       "Alignment problem (0x%08lx)", (unsigned long long)start);
-	  __ emit_data64(0x4847464544434241, relocInfo::none);
-	  __ emit_data64(0x504f4e4d4c4b4a49, relocInfo::none);
-	  __ emit_data64(0x5857565554535251, relocInfo::none);
-	  __ emit_data64(0x6665646362615a59, relocInfo::none);
-	  __ emit_data64(0x6e6d6c6b6a696867, relocInfo::none);
-	  __ emit_data64(0x767574737271706f, relocInfo::none);
-	  __ emit_data64(0x333231307a797877, relocInfo::none);
-	  __ emit_data64(0x2f2b393837363534, relocInfo::none);
+    __ align(64, (unsigned long long)__ pc());
+    StubCodeMark mark(this, "StubRoutines", "encoding_table_base64");
+    address start = __ pc();
+    assert(((unsigned long long)start & 0x3f) == 0,
+           "Alignment problem (0x%08lx)", (unsigned long long)start);
+    __ emit_data64(0x4847464544434241, relocInfo::none);
+    __ emit_data64(0x504f4e4d4c4b4a49, relocInfo::none);
+    __ emit_data64(0x5857565554535251, relocInfo::none);
+    __ emit_data64(0x6665646362615a59, relocInfo::none);
+    __ emit_data64(0x6e6d6c6b6a696867, relocInfo::none);
+    __ emit_data64(0x767574737271706f, relocInfo::none);
+    __ emit_data64(0x333231307a797877, relocInfo::none);
+    __ emit_data64(0x2f2b393837363534, relocInfo::none);
 
-	  // URL table
-	  __ emit_data64(0x4847464544434241, relocInfo::none);
-	  __ emit_data64(0x504f4e4d4c4b4a49, relocInfo::none);
-	  __ emit_data64(0x5857565554535251, relocInfo::none);
-	  __ emit_data64(0x6665646362615a59, relocInfo::none);
-	  __ emit_data64(0x6e6d6c6b6a696867, relocInfo::none);
-	  __ emit_data64(0x767574737271706f, relocInfo::none);
-	  __ emit_data64(0x333231307a797877, relocInfo::none);
-	  __ emit_data64(0x5f2d393837363534, relocInfo::none);
-	  return start;
+    // URL table
+    __ emit_data64(0x4847464544434241, relocInfo::none);
+    __ emit_data64(0x504f4e4d4c4b4a49, relocInfo::none);
+    __ emit_data64(0x5857565554535251, relocInfo::none);
+    __ emit_data64(0x6665646362615a59, relocInfo::none);
+    __ emit_data64(0x6e6d6c6b6a696867, relocInfo::none);
+    __ emit_data64(0x767574737271706f, relocInfo::none);
+    __ emit_data64(0x333231307a797877, relocInfo::none);
+    __ emit_data64(0x5f2d393837363534, relocInfo::none);
+    return start;
   }
 
   // Code for generating Base64 encoding.
@@ -5380,379 +5380,379 @@ address generate_avx_ghash_processBlocks() {
   // boolean isURL) {
   address generate_base64_encodeBlock()
   {
-	  __ align(CodeEntryAlignment);
-	  StubCodeMark mark(this, "StubRoutines", "implEncode");
-	  address start = __ pc();
-	  __ enter();
+    __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", "implEncode");
+    address start = __ pc();
+    __ enter();
 
-	  // Save callee-saved registers before using them
-	  __ push(r12);
-	  __ push(r13);
-	  __ push(r14);
-	  __ push(r15);
+    // Save callee-saved registers before using them
+    __ push(r12);
+    __ push(r13);
+    __ push(r14);
+    __ push(r15);
 
-	  // arguments
-	  const Register source = c_rarg0;       // Source Array
-	  const Register start_offset = c_rarg1; // start offset
-	  const Register end_offset = c_rarg2;   // end offset
-	  const Register dest = c_rarg3;	 // destination array
+    // arguments
+    const Register source = c_rarg0;       // Source Array
+    const Register start_offset = c_rarg1; // start offset
+    const Register end_offset = c_rarg2;   // end offset
+    const Register dest = c_rarg3;   // destination array
 
 #ifndef _WIN64
-	  const Register dp = c_rarg4;    // Position for writing to dest array
-	  const Register isURL = c_rarg5; // Base64 or URL character set
+    const Register dp = c_rarg4;    // Position for writing to dest array
+    const Register isURL = c_rarg5; // Base64 or URL character set
 #else
-	  const Address dp_mem(rbp,
-			       6 * wordSize); // length is on stack on Win64
-	  const Address isURL_mem(rbp, 7 * wordSize);
-	  const Register isURL = r10; // pick the volatile windows register
-	  const Register dp = r12;
-	  __ movl(dp, dp_mem);
-	  __ movl(isURL, isURL_mem);
+    const Address dp_mem(rbp,
+             6 * wordSize); // length is on stack on Win64
+    const Address isURL_mem(rbp, 7 * wordSize);
+    const Register isURL = r10; // pick the volatile windows register
+    const Register dp = r12;
+    __ movl(dp, dp_mem);
+    __ movl(isURL, isURL_mem);
 #endif
 
-	  const Register length = r14;
-	  const Register encode_table = r13;
-	  Label L_process3, L_exit, L_processdata, L_vbmiLoop, L_not512,
-		  L_32byteLoop;
+    const Register length = r14;
+    const Register encode_table = r13;
+    Label L_process3, L_exit, L_processdata, L_vbmiLoop, L_not512,
+      L_32byteLoop;
 
-	  // calculate length from offsets
-	  __ movl(length, end_offset);
-	  __ subl(length, start_offset);
-	  __ cmpl(length, 0);
-	  __ jcc(Assembler::lessEqual, L_exit);
+    // calculate length from offsets
+    __ movl(length, end_offset);
+    __ subl(length, start_offset);
+    __ cmpl(length, 0);
+    __ jcc(Assembler::lessEqual, L_exit);
 
-	  // Code for 512-bit VBMI encoding.  Encodes 48 input bytes into 64
-	  // output bytes. We read 64 input bytes and ignore the last 16, so be
-	  // sure not to read past the end of the input buffer.
-	  if (VM_Version::supports_avx512_vbmi()) {
-		  __ cmpl(length, 64); // Do not overrun input buffer.
-		  __ jcc(Assembler::below, L_not512);
+    // Code for 512-bit VBMI encoding.  Encodes 48 input bytes into 64
+    // output bytes. We read 64 input bytes and ignore the last 16, so be
+    // sure not to read past the end of the input buffer.
+    if (VM_Version::supports_avx512_vbmi()) {
+      __ cmpl(length, 64); // Do not overrun input buffer.
+      __ jcc(Assembler::below, L_not512);
 
-		  __ shll(isURL, 6); // index into decode table based on isURL
-		  __ lea(encode_table, ExternalAddress(StubRoutines::x86::base64_encoding_table_addr()));
-		  __ addptr(encode_table, isURL);
-		  __ shrl(isURL, 6); // restore isURL
+      __ shll(isURL, 6); // index into decode table based on isURL
+      __ lea(encode_table, ExternalAddress(StubRoutines::x86::base64_encoding_table_addr()));
+      __ addptr(encode_table, isURL);
+      __ shrl(isURL, 6); // restore isURL
 
-		  __ mov64(rax, 0x3036242a1016040a); // Shifts
-		  __ evmovdquq(xmm3, ExternalAddress(StubRoutines::x86::base64_shuffle_addr()),
-			  Assembler::AVX_512bit, r15);
-		  __ evmovdquq(xmm2, Address(encode_table, 0), Assembler::AVX_512bit);
-		  __ evpbroadcastq(xmm1, rax, Assembler::AVX_512bit);
+      __ mov64(rax, 0x3036242a1016040a); // Shifts
+      __ evmovdquq(xmm3, ExternalAddress(StubRoutines::x86::base64_shuffle_addr()),
+        Assembler::AVX_512bit, r15);
+      __ evmovdquq(xmm2, Address(encode_table, 0), Assembler::AVX_512bit);
+      __ evpbroadcastq(xmm1, rax, Assembler::AVX_512bit);
 
-		  __ align(32);
-		  __ BIND(L_vbmiLoop);
+      __ align(32);
+      __ BIND(L_vbmiLoop);
 
-		  __ vpermb(xmm0, xmm3, Address(source, start_offset), Assembler::AVX_512bit);
-		  __ subl(length, 48);
+      __ vpermb(xmm0, xmm3, Address(source, start_offset), Assembler::AVX_512bit);
+      __ subl(length, 48);
 
-		  // Put the input bytes into the proper lanes for writing, then
-		  // encode them.
-		  __ evpmultishiftqb(xmm0, xmm1, xmm0, Assembler::AVX_512bit);
-		  __ vpermb(xmm0, xmm0, xmm2, Assembler::AVX_512bit);
+      // Put the input bytes into the proper lanes for writing, then
+      // encode them.
+      __ evpmultishiftqb(xmm0, xmm1, xmm0, Assembler::AVX_512bit);
+      __ vpermb(xmm0, xmm0, xmm2, Assembler::AVX_512bit);
 
-		  // Write to destination
-		  __ evmovdquq(Address(dest, dp), xmm0, Assembler::AVX_512bit);
+      // Write to destination
+      __ evmovdquq(Address(dest, dp), xmm0, Assembler::AVX_512bit);
 
-		  __ addptr(dest, 64);
-		  __ addptr(source, 48);
-		  __ cmpl(length, 64);
-		  __ jcc(Assembler::aboveEqual, L_vbmiLoop);
+      __ addptr(dest, 64);
+      __ addptr(source, 48);
+      __ cmpl(length, 64);
+      __ jcc(Assembler::aboveEqual, L_vbmiLoop);
 
-		  __ vzeroupper();
-	  }
+      __ vzeroupper();
+    }
 
-	  __ BIND(L_not512);
-	  if (VM_Version::supports_avx2()
-	      && VM_Version::supports_avx512vlbw()) {
-		  /*
-		  ** This AVX2 encoder is based off the paper at:
-		  **      https://dl.acm.org/doi/10.1145/3132709
-		  **
-		  ** We use AVX2 SIMD instructions to encode 24 bytes into 32
-		  ** output bytes.
-		  **
-		  */
-		  // Lengths under 32 bytes are done with scalar routine
-		  __ cmpl(length, 31);
-		  __ jcc(Assembler::belowEqual, L_process3);
+    __ BIND(L_not512);
+    if (VM_Version::supports_avx2()
+        && VM_Version::supports_avx512vlbw()) {
+      /*
+      ** This AVX2 encoder is based off the paper at:
+      **      https://dl.acm.org/doi/10.1145/3132709
+      **
+      ** We use AVX2 SIMD instructions to encode 24 bytes into 32
+      ** output bytes.
+      **
+      */
+      // Lengths under 32 bytes are done with scalar routine
+      __ cmpl(length, 31);
+      __ jcc(Assembler::belowEqual, L_process3);
 
-		  // Set up supporting constant table data
-		  __ vmovdqu(xmm9, ExternalAddress(StubRoutines::x86::base64_avx2_shuffle_addr()));
-		  // 6-bit mask for 2nd and 4th (and multiples) 6-bit values
-		  __ movl(rax, 0x0fc0fc00);
-		  __ vmovdqu(xmm1, ExternalAddress(StubRoutines::x86::base64_avx2_input_mask_addr()));
-		  __ evpbroadcastd(xmm8, rax, Assembler::AVX_256bit);
+      // Set up supporting constant table data
+      __ vmovdqu(xmm9, ExternalAddress(StubRoutines::x86::base64_avx2_shuffle_addr()));
+      // 6-bit mask for 2nd and 4th (and multiples) 6-bit values
+      __ movl(rax, 0x0fc0fc00);
+      __ vmovdqu(xmm1, ExternalAddress(StubRoutines::x86::base64_avx2_input_mask_addr()));
+      __ evpbroadcastd(xmm8, rax, Assembler::AVX_256bit);
 
-		  // Multiplication constant for "shifting" right by 6 and 10
-		  // bits
-		  __ movl(rax, 0x04000040);
+      // Multiplication constant for "shifting" right by 6 and 10
+      // bits
+      __ movl(rax, 0x04000040);
 
-		  __ subl(length, 24);
-		  __ evpbroadcastd(xmm7, rax, Assembler::AVX_256bit);
+      __ subl(length, 24);
+      __ evpbroadcastd(xmm7, rax, Assembler::AVX_256bit);
 
-		  // For the first load, we mask off reading of the first 4
-		  // bytes into the register. This is so we can get 4 3-byte
-		  // chunks into each lane of the register, avoiding having to
-		  // handle end conditions.  We then shuffle these bytes into a
-		  // specific order so that manipulation is easier.
-		  //
-		  // The initial read loads the XMM register like this:
-		  //
-		  // Lower 128-bit lane:
-		  // +----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
-		  // | XX | XX | XX | XX | A0 | A1 | A2 | B0 | B1 | B2 | C0 | C1
-		  // | C2 | D0 | D1 | D2 |
-		  // +----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
-		  //
-		  // Upper 128-bit lane:
-		  // +----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
-		  // | E0 | E1 | E2 | F0 | F1 | F2 | G0 | G1 | G2 | H0 | H1 | H2
-		  // | XX | XX | XX | XX |
-		  // +----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
-		  //
-		  // Where A0 is the first input byte, B0 is the fourth, etc.
-		  // The alphabetical significance denotes the 3 bytes to be
-		  // consumed and encoded into 4 bytes.
-		  //
-		  // We then shuffle the register so each 32-bit word contains
-		  // the sequence:
-		  //    A1 A0 A2 A1, B1, B0, B2, B1, etc.
-		  // Each of these byte sequences are then manipulated into 4
-		  // 6-bit values ready for encoding.
-		  //
-		  // If we focus on one set of 3-byte chunks, changing the
-		  // nomenclature such that A0 => a, A1 => b, and A2 => c, we
-		  // shuffle such that each 24-bit chunk contains:
-		  //
-		  // b7 b6 b5 b4 b3 b2 b1 b0 | a7 a6 a5 a4 a3 a2 a1 a0 | c7 c6
-		  // c5 c4 c3 c2 c1 c0 | b7 b6 b5 b4 b3 b2 b1 b0
-		  // Explain this step.
-		  // b3 b2 b1 b0 c5 c4 c3 c2 | c1 c0 d5 d4 d3 d2 d1 d0 | a5 a4
-		  // a3 a2 a1 a0 b5 b4 | b3 b2 b1 b0 c5 c4 c3 c2
-		  //
-		  // W first and off all but bits 4-9 and 16-21 (c5..c0 and
-		  // a5..a0) and shift them using a vector multiplication
-		  // operation (vpmulhuw) which effectively shifts c right by 6
-		  // bits and a right by 10 bits.  We similarly mask bits 10-15
-		  // (d5..d0) and 22-27 (b5..b0) and shift them left by 8 and 4
-		  // bits respecively.  This is done using vpmullw.  We end up
-		  // with 4 6-bit values, thus splitting the 3 input bytes,
-		  // ready for encoding:
-		  //    0 0 d5..d0 0 0 c5..c0 0 0 b5..b0 0 0 a5..a0
-		  //
-		  // For translation, we recognize that there are 5 distinct
-		  // ranges of legal Base64 characters as below:
-		  //
-		  //   +-------------+-------------+------------+
-		  //   | 6-bit value | ASCII range |   offset   |
-		  //   +-------------+-------------+------------+
-		  //   |    0..25    |    A..Z     |     65     |
-		  //   |   26..51    |    a..z     |     71     |
-		  //   |   52..61    |    0..9     |     -4     |
-		  //   |     62      |   + or -    | -19 or -17 |
-		  //   |     63      |   / or _    | -16 or 32  |
-		  //   +-------------+-------------+------------+
-		  //
-		  // We note that vpshufb does a parallel lookup in a
-		  // destination register using the lower 4 bits of bytes from a
-		  // source register.  If we use a saturated subtraction and
-		  // subtract 51 from each 6-bit value, bytes from [0,51]
-		  // saturate to 0, and [52,63] map to a range of [1,12].  We
-		  // distinguish the [0,25] and [26,51] ranges by assigning a
-		  // value of 13 for all 6-bit values less than 26.  We end up
-		  // with:
-		  //
-		  //   +-------------+-------------+------------+
-		  //   | 6-bit value |   Reduced   |   offset   |
-		  //   +-------------+-------------+------------+
-		  //   |    0..25    |     13      |     65     |
-		  //   |   26..51    |      0      |     71     |
-		  //   |   52..61    |    0..9     |     -4     |
-		  //   |     62      |     11      | -19 or -17 |
-		  //   |     63      |     12      | -16 or 32  |
-		  //   +-------------+-------------+------------+
-		  //
-		  // We then use a final vpshufb to add the appropriate offset,
-		  // translating the bytes.
-		  //
-		  // Load input bytes - only 28 bytes.  Mask the first load to
-		  // not load into the full register.
-		  __ vpmaskmovd(xmm1, xmm1, Address(source, start_offset, Address::times_1, -4), Assembler::AVX_256bit);
+      // For the first load, we mask off reading of the first 4
+      // bytes into the register. This is so we can get 4 3-byte
+      // chunks into each lane of the register, avoiding having to
+      // handle end conditions.  We then shuffle these bytes into a
+      // specific order so that manipulation is easier.
+      //
+      // The initial read loads the XMM register like this:
+      //
+      // Lower 128-bit lane:
+      // +----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
+      // | XX | XX | XX | XX | A0 | A1 | A2 | B0 | B1 | B2 | C0 | C1
+      // | C2 | D0 | D1 | D2 |
+      // +----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
+      //
+      // Upper 128-bit lane:
+      // +----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
+      // | E0 | E1 | E2 | F0 | F1 | F2 | G0 | G1 | G2 | H0 | H1 | H2
+      // | XX | XX | XX | XX |
+      // +----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
+      //
+      // Where A0 is the first input byte, B0 is the fourth, etc.
+      // The alphabetical significance denotes the 3 bytes to be
+      // consumed and encoded into 4 bytes.
+      //
+      // We then shuffle the register so each 32-bit word contains
+      // the sequence:
+      //    A1 A0 A2 A1, B1, B0, B2, B1, etc.
+      // Each of these byte sequences are then manipulated into 4
+      // 6-bit values ready for encoding.
+      //
+      // If we focus on one set of 3-byte chunks, changing the
+      // nomenclature such that A0 => a, A1 => b, and A2 => c, we
+      // shuffle such that each 24-bit chunk contains:
+      //
+      // b7 b6 b5 b4 b3 b2 b1 b0 | a7 a6 a5 a4 a3 a2 a1 a0 | c7 c6
+      // c5 c4 c3 c2 c1 c0 | b7 b6 b5 b4 b3 b2 b1 b0
+      // Explain this step.
+      // b3 b2 b1 b0 c5 c4 c3 c2 | c1 c0 d5 d4 d3 d2 d1 d0 | a5 a4
+      // a3 a2 a1 a0 b5 b4 | b3 b2 b1 b0 c5 c4 c3 c2
+      //
+      // W first and off all but bits 4-9 and 16-21 (c5..c0 and
+      // a5..a0) and shift them using a vector multiplication
+      // operation (vpmulhuw) which effectively shifts c right by 6
+      // bits and a right by 10 bits.  We similarly mask bits 10-15
+      // (d5..d0) and 22-27 (b5..b0) and shift them left by 8 and 4
+      // bits respecively.  This is done using vpmullw.  We end up
+      // with 4 6-bit values, thus splitting the 3 input bytes,
+      // ready for encoding:
+      //    0 0 d5..d0 0 0 c5..c0 0 0 b5..b0 0 0 a5..a0
+      //
+      // For translation, we recognize that there are 5 distinct
+      // ranges of legal Base64 characters as below:
+      //
+      //   +-------------+-------------+------------+
+      //   | 6-bit value | ASCII range |   offset   |
+      //   +-------------+-------------+------------+
+      //   |    0..25    |    A..Z     |     65     |
+      //   |   26..51    |    a..z     |     71     |
+      //   |   52..61    |    0..9     |     -4     |
+      //   |     62      |   + or -    | -19 or -17 |
+      //   |     63      |   / or _    | -16 or 32  |
+      //   +-------------+-------------+------------+
+      //
+      // We note that vpshufb does a parallel lookup in a
+      // destination register using the lower 4 bits of bytes from a
+      // source register.  If we use a saturated subtraction and
+      // subtract 51 from each 6-bit value, bytes from [0,51]
+      // saturate to 0, and [52,63] map to a range of [1,12].  We
+      // distinguish the [0,25] and [26,51] ranges by assigning a
+      // value of 13 for all 6-bit values less than 26.  We end up
+      // with:
+      //
+      //   +-------------+-------------+------------+
+      //   | 6-bit value |   Reduced   |   offset   |
+      //   +-------------+-------------+------------+
+      //   |    0..25    |     13      |     65     |
+      //   |   26..51    |      0      |     71     |
+      //   |   52..61    |    0..9     |     -4     |
+      //   |     62      |     11      | -19 or -17 |
+      //   |     63      |     12      | -16 or 32  |
+      //   +-------------+-------------+------------+
+      //
+      // We then use a final vpshufb to add the appropriate offset,
+      // translating the bytes.
+      //
+      // Load input bytes - only 28 bytes.  Mask the first load to
+      // not load into the full register.
+      __ vpmaskmovd(xmm1, xmm1, Address(source, start_offset, Address::times_1, -4), Assembler::AVX_256bit);
 
-		  // Move 3-byte chunks of input (12 bytes) into 16 bytes,
-		  // ordering by:
-		  //   1, 0, 2, 1; 4, 3, 5, 4; etc.  This groups 6-bit chunks
-		  //   for easy masking
-		  __ vpshufb(xmm1, xmm1, xmm9, Assembler::AVX_256bit);
+      // Move 3-byte chunks of input (12 bytes) into 16 bytes,
+      // ordering by:
+      //   1, 0, 2, 1; 4, 3, 5, 4; etc.  This groups 6-bit chunks
+      //   for easy masking
+      __ vpshufb(xmm1, xmm1, xmm9, Assembler::AVX_256bit);
 
-		  __ addl(start_offset, 24);
+      __ addl(start_offset, 24);
 
-		  // Load masking register for first and third (and multiples)
-		  // 6-bit values.
-		  __ movl(rax, 0x003f03f0);
-		  __ evpbroadcastd(xmm6, rax, Assembler::AVX_256bit);
-		  // Multiplication constant for "shifting" left by 4 and 8 bits
-		  __ movl(rax, 0x01000010);
-		  __ evpbroadcastd(xmm5, rax, Assembler::AVX_256bit);
+      // Load masking register for first and third (and multiples)
+      // 6-bit values.
+      __ movl(rax, 0x003f03f0);
+      __ evpbroadcastd(xmm6, rax, Assembler::AVX_256bit);
+      // Multiplication constant for "shifting" left by 4 and 8 bits
+      __ movl(rax, 0x01000010);
+      __ evpbroadcastd(xmm5, rax, Assembler::AVX_256bit);
 
-		  // Isolate 6-bit chunks of interest
-		  __ vpand(xmm0, xmm8, xmm1, Assembler::AVX_256bit);
+      // Isolate 6-bit chunks of interest
+      __ vpand(xmm0, xmm8, xmm1, Assembler::AVX_256bit);
 
-		  // Load constants for encoding
-		  __ movl(rax, 0x19191919);
-		  __ evpbroadcastd(xmm3, rax, Assembler::AVX_256bit);
-		  __ movl(rax, 0x33333333);
-		  __ evpbroadcastd(xmm4, rax, Assembler::AVX_256bit);
+      // Load constants for encoding
+      __ movl(rax, 0x19191919);
+      __ evpbroadcastd(xmm3, rax, Assembler::AVX_256bit);
+      __ movl(rax, 0x33333333);
+      __ evpbroadcastd(xmm4, rax, Assembler::AVX_256bit);
 
-		  // Shift output bytes 0 and 2 into proper lanes
-		  __ vpmulhuw(xmm2, xmm0, xmm7, Assembler::AVX_256bit);
+      // Shift output bytes 0 and 2 into proper lanes
+      __ vpmulhuw(xmm2, xmm0, xmm7, Assembler::AVX_256bit);
 
-		  // Mask and shift output bytes 1 and 3 into proper lanes and
-		  // combine
-		  __ vpand(xmm0, xmm6, xmm1, Assembler::AVX_256bit);
-		  __ vpmullw(xmm0, xmm5, xmm0, Assembler::AVX_256bit);
-		  __ vpor(xmm0, xmm0, xmm2, Assembler::AVX_256bit);
+      // Mask and shift output bytes 1 and 3 into proper lanes and
+      // combine
+      __ vpand(xmm0, xmm6, xmm1, Assembler::AVX_256bit);
+      __ vpmullw(xmm0, xmm5, xmm0, Assembler::AVX_256bit);
+      __ vpor(xmm0, xmm0, xmm2, Assembler::AVX_256bit);
 
-		  // Find out which are 0..25.  This indicates which input
-		  // values fall in the range of 'A'-'Z', which require an
-		  // additional offset (see comments above)
-		  __ vpcmpgtb(xmm2, xmm0, xmm3, Assembler::AVX_256bit);
-		  __ vpsubusb(xmm1, xmm0, xmm4, Assembler::AVX_256bit);
-		  __ vpsubb(xmm1, xmm1, xmm2, Assembler::AVX_256bit);
+      // Find out which are 0..25.  This indicates which input
+      // values fall in the range of 'A'-'Z', which require an
+      // additional offset (see comments above)
+      __ vpcmpgtb(xmm2, xmm0, xmm3, Assembler::AVX_256bit);
+      __ vpsubusb(xmm1, xmm0, xmm4, Assembler::AVX_256bit);
+      __ vpsubb(xmm1, xmm1, xmm2, Assembler::AVX_256bit);
 
-		  // Load the proper lookup table
-		  __ lea(r11, ExternalAddress(StubRoutines::x86::base64_avx2_lut_addr()));
-		  __ movl(r15, isURL);
-		  __ shll(r15, 5);
-		  __ vmovdqu(xmm2, Address(r11, r15));
+      // Load the proper lookup table
+      __ lea(r11, ExternalAddress(StubRoutines::x86::base64_avx2_lut_addr()));
+      __ movl(r15, isURL);
+      __ shll(r15, 5);
+      __ vmovdqu(xmm2, Address(r11, r15));
 
-		  // Shuffle the offsets based on the range calculation done
-		  // above. This allows us to add the correct offset to the
-		  // 6-bit value corresponding to the range documented above.
-		  __ vpshufb(xmm1, xmm2, xmm1, Assembler::AVX_256bit);
-		  __ vpaddb(xmm0, xmm1, xmm0, Assembler::AVX_256bit);
+      // Shuffle the offsets based on the range calculation done
+      // above. This allows us to add the correct offset to the
+      // 6-bit value corresponding to the range documented above.
+      __ vpshufb(xmm1, xmm2, xmm1, Assembler::AVX_256bit);
+      __ vpaddb(xmm0, xmm1, xmm0, Assembler::AVX_256bit);
 
-		  // Store the encoded bytes
-		  __ vmovdqu(Address(dest, dp), xmm0);
-		  __ addl(dp, 32);
+      // Store the encoded bytes
+      __ vmovdqu(Address(dest, dp), xmm0);
+      __ addl(dp, 32);
 
-		  __ cmpl(length, 31);
-		  __ jcc(Assembler::belowEqual, L_process3);
+      __ cmpl(length, 31);
+      __ jcc(Assembler::belowEqual, L_process3);
 
-		  __ align(32);
-		  __ BIND(L_32byteLoop);
+      __ align(32);
+      __ BIND(L_32byteLoop);
 
-		  // Get next 32 bytes
-		  __ vmovdqu(xmm1, Address(source, start_offset, Address::times_1, -4));
+      // Get next 32 bytes
+      __ vmovdqu(xmm1, Address(source, start_offset, Address::times_1, -4));
 
-		  __ subl(length, 24);
-		  __ addl(start_offset, 24);
+      __ subl(length, 24);
+      __ addl(start_offset, 24);
 
-		  // This logic is identical to the above, with only constant
-		  // register loads removed.  Shuffle the input, mask off 6-bit
-		  // chunks, shift them into place, then add the offset to
-		  // encode.
-		  __ vpshufb(xmm1, xmm1, xmm9, Assembler::AVX_256bit);
+      // This logic is identical to the above, with only constant
+      // register loads removed.  Shuffle the input, mask off 6-bit
+      // chunks, shift them into place, then add the offset to
+      // encode.
+      __ vpshufb(xmm1, xmm1, xmm9, Assembler::AVX_256bit);
 
-		  __ vpand(xmm0, xmm8, xmm1, Assembler::AVX_256bit);
-		  __ vpmulhuw(xmm10, xmm0, xmm7, Assembler::AVX_256bit);
-		  __ vpand(xmm0, xmm6, xmm1, Assembler::AVX_256bit);
-		  __ vpmullw(xmm0, xmm5, xmm0, Assembler::AVX_256bit);
-		  __ vpor(xmm0, xmm0, xmm10, Assembler::AVX_256bit);
-		  __ vpcmpgtb(xmm10, xmm0, xmm3, Assembler::AVX_256bit);
-		  __ vpsubusb(xmm1, xmm0, xmm4, Assembler::AVX_256bit);
-		  __ vpsubb(xmm1, xmm1, xmm10, Assembler::AVX_256bit);
-		  __ vpshufb(xmm1, xmm2, xmm1, Assembler::AVX_256bit);
-		  __ vpaddb(xmm0, xmm1, xmm0, Assembler::AVX_256bit);
+      __ vpand(xmm0, xmm8, xmm1, Assembler::AVX_256bit);
+      __ vpmulhuw(xmm10, xmm0, xmm7, Assembler::AVX_256bit);
+      __ vpand(xmm0, xmm6, xmm1, Assembler::AVX_256bit);
+      __ vpmullw(xmm0, xmm5, xmm0, Assembler::AVX_256bit);
+      __ vpor(xmm0, xmm0, xmm10, Assembler::AVX_256bit);
+      __ vpcmpgtb(xmm10, xmm0, xmm3, Assembler::AVX_256bit);
+      __ vpsubusb(xmm1, xmm0, xmm4, Assembler::AVX_256bit);
+      __ vpsubb(xmm1, xmm1, xmm10, Assembler::AVX_256bit);
+      __ vpshufb(xmm1, xmm2, xmm1, Assembler::AVX_256bit);
+      __ vpaddb(xmm0, xmm1, xmm0, Assembler::AVX_256bit);
 
-		  // Store the encoded bytes
-		  __ vmovdqu(Address(dest, dp), xmm0);
-		  __ addl(dp, 32);
+      // Store the encoded bytes
+      __ vmovdqu(Address(dest, dp), xmm0);
+      __ addl(dp, 32);
 
-		  __ cmpl(length, 31);
-		  __ jcc(Assembler::above, L_32byteLoop);
+      __ cmpl(length, 31);
+      __ jcc(Assembler::above, L_32byteLoop);
 
-		  __ vzeroupper();
-	  }
+      __ vzeroupper();
+    }
 
-	  __ BIND(L_process3);
-	  __ cmpl(length, 3);
-	  __ jcc(Assembler::below, L_exit);
+    __ BIND(L_process3);
+    __ cmpl(length, 3);
+    __ jcc(Assembler::below, L_exit);
 
-	  // Load the encoding table based on isURL
-	  __ lea(r11, ExternalAddress(StubRoutines::x86::base64_encoding_table_addr()));
-	  __ movl(r15, isURL);
-	  __ shll(r15, 5);
-	  __ addptr(r11, r15);
+    // Load the encoding table based on isURL
+    __ lea(r11, ExternalAddress(StubRoutines::x86::base64_encoding_table_addr()));
+    __ movl(r15, isURL);
+    __ shll(r15, 5);
+    __ addptr(r11, r15);
 
-	  __ BIND(L_processdata);
+    __ BIND(L_processdata);
 
-	  // Load 3 bytes
-	  __ load_unsigned_byte(r15, Address(source, start_offset));
-	  __ load_unsigned_byte(r10, Address(source, start_offset, Address::times_1, 1));
-	  __ load_unsigned_byte(r13, Address(source, start_offset, Address::times_1, 2));
+    // Load 3 bytes
+    __ load_unsigned_byte(r15, Address(source, start_offset));
+    __ load_unsigned_byte(r10, Address(source, start_offset, Address::times_1, 1));
+    __ load_unsigned_byte(r13, Address(source, start_offset, Address::times_1, 2));
 
-	  // Build a 32-bit word with bytes 1, 2, 0, 1
-	  __ movl(rax, r10);
-	  __ shll(r10, 24);
-	  __ orl(rax, r10);
+    // Build a 32-bit word with bytes 1, 2, 0, 1
+    __ movl(rax, r10);
+    __ shll(r10, 24);
+    __ orl(rax, r10);
 
-	  __ subl(length, 3);
+    __ subl(length, 3);
 
-	  __ shll(r15, 8);
-	  __ shll(r13, 16);
-	  __ orl(rax, r15);
+    __ shll(r15, 8);
+    __ shll(r13, 16);
+    __ orl(rax, r15);
 
-	  __ addl(start_offset, 3);
+    __ addl(start_offset, 3);
 
-	  __ orl(rax, r13);
-	  // At this point, rax contains | byte1 | byte2 | byte0 | byte1
-	  // r13 has byte2 << 16 - need low-order 6 bits to translate.
-	  // This translated byte is the fourth output byte.
-	  __ shrl(r13, 16);
-	  __ andl(r13, 0x3f);
+    __ orl(rax, r13);
+    // At this point, rax contains | byte1 | byte2 | byte0 | byte1
+    // r13 has byte2 << 16 - need low-order 6 bits to translate.
+    // This translated byte is the fourth output byte.
+    __ shrl(r13, 16);
+    __ andl(r13, 0x3f);
 
-	  // The high-order 6 bits of r15 (byte0) is translated.
-	  // The translated byte is the first output byte.
-	  __ shrl(r15, 10);
+    // The high-order 6 bits of r15 (byte0) is translated.
+    // The translated byte is the first output byte.
+    __ shrl(r15, 10);
 
-	  __ load_unsigned_byte(r13, Address(r11, r13));
-	  __ load_unsigned_byte(r15, Address(r11, r15));
+    __ load_unsigned_byte(r13, Address(r11, r13));
+    __ load_unsigned_byte(r15, Address(r11, r15));
 
-	  __ movb(Address(dest, dp, Address::times_1, 3), r13);
+    __ movb(Address(dest, dp, Address::times_1, 3), r13);
 
-	  // Extract high-order 4 bits of byte1 and low-order 2 bits of byte0.
-	  // This translated byte is the second output byte.
-	  __ shrl(rax, 4);
-	  __ movl(r10, rax);
-	  __ andl(rax, 0x3f);
+    // Extract high-order 4 bits of byte1 and low-order 2 bits of byte0.
+    // This translated byte is the second output byte.
+    __ shrl(rax, 4);
+    __ movl(r10, rax);
+    __ andl(rax, 0x3f);
 
-	  __ movb(Address(dest, dp, Address::times_1, 0), r15);
+    __ movb(Address(dest, dp, Address::times_1, 0), r15);
 
-	  __ load_unsigned_byte(rax, Address(r11, rax));
+    __ load_unsigned_byte(rax, Address(r11, rax));
 
-	  // Extract low-order 2 bits of byte1 and high-order 4 bits of byte2.
-	  // This translated byte is the third output byte.
-	  __ shrl(r10, 18);
-	  __ andl(r10, 0x3f);
+    // Extract low-order 2 bits of byte1 and high-order 4 bits of byte2.
+    // This translated byte is the third output byte.
+    __ shrl(r10, 18);
+    __ andl(r10, 0x3f);
 
-	  __ load_unsigned_byte(r10, Address(r11, r10));
+    __ load_unsigned_byte(r10, Address(r11, r10));
 
-	  __ movb(Address(dest, dp, Address::times_1, 1), rax);
-	  __ movb(Address(dest, dp, Address::times_1, 2), r10);
+    __ movb(Address(dest, dp, Address::times_1, 1), rax);
+    __ movb(Address(dest, dp, Address::times_1, 2), r10);
 
-	  __ addl(dp, 4);
-	  __ cmpl(length, 3);
-	  __ jcc(Assembler::aboveEqual, L_processdata);
+    __ addl(dp, 4);
+    __ cmpl(length, 3);
+    __ jcc(Assembler::aboveEqual, L_processdata);
 
-	  __ BIND(L_exit);
-	  __ pop(r15);
-	  __ pop(r14);
-	  __ pop(r13);
-	  __ pop(r12);
-	  __ leave();
-	  __ ret(0);
-	  return start;
+    __ BIND(L_exit);
+    __ pop(r15);
+    __ pop(r14);
+    __ pop(r13);
+    __ pop(r12);
+    __ leave();
+    __ ret(0);
+    return start;
   }
 
   // base64 AVX512vbmi tables

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -5288,11 +5288,11 @@ address generate_avx_ghash_processBlocks() {
 
   address base64_shuffle_addr()
   {
-	  __ align(64, (unsigned long)__ pc());
+	  __ align(64, (unsigned long long)__ pc());
 	  StubCodeMark mark(this, "StubRoutines", "shuffle_base64");
 	  address start = __ pc();
-	  assert(((unsigned long)start & 0x3f) == 0,
-		 "Alignment problem (0x%08lx)", (unsigned long)start);
+	  assert(((unsigned long long)start & 0x3f) == 0,
+		       "Alignment problem (0x%08lx)", (unsigned long long)start);
 	  __ emit_data64(0x0405030401020001, relocInfo::none);
 	  __ emit_data64(0x0a0b090a07080607, relocInfo::none);
 	  __ emit_data64(0x10110f100d0e0c0d, relocInfo::none);
@@ -5348,11 +5348,11 @@ address generate_avx_ghash_processBlocks() {
 
   address base64_encoding_table_addr()
   {
-	  __ align(64, (unsigned long)__ pc());
+	  __ align(64, (unsigned long long)__ pc());
 	  StubCodeMark mark(this, "StubRoutines", "encoding_table_base64");
 	  address start = __ pc();
-	  assert(((unsigned long)start & 0x3f) == 0,
-		 "Alignment problem (0x%08lx)", (unsigned long)start);
+	  assert(((unsigned long long)start & 0x3f) == 0,
+		       "Alignment problem (0x%08lx)", (unsigned long long)start);
 	  __ emit_data64(0x4847464544434241, relocInfo::none);
 	  __ emit_data64(0x504f4e4d4c4b4a49, relocInfo::none);
 	  __ emit_data64(0x5857565554535251, relocInfo::none);
@@ -7688,16 +7688,16 @@ address generate_avx_ghash_processBlocks() {
       StubRoutines::x86::_encoding_table_base64 = base64_encoding_table_addr();
       if (VM_Version::supports_avx512_vbmi()) {
         StubRoutines::x86::_shuffle_base64 = base64_shuffle_addr();
-        StubRoutines::x86::_lookup_lo = base64_vbmi_lookup_lo_addr();
-        StubRoutines::x86::_lookup_hi = base64_vbmi_lookup_hi_addr();
-        StubRoutines::x86::_lookup_lo_url = base64_vbmi_lookup_lo_url_addr();
-        StubRoutines::x86::_lookup_hi_url = base64_vbmi_lookup_hi_url_addr();
-        StubRoutines::x86::_pack_vec = base64_vbmi_pack_vec_addr();
-        StubRoutines::x86::_join_0_1 = base64_vbmi_join_0_1_addr();
-        StubRoutines::x86::_join_1_2 = base64_vbmi_join_1_2_addr();
-        StubRoutines::x86::_join_2_3 = base64_vbmi_join_2_3_addr();
+        StubRoutines::x86::_lookup_lo_base64 = base64_vbmi_lookup_lo_addr();
+        StubRoutines::x86::_lookup_hi_base64 = base64_vbmi_lookup_hi_addr();
+        StubRoutines::x86::_lookup_lo_base64url = base64_vbmi_lookup_lo_url_addr();
+        StubRoutines::x86::_lookup_hi_base64url = base64_vbmi_lookup_hi_url_addr();
+        StubRoutines::x86::_pack_vec_base64 = base64_vbmi_pack_vec_addr();
+        StubRoutines::x86::_join_0_1_base64 = base64_vbmi_join_0_1_addr();
+        StubRoutines::x86::_join_1_2_base64 = base64_vbmi_join_1_2_addr();
+        StubRoutines::x86::_join_2_3_base64 = base64_vbmi_join_2_3_addr();
       }
-      StubRoutines::x86::_decoding_table = base64_decoding_table_addr();
+      StubRoutines::x86::_decoding_table_base64 = base64_decoding_table_addr();
       StubRoutines::_base64_encodeBlock = generate_base64_encodeBlock();
       StubRoutines::_base64_decodeBlock = generate_base64_decodeBlock();
     }

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -6106,7 +6106,7 @@ address generate_avx_ghash_processBlocks() {
       __ vpternlogd(input0, 0xfe, input1, input2, Assembler::AVX_512bit);
 
       __ vpternlogd(input3, 0xfe, translated0, translated1, Assembler::AVX_512bit);
-      __ vpternlogd(input0, 0xfe, translated1, translated2, Assembler::AVX_512bit);
+      __ vpternlogd(input0, 0xfe, translated2, translated3, Assembler::AVX_512bit);
       __ vpor(errorvec, input3, input0, Assembler::AVX_512bit);
 
       // Check if there was an error - if so, try 64-byte chunks

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -5351,8 +5351,7 @@ address generate_avx_ghash_processBlocks() {
     __ align(64, (unsigned long long)__ pc());
     StubCodeMark mark(this, "StubRoutines", "encoding_table_base64");
     address start = __ pc();
-    assert(((unsigned long long)start & 0x3f) == 0,
-           "Alignment problem (0x%08llx)", (unsigned long long)start);
+    assert(((unsigned long long)start & 0x3f) == 0, "Alignment problem (0x%08llx)", (unsigned long long)start);
     __ emit_data64(0x4847464544434241, relocInfo::none);
     __ emit_data64(0x504f4e4d4c4b4a49, relocInfo::none);
     __ emit_data64(0x5857565554535251, relocInfo::none);
@@ -5401,8 +5400,7 @@ address generate_avx_ghash_processBlocks() {
     const Register dp = c_rarg4;    // Position for writing to dest array
     const Register isURL = c_rarg5; // Base64 or URL character set
 #else
-    const Address dp_mem(rbp,
-             6 * wordSize); // length is on stack on Win64
+    const Address dp_mem(rbp, 6 * wordSize); // length is on stack on Win64
     const Address isURL_mem(rbp, 7 * wordSize);
     const Register isURL = r10; // pick the volatile windows register
     const Register dp = r12;
@@ -5434,8 +5432,7 @@ address generate_avx_ghash_processBlocks() {
       __ shrl(isURL, 6); // restore isURL
 
       __ mov64(rax, 0x3036242a1016040a); // Shifts
-      __ evmovdquq(xmm3, ExternalAddress(StubRoutines::x86::base64_shuffle_addr()),
-        Assembler::AVX_512bit, r15);
+      __ evmovdquq(xmm3, ExternalAddress(StubRoutines::x86::base64_shuffle_addr()), Assembler::AVX_512bit, r15);
       __ evmovdquq(xmm2, Address(encode_table, 0), Assembler::AVX_512bit);
       __ evpbroadcastq(xmm1, rax, Assembler::AVX_512bit);
 
@@ -5682,7 +5679,7 @@ address generate_avx_ghash_processBlocks() {
     // Load the encoding table based on isURL
     __ lea(r11, ExternalAddress(StubRoutines::x86::base64_encoding_table_addr()));
     __ movl(r15, isURL);
-    __ shll(r15, 5);
+    __ shll(r15, 6);
     __ addptr(r11, r15);
 
     __ BIND(L_processdata);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -5410,8 +5410,7 @@ address generate_avx_ghash_processBlocks() {
 
     const Register length = r14;
     const Register encode_table = r13;
-    Label L_process3, L_exit, L_processdata, L_vbmiLoop, L_not512,
-      L_32byteLoop;
+    Label L_process3, L_exit, L_processdata, L_vbmiLoop, L_not512, L_32byteLoop;
 
     // calculate length from offsets
     __ movl(length, end_offset);
@@ -5431,7 +5430,7 @@ address generate_avx_ghash_processBlocks() {
       __ addptr(encode_table, isURL);
       __ shrl(isURL, 6); // restore isURL
 
-      __ mov64(rax, 0x3036242a1016040a); // Shifts
+      __ mov64(rax, 0x3036242a1016040aull); // Shifts
       __ evmovdquq(xmm3, ExternalAddress(StubRoutines::x86::base64_shuffle_addr()), Assembler::AVX_512bit, r15);
       __ evmovdquq(xmm2, Address(encode_table, 0), Assembler::AVX_512bit);
       __ evpbroadcastq(xmm1, rax, Assembler::AVX_512bit);
@@ -5474,10 +5473,10 @@ address generate_avx_ghash_processBlocks() {
       __ jcc(Assembler::belowEqual, L_process3);
 
       // Set up supporting constant table data
-      __ vmovdqu(xmm9, ExternalAddress(StubRoutines::x86::base64_avx2_shuffle_addr()));
+      __ vmovdqu(xmm9, ExternalAddress(StubRoutines::x86::base64_avx2_shuffle_addr()), rax);
       // 6-bit mask for 2nd and 4th (and multiples) 6-bit values
       __ movl(rax, 0x0fc0fc00);
-      __ vmovdqu(xmm1, ExternalAddress(StubRoutines::x86::base64_avx2_input_mask_addr()));
+      __ vmovdqu(xmm1, ExternalAddress(StubRoutines::x86::base64_avx2_input_mask_addr()), rax);
       __ evpbroadcastd(xmm8, rax, Assembler::AVX_256bit);
 
       // Multiplication constant for "shifting" right by 6 and 10
@@ -5669,10 +5668,12 @@ address generate_avx_ghash_processBlocks() {
       __ cmpl(length, 31);
       __ jcc(Assembler::above, L_32byteLoop);
 
+      __ BIND(L_process3);
       __ vzeroupper();
+    } else {
+      __ BIND(L_process3);
     }
 
-    __ BIND(L_process3);
     __ cmpl(length, 3);
     __ jcc(Assembler::below, L_exit);
 

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -5429,27 +5429,20 @@ address generate_avx_ghash_processBlocks() {
 		  __ jcc(Assembler::below, L_not512);
 
 		  __ shll(isURL, 6); // index into decode table based on isURL
-		  __ lea(encode_table,
-			 ExternalAddress(StubRoutines::x86::
-						 base64_encoding_table_addr()));
+		  __ lea(encode_table, ExternalAddress(StubRoutines::x86::base64_encoding_table_addr()));
 		  __ addptr(encode_table, isURL);
 		  __ shrl(isURL, 6); // restore isURL
 
 		  __ mov64(rax, 0x3036242a1016040a); // Shifts
-		  __ evmovdquq(
-			  xmm3,
-			  ExternalAddress(
-				  StubRoutines::x86::base64_shuffle_addr()),
+		  __ evmovdquq(xmm3, ExternalAddress(StubRoutines::x86::base64_shuffle_addr()),
 			  Assembler::AVX_512bit, r15);
-		  __ evmovdquq(xmm2, Address(encode_table, 0),
-			       Assembler::AVX_512bit);
+		  __ evmovdquq(xmm2, Address(encode_table, 0), Assembler::AVX_512bit);
 		  __ evpbroadcastq(xmm1, rax, Assembler::AVX_512bit);
 
 		  __ align(32);
 		  __ BIND(L_vbmiLoop);
 
-		  __ vpermb(xmm0, xmm3, Address(source, start_offset),
-			    Assembler::AVX_512bit);
+		  __ vpermb(xmm0, xmm3, Address(source, start_offset), Assembler::AVX_512bit);
 		  __ subl(length, 48);
 
 		  // Put the input bytes into the proper lanes for writing, then
@@ -5476,7 +5469,7 @@ address generate_avx_ghash_processBlocks() {
 		  **      https://dl.acm.org/doi/10.1145/3132709
 		  **
 		  ** We use AVX2 SIMD instructions to encode 24 bytes into 32
-		  *output bytes.
+		  ** output bytes.
 		  **
 		  */
 		  // Lengths under 32 bytes are done with scalar routine
@@ -5484,15 +5477,10 @@ address generate_avx_ghash_processBlocks() {
 		  __ jcc(Assembler::belowEqual, L_process3);
 
 		  // Set up supporting constant table data
-		  __ vmovdqu(xmm9, ExternalAddress(
-					   StubRoutines::x86::
-						   base64_avx2_shuffle_addr()));
+		  __ vmovdqu(xmm9, ExternalAddress(StubRoutines::x86::base64_avx2_shuffle_addr()));
 		  // 6-bit mask for 2nd and 4th (and multiples) 6-bit values
 		  __ movl(rax, 0x0fc0fc00);
-		  __ vmovdqu(xmm1,
-			     ExternalAddress(
-				     StubRoutines::x86::
-					     base64_avx2_input_mask_addr()));
+		  __ vmovdqu(xmm1, ExternalAddress(StubRoutines::x86::base64_avx2_input_mask_addr()));
 		  __ evpbroadcastd(xmm8, rax, Assembler::AVX_256bit);
 
 		  // Multiplication constant for "shifting" right by 6 and 10
@@ -5589,10 +5577,7 @@ address generate_avx_ghash_processBlocks() {
 		  //
 		  // Load input bytes - only 28 bytes.  Mask the first load to
 		  // not load into the full register.
-		  __ vpmaskmovd(
-			  xmm1, xmm1,
-			  Address(source, start_offset, Address::times_1, -4),
-			  Assembler::AVX_256bit);
+		  __ vpmaskmovd(xmm1, xmm1, Address(source, start_offset, Address::times_1, -4), Assembler::AVX_256bit);
 
 		  // Move 3-byte chunks of input (12 bytes) into 16 bytes,
 		  // ordering by:
@@ -5636,9 +5621,7 @@ address generate_avx_ghash_processBlocks() {
 		  __ vpsubb(xmm1, xmm1, xmm2, Assembler::AVX_256bit);
 
 		  // Load the proper lookup table
-		  __ lea(r11,
-			 ExternalAddress(
-				 StubRoutines::x86::base64_avx2_lut_addr()));
+		  __ lea(r11, ExternalAddress(StubRoutines::x86::base64_avx2_lut_addr()));
 		  __ movl(r15, isURL);
 		  __ shll(r15, 5);
 		  __ vmovdqu(xmm2, Address(r11, r15));
@@ -5660,8 +5643,7 @@ address generate_avx_ghash_processBlocks() {
 		  __ BIND(L_32byteLoop);
 
 		  // Get next 32 bytes
-		  __ vmovdqu(xmm1, Address(source, start_offset,
-					   Address::times_1, -4));
+		  __ vmovdqu(xmm1, Address(source, start_offset, Address::times_1, -4));
 
 		  __ subl(length, 24);
 		  __ addl(start_offset, 24);
@@ -5691,7 +5673,6 @@ address generate_avx_ghash_processBlocks() {
 		  __ jcc(Assembler::above, L_32byteLoop);
 
 		  __ vzeroupper();
-		  __ addl(dp, 32);
 	  }
 
 	  __ BIND(L_process3);
@@ -5699,8 +5680,7 @@ address generate_avx_ghash_processBlocks() {
 	  __ jcc(Assembler::below, L_exit);
 
 	  // Load the encoding table based on isURL
-	  __ lea(r11, ExternalAddress(
-			      StubRoutines::x86::base64_encoding_table_addr()));
+	  __ lea(r11, ExternalAddress(StubRoutines::x86::base64_encoding_table_addr()));
 	  __ movl(r15, isURL);
 	  __ shll(r15, 5);
 	  __ addptr(r11, r15);
@@ -5709,10 +5689,8 @@ address generate_avx_ghash_processBlocks() {
 
 	  // Load 3 bytes
 	  __ load_unsigned_byte(r15, Address(source, start_offset));
-	  __ load_unsigned_byte(
-		  r10, Address(source, start_offset, Address::times_1, 1));
-	  __ load_unsigned_byte(
-		  r13, Address(source, start_offset, Address::times_1, 2));
+	  __ load_unsigned_byte(r10, Address(source, start_offset, Address::times_1, 1));
+	  __ load_unsigned_byte(r13, Address(source, start_offset, Address::times_1, 2));
 
 	  // Build a 32-bit word with bytes 1, 2, 0, 1
 	  __ movl(rax, r10);

--- a/src/hotspot/cpu/x86/stubRoutines_x86.cpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86.cpp
@@ -71,15 +71,15 @@ address StubRoutines::x86::_avx2_shuffle_base64 = NULL;
 address StubRoutines::x86::_avx2_input_mask_base64 = NULL;
 address StubRoutines::x86::_avx2_lut_base64 = NULL;
 address StubRoutines::x86::_counter_mask_addr = NULL;
-address StubRoutines::x86::_lookup_lo = NULL;
-address StubRoutines::x86::_lookup_hi = NULL;
-address StubRoutines::x86::_lookup_lo_url = NULL;
-address StubRoutines::x86::_lookup_hi_url = NULL;
-address StubRoutines::x86::_pack_vec = NULL;
-address StubRoutines::x86::_join_0_1 = NULL;
-address StubRoutines::x86::_join_1_2 = NULL;
-address StubRoutines::x86::_join_2_3 = NULL;
-address StubRoutines::x86::_decoding_table = NULL;
+address StubRoutines::x86::_lookup_lo_base64 = NULL;
+address StubRoutines::x86::_lookup_hi_base64 = NULL;
+address StubRoutines::x86::_lookup_lo_base64url = NULL;
+address StubRoutines::x86::_lookup_hi_base64url = NULL;
+address StubRoutines::x86::_pack_vec_base64 = NULL;
+address StubRoutines::x86::_join_0_1_base64 = NULL;
+address StubRoutines::x86::_join_1_2_base64 = NULL;
+address StubRoutines::x86::_join_2_3_base64 = NULL;
+address StubRoutines::x86::_decoding_table_base64 = NULL;
 #endif
 address StubRoutines::x86::_pshuffle_byte_flip_mask_addr = NULL;
 

--- a/src/hotspot/cpu/x86/stubRoutines_x86.cpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86.cpp
@@ -65,23 +65,21 @@ address StubRoutines::x86::_k256_W_adr = NULL;
 address StubRoutines::x86::_k512_W_addr = NULL;
 address StubRoutines::x86::_pshuffle_byte_flip_mask_addr_sha512 = NULL;
 // Base64 masks
-address StubRoutines::x86::_bswap_mask = NULL;
-address StubRoutines::x86::_base64_charset = NULL;
-address StubRoutines::x86::_gather_mask = NULL;
-address StubRoutines::x86::_right_shift_mask = NULL;
-address StubRoutines::x86::_left_shift_mask = NULL;
-address StubRoutines::x86::_and_mask = NULL;
-address StubRoutines::x86::_url_charset = NULL;
+address StubRoutines::x86::_encoding_table_base64 = NULL;
+address StubRoutines::x86::_shuffle_base64 = NULL;
+address StubRoutines::x86::_avx2_shuffle_base64 = NULL;
+address StubRoutines::x86::_avx2_input_mask_base64 = NULL;
+address StubRoutines::x86::_avx2_lut_base64 = NULL;
 address StubRoutines::x86::_counter_mask_addr = NULL;
-address StubRoutines::x86::_lookup_lo_base64 = NULL;
-address StubRoutines::x86::_lookup_hi_base64 = NULL;
-address StubRoutines::x86::_lookup_lo_base64url = NULL;
-address StubRoutines::x86::_lookup_hi_base64url = NULL;
-address StubRoutines::x86::_pack_vec_base64 = NULL;
-address StubRoutines::x86::_join_0_1_base64 = NULL;
-address StubRoutines::x86::_join_1_2_base64 = NULL;
-address StubRoutines::x86::_join_2_3_base64 = NULL;
-address StubRoutines::x86::_decoding_table_base64 = NULL;
+address StubRoutines::x86::_lookup_lo = NULL;
+address StubRoutines::x86::_lookup_hi = NULL;
+address StubRoutines::x86::_lookup_lo_url = NULL;
+address StubRoutines::x86::_lookup_hi_url = NULL;
+address StubRoutines::x86::_pack_vec = NULL;
+address StubRoutines::x86::_join_0_1 = NULL;
+address StubRoutines::x86::_join_1_2 = NULL;
+address StubRoutines::x86::_join_2_3 = NULL;
+address StubRoutines::x86::_decoding_table = NULL;
 #endif
 address StubRoutines::x86::_pshuffle_byte_flip_mask_addr = NULL;
 

--- a/src/hotspot/cpu/x86/stubRoutines_x86.hpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86.hpp
@@ -189,15 +189,15 @@ class x86 {
   static address _avx2_shuffle_base64;
   static address _avx2_input_mask_base64;
   static address _avx2_lut_base64;
-  static address _lookup_lo;
-  static address _lookup_hi;
-  static address _lookup_lo_url;
-  static address _lookup_hi_url;
-  static address _pack_vec;
-  static address _join_0_1;
-  static address _join_1_2;
-  static address _join_2_3;
-  static address _decoding_table;
+  static address _lookup_lo_base64;
+  static address _lookup_hi_base64;
+  static address _lookup_lo_base64url;
+  static address _lookup_hi_base64url;
+  static address _pack_vec_base64;
+  static address _join_0_1_base64;
+  static address _join_1_2_base64;
+  static address _join_2_3_base64;
+  static address _decoding_table_base64;
 #endif
   // byte flip mask for sha256
   static address _pshuffle_byte_flip_mask_addr;
@@ -341,15 +341,15 @@ class x86 {
   static address base64_avx2_input_mask_addr() { return _avx2_input_mask_base64; }
   static address base64_avx2_lut_addr() { return _avx2_lut_base64; }
   static address counter_mask_addr() { return _counter_mask_addr; }
-  static address base64_vbmi_lookup_lo_addr() { return _lookup_lo; }
-  static address base64_vbmi_lookup_hi_addr() { return _lookup_hi; }
-  static address base64_vbmi_lookup_lo_url_addr() { return _lookup_lo_url; }
-  static address base64_vbmi_lookup_hi_url_addr() { return _lookup_hi_url; }
-  static address base64_vbmi_pack_vec_addr() { return _pack_vec; }
-  static address base64_vbmi_join_0_1_addr() { return _join_0_1; }
-  static address base64_vbmi_join_1_2_addr() { return _join_1_2; }
-  static address base64_vbmi_join_2_3_addr() { return _join_2_3; }
-  static address base64_decoding_table_addr() { return _decoding_table; }
+  static address base64_vbmi_lookup_lo_addr() { return _lookup_lo_base64; }
+  static address base64_vbmi_lookup_hi_addr() { return _lookup_hi_base64; }
+  static address base64_vbmi_lookup_lo_url_addr() { return _lookup_lo_base64url; }
+  static address base64_vbmi_lookup_hi_url_addr() { return _lookup_hi_base64url; }
+  static address base64_vbmi_pack_vec_addr() { return _pack_vec_base64; }
+  static address base64_vbmi_join_0_1_addr() { return _join_0_1_base64; }
+  static address base64_vbmi_join_1_2_addr() { return _join_1_2_base64; }
+  static address base64_vbmi_join_2_3_addr() { return _join_2_3_base64; }
+  static address base64_decoding_table_addr() { return _decoding_table_base64; }
 #endif
   static address pshuffle_byte_flip_mask_addr() { return _pshuffle_byte_flip_mask_addr; }
   static void generate_CRC32C_table(bool is_pclmulqdq_supported);

--- a/src/hotspot/cpu/x86/stubRoutines_x86.hpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86.hpp
@@ -184,22 +184,20 @@ class x86 {
   static address _pshuffle_byte_flip_mask_addr_sha512;
   static address _counter_mask_addr;
   // Masks for base64
-  static address _base64_charset;
-  static address _bswap_mask;
-  static address _gather_mask;
-  static address _right_shift_mask;
-  static address _left_shift_mask;
-  static address _and_mask;
-  static address _url_charset;
-  static address _lookup_lo_base64;
-  static address _lookup_hi_base64;
-  static address _lookup_lo_base64url;
-  static address _lookup_hi_base64url;
-  static address _pack_vec_base64;
-  static address _join_0_1_base64;
-  static address _join_1_2_base64;
-  static address _join_2_3_base64;
-  static address _decoding_table_base64;
+  static address _encoding_table_base64;
+  static address _shuffle_base64;
+  static address _avx2_shuffle_base64;
+  static address _avx2_input_mask_base64;
+  static address _avx2_lut_base64;
+  static address _lookup_lo;
+  static address _lookup_hi;
+  static address _lookup_lo_url;
+  static address _lookup_hi_url;
+  static address _pack_vec;
+  static address _join_0_1;
+  static address _join_1_2;
+  static address _join_2_3;
+  static address _decoding_table;
 #endif
   // byte flip mask for sha256
   static address _pshuffle_byte_flip_mask_addr;
@@ -337,23 +335,21 @@ class x86 {
   static address k256_W_addr()    { return _k256_W_adr; }
   static address k512_W_addr()    { return _k512_W_addr; }
   static address pshuffle_byte_flip_mask_addr_sha512() { return _pshuffle_byte_flip_mask_addr_sha512; }
-  static address base64_charset_addr() { return _base64_charset; }
-  static address base64url_charset_addr() { return _url_charset; }
-  static address base64_bswap_mask_addr() { return _bswap_mask; }
-  static address base64_gather_mask_addr() { return _gather_mask; }
-  static address base64_right_shift_mask_addr() { return _right_shift_mask; }
-  static address base64_left_shift_mask_addr() { return _left_shift_mask; }
-  static address base64_and_mask_addr() { return _and_mask; }
+  static address base64_encoding_table_addr() { return _encoding_table_base64; }
+  static address base64_shuffle_addr() { return _shuffle_base64; }
+  static address base64_avx2_shuffle_addr() { return _avx2_shuffle_base64; }
+  static address base64_avx2_input_mask_addr() { return _avx2_input_mask_base64; }
+  static address base64_avx2_lut_addr() { return _avx2_lut_base64; }
   static address counter_mask_addr() { return _counter_mask_addr; }
-  static address base64_vbmi_lookup_lo_addr() { return _lookup_lo_base64; }
-  static address base64_vbmi_lookup_hi_addr() { return _lookup_hi_base64; }
-  static address base64_vbmi_lookup_lo_url_addr() { return _lookup_lo_base64url; }
-  static address base64_vbmi_lookup_hi_url_addr() { return _lookup_hi_base64url; }
-  static address base64_vbmi_pack_vec_addr() { return _pack_vec_base64; }
-  static address base64_vbmi_join_0_1_addr() { return _join_0_1_base64; }
-  static address base64_vbmi_join_1_2_addr() { return _join_1_2_base64; }
-  static address base64_vbmi_join_2_3_addr() { return _join_2_3_base64; }
-  static address base64_decoding_table_addr() { return _decoding_table_base64; }
+  static address base64_vbmi_lookup_lo_addr() { return _lookup_lo; }
+  static address base64_vbmi_lookup_hi_addr() { return _lookup_hi; }
+  static address base64_vbmi_lookup_lo_url_addr() { return _lookup_lo_url; }
+  static address base64_vbmi_lookup_hi_url_addr() { return _lookup_hi_url; }
+  static address base64_vbmi_pack_vec_addr() { return _pack_vec; }
+  static address base64_vbmi_join_0_1_addr() { return _join_0_1; }
+  static address base64_vbmi_join_1_2_addr() { return _join_1_2; }
+  static address base64_vbmi_join_2_3_addr() { return _join_2_3; }
+  static address base64_decoding_table_addr() { return _decoding_table; }
 #endif
   static address pshuffle_byte_flip_mask_addr() { return _pshuffle_byte_flip_mask_addr; }
   static void generate_CRC32C_table(bool is_pclmulqdq_supported);


### PR DESCRIPTION
Enhance the Base64 Encode intrinsic for x86 using AVX-512 to get better performance. Also allow for performance improvement on non-AVX-512 enabled platforms.

Added AVX-512 code for encoding Base64 blocks, including slight improvements for non-AVX-512 x86 platforms.

Running the Base64Decode benchmark, this change increases decode performance by an average of 2.6x with a maximum 9.7x for buffers > ~20k.  The numbers are given in the table below.

**Base Score** is without intrinsic support, **Optimized Score** is using this intrinsic, and **Gain** is **Base** / **Optimized**.

Benchmark Name | Base Score | Optimized Score | Gain
-- | -- | -- | --
testBase64Encode size 1 | 8.10 | 8.04 | 1.01
testBase64Encode size 2 | 8.51 | 8.43 | 1.01
testBase64Encode size 3 | 11.08 | 10.72 | 1.03
testBase64Encode size 6 | 13.98 | 13.12 | 1.07
testBase64Encode size 7 | 14.44 | 13.38 | 1.08
testBase64Encode size 9 | 15.44 | 14.37 | 1.07
testBase64Encode size 10 | 16.13 | 14.97 | 1.08
testBase64Encode size 48 | 27.14 | 23.23 | 1.17
testBase64Encode size 512 | 123.86 | 30.75 | 4.03
testBase64Encode size 1000 | 224.42 | 37.71 | 5.95
testBase64Encode size 20000 | 4202.11 | 430.16 | 9.77

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269404](https://bugs.openjdk.java.net/browse/JDK-8269404): Base64 Encoding optimization enhancements for x86 using AVX-512


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to c4cbe97d9f4a95b0508e8a13bd676dc1f2c4b535
 * [Sandhya Viswanathan](https://openjdk.java.net/census#sviswanathan) (@sviswa7 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4601/head:pull/4601` \
`$ git checkout pull/4601`

Update a local copy of the PR: \
`$ git checkout pull/4601` \
`$ git pull https://git.openjdk.java.net/jdk pull/4601/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4601`

View PR using the GUI difftool: \
`$ git pr show -t 4601`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4601.diff">https://git.openjdk.java.net/jdk/pull/4601.diff</a>

</details>
