### PR TITLE
JDK-8268870: Remove dead code in metaspaceShared

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.hpp
+++ b/src/hotspot/share/cds/metaspaceShared.hpp
@@ -101,17 +101,12 @@ public:
     _archive_loading_failed = true;
   }
 
-  static bool map_shared_spaces(FileMapInfo* mapinfo) NOT_CDS_RETURN_(false);
   static void initialize_shared_spaces() NOT_CDS_RETURN;
 
   // Return true if given address is in the shared metaspace regions (i.e., excluding any
   // mapped shared heap regions.)
   static bool is_in_shared_metaspace(const void* p) {
     return MetaspaceObj::is_shared((const MetaspaceObj*)p);
-  }
-
-  static address shared_metaspace_top() {
-    return (address)MetaspaceObj::shared_metaspace_top();
   }
 
   static void set_shared_metaspace_range(void* base, void *static_top, void* top) NOT_CDS_RETURN;


### PR DESCRIPTION
a trivial cleanup in metaspaceShared.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268870](https://bugs.openjdk.java.net/browse/JDK-8268870): Remove dead code in metaspaceShared


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4636/head:pull/4636` \
`$ git checkout pull/4636`

Update a local copy of the PR: \
`$ git checkout pull/4636` \
`$ git pull https://git.openjdk.java.net/jdk pull/4636/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4636`

View PR using the GUI difftool: \
`$ git pr show -t 4636`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4636.diff">https://git.openjdk.java.net/jdk/pull/4636.diff</a>

</details>
