### PR TITLE
8225559: assertion error at TransTypes.visitApply

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/DeferredAttr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/DeferredAttr.java
@@ -157,7 +157,7 @@ public class DeferredAttr extends JCTree.Visitor {
                         JCExpression clazz = copy(t.clazz, p);
                         List<JCExpression> args = copy(t.args, p);
                         JCClassDecl def = null;
-                        return make.at(t.pos).SpeculativeNewClass(encl, typeargs, clazz, args, def, t.def != null);
+                        return make.at(t.pos).SpeculativeNewClass(encl, typeargs, clazz, args, def, t.def != null || t.classDeclRemoved());
                     } else {
                         return super.visitNewClass(node, p);
                     }

--- a/test/langtools/tools/javac/generics/diamond/protectedConstructor/ProtectedConstructorTest.java
+++ b/test/langtools/tools/javac/generics/diamond/protectedConstructor/ProtectedConstructorTest.java
@@ -29,11 +29,15 @@
  */
 
 import pkg.Bar;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 class ProtectedConstructorTest {
     public void foo() {
         supply(getSupplier(new Bar<>(){}));
+        CompletableFuture<List<String>> completableFuture = getCompletableFuture(getSupplier(new Bar<>(){}));
+        completableFuture = getCompletableFuture(() -> getList(null, new Bar<>() {}));
     }
 
     static <U> Supplier<U> getSupplier(Bar<U> t) {
@@ -41,4 +45,6 @@ class ProtectedConstructorTest {
     }
 
     static <U> void supply(Supplier<U> supplier) {}
+    static <U> CompletableFuture<U> getCompletableFuture(Supplier<U> supplier) { return null; }
+    <T> List<T> getList(final Supplier<List<T>> supplier, Bar<T> t) { return null; }
 }

--- a/test/langtools/tools/javac/generics/diamond/protectedConstructor/ProtectedConstructorTest.java
+++ b/test/langtools/tools/javac/generics/diamond/protectedConstructor/ProtectedConstructorTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8225559
+ * @summary assertion error at TransTypes.visitApply
+ * @compile ProtectedConstructorTest.java
+ */
+
+import pkg.Bar;
+import java.util.function.Supplier;
+
+class ProtectedConstructorTest {
+    public void foo() {
+        supply(getSupplier(new Bar<>(){}));
+    }
+
+    static <U> Supplier<U> getSupplier(Bar<U> t) {
+        return null;
+    }
+
+    static <U> void supply(Supplier<U> supplier) {}
+}

--- a/test/langtools/tools/javac/generics/diamond/protectedConstructor/pkg/Bar.java
+++ b/test/langtools/tools/javac/generics/diamond/protectedConstructor/pkg/Bar.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package pkg;
+
+public abstract class Bar<T> {
+    protected Bar() {}
+    protected Bar(Class<?> c) {}
+}


### PR DESCRIPTION
Please review this PR that is fixing a bug in javac. Depending on variations of the input the compiler fails with an assertion error or with the infamous NPE. So for code like:
```
src/pkg/Bar.java:

package pkg;
public abstract class Bar<T> {
    protected Bar() {}
    protected Bar(Class<?> c) {}
}

src/Test.java:

import pkg.Bar;
import java.util.function.Supplier;

class Test {
    public void foo() {
        supply(getSupplier(new Bar<>(){}));
    }

    static <U> Supplier<U> getSupplier(Bar<U> t) {
        return null;
    }

    static <U> void supply(Supplier<U> supplier) {}
}
```
see that the new class expression is defining an anonymous class which is invoking a protected constructor in the super class, all of this should just work, and it works if the user doesn't use diamond and instead the type parameters are provided explicitly. So what happens with the diamond?

The reason is deep into the speculative attribution machinery, oh boy.... So when we are dealing with diamond expression that define anonymous classes, the speculative attribution will at some point clone that expression but it will nuke its class definition basically in the expression: `new Bar<>(){}` the `{}` will be removed.

so we have:
`new Bar<>(){}  (Original)`
`new Bar<>()    (Copy1)`

but in order for the rest of the code to know that the original expression was actually defining an anonymous class, the compiler does a trick. Which can be seen at: `com.sun.tools.javac.tree.TreeMaker::SpeculativeNewClass` basically an anonymous class which overrides method `JCTree.JCNewClass::classDeclRemoved` is created. But the bug presented itself for cases when the speculative attribution needs to clone `Copy1` and now it doesn't have the `{}`, the class definition, for the cloning code to know that that expression was copied from `Original` which was defining an anonymous class. So we need to double check by making use of method JCTree.JCNewClass::classDeclRemoved which is what this fix is doing.

Also it is important to know if the new class expression was defining an anonymous inner class or not because that makes the difference in case the new class expression is accessing a protected constructor as in this case.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8225559](https://bugs.openjdk.java.net/browse/JDK-8225559): assertion error at TransTypes.visitApply


### Reviewers
 * [Srikanth Adayapalam](https://openjdk.java.net/census#sadayapalam) (@sadayapalam - **Reviewer**) ⚠️ Review applies to abe51ca34532f7c83c729c301ba010b8cc361f5e
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**) ⚠️ Review applies to abe51ca34532f7c83c729c301ba010b8cc361f5e


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4647/head:pull/4647` \
`$ git checkout pull/4647`

Update a local copy of the PR: \
`$ git checkout pull/4647` \
`$ git pull https://git.openjdk.java.net/jdk pull/4647/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4647`

View PR using the GUI difftool: \
`$ git pr show -t 4647`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4647.diff">https://git.openjdk.java.net/jdk/pull/4647.diff</a>

</details>
