### PR TITLE
Exception chaining in java.awt.Font

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Font.java
+++ b/src/java.desktop/share/classes/java/awt/Font.java
@@ -971,7 +971,7 @@ public class Font implements java.io.Serializable
             }
             return createFont0(fontFormat, fontStream, true, tracker);
         } catch (InterruptedException e) {
-            throw new IOException("Problem reading font data.");
+            throw new IOException("Problem reading font data.", e);
         } finally {
             if (acquired) {
                 tracker.releasePermit();
@@ -1205,7 +1205,7 @@ public class Font implements java.io.Serializable
             if (cause instanceof FontFormatException) {
                 throw (FontFormatException)cause;
             }
-            throw new IOException("Problem reading font data.");
+            throw new IOException("Problem reading font data.", t);
         }
     }
 


### PR DESCRIPTION
In some cases the `java.awt.Font.createFont()` method hides the underlying error when the font can't be created. I'd like to suggest chaining the root cause with the IOException thrown to improve the error reported.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4628/head:pull/4628` \
`$ git checkout pull/4628`

Update a local copy of the PR: \
`$ git checkout pull/4628` \
`$ git pull https://git.openjdk.java.net/jdk pull/4628/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4628`

View PR using the GUI difftool: \
`$ git pr show -t 4628`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4628.diff">https://git.openjdk.java.net/jdk/pull/4628.diff</a>

</details>
