### PR TITLE
JDK-8269423: ZGC: Support pinned Object and remove/simplify GCLocker usage in ZGC

### DIFF
--- a/src/hotspot/share/gc/z/zCollectedHeap.cpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.cpp
@@ -291,6 +291,15 @@ void ZCollectedHeap::safepoint_synchronize_end() {
   SuspendibleThreadSet::desynchronize();
 }
 
+oop ZCollectedHeap::pin_object(JavaThread* thr, oop o) {
+  _heap.pin_object(o);
+  return o;
+}
+
+void ZCollectedHeap::unpin_object(JavaThread* thr, oop o) {
+  _heap.unpin_object(o);
+}
+
 void ZCollectedHeap::prepare_for_verify() {
   // Does nothing
 }

--- a/src/hotspot/share/gc/z/zCollectedHeap.hpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.hpp
@@ -113,6 +113,11 @@ public:
   virtual void safepoint_synchronize_begin();
   virtual void safepoint_synchronize_end();
 
+  // Pinning hooks
+  virtual oop pin_object(JavaThread* thread, oop obj);
+  virtual void unpin_object(JavaThread* thread, oop obj);
+  virtual bool supports_object_pinning() const { return true; }
+
   virtual void print_on(outputStream* st) const;
   virtual void print_on_error(outputStream* st) const;
   virtual void print_extended_on(outputStream* st) const;

