### PR TITLE
8269232: assert(!is_jweak(handle)) failed: wrong method for detroying jweak

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/commonRef.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/commonRef.c
@@ -205,7 +205,9 @@ weakenNode(JNIEnv *env, RefNode *node)
         }
         return weakRef;
     } else {
-        node->strongCount--;
+        if (node->strongCount > 0) {
+            node->strongCount--;
+        }
         return node->ref;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/EnableCollection/enablecol001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/EnableCollection/enablecol001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -143,7 +143,11 @@ public class enablecol001 {
                 disableObjectCollection(objectID);
 
                 // perform testing JDWP command
-                log.display("\n>>> Testing JDWP command \n");
+                log.display("\n>>> Testing JDWP EnableCollection command after JDWP DisableCollection\n");
+                testCommand(objectID);
+
+                // perform testing JDWP command
+                log.display("\n>>> Testing JDWP EnableCollection command with no JDWP DisableCollection\n");
                 testCommand(objectID);
 
             } finally {


### PR DESCRIPTION
Don't let node->strongRef go below 0, or we end up thinking we still have a strongref when it is a weakref. Note the fact that we are doing nesting counts is still a bug (and the main cause of this issue). However, the fix for that is more complex, and for 17 I would prefer to just apply this simpler fix. For addressing the bigger issue, I filed the following:

    [JDK-8269542](https://bugs.openjdk.java.net/browse/JDK-8269542): JDWP: EnableCollection support is no longer spec compliant after [JDK-8255987](https://bugs.openjdk.java.net/browse/JDK-8255987) 