### PR TITLE
8269760: idea.sh should not invoke cygpath directly

### DIFF
--- a/bin/idea.sh
+++ b/bin/idea.sh
@@ -153,14 +153,14 @@ add_replacement "###MODULE_NAMES###" "$MODULE_NAMES"
 add_replacement "###VCS_TYPE###" "$VCS_TYPE"
 SPEC_DIR=`dirname $SPEC`
 if [ "x$CYGPATH" != "x" ]; then
-    add_replacement "###BUILD_DIR###" "`cygpath -am $SPEC_DIR`"
-    add_replacement "###IMAGES_DIR###" "`cygpath -am $SPEC_DIR`/images/jdk"
-    add_replacement "###ROOT_DIR###" "`cygpath -am $TOPLEVEL_DIR`"
-    add_replacement "###IDEA_DIR###" "`cygpath -am $IDEA_OUTPUT`"
+    add_replacement "###BUILD_DIR###" "`$CYGPATH -am $SPEC_DIR`"
+    add_replacement "###IMAGES_DIR###" "`$CYGPATH -am $SPEC_DIR`/images/jdk"
+    add_replacement "###ROOT_DIR###" "`$CYGPATH -am $TOPLEVEL_DIR`"
+    add_replacement "###IDEA_DIR###" "`$CYGPATH -am $IDEA_OUTPUT`"
     if [ "x$JT_HOME" = "x" ]; then
       add_replacement "###JTREG_HOME###" ""
     else
-      add_replacement "###JTREG_HOME###" "`cygpath -am $JT_HOME`"
+      add_replacement "###JTREG_HOME###" "`$CYGPATH -am $JT_HOME`"
     fi
 elif [ "x$WSL_DISTRO_NAME" != "x" ]; then
     add_replacement "###BUILD_DIR###" "`wslpath -am $SPEC_DIR`"
@@ -185,7 +185,7 @@ SOURCE_POSTFIX="\" isTestSource=\"false\" />"
 
 for root in $MODULE_ROOTS; do
     if [ "x$CYGPATH" != "x" ]; then
-      root=`cygpath -am $root`
+      root=`$CYGPATH -am $root`
     elif [ "x$WSL_DISTRO_NAME" != "x" ]; then
       root=`wslpath -am $root`
     fi
@@ -225,10 +225,10 @@ CP=$ANT_HOME/lib/ant.jar
 rm -rf $CLASSES; mkdir $CLASSES
 
 if [ "x$CYGPATH" != "x" ] ; then ## CYGPATH may be set in env.cfg
-  JAVAC_SOURCE_FILE=`cygpath -am $IDEA_OUTPUT/src/idea/IdeaLoggerWrapper.java`
-  JAVAC_SOURCE_PATH=`cygpath -am $IDEA_OUTPUT/src`
-  JAVAC_CLASSES=`cygpath -am $CLASSES`
-  JAVAC_CP=`cygpath -am $CP`
+  JAVAC_SOURCE_FILE=`$CYGPATH -am $IDEA_OUTPUT/src/idea/IdeaLoggerWrapper.java`
+  JAVAC_SOURCE_PATH=`$CYGPATH -am $IDEA_OUTPUT/src`
+  JAVAC_CLASSES=`$CYGPATH -am $CLASSES`
+  JAVAC_CP=`$CYGPATH -am $CP`
   JAVAC=javac
 elif [ "x$WSL_DISTRO_NAME" != "x" ]; then
   JAVAC_SOURCE_FILE=`realpath --relative-to=./ $IDEA_OUTPUT/src/idea/IdeaLoggerWrapper.java`

--- a/bin/idea.sh
+++ b/bin/idea.sh
@@ -25,7 +25,7 @@
 # Shell script for generating an IDEA project from a given list of modules
 
 usage() {
-      echo "usage: $0 [-h|--help] [-v|--verbose] [-o|--output <path>] [modules]+"
+      echo "usage: $0 [-h|--help] [-v|--verbose] [-o|--output <path>] [-c|--conf <conf_name>] [modules]+"
       exit 1
 }
 
@@ -37,6 +37,7 @@ cd $TOP;
 
 IDEA_OUTPUT=$TOP/.idea
 VERBOSE="false"
+CONF_ARG=
 while [ $# -gt 0 ]
 do
   case $1 in
@@ -50,6 +51,10 @@ do
 
     -o | --output )
       IDEA_OUTPUT=$2/.idea
+      shift
+      ;;
+    -c | --conf )
+      CONF_ARG="CONF_NAME=$2"
       shift
       ;;
 
@@ -91,7 +96,7 @@ if [ "$VERBOSE" = "true" ] ; then
   echo "idea template dir: $IDEA_TEMPLATE"
 fi
 
-cd $TOP ; make -f "$IDEA_MAKE/idea.gmk" -I $MAKE_DIR/.. idea MAKEOVERRIDES= OUT=$IDEA_OUTPUT/env.cfg MODULES="$*" || exit 1
+cd $TOP ; make -f "$IDEA_MAKE/idea.gmk" -I $MAKE_DIR/.. idea MAKEOVERRIDES= OUT=$IDEA_OUTPUT/env.cfg MODULES="$*" $CONF_ARG || exit 1
 cd $SCRIPT_DIR
 
 . $IDEA_OUTPUT/env.cfg


### PR DESCRIPTION
From the JBS issue:

Currently idea.sh checks if `CYGPATH` is set, and then continues by invoking `cygpath` directly.

This doesn't work if `CYGPATH` is not actually set to `cygpath`, but to something else, such as `wslpath`.

Instead of invoking `cygpath` directly, the value of the `CYGPATH` variable should be used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269760](https://bugs.openjdk.java.net/browse/JDK-8269760): idea.sh should not invoke cygpath directly


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4655/head:pull/4655` \
`$ git checkout pull/4655`

Update a local copy of the PR: \
`$ git checkout pull/4655` \
`$ git pull https://git.openjdk.java.net/jdk pull/4655/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4655`

View PR using the GUI difftool: \
`$ git pr show -t 4655`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4655.diff">https://git.openjdk.java.net/jdk/pull/4655.diff</a>

</details>
