### PR TITLE
8269803: G1: remove unnecessary NoRefDiscovery

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2992,12 +2992,6 @@ void G1CollectedHeap::do_collection_pause_at_safepoint_helper(double target_paus
         // reference processing currently works in G1.
         _ref_processor_stw->start_discovery(false /* always_clear */);
 
-        // We want to temporarily turn off discovery by the
-        // CM ref processor, if necessary, and turn it back on
-        // on again later if we do. Using a scoped
-        // NoRefDiscovery object will do this.
-        NoRefDiscovery no_cm_discovery(_ref_processor_cm);
-
         policy()->record_collection_pause_start(sample_start_time_sec);
 
         // Forget the current allocation region (we might even choose it to be part

--- a/src/hotspot/share/gc/shared/referenceProcessor.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.hpp
@@ -456,27 +456,6 @@ public:
   }
 };
 
-// A utility class to disable reference discovery in
-// the scope which contains it, for given ReferenceProcessor.
-class NoRefDiscovery: StackObj {
- private:
-  ReferenceProcessor* _rp;
-  bool _was_discovering_refs;
- public:
-  NoRefDiscovery(ReferenceProcessor* rp) : _rp(rp) {
-    _was_discovering_refs = _rp->discovery_enabled();
-    if (_was_discovering_refs) {
-      _rp->disable_discovery();
-    }
-  }
-
-  ~NoRefDiscovery() {
-    if (_was_discovering_refs) {
-      _rp->enable_discovery(false /*check_no_refs*/);
-    }
-  }
-};
-
 // A utility class to temporarily mutate the subject discovery closure of the
 // given ReferenceProcessor in the scope that contains it.
 class ReferenceProcessorSubjectToDiscoveryMutator : StackObj {


### PR DESCRIPTION
Simple change of removing the unnecessary disable of ref-discovery for CM during young-gc pause.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269803](https://bugs.openjdk.java.net/browse/JDK-8269803): G1: remove unnecessary NoRefDiscovery


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4664/head:pull/4664` \
`$ git checkout pull/4664`

Update a local copy of the PR: \
`$ git checkout pull/4664` \
`$ git pull https://git.openjdk.java.net/jdk pull/4664/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4664`

View PR using the GUI difftool: \
`$ git pr show -t 4664`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4664.diff">https://git.openjdk.java.net/jdk/pull/4664.diff</a>

</details>
