### PR TITLE
8269466: Factor out the common code for initializing and starting internal VM JavaThreads

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -904,9 +904,9 @@ JavaThread* CompileBroker::make_thread(ThreadType type, jobject thread_handle, C
 
 
   // At this point it may be possible that no osthread was created for the
-  // JavaThread due to lack of memory. We will handle that failure below.
+  // JavaThread due to lack of resources. We will handle that failure below.
 
-  if (new_thread != NULL && new_thread->osthread() != NULL) {
+  if (new_thread->osthread() != NULL) {
     Handle thread_oop(THREAD, JNIHandles::resolve_non_null(thread_handle));
 
     if (type == compiler_t) {
@@ -932,10 +932,10 @@ JavaThread* CompileBroker::make_thread(ThreadType type, jobject thread_handle, C
     // definition is limited to Java priorities and not OS priorities.
     JavaThread::start_internal_daemon(THREAD, new_thread, thread_oop, NearMaxPriority);
 
-  } else { // Allocation failure
+  } else { // osthread initialization failure
     if (UseDynamicNumberOfCompilerThreads && type == compiler_t
         && comp->num_compiler_threads() > 0) {
-      // the new thread is not known to Thread-SMR yet so we can just delete
+      // The new thread is not known to Thread-SMR yet so we can just delete.
       delete new_thread;
       return NULL;
     } else {

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -909,15 +909,13 @@ JavaThread* CompileBroker::make_thread(ThreadType type, jobject thread_handle, C
   if (new_thread != NULL && new_thread->osthread() != NULL) {
     Handle thread_oop(THREAD, JNIHandles::resolve_non_null(thread_handle));
 
-    // Note that this only sets the JavaThread _priority field, which by
-    // definition is limited to Java priorities and not OS priorities.
-
-    JavaThread::startInternalDaemon(THREAD, new_thread, thread_oop, NearMaxPriority,
-                                    static_cast<JavaThread**>(nullptr));
-
     if (type == compiler_t) {
       CompilerThread::cast(new_thread)->set_compiler(comp);
     }
+
+    // Note that this only sets the JavaThread _priority field, which by
+    // definition is limited to Java priorities and not OS priorities.
+    JavaThread::start_internal_daemon(THREAD, new_thread, thread_oop, NearMaxPriority);
 
     // Note that we cannot call os::set_priority because it expects Java
     // priorities and we are *explicitly* using OS priorities so that it's

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -875,90 +875,77 @@ void DeoptimizeObjectsALotThread::deoptimize_objects_alot_loop_all() {
 
 JavaThread* CompileBroker::make_thread(ThreadType type, jobject thread_handle, CompileQueue* queue, AbstractCompiler* comp, JavaThread* THREAD) {
   JavaThread* new_thread = NULL;
-  {
-    MutexLocker mu(THREAD, Threads_lock);
-    switch (type) {
-      case compiler_t:
-        assert(comp != NULL, "Compiler instance missing.");
-        if (!InjectCompilerCreationFailure || comp->num_compiler_threads() == 0) {
-          CompilerCounters* counters = new CompilerCounters();
-          new_thread = new CompilerThread(queue, counters);
-        }
-        break;
-      case sweeper_t:
-        new_thread = new CodeCacheSweeperThread();
-        break;
+
+  switch (type) {
+    case compiler_t:
+      assert(comp != NULL, "Compiler instance missing.");
+      if (!InjectCompilerCreationFailure || comp->num_compiler_threads() == 0) {
+        CompilerCounters* counters = new CompilerCounters();
+        new_thread = new CompilerThread(queue, counters);
+      }
+      break;
+    case sweeper_t:
+      new_thread = new CodeCacheSweeperThread();
+      break;
 #if defined(ASSERT) && COMPILER2_OR_JVMCI
-      case deoptimizer_t:
-        new_thread = new DeoptimizeObjectsALotThread();
-        break;
+    case deoptimizer_t:
+      new_thread = new DeoptimizeObjectsALotThread();
+      break;
 #endif // ASSERT
-      default:
-        ShouldNotReachHere();
-    }
-
-    // At this point the new CompilerThread data-races with this startup
-    // thread (which I believe is the primoridal thread and NOT the VM
-    // thread).  This means Java bytecodes being executed at startup can
-    // queue compile jobs which will run at whatever default priority the
-    // newly created CompilerThread runs at.
-
-
-    // At this point it may be possible that no osthread was created for the
-    // JavaThread due to lack of memory. We would have to throw an exception
-    // in that case. However, since this must work and we do not allow
-    // exceptions anyway, check and abort if this fails. But first release the
-    // lock.
-
-    if (new_thread != NULL && new_thread->osthread() != NULL) {
-
-      java_lang_Thread::set_thread(JNIHandles::resolve_non_null(thread_handle), new_thread);
-
-      // Note that this only sets the JavaThread _priority field, which by
-      // definition is limited to Java priorities and not OS priorities.
-      // The os-priority is set in the CompilerThread startup code itself
-
-      java_lang_Thread::set_priority(JNIHandles::resolve_non_null(thread_handle), NearMaxPriority);
-
-      // Note that we cannot call os::set_priority because it expects Java
-      // priorities and we are *explicitly* using OS priorities so that it's
-      // possible to set the compiler thread priority higher than any Java
-      // thread.
-
-      int native_prio = CompilerThreadPriority;
-      if (native_prio == -1) {
-        if (UseCriticalCompilerThreadPriority) {
-          native_prio = os::java_to_os_priority[CriticalPriority];
-        } else {
-          native_prio = os::java_to_os_priority[NearMaxPriority];
-        }
-      }
-      os::set_native_priority(new_thread, native_prio);
-
-      java_lang_Thread::set_daemon(JNIHandles::resolve_non_null(thread_handle));
-
-      new_thread->set_threadObj(JNIHandles::resolve_non_null(thread_handle));
-      if (type == compiler_t) {
-        CompilerThread::cast(new_thread)->set_compiler(comp);
-      }
-      Threads::add(new_thread);
-      Thread::start(new_thread);
-    }
+    default:
+      ShouldNotReachHere();
   }
 
-  // First release lock before aborting VM.
-  if (new_thread == NULL || new_thread->osthread() == NULL) {
-    if (UseDynamicNumberOfCompilerThreads && type == compiler_t && comp->num_compiler_threads() > 0) {
-      if (new_thread != NULL) {
-        new_thread->smr_delete();
+  // At this point the new CompilerThread data-races with this startup
+  // thread (which is the main thread and NOT the VM thread).
+  // This means Java bytecodes being executed at startup can
+  // queue compile jobs which will run at whatever default priority the
+  // newly created CompilerThread runs at.
+
+
+  // At this point it may be possible that no osthread was created for the
+  // JavaThread due to lack of memory. We will handle that failure below.
+
+  if (new_thread != NULL && new_thread->osthread() != NULL) {
+    Handle thread_oop(THREAD, JNIHandles::resolve_non_null(thread_handle));
+
+    // Note that this only sets the JavaThread _priority field, which by
+    // definition is limited to Java priorities and not OS priorities.
+
+    JavaThread::startInternalDaemon(THREAD, new_thread, thread_oop, NearMaxPriority,
+                                    static_cast<JavaThread**>(nullptr));
+
+    if (type == compiler_t) {
+      CompilerThread::cast(new_thread)->set_compiler(comp);
+    }
+
+    // Note that we cannot call os::set_priority because it expects Java
+    // priorities and we are *explicitly* using OS priorities so that it's
+    // possible to set the compiler thread priority higher than any Java
+    // thread.
+
+    int native_prio = CompilerThreadPriority;
+    if (native_prio == -1) {
+      if (UseCriticalCompilerThreadPriority) {
+        native_prio = os::java_to_os_priority[CriticalPriority];
+      } else {
+        native_prio = os::java_to_os_priority[NearMaxPriority];
       }
+    }
+    os::set_native_priority(new_thread, native_prio);
+
+  } else { // Allocation failure
+    if (UseDynamicNumberOfCompilerThreads && type == compiler_t
+        && comp->num_compiler_threads() > 0) {
+      // the new thread is not known to Thread-SMR yet so we can just delete
+      delete new_thread;
       return NULL;
+    } else {
+      vm_exit_during_initialization("java.lang.OutOfMemoryError",
+                                    os::native_thread_creation_failed_msg());
     }
-    vm_exit_during_initialization("java.lang.OutOfMemoryError",
-                                  os::native_thread_creation_failed_msg());
   }
 
-  // Let go of Threads_lock before yielding
   os::naked_yield(); // make sure that the compiler thread is started early (especially helpful on SOLARIS)
 
   return new_thread;

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -905,8 +905,8 @@ JavaThread* CompileBroker::make_thread(ThreadType type, jobject thread_handle, C
 
   // At this point it may be possible that no osthread was created for the
   // JavaThread due to lack of resources. We will handle that failure below.
-
-  if (new_thread->osthread() != NULL) {
+  // Also check new_thread so that static analysis is happy.
+  if (new_thread != NULL && new_thread->osthread() != NULL) {
     Handle thread_oop(THREAD, JNIHandles::resolve_non_null(thread_handle));
 
     if (type == compiler_t) {

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -913,10 +913,6 @@ JavaThread* CompileBroker::make_thread(ThreadType type, jobject thread_handle, C
       CompilerThread::cast(new_thread)->set_compiler(comp);
     }
 
-    // Note that this only sets the JavaThread _priority field, which by
-    // definition is limited to Java priorities and not OS priorities.
-    JavaThread::start_internal_daemon(THREAD, new_thread, thread_oop, NearMaxPriority);
-
     // Note that we cannot call os::set_priority because it expects Java
     // priorities and we are *explicitly* using OS priorities so that it's
     // possible to set the compiler thread priority higher than any Java
@@ -931,6 +927,10 @@ JavaThread* CompileBroker::make_thread(ThreadType type, jobject thread_handle, C
       }
     }
     os::set_native_priority(new_thread, native_prio);
+
+    // Note that this only sets the JavaThread _priority field, which by
+    // definition is limited to Java priorities and not OS priorities.
+    JavaThread::start_internal_daemon(THREAD, new_thread, thread_oop, NearMaxPriority);
 
   } else { // Allocation failure
     if (UseDynamicNumberOfCompilerThreads && type == compiler_t

--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderThread.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderThread.cpp
@@ -55,8 +55,7 @@ static Thread* start_thread(instanceHandle thread_oop, ThreadFunction proc, TRAP
     JfrJavaSupport::throw_out_of_memory_error("Unable to create native recording thread for JFR", THREAD);
     return NULL;
   } else {
-    JavaThread::startInternalDaemon(THREAD, new_thread, thread_oop, NormPriority,
-                                    static_cast<JavaThread**>(nullptr));
+    JavaThread::start_internal_daemon(THREAD, new_thread, thread_oop, NormPriority);
     return new_thread;
   }
 }

--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderThread.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderThread.cpp
@@ -49,7 +49,7 @@ static Thread* start_thread(instanceHandle thread_oop, ThreadFunction proc, TRAP
   JavaThread* new_thread = new JavaThread(proc);
 
   // At this point it may be possible that no
-  // osthread was created for the JavaThread due to lack of memory.
+  // osthread was created for the JavaThread due to lack of resources.
   if (new_thread->osthread() == NULL) {
     delete new_thread;
     JfrJavaSupport::throw_out_of_memory_error("Unable to create native recording thread for JFR", THREAD);

--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderThread.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderThread.cpp
@@ -46,29 +46,19 @@ static Thread* start_thread(instanceHandle thread_oop, ThreadFunction proc, TRAP
   assert(thread_oop.not_null(), "invariant");
   assert(proc != NULL, "invariant");
 
-  bool allocation_failed = false;
-  JavaThread* new_thread = NULL;
-  {
-    MutexLocker mu(THREAD, Threads_lock);
-    new_thread = new JavaThread(proc);
-    // At this point it may be possible that no
-    // osthread was created for the JavaThread due to lack of memory.
-    if (new_thread == NULL || new_thread->osthread() == NULL) {
-      delete new_thread;
-      allocation_failed = true;
-    } else {
-      java_lang_Thread::set_thread(thread_oop(), new_thread);
-      java_lang_Thread::set_priority(thread_oop(), NormPriority);
-      java_lang_Thread::set_daemon(thread_oop());
-      new_thread->set_threadObj(thread_oop());
-      Threads::add(new_thread);
-    }
+  JavaThread* new_thread = new JavaThread(proc);
+
+  // At this point it may be possible that no
+  // osthread was created for the JavaThread due to lack of memory.
+  if (new_thread == NULL || new_thread->osthread() == NULL) {
+    delete new_thread;
+    JfrJavaSupport::throw_out_of_memory_error("Unable to create native recording thread for JFR", THREAD);
+    return NULL;
+  } else {
+    JavaThread::startInternalDaemon(THREAD, new_thread, thread_oop, NormPriority,
+                                    static_cast<JavaThread**>(nullptr));
+    return new_thread;
   }
-  if (allocation_failed) {
-    JfrJavaSupport::throw_out_of_memory_error("Unable to create native recording thread for JFR", CHECK_NULL);
-  }
-  Thread::start(new_thread);
-  return new_thread;
 }
 
 JfrPostBox* JfrRecorderThread::_post_box = NULL;

--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderThread.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderThread.cpp
@@ -50,7 +50,7 @@ static Thread* start_thread(instanceHandle thread_oop, ThreadFunction proc, TRAP
 
   // At this point it may be possible that no
   // osthread was created for the JavaThread due to lack of memory.
-  if (new_thread == NULL || new_thread->osthread() == NULL) {
+  if (new_thread->osthread() == NULL) {
     delete new_thread;
     JfrJavaSupport::throw_out_of_memory_error("Unable to create native recording thread for JFR", THREAD);
     return NULL;

--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -1326,28 +1326,19 @@ JvmtiEnv::RunAgentThread(jthread thread, jvmtiStartFunction proc, const void* ar
   }
 
   Handle thread_hndl(current_thread, thread_oop);
-  {
-    MutexLocker mu(current_thread, Threads_lock); // grab Threads_lock
 
-    JvmtiAgentThread *new_thread = new JvmtiAgentThread(this, proc, arg);
+  JvmtiAgentThread* new_thread = new JvmtiAgentThread(this, proc, arg);
 
-    // At this point it may be possible that no osthread was created for the
-    // JavaThread due to lack of memory.
-    if (new_thread == NULL || new_thread->osthread() == NULL) {
-      if (new_thread != NULL) {
-        new_thread->smr_delete();
-      }
-      return JVMTI_ERROR_OUT_OF_MEMORY;
-    }
+  // At this point it may be possible that no osthread was created for the
+  // JavaThread due to lack of memory.
+  if (new_thread == NULL || new_thread->osthread() == NULL) {
+    // the new thread is not known to Thread-SMR yet so we can just delete
+    delete new_thread;
+    return JVMTI_ERROR_OUT_OF_MEMORY;
+  }
 
-    java_lang_Thread::set_thread(thread_hndl(), new_thread);
-    java_lang_Thread::set_priority(thread_hndl(), (ThreadPriority)priority);
-    java_lang_Thread::set_daemon(thread_hndl());
-
-    new_thread->set_threadObj(thread_hndl());
-    Threads::add(new_thread);
-    Thread::start(new_thread);
-  } // unlock Threads_lock
+  JavaThread::startInternalDaemon(current_thread, new_thread, thread_hndl,
+                                  (ThreadPriority)priority, static_cast<JvmtiAgentThread**>(nullptr));
 
   return JVMTI_ERROR_NONE;
 } /* end RunAgentThread */

--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -1330,9 +1330,9 @@ JvmtiEnv::RunAgentThread(jthread thread, jvmtiStartFunction proc, const void* ar
   JvmtiAgentThread* new_thread = new JvmtiAgentThread(this, proc, arg);
 
   // At this point it may be possible that no osthread was created for the
-  // JavaThread due to lack of memory.
-  if (new_thread == NULL || new_thread->osthread() == NULL) {
-    // the new thread is not known to Thread-SMR yet so we can just delete
+  // JavaThread due to lack of resources.
+  if (new_thread->osthread() == NULL) {
+    // The new thread is not known to Thread-SMR yet so we can just delete.
     delete new_thread;
     return JVMTI_ERROR_OUT_OF_MEMORY;
   }

--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -1337,8 +1337,8 @@ JvmtiEnv::RunAgentThread(jthread thread, jvmtiStartFunction proc, const void* ar
     return JVMTI_ERROR_OUT_OF_MEMORY;
   }
 
-  JavaThread::startInternalDaemon(current_thread, new_thread, thread_hndl,
-                                  (ThreadPriority)priority, static_cast<JvmtiAgentThread**>(nullptr));
+  JavaThread::start_internal_daemon(current_thread, new_thread, thread_hndl,
+                                    (ThreadPriority)priority);
 
   return JVMTI_ERROR_NONE;
 } /* end RunAgentThread */

--- a/src/hotspot/share/runtime/monitorDeflationThread.cpp
+++ b/src/hotspot/share/runtime/monitorDeflationThread.cpp
@@ -33,8 +33,6 @@
 #include "runtime/monitorDeflationThread.hpp"
 #include "runtime/mutexLocker.hpp"
 
-MonitorDeflationThread* MonitorDeflationThread::_instance = NULL;
-
 void MonitorDeflationThread::initialize() {
   EXCEPTION_MARK;
 
@@ -51,10 +49,9 @@ void MonitorDeflationThread::initialize() {
                           CHECK);
 
   MonitorDeflationThread* thread =  new MonitorDeflationThread(&monitor_deflation_thread_entry);
-  JavaThread::exit_on_thread_allocation_failure(thread);
+  JavaThread::vm_exit_on_thread_allocation_failure(thread);
 
-  JavaThread::startInternalDaemon(THREAD, thread, thread_oop, NearMaxPriority,
-                                  &_instance);
+  JavaThread::start_internal_daemon(THREAD, thread, thread_oop, NearMaxPriority);
 }
 
 void MonitorDeflationThread::monitor_deflation_thread_entry(JavaThread* jt, TRAPS) {

--- a/src/hotspot/share/runtime/monitorDeflationThread.cpp
+++ b/src/hotspot/share/runtime/monitorDeflationThread.cpp
@@ -48,7 +48,7 @@ void MonitorDeflationThread::initialize() {
                           string,
                           CHECK);
 
-  MonitorDeflationThread* thread =  new MonitorDeflationThread(&monitor_deflation_thread_entry);
+  MonitorDeflationThread* thread = new MonitorDeflationThread(&monitor_deflation_thread_entry);
   JavaThread::vm_exit_on_thread_allocation_failure(thread);
 
   JavaThread::start_internal_daemon(THREAD, thread, thread_oop, NearMaxPriority);

--- a/src/hotspot/share/runtime/monitorDeflationThread.cpp
+++ b/src/hotspot/share/runtime/monitorDeflationThread.cpp
@@ -49,7 +49,7 @@ void MonitorDeflationThread::initialize() {
                           CHECK);
 
   MonitorDeflationThread* thread = new MonitorDeflationThread(&monitor_deflation_thread_entry);
-  JavaThread::vm_exit_on_thread_allocation_failure(thread);
+  JavaThread::vm_exit_on_osthread_failure(thread);
 
   JavaThread::start_internal_daemon(THREAD, thread, thread_oop, NearMaxPriority);
 }

--- a/src/hotspot/share/runtime/monitorDeflationThread.cpp
+++ b/src/hotspot/share/runtime/monitorDeflationThread.cpp
@@ -50,28 +50,11 @@ void MonitorDeflationThread::initialize() {
                           string,
                           CHECK);
 
-  {
-    MutexLocker mu(THREAD, Threads_lock);
-    MonitorDeflationThread* thread =  new MonitorDeflationThread(&monitor_deflation_thread_entry);
+  MonitorDeflationThread* thread =  new MonitorDeflationThread(&monitor_deflation_thread_entry);
+  JavaThread::exit_on_thread_allocation_failure(thread);
 
-    // At this point it may be possible that no osthread was created for the
-    // JavaThread due to lack of memory. We would have to throw an exception
-    // in that case. However, since this must work and we do not allow
-    // exceptions anyway, check and abort if this fails.
-    if (thread == NULL || thread->osthread() == NULL) {
-      vm_exit_during_initialization("java.lang.OutOfMemoryError",
-                                    os::native_thread_creation_failed_msg());
-    }
-
-    java_lang_Thread::set_thread(thread_oop(), thread);
-    java_lang_Thread::set_priority(thread_oop(), NearMaxPriority);
-    java_lang_Thread::set_daemon(thread_oop());
-    thread->set_threadObj(thread_oop());
-    _instance = thread;
-
-    Threads::add(thread);
-    Thread::start(thread);
-  }
+  JavaThread::startInternalDaemon(THREAD, thread, thread_oop, NearMaxPriority,
+                                  &_instance);
 }
 
 void MonitorDeflationThread::monitor_deflation_thread_entry(JavaThread* jt, TRAPS) {

--- a/src/hotspot/share/runtime/monitorDeflationThread.hpp
+++ b/src/hotspot/share/runtime/monitorDeflationThread.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/monitorDeflationThread.hpp
+++ b/src/hotspot/share/runtime/monitorDeflationThread.hpp
@@ -32,7 +32,6 @@
 class MonitorDeflationThread : public JavaThread {
   friend class VMStructs;
  private:
-  static MonitorDeflationThread* _instance;
 
   static void monitor_deflation_thread_entry(JavaThread* thread, TRAPS);
   MonitorDeflationThread(ThreadFunction entry_point) : JavaThread(entry_point) {};

--- a/src/hotspot/share/runtime/notificationThread.cpp
+++ b/src/hotspot/share/runtime/notificationThread.cpp
@@ -35,8 +35,6 @@
 #include "services/gcNotifier.hpp"
 #include "services/lowMemoryDetector.hpp"
 
-NotificationThread* NotificationThread::_instance = NULL;
-
 void NotificationThread::initialize() {
   EXCEPTION_MARK;
 
@@ -63,10 +61,9 @@ void NotificationThread::initialize() {
                           THREAD);
 
    NotificationThread* thread =  new NotificationThread(&notification_thread_entry);
-   JavaThread::exit_on_thread_allocation_failure(thread);
+   JavaThread::vm_exit_on_thread_allocation_failure(thread);
 
-   JavaThread::startInternalDaemon(THREAD, thread, thread_oop, NearMaxPriority,
-                                   &_instance);
+   JavaThread::start_internal_daemon(THREAD, thread, thread_oop, NearMaxPriority);
 }
 
 

--- a/src/hotspot/share/runtime/notificationThread.cpp
+++ b/src/hotspot/share/runtime/notificationThread.cpp
@@ -60,7 +60,7 @@ void NotificationThread::initialize() {
                           thread_oop,
                           THREAD);
 
-   NotificationThread* thread =  new NotificationThread(&notification_thread_entry);
+   NotificationThread* thread = new NotificationThread(&notification_thread_entry);
    JavaThread::vm_exit_on_thread_allocation_failure(thread);
 
    JavaThread::start_internal_daemon(THREAD, thread, thread_oop, NearMaxPriority);

--- a/src/hotspot/share/runtime/notificationThread.cpp
+++ b/src/hotspot/share/runtime/notificationThread.cpp
@@ -61,28 +61,12 @@ void NotificationThread::initialize() {
                           vmSymbols::thread_void_signature(),
                           thread_oop,
                           THREAD);
-  {
-    MutexLocker mu(THREAD, Threads_lock);
-    NotificationThread* thread =  new NotificationThread(&notification_thread_entry);
 
-    // At this point it may be possible that no osthread was created for the
-    // JavaThread due to lack of memory. We would have to throw an exception
-    // in that case. However, since this must work and we do not allow
-    // exceptions anyway, check and abort if this fails.
-    if (thread == NULL || thread->osthread() == NULL) {
-      vm_exit_during_initialization("java.lang.OutOfMemoryError",
-                                    os::native_thread_creation_failed_msg());
-    }
+   NotificationThread* thread =  new NotificationThread(&notification_thread_entry);
+   JavaThread::exit_on_thread_allocation_failure(thread);
 
-    java_lang_Thread::set_thread(thread_oop(), thread);
-    java_lang_Thread::set_priority(thread_oop(), NearMaxPriority);
-    java_lang_Thread::set_daemon(thread_oop());
-    thread->set_threadObj(thread_oop());
-    _instance = thread;
-
-    Threads::add(thread);
-    Thread::start(thread);
-  }
+   JavaThread::startInternalDaemon(THREAD, thread, thread_oop, NearMaxPriority,
+                                   &_instance);
 }
 
 
@@ -128,4 +112,3 @@ void NotificationThread::notification_thread_entry(JavaThread* jt, TRAPS) {
 
   }
 }
-

--- a/src/hotspot/share/runtime/notificationThread.cpp
+++ b/src/hotspot/share/runtime/notificationThread.cpp
@@ -61,7 +61,7 @@ void NotificationThread::initialize() {
                           THREAD);
 
    NotificationThread* thread = new NotificationThread(&notification_thread_entry);
-   JavaThread::vm_exit_on_thread_allocation_failure(thread);
+   JavaThread::vm_exit_on_osthread_failure(thread);
 
    JavaThread::start_internal_daemon(THREAD, thread, thread_oop, NearMaxPriority);
 }

--- a/src/hotspot/share/runtime/notificationThread.hpp
+++ b/src/hotspot/share/runtime/notificationThread.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/notificationThread.hpp
+++ b/src/hotspot/share/runtime/notificationThread.hpp
@@ -36,8 +36,6 @@ class NotificationThread : public JavaThread {
   friend class VMStructs;
  private:
 
-  static NotificationThread* _instance;
-
   static void notification_thread_entry(JavaThread* thread, TRAPS);
   NotificationThread(ThreadFunction entry_point) : JavaThread(entry_point) {};
 

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -491,7 +491,7 @@ void os::initialize_jdk_signal_support(TRAPS) {
                             CHECK);
 
     JavaThread* thread = new JavaThread(&signal_thread_entry);
-    JavaThread::vm_exit_on_thread_allocation_failure(thread);
+    JavaThread::vm_exit_on_osthread_failure(thread);
 
     JavaThread::start_internal_daemon(THREAD, thread, thread_oop, NearMaxPriority);
 

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -491,10 +491,9 @@ void os::initialize_jdk_signal_support(TRAPS) {
                             CHECK);
 
     JavaThread* thread = new JavaThread(&signal_thread_entry);
-    JavaThread::exit_on_thread_allocation_failure(thread);
+    JavaThread::vm_exit_on_thread_allocation_failure(thread);
 
-    JavaThread::startInternalDaemon(THREAD, thread, thread_oop, NearMaxPriority,
-                                    static_cast<JavaThread**>(nullptr));
+    JavaThread::start_internal_daemon(THREAD, thread, thread_oop, NearMaxPriority);
 
     // Handle ^BREAK
     os::signal(SIGBREAK, os::user_handler());

--- a/src/hotspot/share/runtime/serviceThread.cpp
+++ b/src/hotspot/share/runtime/serviceThread.cpp
@@ -51,7 +51,7 @@
 #include "services/lowMemoryDetector.hpp"
 #include "services/threadIdTable.hpp"
 
-ServiceThread* ServiceThread::_instance = NULL;
+DEBUG_ONLY(JavaThread* ServiceThread::_instance = NULL;)
 JvmtiDeferredEvent* ServiceThread::_jvmti_event = NULL;
 // The service thread has it's own static deferred event queue.
 // Events can be posted before JVMTI vm_start, so it's too early to call JvmtiThreadState::state_for
@@ -104,10 +104,10 @@ void ServiceThread::initialize() {
                           CHECK);
 
   ServiceThread* thread =  new ServiceThread(&service_thread_entry);
-  JavaThread::exit_on_thread_allocation_failure(thread);
+  JavaThread::vm_exit_on_thread_allocation_failure(thread);
 
-  JavaThread::startInternalDaemon(THREAD, thread, thread_oop, NearMaxPriority,
-                                  &_instance);
+  JavaThread::start_internal_daemon(THREAD, thread, thread_oop, NearMaxPriority);
+  DEBUG_ONLY(_instance = thread;)
 }
 
 static void cleanup_oopstorages() {

--- a/src/hotspot/share/runtime/serviceThread.cpp
+++ b/src/hotspot/share/runtime/serviceThread.cpp
@@ -103,28 +103,11 @@ void ServiceThread::initialize() {
                           string,
                           CHECK);
 
-  {
-    MutexLocker mu(THREAD, Threads_lock);
-    ServiceThread* thread =  new ServiceThread(&service_thread_entry);
+  ServiceThread* thread =  new ServiceThread(&service_thread_entry);
+  JavaThread::exit_on_thread_allocation_failure(thread);
 
-    // At this point it may be possible that no osthread was created for the
-    // JavaThread due to lack of memory. We would have to throw an exception
-    // in that case. However, since this must work and we do not allow
-    // exceptions anyway, check and abort if this fails.
-    if (thread == NULL || thread->osthread() == NULL) {
-      vm_exit_during_initialization("java.lang.OutOfMemoryError",
-                                    os::native_thread_creation_failed_msg());
-    }
-
-    java_lang_Thread::set_thread(thread_oop(), thread);
-    java_lang_Thread::set_priority(thread_oop(), NearMaxPriority);
-    java_lang_Thread::set_daemon(thread_oop());
-    thread->set_threadObj(thread_oop());
-    _instance = thread;
-
-    Threads::add(thread);
-    Thread::start(thread);
-  }
+  JavaThread::startInternalDaemon(THREAD, thread, thread_oop, NearMaxPriority,
+                                  &_instance);
 }
 
 static void cleanup_oopstorages() {

--- a/src/hotspot/share/runtime/serviceThread.cpp
+++ b/src/hotspot/share/runtime/serviceThread.cpp
@@ -103,7 +103,7 @@ void ServiceThread::initialize() {
                           string,
                           CHECK);
 
-  ServiceThread* thread =  new ServiceThread(&service_thread_entry);
+  ServiceThread* thread = new ServiceThread(&service_thread_entry);
   JavaThread::vm_exit_on_thread_allocation_failure(thread);
 
   JavaThread::start_internal_daemon(THREAD, thread, thread_oop, NearMaxPriority);

--- a/src/hotspot/share/runtime/serviceThread.cpp
+++ b/src/hotspot/share/runtime/serviceThread.cpp
@@ -104,7 +104,7 @@ void ServiceThread::initialize() {
                           CHECK);
 
   ServiceThread* thread = new ServiceThread(&service_thread_entry);
-  JavaThread::vm_exit_on_thread_allocation_failure(thread);
+  JavaThread::vm_exit_on_osthread_failure(thread);
 
   JavaThread::start_internal_daemon(THREAD, thread, thread_oop, NearMaxPriority);
   DEBUG_ONLY(_instance = thread;)

--- a/src/hotspot/share/runtime/serviceThread.hpp
+++ b/src/hotspot/share/runtime/serviceThread.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/serviceThread.hpp
+++ b/src/hotspot/share/runtime/serviceThread.hpp
@@ -36,7 +36,7 @@ class JvmtiDeferredEvent;
 class ServiceThread : public JavaThread {
   friend class VMStructs;
  private:
-  static ServiceThread* _instance;
+  DEBUG_ONLY(static JavaThread* _instance;)
   static JvmtiDeferredEvent* _jvmti_event;
   static JvmtiDeferredEventQueue _jvmti_service_queue;
 

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -3908,7 +3908,7 @@ void JavaThread::verify_cross_modify_fence_failure(JavaThread *thread) {
 // properly initialized singleton instance is seen by other threads.
 // The Threads_lock is held for the duration.
 void JavaThread::start_internal_daemon(JavaThread* current, JavaThread* target,
-                                     Handle thread_oop, ThreadPriority prio) {
+                                       Handle thread_oop, ThreadPriority prio) {
   MutexLocker mu(current, Threads_lock);
 
   // Initialize the fields of the thread_oop first

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -3907,10 +3907,8 @@ void JavaThread::verify_cross_modify_fence_failure(JavaThread *thread) {
 // complete and before adding to the ThreadsList. This ensures only a
 // properly initialized singleton instance is seen by other threads.
 // The Threads_lock is held for the duration.
-template <typename T, ENABLE_IF_SDEFN(std::is_base_of<JavaThread, T>::value)>
-void JavaThread::startInternalDaemon(JavaThread* current, T* target,
-                                     Handle thread_oop, ThreadPriority prio,
-                                     T** instance) {
+void JavaThread::start_internal_daemon(JavaThread* current, JavaThread* target,
+                                     Handle thread_oop, ThreadPriority prio) {
   MutexLocker mu(current, Threads_lock);
 
   // Initialize the fields of the thread_oop first
@@ -3928,17 +3926,11 @@ void JavaThread::startInternalDaemon(JavaThread* current, T* target,
   // Now bind the thread_oop to the target JavaThread
   target->set_threadObj(thread_oop());
 
-  // We must set the field after the threadObj is fully prepared,
-  // but before we release the newly created thread.
-  if (instance != nullptr) {
-    *instance = target;
-  }
-
   Threads::add(target); // target is now visible for safepoint/handshake
   Thread::start(target);
 }
 
-void JavaThread::exit_on_thread_allocation_failure(JavaThread* thread) {
+void JavaThread::vm_exit_on_thread_allocation_failure(JavaThread* thread) {
   // At this point it may be possible that no osthread was created for the
   // JavaThread due to lack of memory. We would have to throw an exception
   // in that case. However, since this must work and we do not allow

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -3908,7 +3908,7 @@ void JavaThread::start_internal_daemon(JavaThread* current, JavaThread* target,
                                        Handle thread_oop, ThreadPriority prio) {
   MutexLocker mu(current, Threads_lock);
 
-  // Initialize the fields of the thread_oop first
+  // Initialize the fields of the thread_oop first.
 
   java_lang_Thread::set_thread(thread_oop(), target); // isAlive == true now
 
@@ -3920,14 +3920,14 @@ void JavaThread::start_internal_daemon(JavaThread* current, JavaThread* target,
 
   java_lang_Thread::set_daemon(thread_oop());
 
-  // Now bind the thread_oop to the target JavaThread
+  // Now bind the thread_oop to the target JavaThread.
   target->set_threadObj(thread_oop());
 
   Threads::add(target); // target is now visible for safepoint/handshake
   Thread::start(target);
 }
 
-void JavaThread::vm_exit_on_thread_allocation_failure(JavaThread* thread) {
+void JavaThread::vm_exit_on_osthread_failure(JavaThread* thread) {
   // At this point it may be possible that no osthread was created for the
   // JavaThread due to lack of resources. However, since this must work
   // for critical system threads just check and abort if this fails.

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -3929,10 +3929,11 @@ void JavaThread::start_internal_daemon(JavaThread* current, JavaThread* target,
 
 void JavaThread::vm_exit_on_thread_allocation_failure(JavaThread* thread) {
   // At this point it may be possible that no osthread was created for the
-  // JavaThread due to lack of memory. We would have to throw an exception
-  // in that case. However, since this must work and we do not allow
-  // exceptions anyway, check and abort if this fails.
-  if (thread == nullptr || thread->osthread() == nullptr) {
+  // JavaThread due to lack of resources. However, since this must work
+  // for critical system threads just check and abort if this fails.
+  if (thread->osthread() == nullptr) {
+    // This isn't really an OOM condition, but historically this is what
+    // we report.
     vm_exit_during_initialization("java.lang.OutOfMemoryError",
                                   os::native_thread_creation_failed_msg());
   }

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -3902,10 +3902,7 @@ void JavaThread::verify_cross_modify_fence_failure(JavaThread *thread) {
 #endif
 
 // Starts the target JavaThread as a daemon of the given priority, and
-// bound to the given java.lang.Thread instance. If instance is non-NULL
-// it is set to the value of target once the j.l.Thread association is
-// complete and before adding to the ThreadsList. This ensures only a
-// properly initialized singleton instance is seen by other threads.
+// bound to the given java.lang.Thread instance.
 // The Threads_lock is held for the duration.
 void JavaThread::start_internal_daemon(JavaThread* current, JavaThread* target,
                                        Handle thread_oop, ThreadPriority prio) {

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -3907,7 +3907,7 @@ void JavaThread::verify_cross_modify_fence_failure(JavaThread *thread) {
 // complete and before adding to the ThreadsList. This ensures only a
 // properly initialized singleton instance is seen by other threads.
 // The Threads_lock is held for the duration.
-template <typename T, ENABLE_IF(std::is_base_of<JavaThread, T>::value)>
+template <typename T, ENABLE_IF_SDEFN(std::is_base_of<JavaThread, T>::value)>
 void JavaThread::startInternalDaemon(JavaThread* current, T* target,
                                      Handle thread_oop, ThreadPriority prio,
                                      T** instance) {
@@ -3928,6 +3928,8 @@ void JavaThread::startInternalDaemon(JavaThread* current, T* target,
   // Now bind the thread_oop to the target JavaThread
   target->set_threadObj(thread_oop());
 
+  // We must set the field after the threadObj is fully prepared,
+  // but before we release the newly created thread.
   if (instance != nullptr) {
     *instance = target;
   }

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -3906,6 +3906,9 @@ void JavaThread::verify_cross_modify_fence_failure(JavaThread *thread) {
 // The Threads_lock is held for the duration.
 void JavaThread::start_internal_daemon(JavaThread* current, JavaThread* target,
                                        Handle thread_oop, ThreadPriority prio) {
+
+  assert(target->osthread()!= NULL, "target thread is not properly initialized");
+
   MutexLocker mu(current, Threads_lock);
 
   // Initialize the fields of the thread_oop first.

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -701,7 +701,6 @@ class JavaThread: public Thread {
   int _java_call_counter;
 
  public:
-
   int  java_call_counter()                       { return _java_call_counter; }
   void inc_java_call_counter()                   { _java_call_counter++; }
   void dec_java_call_counter() {
@@ -1594,19 +1593,6 @@ public:
   static OopStorage* thread_oop_storage();
 
   static void verify_cross_modify_fence_failure(JavaThread *thread) PRODUCT_RETURN;
-
-  template <typename T>
-  class InstanceSetter : public StackObj {
-    T* _value;
-    T** _field;
-   public:
-    void set() {
-      if (_field != nullptr) {
-        *_field = _value;
-      }
-    }
-    InstanceSetter(T* value, T** field) : _value(value), _field(field) { }
-  };
 
   // Helper function to start a VM-internal daemon thread.
   // E.g. ServiceThread, NotificationThread, CompilerThread etc.

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1612,7 +1612,7 @@ public:
   // Helper function to start a VM-internal daemon thread.
   // E.g. ServiceThread, NotificationThread, CompilerThread etc.
   static void start_internal_daemon(JavaThread* current, JavaThread* target,
-                                  Handle thread_oop, ThreadPriority prio);
+                                    Handle thread_oop, ThreadPriority prio);
 
   // Helper function to do vm_exit_on_initialization for thread allocation
   // failure.

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1599,9 +1599,9 @@ public:
   static void start_internal_daemon(JavaThread* current, JavaThread* target,
                                     Handle thread_oop, ThreadPriority prio);
 
-  // Helper function to do vm_exit_on_initialization for thread allocation
-  // failure.
-  static void vm_exit_on_thread_allocation_failure(JavaThread* thread);
+  // Helper function to do vm_exit_on_initialization for osthread
+  // resource allocation failure.
+  static void vm_exit_on_osthread_failure(JavaThread* thread);
 };
 
 // The active thread queue. It also keeps track of the current used

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -54,6 +54,7 @@
 #include "jfr/support/jfrThreadExtension.hpp"
 #endif
 
+#include <type_traits>
 
 class SafeThreadsListPtr;
 class ThreadSafepointState;
@@ -702,6 +703,17 @@ class JavaThread: public Thread {
   int _java_call_counter;
 
  public:
+
+  // Helper function to start a VM-internal daemon thread.
+  // E.g. ServiceThread, NotificationThread, CompilerThread etc.
+  template <typename T, ENABLE_IF(std::is_base_of<JavaThread, T>::value)>
+  static void startInternalDaemon(JavaThread* current, T* target,
+                                  Handle thread_oop, ThreadPriority prio,
+                                  T** instance);
+  // Helper function to do vm_exit_on_initialization for thread allocation
+  // failure.
+  static void exit_on_thread_allocation_failure(JavaThread* thread);
+
   int  java_call_counter()                       { return _java_call_counter; }
   void inc_java_call_counter()                   { _java_call_counter++; }
   void dec_java_call_counter() {

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -703,16 +703,6 @@ class JavaThread: public Thread {
 
  public:
 
-  // Helper function to start a VM-internal daemon thread.
-  // E.g. ServiceThread, NotificationThread, CompilerThread etc.
-  template <typename T, ENABLE_IF(std::is_base_of<JavaThread, T>::value)>
-  static void startInternalDaemon(JavaThread* current, T* target,
-                                  Handle thread_oop, ThreadPriority prio,
-                                  T** instance);
-  // Helper function to do vm_exit_on_initialization for thread allocation
-  // failure.
-  static void exit_on_thread_allocation_failure(JavaThread* thread);
-
   int  java_call_counter()                       { return _java_call_counter; }
   void inc_java_call_counter()                   { _java_call_counter++; }
   void dec_java_call_counter() {
@@ -1605,6 +1595,28 @@ public:
   static OopStorage* thread_oop_storage();
 
   static void verify_cross_modify_fence_failure(JavaThread *thread) PRODUCT_RETURN;
+
+  template <typename T>
+  class InstanceSetter : public StackObj {
+    T* _value;
+    T** _field;
+   public:
+    void set() {
+      if (_field != nullptr) {
+        *_field = _value;
+      }
+    }
+    InstanceSetter(T* value, T** field) : _value(value), _field(field) { }
+  };
+
+  // Helper function to start a VM-internal daemon thread.
+  // E.g. ServiceThread, NotificationThread, CompilerThread etc.
+  static void start_internal_daemon(JavaThread* current, JavaThread* target,
+                                  Handle thread_oop, ThreadPriority prio);
+
+  // Helper function to do vm_exit_on_initialization for thread allocation
+  // failure.
+  static void vm_exit_on_thread_allocation_failure(JavaThread* thread);
 };
 
 // The active thread queue. It also keeps track of the current used

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -30,6 +30,7 @@
 #include "gc/shared/gcThreadLocalData.hpp"
 #include "gc/shared/threadLocalAllocBuffer.hpp"
 #include "memory/allocation.hpp"
+#include "metaprogramming/enableIf.hpp"
 #include "oops/oop.hpp"
 #include "oops/oopHandle.hpp"
 #include "runtime/frame.hpp"
@@ -53,8 +54,6 @@
 #if INCLUDE_JFR
 #include "jfr/support/jfrThreadExtension.hpp"
 #endif
-
-#include <type_traits>
 
 class SafeThreadsListPtr;
 class ThreadSafepointState;

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -30,7 +30,6 @@
 #include "gc/shared/gcThreadLocalData.hpp"
 #include "gc/shared/threadLocalAllocBuffer.hpp"
 #include "memory/allocation.hpp"
-#include "metaprogramming/enableIf.hpp"
 #include "oops/oop.hpp"
 #include "oops/oopHandle.hpp"
 #include "runtime/frame.hpp"

--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -485,10 +485,9 @@ void AttachListener::init() {
   }
 
   JavaThread* thread = new JavaThread(&attach_listener_thread_entry);
-  JavaThread::exit_on_thread_allocation_failure(thread);
+  JavaThread::vm_exit_on_thread_allocation_failure(thread);
 
-  JavaThread::startInternalDaemon(THREAD, thread, thread_oop, NoPriority,
-                                  static_cast<JavaThread**>(nullptr));
+  JavaThread::start_internal_daemon(THREAD, thread, thread_oop, NoPriority);
 }
 
 // Performs clean-up tasks on platforms where we can detect that the last

--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -485,7 +485,7 @@ void AttachListener::init() {
   }
 
   JavaThread* thread = new JavaThread(&attach_listener_thread_entry);
-  JavaThread::vm_exit_on_thread_allocation_failure(thread);
+  JavaThread::vm_exit_on_osthread_failure(thread);
 
   JavaThread::start_internal_daemon(THREAD, thread, thread_oop, NoPriority);
 }

--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -484,22 +484,11 @@ void AttachListener::init() {
     return;
   }
 
-  { MutexLocker mu(THREAD, Threads_lock);
-    JavaThread* listener_thread = new JavaThread(&attach_listener_thread_entry);
+  JavaThread* thread = new JavaThread(&attach_listener_thread_entry);
+  JavaThread::exit_on_thread_allocation_failure(thread);
 
-    // Check that thread and osthread were created
-    if (listener_thread == NULL || listener_thread->osthread() == NULL) {
-      vm_exit_during_initialization("java.lang.OutOfMemoryError",
-                                    os::native_thread_creation_failed_msg());
-    }
-
-    java_lang_Thread::set_thread(thread_oop(), listener_thread);
-    java_lang_Thread::set_daemon(thread_oop());
-
-    listener_thread->set_threadObj(thread_oop());
-    Threads::add(listener_thread);
-    Thread::start(listener_thread);
-  }
+  JavaThread::startInternalDaemon(THREAD, thread, thread_oop, NoPriority,
+                                  static_cast<JavaThread**>(nullptr));
 }
 
 // Performs clean-up tasks on platforms where we can detect that the last


### PR DESCRIPTION
Please see the JBS issue for more details, but basically we have 8 different kinds of internal VM JavaThreads (grouping the three types of CompilerThread together) that all basically duplicated the logic for initializing (preparing is the term we use for user-defined JavaThreads) and starting the new thread. This common code can be factored out into static helpers in JavaThread.

This change does not look at the way the java.lang.Thread instance is created - that will be handled by a separate RFE.

The semantics of the changes are not identical, but I don't believe there is any observable change in behaviour. The scope of holding the Threads_lock has been reduced, and we now create the JavaThread instances ("new XXXThread(...)") outside of the lock. As far as I can see nothing in the construction process needs to happen under the Threads_lock.

A few of the threads use a static `_instance` field to hold a reference to the create JavaThread. This proved very difficult to handle, as logically the field would need to be updated in the middle of the new factored-out method: after setting all the fields but before releasing the newly started thread. I eventually realized that in all but one case those `_instance` fields are never used and so could be deleted. The one case remaining does not need to be set as I just described, but can be set after the thread has started, as the new thread does not examine it (arguably its existence is unnecessary).

The trickiest changes related to the CompilerThreads, so they need particular scrutiny.

Testing: tiers 1-3

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269466](https://bugs.openjdk.java.net/browse/JDK-8269466): Factor out the common code for initializing and starting internal VM JavaThreads


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to 8275b1844219e64c214edd00b856473c8dc6f7a0
 * [Patricio Chilano Mateo](https://openjdk.java.net/census#pchilanomate) (@pchilano - Committer) ⚠️ Review applies to e547e0a5ee8bb395b9d6e5d7d63a603053fd1dd3
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to 8275b1844219e64c214edd00b856473c8dc6f7a0
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to 8275b1844219e64c214edd00b856473c8dc6f7a0
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4629/head:pull/4629` \
`$ git checkout pull/4629`

Update a local copy of the PR: \
`$ git checkout pull/4629` \
`$ git pull https://git.openjdk.java.net/jdk pull/4629/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4629`

View PR using the GUI difftool: \
`$ git pr show -t 4629`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4629.diff">https://git.openjdk.java.net/jdk/pull/4629.diff</a>

</details>
