### PR TITLE
8269481: SctpMultiChannel never releases own file descriptor

### DIFF
--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpChannelImpl.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpChannelImpl.java
@@ -639,8 +639,8 @@ public class SctpChannelImpl extends SctpChannel
             if (state == ChannelState.KILLED)
                 return;
             if (state == ChannelState.UNINITIALIZED) {
-                SctpNet.close(fdVal);
                 state = ChannelState.KILLED;
+                SctpNet.close(fdVal);
                 return;
             }
             assert !isOpen() && !isRegistered();

--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpChannelImpl.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpChannelImpl.java
@@ -639,6 +639,7 @@ public class SctpChannelImpl extends SctpChannel
             if (state == ChannelState.KILLED)
                 return;
             if (state == ChannelState.UNINITIALIZED) {
+                SctpNet.close(fdVal);
                 state = ChannelState.KILLED;
                 return;
             }

--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpChannelImpl.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpChannelImpl.java
@@ -648,8 +648,8 @@ public class SctpChannelImpl extends SctpChannel
             /* Postpone the kill if there is a waiting reader
              * or writer thread. */
             if (receiverThread == 0 && senderThread == 0) {
-                SctpNet.close(fdVal);
                 state = ChannelState.KILLED;
+                SctpNet.close(fdVal);
             } else {
                 state = ChannelState.KILLPENDING;
             }

--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpMultiChannelImpl.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpMultiChannelImpl.java
@@ -373,6 +373,7 @@ public class SctpMultiChannelImpl extends SctpMultiChannel
             if (state == ChannelState.KILLED)
                 return;
             if (state == ChannelState.UNINITIALIZED) {
+                SctpNet.close(fdVal);
                 state = ChannelState.KILLED;
                 return;
             }

--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpMultiChannelImpl.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpMultiChannelImpl.java
@@ -373,8 +373,8 @@ public class SctpMultiChannelImpl extends SctpMultiChannel
             if (state == ChannelState.KILLED)
                 return;
             if (state == ChannelState.UNINITIALIZED) {
-                SctpNet.close(fdVal);
                 state = ChannelState.KILLED;
+                SctpNet.close(fdVal);
                 return;
             }
             assert !isOpen() && !isRegistered();

--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpMultiChannelImpl.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpMultiChannelImpl.java
@@ -381,8 +381,8 @@ public class SctpMultiChannelImpl extends SctpMultiChannel
 
             /* Postpone the kill if there is a thread sending or receiving. */
             if (receiverThread == 0 && senderThread == 0) {
-                SctpNet.close(fdVal);
                 state = ChannelState.KILLED;
+                SctpNet.close(fdVal);
             } else {
                 state = ChannelState.KILLPENDING;
             }

--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpServerChannelImpl.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpServerChannelImpl.java
@@ -281,6 +281,7 @@ public class SctpServerChannelImpl extends SctpServerChannel
             if (state == ChannelState.KILLED)
                 return;
             if (state == ChannelState.UNINITIALIZED) {
+                SctpNet.close(fdVal);
                 state = ChannelState.KILLED;
                 return;
             }

--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpServerChannelImpl.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpServerChannelImpl.java
@@ -281,8 +281,8 @@ public class SctpServerChannelImpl extends SctpServerChannel
             if (state == ChannelState.KILLED)
                 return;
             if (state == ChannelState.UNINITIALIZED) {
-                SctpNet.close(fdVal);
                 state = ChannelState.KILLED;
+                SctpNet.close(fdVal);
                 return;
             }
             assert !isOpen() && !isRegistered();

--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpServerChannelImpl.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpServerChannelImpl.java
@@ -289,8 +289,8 @@ public class SctpServerChannelImpl extends SctpServerChannel
 
             // Postpone the kill if there is a thread in accept
             if (thread == 0) {
-                SctpNet.close(fdVal);
                 state = ChannelState.KILLED;
+                SctpNet.close(fdVal);
             } else {
                 state = ChannelState.KILLPENDING;
             }

--- a/test/jdk/com/sun/nio/sctp/SctpMultiChannel/CloseDescriptors.java
+++ b/test/jdk/com/sun/nio/sctp/SctpMultiChannel/CloseDescriptors.java
@@ -29,6 +29,10 @@
 
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
 import com.sun.nio.sctp.MessageInfo;
 import com.sun.nio.sctp.SctpMultiChannel;
 
