### PR TITLE
8269823: JFR: Eliminate 'is_large' check for native JFR event if the size range is certain

### DIFF
--- a/make/src/classes/build/tools/jfr/GenerateJfrFiles.java
+++ b/make/src/classes/build/tools/jfr/GenerateJfrFiles.java
@@ -456,10 +456,12 @@ public class GenerateJfrFiles {
             event.maxSize += event.id <= 127 ? 1 : 2;
             event.minSize ++;
 
+            // start time
             event.maxSize += 9;
             event.minSize += 1;
 
-            if (!event.startTime || !event.period.isEmpty() || event.cutoff) {
+            if (!(!event.startTime || !event.period.isEmpty()) || event.cutoff) {
+                // end time
                 event.maxSize += 9;
                 event.minSize += 1;
             }

--- a/make/src/classes/build/tools/jfr/GenerateJfrFiles.java
+++ b/make/src/classes/build/tools/jfr/GenerateJfrFiles.java
@@ -459,7 +459,7 @@ public class GenerateJfrFiles {
 
             if (event.maxSize < 127) {
                 event.sizeRange = EventSizeRange.LT_128;
-            } else if (event.minSize >=127) {
+            } else if (event.minSize >= 127) {
                 event.sizeRange = EventSizeRange.GE_128;
             } else {
                 event.sizeRange = EventSizeRange.UNCERTAIN;

--- a/make/src/classes/build/tools/jfr/GenerateJfrFiles.java
+++ b/make/src/classes/build/tools/jfr/GenerateJfrFiles.java
@@ -239,6 +239,30 @@ public class GenerateJfrFiles {
         private TypeCounter eventCounter;
         private TypeCounter typeCounter;
 
+        static Map<String, Integer> maxSizeMap = new LinkedHashMap<>();
+
+        static {
+            maxSizeMap.put("const PackageEntry*", 9);
+            maxSizeMap.put("const Klass*", 9);
+            maxSizeMap.put("const ModuleEntry*", 9);
+            maxSizeMap.put("const ClassLoaderData*", 9);
+            maxSizeMap.put("const Method*", 9);
+            maxSizeMap.put("u8", 9);
+            maxSizeMap.put("Tickspan", 9);
+            maxSizeMap.put("Ticks", 9);
+            maxSizeMap.put("unsigned", 5);
+            maxSizeMap.put("u2", 3);
+            maxSizeMap.put("u1", 2);
+            maxSizeMap.put("s8", 9);
+            maxSizeMap.put("s4", 5);
+            maxSizeMap.put("s2", 3);
+            maxSizeMap.put("s1", 2);
+            maxSizeMap.put("double", 9);
+            maxSizeMap.put("float", 5);
+            maxSizeMap.put("bool", 1);
+            maxSizeMap.put("char", 2);
+        }
+
         Metadata(File metadataXml, File metadataSchema)
                 throws ParserConfigurationException, SAXException, FileNotFoundException, IOException {
             SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
@@ -409,18 +433,11 @@ public class GenerateJfrFiles {
                     te.minSize += field.type.minSize;
                 } else {
                     te.minSize += 1;
-                    if (type.equals("u8") || type.equals("double") || type.equals("s8") || type.equals("Ticks")
-                        || type.equals("Tickspan") || type.endsWith("*")) {
-                        te.maxSize += 9;
-                    } else if (type.equals("float") || type.equals("s4") || type.equals("unsigned")) {
-                        te.maxSize += 5;
-                    } else if (type.equals("char") || type.equals("s1") || type.equals("u1")) {
-                        te.maxSize += 2;
-                    } else if (type.equals("bool")) {
-                        te.maxSize += 1;
-                    } else {
-                        te.maxSize += 9;
+                    Integer maxSize = maxSizeMap.get(type);
+                    if (maxSize == null) {
+                        throw new RuntimeException("Unknown max size for type: " + type);
                     }
+                    te.maxSize += maxSize;
                 }
             }
         }

--- a/src/hotspot/share/jfr/recorder/service/jfrEvent.hpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrEvent.hpp
@@ -196,9 +196,9 @@ class JfrEvent {
       return;
     }
 
-    if (T::sizeRange == LT_128) {
-      write_sized_event(buffer, event_thread, tl, false);
-    } else if (T::sizeRange == UNCERTAIN) {
+    if (T::sizeRange != UNCERTAIN) {
+      write_sized_event(buffer, event_thread, tl, T::sizeRange == GE_128);
+    } else {
       bool large = is_large();
       if (write_sized_event(buffer, event_thread, tl, large)) {
         // Event written succesfully
@@ -211,8 +211,6 @@ class JfrEvent {
           set_large();
         }
       }
-    } else if (T::sizeRange == GE_128) {
-      write_sized_event(buffer, event_thread, tl, true);
     }
   }
 

--- a/src/hotspot/share/jfr/utilities/jfrTypes.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrTypes.hpp
@@ -57,4 +57,9 @@ enum JfrCheckpointType {
   THREADS = 8
 };
 
+enum EventSizeRange {
+  LT_128,
+  GE_128,
+  UNCERTAIN
+};
 #endif // SHARE_JFR_UTILITIES_JFRTYPES_HPP

--- a/src/hotspot/share/jfr/utilities/jfrTypes.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrTypes.hpp
@@ -62,4 +62,5 @@ enum EventSizeRange {
   GE_128,
   UNCERTAIN
 };
+
 #endif // SHARE_JFR_UTILITIES_JFRTYPES_HPP

--- a/src/hotspot/share/jfr/writers/jfrEventWriterHost.hpp
+++ b/src/hotspot/share/jfr/writers/jfrEventWriterHost.hpp
@@ -35,7 +35,9 @@ class EventWriterHost : public WriterHost<BE, IE, WriterPolicyImpl> {
   EventWriterHost(Thread* thread);
   void begin_write();
   intptr_t end_write();
+  template <EventSizeRange RANGE = UNCERTAIN>
   void begin_event_write(bool large);
+  template <EventSizeRange RANGE= UNCERTAIN>
   intptr_t end_event_write(bool large);
 };
 

--- a/src/hotspot/share/jfr/writers/jfrEventWriterHost.hpp
+++ b/src/hotspot/share/jfr/writers/jfrEventWriterHost.hpp
@@ -37,7 +37,7 @@ class EventWriterHost : public WriterHost<BE, IE, WriterPolicyImpl> {
   intptr_t end_write();
   template <EventSizeRange RANGE = UNCERTAIN>
   void begin_event_write(bool large);
-  template <EventSizeRange RANGE= UNCERTAIN>
+  template <EventSizeRange RANGE = UNCERTAIN>
   intptr_t end_event_write(bool large);
 };
 


### PR DESCRIPTION
Hi,

Could I have a review of this improvement that eliminates 'is_large' check if the event size range is certain?

JDK-8246260 introduced event large checks to reduce the recording size.
This check could be eliminated at compile/build time when one of the following conditions is satisfied:
1. if the max size is < 128
2. if the min size is >= 128

The max size and the min size could be computed for the most native events at the generation phase.

And I think this improvement may also be done for JDK events.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8269823](https://bugs.openjdk.java.net/browse/JDK-8269823): JFR: Eliminate 'is_large' check for native JFR event if the size range is certain


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4670/head:pull/4670` \
`$ git checkout pull/4670`

Update a local copy of the PR: \
`$ git checkout pull/4670` \
`$ git pull https://git.openjdk.java.net/jdk pull/4670/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4670`

View PR using the GUI difftool: \
`$ git pr show -t 4670`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4670.diff">https://git.openjdk.java.net/jdk/pull/4670.diff</a>

</details>
