### PR TITLE
8269743: test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/jni/nativeAndMH/Test.java crash with small heap (-Xmx50m)

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/jni/nativeAndMH/nativeAndMH.cpp
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/jni/nativeAndMH/nativeAndMH.cpp
@@ -56,7 +56,8 @@ Java_vm_mlvm_meth_stress_jni_nativeAndMH_Test_native01(
 
     NSK_JNI_VERIFY(pEnv, NULL != (objectClass = pEnv->FindClass("java/lang/Object")));
 
-    NSK_JNI_VERIFY(pEnv, NULL != (arguments = pEnv->NewObjectArray(ARGS_COUNT, objectClass, NULL)));
+    if (!NSK_JNI_VERIFY(pEnv, NULL != (arguments = pEnv->NewObjectArray(ARGS_COUNT, objectClass, NULL))))
+        return NULL;
 
     NSK_JNI_VERIFY_VOID(pEnv, pEnv->SetObjectArrayElement(arguments, 0, a1));
     NSK_JNI_VERIFY_VOID(pEnv, pEnv->SetObjectArrayElement(arguments, 1, a2));


### PR DESCRIPTION
JDK-8269743
test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/jni/nativeAndMH/Test.java crash with small heap (-Xmx50m)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269743](https://bugs.openjdk.java.net/browse/JDK-8269743): test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/jni/nativeAndMH/Test.java crash with small heap (-Xmx50m)


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4651/head:pull/4651` \
`$ git checkout pull/4651`

Update a local copy of the PR: \
`$ git checkout pull/4651` \
`$ git pull https://git.openjdk.java.net/jdk pull/4651/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4651`

View PR using the GUI difftool: \
`$ git pr show -t 4651`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4651.diff">https://git.openjdk.java.net/jdk/pull/4651.diff</a>

</details>
