### PR TITLE
JDK-8270147: Increase stride size allowing unrolling more loops

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -174,10 +174,6 @@
           "Unroll loop bodies with node count less than this")              \
           range(0, max_jint / 4)                                            \
                                                                             \
-  product(bool,  LoopUnrollMaximizeStrideLimit, true, DIAGNOSTIC,           \
-          "Allow large strides in loops during unrolling, allowing more "   \
-          "loops to be undrolled")                                          \
-                                                                            \
   product_pd(intx, LoopPercentProfileLimit,                                 \
              "Unroll loop bodies with % node count of profile limit")       \
              range(10, 100)                                                 \

--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -174,6 +174,10 @@
           "Unroll loop bodies with node count less than this")              \
           range(0, max_jint / 4)                                            \
                                                                             \
+  product(bool,  LoopUnrollMaximizeStrideLimit, true, DIAGNOSTIC,           \
+          "Allow large strides in loops during unrolling, allowing more "   \
+          "loops to be undrolled")                                          \
+                                                                            \
   product_pd(intx, LoopPercentProfileLimit,                                 \
              "Unroll loop bodies with % node count of profile limit")       \
              range(10, 100)                                                 \

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -884,7 +884,6 @@ bool IdealLoopTree::policy_unroll(PhaseIdealLoop *phase) {
   // No abs() use; abs(min_jint) = 1
   if (stride_con < -max_stride_size || stride_con > max_stride_size) return false;
 
-
   // Don't unroll if the next round of unrolling would push us
   // over the expected trip count of the loop.  One is subtracted
   // from the expected trip count because the pre-loop normally
@@ -2007,7 +2006,7 @@ void PhaseIdealLoop::do_unroll(IdealLoopTree *loop, Node_List &old_new, bool adj
   int stride_p = (stride_con > 0) ? stride_con : -stride_con;
   uint old_trip_count = loop_head->trip_count();
   // Verify that unroll policy result is still valid.
-  assert(old_trip_count > 1 && (!adjust_min_trip || stride_p <= 
+  assert(old_trip_count > 1 && (!adjust_min_trip || stride_p <=
     MIN2(max_jint / 2 - 2, MAX2(1<<2, Matcher::max_vector_size(T_BYTE)) * loop_head->unrolled_count())), "sanity");
 
   update_main_loop_skeleton_predicates(ctrl, loop_head, init, stride_con);

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2013,7 +2013,7 @@ void PhaseIdealLoop::do_unroll(IdealLoopTree *loop, Node_List &old_new, bool adj
   uint old_trip_count = loop_head->trip_count();
   // Verify that unroll policy result is still valid.
   assert(old_trip_count > 1 &&
-      (!adjust_min_trip || 
+      (!adjust_min_trip ||
       (LoopUnrollMaximizeStrideLimit && stride_p <= max_jint / 2 - 2) ||
       (!LoopUnrollMaximizeStrideLimit && stride_p <= (1<<3)*loop_head->unrolled_count())), "sanity");
 

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -881,7 +881,7 @@ bool IdealLoopTree::policy_unroll(PhaseIdealLoop *phase) {
   const int initial_stride_sz = MAX2(1<<2, Matcher::max_vector_size(T_BYTE) / 2);
   // Maximum stride size should protect against overflow, when doubling stride unroll_count times
   const int max_stride_size = MIN2(max_jint / 2 - 2, initial_stride_sz * future_unroll_cnt);
-  // No abs() use; abs(min_jint) = 1
+  // No abs() use; abs(min_jint) = 1 (or min_jint)
   if (stride_con < -max_stride_size || stride_con > max_stride_size) return false;
 
   // Don't unroll if the next round of unrolling would push us
@@ -2007,7 +2007,7 @@ void PhaseIdealLoop::do_unroll(IdealLoopTree *loop, Node_List &old_new, bool adj
   uint old_trip_count = loop_head->trip_count();
   // Verify that unroll policy result is still valid.
   assert(old_trip_count > 1 && (!adjust_min_trip || stride_p <=
-    MIN2(max_jint / 2 - 2, MAX2(1<<2, Matcher::max_vector_size(T_BYTE)) * loop_head->unrolled_count())), "sanity");
+    MIN2(max_jint / 2 - 2, MAX2(1<<3, Matcher::max_vector_size(T_BYTE)) * loop_head->unrolled_count())), "sanity");
 
   update_main_loop_skeleton_predicates(ctrl, loop_head, init, stride_con);
 

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -881,7 +881,7 @@ bool IdealLoopTree::policy_unroll(PhaseIdealLoop *phase) {
   const int initial_stride_sz = MAX2(1<<2, Matcher::max_vector_size(T_BYTE) / 2);
   // Maximum stride size should protect against overflow, when doubling stride unroll_count times
   const int max_stride_size = MIN2<int>(max_jint / 2 - 2, initial_stride_sz * future_unroll_cnt);
-  // No abs() use; abs(min_jint) = 1 (or min_jint)
+  // No abs() use; abs(min_jint) = min_jint
   if (stride_con < -max_stride_size || stride_con > max_stride_size) return false;
 
   // Don't unroll if the next round of unrolling would push us
@@ -2007,7 +2007,7 @@ void PhaseIdealLoop::do_unroll(IdealLoopTree *loop, Node_List &old_new, bool adj
   uint old_trip_count = loop_head->trip_count();
   // Verify that unroll policy result is still valid.
   assert(old_trip_count > 1 && (!adjust_min_trip || stride_p <=
-    MIN2(max_jint / 2 - 2, MAX2(1<<3, Matcher::max_vector_size(T_BYTE)) * loop_head->unrolled_count())), "sanity");
+    MIN2<int>(max_jint / 2 - 2, MAX2(1<<3, Matcher::max_vector_size(T_BYTE)) * loop_head->unrolled_count())), "sanity");
 
   update_main_loop_skeleton_predicates(ctrl, loop_head, init, stride_con);
 

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -880,7 +880,7 @@ bool IdealLoopTree::policy_unroll(PhaseIdealLoop *phase) {
   // Check for initial stride being a small enough constant
   const int initial_stride_sz = MAX2(1<<2, Matcher::max_vector_size(T_BYTE) / 2);
   // Maximum stride size should protect against overflow, when doubling stride unroll_count times
-  const int max_stride_size = MIN2(max_jint / 2 - 2, initial_stride_sz * future_unroll_cnt);
+  const int max_stride_size = MIN2<int>(max_jint / 2 - 2, initial_stride_sz * future_unroll_cnt);
   // No abs() use; abs(min_jint) = 1 (or min_jint)
   if (stride_con < -max_stride_size || stride_con > max_stride_size) return false;
 

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -875,13 +875,20 @@ bool IdealLoopTree::policy_unroll(PhaseIdealLoop *phase) {
     if ((future_unroll_cnt / unroll_constraint) > LoopMaxUnroll) return false;
   }
 
-  // Prevent orverflow when multiplying stride by 2, in C2, leave some space for +/- 1
-  // Note: min_jint = -max_jint - 1 (mathematically), abs(min_jint) = 1 (reality)
-  // Stride gets doubled with every unroll iteration
-  const jlong mid = max_jint / 2 - 2;
-  const jlong stride_con = cl->stride_con();
+  const int stride_con = cl->stride_con();
 
-  if (stride_con < -mid || stride_con > mid) return false;
+  if (LoopUnrollMaximizeStrideLimit) {
+    // Prevent orverflow when multiplying stride by 2, in C2, leave some space for +/- 1
+    // Note: min_jint = -max_jint - 1 (mathematically), abs(min_jint) = 1 (reality)
+    // Stride gets doubled with every unroll iteration
+    const int mid = max_jint / 2 - 2;
+
+    if (stride_con < -mid || stride_con > mid)
+      return false;
+  } else {
+      // Check for initial stride being a small enough constant
+      if (abs(cl->stride_con()) > (1<<2)*future_unroll_cnt) return false;
+  }
 
   // Don't unroll if the next round of unrolling would push us
   // over the expected trip count of the loop.  One is subtracted
@@ -2006,7 +2013,9 @@ void PhaseIdealLoop::do_unroll(IdealLoopTree *loop, Node_List &old_new, bool adj
   uint old_trip_count = loop_head->trip_count();
   // Verify that unroll policy result is still valid.
   assert(old_trip_count > 1 &&
-      (!adjust_min_trip || stride_p <= max_jint / 2 - 2), "sanity");
+      (!adjust_min_trip || 
+      (LoopUnrollMaximizeStrideLimit && stride_p <= max_jint / 2 - 2) ||
+      (!LoopUnrollMaximizeStrideLimit && stride_p <= (1<<3)*loop_head->unrolled_count())), "sanity");
 
   update_main_loop_skeleton_predicates(ctrl, loop_head, init, stride_con);
 

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreBytes.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreBytes.java
@@ -1,0 +1,229 @@
+package org.openjdk.bench.jdk.incubator.vector;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.concurrent.TimeUnit;
+import jdk.incubator.foreign.CLinker;
+import jdk.incubator.foreign.MemoryAccess;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
+import jdk.incubator.vector.ByteVector;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 1, jvmArgsAppend = {
+    "--add-modules=jdk.incubator.foreign,jdk.incubator.vector",
+    "-Dforeign.restricted=permit",
+    "--enable-native-access", "ALL-UNNAMED",
+    "-Djdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK=1"})
+public class TestLoadStoreBytes {
+  private static final VectorSpecies<Byte> SPECIES = VectorSpecies.ofLargestShape(byte.class);
+
+  @Param("1024")
+  private int size;
+
+  private byte[] srcArray;
+
+  private byte[] dstArray;
+
+
+  private ByteBuffer srcBufferHeap;
+
+  private ByteBuffer dstBufferHeap;
+
+  private ByteBuffer srcBufferNative;
+
+  private ByteBuffer dstBufferNative;
+
+
+  private ResourceScope implicitScope;
+
+  private MemorySegment srcSegmentImplicit;
+
+  private MemorySegment dstSegmentImplicit;
+
+  private ByteBuffer srcBufferSegmentImplicit;
+
+  private ByteBuffer dstBufferSegmentImplicit;
+
+
+  private MemoryAddress srcAddress;
+
+  private MemoryAddress dstAddress;
+
+  byte[] a, b, c;
+
+  @Setup
+  public void setup() {
+    srcArray = new byte[size];
+    dstArray = srcArray.clone();
+    for (int i = 0; i < srcArray.length; i++) {
+      srcArray[i] = (byte) i;
+    }
+
+
+    srcBufferHeap = ByteBuffer.allocate(size);
+    dstBufferHeap = ByteBuffer.allocate(size);
+
+    srcBufferNative = ByteBuffer.allocateDirect(size);
+    dstBufferNative = ByteBuffer.allocateDirect(size);
+
+
+    implicitScope = ResourceScope.newImplicitScope();
+    srcSegmentImplicit = MemorySegment.allocateNative(size, SPECIES.vectorByteSize(), implicitScope);
+    srcBufferSegmentImplicit = srcSegmentImplicit.asByteBuffer();
+    dstSegmentImplicit = MemorySegment.allocateNative(size, SPECIES.vectorByteSize(), implicitScope);
+    dstBufferSegmentImplicit = dstSegmentImplicit.asByteBuffer();
+
+
+    srcAddress = CLinker.allocateMemory(size);
+    dstAddress = CLinker.allocateMemory(size);
+
+    a = new byte[size];
+    b = new byte[size];
+    c = new byte[size];
+  }
+
+
+  @Benchmark
+  public void array() {
+//    final var srcArray = this.srcArray;
+    for (int i = 0; i < SPECIES.loopBound(srcArray.length); i += SPECIES.length()) {
+      var v = ByteVector.fromArray(SPECIES, srcArray, i);
+      v.intoArray(dstArray, i);
+    }
+  }
+
+  @Benchmark
+  public void array2() {
+//    final var srcArray = this.srcArray;
+    for (int i = 0; i < SPECIES.loopBound(srcArray.length); i += SPECIES.length()) {
+      var v = ByteVector.fromByteArray(SPECIES, srcArray, i, ByteOrder.nativeOrder());
+      v.intoByteArray(dstArray, i, ByteOrder.nativeOrder());
+    }
+  }
+
+  @Benchmark
+  public void arrayScalar() {
+    for (int i = 0; i < SPECIES.loopBound(srcArray.length); i ++) {
+      var v = srcArray[i];
+      dstArray[i] = v;
+    }
+  }
+
+  @Benchmark
+  public void vectAdd1() {
+    var a = this.a;
+    var b = this.b;
+    var c = this.c;
+
+    for (int i = 0; i < a.length; i += SPECIES.length()) {
+      ByteVector av = ByteVector.fromArray(SPECIES, a, i);
+      ByteVector bv = ByteVector.fromArray(SPECIES, b, i);
+      av.lanewise(VectorOperators.ADD, bv).intoArray(c, i);
+    }
+  }
+
+  @Benchmark
+  public void vectAdd2() {
+    var a = this.a;
+    var b = this.b;
+    var c = this.c;
+
+    for (int i = 0; i < a.length/SPECIES.length(); i++) {
+      ByteVector av = ByteVector.fromArray(SPECIES, a, (i*SPECIES.length()));
+      ByteVector bv = ByteVector.fromArray(SPECIES, b, (i*SPECIES.length()));
+      av.lanewise(VectorOperators.ADD, bv).intoArray(c, (i*SPECIES.length()));
+    }
+  }
+
+  @Benchmark
+  public void arrayAdd() {
+    for (int i = 0; i < SPECIES.loopBound(srcArray.length); i += SPECIES.length()) {
+      var v = ByteVector.fromArray(SPECIES, srcArray, i);
+      v = v.add(v);
+      v.intoArray(dstArray, i);
+    }
+  }
+
+  @Benchmark
+  public void bufferHeap() {
+    for (int i = 0; i < SPECIES.loopBound(srcArray.length); i += SPECIES.length()) {
+      var v = ByteVector.fromByteBuffer(SPECIES, srcBufferHeap, i, ByteOrder.nativeOrder());
+      v.intoByteBuffer(dstBufferHeap, i, ByteOrder.nativeOrder());
+    }
+  }
+
+  @Benchmark
+  public void bufferHeapScalar() {
+    for (int i = 0; i < SPECIES.loopBound(srcArray.length); i++) {
+      var v = srcBufferHeap.get(i);
+      dstBufferHeap.put(i, v);
+    }
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.PRINT)
+  public void bufferNative() {
+    for (int i = 0; i < SPECIES.loopBound(srcArray.length); i += SPECIES.length()) {
+      var v = ByteVector.fromByteBuffer(SPECIES, srcBufferNative, i, ByteOrder.nativeOrder());
+      v.intoByteBuffer(dstBufferNative, i, ByteOrder.nativeOrder());
+    }
+  }
+
+  @Benchmark
+  public void bufferNativeScalar() {
+    for (int i = 0; i < SPECIES.loopBound(srcArray.length); i++) {
+      var v = srcBufferNative.get(i);
+      dstBufferNative.put(i, v);
+    }
+  }
+
+
+  @Benchmark
+  public void bufferSegmentImplicit() {
+    for (int i = 0; i < SPECIES.loopBound(srcArray.length); i += SPECIES.length()) {
+      var v = ByteVector.fromByteBuffer(SPECIES, srcBufferSegmentImplicit, i, ByteOrder.nativeOrder());
+      v.intoByteBuffer(dstBufferSegmentImplicit, i, ByteOrder.nativeOrder());
+    }
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.PRINT)
+  public void segmentImplicitScalar() {
+    for (int i = 0; i < SPECIES.loopBound(srcArray.length); i++) {
+      var v = MemoryAccess.getByteAtOffset(srcSegmentImplicit, i);
+      MemoryAccess.setByteAtOffset(dstSegmentImplicit, i, v);
+    }
+  }
+
+  @Benchmark
+  public void bufferSegmentConfined() {
+    try (final var scope = ResourceScope.newConfinedScope()) {
+      final var srcBufferSegmentConfined = srcAddress.asSegment(size, scope).asByteBuffer();
+      final var dstBufferSegmentConfined = dstAddress.asSegment(size, scope).asByteBuffer();
+
+      for (int i = 0; i < SPECIES.loopBound(srcArray.length); i += SPECIES.length()) {
+        var v = ByteVector.fromByteBuffer(SPECIES, srcBufferSegmentConfined, i, ByteOrder.nativeOrder());
+        v.intoByteBuffer(dstBufferSegmentConfined, i, ByteOrder.nativeOrder());
+      }
+    }
+  }
+}

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreBytes.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreBytes.java
@@ -1,3 +1,26 @@
+/*
+ *  Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
 package org.openjdk.bench.jdk.incubator.vector;
 
 import java.nio.ByteBuffer;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreShort.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreShort.java
@@ -1,0 +1,205 @@
+package org.openjdk.bench.jdk.incubator.vector;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.concurrent.TimeUnit;
+import jdk.incubator.foreign.CLinker;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
+import jdk.incubator.vector.ShortVector;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 1, jvmArgsAppend = {
+    "--add-modules=jdk.incubator.foreign,jdk.incubator.vector",
+    "-Dforeign.restricted=permit",
+    "--enable-native-access", "ALL-UNNAMED"})
+public class TestLoadStoreShort {
+  private static final VectorSpecies<Short> SPECIES = VectorSpecies.ofLargestShape(short.class);
+
+  @Param("256")
+  private int size;
+
+  private int longSize;
+
+  private short[] srcArray;
+
+  private short[] dstArray;
+
+
+  private ByteBuffer srcBufferHeap;
+
+  private ByteBuffer dstBufferHeap;
+
+  private ByteBuffer srcBufferNative;
+
+  private ByteBuffer dstBufferNative;
+
+
+  private ResourceScope implicitScope;
+
+  private MemorySegment srcSegmentImplicit;
+
+  private MemorySegment dstSegmentImplicit;
+
+  private ByteBuffer srcBufferSegmentImplicit;
+
+  private ByteBuffer dstBufferSegmentImplicit;
+
+
+  private MemoryAddress srcAddress;
+
+  private MemoryAddress dstAddress;
+
+//  private byte[] bigArray = new byte[Integer.MAX_VALUE];
+
+  private volatile short[] a, b, c;
+  @Setup
+  public void setup() {
+    var longSize = size / Short.BYTES;
+    srcArray = new short[longSize];
+    dstArray = srcArray.clone();
+    for (int i = 0; i < srcArray.length; i++) {
+      srcArray[i] = (short) i;
+    }
+
+
+    srcBufferHeap = ByteBuffer.allocate(size);
+    dstBufferHeap = ByteBuffer.allocate(size);
+
+    srcBufferNative = ByteBuffer.allocateDirect(size);
+    dstBufferNative = ByteBuffer.allocateDirect(size);
+
+
+    implicitScope = ResourceScope.newImplicitScope();
+    srcSegmentImplicit = MemorySegment.allocateNative(size, SPECIES.vectorByteSize(), implicitScope);
+    srcBufferSegmentImplicit = srcSegmentImplicit.asByteBuffer();
+    dstSegmentImplicit = MemorySegment.allocateNative(size, SPECIES.vectorByteSize(), implicitScope);
+    dstBufferSegmentImplicit = dstSegmentImplicit.asByteBuffer();
+
+
+    srcAddress = CLinker.allocateMemory(size);
+    dstAddress = CLinker.allocateMemory(size);
+
+    this.longSize = longSize;
+
+    a = new short[size];
+    b = new short[size];
+    c = new short[size];
+
+  }
+
+  @TearDown
+  public void tearDown() {
+    CLinker.freeMemory(srcAddress);
+    CLinker.freeMemory(dstAddress);
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.PRINT)
+  public void array() {
+    for (int i = 0; i < SPECIES.loopBound(srcArray.length); i += SPECIES.length()) {
+      var v = ShortVector.fromArray(SPECIES, srcArray, i);
+      v.intoArray(dstArray, i);
+    }
+  }
+
+  @Benchmark
+  public void vectAdd1() {
+    var a = this.a;
+    var b = this.b;
+    var c = this.c;
+
+    for (int i = 0; i < a.length; i += SPECIES.length()) {
+      ShortVector av = ShortVector.fromArray(SPECIES, a, i);
+      ShortVector bv = ShortVector.fromArray(SPECIES, b, i);
+      av.lanewise(VectorOperators.ADD, bv).intoArray(c, i);
+    }
+  }
+
+  @Benchmark
+  public void vectAdd2() {
+    var a = this.a;
+    var b = this.b;
+    var c = this.c;
+
+    for (int i = 0; i < a.length/SPECIES.length(); i++) {
+      ShortVector av = ShortVector.fromArray(SPECIES, a, (i*SPECIES.length()));
+      ShortVector bv = ShortVector.fromArray(SPECIES, b, (i*SPECIES.length()));
+      av.lanewise(VectorOperators.ADD, bv).intoArray(c, (i*SPECIES.length()));
+    }
+  }
+
+  @Benchmark
+  public void arrayAdd() {
+    for (int i = 0; i < SPECIES.loopBound(srcArray.length); i += SPECIES.length()) {
+      var v = ShortVector.fromArray(SPECIES, srcArray, i);
+      v = v.add(v);
+      v.intoArray(dstArray, i);
+    }
+  }
+
+  @Benchmark
+  public void bufferHeap() {
+    for (int i = 0; i < SPECIES.loopBound(longSize); i += SPECIES.length()) {
+      var v = ShortVector.fromByteBuffer(SPECIES, srcBufferHeap, i, ByteOrder.nativeOrder());
+      v.intoByteBuffer(dstBufferHeap, i, ByteOrder.nativeOrder());
+    }
+  }
+
+  @Benchmark
+  public void bufferNative() {
+    for (int i = 0; i < SPECIES.loopBound(srcArray.length); i += SPECIES.length()) {
+      var v = ShortVector.fromByteBuffer(SPECIES, srcBufferNative, i, ByteOrder.nativeOrder());
+      v.intoByteBuffer(dstBufferNative, i, ByteOrder.nativeOrder());
+    }
+  }
+
+  @Benchmark
+  public void bufferNativeAdd() {
+    for (int i = 0; i < SPECIES.loopBound(srcArray.length); i += SPECIES.length()) {
+      var v = ShortVector.fromByteBuffer(SPECIES, srcBufferNative, i, ByteOrder.nativeOrder());
+      v = v.add(v);
+      v.intoByteBuffer(dstBufferNative, i, ByteOrder.nativeOrder());
+    }
+  }
+
+  @Benchmark
+  public void bufferSegmentImplicit() {
+    for (int i = 0; i < SPECIES.loopBound(srcArray.length); i += SPECIES.length()) {
+      var v = ShortVector.fromByteBuffer(SPECIES, srcBufferSegmentImplicit, i, ByteOrder.nativeOrder());
+      v.intoByteBuffer(dstBufferSegmentImplicit, i, ByteOrder.nativeOrder());
+    }
+  }
+
+  @Benchmark
+  public void bufferSegmentConfined() {
+    try (final var scope = ResourceScope.newConfinedScope()) {
+      final var srcBufferSegmentConfined = srcAddress.asSegment(size, scope).asByteBuffer();
+      final var dstBufferSegmentConfined = dstAddress.asSegment(size, scope).asByteBuffer();
+
+      for (int i = 0; i < SPECIES.loopBound(srcArray.length); i += SPECIES.length()) {
+        var v = ShortVector.fromByteBuffer(SPECIES, srcBufferSegmentConfined, i, ByteOrder.nativeOrder());
+        v.intoByteBuffer(dstBufferSegmentConfined, i, ByteOrder.nativeOrder());
+      }
+    }
+  }
+}

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreShort.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreShort.java
@@ -1,3 +1,26 @@
+/*
+ *  Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
 package org.openjdk.bench.jdk.incubator.vector;
 
 import java.nio.ByteBuffer;


### PR DESCRIPTION
# Description

Increase allowed stride size for loop unrolling to the maximum vector size on runtime platform. 

The motivation for this change is discussion and research about unrolling vector (SIMD) loops. For vector usage, stride size depends on vector element type, and platform vector size. For AVX256 and int stride size is 8, and loop unroll happens. However short and byte loops could not get unrolled (stride size 16 & 32):
```java
    for (int i = 0; i < SPECIES.loopBound(longSize); i += SPECIES.length() /* 8 for int, 16 for short */ ) { 
      var v = ShortVector.fromByteBuffer(SPECIES, srcBufferHeap, i, ByteOrder.nativeOrder()); 
      v.intoByteBuffer(dstBufferHeap, i, ByteOrder.nativeOrder()); 
    } 
```
After this change, the maximum stride, which allows loops to unroll, will depend on the maximum bytes size of vectors registers (AVX256 - 32, AVX512 - 64, SVE up to 256)

# Notes
Stride size was decreased some time ago https://github.com/openjdk/panama-foreign/commit/2683d5390bd58683ae13bdd8582127c308d8fd04

The exact reasons for this are not known for me (over unroll of some loops?).

Original thread https://mail.openjdk.java.net/pipermail/panama-dev/2021-June/014310.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270147](https://bugs.openjdk.java.net/browse/JDK-8270147): Increase stride size allowing unrolling more loops


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Igor Veresov](https://openjdk.java.net/census#iveresov) (@veresov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4658/head:pull/4658` \
`$ git checkout pull/4658`

Update a local copy of the PR: \
`$ git checkout pull/4658` \
`$ git pull https://git.openjdk.java.net/jdk pull/4658/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4658`

View PR using the GUI difftool: \
`$ git pr show -t 4658`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4658.diff">https://git.openjdk.java.net/jdk/pull/4658.diff</a>

</details>
