### PR TITLE
8269433: Remove effectively unused ReferenceProcessor::_enqueuing_is_done

### DIFF
--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -488,11 +488,7 @@ void GenCollectedHeap::collect_generation(Generation* gen, bool full, size_t siz
       // collect() below will enable discovery as appropriate
     }
     gen->collect(full, clear_soft_refs, size, is_tlab);
-    if (!rp->enqueuing_is_done()) {
-      rp->disable_discovery();
-    } else {
-      rp->set_enqueuing_is_done(false);
-    }
+    rp->disable_discovery();
     rp->verify_no_references_recorded();
   }
 

--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -100,7 +100,6 @@ ReferenceProcessor::ReferenceProcessor(BoolObjectClosure* is_subject_to_discover
                                        BoolObjectClosure* is_alive_non_header)  :
   _is_subject_to_discovery(is_subject_to_discovery),
   _discovering_refs(false),
-  _enqueuing_is_done(false),
   _next_id(0),
   _is_alive_non_header(is_alive_non_header)
 {
@@ -199,7 +198,6 @@ ReferenceProcessorStats ReferenceProcessor::process_discovered_references(RefPro
 
   double start_time = os::elapsedTime();
 
-  assert(!enqueuing_is_done(), "If here enqueuing should not be complete");
   // Stop treating discovered references specially.
   disable_discovery();
 

--- a/src/hotspot/share/gc/shared/referenceProcessor.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.hpp
@@ -202,7 +202,6 @@ private:
                                         // other collectors in configuration
   bool        _discovery_is_mt;         // true if reference discovery is MT.
 
-  bool        _enqueuing_is_done;       // true if all weak references enqueued
   uint        _next_id;                 // round-robin mod _num_queues counter in
                                         // support of work distribution
 
@@ -404,10 +403,6 @@ public:
 
   // Whether we are in a phase when _processing_ is MT.
   bool processing_is_mt() const;
-
-  // whether all enqueueing of weak references is complete
-  bool enqueuing_is_done()  { return _enqueuing_is_done; }
-  void set_enqueuing_is_done(bool v) { _enqueuing_is_done = v; }
 
   // iterate over oops
   void weak_oops_do(OopClosure* f);       // weak roots


### PR DESCRIPTION
Simple change of removing effectively dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269433](https://bugs.openjdk.java.net/browse/JDK-8269433): Remove effectively unused ReferenceProcessor::_enqueuing_is_done


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4605/head:pull/4605` \
`$ git checkout pull/4605`

Update a local copy of the PR: \
`$ git checkout pull/4605` \
`$ git pull https://git.openjdk.java.net/jdk pull/4605/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4605`

View PR using the GUI difftool: \
`$ git pr show -t 4605`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4605.diff">https://git.openjdk.java.net/jdk/pull/4605.diff</a>

</details>
