### PR TITLE
8269652: Factor out the common code for creating system j.l.Thread objects

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -795,14 +795,8 @@ void CompileBroker::compilation_init_phase2() {
 }
 
 Handle CompileBroker::create_thread_oop(const char* name, TRAPS) {
-  Handle string = java_lang_String::create_from_str(name, CHECK_NH);
-  Handle thread_group(THREAD, Universe::system_thread_group());
-  return JavaCalls::construct_new_instance(
-                       vmClasses::Thread_klass(),
-                       vmSymbols::threadgroup_string_void_signature(),
-                       thread_group,
-                       string,
-                       CHECK_NH);
+  Handle thread_oop = JavaThread::create_system_thread_object(name, false /* not visible */, CHECK_NH);
+  return thread_oop;
 }
 
 #if defined(ASSERT) && COMPILER2_OR_JVMCI

--- a/src/hotspot/share/runtime/monitorDeflationThread.cpp
+++ b/src/hotspot/share/runtime/monitorDeflationThread.cpp
@@ -37,16 +37,7 @@ void MonitorDeflationThread::initialize() {
   EXCEPTION_MARK;
 
   const char* name = "Monitor Deflation Thread";
-  Handle string = java_lang_String::create_from_str(name, CHECK);
-
-  // Initialize thread_oop to put it into the system threadGroup
-  Handle thread_group (THREAD, Universe::system_thread_group());
-  Handle thread_oop = JavaCalls::construct_new_instance(
-                          vmClasses::Thread_klass(),
-                          vmSymbols::threadgroup_string_void_signature(),
-                          thread_group,
-                          string,
-                          CHECK);
+  Handle thread_oop = JavaThread::create_system_thread_object(name, false /* not visible */, CHECK);
 
   MonitorDeflationThread* thread = new MonitorDeflationThread(&monitor_deflation_thread_entry);
   JavaThread::vm_exit_on_osthread_failure(thread);

--- a/src/hotspot/share/runtime/notificationThread.cpp
+++ b/src/hotspot/share/runtime/notificationThread.cpp
@@ -39,26 +39,7 @@ void NotificationThread::initialize() {
   EXCEPTION_MARK;
 
   const char* name = "Notification Thread";
-  Handle string = java_lang_String::create_from_str(name, CHECK);
-
-  // Initialize thread_oop to put it into the system threadGroup
-  Handle thread_group (THREAD, Universe::system_thread_group());
-  Handle thread_oop = JavaCalls::construct_new_instance(
-                          vmClasses::Thread_klass(),
-                          vmSymbols::threadgroup_string_void_signature(),
-                          thread_group,
-                          string,
-                          CHECK);
-
-  Klass* group = vmClasses::ThreadGroup_klass();
-  JavaValue result(T_VOID);
-  JavaCalls::call_special(&result,
-                          thread_group,
-                          group,
-                          vmSymbols::add_method_name(),
-                          vmSymbols::thread_void_signature(),
-                          thread_oop,
-                          THREAD);
+  Handle thread_oop = JavaThread::create_system_thread_object(name, true /* visible */, CHECK);
 
    NotificationThread* thread = new NotificationThread(&notification_thread_entry);
    JavaThread::vm_exit_on_osthread_failure(thread);

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -469,26 +469,8 @@ void os::init_before_ergo() {
 void os::initialize_jdk_signal_support(TRAPS) {
   if (!ReduceSignalUsage) {
     // Setup JavaThread for processing signals
-    const char thread_name[] = "Signal Dispatcher";
-    Handle string = java_lang_String::create_from_str(thread_name, CHECK);
-
-    // Initialize thread_oop to put it into the system threadGroup
-    Handle thread_group (THREAD, Universe::system_thread_group());
-    Handle thread_oop = JavaCalls::construct_new_instance(vmClasses::Thread_klass(),
-                           vmSymbols::threadgroup_string_void_signature(),
-                           thread_group,
-                           string,
-                           CHECK);
-
-    Klass* group = vmClasses::ThreadGroup_klass();
-    JavaValue result(T_VOID);
-    JavaCalls::call_special(&result,
-                            thread_group,
-                            group,
-                            vmSymbols::add_method_name(),
-                            vmSymbols::thread_void_signature(),
-                            thread_oop,
-                            CHECK);
+    const char* name = "Signal Dispatcher";
+    Handle thread_oop = JavaThread::create_system_thread_object(name, true /* visible */, CHECK);
 
     JavaThread* thread = new JavaThread(&signal_thread_entry);
     JavaThread::vm_exit_on_osthread_failure(thread);

--- a/src/hotspot/share/runtime/serviceThread.cpp
+++ b/src/hotspot/share/runtime/serviceThread.cpp
@@ -92,16 +92,7 @@ void ServiceThread::initialize() {
   EXCEPTION_MARK;
 
   const char* name = "Service Thread";
-  Handle string = java_lang_String::create_from_str(name, CHECK);
-
-  // Initialize thread_oop to put it into the system threadGroup
-  Handle thread_group (THREAD, Universe::system_thread_group());
-  Handle thread_oop = JavaCalls::construct_new_instance(
-                          vmClasses::Thread_klass(),
-                          vmSymbols::threadgroup_string_void_signature(),
-                          thread_group,
-                          string,
-                          CHECK);
+  Handle thread_oop = JavaThread::create_system_thread_object(name, false /* not visible */, CHECK);
 
   ServiceThread* thread = new ServiceThread(&service_thread_entry);
   JavaThread::vm_exit_on_osthread_failure(thread);

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -3901,13 +3901,50 @@ void JavaThread::verify_cross_modify_fence_failure(JavaThread *thread) {
 }
 #endif
 
+// Helper function to create the java.lang.Thread object for a
+// VM-internal thread. The thread will have the given name, be
+// part of the System ThreadGroup and if is_visible is true will be
+// discoverable via the system ThreadGroup.
+Handle JavaThread::create_system_thread_object(const char* name,
+                                               bool is_visible, TRAPS) {
+  Handle string = java_lang_String::create_from_str(name, CHECK_NH);
+
+  // Initialize thread_oop to put it into the system threadGroup.
+  // This is done by calling the Thread(ThreadGroup tg, String name)
+  // constructor, which adds the new thread to the group as an unstarted
+  // thread.
+  Handle thread_group(THREAD, Universe::system_thread_group());
+  Handle thread_oop =
+    JavaCalls::construct_new_instance(vmClasses::Thread_klass(),
+                                      vmSymbols::threadgroup_string_void_signature(),
+                                      thread_group,
+                                      string,
+                                      CHECK_NH);
+
+  // If the Thread is intended to be visible then we have to mimic what
+  // Thread.start() would do, by adding it to its ThreadGroup: tg.add(t).
+  if (is_visible) {
+    Klass* group = vmClasses::ThreadGroup_klass();
+    JavaValue result(T_VOID);
+    JavaCalls::call_special(&result,
+                            thread_group,
+                            group,
+                            vmSymbols::add_method_name(),
+                            vmSymbols::thread_void_signature(),
+                            thread_oop,
+                            CHECK_NH);
+  }
+
+  return thread_oop;
+}
+
 // Starts the target JavaThread as a daemon of the given priority, and
 // bound to the given java.lang.Thread instance.
 // The Threads_lock is held for the duration.
 void JavaThread::start_internal_daemon(JavaThread* current, JavaThread* target,
                                        Handle thread_oop, ThreadPriority prio) {
 
-  assert(target->osthread()!= NULL, "target thread is not properly initialized");
+  assert(target->osthread() != NULL, "target thread is not properly initialized");
 
   MutexLocker mu(current, Threads_lock);
 

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1594,6 +1594,12 @@ public:
 
   static void verify_cross_modify_fence_failure(JavaThread *thread) PRODUCT_RETURN;
 
+  // Helper function to create the java.lang.Thread object for a
+  // VM-internal thread. The thread will have the given name, be
+  // part of the System ThreadGroup and if is_visible is true will be
+  // discoverable via the system ThreadGroup.
+  static Handle create_system_thread_object(const char* name, bool is_visible, TRAPS);
+
   // Helper function to start a VM-internal daemon thread.
   // E.g. ServiceThread, NotificationThread, CompilerThread etc.
   static void start_internal_daemon(JavaThread* current, JavaThread* target,

--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -451,34 +451,8 @@ bool AttachListener::has_init_error(TRAPS) {
 void AttachListener::init() {
   EXCEPTION_MARK;
 
-  const char thread_name[] = "Attach Listener";
-  Handle string = java_lang_String::create_from_str(thread_name, THREAD);
-  if (has_init_error(THREAD)) {
-    set_state(AL_NOT_INITIALIZED);
-    return;
-  }
-
-  // Initialize thread_oop to put it into the system threadGroup
-  Handle thread_group (THREAD, Universe::system_thread_group());
-  Handle thread_oop = JavaCalls::construct_new_instance(vmClasses::Thread_klass(),
-                       vmSymbols::threadgroup_string_void_signature(),
-                       thread_group,
-                       string,
-                       THREAD);
-  if (has_init_error(THREAD)) {
-    set_state(AL_NOT_INITIALIZED);
-    return;
-  }
-
-  Klass* group = vmClasses::ThreadGroup_klass();
-  JavaValue result(T_VOID);
-  JavaCalls::call_special(&result,
-                        thread_group,
-                        group,
-                        vmSymbols::add_method_name(),
-                        vmSymbols::thread_void_signature(),
-                        thread_oop,
-                        THREAD);
+  const char* name = "Attach Listener";
+  Handle thread_oop = JavaThread::create_system_thread_object(name, true /* visible */, THREAD);
   if (has_init_error(THREAD)) {
     set_state(AL_NOT_INITIALIZED);
     return;


### PR DESCRIPTION
Please review this simple refactoring to share the common code used to create j.l.Thread instances for the internal VM JavaThreads. (Also fix a missing space from my previous change in thread.cpp.)

It is all very straight-forward.

Compiler folk I can go one step further and remove CompileBroker::create_thread_oop if desired.

Testing: tiers 1-3, GHA

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269652](https://bugs.openjdk.java.net/browse/JDK-8269652): Factor out the common code for creating system j.l.Thread objects


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Xin Liu](https://openjdk.java.net/census#xliu) (@navyxliu - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4663/head:pull/4663` \
`$ git checkout pull/4663`

Update a local copy of the PR: \
`$ git checkout pull/4663` \
`$ git pull https://git.openjdk.java.net/jdk pull/4663/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4663`

View PR using the GUI difftool: \
`$ git pr show -t 4663`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4663.diff">https://git.openjdk.java.net/jdk/pull/4663.diff</a>

</details>
