### PR TITLE
JDK-8269651: ZGC: Optimize away gc locker in mark start

### DIFF
--- a/src/hotspot/share/gc/z/zDriver.cpp
+++ b/src/hotspot/share/gc/z/zDriver.cpp
@@ -146,10 +146,6 @@ public:
     return VMOp_ZMarkStart;
   }
 
-  virtual bool needs_inactive_gc_locker() const {
-    return true;
-  }
-
   virtual bool do_operation() {
     ZStatTimer timer(ZPhasePauseMarkStart);
     ZServiceabilityPauseTracer tracer;


### PR DESCRIPTION
Currently, ZGC involves gc locker in mark-start and relocate-start.
It seems gc locker in mark-start is not necessary anymore.
This is to remove this unnecessary(??) gc locker before further optimization is discussed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8269651](https://bugs.openjdk.java.net/browse/JDK-8269651): ZGC: Optimize away gc locker in mark start ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4638/head:pull/4638` \
`$ git checkout pull/4638`

Update a local copy of the PR: \
`$ git checkout pull/4638` \
`$ git pull https://git.openjdk.java.net/jdk pull/4638/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4638`

View PR using the GUI difftool: \
`$ git pr show -t 4638`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4638.diff">https://git.openjdk.java.net/jdk/pull/4638.diff</a>

</details>
