### PR TITLE
8269409: Post JEP 411 refactoring: core-libs with maximum covering > 10K

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputFilter.java
+++ b/src/java.base/share/classes/java/io/ObjectInputFilter.java
@@ -560,7 +560,6 @@ public interface ObjectInputFilter {
      * fully qualified class name of the deserialization filter factory.
      * @since 9
      */
-    @SuppressWarnings("removal")
     final class Config {
         /**
          * Lock object for filter and filter factory.
@@ -628,19 +627,17 @@ public interface ObjectInputFilter {
              */
 
             // Get the values of the system properties, if they are defined
-            String factoryClassName = StaticProperty.jdkSerialFilterFactory();
-            if (factoryClassName == null) {
-                // Fallback to security property
-                factoryClassName = AccessController.doPrivileged((PrivilegedAction<String>) () ->
+            @SuppressWarnings("removal")
+            String factoryClassName = StaticProperty.jdkSerialFilterFactory() != null
+                    ? StaticProperty.jdkSerialFilterFactory()
+                    : AccessController.doPrivileged((PrivilegedAction<String>) () ->
                         Security.getProperty(SERIAL_FILTER_FACTORY_PROPNAME));
-            }
 
-            String filterString = StaticProperty.jdkSerialFilter();
-            if (filterString == null) {
-                // Fallback to security property
-                filterString = AccessController.doPrivileged((PrivilegedAction<String>) () ->
+            @SuppressWarnings("removal")
+            String filterString = StaticProperty.jdkSerialFilter() != null
+                    ? StaticProperty.jdkSerialFilter()
+                    : AccessController.doPrivileged((PrivilegedAction<String>) () ->
                         Security.getProperty(SERIAL_FILTER_PROPNAME));
-            }
 
             traceFilters = GetBooleanAction.privilegedGetProperty(SERIAL_FILTER_TRACE_PROPNAME);
 
@@ -743,6 +740,7 @@ public interface ObjectInputFilter {
          */
         public static void setSerialFilter(ObjectInputFilter filter) {
             Objects.requireNonNull(filter, "filter");
+            @SuppressWarnings("removal")
             SecurityManager sm = System.getSecurityManager();
             if (sm != null) {
                 sm.checkPermission(ObjectStreamConstants.SERIAL_FILTER_PERMISSION);
@@ -836,6 +834,7 @@ public interface ObjectInputFilter {
          */
         public static void setSerialFilterFactory(BinaryOperator<ObjectInputFilter> filterFactory) {
             Objects.requireNonNull(filterFactory, "filterFactory");
+            @SuppressWarnings("removal")
             SecurityManager sm = System.getSecurityManager();
             if (sm != null) {
                 sm.checkPermission(ObjectStreamConstants.SERIAL_FILTER_PERMISSION);

--- a/src/java.base/share/classes/java/net/IDN.java
+++ b/src/java.base/share/classes/java/net/IDN.java
@@ -72,7 +72,6 @@ import jdk.internal.icu.text.UCharacterIterator;
  * @since 1.6
  *
  */
-@SuppressWarnings("removal")
 public final class IDN {
     /**
      * Flag to allow processing of unassigned code points
@@ -224,19 +223,15 @@ public final class IDN {
     private static StringPrep namePrep = null;
 
     static {
-        InputStream stream = null;
-
         try {
             final String IDN_PROFILE = "/sun/net/idn/uidna.spp";
-            if (System.getSecurityManager() != null) {
-                stream = AccessController.doPrivileged(new PrivilegedAction<>() {
-                    public InputStream run() {
-                        return StringPrep.class.getResourceAsStream(IDN_PROFILE);
-                    }
-                });
-            } else {
-                stream = StringPrep.class.getResourceAsStream(IDN_PROFILE);
-            }
+            @SuppressWarnings("removal")
+            InputStream stream = System.getSecurityManager() != null
+                    ? AccessController.doPrivileged(new PrivilegedAction<>() {
+                            public InputStream run() {
+                                return StringPrep.class.getResourceAsStream(IDN_PROFILE);
+                            }})
+                    : StringPrep.class.getResourceAsStream(IDN_PROFILE);
 
             namePrep = new StringPrep(stream);
             stream.close();

--- a/src/java.base/share/classes/java/time/chrono/HijrahChronology.java
+++ b/src/java.base/share/classes/java/time/chrono/HijrahChronology.java
@@ -202,7 +202,6 @@ import sun.util.logging.PlatformLogger;
  *
  * @since 1.8
  */
-@SuppressWarnings("removal")
 public final class HijrahChronology extends AbstractChronology implements Serializable {
 
     /**
@@ -291,8 +290,10 @@ public final class HijrahChronology extends AbstractChronology implements Serial
         AbstractChronology.registerChrono(INSTANCE, "islamic");
 
         // custom config chronologies
-        CONF_PATH = Path.of(AccessController.doPrivileged((PrivilegedAction<String>)
-                () -> System.getProperty("java.home")), "conf", "chronology");
+        @SuppressWarnings("removal")
+        String javaHome = AccessController.doPrivileged((PrivilegedAction<String>)
+                        () -> System.getProperty("java.home"));
+        CONF_PATH = Path.of(javaHome, "conf", "chronology");
         registerCustomChrono();
     }
 
@@ -847,7 +848,7 @@ public final class HijrahChronology extends AbstractChronology implements Serial
             };
         FilePermission perm1 = new FilePermission("<<ALL FILES>>", "read");
         RuntimePermission perm2 = new RuntimePermission("accessSystemModules");
-        try (InputStream is = AccessController.doPrivileged(getResourceAction, null, perm1, perm2)) {
+        try (@SuppressWarnings("removal") InputStream is = AccessController.doPrivileged(getResourceAction, null, perm1, perm2)) {
             if (is == null) {
                 throw new RuntimeException("Hijrah calendar resource not found: " + resourceName);
             }
@@ -1042,6 +1043,7 @@ public final class HijrahChronology extends AbstractChronology implements Serial
      * Look for Hijrah chronology variant properties files in
      * <JAVA_HOME>/conf/chronology directory. Then register its chronology, if any.
      */
+    @SuppressWarnings("removal")
     private static void registerCustomChrono() {
         AccessController.doPrivileged(
             (PrivilegedAction<Void>)() -> {

--- a/src/java.base/share/classes/java/time/zone/ZoneRulesProvider.java
+++ b/src/java.base/share/classes/java/time/zone/ZoneRulesProvider.java
@@ -127,7 +127,6 @@ import java.util.Collections;
  *
  * @since 1.8
  */
-@SuppressWarnings("removal")
 public abstract class ZoneRulesProvider {
 
     /**
@@ -147,26 +146,28 @@ public abstract class ZoneRulesProvider {
     static {
         // if the property java.time.zone.DefaultZoneRulesProvider is
         // set then its value is the class name of the default provider
-        final List<ZoneRulesProvider> loaded = new ArrayList<>();
-        AccessController.doPrivileged(new PrivilegedAction<>() {
-            public Object run() {
-                String prop = System.getProperty("java.time.zone.DefaultZoneRulesProvider");
-                if (prop != null) {
-                    try {
-                        Class<?> c = Class.forName(prop, true, ClassLoader.getSystemClassLoader());
-                        @SuppressWarnings("deprecation")
-                        ZoneRulesProvider provider = ZoneRulesProvider.class.cast(c.newInstance());
-                        registerProvider(provider);
-                        loaded.add(provider);
-                    } catch (Exception x) {
-                        throw new Error(x);
+        @SuppressWarnings("removal")
+        final List<ZoneRulesProvider> loaded =
+                AccessController.doPrivileged(new PrivilegedAction<List<ZoneRulesProvider>>() {
+                    public List<ZoneRulesProvider> run() {
+                        List<ZoneRulesProvider> result = new ArrayList<>();
+                        String prop = System.getProperty("java.time.zone.DefaultZoneRulesProvider");
+                        if (prop != null) {
+                            try {
+                                Class<?> c = Class.forName(prop, true, ClassLoader.getSystemClassLoader());
+                                @SuppressWarnings("deprecation")
+                                ZoneRulesProvider provider = ZoneRulesProvider.class.cast(c.newInstance());
+                                registerProvider(provider);
+                                result.add(provider);
+                            } catch (Exception x) {
+                                throw new Error(x);
+                            }
+                        } else {
+                            registerProvider(new TzdbZoneRulesProvider());
+                        }
+                        return result;
                     }
-                } else {
-                    registerProvider(new TzdbZoneRulesProvider());
-                }
-                return null;
-            }
-        });
+                });
 
         ServiceLoader<ZoneRulesProvider> sl = ServiceLoader.load(ZoneRulesProvider.class, ClassLoader.getSystemClassLoader());
         Iterator<ZoneRulesProvider> it = sl.iterator();

--- a/src/java.base/share/classes/java/util/Currency.java
+++ b/src/java.base/share/classes/java/util/Currency.java
@@ -111,7 +111,6 @@ import sun.util.logging.PlatformLogger;
  * @see java.math.BigDecimal
  * @since 1.4
  */
-@SuppressWarnings("removal")
 public final class Currency implements Serializable {
 
     @java.io.Serial
@@ -210,6 +209,11 @@ public final class Currency implements Serializable {
     private static final int VALID_FORMAT_VERSION = 3;
 
     static {
+        initStatic();
+    }
+
+    @SuppressWarnings("removal")
+    private static void initStatic() {
         AccessController.doPrivileged(new PrivilegedAction<>() {
             @Override
             public Void run() {

--- a/src/java.base/share/classes/java/util/concurrent/atomic/Striped64.java
+++ b/src/java.base/share/classes/java/util/concurrent/atomic/Striped64.java
@@ -47,7 +47,7 @@ import java.util.function.LongBinaryOperator;
  * for classes supporting dynamic striping on 64bit values. The class
  * extends Number so that concrete subclasses must publicly do so.
  */
-@SuppressWarnings({"removal","serial"})
+@SuppressWarnings("serial")
 abstract class Striped64 extends Number {
     /*
      * This class maintains a lazily-initialized table of atomically
@@ -382,12 +382,13 @@ abstract class Striped64 extends Number {
     private static final VarHandle THREAD_PROBE;
     static {
         try {
-            MethodHandles.Lookup l = MethodHandles.lookup();
-            BASE = l.findVarHandle(Striped64.class,
+            MethodHandles.Lookup l1 = MethodHandles.lookup();
+            BASE = l1.findVarHandle(Striped64.class,
                     "base", long.class);
-            CELLSBUSY = l.findVarHandle(Striped64.class,
+            CELLSBUSY = l1.findVarHandle(Striped64.class,
                     "cellsBusy", int.class);
-            l = java.security.AccessController.doPrivileged(
+            @SuppressWarnings("removal")
+            MethodHandles.Lookup l2 = java.security.AccessController.doPrivileged(
                     new java.security.PrivilegedAction<>() {
                         public MethodHandles.Lookup run() {
                             try {
@@ -396,7 +397,7 @@ abstract class Striped64 extends Number {
                                 throw new ExceptionInInitializerError(e);
                             }
                         }});
-            THREAD_PROBE = l.findVarHandle(Thread.class,
+            THREAD_PROBE = l2.findVarHandle(Thread.class,
                     "threadLocalRandomProbe", int.class);
         } catch (ReflectiveOperationException e) {
             throw new ExceptionInInitializerError(e);

--- a/src/java.base/share/classes/sun/net/www/MimeTable.java
+++ b/src/java.base/share/classes/sun/net/www/MimeTable.java
@@ -33,7 +33,6 @@ import java.util.Enumeration;
 import java.util.Properties;
 import java.util.StringTokenizer;
 
-@SuppressWarnings("removal")
 public class MimeTable implements FileNameMap {
     /** Keyed by content type, returns MimeEntries */
     private Hashtable<String, MimeEntry> entries
@@ -44,28 +43,15 @@ public class MimeTable implements FileNameMap {
         = new Hashtable<String, MimeEntry>();
 
     // Will be reset if in the platform-specific data file
-    private static String tempFileTemplate;
-
-    static {
+    @SuppressWarnings("removal")
+    private static String tempFileTemplate =
         java.security.AccessController.doPrivileged(
-            new java.security.PrivilegedAction<Void>() {
-                public Void run() {
-                tempFileTemplate =
-                    System.getProperty("content.types.temp.file.template",
-                                       "/tmp/%s");
-
-                mailcapLocations = new String[] {
-                    System.getProperty("user.mailcap"),
-                    StaticProperty.userHome() + "/.mailcap",
-                    "/etc/mailcap",
-                    "/usr/etc/mailcap",
-                    "/usr/local/etc/mailcap",
-                };
-                return null;
-            }
-        });
-    }
-
+                new java.security.PrivilegedAction<String>() {
+                    public String run() {
+                        return System.getProperty("content.types.temp.file.template",
+                                "/tmp/%s");
+                    }
+                });
 
     private static final String filePreamble = "sun.net.www MIME content-types table";
     private static final String fileMagic = "#" + filePreamble;
@@ -77,6 +63,7 @@ public class MimeTable implements FileNameMap {
     private static class DefaultInstanceHolder {
         static final MimeTable defaultInstance = getDefaultInstance();
 
+        @SuppressWarnings("removal")
         static MimeTable getDefaultInstance() {
             return java.security.AccessController.doPrivileged(
                 new java.security.PrivilegedAction<MimeTable>() {
@@ -220,7 +207,20 @@ public class MimeTable implements FileNameMap {
     // For backward compatibility -- mailcap format files
     // This is not currently used, but may in the future when we add ability
     // to read BOTH the properties format and the mailcap format.
-    protected static String[] mailcapLocations;
+    @SuppressWarnings("removal")
+    protected static String[] mailcapLocations =
+        java.security.AccessController.doPrivileged(
+                new java.security.PrivilegedAction<String[]>() {
+                    public String[] run() {
+                        return new String[]{
+                                System.getProperty("user.mailcap"),
+                                StaticProperty.userHome() + "/.mailcap",
+                                "/etc/mailcap",
+                                "/usr/etc/mailcap",
+                                "/usr/local/etc/mailcap",
+                        };
+                    }
+                });
 
     public synchronized void load() {
         Properties entries = new Properties();
@@ -388,6 +388,7 @@ public class MimeTable implements FileNameMap {
             properties.put("temp.file.template", tempFileTemplate);
             String tag;
             // Perform the property security check for user.name
+            @SuppressWarnings("removal")
             SecurityManager sm = System.getSecurityManager();
             if (sm != null) {
                 sm.checkPropertyAccess("user.name");

--- a/src/java.base/share/classes/sun/net/www/protocol/http/AuthenticationInfo.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/AuthenticationInfo.java
@@ -53,7 +53,6 @@ import sun.net.www.HeaderParser;
 //      policy in HttpURLConnection.  A failure on baz.foo.com shouldn't
 //      uncache foo.com!
 
-@SuppressWarnings("removal")
 public abstract class AuthenticationInfo extends AuthCacheValue implements Cloneable {
 
     @java.io.Serial
@@ -70,12 +69,10 @@ public abstract class AuthenticationInfo extends AuthCacheValue implements Clone
      * repeatedly, via the Authenticator. Default is false, which means that this
      * behavior is switched off.
      */
-    static final boolean serializeAuth;
-    static {
-        serializeAuth = java.security.AccessController.doPrivileged(
+    @SuppressWarnings("removal")
+    static final boolean serializeAuth = java.security.AccessController.doPrivileged(
             new sun.security.action.GetBooleanAction(
                 "http.auth.serializeRequests")).booleanValue();
-    }
 
     /* AuthCacheValue: */
 

--- a/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
+++ b/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
@@ -57,7 +57,6 @@ import sun.security.action.GetPropertyAction;
  * <p>
  * @since 1.8
  */
-@SuppressWarnings("removal")
 public final class ZoneInfoFile {
 
     /**
@@ -249,6 +248,11 @@ public final class ZoneInfoFile {
                 .privilegedGetProperty("sun.timezone.ids.oldmapping", "false")
                 .toLowerCase(Locale.ROOT);
         USE_OLDMAPPING = (oldmapping.equals("yes") || oldmapping.equals("true"));
+        loadTZDB();
+    }
+
+    @SuppressWarnings("removal")
+    private static void loadTZDB() {
         AccessController.doPrivileged(new PrivilegedAction<Void>() {
             public Void run() {
                 try {

--- a/src/java.management/share/classes/java/lang/management/ManagementFactory.java
+++ b/src/java.management/share/classes/java/lang/management/ManagementFactory.java
@@ -474,6 +474,7 @@ public class ManagementFactory {
      * @see javax.management.MBeanServerFactory#createMBeanServer
      */
     public static synchronized MBeanServer getPlatformMBeanServer() {
+        @SuppressWarnings("removal")
         SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
             Permission perm = new MBeanServerPermission("createMBeanServer");
@@ -598,6 +599,7 @@ public class ManagementFactory {
         // Only allow MXBean interfaces from the platform modules loaded by the
         // bootstrap or platform class loader
         final Class<?> cls = mxbeanInterface;
+        @SuppressWarnings("removal")
         ClassLoader loader =
             AccessController.doPrivileged(
                 (PrivilegedAction<ClassLoader>) () -> cls.getClassLoader());
@@ -885,6 +887,7 @@ public class ManagementFactory {
     private static final String NOTIF_EMITTER =
         "javax.management.NotificationEmitter";
 
+    @SuppressWarnings("removal")
     private static void addMXBean(final MBeanServer mbs, String name, final Object pmo)
     {
         try {
@@ -920,6 +923,7 @@ public class ManagementFactory {
 
         static {
             // get all providers
+            @SuppressWarnings("removal")
             List<PlatformMBeanProvider> providers = AccessController.doPrivileged(
                 new PrivilegedAction<List<PlatformMBeanProvider>>() {
                     @Override
@@ -1012,6 +1016,11 @@ public class ManagementFactory {
     }
 
     static {
+        loadNativeLib();
+    }
+
+    @SuppressWarnings("removal")
+    private static void loadNativeLib() {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             System.loadLibrary("management");
             return null;

--- a/src/java.management/share/classes/javax/management/modelmbean/DescriptorSupport.java
+++ b/src/java.management/share/classes/javax/management/modelmbean/DescriptorSupport.java
@@ -81,7 +81,7 @@ import sun.reflect.misc.ReflectUtil;
  *
  * @since 1.5
  */
-@SuppressWarnings({"removal","serial"})  // serialVersionUID not constant
+@SuppressWarnings("serial")  // serialVersionUID not constant
 public class DescriptorSupport
          implements javax.management.Descriptor
 {
@@ -119,16 +119,8 @@ public class DescriptorSupport
     private static final ObjectStreamField[] serialPersistentFields;
     private static final String serialForm;
     static {
-        String form = null;
-        boolean compat = false;
-        try {
-            GetPropertyAction act = new GetPropertyAction("jmx.serial.form");
-            form = AccessController.doPrivileged(act);
-            compat = "1.0".equals(form);  // form may be null
-        } catch (Exception e) {
-            // OK: No compat with 1.0
-        }
-        serialForm = form;
+        serialForm = getForm();
+        boolean compat = "1.0".equals(serialForm);  // serialForm may be null
         if (compat) {
             serialPersistentFields = oldSerialPersistentFields;
             serialVersionUID = oldSerialVersionUID;
@@ -137,6 +129,19 @@ public class DescriptorSupport
             serialVersionUID = newSerialVersionUID;
         }
     }
+
+    @SuppressWarnings("removal")
+    private static String getForm() {
+        String form = null;
+        try {
+            GetPropertyAction act = new GetPropertyAction("jmx.serial.form");
+            return  AccessController.doPrivileged(act);
+        } catch (Exception e) {
+            // OK: No compat with 1.0
+            return null;
+        }
+    }
+
     //
     // END Serialization compatibility stuff
 

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapPoolManager.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapPoolManager.java
@@ -55,7 +55,6 @@ import jdk.internal.misc.InnocuousThread;
  * @author Rosanna Lee
  */
 
-@SuppressWarnings("removal")
 public final class LdapPoolManager {
     private static final String DEBUG =
         "com.sun.jndi.ldap.connect.pool.debug";
@@ -164,23 +163,28 @@ public final class LdapPoolManager {
         }
 
         if (idleTimeout > 0) {
-            // Create cleaner to expire idle connections
-            PrivilegedAction<Void> pa = new PrivilegedAction<Void>() {
-                public Void run() {
-                    Thread t = InnocuousThread.newSystemThread(
-                            "LDAP PoolCleaner",
-                            new PoolCleaner(idleTimeout, pools));
-                    assert t.getContextClassLoader() == null;
-                    t.setDaemon(true);
-                    t.start();
-                    return null;
-                }};
-            AccessController.doPrivileged(pa);
+            startCleanerThread();
         }
 
         if (debug) {
             showStats(System.err);
         }
+    }
+
+    @SuppressWarnings("removal")
+    private static void startCleanerThread() {
+        // Create cleaner to expire idle connections
+        PrivilegedAction<Void> pa = new PrivilegedAction<Void>() {
+            public Void run() {
+                Thread t = InnocuousThread.newSystemThread(
+                        "LDAP PoolCleaner",
+                        new PoolCleaner(idleTimeout, pools));
+                assert t.getContextClassLoader() == null;
+                t.setDaemon(true);
+                t.start();
+                return null;
+            }};
+        AccessController.doPrivileged(pa);
     }
 
     // Cannot instantiate one of these
@@ -396,16 +400,19 @@ public final class LdapPoolManager {
         }
     }
 
+    @SuppressWarnings("removal")
     private static final String getProperty(final String propName, final String defVal) {
         PrivilegedAction<String> pa = () -> System.getProperty(propName, defVal);
         return AccessController.doPrivileged(pa);
     }
 
+    @SuppressWarnings("removal")
     private static final int getInteger(final String propName, final int defVal) {
         PrivilegedAction<Integer> pa = () -> Integer.getInteger(propName, defVal);
         return AccessController.doPrivileged(pa);
     }
 
+    @SuppressWarnings("removal")
     private static final long getLong(final String propName, final long defVal) {
         PrivilegedAction<Long> pa = () -> Long.getLong(propName, defVal);
         return AccessController.doPrivileged(pa);

--- a/src/java.prefs/macosx/classes/java/util/prefs/MacOSXPreferencesFile.java
+++ b/src/java.prefs/macosx/classes/java/util/prefs/MacOSXPreferencesFile.java
@@ -76,10 +76,14 @@ import java.lang.ref.WeakReference;
   it's expensive and is usually not necessary.
 */
 
-@SuppressWarnings("removal")
 class MacOSXPreferencesFile {
 
     static {
+        loadPrefsLib();
+    }
+
+    @SuppressWarnings("removal")
+    private static void loadPrefsLib() {
         java.security.AccessController.doPrivileged(
             new java.security.PrivilegedAction<Void>() {
                 public Void run() {

--- a/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
+++ b/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
@@ -46,10 +46,14 @@ import sun.util.logging.PlatformLogger;
  * @see     Preferences
  * @since   1.4
  */
-@SuppressWarnings("removal")
 class FileSystemPreferences extends AbstractPreferences {
 
     static {
+        loadPrefsLib();
+    }
+
+    @SuppressWarnings("removal")
+    private static void loadPrefsLib() {
         PrivilegedAction<Void> load = () -> {
             System.loadLibrary("prefs");
             return null;
@@ -60,6 +64,7 @@ class FileSystemPreferences extends AbstractPreferences {
     /**
      * Sync interval in seconds.
      */
+    @SuppressWarnings("removal")
     private static final int SYNC_INTERVAL = Math.max(1,
         AccessController.doPrivileged((PrivilegedAction<Integer>) () ->
              Integer.getInteger("java.util.prefs.syncInterval", 30)));
@@ -111,6 +116,7 @@ class FileSystemPreferences extends AbstractPreferences {
         return root;
     }
 
+    @SuppressWarnings("removal")
     private static void setupUserRoot() {
         AccessController.doPrivileged(new PrivilegedAction<Void>() {
             public Void run() {
@@ -178,6 +184,7 @@ class FileSystemPreferences extends AbstractPreferences {
         return root;
     }
 
+    @SuppressWarnings("removal")
     private static void setupSystemRoot() {
         AccessController.doPrivileged(new PrivilegedAction<Void>() {
             public Void run() {
@@ -445,6 +452,11 @@ class FileSystemPreferences extends AbstractPreferences {
     private static Timer syncTimer = new Timer(true); // Daemon Thread
 
     static {
+        addShutdownHook();
+    }
+
+    @SuppressWarnings("removal")
+    private static void addShutdownHook() {
         // Add periodic timer task to periodically sync cached prefs
         syncTimer.schedule(new TimerTask() {
             public void run() {
@@ -513,6 +525,7 @@ class FileSystemPreferences extends AbstractPreferences {
      * parent node and name.  This constructor, called from childSpi,
      * is used to make every node except for the two //roots.
      */
+    @SuppressWarnings("removal")
     private FileSystemPreferences(FileSystemPreferences parent, String name) {
         super(parent, name);
         isUserNode = parent.isUserNode;
@@ -582,6 +595,7 @@ class FileSystemPreferences extends AbstractPreferences {
      * fails, a BackingStoreException is thrown and both prefsCache and
      * lastSyncTime are unaffected by the call.
      */
+    @SuppressWarnings("removal")
     private void loadCache() throws BackingStoreException {
         try {
             AccessController.doPrivileged(
@@ -629,6 +643,7 @@ class FileSystemPreferences extends AbstractPreferences {
      * and lastSyncTime will be unaffected by this call.  This call will
      * NEVER leave prefsFile in a corrupt state.
      */
+    @SuppressWarnings("removal")
     private void writeBackCache() throws BackingStoreException {
         try {
             AccessController.doPrivileged(
@@ -662,6 +677,7 @@ class FileSystemPreferences extends AbstractPreferences {
         return prefsCache.keySet().toArray(new String[prefsCache.size()]);
     }
 
+    @SuppressWarnings("removal")
     protected String[] childrenNamesSpi() {
         return AccessController.doPrivileged(
             new PrivilegedAction<String[]>() {
@@ -700,6 +716,7 @@ class FileSystemPreferences extends AbstractPreferences {
     /**
      * Called with file lock held (in addition to node locks).
      */
+    @SuppressWarnings("removal")
     protected void removeNodeSpi() throws BackingStoreException {
         try {
             AccessController.doPrivileged(
@@ -734,6 +751,7 @@ class FileSystemPreferences extends AbstractPreferences {
         }
     }
 
+    @SuppressWarnings("removal")
     public synchronized void sync() throws BackingStoreException {
         boolean userNode = isUserNode();
         boolean shared;
@@ -783,6 +801,7 @@ class FileSystemPreferences extends AbstractPreferences {
         }
     }
 
+    @SuppressWarnings("removal")
     protected void syncSpi() throws BackingStoreException {
         try {
             AccessController.doPrivileged(

--- a/src/java.prefs/windows/classes/java/util/prefs/WindowsPreferences.java
+++ b/src/java.prefs/windows/classes/java/util/prefs/WindowsPreferences.java
@@ -44,10 +44,14 @@ import sun.util.logging.PlatformLogger;
  * @since 1.4
  */
 
-@SuppressWarnings("removal")
 class WindowsPreferences extends AbstractPreferences {
 
     static {
+        loadPrefsLib();
+    }
+
+    @SuppressWarnings("removal")
+    private static void loadPrefsLib() {
         PrivilegedAction<Void> load = () -> {
             System.loadLibrary("prefs");
             return null;

--- a/src/java.rmi/share/classes/sun/rmi/transport/DGCClient.java
+++ b/src/java.rmi/share/classes/sun/rmi/transport/DGCClient.java
@@ -82,7 +82,6 @@ import java.security.ProtectionDomain;
  * @author  Ann Wollrath
  * @author  Peter Jones
  */
-@SuppressWarnings("removal")
 final class DGCClient {
 
     /** next sequence number for DGC calls (access synchronized on class) */
@@ -92,16 +91,19 @@ final class DGCClient {
     private static VMID vmid = new VMID();
 
     /** lease duration to request (usually ignored by server) */
+    @SuppressWarnings("removal")
     private static final long leaseValue =              // default 10 minutes
         AccessController.doPrivileged((PrivilegedAction<Long>) () ->
             Long.getLong("java.rmi.dgc.leaseValue", 600000));
 
     /** maximum interval between retries of failed clean calls */
+    @SuppressWarnings("removal")
     private static final long cleanInterval =           // default 3 minutes
         AccessController.doPrivileged((PrivilegedAction<Long>) () ->
             Long.getLong("sun.rmi.dgc.cleanInterval", 180000));
 
     /** maximum interval between complete garbage collections of local heap */
+    @SuppressWarnings("removal")
     private static final long gcInterval =              // default 1 hour
         AccessController.doPrivileged((PrivilegedAction<Long>) () ->
             Long.getLong("sun.rmi.dgc.client.gcInterval", 3600000));
@@ -122,12 +124,15 @@ final class DGCClient {
      * An AccessControlContext with only socket permissions,
      * suitable for an RMIClientSocketFactory.
      */
-    private static final AccessControlContext SOCKET_ACC;
-    static {
+    @SuppressWarnings("removal")
+    private static final AccessControlContext SOCKET_ACC = createSocketAcc();
+
+    @SuppressWarnings("removal")
+    private static AccessControlContext createSocketAcc() {
         Permissions perms = new Permissions();
         perms.add(new SocketPermission("*", "connect,resolve"));
         ProtectionDomain[] pd = { new ProtectionDomain(null, perms) };
-        SOCKET_ACC = new AccessControlContext(pd);
+        return new AccessControlContext(pd);
     }
 
     /*
@@ -251,6 +256,7 @@ final class DGCClient {
             }
         }
 
+        @SuppressWarnings("removal")
         private EndpointEntry(final Endpoint endpoint) {
             this.endpoint = endpoint;
             try {
@@ -490,6 +496,7 @@ final class DGCClient {
          *
          * This method must ONLY be called while synchronized on this entry.
          */
+        @SuppressWarnings("removal")
         private void setRenewTime(long newRenewTime) {
             assert Thread.holdsLock(this);
 
@@ -515,6 +522,7 @@ final class DGCClient {
          */
         private class RenewCleanThread implements Runnable {
 
+            @SuppressWarnings("removal")
             public void run() {
                 do {
                     long timeToWait;

--- a/src/java.rmi/share/classes/sun/rmi/transport/DGCImpl.java
+++ b/src/java.rmi/share/classes/sun/rmi/transport/DGCImpl.java
@@ -64,25 +64,29 @@ import sun.rmi.server.Util;
  *
  * @author Ann Wollrath
  */
-@SuppressWarnings({"removal","deprecation"})
+@SuppressWarnings("deprecation")
 final class DGCImpl implements DGC {
 
     /* dgc system log */
+    @SuppressWarnings("removal")
     static final Log dgcLog = Log.getLog("sun.rmi.dgc", "dgc",
         LogStream.parseLevel(AccessController.doPrivileged(
             (PrivilegedAction<String>) () -> System.getProperty("sun.rmi.dgc.logLevel"))));
 
     /** lease duration to grant to clients */
+    @SuppressWarnings("removal")
     private static final long leaseValue =              // default 10 minutes
         AccessController.doPrivileged(
             (PrivilegedAction<Long>) () -> Long.getLong("java.rmi.dgc.leaseValue", 600000));
 
     /** lease check interval; default is half of lease grant duration */
+    @SuppressWarnings("removal")
     private static final long leaseCheckInterval =
         AccessController.doPrivileged(
             (PrivilegedAction<Long>) () -> Long.getLong("sun.rmi.dgc.checkInterval", leaseValue / 2));
 
     /** thread pool for scheduling delayed tasks */
+    @SuppressWarnings("removal")
     private static final ScheduledExecutorService scheduler =
         AccessController.doPrivileged(
             new RuntimeUtil.GetInstanceAction()).getScheduler();
@@ -120,6 +124,7 @@ final class DGCImpl implements DGC {
      * The dgcFilter created from the value of the {@code  "sun.rmi.transport.dgcFilter"}
      * property.
      */
+    @SuppressWarnings("removal")
     private static final ObjectInputFilter dgcFilter =
             AccessController.doPrivileged((PrivilegedAction<ObjectInputFilter>)DGCImpl::initDgcFilter);
 
@@ -315,6 +320,11 @@ final class DGCImpl implements DGC {
     }
 
     static {
+        exportSingleton();
+    }
+
+    @SuppressWarnings("removal")
+    private static void exportSingleton() {
         /*
          * "Export" the singleton DGCImpl in a context isolated from
          * the arbitrary current thread context.

--- a/src/java.rmi/share/classes/sun/rmi/transport/tcp/TCPTransport.java
+++ b/src/java.rmi/share/classes/sun/rmi/transport/tcp/TCPTransport.java
@@ -83,21 +83,24 @@ import sun.rmi.transport.TransportConstants;
  * @author Ann Wollrath
  * @author Peter Jones
  */
-@SuppressWarnings({"removal","deprecation"})
+@SuppressWarnings("deprecation")
 public class TCPTransport extends Transport {
 
     /* tcp package log */
+    @SuppressWarnings("removal")
     static final Log tcpLog = Log.getLog("sun.rmi.transport.tcp", "tcp",
         LogStream.parseLevel(AccessController.doPrivileged(
             (PrivilegedAction<String>) () -> System.getProperty("sun.rmi.transport.tcp.logLevel"))));
 
     /** maximum number of connection handler threads */
+    @SuppressWarnings("removal")
     private static final int maxConnectionThreads =     // default no limit
         AccessController.doPrivileged((PrivilegedAction<Integer>) () ->
             Integer.getInteger("sun.rmi.transport.tcp.maxConnectionThreads",
                                Integer.MAX_VALUE));
 
     /** keep alive time for idle connection handler threads */
+    @SuppressWarnings("removal")
     private static final long threadKeepAliveTime =     // default 1 minute
         AccessController.doPrivileged((PrivilegedAction<Long>) () ->
             Long.getLong("sun.rmi.transport.tcp.threadKeepAliveTime", 60000));
@@ -108,6 +111,7 @@ public class TCPTransport extends Transport {
             threadKeepAliveTime, TimeUnit.MILLISECONDS,
             new SynchronousQueue<Runnable>(),
             new ThreadFactory() {
+                @SuppressWarnings("removal")
                 public Thread newThread(Runnable runnable) {
                     return AccessController.doPrivileged(new NewThreadAction(
                         runnable, "TCP Connection(idle)", true, true));
@@ -122,11 +126,14 @@ public class TCPTransport extends Transport {
         threadConnectionHandler = new ThreadLocal<>();
 
     /** an AccessControlContext with no permissions */
-    private static final AccessControlContext NOPERMS_ACC;
-    static {
+    @SuppressWarnings("removal")
+    private static final AccessControlContext NOPERMS_ACC = createNopermsAcc();
+
+    @SuppressWarnings("removal")
+    private static AccessControlContext createNopermsAcc() {
         Permissions perms = new Permissions();
         ProtectionDomain[] pd = { new ProtectionDomain(null, perms) };
-        NOPERMS_ACC = new AccessControlContext(pd);
+        return new AccessControlContext(pd);
     }
 
     /** endpoints for this transport */
@@ -148,6 +155,7 @@ public class TCPTransport extends Transport {
      * The maximum representable value is slightly more than 24 days
      * and 20 hours.
      */
+    @SuppressWarnings("removal")
     private static final int connectionReadTimeout =    // default 2 hours
         AccessController.doPrivileged((PrivilegedAction<Integer>) () ->
             Integer.getInteger("sun.rmi.transport.tcp.readTimeout", 2 * 3600 * 1000));
@@ -298,7 +306,8 @@ public class TCPTransport extends Transport {
      * Verify that the current access control context has permission to
      * accept the connection being dispatched by the current thread.
      */
-    protected void checkAcceptPermission(AccessControlContext acc) {
+    protected void checkAcceptPermission(@SuppressWarnings("removal") AccessControlContext acc) {
+        @SuppressWarnings("removal")
         SecurityManager sm = System.getSecurityManager();
         if (sm == null) {
             return;
@@ -338,6 +347,7 @@ public class TCPTransport extends Transport {
                  * "port in use" will cause export to hang if an
                  * RMIFailureHandler is not installed.
                  */
+                @SuppressWarnings("removal")
                 Thread t = AccessController.doPrivileged(
                     new NewThreadAction(new AcceptLoop(server),
                                         "TCP Accept-" + port, true));
@@ -350,6 +360,7 @@ public class TCPTransport extends Transport {
 
         } else {
             // otherwise verify security access to existing server socket
+            @SuppressWarnings("removal")
             SecurityManager sm = System.getSecurityManager();
             if (sm != null) {
                 sm.checkListen(port);
@@ -646,11 +657,14 @@ public class TCPTransport extends Transport {
         private static final int POST = 0x504f5354;
 
         /** most recently accept-authorized AccessControlContext */
+        @SuppressWarnings("removal")
         private AccessControlContext okContext;
         /** cache of accept-authorized AccessControlContexts */
+        @SuppressWarnings("removal")
         private Map<AccessControlContext,
                     Reference<AccessControlContext>> authCache;
         /** security manager which authorized contexts in authCache */
+        @SuppressWarnings("removal")
         private SecurityManager cacheSecurityManager = null;
 
         private Socket socket;
@@ -669,6 +683,7 @@ public class TCPTransport extends Transport {
          * Verify that the given AccessControlContext has permission to
          * accept this connection.
          */
+        @SuppressWarnings("removal")
         void checkAcceptPermission(SecurityManager sm,
                                    AccessControlContext acc)
         {
@@ -694,6 +709,7 @@ public class TCPTransport extends Transport {
             okContext = acc;
         }
 
+        @SuppressWarnings("removal")
         public void run() {
             Thread t = Thread.currentThread();
             String name = t.getName();

--- a/src/jdk.attach/share/classes/sun/tools/attach/HotSpotVirtualMachine.java
+++ b/src/jdk.attach/share/classes/sun/tools/attach/HotSpotVirtualMachine.java
@@ -45,15 +45,18 @@ import java.util.stream.Collectors;
  * The HotSpot implementation of com.sun.tools.attach.VirtualMachine.
  */
 
-@SuppressWarnings("removal")
 public abstract class HotSpotVirtualMachine extends VirtualMachine {
 
-    private static final long CURRENT_PID;
+    private static final long CURRENT_PID = pid();
+
+    @SuppressWarnings("removal")
+    private static long pid() {
+        PrivilegedAction<ProcessHandle> pa = () -> ProcessHandle.current();
+        return AccessController.doPrivileged(pa).pid();
+    }
+
     private static final boolean ALLOW_ATTACH_SELF;
     static {
-        PrivilegedAction<ProcessHandle> pa = ProcessHandle::current;
-        CURRENT_PID = AccessController.doPrivileged(pa).pid();
-
         String s = VM.getSavedProperty("jdk.attach.allowAttachSelf");
         ALLOW_ATTACH_SELF = "".equals(s) || Boolean.parseBoolean(s);
     }

--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpChannelImpl.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpChannelImpl.java
@@ -71,7 +71,6 @@ import static sun.nio.ch.sctp.ResultContainer.SHUTDOWN;
 /**
  * An implementation of an SctpChannel
  */
-@SuppressWarnings("removal")
 public class SctpChannelImpl extends SctpChannel
     implements SelChImpl
 {
@@ -188,6 +187,7 @@ public class SctpChannelImpl extends SctpChannel
                         SctpNet.throwAlreadyBoundException();
                     InetSocketAddress isa = (local == null) ?
                         new InetSocketAddress(0) : Net.checkAddress(local);
+                    @SuppressWarnings("removal")
                     SecurityManager sm = System.getSecurityManager();
                     if (sm != null) {
                         sm.checkListen(isa.getPort());
@@ -358,6 +358,7 @@ public class SctpChannelImpl extends SctpChannel
             synchronized (sendLock) {
                 ensureOpenAndUnconnected();
                 InetSocketAddress isa = Net.checkAddress(endpoint);
+                @SuppressWarnings("removal")
                 SecurityManager sm = System.getSecurityManager();
                 if (sm != null)
                     sm.checkConnect(isa.getAddress().getHostAddress(),
@@ -1089,6 +1090,11 @@ public class SctpChannelImpl extends SctpChannel
             boolean unordered, int ppid) throws IOException;
 
     static {
+        loadSctpLibrary();
+    }
+
+    @SuppressWarnings("removal")
+    private static void loadSctpLibrary() {
         IOUtil.load();   /* loads nio & net native libraries */
         java.security.AccessController.doPrivileged(
             new java.security.PrivilegedAction<Void>() {

--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpNet.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpNet.java
@@ -40,8 +40,8 @@ import sun.nio.ch.Net;
 import com.sun.nio.sctp.SctpSocketOption;
 import static com.sun.nio.sctp.SctpStandardSocketOptions.*;
 
-@SuppressWarnings("removal")
 public class SctpNet {
+    @SuppressWarnings("removal")
     private static final String osName = AccessController.doPrivileged(
         (PrivilegedAction<String>) () -> System.getProperty("os.name"));
 
@@ -104,6 +104,7 @@ public class SctpNet {
     private static Set<SocketAddress> getRevealedLocalAddressSet(
             SocketAddress[] saa)
     {
+         @SuppressWarnings("removal")
          SecurityManager sm = System.getSecurityManager();
          Set<SocketAddress> set = new HashSet<>(saa.length);
          for (SocketAddress sa : saa) {
@@ -113,7 +114,7 @@ public class SctpNet {
     }
 
     private static SocketAddress getRevealedLocalAddress(SocketAddress sa,
-                                                         SecurityManager sm)
+                                                         @SuppressWarnings("removal") SecurityManager sm)
     {
         if (sm == null || sa == null)
             return sa;
@@ -336,6 +337,11 @@ public class SctpNet {
     static native void init();
 
     static {
+        loadSctpLibrary();
+    }
+
+    @SuppressWarnings("removal")
+    private static void loadSctpLibrary() {
         IOUtil.load();   // loads nio & net native libraries
         java.security.AccessController.doPrivileged(
                 new java.security.PrivilegedAction<Void>() {


### PR DESCRIPTION
More refactoring to limit the scope of `@SuppressWarnings` annotations.

Sometimes I introduce new methods. Please feel free to suggest method names you like to use.

Note: this is copied from https://github.com/openjdk/jdk17/pull/152.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269409](https://bugs.openjdk.java.net/browse/JDK-8269409): Post JEP 411 refactoring: core-libs with maximum covering > 10K


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * naoto - **Reviewer** ⚠️ Added manually

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4615/head:pull/4615` \
`$ git checkout pull/4615`

Update a local copy of the PR: \
`$ git checkout pull/4615` \
`$ git pull https://git.openjdk.java.net/jdk pull/4615/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4615`

View PR using the GUI difftool: \
`$ git pr show -t 4615`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4615.diff">https://git.openjdk.java.net/jdk/pull/4615.diff</a>

</details>
