### PR TITLE
8269615: Fix for 8263640 broke Windows build

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1116,7 +1116,7 @@ void Arguments::print_on(outputStream* st) {
     if (len == 0) {
       st->print_raw_cr("<not set>");
     } else {
-      st->print_raw_cr(path, len);
+      st->print_raw_cr(path, (int)len);
     }
   }
   st->print_cr("Launcher Type: %s", _sun_java_launcher);


### PR DESCRIPTION
Please review this trivial change for fixing build failure on Windows.

Testing:

- [x] windows-x64-debug build
- [x] tier1 (in progress)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269615](https://bugs.openjdk.java.net/browse/JDK-8269615): Fix for 8263640 broke Windows build


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4626/head:pull/4626` \
`$ git checkout pull/4626`

Update a local copy of the PR: \
`$ git checkout pull/4626` \
`$ git pull https://git.openjdk.java.net/jdk pull/4626/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4626`

View PR using the GUI difftool: \
`$ git pr show -t 4626`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4626.diff">https://git.openjdk.java.net/jdk/pull/4626.diff</a>

</details>
