### PR TITLE
8269596: Snapshot soft ref policy before marking/copying

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2991,6 +2991,7 @@ void G1CollectedHeap::do_collection_pause_at_safepoint_helper(double target_paus
         // G1CollectedHeap::ref_processing_init() to see how
         // reference processing currently works in G1.
         _ref_processor_stw->enable_discovery();
+        _ref_processor_stw->setup_policy(false);
 
         // We want to temporarily turn off discovery by the
         // CM ref processor, if necessary, and turn it back on
@@ -3269,8 +3270,6 @@ void G1CollectedHeap::process_discovered_references(G1ParScanThreadStateSet* per
   pss->set_ref_discoverer(NULL);
   assert(pss->queue_is_empty(), "pre-condition");
 
-  // Setup the soft refs policy...
-  rp->setup_policy(false);
 
   ReferenceProcessorPhaseTimes& pt = *phase_times()->ref_phase_times();
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2990,8 +2990,7 @@ void G1CollectedHeap::do_collection_pause_at_safepoint_helper(double target_paus
         // Please see comment in g1CollectedHeap.hpp and
         // G1CollectedHeap::ref_processing_init() to see how
         // reference processing currently works in G1.
-        _ref_processor_stw->enable_discovery();
-        _ref_processor_stw->setup_policy(false);
+        _ref_processor_stw->start_discovery(false /* always_clear */);
 
         // We want to temporarily turn off discovery by the
         // CM ref processor, if necessary, and turn it back on

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1125,7 +1125,7 @@ void G1ConcurrentMark::remark() {
 
   bool const mark_finished = !has_overflown();
   if (mark_finished) {
-    weak_refs_work(false /* clear_all_soft_refs */);
+    weak_refs_work();
 
     SATBMarkQueueSet& satb_mq_set = G1BarrierSet::satb_mark_queue_set();
     // We're done with marking.
@@ -1492,7 +1492,7 @@ public:
   }
 };
 
-void G1ConcurrentMark::weak_refs_work(bool clear_all_soft_refs) {
+void G1ConcurrentMark::weak_refs_work() {
   ResourceMark rm;
 
   // Is alive closure.
@@ -1506,8 +1506,6 @@ void G1ConcurrentMark::weak_refs_work(bool clear_all_soft_refs) {
     // See the comment in G1CollectedHeap::ref_processing_init()
     // about how reference processing currently works in G1.
 
-    // Set the soft reference policy
-    rp->setup_policy(clear_all_soft_refs);
     assert(_global_mark_stack.is_empty(), "mark stack should be empty");
 
     // We need at least one active thread. If reference processing

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -716,9 +716,7 @@ void G1ConcurrentMark::pre_concurrent_start(GCCause::Cause cause) {
 void G1ConcurrentMark::post_concurrent_mark_start() {
   // Start Concurrent Marking weak-reference discovery.
   ReferenceProcessor* rp = _g1h->ref_processor_cm();
-  // enable ("weak") refs discovery
-  rp->enable_discovery();
-  rp->setup_policy(false); // snapshot the soft ref policy to be used in this cycle
+  rp->start_discovery(false /* always_clear */);
 
   SATBMarkQueueSet& satb_mq_set = G1BarrierSet::satb_mark_queue_set();
   // This is the start of  the marking cycle, we're expected all

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -362,8 +362,7 @@ class G1ConcurrentMark : public CHeapObj<mtGC> {
 
   void finalize_marking();
 
-  void weak_refs_work_parallel_part(BoolObjectClosure* is_alive, bool purged_classes);
-  void weak_refs_work(bool clear_all_soft_refs);
+  void weak_refs_work();
 
   void report_object_count(bool mark_completed);
 

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -182,8 +182,7 @@ void G1FullCollector::prepare_collection() {
   PrepareRegionsClosure cl(this);
   _heap->heap_region_iterate(&cl);
 
-  reference_processor()->enable_discovery();
-  reference_processor()->setup_policy(scope()->should_clear_soft_refs());
+  reference_processor()->start_discovery(scope()->should_clear_soft_refs());
 
   // Clear and activate derived pointer collection.
   clear_and_activate_derived_pointers();

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -1786,10 +1786,7 @@ bool PSParallelCompact::invoke_no_policy(bool maximum_heap_compaction) {
     DerivedPointerTable::clear();
 #endif
 
-    ref_processor()->enable_discovery();
-    ref_processor()->setup_policy(maximum_heap_compaction);
-
-    bool marked_for_unloading = false;
+    ref_processor()->start_discovery(maximum_heap_compaction);
 
     marking_start.update();
     marking_phase(vmthread_cm, maximum_heap_compaction, &_gc_tracer);

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -448,8 +448,7 @@ bool PSScavenge::invoke_no_policy() {
     DerivedPointerTable::clear();
 #endif
 
-    reference_processor()->enable_discovery();
-    reference_processor()->setup_policy(false);
+    reference_processor()->start_discovery(false /* always_clear */);
 
     const PreGenGCValues pre_gc_values = heap->get_pre_gc_values();
 

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -485,7 +485,6 @@ bool PSScavenge::invoke_no_policy() {
     {
       GCTraceTime(Debug, gc, phases) tm("Reference Processing", &_gc_timer);
 
-      reference_processor()->setup_policy(false); // not always_clear
       reference_processor()->set_active_mt_degree(active_workers);
       ReferenceProcessorStats stats;
       ReferenceProcessorPhaseTimes pt(&_gc_timer, reference_processor()->max_num_queues());

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -584,7 +584,6 @@ void DefNewGeneration::collect(bool   full,
 
   FastKeepAliveClosure keep_alive(this, &scan_weak_ref);
   ReferenceProcessor* rp = ref_processor();
-  rp->setup_policy(clear_all_soft_refs);
   ReferenceProcessorPhaseTimes pt(_gc_timer, rp->max_num_queues());
   SerialGCRefProcProxyTask task(is_alive, keep_alive, evacuate_followers);
   const ReferenceProcessorStats& stats = rp->process_discovered_references(task, pt);

--- a/src/hotspot/share/gc/serial/genMarkSweep.cpp
+++ b/src/hotspot/share/gc/serial/genMarkSweep.cpp
@@ -77,7 +77,6 @@ void GenMarkSweep::invoke_at_safepoint(ReferenceProcessor* rp, bool clear_all_so
   assert(ref_processor() == NULL, "no stomping");
   assert(rp != NULL, "should be non-NULL");
   set_ref_processor(rp);
-  rp->setup_policy(clear_all_softrefs);
 
   gch->trace_heap_before_gc(_gc_tracer);
 
@@ -198,7 +197,6 @@ void GenMarkSweep::mark_sweep_phase1(bool clear_all_softrefs) {
   {
     GCTraceTime(Debug, gc, phases) tm_m("Reference Processing", gc_timer());
 
-    ref_processor()->setup_policy(clear_all_softrefs);
     ReferenceProcessorPhaseTimes pt(_gc_timer, ref_processor()->max_num_queues());
     SerialGCRefProcProxyTask task(is_alive, keep_alive, follow_stack_closure);
     const ReferenceProcessorStats& stats = ref_processor()->process_discovered_references(task, pt);

--- a/src/hotspot/share/gc/serial/genMarkSweep.hpp
+++ b/src/hotspot/share/gc/serial/genMarkSweep.hpp
@@ -28,7 +28,6 @@
 #include "gc/serial/markSweep.hpp"
 
 class GenMarkSweep : public MarkSweep {
-  friend class VM_MarkSweep;
  public:
   static void invoke_at_safepoint(ReferenceProcessor* rp, bool clear_all_softrefs);
 

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -478,12 +478,10 @@ void GenCollectedHeap::collect_generation(Generation* gen, bool full, size_t siz
     // enqueue_discovered_references if the generation returns
     // without doing any work.
     ReferenceProcessor* rp = gen->ref_processor();
-    rp->enable_discovery();
-    rp->setup_policy(clear_soft_refs);
+    rp->start_discovery(clear_soft_refs);
 
     gen->collect(full, clear_soft_refs, size, is_tlab);
 
-    rp->disable_discovery();
     rp->verify_no_references_recorded();
   }
 

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -482,6 +482,7 @@ void GenCollectedHeap::collect_generation(Generation* gen, bool full, size_t siz
 
     gen->collect(full, clear_soft_refs, size, is_tlab);
 
+    rp->disable_discovery();
     rp->verify_no_references_recorded();
   }
 

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -478,16 +478,11 @@ void GenCollectedHeap::collect_generation(Generation* gen, bool full, size_t siz
     // enqueue_discovered_references if the generation returns
     // without doing any work.
     ReferenceProcessor* rp = gen->ref_processor();
-    // If the discovery of ("weak") refs in this generation is
-    // atomic wrt other collectors in this configuration, we
-    // are guaranteed to have empty discovered ref lists.
-    if (rp->discovery_is_atomic()) {
-      rp->enable_discovery();
-      rp->setup_policy(clear_soft_refs);
-    } else {
-      // collect() below will enable discovery as appropriate
-    }
+    rp->enable_discovery();
+    rp->setup_policy(clear_soft_refs);
+
     gen->collect(full, clear_soft_refs, size, is_tlab);
+
     rp->disable_discovery();
     rp->verify_no_references_recorded();
   }

--- a/src/hotspot/share/gc/shared/referenceProcessor.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.hpp
@@ -285,6 +285,12 @@ private:
                                    OopClosure*        keep_alive,
                                    VoidClosure*       complete_gc);
 
+
+  void setup_policy(bool always_clear) {
+    _current_soft_ref_policy = always_clear ?
+                               _always_clear_soft_ref_policy : _default_soft_ref_policy;
+    _current_soft_ref_policy->setup();   // snapshot the policy threshold
+  }
 public:
   static int number_of_subclasses_of_ref() { return (REF_PHANTOM - REF_OTHER); }
 
@@ -292,11 +298,9 @@ public:
   uint max_num_queues() const              { return _max_num_queues; }
   void set_active_mt_degree(uint v);
 
-  ReferencePolicy* setup_policy(bool always_clear) {
-    _current_soft_ref_policy = always_clear ?
-      _always_clear_soft_ref_policy : _default_soft_ref_policy;
-    _current_soft_ref_policy->setup();   // snapshot the policy threshold
-    return _current_soft_ref_policy;
+  void start_discovery(bool always_clear) {
+    enable_discovery();
+    setup_policy(always_clear);
   }
 
   // "Preclean" all the discovered reference lists by removing references that


### PR DESCRIPTION
Set up soft ref policy before marking/copying for Serial, Parallel and G1. With this change, all collectors do soft-ref policy setup in the beginning of a GC cycle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269596](https://bugs.openjdk.java.net/browse/JDK-8269596): Snapshot soft ref policy before marking/copying


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to ca0e71ebd8a04b033003aa75626192a82a1413f0
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4624/head:pull/4624` \
`$ git checkout pull/4624`

Update a local copy of the PR: \
`$ git checkout pull/4624` \
`$ git pull https://git.openjdk.java.net/jdk pull/4624/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4624`

View PR using the GUI difftool: \
`$ git pr show -t 4624`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4624.diff">https://git.openjdk.java.net/jdk/pull/4624.diff</a>

</details>
