### PR TITLE
8269700: source level for IntelliJ JDK project is set incorrectly

### DIFF
--- a/make/ide/idea/jdk/template/misc.xml
+++ b/make/ide/idea/jdk/template/misc.xml
@@ -12,7 +12,7 @@
       <target file="file://###ROOT_DIR###/make/ide/idea/jdk/build.xml" name="images" />
     </ant>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_16" assert-keyword="true" jdk-15="true">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_X" assert-keyword="true" project-jdk-type="JavaSDK">
     <output url="file://###BUILD_DIR###/idea" />
   </component>
 </project>


### PR DESCRIPTION
After generating an Intellij project with the `idea.sh` script, IDEA might get confused 
with the language level settings in generated .idea/misc.xml. This results in a problem 
with modules discussed in https://mail.openjdk.java.net/pipermail/ide-support-dev/2021-June/000082.html.
To mitigate the problem changing the project's language level helps.

This patch sets language level for jdk Intellij Project to [X (Experimental Features)](https://github.com/JetBrains/intellij-community/blob/master/jps/model-api/src/org/jetbrains/jps/model/java/LanguageLevel.java) to avoid such problems.

As a side effect following term needs to be accepted in IDEA once opening the project for the first time:
```
You must accept the terms of legal notice of the beta Java specification 
to enable support for "X - Experimental features".  The implementation 
of an early-draft specification developed under the Java Community Process (JCP) 
is made available for testing and evaluation purposes only and is not 
compatible with any specification of the JCP.
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269700](https://bugs.openjdk.java.net/browse/JDK-8269700): source level for IntelliJ JDK project is set incorrectly


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4634/head:pull/4634` \
`$ git checkout pull/4634`

Update a local copy of the PR: \
`$ git checkout pull/4634` \
`$ git pull https://git.openjdk.java.net/jdk pull/4634/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4634`

View PR using the GUI difftool: \
`$ git pr show -t 4634`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4634.diff">https://git.openjdk.java.net/jdk/pull/4634.diff</a>

</details>
