### PR TITLE
JDK-8269571: NMT should print total malloc bytes and invocation count

### DIFF
--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -60,6 +60,15 @@ size_t MemoryCounter::peak_size() const {
 }
 #endif
 
+// Total malloc invocation count
+size_t MallocMemorySnapshot::total_count() const {
+  size_t amount = 0;
+  for (int index = 0; index < mt_number_of_types; index ++) {
+    amount += _malloc[index].malloc_count();
+  }
+  return amount;
+}
+
 // Total malloc'd memory amount
 size_t MallocMemorySnapshot::total() const {
   size_t amount = 0;

--- a/src/hotspot/share/services/mallocTracker.hpp
+++ b/src/hotspot/share/services/mallocTracker.hpp
@@ -153,6 +153,8 @@ class MallocMemorySnapshot : public ResourceObj {
     return &_tracking_header;
   }
 
+  // Total malloc invocation count
+  size_t total_count() const;
   // Total malloc'd memory amount
   size_t total() const;
   // Total malloc'd memory used by arenas

--- a/src/hotspot/share/services/memReporter.cpp
+++ b/src/hotspot/share/services/memReporter.cpp
@@ -98,10 +98,12 @@ void MemReporterBase::print_virtual_memory_region(const char* type, address base
 
 void MemSummaryReporter::report() {
   outputStream* out = output();
-  size_t total_reserved_amount = _malloc_snapshot->total() +
-    _vm_snapshot->total_reserved();
-  size_t total_committed_amount = _malloc_snapshot->total() +
-    _vm_snapshot->total_committed();
+  const size_t total_malloced_bytes = _malloc_snapshot->total();
+  const size_t total_mmap_reserved_bytes = _vm_snapshot->total_reserved();
+  const size_t total_mmap_committed_bytes = _vm_snapshot->total_committed();
+
+  size_t total_reserved_amount = total_malloced_bytes + total_mmap_reserved_bytes;
+  size_t total_committed_amount = total_malloced_bytes + total_mmap_committed_bytes;
 
   // Overall total
   out->print_cr("\nNative Memory Tracking:\n");
@@ -113,7 +115,14 @@ void MemSummaryReporter::report() {
 
   out->print("Total: ");
   print_total(total_reserved_amount, total_committed_amount);
-  out->print("\n");
+  out->cr();
+  out->print_cr("       malloc: " SIZE_FORMAT "%s #" SIZE_FORMAT,
+                amount_in_current_scale(total_malloced_bytes), current_scale(),
+                _malloc_snapshot->total_count());
+  out->print("       mmap:   ");
+  print_total(total_mmap_reserved_bytes, total_mmap_committed_bytes);
+  out->cr();
+  out->cr();
 
   // Summary by memory type
   for (int index = 0; index < mt_number_of_types; index ++) {


### PR DESCRIPTION
At the moment NMT prints a total of reserved and committed bytes. If one wants to know how much C-Heap the VM uses, one needs to add all numbers from the sub categories.

It would be helpful would NMT print the total number of malloced memory and additionally the malloc invocation count.

----

This patch modifes the printout to print, in addition to totals, the number of malloced bytes, malloc invocation counts, and number of mmap reserved/committed bytes. This mirrors the way we print individual sub categories and allocation sites.

Before:
```
Native Memory Tracking:

Total: reserved=18489703KB, committed=1183967KB
```

After:

```
Native Memory Tracking:

Total: reserved=18491726KB, committed=1183178KB
       malloc: 40590KB #13669
       mmap:   reserved=18451136KB, committed=1142588KB
```

Tests: Ran hotspot/runtime/NMT jtreg tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269571](https://bugs.openjdk.java.net/browse/JDK-8269571): NMT should print total malloc bytes and invocation count


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Xin Liu](https://openjdk.java.net/census#xliu) (@navyxliu - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4622/head:pull/4622` \
`$ git checkout pull/4622`

Update a local copy of the PR: \
`$ git checkout pull/4622` \
`$ git pull https://git.openjdk.java.net/jdk pull/4622/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4622`

View PR using the GUI difftool: \
`$ git pr show -t 4622`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4622.diff">https://git.openjdk.java.net/jdk/pull/4622.diff</a>

</details>
