### PR TITLE
8244162: Additional opportunities to use NONCOPYABLE

### DIFF
--- a/src/hotspot/share/asm/assembler.hpp
+++ b/src/hotspot/share/asm/assembler.hpp
@@ -91,7 +91,7 @@ class Label {
   int _patch_index;
   GrowableArray<int>* _patch_overflow;
 
-  Label(const Label&) { ShouldNotReachHere(); }
+  NONCOPYABLE(Label);
  protected:
 
   // The label will be bound to a location near its users.

--- a/src/hotspot/share/classfile/stackMapTableFormat.hpp
+++ b/src/hotspot/share/classfile/stackMapTableFormat.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,11 +41,11 @@ class verification_type_info {
   address tag_addr() const { return (address)this; }
   address cpool_index_addr() const { return tag_addr() + sizeof(u1); }
   address bci_addr() const { return cpool_index_addr(); }
+  NONCOPYABLE(verification_type_info);
 
  protected:
   // No constructors  - should be 'private', but GCC issues a warning if it is
   verification_type_info() {}
-  verification_type_info(const verification_type_info&) {}
 
  public:
 
@@ -169,12 +169,13 @@ FOR_EACH_STACKMAP_FRAME_TYPE(SM_FORWARD_DECL, x, x)
 #undef SM_FORWARD_DECL
 
 class stack_map_frame {
+  NONCOPYABLE(stack_map_frame);
+
  protected:
   address frame_type_addr() const { return (address)this; }
 
   // No constructors  - should be 'private', but GCC issues a warning if it is
   stack_map_frame() {}
-  stack_map_frame(const stack_map_frame&) {}
 
  public:
 
@@ -901,11 +902,11 @@ class stack_map_table {
   address entries_addr() const {
     return number_of_entries_addr() + sizeof(u2);
   }
+  NONCOPYABLE(stack_map_table);
 
  protected:
   // No constructors  - should be 'private', but GCC issues a warning if it is
   stack_map_table() {}
-  stack_map_table(const stack_map_table&) {}
 
  public:
 
@@ -933,11 +934,11 @@ class stack_map_table_attribute {
       return name_index_addr() + sizeof(u2); }
   address stack_map_table_addr() const {
       return attribute_length_addr() + sizeof(u4); }
+  NONCOPYABLE(stack_map_table_attribute);
 
  protected:
   // No constructors  - should be 'private', but GCC issues a warning if it is
   stack_map_table_attribute() {}
-  stack_map_table_attribute(const stack_map_table_attribute&) {}
 
  public:
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.hpp
@@ -82,12 +82,10 @@ private:
   Counters _encountered_count;
   Counters _discovered_count;
   Counters _enqueued_count;
+  NONCOPYABLE(ShenandoahRefProcThreadLocal);
 
 public:
   ShenandoahRefProcThreadLocal();
-
-  ShenandoahRefProcThreadLocal(const ShenandoahRefProcThreadLocal&) = delete; // non construction-copyable
-  ShenandoahRefProcThreadLocal& operator=(const ShenandoahRefProcThreadLocal&) = delete; // non copyable
 
   void reset();
 

--- a/src/hotspot/share/logging/logMessageBuffer.hpp
+++ b/src/hotspot/share/logging/logMessageBuffer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,8 +54,7 @@ class LogMessageBuffer : public StackObj {
 
  private:
   // Forbid copy assignment and copy constructor.
-  void operator=(const LogMessageBuffer& ref) {}
-  LogMessageBuffer(const LogMessageBuffer& ref) {}
+  NONCOPYABLE(LogMessageBuffer);
 
  public:
   LogMessageBuffer();

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -220,8 +220,7 @@ class Node {
   friend class VMStructs;
 
   // Lots of restrictions on cloning Nodes
-  Node(const Node&);            // not defined; linker error to use these
-  Node &operator=(const Node &rhs);
+  NONCOPYABLE(Node);
 
 public:
   friend class Compile;

--- a/src/hotspot/share/utilities/formatBuffer.hpp
+++ b/src/hotspot/share/utilities/formatBuffer.hpp
@@ -62,7 +62,7 @@ class FormatBuffer : public FormatBufferBase {
   int size() { return bufsz; }
 
  private:
-  FormatBuffer(const FormatBuffer &); // prevent copies
+  NONCOPYABLE(FormatBuffer);
   char _buffer[bufsz];
 
  protected:


### PR DESCRIPTION
Please review this small change to use NONCOPYABLE macro where applicable.  The change was tested by running Mach5 tiers 1-2 on Linux, Mac OS, and Windows, and Mach5 tiers 3-5 on Linux x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244162](https://bugs.openjdk.java.net/browse/JDK-8244162): Additional opportunities to use NONCOPYABLE


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4652/head:pull/4652` \
`$ git checkout pull/4652`

Update a local copy of the PR: \
`$ git checkout pull/4652` \
`$ git pull https://git.openjdk.java.net/jdk pull/4652/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4652`

View PR using the GUI difftool: \
`$ git pr show -t 4652`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4652.diff">https://git.openjdk.java.net/jdk/pull/4652.diff</a>

</details>
