### PR TITLE
8268635: Corrupt oop in ClassLoaderData

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -458,8 +458,6 @@ void ClassLoaderData::record_dependency(const Klass* k) {
     }
     Handle dependency(Thread::current(), to);
     add_handle(dependency);
-    // Added a potentially young gen oop to the ClassLoaderData
-    record_modified_oops();
   }
 }
 
@@ -781,6 +779,7 @@ ClassLoaderMetaspace* ClassLoaderData::metaspace_non_null() {
 
 OopHandle ClassLoaderData::add_handle(Handle h) {
   MutexLocker ml(metaspace_lock(),  Mutex::_no_safepoint_check_flag);
+  // Added a potentially young gen oop to the ClassLoaderData
   record_modified_oops();
   return _handles.add(h());
 }

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -799,6 +799,8 @@ void ClassLoaderData::init_handle_locked(OopHandle& dest, Handle h) {
   if (dest.resolve() != NULL) {
     return;
   } else {
+    // record_modified_oops();
+    tty->print_cr("init_handle_locked " INTPTR_FORMAT, p2i(h()));
     dest = _handles.add(h());
   }
 }

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3328,6 +3328,23 @@ static void print_vtable(vtableEntry* start, int len, outputStream* st) {
   return print_vtable(reinterpret_cast<intptr_t*>(start), len, st);
 }
 
+void InstanceKlass::print_misc_flags(outputStream* st) const {
+  if (is_rewritten())                         st->print("rewritten ");
+  if (has_nonstatic_fields())                 st->print("has_nonstatic_fields ");
+  if (should_verify_class())                  st->print("should_verify_class ");
+  if (is_contended())                         st->print("is_contended ");
+  if (has_nonstatic_concrete_methods())       st->print("has_nonstatic_concrete_methods ");
+  if (declares_nonstatic_concrete_methods())  st->print("declares_nonstatic_concrete_methods ");
+  if (has_been_redefined())                   st->print("has_been_redefined ");
+  if (is_scratch_class())                     st->print("is_scratch_class ");
+  if (is_shared_boot_class())                 st->print("is_shared_boot_class ");
+  if (is_shared_platform_class())             st->print("is_shared_platform_class ");
+  if (is_shared_app_class())                  st->print("is_shared_app_class ");
+  if (has_resolved_methods())                 st->print("has_resolved_methods ");
+  if (is_being_redefined())                   st->print("is_being_redefined ");
+  if (has_contended_annotations())            st->print("has_contended_annotations");
+}
+
 void InstanceKlass::print_on(outputStream* st) const {
   assert(is_klass(), "must be klass");
   Klass::print_on(st);
@@ -3335,6 +3352,7 @@ void InstanceKlass::print_on(outputStream* st) const {
   st->print(BULLET"instance size:     %d", size_helper());                        st->cr();
   st->print(BULLET"klass size:        %d", size());                               st->cr();
   st->print(BULLET"access:            "); access_flags().print_on(st);            st->cr();
+  st->print(BULLET"misc_flags:        "); print_misc_flags(st);                   st->cr();
   st->print(BULLET"state:             "); st->print_cr("%s", state_names[_init_state]);
   st->print(BULLET"name:              "); name()->print_value_on(st);             st->cr();
   st->print(BULLET"super:             "); Metadata::print_value_on_maybe_null(st, super()); st->cr();

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -1240,6 +1240,7 @@ public:
   // Printing
   void print_on(outputStream* st) const;
   void print_value_on(outputStream* st) const;
+  void print_misc_flags(outputStream* st) const;
 
   void oop_print_value_on(oop obj, outputStream* st);
 


### PR DESCRIPTION
Draft for Ioi, bunch of other stuff ...

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8268635](https://bugs.openjdk.java.net/browse/JDK-8268635): Corrupt oop in ClassLoaderData


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4627/head:pull/4627` \
`$ git checkout pull/4627`

Update a local copy of the PR: \
`$ git checkout pull/4627` \
`$ git pull https://git.openjdk.java.net/jdk pull/4627/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4627`

View PR using the GUI difftool: \
`$ git pr show -t 4627`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4627.diff">https://git.openjdk.java.net/jdk/pull/4627.diff</a>

</details>
