### PR TITLE
8269761: idea.sh missing .exe suffix when invoking javac on WSL

### DIFF
--- a/bin/idea.sh
+++ b/bin/idea.sh
@@ -153,14 +153,14 @@ add_replacement "###MODULE_NAMES###" "$MODULE_NAMES"
 add_replacement "###VCS_TYPE###" "$VCS_TYPE"
 SPEC_DIR=`dirname $SPEC`
 if [ "x$CYGPATH" != "x" ]; then
-    add_replacement "###BUILD_DIR###" "`cygpath -am $SPEC_DIR`"
-    add_replacement "###IMAGES_DIR###" "`cygpath -am $SPEC_DIR`/images/jdk"
-    add_replacement "###ROOT_DIR###" "`cygpath -am $TOPLEVEL_DIR`"
-    add_replacement "###IDEA_DIR###" "`cygpath -am $IDEA_OUTPUT`"
+    add_replacement "###BUILD_DIR###" "`$CYGPATH -am $SPEC_DIR`"
+    add_replacement "###IMAGES_DIR###" "`$CYGPATH -am $SPEC_DIR`/images/jdk"
+    add_replacement "###ROOT_DIR###" "`$CYGPATH -am $TOPLEVEL_DIR`"
+    add_replacement "###IDEA_DIR###" "`$CYGPATH -am $IDEA_OUTPUT`"
     if [ "x$JT_HOME" = "x" ]; then
       add_replacement "###JTREG_HOME###" ""
     else
-      add_replacement "###JTREG_HOME###" "`cygpath -am $JT_HOME`"
+      add_replacement "###JTREG_HOME###" "`$CYGPATH -am $JT_HOME`"
     fi
 elif [ "x$WSL_DISTRO_NAME" != "x" ]; then
     add_replacement "###BUILD_DIR###" "`wslpath -am $SPEC_DIR`"
@@ -185,7 +185,7 @@ SOURCE_POSTFIX="\" isTestSource=\"false\" />"
 
 for root in $MODULE_ROOTS; do
     if [ "x$CYGPATH" != "x" ]; then
-      root=`cygpath -am $root`
+      root=`$CYGPATH -am $root`
     elif [ "x$WSL_DISTRO_NAME" != "x" ]; then
       root=`wslpath -am $root`
     fi
@@ -225,10 +225,10 @@ CP=$ANT_HOME/lib/ant.jar
 rm -rf $CLASSES; mkdir $CLASSES
 
 if [ "x$CYGPATH" != "x" ] ; then ## CYGPATH may be set in env.cfg
-  JAVAC_SOURCE_FILE=`cygpath -am $IDEA_OUTPUT/src/idea/IdeaLoggerWrapper.java`
-  JAVAC_SOURCE_PATH=`cygpath -am $IDEA_OUTPUT/src`
-  JAVAC_CLASSES=`cygpath -am $CLASSES`
-  JAVAC_CP=`cygpath -am $CP`
+  JAVAC_SOURCE_FILE=`$CYGPATH -am $IDEA_OUTPUT/src/idea/IdeaLoggerWrapper.java`
+  JAVAC_SOURCE_PATH=`$CYGPATH -am $IDEA_OUTPUT/src`
+  JAVAC_CLASSES=`$CYGPATH -am $CLASSES`
+  JAVAC_CP=`$CYGPATH -am $CP`
   JAVAC=javac
 elif [ "x$WSL_DISTRO_NAME" != "x" ]; then
   JAVAC_SOURCE_FILE=`realpath --relative-to=./ $IDEA_OUTPUT/src/idea/IdeaLoggerWrapper.java`

--- a/bin/idea.sh
+++ b/bin/idea.sh
@@ -25,7 +25,7 @@
 # Shell script for generating an IDEA project from a given list of modules
 
 usage() {
-      echo "usage: $0 [-h|--help] [-v|--verbose] [-o|--output <path>] [modules]+"
+      echo "usage: $0 [-h|--help] [-v|--verbose] [-o|--output <path>] [-c|--conf <conf_name>] [modules]+"
       exit 1
 }
 
@@ -37,6 +37,7 @@ cd $TOP;
 
 IDEA_OUTPUT=$TOP/.idea
 VERBOSE="false"
+CONF_ARG=
 while [ $# -gt 0 ]
 do
   case $1 in
@@ -50,6 +51,10 @@ do
 
     -o | --output )
       IDEA_OUTPUT=$2/.idea
+      shift
+      ;;
+    -c | --conf )
+      CONF_ARG="CONF_NAME=$2"
       shift
       ;;
 
@@ -91,7 +96,7 @@ if [ "$VERBOSE" = "true" ] ; then
   echo "idea template dir: $IDEA_TEMPLATE"
 fi
 
-cd $TOP ; make -f "$IDEA_MAKE/idea.gmk" -I $MAKE_DIR/.. idea MAKEOVERRIDES= OUT=$IDEA_OUTPUT/env.cfg MODULES="$*" || exit 1
+cd $TOP ; make -f "$IDEA_MAKE/idea.gmk" -I $MAKE_DIR/.. idea MAKEOVERRIDES= OUT=$IDEA_OUTPUT/env.cfg MODULES="$*" $CONF_ARG || exit 1
 cd $SCRIPT_DIR
 
 . $IDEA_OUTPUT/env.cfg

--- a/bin/idea.sh
+++ b/bin/idea.sh
@@ -69,6 +69,9 @@ do
   shift
 done
 
