### PR TITLE
8269668: [aarch64] java.library.path not including /usr/lib64

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -412,7 +412,7 @@ void os::init_system_properties_values() {
   //        ...
   //        7: The default directories, normally /lib and /usr/lib.
 #ifndef OVERRIDE_LIBPATH
-  #if defined(AMD64) || (defined(_LP64) && defined(SPARC)) || defined(PPC64) || defined(S390)
+  #if defined(_LP64)
     #define DEFAULT_LIBPATH "/usr/lib64:/lib64:/lib:/usr/lib"
   #else
     #define DEFAULT_LIBPATH "/lib:/usr/lib"


### PR DESCRIPTION
This fix simplifies the `if` condition to use a default 64-bit library path including default setting when `_LP64` is defined (os has 64-bitness). This should be safe IMHO and seems better than explicitly enumerating all 64 bit Linux architectures. An alternative patch would be:

```
diff --git a/src/hotspot/os/linux/os_linux.cpp b/src/hotspot/os/linux/os_linux.cpp
index 4ebf50ef0d3..5db22f8dff3 100644
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -412,7 +412,7 @@ void os::init_system_properties_values() {
   //        ...
   //        7: The default directories, normally /lib and /usr/lib.
 #ifndef OVERRIDE_LIBPATH
-  #if defined(AMD64) || (defined(_LP64) && defined(SPARC)) || defined(PPC64) || defined(S390)
+  #if defined(AMD64) || (defined(_LP64) && defined(SPARC)) || defined(PPC64) || defined(S390) || defined(AARCH64)
     #define DEFAULT_LIBPATH "/usr/lib64:/lib64:/lib:/usr/lib"
   #else
     #define DEFAULT_LIBPATH "/lib:/usr/lib"
```

This issue affects older releases and I'd like to get this fix into JDK 17 too. With that in mind, please let me know what the preference is. Note that SPARC support has been removed with JEP 381 in JDK 15. Thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269668](https://bugs.openjdk.java.net/browse/JDK-8269668): [aarch64] java.library.path not including /usr/lib64


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4657/head:pull/4657` \
`$ git checkout pull/4657`

Update a local copy of the PR: \
`$ git checkout pull/4657` \
`$ git pull https://git.openjdk.java.net/jdk pull/4657/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4657`

View PR using the GUI difftool: \
`$ git pr show -t 4657`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4657.diff">https://git.openjdk.java.net/jdk/pull/4657.diff</a>

</details>
