### PR TITLE
8269758: idea.sh doesn't work when there are multiple configurations available.

### DIFF
--- a/bin/idea.sh
+++ b/bin/idea.sh
@@ -25,7 +25,7 @@
 # Shell script for generating an IDEA project from a given list of modules
 
 usage() {
-      echo "usage: $0 [-h|--help] [-v|--verbose] [-o|--output <path>] [modules]+"
+      echo "usage: $0 [-h|--help] [-v|--verbose] [-o|--output <path>] [-c|--conf <conf_name>] [modules]+"
       exit 1
 }
 
@@ -37,6 +37,7 @@ cd $TOP;
 
 IDEA_OUTPUT=$TOP/.idea
 VERBOSE="false"
+CONF_ARG=
 while [ $# -gt 0 ]
 do
   case $1 in
@@ -50,6 +51,10 @@ do
 
     -o | --output )
       IDEA_OUTPUT=$2/.idea
+      shift
+      ;;
+    -c | --conf )
+      CONF_ARG="CONF_NAME=$2"
       shift
       ;;
 
@@ -91,7 +96,7 @@ if [ "$VERBOSE" = "true" ] ; then
   echo "idea template dir: $IDEA_TEMPLATE"
 fi
 
-cd $TOP ; make -f "$IDEA_MAKE/idea.gmk" -I $MAKE_DIR/.. idea MAKEOVERRIDES= OUT=$IDEA_OUTPUT/env.cfg MODULES="$*" || exit 1
+cd $TOP ; make -f "$IDEA_MAKE/idea.gmk" -I $MAKE_DIR/.. idea MAKEOVERRIDES= OUT=$IDEA_OUTPUT/env.cfg MODULES="$*" $CONF_ARG || exit 1
 cd $SCRIPT_DIR
 
 . $IDEA_OUTPUT/env.cfg


### PR DESCRIPTION
From the JBS issue:

The idea.sh script invokes `make`, but doesn't specify a configuration. So, when multiple configurations are present, this results in an error like this:

```
$ bash bin/idea.sh java.base
Error: No CONF given, but more than one configuration found.
Available configurations in /mnt/c/jdk/build:
* conf1
* conf2
* conf3
Please retry building with CONF=<config pattern> (or SPEC=<spec file>).

/mnt/c/jdk/make/Init.gmk:124: *** Cannot continue. Stop.
```

This patch adds an option to the script for specifying the configuration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269758](https://bugs.openjdk.java.net/browse/JDK-8269758): idea.sh doesn't work when there are multiple configurations available.


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4654/head:pull/4654` \
`$ git checkout pull/4654`

Update a local copy of the PR: \
`$ git checkout pull/4654` \
`$ git pull https://git.openjdk.java.net/jdk pull/4654/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4654`

View PR using the GUI difftool: \
`$ git pr show -t 4654`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4654.diff">https://git.openjdk.java.net/jdk/pull/4654.diff</a>

</details>
