### PR TITLE
JDK-8269110: ZGC: Remove dead code in zBarrier

### DIFF
--- a/src/hotspot/share/gc/z/zBarrier.hpp
+++ b/src/hotspot/share/gc/z/zBarrier.hpp
@@ -97,10 +97,8 @@ public:
   static oop weak_load_barrier_on_oop_field(volatile oop* p);
   static oop weak_load_barrier_on_oop_field_preloaded(volatile oop* p, oop o);
   static oop weak_load_barrier_on_weak_oop(oop o);
-  static oop weak_load_barrier_on_weak_oop_field(volatile oop* p);
   static oop weak_load_barrier_on_weak_oop_field_preloaded(volatile oop* p, oop o);
   static oop weak_load_barrier_on_phantom_oop(oop o);
-  static oop weak_load_barrier_on_phantom_oop_field(volatile oop* p);
   static oop weak_load_barrier_on_phantom_oop_field_preloaded(volatile oop* p, oop o);
 
   // Is alive barrier
@@ -116,7 +114,6 @@ public:
   // Mark barrier
   static void mark_barrier_on_oop_field(volatile oop* p, bool finalizable);
   static void mark_barrier_on_oop_array(volatile oop* p, size_t length, bool finalizable);
-  static void mark_barrier_on_invisible_root_oop_field(oop* p);
 
   // Narrow oop variants, never used.
   static oop  load_barrier_on_oop_field(volatile narrowOop* p);

--- a/src/hotspot/share/gc/z/zBarrier.inline.hpp
+++ b/src/hotspot/share/gc/z/zBarrier.inline.hpp
@@ -287,11 +287,6 @@ inline oop ZBarrier::weak_load_barrier_on_weak_oop(oop o) {
   return weak_load_barrier_on_weak_oop_field_preloaded((oop*)NULL, o);
 }
 
-inline oop ZBarrier::weak_load_barrier_on_weak_oop_field(volatile oop* p) {
-  const oop o = Atomic::load(p);
-  return weak_load_barrier_on_weak_oop_field_preloaded(p, o);
-}
-
 inline oop ZBarrier::weak_load_barrier_on_weak_oop_field_preloaded(volatile oop* p, oop o) {
   verify_on_weak(p);
 
@@ -304,11 +299,6 @@ inline oop ZBarrier::weak_load_barrier_on_weak_oop_field_preloaded(volatile oop*
 
 inline oop ZBarrier::weak_load_barrier_on_phantom_oop(oop o) {
   return weak_load_barrier_on_phantom_oop_field_preloaded((oop*)NULL, o);
-}
-
-inline oop ZBarrier::weak_load_barrier_on_phantom_oop_field(volatile oop* p) {
-  const oop o = Atomic::load(p);
-  return weak_load_barrier_on_phantom_oop_field_preloaded(p, o);
 }
 
 inline oop ZBarrier::weak_load_barrier_on_phantom_oop_field_preloaded(volatile oop* p, oop o) {


### PR DESCRIPTION
this is a trivial cleanup to remove some dead code in zBarrier.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269110](https://bugs.openjdk.java.net/browse/JDK-8269110): ZGC: Remove dead code in zBarrier


### Reviewers
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4649/head:pull/4649` \
`$ git checkout pull/4649`

Update a local copy of the PR: \
`$ git checkout pull/4649` \
`$ git pull https://git.openjdk.java.net/jdk pull/4649/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4649`

View PR using the GUI difftool: \
`$ git pr show -t 4649`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4649.diff">https://git.openjdk.java.net/jdk/pull/4649.diff</a>

</details>
