### PR TITLE
8268869: java in source-file mode suggests javac-only Xlint flags

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/Main.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/Main.java
@@ -352,7 +352,8 @@ public class Main {
         // add implicit options
         javacOpts.add("-proc:none");
         javacOpts.add("-Xdiags:verbose");
-
+        javacOpts.add("-Xlint:deprecation");
+        javacOpts.add("-Xlint:unchecked");
         return javacOpts;
     }
 

--- a/test/langtools/tools/javac/launcher/SourceLauncherTest.java
+++ b/test/langtools/tools/javac/launcher/SourceLauncherTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8192920 8204588 8246774
+ * @bug 8192920 8204588 8246774 8248843 8268869
  * @summary Test source launcher
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -596,6 +596,38 @@ public class SourceLauncherTest extends TestRunner {
                 "^\n" +
                 "1 error\n",
                 "error: compilation failed");
+    }
+
+    @Test
+    public void testNoRecompileWithSuggestions(Path base) throws IOException {
+        tb.writeJavaFiles(base,
+            "class NoRecompile {\n" +
+            "    void use(String s) {}\n" +
+            "    void test() {\n" +
+            "        use(1);\n" +
+            "    }\n" +
+            "    <T> void test(T t, Object o) {\n" +
+            "        T t1 = (T) o;\n" +
+            "    }\n" +
+            "    static class Generic<T> {\n" +
+            "        T t;\n" +
+            "        void raw(Generic raw) {\n" +
+            "            raw.t = \"\";\n" +
+            "        }\n" +
+            "    }\n" +
+            "    void deprecation() {\n" +
+            "        Thread.currentThread().stop();\n" +
+            "    }\n" +
+            "    void preview(Object o) {\n" +
+            "      if (o instanceof String s) {\n" +
+            "          System.out.println(s);\n" +
+            "      }\n" +
+            "    }\n" +
+            "}");
+        Result r = run(base.resolve("NoRecompile.java"), Collections.emptyList(), Collections.emptyList());
+        if (r.stdErr.contains("recompile with")) {
+            error("Unexpected recompile suggestions in error output: " + r.stdErr);
+        }
     }
 
     void testError(Path file, String expectStdErr, String expectFault) throws IOException {


### PR DESCRIPTION
java in source-file mode (see JEP 330) displays compiler notes suggesting recompile with -Xlint:deprecation and -Xlint:unchecked. According JEP 330 these advanced javac optionns are not allowed. The goal with JEP 330 was to support developers that are at the early stages of learning Java, so options such as -Xlint are out of their scope.

This patch prevents displaying "Note: Recompile with -Xlint:deprecation for details." and "Note: Recompile with -Xlint:unchecked for details."   by implicitly enabling -Xlint:deprecation and -Xlint:unchecked in com.sun.tool.javac.launcher.Main for all invocations.

Beside avoiding prohibited javac option suggestion notes this patch has positive effect of more verbose compilation diagnostic. Higher diagnostic verbosity is appreciated by users learning Java on single-source programs in java source-file mode.

Similar case with -Xdiags:verbose was reported in JDK-8248843 and resolved in commit openjdk/jdk/31d0f0d8after review openjdk/jdk/4094

The patch also provides new test "testNoRecompileWithSuggestions" detecting unwanted recompilation suggestions in java in source-file mode execution. The test cover also case from JDK-8248843 with -Xdiags:verbose

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268869](https://bugs.openjdk.java.net/browse/JDK-8268869): java in source-file mode suggests javac-only Xlint flags


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4613/head:pull/4613` \
`$ git checkout pull/4613`

Update a local copy of the PR: \
`$ git checkout pull/4613` \
`$ git pull https://git.openjdk.java.net/jdk pull/4613/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4613`

View PR using the GUI difftool: \
`$ git pr show -t 4613`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4613.diff">https://git.openjdk.java.net/jdk/pull/4613.diff</a>

</details>
