### PR TITLE
8263640: hs_err improvement: handle class path longer than O_BUFLEN

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1115,10 +1115,7 @@ void Arguments::print_on(outputStream* st) {
     if (len < O_BUFLEN) {
       st->print_cr("%s", len == 0 ? "<not set>" : path );
     } else {
-      for (size_t i = 0; i < len; i++) {
-        st->put(path[i]);
-      }
-      st->cr();
+      st->print_raw_cr(path, len);
     }
   }
   st->print_cr("Launcher Type: %s", _sun_java_launcher);

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1112,8 +1112,8 @@ void Arguments::print_on(outputStream* st) {
     char* path = _java_class_path->value();
     size_t len = strlen(path);
     st->print("java_class_path (initial): ");
-    if (len < O_BUFLEN) {
-      st->print_cr("%s", len == 0 ? "<not set>" : path );
+    if (len == 0) {
+      st->print_raw_cr("<not set>");
     } else {
       st->print_raw_cr(path, len);
     }

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1110,7 +1110,16 @@ void Arguments::print_on(outputStream* st) {
   st->print_cr("java_command: %s", java_command() ? java_command() : "<unknown>");
   if (_java_class_path != NULL) {
     char* path = _java_class_path->value();
-    st->print_cr("java_class_path (initial): %s", strlen(path) == 0 ? "<not set>" : path );
+    size_t len = strlen(path);
+    st->print("java_class_path (initial): ");
+    if (len < O_BUFLEN) {
+      st->print_cr("%s", len == 0 ? "<not set>" : path );
+    } else {
+      for (size_t i = 0; i < len; i++) {
+        st->put(path[i]);
+      }
+      st->cr();
+    }
   }
   st->print_cr("Launcher Type: %s", _sun_java_launcher);
 }

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1112,6 +1112,7 @@ void Arguments::print_on(outputStream* st) {
     char* path = _java_class_path->value();
     size_t len = strlen(path);
     st->print("java_class_path (initial): ");
+    // Avoid using st->print_cr() because path length maybe longer than O_BUFLEN.
     if (len == 0) {
       st->print_raw_cr("<not set>");
     } else {

--- a/test/hotspot/jtreg/runtime/jcmd/JcmdCmdLine.java
+++ b/test/hotspot/jtreg/runtime/jcmd/JcmdCmdLine.java
@@ -27,7 +27,6 @@
  * @bug 8263640
  * @summary In case of a class path is longer than O_BUFLEN, the class path
  *          should not be truncated in the output from jcmd VM.command_line.
- * @requires vm.cds
  * @library /test/lib
  * @run driver JcmdCmdLine
  */

--- a/test/hotspot/jtreg/runtime/jcmd/JcmdCmdLine.java
+++ b/test/hotspot/jtreg/runtime/jcmd/JcmdCmdLine.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8263640
+ * @summary In case of a class path is longer than O_BUFLEN, the class path
+ *          should not be truncated in the output from jcmd VM.command_line.
+ * @requires vm.cds
+ * @library /test/lib
+ * @run driver JcmdCmdLine
+ */
+
+import java.io.File;
+import java.util.List;
+import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.dcmd.PidJcmdExecutor;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class JcmdCmdLine {
+    private static LingeredApp theApp = null;
+    private static final int BUFFER_LEN = 2000;
+    private static final String JCMD_OPT = "VM.command_line";
+    private static final String CLASS_PATH_LINE = "java_class_path (initial):";
+    private static final String TRUNCATE_WARNING = "outputStream::do_vsnprintf output truncated";
+    public static void main(String[] args) throws Exception {
+        try {
+            theApp = new LingeredApp();
+            theApp.setUseDefaultClasspath(false);
+            String classPath = System.getProperty("test.class.path");
+            while (classPath.length() < BUFFER_LEN) {
+                classPath += File.pathSeparator + classPath;
+            }
+            LingeredApp.startAppExactJvmOpts(theApp, "-cp",  classPath);
+            long pid = theApp.getPid();
+
+            PidJcmdExecutor cmdExecutor = new PidJcmdExecutor(String.valueOf(pid));
+            OutputAnalyzer output = cmdExecutor.execute(JCMD_OPT, true/*silent*/);
+            output.shouldHaveExitValue(0);
+            boolean seenClassPath = false;
+            List<String> lines = output.asLines();
+            for (int i = 0; i < lines.size(); i++) {
+                String line = lines.get(i);
+                if (line.startsWith(CLASS_PATH_LINE)) {
+                    seenClassPath = true;
+                    if (!line.endsWith(classPath)) {
+                        throw new RuntimeException("Incomplete java_class_path line.");
+                    }
+                }
+            }
+            if (!seenClassPath) {
+                throw new RuntimeException("Missing java_class_path line.");
+            }
+        } finally {
+            LingeredApp.stopApp(theApp);
+            if (theApp.getOutput().getStderr().contains(TRUNCATE_WARNING)) {
+                throw new RuntimeException("Unexpected truncation warning.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Please review this patch for handling the printing of class path with length longer than O_BUFLEN.
The bug is also reproducible using the `jcmd VM.command_line`. The new test uses `jcmd` to verify this change.

Testing: 
- [x] tiers 1,2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263640](https://bugs.openjdk.java.net/browse/JDK-8263640): hs_err improvement: handle class path longer than O_BUFLEN


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to b4b645cdd754afa04c024359b66054ee11cf7be6
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**) ⚠️ Review applies to b4b645cdd754afa04c024359b66054ee11cf7be6
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to b4b645cdd754afa04c024359b66054ee11cf7be6


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4616/head:pull/4616` \
`$ git checkout pull/4616`

Update a local copy of the PR: \
`$ git checkout pull/4616` \
`$ git pull https://git.openjdk.java.net/jdk pull/4616/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4616`

View PR using the GUI difftool: \
`$ git pr show -t 4616`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4616.diff">https://git.openjdk.java.net/jdk/pull/4616.diff</a>

</details>