+if [ -e $IDEA_OUTPUT ] ; then
+    rm -r $IDEA_OUTPUT
+fi
 mkdir -p $IDEA_OUTPUT || exit 1
 cd $IDEA_OUTPUT; IDEA_OUTPUT=`pwd`
 
@@ -224,34 +227,36 @@ fi
 CP=$ANT_HOME/lib/ant.jar
 rm -rf $CLASSES; mkdir $CLASSES
 
-if [ "x$CYGPATH" != "x" ] ; then ## CYGPATH may be set in env.cfg
-  JAVAC_SOURCE_FILE=`$CYGPATH -am $IDEA_OUTPUT/src/idea/IdeaLoggerWrapper.java`
-  JAVAC_SOURCE_PATH=`$CYGPATH -am $IDEA_OUTPUT/src`
-  JAVAC_CLASSES=`$CYGPATH -am $CLASSES`
-  JAVAC_CP=`$CYGPATH -am $CP`
+# If we have a Windows boot JDK, we need a .exe suffix
+if [ -e "$BOOT_JDK/bin/java.exe" ] ; then
+  JAVAC=javac.exe
+else 
   JAVAC=javac
-elif [ "x$WSL_DISTRO_NAME" != "x" ]; then
+fi
+
+# If we are on WSL, the boot JDK might be either Windows or Linux,
+# and we need to use realpath instead of CYGPATH to make javac work on both.
+# We need to handle this case first since CYGPATH might be set on WSL.
+if [ "x$WSL_DISTRO_NAME" != "x" ]; then
   JAVAC_SOURCE_FILE=`realpath --relative-to=./ $IDEA_OUTPUT/src/idea/IdeaLoggerWrapper.java`
   JAVAC_SOURCE_PATH=`realpath --relative-to=./ $IDEA_OUTPUT/src`
   JAVAC_CLASSES=`realpath --relative-to=./ $CLASSES`
   ANT_TEMP=`mktemp -d -p ./`
   cp $ANT_HOME/lib/ant.jar $ANT_TEMP/ant.jar
   JAVAC_CP=$ANT_TEMP/ant.jar
-  JAVAC=javac.exe
+elif [ "x$CYGPATH" != "x" ] ; then ## CYGPATH may be set in env.cfg
+  JAVAC_SOURCE_FILE=`$CYGPATH -am $IDEA_OUTPUT/src/idea/IdeaLoggerWrapper.java`
+  JAVAC_SOURCE_PATH=`$CYGPATH -am $IDEA_OUTPUT/src`
+  JAVAC_CLASSES=`$CYGPATH -am $CLASSES`
+  JAVAC_CP=`$CYGPATH -am $CP`
 else
   JAVAC_SOURCE_FILE=$IDEA_OUTPUT/src/idea/IdeaLoggerWrapper.java
   JAVAC_SOURCE_PATH=$IDEA_OUTPUT/src
   JAVAC_CLASSES=$CLASSES
   JAVAC_CP=$CP
-  JAVAC=javac
 fi
 
-EXE_SUFFIX=
-if [ "x$WSL_DISTRO_NAME" != "x" ]; then
-  EXE_SUFFIX=.exe
-fi
-
-$BOOT_JDK/bin/$JAVAC$EXE_SUFFIX -d $JAVAC_CLASSES -sourcepath $JAVAC_SOURCE_PATH -cp $JAVAC_CP $JAVAC_SOURCE_FILE
+$BOOT_JDK/bin/$JAVAC -d $JAVAC_CLASSES -sourcepath $JAVAC_SOURCE_PATH -cp $JAVAC_CP $JAVAC_SOURCE_FILE
 
 if [ "x$WSL_DISTRO_NAME" != "x" ]; then
   rm -rf $ANT_TEMP

--- a/bin/idea.sh
+++ b/bin/idea.sh
@@ -246,7 +246,12 @@ else
   JAVAC=javac
 fi
 
-$BOOT_JDK/bin/$JAVAC -d $JAVAC_CLASSES -sourcepath $JAVAC_SOURCE_PATH -cp $JAVAC_CP $JAVAC_SOURCE_FILE
+EXE_SUFFIX=
+if [ "x$WSL_DISTRO_NAME" != "x" ]; then
+  EXE_SUFFIX=.exe
+fi
+
+$BOOT_JDK/bin/$JAVAC$EXE_SUFFIX -d $JAVAC_CLASSES -sourcepath $JAVAC_SOURCE_PATH -cp $JAVAC_CP $JAVAC_SOURCE_FILE
 
 if [ "x$WSL_DISTRO_NAME" != "x" ]; then
   rm -rf $ANT_TEMP


### PR DESCRIPTION
From the JBS issue:

At the end, idea.sh tries to invoke javac, but when running on WSL this results in the following error:

    bin/idea.sh: line 249: /mnt/c/progra~1/java/jdk-16/bin/javac: No such file or directory

Adding a .exe suffix to the javac path fixes this issue, which can be done just for WSL.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269761](https://bugs.openjdk.java.net/browse/JDK-8269761): idea.sh missing .exe suffix when invoking javac on WSL


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4656/head:pull/4656` \
`$ git checkout pull/4656`

Update a local copy of the PR: \
`$ git checkout pull/4656` \
`$ git pull https://git.openjdk.java.net/jdk pull/4656/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4656`

View PR using the GUI difftool: \
`$ git pr show -t 4656`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4656.diff">https://git.openjdk.java.net/jdk/pull/4656.diff</a>

</details>
