### PR TITLE
8269821: Remove is-queue-active check in inner loop of write_ref_array_pre_work

### DIFF
--- a/src/hotspot/share/gc/g1/g1BarrierSet.cpp
+++ b/src/hotspot/share/gc/g1/g1BarrierSet.cpp
@@ -72,11 +72,15 @@ void G1BarrierSet::enqueue(oop pre_val) {
 template <class T> void
 G1BarrierSet::write_ref_array_pre_work(T* dst, size_t count) {
   if (!_satb_mark_queue_set.is_active()) return;
+
+  SATBMarkQueue& queue = G1ThreadLocalData::satb_mark_queue(Thread::current());
+  G1SATBMarkQueueSet& queue_set = G1BarrierSet::satb_mark_queue_set();
+
   T* elem_ptr = dst;
   for (size_t i = 0; i < count; i++, elem_ptr++) {
     T heap_oop = RawAccess<>::oop_load(elem_ptr);
     if (!CompressedOops::is_null(heap_oop)) {
-      enqueue(CompressedOops::decode_not_null(heap_oop));
+      queue_set.enqueue_known_active(queue, CompressedOops::decode_not_null(heap_oop));
     }
   }
 }

--- a/src/hotspot/share/gc/g1/g1BarrierSet.cpp
+++ b/src/hotspot/share/gc/g1/g1BarrierSet.cpp
@@ -71,10 +71,10 @@ void G1BarrierSet::enqueue(oop pre_val) {
 
 template <class T> void
 G1BarrierSet::write_ref_array_pre_work(T* dst, size_t count) {
-  if (!_satb_mark_queue_set.is_active()) return;
+  G1SATBMarkQueueSet& queue_set = G1BarrierSet::satb_mark_queue_set();
+  if (!queue_set.is_active()) return;
 
   SATBMarkQueue& queue = G1ThreadLocalData::satb_mark_queue(Thread::current());
-  G1SATBMarkQueueSet& queue_set = G1BarrierSet::satb_mark_queue_set();
 
   T* elem_ptr = dst;
   for (size_t i = 0; i < count; i++, elem_ptr++) {


### PR DESCRIPTION
Hi all,

  can I have reviews for this small micro-optimization that removes unnecessary work in the innermost loop of  write_ref_array_pre_work()?

In particular it removes the superfluous check whether marking is active (already done at the top of the loop) and hoists out several other code that the compiler for some reason does not automatically hoist.

Testing: tier1

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269821](https://bugs.openjdk.java.net/browse/JDK-8269821): Remove is-queue-active check in inner loop of write_ref_array_pre_work


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Committer)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4669/head:pull/4669` \
`$ git checkout pull/4669`

Update a local copy of the PR: \
`$ git checkout pull/4669` \
`$ git pull https://git.openjdk.java.net/jdk pull/4669/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4669`

View PR using the GUI difftool: \
`$ git pr show -t 4669`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4669.diff">https://git.openjdk.java.net/jdk/pull/4669.diff</a>

</details>