--- a/src/hotspot/share/gc/z/zDriver.hpp
+++ b/src/hotspot/share/gc/z/zDriver.hpp
@@ -49,7 +49,6 @@ public:
 class ZDriver : public ConcurrentGCThread {
 private:
   ZMessagePort<ZDriverRequest> _gc_cycle_port;
-  ZRendezvousPort              _gc_locker_port;
 
   template <typename T> bool pause();
 

--- a/src/hotspot/share/gc/z/zForwarding.hpp
+++ b/src/hotspot/share/gc/z/zForwarding.hpp
@@ -68,6 +68,7 @@ public:
   size_t object_alignment_shift() const;
   void object_iterate(ObjectClosure *cl);
 
+  ZPage* get_page() const { return _page; }
   bool retain_page();
   ZPage* claim_page();
   void release_page();

--- a/src/hotspot/share/gc/z/zHeap.hpp
+++ b/src/hotspot/share/gc/z/zHeap.hpp
@@ -34,6 +34,7 @@
 #include "gc/z/zReferenceProcessor.hpp"
 #include "gc/z/zRelocate.hpp"
 #include "gc/z/zRelocationSet.hpp"
+#include "gc/z/zRelocationSetSelector.hpp"
 #include "gc/z/zWeakRootsProcessor.hpp"
 #include "gc/z/zServiceability.hpp"
 #include "gc/z/zUnload.hpp"
@@ -59,6 +60,7 @@ private:
   ZWeakRootsProcessor _weak_roots_processor;
   ZRelocate           _relocate;
   ZRelocationSet      _relocation_set;
+  ZRelocationSetSelector _selector;
   ZUnload             _unload;
   ZServiceability     _serviceability;
 
@@ -138,6 +140,10 @@ public:
   uintptr_t relocate_object(uintptr_t addr);
   uintptr_t remap_object(uintptr_t addr);
   void relocate();
+
+  // Pinning hooks
+  oop pin_object(oop obj);
+  void unpin_object(oop obj);
 
   // Iteration
   void object_iterate(ObjectClosure* cl, bool visit_weaks);

--- a/src/hotspot/share/gc/z/zPage.hpp
+++ b/src/hotspot/share/gc/z/zPage.hpp
@@ -44,6 +44,7 @@ private:
   uint64_t           _last_used;
   ZPhysicalMemory    _physical;
   ZListNode<ZPage>   _node;
+  volatile size_t    _critical_pins;
 
   void assert_initialized() const;
 
@@ -108,6 +109,10 @@ public:
 
   bool undo_alloc_object(uintptr_t addr, size_t size);
   bool undo_alloc_object_atomic(uintptr_t addr, size_t size);
+
+  void record_pin();
+  void record_unpin();
+  size_t pin_count() const;
 
   void print_on(outputStream* out) const;
   void print() const;

--- a/src/hotspot/share/gc/z/zRelocationSetSelector.cpp
+++ b/src/hotspot/share/gc/z/zRelocationSetSelector.cpp
@@ -53,6 +53,12 @@ ZRelocationSetSelectorGroup::ZRelocationSetSelectorGroup(const char* name,
     _forwarding_entries(0),
     _stats() {}
 
+void ZRelocationSetSelectorGroup::reset() {
+  _live_pages.clear_and_deallocate();
+  _forwarding_entries = 0;
+  _stats.reset();
+}
+
 bool ZRelocationSetSelectorGroup::is_disabled() {
   // Medium pages are disabled when their page size is zero
   return _page_type == ZPageTypeMedium && _page_size == 0;
@@ -181,6 +187,13 @@ ZRelocationSetSelector::ZRelocationSetSelector() :
     _medium("Medium", ZPageTypeMedium, ZPageSizeMedium, ZObjectSizeLimitMedium),
     _large("Large", ZPageTypeLarge, 0 /* page_size */, 0 /* object_size_limit */),
     _empty_pages() {}
+
+void ZRelocationSetSelector::reset() {
+  _small.reset();
+  _medium.reset();
+  _large.reset();
+  _empty_pages.clear_and_deallocate();
+}
 
 void ZRelocationSetSelector::select() {
   // Select pages to relocate. The resulting relocation set will be

--- a/src/hotspot/share/gc/z/zRelocationSetSelector.hpp
+++ b/src/hotspot/share/gc/z/zRelocationSetSelector.hpp
@@ -47,6 +47,7 @@ public:
   size_t live() const;
   size_t empty() const;
   size_t relocate() const;
+  void reset();
 };
 
 class ZRelocationSetSelectorStats {
@@ -85,6 +86,8 @@ public:
                               size_t page_size,
                               size_t object_size_limit);
 
+  void reset();
+
   void register_live_page(ZPage* page);
   void register_empty_page(ZPage* page);
   void select();
@@ -108,6 +111,8 @@ private:
 
 public:
   ZRelocationSetSelector();
+
+  void reset();
 
   void register_live_page(ZPage* page);
   void register_empty_page(ZPage* page);

--- a/src/hotspot/share/gc/z/zRelocationSetSelector.inline.hpp
+++ b/src/hotspot/share/gc/z/zRelocationSetSelector.inline.hpp
@@ -146,6 +146,14 @@ inline size_t ZRelocationSetSelector::relocate() const {
   return _small.stats().relocate() + _medium.stats().relocate() + _large.stats().relocate();
 }
 
+inline void ZRelocationSetSelectorGroupStats::reset() {
+  _npages = 0;
+  _total = 0;
+  _live = 0;
+  _empty = 0;
+  _relocate = 0;
+}
+
 inline const ZArray<ZPage*>* ZRelocationSetSelector::small() const {
   return _small.selected();
 }


### PR DESCRIPTION
This PR is not an real intention to push current implementation, and current implementation does not support ZVerifyViews (which was pointed out by Per at https://github.com/openjdk/jdk/pull/4638#issuecomment-872033165).

Let's see if this solution is feasible and how to support ZVerifyViews efficiently.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8269423](https://bugs.openjdk.java.net/browse/JDK-8269423): ZGC: Support pinned Object and remove/simplify GCLocker usage in ZGC


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4650/head:pull/4650` \
`$ git checkout pull/4650`

Update a local copy of the PR: \
`$ git checkout pull/4650` \
`$ git pull https://git.openjdk.java.net/jdk pull/4650/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4650`

View PR using the GUI difftool: \
`$ git pr show -t 4650`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4650.diff">https://git.openjdk.java.net/jdk/pull/4650.diff</a>

</details>
