### PR TITLE
8269530: runtime/ParallelLoad/ParallelSuperTest.java timeout

### DIFF
--- a/test/hotspot/jtreg/runtime/ParallelLoad/ClassLoadingThread.java
+++ b/test/hotspot/jtreg/runtime/ParallelLoad/ClassLoadingThread.java
@@ -21,14 +21,16 @@
  * questions.
  */
 
+import java.util.concurrent.Semaphore;
+
 class ClassLoadingThread extends Thread {
 
     private ClassLoader ldr = null;
-    private Object thread_sync = null;
+    private Semaphore mainSync = null;
 
-    public ClassLoadingThread(ClassLoader loader, Object sync) {
+    public ClassLoadingThread(ClassLoader loader, Semaphore sem) {
         ldr = loader;
-        thread_sync = sync;
+        mainSync = sem;
     }
 
     private boolean success = true;
@@ -47,9 +49,9 @@ class ClassLoadingThread extends Thread {
             success = false;
         } finally {
             ThreadPrint.println("Finished");
-            // Wake up the second thread
-            synchronized (thread_sync) {
-                thread_sync.notify();
+            // Signal main thread to start t2.
+            if (mainSync != null) {
+                mainSync.release();
             }
         }
     }


### PR DESCRIPTION
Hi,

Please review this small fix to test ParallelSuperTest.java. I only saw the timeout once on one of my GHA tests but the issue can be easily reproduced by adding a delay in startLoading() before the main thread tries to synchronize on thread_sync.
Run the test with and without the added delay. The test times out without the patch and passes with the patch.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269530](https://bugs.openjdk.java.net/browse/JDK-8269530): runtime/ParallelLoad/ParallelSuperTest.java timeout


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4614/head:pull/4614` \
`$ git checkout pull/4614`

Update a local copy of the PR: \
`$ git checkout pull/4614` \
`$ git pull https://git.openjdk.java.net/jdk pull/4614/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4614`

View PR using the GUI difftool: \
`$ git pr show -t 4614`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4614.diff">https://git.openjdk.java.net/jdk/pull/4614.diff</a>

</details>
