### PR TITLE
8268897: [TESTBUG] compiler/compilercontrol/mixed/RandomCommandsTest.java must not fail on Command.quiet

### DIFF
--- a/test/hotspot/jtreg/compiler/compilercontrol/share/MultiCommand.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/share/MultiCommand.java
@@ -72,7 +72,9 @@ public class MultiCommand extends AbstractTestBase {
 
             Executable exec = Utils.getRandomElement(METHODS).first;
             MethodDescriptor md;
-            if (validOnly) {
+
+            // Command.quiet discards the method descriptor - can never fail on the method descriptor
+            if (validOnly || cmd == Command.QUIET) {
                 md = AbstractTestBase.getValidMethodDescriptor(exec);
             } else {
                 md = AbstractTestBase.METHOD_GEN.generateRandomDescriptor(exec);


### PR DESCRIPTION
Hi,

This is a small fix of a test bug. 

RandomCommandsTest.java can generate command file only containing a quiet command but with an invalid method descriptor. But Quiet commands are handled separately in the parser because they are just a global option. Any method descriptor will be discarded without validation.

This fix just makes sure we don't generate bad descriptor for quiet. That means we won't expect them to fail on the descriptor.

Please review,
Best regards,
Nils Eliasson

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268897](https://bugs.openjdk.java.net/browse/JDK-8268897): [TESTBUG] compiler/compilercontrol/mixed/RandomCommandsTest.java must not fail on Command.quiet


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4635/head:pull/4635` \
`$ git checkout pull/4635`

Update a local copy of the PR: \
`$ git checkout pull/4635` \
`$ git pull https://git.openjdk.java.net/jdk pull/4635/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4635`

View PR using the GUI difftool: \
`$ git pr show -t 4635`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4635.diff">https://git.openjdk.java.net/jdk/pull/4635.diff</a>

</details>
