### PR TITLE
8269692: sun.net.httpserver.ServerImpl::createContext should throw IAE

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ContextList.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ContextList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,18 +26,23 @@
 package sun.net.httpserver;
 
 import java.util.*;
-import com.sun.net.httpserver.*;
-import com.sun.net.httpserver.spi.*;
 
 class ContextList {
 
     final static int MAX_CONTEXTS = 50;
 
-    LinkedList<HttpContextImpl> list = new LinkedList<HttpContextImpl>();
+    private final LinkedList<HttpContextImpl> list = new LinkedList<>();
 
     public synchronized void add (HttpContextImpl ctx) {
         assert ctx.getPath() != null;
+        if (contains(ctx)) {
+            throw new IllegalArgumentException ("cannot add context to list");
+        }
         list.add (ctx);
+    }
+
+    synchronized boolean contains(HttpContextImpl ctx) {
+        return findContext(ctx.getProtocol(), ctx.getPath(), true) != null;
     }
 
     public synchronized int size () {

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ContextList.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ContextList.java
@@ -29,8 +29,6 @@ import java.util.*;
 
 class ContextList {
 
-    final static int MAX_CONTEXTS = 50;
-
     private final LinkedList<HttpContextImpl> list = new LinkedList<>();
 
     public synchronized void add (HttpContextImpl ctx) {
@@ -41,7 +39,7 @@ class ContextList {
         list.add (ctx);
     }
 
-    synchronized boolean contains(HttpContextImpl ctx) {
+    boolean contains(HttpContextImpl ctx) {
         return findContext(ctx.getProtocol(), ctx.getPath(), true) != null;
     }
 

--- a/test/jdk/com/sun/net/httpserver/HttpContextTest.java
+++ b/test/jdk/com/sun/net/httpserver/HttpContextTest.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 import com.sun.net.httpserver.HttpContext;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
-import com.sun.net.httpserver.HttpsServer;
+import com.sun.net.httpserver.HttpServer;
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
@@ -44,7 +44,7 @@ public class HttpContextTest {
     
     @Test
     public static void test() throws IOException {
-        final var server = HttpsServer.create(null, 0);
+        final var server = HttpServer.create(null, 0);
         final var path = "/foo/";
 
         assertThrows(IAE, () -> server.removeContext(path));

--- a/test/jdk/com/sun/net/httpserver/HttpContextTest.java
+++ b/test/jdk/com/sun/net/httpserver/HttpContextTest.java
@@ -68,6 +68,20 @@ public class HttpContextTest {
     }
 
     /**
+     * Confirms that it is possible to create a subcontext, a context whose path
+     * shares the prefix of an existing context.
+     */
+    @Test
+    public static void testSubcontext() throws IOException {
+        final var server = HttpServer.create(null, 0);
+        server.createContext("/foo/bar/");
+        server.createContext("/foo/");
+
+        server.createContext("/foo");
+        server.createContext("/foo/bar");
+    }
+
+    /**
      * A no-op handler
      */
     static class Handler implements HttpHandler {

--- a/test/jdk/com/sun/net/httpserver/HttpContextTest.java
+++ b/test/jdk/com/sun/net/httpserver/HttpContextTest.java
@@ -41,7 +41,7 @@ import static org.testng.Assert.assertThrows;
 public class HttpContextTest {
 
     static final Class<IllegalArgumentException> IAE = IllegalArgumentException.class;
-    
+
     @Test
     public static void test() throws IOException {
         final var server = HttpServer.create(null, 0);

--- a/test/jdk/com/sun/net/httpserver/HttpContextTest.java
+++ b/test/jdk/com/sun/net/httpserver/HttpContextTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8269692
+ * @summary HttpContext::createContext should throw IllegalArgumentException
+ *          if context already exists
+ * @run testng/othervm HttpContextTest
+ */
+
+import java.io.IOException;
+import com.sun.net.httpserver.HttpContext;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpsServer;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+public class HttpContextTest {
+
+    static final Class<IllegalArgumentException> IAE = IllegalArgumentException.class;
+    
+    @Test
+    public static void test() throws IOException {
+        final var server = HttpsServer.create(null, 0);
+        final var path = "/foo/";
+
+        assertThrows(IAE, () -> server.removeContext(path));
+        HttpContext context = server.createContext(path);
+        assertEquals(context.getPath(), path);
+        assertThrows(IAE, () -> server.createContext(path));
+        assertThrows(IAE, () -> server.createContext(path, new Handler()));
+
+        context.setHandler(new Handler());
+        assertThrows(IAE, () -> server.createContext(path));
+        assertThrows(IAE, () -> server.createContext(path, new Handler()));
+        server.removeContext(context);
+        assertThrows(IAE, () -> server.removeContext(path));
+
+        context = server.createContext(path, new Handler());
+        assertEquals(context.getPath(), path);
+        assertThrows(IAE, () -> server.createContext(path));
+        assertThrows(IAE, () -> server.createContext(path, new Handler()));
+        server.removeContext(path);
+        assertThrows(IAE, () -> server.removeContext(path));
+    }
+
+    /**
+     * A no-op handler
+     */
+    static class Handler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException { }
+    }
+}


### PR DESCRIPTION
`com.sun.net.httpserver.HttpServer::createContext` specifies `IllegalArgumentException` to be thrown if a context already exists for the path provided. The implementation class`sun.net.httpserver.ServerImpl` does not comply with this, which is fixed by this change.

Testing: Tier 1-3 all clear.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269692](https://bugs.openjdk.java.net/browse/JDK-8269692): sun.net.httpserver.ServerImpl::createContext should throw IAE


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4665/head:pull/4665` \
`$ git checkout pull/4665`

Update a local copy of the PR: \
`$ git checkout pull/4665` \
`$ git pull https://git.openjdk.java.net/jdk pull/4665/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4665`

View PR using the GUI difftool: \
`$ git pr show -t 4665`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4665.diff">https://git.openjdk.java.net/jdk/pull/4665.diff</a>

</details>
