### PR TITLE
8269665: Clean-up toString() methods of some primitive wrappers

### DIFF
--- a/src/java.base/share/classes/java/lang/Boolean.java
+++ b/src/java.base/share/classes/java/lang/Boolean.java
@@ -216,8 +216,9 @@ public final class Boolean implements java.io.Serializable,
      *
      * @return  a string representation of this object.
      */
+    @Override
     public String toString() {
-        return value ? "true" : "false";
+        return toString(value);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Boolean.java
+++ b/src/java.base/share/classes/java/lang/Boolean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -205,7 +205,7 @@ public final class Boolean implements java.io.Serializable,
      * @since 1.4
      */
     public static String toString(boolean b) {
-        return b ? "true" : "false";
+        return String.valueOf(b);
     }
 
     /**
@@ -218,7 +218,7 @@ public final class Boolean implements java.io.Serializable,
      */
     @Override
     public String toString() {
-        return toString(value);
+        return String.valueOf(value);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Byte.java
+++ b/src/java.base/share/classes/java/lang/Byte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/Byte.java
+++ b/src/java.base/share/classes/java/lang/Byte.java
@@ -90,7 +90,7 @@ public final class Byte extends Number implements Comparable<Byte>, Constable {
      * @see java.lang.Integer#toString(int)
      */
     public static String toString(byte b) {
-        return Integer.toString((int)b, 10);
+        return Integer.toString(b);
     }
 
     /**
@@ -436,8 +436,9 @@ public final class Byte extends Number implements Comparable<Byte>, Constable {
      * @return  a string representation of the value of this object in
      *          base&nbsp;10.
      */
+    @Override
     public String toString() {
-        return Integer.toString((int)value);
+        return toString(value);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Byte.java
+++ b/src/java.base/share/classes/java/lang/Byte.java
@@ -438,7 +438,7 @@ public final class Byte extends Number implements Comparable<Byte>, Constable {
      */
     @Override
     public String toString() {
-        return toString(value);
+        return Integer.toString(value);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Character.java
+++ b/src/java.base/share/classes/java/lang/Character.java
@@ -8656,8 +8656,9 @@ class Character implements java.io.Serializable, Comparable<Character>, Constabl
      *
      * @return  a string representation of this object.
      */
+    @Override
     public String toString() {
-        return String.valueOf(value);
+        return toString(value);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Character.java
+++ b/src/java.base/share/classes/java/lang/Character.java
@@ -8658,7 +8658,7 @@ class Character implements java.io.Serializable, Comparable<Character>, Constabl
      */
     @Override
     public String toString() {
-        return toString(value);
+        return String.valueOf(value);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Short.java
+++ b/src/java.base/share/classes/java/lang/Short.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/Short.java
+++ b/src/java.base/share/classes/java/lang/Short.java
@@ -89,7 +89,7 @@ public final class Short extends Number implements Comparable<Short>, Constable 
      * @see java.lang.Integer#toString(int)
      */
     public static String toString(short s) {
-        return Integer.toString((int)s, 10);
+        return Integer.toString(s);
     }
 
     /**
@@ -441,8 +441,9 @@ public final class Short extends Number implements Comparable<Short>, Constable 
      * @return  a string representation of the value of this object in
      *          base&nbsp;10.
      */
+    @Override
     public String toString() {
-        return Integer.toString((int)value);
+        return toString(value);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Short.java
+++ b/src/java.base/share/classes/java/lang/Short.java
@@ -443,7 +443,7 @@ public final class Short extends Number implements Comparable<Short>, Constable 
      */
     @Override
     public String toString() {
-        return toString(value);
+        return Integer.toString(value);
     }
 
     /**


### PR DESCRIPTION
As of JDK 17 some of primitive wrappers, e.g. `Long`, `Integer`, `Double` and `Float` in their implementations of `Object.toString()` delegate to own utility `toString(primitive)` methods.

Unlike those, `Boolean`, `Byte`, `Character` and `Short` just duplicate the contents of utility methods in implementations of `Object.toString()`.

Yet another issue is a tiny discrepancy in implementation related to `Byte` and `Short` (see the first):
```java
public static String toString(byte b) {
    return Integer.toString((int)b, 10);
}

public String toString() {
    return Integer.toString((int)value);
}
```
Unlike in overriden method, In utility one they explicitly specify radix which can be skipped, as implementation of `Integer.toString(int,int)` has a fast-path for radix 10, ending in `Integer.toString(int)`. This simplification gives tiny improvement, see benchmark:
```java
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@Fork(jvmArgsAppend = {"-Xms2g", "-Xmx2g"})
public class ByteToStringBenchmark {
    @Benchmark
    public String byteToString() {
        return Byte.toString((byte) 1);
    }
}
```
Results:
```
before

Benchmark                                                            Mode  Cnt     Score     Error   Units
ByteToStringBenchmark.byteToString                                   avgt   30    11,648 ±   1,906   ns/op
ByteToStringBenchmark.byteToString:·gc.alloc.rate                    avgt   30  3288,576 ± 418,119  MB/sec
ByteToStringBenchmark.byteToString:·gc.alloc.rate.norm               avgt   30    48,001 ±   0,001    B/op
ByteToStringBenchmark.byteToString:·gc.churn.G1_Eden_Space           avgt   30  3301,804 ± 455,932  MB/sec
ByteToStringBenchmark.byteToString:·gc.churn.G1_Eden_Space.norm      avgt   30    48,158 ±   2,085    B/op
ByteToStringBenchmark.byteToString:·gc.churn.G1_Survivor_Space       avgt   30     0,004 ±   0,001  MB/sec
ByteToStringBenchmark.byteToString:·gc.churn.G1_Survivor_Space.norm  avgt   30    ≈ 10⁻⁴              B/op
ByteToStringBenchmark.byteToString:·gc.count                         avgt   30   202,000            counts
ByteToStringBenchmark.byteToString:·gc.time                          avgt   30   413,000                ms

after

Benchmark                                                            Mode  Cnt     Score     Error   Units
ByteToStringBenchmark.byteToString                                   avgt   30    10,016 ±   0,530   ns/op
ByteToStringBenchmark.byteToString:·gc.alloc.rate                    avgt   30  3673,700 ± 167,450  MB/sec
ByteToStringBenchmark.byteToString:·gc.alloc.rate.norm               avgt   30    48,001 ±   0,001    B/op
ByteToStringBenchmark.byteToString:·gc.churn.G1_Eden_Space           avgt   30  3662,406 ± 205,978  MB/sec
ByteToStringBenchmark.byteToString:·gc.churn.G1_Eden_Space.norm      avgt   30    47,870 ±   1,750    B/op
ByteToStringBenchmark.byteToString:·gc.churn.G1_Survivor_Space       avgt   30     0,004 ±   0,002  MB/sec
ByteToStringBenchmark.byteToString:·gc.churn.G1_Survivor_Space.norm  avgt   30    ≈ 10⁻⁴              B/op
ByteToStringBenchmark.byteToString:·gc.count                         avgt   30   224,000            counts
ByteToStringBenchmark.byteToString:·gc.time                          avgt   30   358,000                ms
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269665](https://bugs.openjdk.java.net/browse/JDK-8269665): Clean-up toString() methods of some primitive wrappers


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4633/head:pull/4633` \
`$ git checkout pull/4633`

Update a local copy of the PR: \
`$ git checkout pull/4633` \
`$ git pull https://git.openjdk.java.net/jdk pull/4633/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4633`

View PR using the GUI difftool: \
`$ git pr show -t 4633`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4633.diff">https://git.openjdk.java.net/jdk/pull/4633.diff</a>

</details>
