### PR TITLE
8269416: [JVMCI] capture libjvmci crash data to a file

### DIFF
--- a/src/hotspot/share/jvmci/jvmci.cpp
+++ b/src/hotspot/share/jvmci/jvmci.cpp
@@ -220,12 +220,12 @@ void JVMCI::fatal_log(const char* buf, size_t count) {
   intx invalid_id = -1;
   int log_fd;
   if (_fatal_log_init_thread == invalid_id && Atomic::cmpxchg(&_fatal_log_init_thread, invalid_id, current_thread_id) == invalid_id) {
-    static char name_buffer[O_BUFLEN];
     if (ErrorFileToStdout) {
       log_fd = 1;
     } else if (ErrorFileToStderr) {
       log_fd = 2;
     } else {
+      static char name_buffer[O_BUFLEN];
       log_fd = VMError::prepare_log_file(JVMCINativeLibraryErrorFile, LIBJVMCI_ERR_FILE, true, name_buffer, sizeof(name_buffer));
       if (log_fd != -1) {
         _fatal_log_filename = name_buffer;

--- a/src/hotspot/share/jvmci/jvmci.hpp
+++ b/src/hotspot/share/jvmci/jvmci.hpp
@@ -74,14 +74,14 @@ class JVMCI : public AllStatic {
   // Access to the HotSpot heap based JVMCIRuntime
   static JVMCIRuntime* _java_runtime;
 
-  // The stream to which fatal_log() writes. The stream is configured on
+  // The file descriptor to which fatal_log() writes. Initialized on
   // first call to fatal_log().
-  static volatile outputStream* _fatal_log_stream;
+  static volatile int _fatal_log_fd;
 
-  // The path of the file underlying _fatal_log_stream if it is a fileStream.
+  // The path of the file underlying _fatal_log_fd if it is a normal file.
   static const char* _fatal_log_filename;
 
-  // Native thread id of thread that will initialize _fatal_log_stream.
+  // Native thread id of thread that will initialize _fatal_log_fd.
   static volatile intx _fatal_log_init_thread;
 
   // JVMCI event log (shows up in hs_err crash logs).

--- a/src/hotspot/share/jvmci/jvmci.hpp
+++ b/src/hotspot/share/jvmci/jvmci.hpp
@@ -74,6 +74,16 @@ class JVMCI : public AllStatic {
   // Access to the HotSpot heap based JVMCIRuntime
   static JVMCIRuntime* _java_runtime;
 
+  // The stream to which fatal_log() writes. The stream is configured on
+  // first call to fatal_log().
+  static volatile outputStream* _fatal_log_stream;
+
+  // The path of the file underlying _fatal_log_stream if it is a fileStream.
+  static const char* _fatal_log_filename;
+
+  // Native thread id of thread that will initialize _fatal_log_stream.
+  static volatile intx _fatal_log_init_thread;
+
   // JVMCI event log (shows up in hs_err crash logs).
   static StringEventLog* _events;
   static StringEventLog* _verbose_events;
@@ -99,6 +109,13 @@ class JVMCI : public AllStatic {
   // which the library is loaded is returned in `path`. If
   // `load` is true then JVMCI_lock must be locked.
   static void* get_shared_library(char*& path, bool load);
+
+  // Logs the fatal crash data in `buf` to the appropriate stream.
+  static void fatal_log(const char* buf, size_t count);
+
+  // Gets the name of the opened JVMCI shared library crash data file or NULL
+  // if this file has not been created.
+  static const char* fatal_log_filename() { return _fatal_log_filename; }
 
   static void do_unloading(bool unloading_occurred);
 

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -891,6 +891,12 @@ static void _log(const char* buf, size_t count) {
   tty->write((char*) buf, count);
 }
 
+// Function for redirecting shared library JavaVM fatal error data to a log file.
+// The log file is opened on first call to this function.
+static void _fatal_log(const char* buf, size_t count) {
+  JVMCI::fatal_log(buf, count);
+}
+
 // Function for shared library JavaVM to flush tty
 static void _flush_log() {
   tty->flush();
@@ -898,7 +904,8 @@ static void _flush_log() {
 
 // Function for shared library JavaVM to exit HotSpot on a fatal error
 static void _fatal() {
-  fatal("Fatal error in JVMCI shared library");
+  intx current_thread_id = os::current_thread_id();
+  fatal("thread " INTX_FORMAT ": Fatal error in JVMCI shared library", current_thread_id);
 }
 
 JNIEnv* JVMCIRuntime::init_shared_library_javavm() {
@@ -925,7 +932,7 @@ JNIEnv* JVMCIRuntime::init_shared_library_javavm() {
     JavaVMInitArgs vm_args;
     vm_args.version = JNI_VERSION_1_2;
     vm_args.ignoreUnrecognized = JNI_TRUE;
-    JavaVMOption options[4];
+    JavaVMOption options[5];
     jlong javaVM_id = 0;
 
     // Protocol: JVMCI shared library JavaVM should support a non-standard "_javavm_id"
@@ -940,6 +947,8 @@ JNIEnv* JVMCIRuntime::init_shared_library_javavm() {
     options[2].extraInfo = (void*) _flush_log;
     options[3].optionString = (char*) "_fatal";
     options[3].extraInfo = (void*) _fatal;
+    options[4].optionString = (char*) "_fatal_log";
+    options[4].extraInfo = (void*) _fatal_log;
 
     vm_args.version = JNI_VERSION_1_2;
     vm_args.options = options;

--- a/src/hotspot/share/jvmci/jvmci_globals.cpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.cpp
@@ -121,6 +121,7 @@ bool JVMCIGlobals::check_jvmci_flags_are_consistent() {
   CHECK_NOT_SET(JVMCIPrintProperties,         EnableJVMCI)
   CHECK_NOT_SET(UseJVMCINativeLibrary,        EnableJVMCI)
   CHECK_NOT_SET(JVMCILibPath,                 EnableJVMCI)
+  CHECK_NOT_SET(JVMCINativeLibraryErrorFile,  EnableJVMCI)
   CHECK_NOT_SET(JVMCILibDumpJNIConfig,        EnableJVMCI)
 
 #ifndef COMPILER2
@@ -176,6 +177,7 @@ bool JVMCIGlobals::enable_jvmci_product_mode(JVMFlagOrigin origin) {
     "JVMCILibPath",
     "JVMCILibDumpJNIConfig",
     "UseJVMCINativeLibrary",
+    "JVMCINativeLibraryErrorFile",
     NULL
   };
 

--- a/src/hotspot/share/jvmci/jvmci_globals.hpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.hpp
@@ -30,6 +30,8 @@
 
 class fileStream;
 
+#define LIBJVMCI_ERR_FILE "hs_err_pid%p_libjvmci.log"
+
 //
 // Declare all global flags used by the JVMCI compiler. Only flags that need
 // to be accessible to the JVMCI C++ code should be defined here.
@@ -122,6 +124,11 @@ class fileStream;
           "instead of loading it from class files and executing it "        \
           "on the HotSpot heap. Defaults to true if EnableJVMCIProduct is " \
           "true and a JVMCI native library is available.")                  \
+                                                                            \
+  product(ccstr, JVMCINativeLibraryErrorFile, NULL, EXPERIMENTAL,           \
+          "If an error in the JVMCI native library occurs, save the "       \
+          "error data to this file"                                         \
+          "[default: ./" LIBJVMCI_ERR_FILE "] (%p replaced with pid)")      \
                                                                             \
   NOT_COMPILER2(product(bool, UseMultiplyToLenIntrinsic, false, DIAGNOSTIC, \
           "Enables intrinsification of BigInteger.multiplyToLen()"))        \

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1589,7 +1589,7 @@ void VMError::report_and_die(int id, const char* message, const char* detail_fmt
 
 #if INCLUDE_JVMCI
   if (JVMCI::fatal_log_filename() != NULL) {
-    out.print_raw("#\n# The JVMCI shared library error data is saved as:\n# ");
+    out.print_raw("#\n# The JVMCI shared library error report file is saved as:\n# ");
     out.print_raw_cr(JVMCI::fatal_log_filename());
   }
 #endif

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -63,6 +63,9 @@
 #if INCLUDE_JFR
 #include "jfr/jfr.hpp"
 #endif
+#if INCLUDE_JVMCI
+#include "jvmci/jvmci.hpp"
+#endif
 
 #ifndef PRODUCT
 #include <signal.h>
@@ -1273,7 +1276,7 @@ static int expand_and_open(const char* pattern, bool overwrite_existing, char* b
  * Name and location depends on pattern, default_pattern params and access
  * permissions.
  */
-static int prepare_log_file(const char* pattern, const char* default_pattern, bool overwrite_existing, char* buf, size_t buflen) {
+int VMError::prepare_log_file(const char* pattern, const char* default_pattern, bool overwrite_existing, char* buf, size_t buflen) {
   int fd = -1;
 
   // If possible, use specified pattern to construct log file name
@@ -1583,6 +1586,13 @@ void VMError::report_and_die(int id, const char* message, const char* detail_fmt
       }
     }
   }
+
+#if INCLUDE_JVMCI
+  if (JVMCI::fatal_log_filename() != NULL) {
+    out.print_raw("#\n# The JVMCI shared library error data is saved as:\n# ");
+    out.print_raw_cr(JVMCI::fatal_log_filename());
+  }
+#endif
 
   static bool skip_bug_url = !should_submit_bug_report(_id);
   if (!skip_bug_url) {

--- a/src/hotspot/share/utilities/vmError.hpp
+++ b/src/hotspot/share/utilities/vmError.hpp
@@ -184,5 +184,10 @@ public:
   // Needed when printing signal handlers.
   NOT_WINDOWS(static const void* crash_handler_address;)
 
+  // Construct file name for a log file and return it's file descriptor.
+  // Name and location depends on pattern, default_pattern params and access
+  // permissions.
+  static int prepare_log_file(const char* pattern, const char* default_pattern, bool overwrite_existing, char* buf, size_t buflen);
+
 };
 #endif // SHARE_UTILITIES_VMERROR_HPP


### PR DESCRIPTION
When a fatal error occurs in libgraal, it writes a crash dump to `tty`. Instead, it should be captured in a separate log file that is then referenced in the HotSpot crash summary (just like the hs_err_pid and CI replay compile log files are). This allows libgraal crash data to be more easily submitted along with VM crash reports.

For example:
```
> java -Dlibgraal.CrashAtIsFatal=true -Dgraal.CrashAt=String.equals -cp bin CountUppercase skjdf
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (jvmciRuntime.cpp:909), pid=36298, tid=41219
#  fatal error: thread 41219: Fatal error in JVMCI shared library
#
# JRE version: OpenJDK Runtime Environment GraalVM LIBGRAAL 21.3.0-dev (16.0.2) (build 16.0.2-internal+0-adhoc.dnsimon.labsjdk-ce-16)
# Java VM: OpenJDK 64-Bit Server VM GraalVM LIBGRAAL 21.3.0-dev (16.0.2-internal+0-adhoc.dnsimon.labsjdk-ce-16, mixed mode, tiered, jvmci, jvmci compiler, compressed oops, compressed class ptrs, g1 gc, bsd-amd64)
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# An error report file with more information is saved as:
# /Users/dnsimon/graal/graal/compiler/hs_err_pid36298.log
#
# The JVMCI shared library error data is saved as:
# /Users/dnsimon/graal/graal/compiler/hs_err_pid36298_libjvmci.log
#
# If you would like to submit a bug report, please visit:
#   https://bugreport.java.com/bugreport/crash.jsp
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
#
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269416](https://bugs.openjdk.java.net/browse/JDK-8269416): [JVMCI] capture libjvmci crash data to a file


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to ba004ef0b39f2d8d526a8195b497f9e4f2e56b3e
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to ba004ef0b39f2d8d526a8195b497f9e4f2e56b3e


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4620/head:pull/4620` \
`$ git checkout pull/4620`

Update a local copy of the PR: \
`$ git checkout pull/4620` \
`$ git pull https://git.openjdk.java.net/jdk pull/4620/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4620`

View PR using the GUI difftool: \
`$ git pr show -t 4620`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4620.diff">https://git.openjdk.java.net/jdk/pull/4620.diff</a>

</details>
