### PR TITLE
8268298: jdk/jfr/api/consumer/log/TestVerbosity.java fails: unexpected log message

### DIFF
--- a/test/jdk/jdk/jfr/api/consumer/log/TestVerbosity.java
+++ b/test/jdk/jdk/jfr/api/consumer/log/TestVerbosity.java
@@ -42,7 +42,7 @@ import jdk.jfr.Name;
  *      jdk.jfr.api.consumer.log.TestVerbosity trace
  * @run main/othervm
  *      -Xlog:jfr+event*=debug:file=debug.log
- *      -XX:StartFlightRecording
+ *      -XX:StartFlightRecording:jdk.ExecutionSample#enabled=false
  *      jdk.jfr.api.consumer.log.TestVerbosity debug
  * @run main/othervm
  *      -Xlog:jfr+event*=info:file=info.log


### PR DESCRIPTION
Hi,

Could I have a review of this small test fix that disables `jdk.ExecutionSample` when run TestVerbosity with arg `debug` to prevent unexpected `method1`.

Regards,
Denghui

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268298](https://bugs.openjdk.java.net/browse/JDK-8268298): jdk/jfr/api/consumer/log/TestVerbosity.java fails: unexpected log message


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4631/head:pull/4631` \
`$ git checkout pull/4631`

Update a local copy of the PR: \
`$ git checkout pull/4631` \
`$ git pull https://git.openjdk.java.net/jdk pull/4631/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4631`

View PR using the GUI difftool: \
`$ git pr show -t 4631`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4631.diff">https://git.openjdk.java.net/jdk/pull/4631.diff</a>

</details>
