### PR TITLE
8269770: nsk tests should start IOPipe channel before launch debuggee - Debugee.prepareDebugee

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPackagePrivate/accipp001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPackagePrivate/accipp001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -109,24 +109,8 @@ public class accipp001 extends Log {
         logHandler      = new Log(out, argsHandler);
         Binder binder   = new Binder(argsHandler, logHandler);
 
-
-        if (argsHandler.verbose()) {
-            debugee = binder.bindToDebugee(debugeeName + " -vbs");
-        } else {
-            debugee = binder.bindToDebugee(debugeeName);
-        }
-
-        IOPipe pipe     = new IOPipe(debugee);
-
-
-        debugee.redirectStderr(out);
-        debugee.resume();
-
-        String line = pipe.readln();
-        if (!line.equals("ready")) {
-            logHandler.complain("# Cannot recognize debugee's signal: " + line);
-            return 2;
-        };
+        debugee = Debugee.prepareDebugee(argsHandler, logHandler,
+                debugeeName + (argsHandler.verbose() ? " -vbs" : ""));
 
 //        ReferenceType classes[] = debugee.classes();
 //        for (int i=0; i<classes.length; i++) {
@@ -165,10 +149,8 @@ public class accipp001 extends Log {
             return 2;
         };
 
-        pipe.println("quit");
-        debugee.waitFor();
-
-        int status = debugee.getStatus();
+        debugee.sendSignal("quit");
+        int status = debugee.endDebugee();
         if (status != 95) {
             logHandler.complain("Debugee's exit status=" + status);
             return 2;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeProcess.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeProcess.java
@@ -108,7 +108,7 @@ abstract public class DebugeeProcess extends FinalizableObject {
 
     // --------------------------------------------------- //
 
-    /** Created and return new IOPipe channel to the debuggee VM.
+    /** Create and return new IOPipe channel to the debuggee VM.
      * The channel should be created before debuggee starts execution,
      * i.e. the method assumes debuggee is started, but suspended before
      * its main class is loaded.

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeProcess.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeProcess.java
@@ -108,12 +108,16 @@ abstract public class DebugeeProcess extends FinalizableObject {
 
     // --------------------------------------------------- //
 
-    /** Created and return new IOPipe channel to the debugee VM. */
+    /** Created and return new IOPipe channel to the debuggee VM.
+     * The channel should be created before debuggee starts execution,
+     * i.e. the method assumes debuggee is started, but suspended before
+     * its main class is loaded.
+     */
     public IOPipe createIOPipe() {
         if (pipe != null) {
             throw new TestBug("IOPipe channel is already created");
         }
-        pipe = new IOPipe(this);
+        pipe = IOPipe.startDebuggerPipe(binder);
         return pipe;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/IOPipe.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/IOPipe.java
@@ -84,7 +84,7 @@ public class IOPipe extends SocketIOPipe {
     /**
      * Creates and starts listening <code>IOPipe</code> at debugger side.
      */
-    public static IOPipe startDebuggerPipe(Binder binder) {
+    public static IOPipe startDebuggerPipe(DebugeeBinder binder) {
         IOPipe ioPipe = new IOPipe(binder.getLog(),
                 binder.getArgumentHandler().getDebugeeHost(),
                 binder.getArgumentHandler().getPipePortNumber(),
@@ -94,7 +94,6 @@ public class IOPipe extends SocketIOPipe {
         ioPipe.startListening();
         return ioPipe;
     }
-
 
     protected void connect() {
         super.connect();


### PR DESCRIPTION
The change fixes several hundreds tests which launch debugee by using uses Debugee.prepareDebugee() method or use 
debugee = Binder.bindToDebugee(...);
IOPipe pipe = debugee.createIOPipe();
logic.
Debugee.prepareDebugee() and Binder.bindToDebugee() launch debuggee by using CommandLineLaunch JDI connector with suspend=="true" argument, so they return debuggee suspended before the main class is loaded.
The fix starts IOPipe listening before debuggee VM is resumed.

Simplified isPackagePrivate/accipp001.java test to use Debugee.prepareDebugee() - it does exactly the same as Debugee.prepareDebugee() does (the only difference is using deprecated IOPipe ctor instead of Debugee.createIOPipe())

Tested all affected tests:
test/hotspot/jtreg/vmTestbase/nsk/jdi
test/hotspot/jtreg/vmTestbase/nsk/jdwp
test/hotspot/jtreg/serviceability/dcmd

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269770](https://bugs.openjdk.java.net/browse/JDK-8269770): nsk tests should start IOPipe channel before launch debuggee - Debugee.prepareDebugee


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4659/head:pull/4659` \
`$ git checkout pull/4659`

Update a local copy of the PR: \
`$ git checkout pull/4659` \
`$ git pull https://git.openjdk.java.net/jdk pull/4659/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4659`

View PR using the GUI difftool: \
`$ git pr show -t 4659`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4659.diff">https://git.openjdk.java.net/jdk/pull/4659.diff</a>

</details>
