### PR TITLE
8269470: Add truncation and compression information to EventHeapDump

### DIFF
--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -1074,6 +1074,9 @@
     <Field type="long" name="size" label="Size" />
     <Field type="boolean" name="gcBeforeDump" label="GC Before Dump" />
     <Field type="boolean" name="onOutOfMemoryError" label="On Out of Memory Error" />
+    <Field type="boolean" name="compressed" label="Compressed" />
+    <Field type="uint" name="truncatedArrayCount" label="Truncated Array Count" />
+    <Field type="ulong" contentType="bytes" name="truncatedLength" label="Truncated length" />
   </Event>
 
   <Event name="GCLocker" category="Java Virtual Machine, GC, Detailed" label="GC Locker" startTime="true" thread="true" stackTrace="true">

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -452,7 +452,7 @@ class DumpWriter : public StackObj {
   void deactivate()                     { flush(); _backend.deactivate(); }
 
   uint truncated_array_count() { return _truncated_array_count; }
-  uint truncated_length() { return _truncated_length; }
+  size_t truncated_length() { return _truncated_length; }
 
   void count_truncation(size_t length) {
     _truncated_array_count++;


### PR DESCRIPTION
Could I have a review of this change that adds the truncation and compression information to EventHeapDump?

We occasionally receive feedback from users that the heap size parsed from the heap dump does not match the GC log. We think this may be caused by the truncation of the heap dump.

It would be nice to add truncation info to the EventHeapDump.

Also, this patch adds the compression info which is trivial to add.

Regards,
Denghui

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8269470](https://bugs.openjdk.java.net/browse/JDK-8269470): Add truncation and compression information to EventHeapDump


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4608/head:pull/4608` \
`$ git checkout pull/4608`

Update a local copy of the PR: \
`$ git checkout pull/4608` \
`$ git pull https://git.openjdk.java.net/jdk pull/4608/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4608`

View PR using the GUI difftool: \
`$ git pr show -t 4608`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4608.diff">https://git.openjdk.java.net/jdk/pull/4608.diff</a>

</details>
