### PR TITLE
8051680: (ref) unnecessary process_soft_ref_reconsider

### DIFF
--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -199,17 +199,17 @@ ReferenceProcessorStats ReferenceProcessor::process_discovered_references(RefPro
   update_soft_ref_master_clock();
 
   {
-    RefProcTotalPhaseTimesTracker tt(RefPhase1, &phase_times);
+    RefProcTotalPhaseTimesTracker tt(RefPhase2, &phase_times);
     process_soft_weak_final_refs(proxy_task, phase_times);
   }
 
   {
-    RefProcTotalPhaseTimesTracker tt(RefPhase2, &phase_times);
+    RefProcTotalPhaseTimesTracker tt(RefPhase3, &phase_times);
     process_final_keep_alive(proxy_task, phase_times);
   }
 
   {
-    RefProcTotalPhaseTimesTracker tt(RefPhase3, &phase_times);
+    RefProcTotalPhaseTimesTracker tt(RefPhase4, &phase_times);
     process_phantom_refs(proxy_task, phase_times);
   }
 
@@ -452,8 +452,8 @@ size_t ReferenceProcessor::total_reference_count(ReferenceType type) const {
 }
 
 
-class RefProcPhase1Task: public RefProcTask {
-  void run_phase1(uint worker_id,
+class RefProcPhase2Task: public RefProcTask {
+  void run_phase2(uint worker_id,
                   DiscoveredList list[],
                   BoolObjectClosure* is_alive,
                   OopClosure* keep_alive,
@@ -467,37 +467,6 @@ class RefProcPhase1Task: public RefProcTask {
   }
 
 public:
-  RefProcPhase1Task(ReferenceProcessor& ref_processor,
-                    ReferenceProcessorPhaseTimes* phase_times)
-    : RefProcTask(ref_processor,
-                  phase_times) {}
-
-  void rp_work(uint worker_id,
-               BoolObjectClosure* is_alive,
-               OopClosure* keep_alive,
-               VoidClosure* complete_gc) override {
-    ResourceMark rm;
-    RefProcWorkerTimeTracker t(_phase_times->phase1_worker_time_sec(), tracker_id(worker_id));
-    {
-      RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::SoftRefSubPhase1, _phase_times, tracker_id(worker_id));
-      run_phase1(worker_id, _ref_processor._discoveredSoftRefs, is_alive, keep_alive, true /* do_enqueue_and_clear */, REF_SOFT);
-    }
-    {
-      RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::WeakRefSubPhase1, _phase_times, tracker_id(worker_id));
-      run_phase1(worker_id, _ref_processor._discoveredWeakRefs, is_alive, keep_alive, true /* do_enqueue_and_clear */, REF_WEAK);
-    }
-    {
-      RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::FinalRefSubPhase1, _phase_times, tracker_id(worker_id));
-      run_phase1(worker_id, _ref_processor._discoveredFinalRefs, is_alive, keep_alive, false /* do_enqueue_and_clear */, REF_FINAL);
-    }
-    // Close the reachable set; needed for collectors which keep_alive_closure do
-    // not immediately complete their work.
-    complete_gc->do_void();
-  }
-};
-
-class RefProcPhase2Task: public RefProcTask {
-public:
   RefProcPhase2Task(ReferenceProcessor& ref_processor,
                     ReferenceProcessorPhaseTimes* phase_times)
     : RefProcTask(ref_processor,
@@ -508,8 +477,22 @@ public:
                OopClosure* keep_alive,
                VoidClosure* complete_gc) override {
     ResourceMark rm;
-    RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::FinalRefSubPhase2, _phase_times, tracker_id(worker_id));
-    _ref_processor.process_final_keep_alive_work(_ref_processor._discoveredFinalRefs[worker_id], keep_alive, complete_gc);
+    RefProcWorkerTimeTracker t(_phase_times->phase2_worker_time_sec(), tracker_id(worker_id));
+    {
+      RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::SoftRefSubPhase2, _phase_times, tracker_id(worker_id));
+      run_phase2(worker_id, _ref_processor._discoveredSoftRefs, is_alive, keep_alive, true /* do_enqueue_and_clear */, REF_SOFT);
+    }
+    {
+      RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::WeakRefSubPhase2, _phase_times, tracker_id(worker_id));
+      run_phase2(worker_id, _ref_processor._discoveredWeakRefs, is_alive, keep_alive, true /* do_enqueue_and_clear */, REF_WEAK);
+    }
+    {
+      RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::FinalRefSubPhase2, _phase_times, tracker_id(worker_id));
+      run_phase2(worker_id, _ref_processor._discoveredFinalRefs, is_alive, keep_alive, false /* do_enqueue_and_clear */, REF_FINAL);
+    }
+    // Close the reachable set; needed for collectors which keep_alive_closure do
+    // not immediately complete their work.
+    complete_gc->do_void();
   }
 };
 