@@ -41,6 +45,17 @@ public class CloseDescriptors {
     public static void main(String[] args) throws Exception {
         if (!Util.isSCTPSupported()) {
             System.out.println("SCTP protocol is not supported");
+            System.out.println("Test cannot be run");
+            return;
+        }
+
+        List<String> lsofDirs = List.of("/usr/bin", "/usr/sbin");
+        Optional<Path> lsof = lsofDirs.stream()
+                .map(s -> Path.of(s, "lsof"))
+                .filter(f -> Files.isExecutable(f))
+                .findFirst();
+        if (!lsof.isPresent()) {
+            System.out.println("Cannot locate lsof in " + lsofDirs);
             System.out.println("Test cannot be run");
             return;
         }
@@ -65,9 +80,9 @@ public class CloseDescriptors {
         }
         System.out.println("end");
 
-        long myPid = ProcessHandle.current().pid();
+        long pid = ProcessHandle.current().pid();
         ProcessBuilder pb = new ProcessBuilder(
-                "lsof", "-U", "-a", "-p", Long.toString(myPid));
+                lsof.get().toString(), "-U", "-a", "-p", Long.toString(pid));
         Process p = pb.start();
         Object[] lines = p.inputReader().lines().toArray();
         p.waitFor();

--- a/test/jdk/com/sun/nio/sctp/SctpMultiChannel/CloseDescriptors.java
+++ b/test/jdk/com/sun/nio/sctp/SctpMultiChannel/CloseDescriptors.java
@@ -87,10 +87,9 @@ public class CloseDescriptors {
         p.waitFor();
 
         int nfds = lines.length - 1;
-        if (nfds > 3) {
-            String msg =
-                String.format("Number of open descriptors (%d) > 2%n", nfds);
-            throw new RuntimeException(msg);
+        if (nfds > MAX_DESC) {
+            throw new RuntimeException("Number of open descriptors " +
+                nfds + " > " + MAX_DESC);
         }
     }
 

--- a/test/jdk/com/sun/nio/sctp/SctpMultiChannel/CloseDescriptors.java
+++ b/test/jdk/com/sun/nio/sctp/SctpMultiChannel/CloseDescriptors.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8269481
+ * @summary Tests that file descriptors are closed
+ * @requires (os.family == "linux")
+ */
+
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import com.sun.nio.sctp.MessageInfo;
+import com.sun.nio.sctp.SctpMultiChannel;
+
+public class CloseDescriptors {
+
+    private static final int NUM      = 5;
+    private static final int SIZE     = 1024;
+    private static final int MAX_DESC = 3;
+
+    public static void main(String[] args) throws Exception {
+        if (!Util.isSCTPSupported()) {
+            System.out.println("SCTP protocol is not supported");
+            System.out.println("Test cannot be run");
+            return;
+        }
+
+        int port = 12345;
+        if (args.length == 1) {
+            try {
+                port = Integer.parseInt(args[0]);
+            } catch (Exception e) {
+            }
+        }
+
+        Thread server = new Server(port);
+        server.start();
+        Thread.sleep(100); // wait for server to be ready
+
+        System.out.println("begin");
+        for (int i = 0; i < 5; ++i) {
+            System.out.println(i);
+            doIt(port);
+            Thread.sleep(100);
+        }
+        System.out.println("end");
+
+        long myPid = ProcessHandle.current().pid();
+        ProcessBuilder pb = new ProcessBuilder(
+                "lsof", "-U", "-a", "-p", Long.toString(myPid));
+        Process p = pb.start();
+        Object[] lines = p.inputReader().lines().toArray();
+        p.waitFor();
+
+        server.join();
+
+        int nfds = lines.length - 1;
+        if (nfds > 3) {
+            String msg =
+                String.format("Number of open descriptors (%d) > 2%n", nfds);
+            throw new RuntimeException(msg);
+        }
+    }
+
+    static void doIt(int port) throws Exception {
+        InetSocketAddress sa = new InetSocketAddress("localhost", port);
+
+        for (int i = 0; i < NUM; ++i) {
+            System.out.println("  " + i);
+            SctpMultiChannel channel = SctpMultiChannel.open();
+            channel.configureBlocking(true);
+            MessageInfo info = MessageInfo.createOutgoing(sa, 0);
+            ByteBuffer buffer = ByteBuffer.allocateDirect(SIZE);
+            channel.send(buffer, info);
+            channel.close();
+
+            Thread.sleep(200);
+        }
+    }
+
+    static class Server extends Thread {
+        int port;
+
+        Server(int port) {
+            this.port = port;
+        }
+
+        @Override
+        public void run() {
+            for (int i = 0; i < NUM; i++) {
+                try {
+                    SctpMultiChannel sm = SctpMultiChannel.open();
+                    InetSocketAddress sa =
+                        new InetSocketAddress("localhost", port);
+                    sm.bind(sa);
+                    ByteBuffer buffer = ByteBuffer.allocateDirect(SIZE);
+                    MessageInfo info = sm.receive(buffer, null, null);
+                    sm.close();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Please review this change to the Unix implementations of `sun.nio.ch.sctp.Sctp*ChannelImpl#kill()` to close the socket if `state == ChannelState.UNINITIALIZED`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269481](https://bugs.openjdk.java.net/browse/JDK-8269481): SctpMultiChannel never releases own file descriptor


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to 8ca5b5c086e3c05682f47908e79a126df36dff8d
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4621/head:pull/4621` \
`$ git checkout pull/4621`

Update a local copy of the PR: \
`$ git checkout pull/4621` \
`$ git pull https://git.openjdk.java.net/jdk pull/4621/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4621`

View PR using the GUI difftool: \
`$ git pr show -t 4621`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4621.diff">https://git.openjdk.java.net/jdk/pull/4621.diff</a>

</details>
