### PR TITLE
8268788: Annotations with lambda expressions can still cause AnnotationFormatError

### DIFF
--- a/src/java.base/share/classes/sun/reflect/annotation/AnnotationInvocationHandler.java
+++ b/src/java.base/share/classes/sun/reflect/annotation/AnnotationInvocationHandler.java
@@ -502,9 +502,11 @@ class AnnotationInvocationHandler implements InvocationHandler, Serializable {
             // similar construct. A static initializer may be used for
             // purposes such as initializing a lambda stored in an
             // interface field.
+            // Methods that have no arguments (lambdas without parameters)
+            // as well as methods with arguments (lambdas with parameters)
+            // should be skipped.
             if (method.isSynthetic() &&
-                (modifiers & (Modifier.STATIC | Modifier.PRIVATE)) != 0 &&
-                method.getParameterCount() == 0) {
+                (modifiers & (Modifier.STATIC | Modifier.PRIVATE)) != 0) {
                 continue;
             }
 

--- a/test/jdk/java/lang/annotation/EqualityTest.java
+++ b/test/jdk/java/lang/annotation/EqualityTest.java
@@ -33,6 +33,7 @@
 
 import java.lang.annotation.*;
 import java.lang.reflect.*;
+import java.util.function.Function;
 
 @TestAnnotation
 public class EqualityTest {
@@ -59,7 +60,8 @@ public class EqualityTest {
 
 @Retention(RetentionPolicy.RUNTIME)
 @interface TestAnnotation {
-    // Trigger creation of synthetic method to initialize r.
+    // Trigger creation of synthetic method to initialize r and f.
     public static final Runnable r = () -> {};
+    public static final Function<Integer,Integer> f = x -> x;
 }
 


### PR DESCRIPTION
Change #3294 helps to avoid `AnnotaionFormatException` in `sun.reflect.annotation.AnnotationInvocationHandler.validateAnnotationMethods`. While it fixes the case with e.g. `Runnable`  that generates the synthetic method without parameters, validation still fails on synthetic methods that have parameters e.g. `Function`, `BiFunction`, etc.

This change removes the restriction on parameters count to be zero i.e. lambdas with parameters
would be skipped from validation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8268788](https://bugs.openjdk.java.net/browse/JDK-8268788): Annotations with lambda expressions can still cause AnnotationFormatError


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4642/head:pull/4642` \
`$ git checkout pull/4642`

Update a local copy of the PR: \
`$ git checkout pull/4642` \
`$ git pull https://git.openjdk.java.net/jdk pull/4642/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4642`

View PR using the GUI difftool: \
`$ git pr show -t 4642`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4642.diff">https://git.openjdk.java.net/jdk/pull/4642.diff</a>

</details>