@@ -525,7 +508,24 @@ public:
                OopClosure* keep_alive,
                VoidClosure* complete_gc) override {
     ResourceMark rm;
-    RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::PhantomRefSubPhase3, _phase_times, tracker_id(worker_id));
+    RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::FinalRefSubPhase3, _phase_times, tracker_id(worker_id));
+    _ref_processor.process_final_keep_alive_work(_ref_processor._discoveredFinalRefs[worker_id], keep_alive, complete_gc);
+  }
+};
+
+class RefProcPhase4Task: public RefProcTask {
+public:
+  RefProcPhase4Task(ReferenceProcessor& ref_processor,
+                    ReferenceProcessorPhaseTimes* phase_times)
+    : RefProcTask(ref_processor,
+                  phase_times) {}
+
+  void rp_work(uint worker_id,
+               BoolObjectClosure* is_alive,
+               OopClosure* keep_alive,
+               VoidClosure* complete_gc) override {
+    ResourceMark rm;
+    RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::PhantomRefSubPhase4, _phase_times, tracker_id(worker_id));
     size_t const removed = _ref_processor.process_phantom_refs_work(_ref_processor._discoveredPhantomRefs[worker_id],
                                                                     is_alive,
                                                                     keep_alive,
@@ -720,31 +720,31 @@ void ReferenceProcessor::process_soft_weak_final_refs(RefProcProxyTask& proxy_ta
   phase_times.set_processing_is_mt(processing_is_mt());
 
   if (num_total_refs == 0) {
-    log_debug(gc, ref)("Skipped phase 1 of Reference Processing: no references");
+    log_debug(gc, ref)("Skipped phase 2 of Reference Processing: no references");
     return;
   }
 
-  RefProcMTDegreeAdjuster a(this, RefPhase1, num_total_refs);
+  RefProcMTDegreeAdjuster a(this, RefPhase2, num_total_refs);
 
   if (processing_is_mt()) {
-    RefProcBalanceQueuesTimeTracker tt(RefPhase1, &phase_times);
+    RefProcBalanceQueuesTimeTracker tt(RefPhase2, &phase_times);
     maybe_balance_queues(_discoveredSoftRefs);
     maybe_balance_queues(_discoveredWeakRefs);
     maybe_balance_queues(_discoveredFinalRefs);
   }
 
-  RefProcPhaseTimeTracker tt(RefPhase1, &phase_times);
+  RefProcPhaseTimeTracker tt(RefPhase2, &phase_times);
 
-  log_reflist("Phase 1 Soft before", _discoveredSoftRefs, _max_num_queues);
-  log_reflist("Phase 1 Weak before", _discoveredWeakRefs, _max_num_queues);
-  log_reflist("Phase 1 Final before", _discoveredFinalRefs, _max_num_queues);
+  log_reflist("Phase 2 Soft before", _discoveredSoftRefs, _max_num_queues);
+  log_reflist("Phase 2 Weak before", _discoveredWeakRefs, _max_num_queues);
+  log_reflist("Phase 2 Final before", _discoveredFinalRefs, _max_num_queues);
 
-  RefProcPhase1Task phase1(*this, &phase_times);
-  run_task(phase1, proxy_task, false);
+  RefProcPhase2Task phase2(*this, &phase_times);
+  run_task(phase2, proxy_task, false);
 
   verify_total_count_zero(_discoveredSoftRefs, "SoftReference");
   verify_total_count_zero(_discoveredWeakRefs, "WeakReference");
-  log_reflist("Phase 1 Final after", _discoveredFinalRefs, _max_num_queues);
+  log_reflist("Phase 2 Final after", _discoveredFinalRefs, _max_num_queues);
 }
 
 void ReferenceProcessor::process_final_keep_alive(RefProcProxyTask& proxy_task,
@@ -754,22 +754,22 @@ void ReferenceProcessor::process_final_keep_alive(RefProcProxyTask& proxy_task,
   phase_times.set_processing_is_mt(processing_is_mt());
 
   if (num_final_refs == 0) {
-    log_debug(gc, ref)("Skipped phase 2 of Reference Processing: no references");
+    log_debug(gc, ref)("Skipped phase 3 of Reference Processing: no references");
     return;
   }
 
-  RefProcMTDegreeAdjuster a(this, RefPhase2, num_final_refs);
+  RefProcMTDegreeAdjuster a(this, RefPhase3, num_final_refs);
 
   if (processing_is_mt()) {
-    RefProcBalanceQueuesTimeTracker tt(RefPhase2, &phase_times);
+    RefProcBalanceQueuesTimeTracker tt(RefPhase3, &phase_times);
     maybe_balance_queues(_discoveredFinalRefs);
   }
 
-  // Phase 2:
+  // Phase 3:
   // . Traverse referents of final references and keep them and followers alive.
-  RefProcPhaseTimeTracker tt(RefPhase2, &phase_times);
-  RefProcPhase2Task phase2(*this, &phase_times);
-  run_task(phase2, proxy_task, true);
+  RefProcPhaseTimeTracker tt(RefPhase3, &phase_times);
+  RefProcPhase3Task phase3(*this, &phase_times);
+  run_task(phase3, proxy_task, true);
 
   verify_total_count_zero(_discoveredFinalRefs, "FinalReference");
 }
@@ -782,24 +782,24 @@ void ReferenceProcessor::process_phantom_refs(RefProcProxyTask& proxy_task,
   phase_times.set_processing_is_mt(processing_is_mt());
 
   if (num_phantom_refs == 0) {
-    log_debug(gc, ref)("Skipped phase 3 of Reference Processing: no references");
+    log_debug(gc, ref)("Skipped phase 4 of Reference Processing: no references");
     return;
   }
 
-  RefProcMTDegreeAdjuster a(this, RefPhase3, num_phantom_refs);
+  RefProcMTDegreeAdjuster a(this, RefPhase4, num_phantom_refs);
 
   if (processing_is_mt()) {
-    RefProcBalanceQueuesTimeTracker tt(RefPhase3, &phase_times);
+    RefProcBalanceQueuesTimeTracker tt(RefPhase4, &phase_times);
     maybe_balance_queues(_discoveredPhantomRefs);
   }
 
-  // Phase 3: Walk phantom references appropriately.
-  RefProcPhaseTimeTracker tt(RefPhase3, &phase_times);
+  // Phase 4: Walk phantom references appropriately.
+  RefProcPhaseTimeTracker tt(RefPhase4, &phase_times);
 
   log_reflist("Phase 4 Phantom before", _discoveredPhantomRefs, _max_num_queues);
 
-  RefProcPhase3Task phase3(*this, &phase_times);
-  run_task(phase3, proxy_task, false);
+  RefProcPhase4Task phase4(*this, &phase_times);
+  run_task(phase4, proxy_task, false);
 
   verify_total_count_zero(_discoveredPhantomRefs, "PhantomReference");
 }
@@ -1190,7 +1190,7 @@ uint RefProcMTDegreeAdjuster::ergo_proc_thread_count(size_t ref_count,
 
 bool RefProcMTDegreeAdjuster::use_max_threads(RefProcPhases phase) const {
   // Even a small number of references in this phase could produce large amounts of work.
-  return phase == ReferenceProcessor::RefPhase2;
+  return phase == ReferenceProcessor::RefPhase3;
 }
 
 RefProcMTDegreeAdjuster::RefProcMTDegreeAdjuster(ReferenceProcessor* rp,

--- a/src/hotspot/share/gc/shared/referenceProcessor.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.hpp
@@ -160,26 +160,26 @@ public:
 // straightforward manner in a general, non-generational, non-contiguous generation
 // (or heap) setting.
 class ReferenceProcessor : public ReferenceDiscoverer {
-  friend class RefProcPhase1Task;
   friend class RefProcPhase2Task;
   friend class RefProcPhase3Task;
+  friend class RefProcPhase4Task;
 public:
   // Names of sub-phases of reference processing. Indicates the type of the reference
   // processed and the associated phase number at the end.
   enum RefProcSubPhases {
-    SoftRefSubPhase1,
-    WeakRefSubPhase1,
-    FinalRefSubPhase1,
+    SoftRefSubPhase2,
+    WeakRefSubPhase2,
     FinalRefSubPhase2,
-    PhantomRefSubPhase3,
+    FinalRefSubPhase3,
+    PhantomRefSubPhase4,
     RefSubPhaseMax
   };
 
   // Main phases of reference processing.
   enum RefProcPhases {
-    RefPhase1,
     RefPhase2,
     RefPhase3,
+    RefPhase4,
     RefPhaseMax
   };
 
@@ -234,16 +234,16 @@ private:
 
   void run_task(RefProcTask& task, RefProcProxyTask& proxy_task, bool marks_oops_alive);
 
-  // Phase 1: Drop Soft/Weak/Final references with a NULL or live referent, and clear
+  // Phase 2: Drop Soft/Weak/Final references with a NULL or live referent, and clear
   // and enqueue non-Final references.
   void process_soft_weak_final_refs(RefProcProxyTask& proxy_task,
                                     ReferenceProcessorPhaseTimes& phase_times);
 
-  // Phase 2: Keep alive followers of Final references, and enqueue.
+  // Phase 3: Keep alive followers of Final references, and enqueue.
   void process_final_keep_alive(RefProcProxyTask& proxy_task,
                                 ReferenceProcessorPhaseTimes& phase_times);
 
-  // Phase 3: Drop and keep alive live Phantom references, or clear and enqueue if dead.
+  // Phase 4: Drop and keep alive live Phantom references, or clear and enqueue if dead.
   void process_phantom_refs(RefProcProxyTask& proxy_task,
                             ReferenceProcessorPhaseTimes& phase_times);
 

--- a/src/hotspot/share/gc/shared/referenceProcessor.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.hpp
@@ -160,7 +160,6 @@ public:
 // straightforward manner in a general, non-generational, non-contiguous generation
 // (or heap) setting.
 class ReferenceProcessor : public ReferenceDiscoverer {
-  friend class RefProcPhase1Task;
   friend class RefProcPhase2Task;
   friend class RefProcPhase3Task;
   friend class RefProcPhase4Task;
@@ -168,7 +167,6 @@ public:
   // Names of sub-phases of reference processing. Indicates the type of the reference
   // processed and the associated phase number at the end.
   enum RefProcSubPhases {
-    SoftRefSubPhase1,
     SoftRefSubPhase2,
     WeakRefSubPhase2,
     FinalRefSubPhase2,
@@ -179,7 +177,6 @@ public:
 
   // Main phases of reference processing.
   enum RefProcPhases {
-    RefPhase1,
     RefPhase2,
     RefPhase3,
     RefPhase4,
@@ -237,10 +234,6 @@ private:
 
   void run_task(RefProcTask& task, RefProcProxyTask& proxy_task, bool marks_oops_alive);
 
-  // Phase 1: Re-evaluate soft ref policy.
-  void process_soft_ref_reconsider(RefProcProxyTask& proxy_task,
-                                   ReferenceProcessorPhaseTimes& phase_times);
-
   // Phase 2: Drop Soft/Weak/Final references with a NULL or live referent, and clear
   // and enqueue non-Final references.
   void process_soft_weak_final_refs(RefProcProxyTask& proxy_task,
@@ -256,15 +249,6 @@ private:
 
   // Work methods used by the process_* methods. All methods return the number of
   // removed elements.
-
-  // (SoftReferences only) Traverse the list and remove any SoftReferences whose
-  // referents are not alive, but that should be kept alive for policy reasons.
-  // Keep alive the transitive closure of all such referents.
-  size_t process_soft_ref_reconsider_work(DiscoveredList&     refs_list,
-                                          ReferencePolicy*    policy,
-                                          BoolObjectClosure*  is_alive,
-                                          OopClosure*         keep_alive,
-                                          VoidClosure*        complete_gc);
 
   // Traverse the list and remove any Refs whose referents are alive,
   // or NULL if discovery is not atomic. Enqueue and clear the reference for

--- a/src/hotspot/share/gc/shared/referenceProcessor.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.hpp
@@ -160,26 +160,26 @@ public:
 // straightforward manner in a general, non-generational, non-contiguous generation
 // (or heap) setting.
 class ReferenceProcessor : public ReferenceDiscoverer {
+  friend class RefProcPhase1Task;
   friend class RefProcPhase2Task;
   friend class RefProcPhase3Task;
-  friend class RefProcPhase4Task;
 public:
   // Names of sub-phases of reference processing. Indicates the type of the reference
   // processed and the associated phase number at the end.
   enum RefProcSubPhases {
-    SoftRefSubPhase2,
-    WeakRefSubPhase2,
+    SoftRefSubPhase1,
+    WeakRefSubPhase1,
+    FinalRefSubPhase1,
     FinalRefSubPhase2,
-    FinalRefSubPhase3,
-    PhantomRefSubPhase4,
+    PhantomRefSubPhase3,
     RefSubPhaseMax
   };
 
   // Main phases of reference processing.
   enum RefProcPhases {
+    RefPhase1,
     RefPhase2,
     RefPhase3,
-    RefPhase4,
     RefPhaseMax
   };
 
@@ -234,16 +234,16 @@ private:
 
   void run_task(RefProcTask& task, RefProcProxyTask& proxy_task, bool marks_oops_alive);
 
-  // Phase 2: Drop Soft/Weak/Final references with a NULL or live referent, and clear
+  // Phase 1: Drop Soft/Weak/Final references with a NULL or live referent, and clear
   // and enqueue non-Final references.
   void process_soft_weak_final_refs(RefProcProxyTask& proxy_task,
                                     ReferenceProcessorPhaseTimes& phase_times);
 
-  // Phase 3: Keep alive followers of Final references, and enqueue.
+  // Phase 2: Keep alive followers of Final references, and enqueue.
   void process_final_keep_alive(RefProcProxyTask& proxy_task,
                                 ReferenceProcessorPhaseTimes& phase_times);
 
-  // Phase 4: Drop and keep alive live Phantom references, or clear and enqueue if dead.
+  // Phase 3: Drop and keep alive live Phantom references, or clear and enqueue if dead.
   void process_phantom_refs(RefProcProxyTask& proxy_task,
                             ReferenceProcessorPhaseTimes& phase_times);
 

--- a/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
@@ -36,16 +36,15 @@
 #define ASSERT_REF_TYPE(ref_type) assert((ref_type) >= REF_SOFT && (ref_type) <= REF_PHANTOM, \
                                          "Invariant (%d)", (int)ref_type)
 
-#define ASSERT_PHASE(phase) assert((phase) >= ReferenceProcessor::RefPhase1 && \
+#define ASSERT_PHASE(phase) assert((phase) >= ReferenceProcessor::RefPhase2 && \
                                    (phase) < ReferenceProcessor::RefPhaseMax,  \
                                    "Invariant (%d)", (int)phase);
 
-#define ASSERT_SUB_PHASE(phase) assert((phase) >= ReferenceProcessor::SoftRefSubPhase1 && \
+#define ASSERT_SUB_PHASE(phase) assert((phase) >= ReferenceProcessor::SoftRefSubPhase2 && \
                                        (phase) < ReferenceProcessor::RefSubPhaseMax, \
                                        "Invariant (%d)", (int)phase);
 
 static const char* SubPhasesParWorkTitle[ReferenceProcessor::RefSubPhaseMax] = {
-       "SoftRef (ms):",
        "SoftRef (ms):",
        "WeakRef (ms):",
        "FinalRef (ms):",
@@ -56,7 +55,6 @@ static const char* SubPhasesParWorkTitle[ReferenceProcessor::RefSubPhaseMax] = {
 static const char* Phase2ParWorkTitle = "Total (ms):";
 
 static const char* SubPhasesSerWorkTitle[ReferenceProcessor::RefSubPhaseMax] = {
-       "SoftRef:",
        "SoftRef:",
        "WeakRef:",
        "FinalRef:",
@@ -69,7 +67,6 @@ static const char* Phase2SerWorkTitle = "Total:";
 static const char* Indents[6] = {"", "  ", "    ", "      ", "        ", "          "};
 
 static const char* PhaseNames[ReferenceProcessor::RefPhaseMax] = {
-       "Reconsider SoftReferences",
        "Notify Soft/WeakReferences",
        "Notify and keep alive finalizable",
        "Notify PhantomReferences"
@@ -279,7 +276,6 @@ void ReferenceProcessorPhaseTimes::print_all_references(uint base_indent, bool p
   }
 
   uint next_indent = base_indent + 1;
-  print_phase(ReferenceProcessor::RefPhase1, next_indent);
   print_phase(ReferenceProcessor::RefPhase2, next_indent);
   print_phase(ReferenceProcessor::RefPhase3, next_indent);
   print_phase(ReferenceProcessor::RefPhase4, next_indent);
@@ -333,9 +329,6 @@ void ReferenceProcessorPhaseTimes::print_phase(ReferenceProcessor::RefProcPhases
     }
 
     switch (phase) {
-      case ReferenceProcessor::RefPhase1:
-        print_sub_phase(&ls, ReferenceProcessor::SoftRefSubPhase1, indent + 1);
-        break;
       case ReferenceProcessor::RefPhase2:
         print_sub_phase(&ls, ReferenceProcessor::SoftRefSubPhase2, indent + 1);
         print_sub_phase(&ls, ReferenceProcessor::WeakRefSubPhase2, indent + 1);

--- a/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
@@ -36,11 +36,11 @@
 #define ASSERT_REF_TYPE(ref_type) assert((ref_type) >= REF_SOFT && (ref_type) <= REF_PHANTOM, \
                                          "Invariant (%d)", (int)ref_type)
 
-#define ASSERT_PHASE(phase) assert((phase) >= ReferenceProcessor::RefPhase1 && \
+#define ASSERT_PHASE(phase) assert((phase) >= ReferenceProcessor::RefPhase2 && \
                                    (phase) < ReferenceProcessor::RefPhaseMax,  \
                                    "Invariant (%d)", (int)phase);
 
-#define ASSERT_SUB_PHASE(phase) assert((phase) >= ReferenceProcessor::SoftRefSubPhase1 && \
+#define ASSERT_SUB_PHASE(phase) assert((phase) >= ReferenceProcessor::SoftRefSubPhase2 && \
                                        (phase) < ReferenceProcessor::RefSubPhaseMax, \
                                        "Invariant (%d)", (int)phase);
 
@@ -52,7 +52,7 @@ static const char* SubPhasesParWorkTitle[ReferenceProcessor::RefSubPhaseMax] = {
        "PhantomRef (ms):"
        };
 
-static const char* Phase1ParWorkTitle = "Total (ms):";
+static const char* Phase2ParWorkTitle = "Total (ms):";
 
 static const char* SubPhasesSerWorkTitle[ReferenceProcessor::RefSubPhaseMax] = {
        "SoftRef:",
@@ -62,7 +62,7 @@ static const char* SubPhasesSerWorkTitle[ReferenceProcessor::RefSubPhaseMax] = {
        "PhantomRef:"
        };
 
-static const char* Phase1SerWorkTitle = "Total:";
+static const char* Phase2SerWorkTitle = "Total:";
 
 static const char* Indents[6] = {"", "  ", "    ", "      ", "        ", "          "};
 
@@ -176,7 +176,7 @@ ReferenceProcessorPhaseTimes::ReferenceProcessorPhaseTimes(GCTimer* gc_timer, ui
   for (uint i = 0; i < ReferenceProcessor::RefSubPhaseMax; i++) {
     _sub_phases_worker_time_sec[i] = new WorkerDataArray<double>(NULL, SubPhasesParWorkTitle[i], max_gc_threads);
   }
-  _phase1_worker_time_sec = new WorkerDataArray<double>(NULL, Phase1ParWorkTitle, max_gc_threads);
+  _phase2_worker_time_sec = new WorkerDataArray<double>(NULL, Phase2ParWorkTitle, max_gc_threads);
 
   reset();
 }
@@ -212,7 +212,7 @@ void ReferenceProcessorPhaseTimes::reset() {
     _balance_queues_time_ms[i] = uninitialized();
   }
 
-  _phase1_worker_time_sec->reset();
+  _phase2_worker_time_sec->reset();
 
   for (int i = 0; i < number_of_subclasses_of_ref; i++) {
     _ref_cleared[i] = 0;
@@ -228,7 +228,7 @@ ReferenceProcessorPhaseTimes::~ReferenceProcessorPhaseTimes() {
   for (int i = 0; i < ReferenceProcessor::RefSubPhaseMax; i++) {
     delete _sub_phases_worker_time_sec[i];
   }
-  delete _phase1_worker_time_sec;
+  delete _phase2_worker_time_sec;
 }
 
 double ReferenceProcessorPhaseTimes::sub_phase_total_time_ms(ReferenceProcessor::RefProcSubPhases sub_phase) const {
@@ -276,9 +276,9 @@ void ReferenceProcessorPhaseTimes::print_all_references(uint base_indent, bool p
   }
 
   uint next_indent = base_indent + 1;
-  print_phase(ReferenceProcessor::RefPhase1, next_indent);
   print_phase(ReferenceProcessor::RefPhase2, next_indent);
   print_phase(ReferenceProcessor::RefPhase3, next_indent);
+  print_phase(ReferenceProcessor::RefPhase4, next_indent);
 
   print_reference(REF_SOFT, next_indent);
   print_reference(REF_WEAK, next_indent);
@@ -329,22 +329,22 @@ void ReferenceProcessorPhaseTimes::print_phase(ReferenceProcessor::RefProcPhases
     }
 
     switch (phase) {
-      case ReferenceProcessor::RefPhase1:
-        print_sub_phase(&ls, ReferenceProcessor::SoftRefSubPhase1, indent + 1);
-        print_sub_phase(&ls, ReferenceProcessor::WeakRefSubPhase1, indent + 1);
-        print_sub_phase(&ls, ReferenceProcessor::FinalRefSubPhase1, indent + 1);
-        break;
       case ReferenceProcessor::RefPhase2:
+        print_sub_phase(&ls, ReferenceProcessor::SoftRefSubPhase2, indent + 1);
+        print_sub_phase(&ls, ReferenceProcessor::WeakRefSubPhase2, indent + 1);
         print_sub_phase(&ls, ReferenceProcessor::FinalRefSubPhase2, indent + 1);
         break;
       case ReferenceProcessor::RefPhase3:
-        print_sub_phase(&ls, ReferenceProcessor::PhantomRefSubPhase3, indent + 1);
+        print_sub_phase(&ls, ReferenceProcessor::FinalRefSubPhase3, indent + 1);
+        break;
+      case ReferenceProcessor::RefPhase4:
+        print_sub_phase(&ls, ReferenceProcessor::PhantomRefSubPhase4, indent + 1);
         break;
       default:
         ShouldNotReachHere();
     }
-    if (phase == ReferenceProcessor::RefPhase1) {
-      print_worker_time(&ls, _phase1_worker_time_sec, Phase1SerWorkTitle, indent + 1);
+    if (phase == ReferenceProcessor::RefPhase2) {
+      print_worker_time(&ls, _phase2_worker_time_sec, Phase2SerWorkTitle, indent + 1);
     }
   }
 }

--- a/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.hpp
@@ -49,7 +49,7 @@ class ReferenceProcessorPhaseTimes : public CHeapObj<mtGC> {
   // Records total queue balancing for each phase.
   double                   _balance_queues_time_ms[ReferenceProcessor::RefPhaseMax];
 
-  WorkerDataArray<double>* _phase2_worker_time_sec;
+  WorkerDataArray<double>* _phase1_worker_time_sec;
 
   // Total spent time for reference processing.
   double                   _total_time_ms;
@@ -80,7 +80,7 @@ public:
   ReferenceProcessorPhaseTimes(GCTimer* gc_timer, uint max_gc_threads);
   ~ReferenceProcessorPhaseTimes();
 
-  WorkerDataArray<double>* phase2_worker_time_sec() const { return _phase2_worker_time_sec; }
+  WorkerDataArray<double>* phase1_worker_time_sec() const { return _phase1_worker_time_sec; }
   WorkerDataArray<double>* sub_phase_worker_time_sec(ReferenceProcessor::RefProcSubPhases phase) const;
   void set_phase_time_ms(ReferenceProcessor::RefProcPhases phase, double par_phase_time_ms);
 

--- a/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.hpp
@@ -49,7 +49,7 @@ class ReferenceProcessorPhaseTimes : public CHeapObj<mtGC> {
   // Records total queue balancing for each phase.
   double                   _balance_queues_time_ms[ReferenceProcessor::RefPhaseMax];
 
-  WorkerDataArray<double>* _phase1_worker_time_sec;
+  WorkerDataArray<double>* _phase2_worker_time_sec;
 
   // Total spent time for reference processing.
   double                   _total_time_ms;
@@ -80,7 +80,7 @@ public:
   ReferenceProcessorPhaseTimes(GCTimer* gc_timer, uint max_gc_threads);
   ~ReferenceProcessorPhaseTimes();
 
-  WorkerDataArray<double>* phase1_worker_time_sec() const { return _phase1_worker_time_sec; }
+  WorkerDataArray<double>* phase2_worker_time_sec() const { return _phase2_worker_time_sec; }
   WorkerDataArray<double>* sub_phase_worker_time_sec(ReferenceProcessor::RefProcSubPhases phase) const;
   void set_phase_time_ms(ReferenceProcessor::RefProcPhases phase, double par_phase_time_ms);
 

--- a/test/hotspot/jtreg/gc/logging/TestPrintReferences.java
+++ b/test/hotspot/jtreg/gc/logging/TestPrintReferences.java
@@ -50,7 +50,6 @@ public class TestPrintReferences {
     static final String finalReference = "FinalReference";
     static final String phantomReference = "PhantomReference";
 
-    static final String phaseReconsiderSoftReferences = "Reconsider SoftReferences";
     static final String phaseNotifySoftWeakReferences = "Notify Soft/WeakReferences";
     static final String phaseNotifyKeepAliveFinalizer = "Notify and keep alive finalizable";
     static final String phaseNotifyPhantomReferences  = "Notify PhantomReferences";
@@ -137,7 +136,6 @@ public class TestPrintReferences {
 
         final boolean p = parallelRefProcEnabled;
 
-        String phase1Regex = gcLogTimeRegex + phaseRegex(phaseReconsiderSoftReferences) + balanceRegex + subphaseRegex("SoftRef", p);
         String phase2Regex = gcLogTimeRegex + phaseRegex(phaseNotifySoftWeakReferences) +
                              balanceRegex +
                              subphaseRegex("SoftRef", p) +
@@ -148,7 +146,6 @@ public class TestPrintReferences {
         String phase4Regex = gcLogTimeRegex + phaseRegex(phaseNotifyPhantomReferences) + balanceRegex + subphaseRegex("PhantomRef", p);
 
         output.shouldMatch(totalRegex +
-                           phase1Regex +
                            phase2Regex +
                            phase3Regex +
                            phase4Regex);
@@ -220,14 +217,14 @@ public class TestPrintReferences {
     private static void checkTrimmedLogValue() {
         BigDecimal refProcTime = getTimeValue(referenceProcessing, 0);
 
-        BigDecimal sumOfSubPhasesTime = getTimeValue(phaseReconsiderSoftReferences, 2);
+        BigDecimal sumOfSubPhasesTime = BigDecimal.ZERO;
         sumOfSubPhasesTime = sumOfSubPhasesTime.add(getTimeValue(phaseNotifySoftWeakReferences, 2));
         sumOfSubPhasesTime = sumOfSubPhasesTime.add(getTimeValue(phaseNotifyKeepAliveFinalizer, 2));
         sumOfSubPhasesTime = sumOfSubPhasesTime.add(getTimeValue(phaseNotifyPhantomReferences, 2));
 
-        // If there are 4 phases, we should allow 0.2 tolerance.
-        final BigDecimal toleranceFor4SubPhases = BigDecimal.valueOf(0.2);
-        if (!greaterThanOrApproximatelyEqual(refProcTime, sumOfSubPhasesTime, toleranceFor4SubPhases)) {
+        // If there are 3 phases, we should allow 0.2 tolerance.
+        final BigDecimal toleranceFor3SubPhases = BigDecimal.valueOf(0.2);
+        if (!greaterThanOrApproximatelyEqual(refProcTime, sumOfSubPhasesTime, toleranceFor3SubPhases)) {
             throw new RuntimeException("Reference Processing time(" + refProcTime + "ms) is less than the sum("
                                        + sumOfSubPhasesTime + "ms) of each phases");
         }

--- a/test/hotspot/jtreg/gc/logging/TestPrintReferences.java
+++ b/test/hotspot/jtreg/gc/logging/TestPrintReferences.java
@@ -136,19 +136,19 @@ public class TestPrintReferences {
 
         final boolean p = parallelRefProcEnabled;
 
-        String phase2Regex = gcLogTimeRegex + phaseRegex(phaseNotifySoftWeakReferences) +
+        String phase1Regex = gcLogTimeRegex + phaseRegex(phaseNotifySoftWeakReferences) +
                              balanceRegex +
                              subphaseRegex("SoftRef", p) +
                              subphaseRegex("WeakRef", p) +
                              subphaseRegex("FinalRef", p) +
                              subphaseRegex("Total", p);
-        String phase3Regex = gcLogTimeRegex + phaseRegex(phaseNotifyKeepAliveFinalizer) + balanceRegex + subphaseRegex("FinalRef", p);
-        String phase4Regex = gcLogTimeRegex + phaseRegex(phaseNotifyPhantomReferences) + balanceRegex + subphaseRegex("PhantomRef", p);
+        String phase2Regex = gcLogTimeRegex + phaseRegex(phaseNotifyKeepAliveFinalizer) + balanceRegex + subphaseRegex("FinalRef", p);
+        String phase3Regex = gcLogTimeRegex + phaseRegex(phaseNotifyPhantomReferences) + balanceRegex + subphaseRegex("PhantomRef", p);
 
         output.shouldMatch(totalRegex +
+                           phase1Regex +
                            phase2Regex +
-                           phase3Regex +
-                           phase4Regex);
+                           phase3Regex);
     }
 
     // After getting time value, update 'output' for next use.

--- a/test/hotspot/jtreg/gc/logging/TestPrintReferences.java
+++ b/test/hotspot/jtreg/gc/logging/TestPrintReferences.java
@@ -136,19 +136,19 @@ public class TestPrintReferences {
 
         final boolean p = parallelRefProcEnabled;
 
-        String phase1Regex = gcLogTimeRegex + phaseRegex(phaseNotifySoftWeakReferences) +
+        String phase2Regex = gcLogTimeRegex + phaseRegex(phaseNotifySoftWeakReferences) +
                              balanceRegex +
                              subphaseRegex("SoftRef", p) +
                              subphaseRegex("WeakRef", p) +
                              subphaseRegex("FinalRef", p) +
                              subphaseRegex("Total", p);
-        String phase2Regex = gcLogTimeRegex + phaseRegex(phaseNotifyKeepAliveFinalizer) + balanceRegex + subphaseRegex("FinalRef", p);
-        String phase3Regex = gcLogTimeRegex + phaseRegex(phaseNotifyPhantomReferences) + balanceRegex + subphaseRegex("PhantomRef", p);
+        String phase3Regex = gcLogTimeRegex + phaseRegex(phaseNotifyKeepAliveFinalizer) + balanceRegex + subphaseRegex("FinalRef", p);
+        String phase4Regex = gcLogTimeRegex + phaseRegex(phaseNotifyPhantomReferences) + balanceRegex + subphaseRegex("PhantomRef", p);
 
         output.shouldMatch(totalRegex +
-                           phase1Regex +
                            phase2Regex +
-                           phase3Regex);
+                           phase3Regex +
+                           phase4Regex);
     }
 
     // After getting time value, update 'output' for next use.


### PR DESCRIPTION
This PR consists of 3 commits:

1. Removes the soft-ref reconsideration phase because the soft-ref policy is set before marking (JDK-8269596) and stays the same across the GC cycle. Reconsideration phase should not find anything interesting. That being said, there might be some benefit of using more precise heap usage after marking for soft-ref processing, created JDK-8269798 for exploring that.

2. Removes reloading of `_soft_ref_timestamp_clock` from `java_lang_ref_SoftReference::clock();` because the master clock should only be changed by GC.

3. Rename phase{2,3,4} to phase{1,2,3}.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8051680](https://bugs.openjdk.java.net/browse/JDK-8051680): (ref) unnecessary process_soft_ref_reconsider


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4667/head:pull/4667` \
`$ git checkout pull/4667`

Update a local copy of the PR: \
`$ git checkout pull/4667` \
`$ git pull https://git.openjdk.java.net/jdk pull/4667/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4667`

View PR using the GUI difftool: \
`$ git pr show -t 4667`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4667.diff">https://git.openjdk.java.net/jdk/pull/4667.diff</a>

</details>
