### PR TITLE
8267303: Replace MinObjectAlignmentSize usages for non-Java heap objects

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -323,7 +323,7 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   Symbol* name_and_id() const { return _name_and_id; }
 
   unsigned identity_hash() const {
-    return (unsigned)((uintptr_t)this >> 3);
+    return (unsigned)((uintptr_t)this >> LogBytesPerWord);
   }
 
   JFR_ONLY(DEFINE_TRACE_ID_METHODS;)

--- a/src/hotspot/share/oops/symbol.hpp
+++ b/src/hotspot/share/oops/symbol.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -155,7 +155,7 @@ class Symbol : public MetaspaceObj {
   // Returns the largest size symbol we can safely hold.
   static int max_length() { return max_symbol_length; }
   unsigned identity_hash() const {
-    unsigned addr_bits = (unsigned)((uintptr_t)this >> (LogMinObjAlignmentInBytes + 3));
+    unsigned addr_bits = (unsigned)((uintptr_t)this >> (LogBytesPerWord + 3));
     return ((unsigned)extract_hash(_hash_and_refcount) & 0xffff) |
            ((addr_bits ^ (length() << 8) ^ (( _body[0] << 8) | _body[1])) << 16);
   }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Symbol.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Symbol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,7 +84,7 @@ public class Symbol extends VMObject {
   public long identityHash() {
     long addr_value = getAddress().asLongValue();
     long addr_bits =
-      (addr_value >> (VM.getVM().getLogMinObjAlignmentInBytes() + 3)) & 0xffffffffL;
+      (addr_value >> (VM.getVM().getLogBytesPerWord() + 3)) & 0xffffffffL;
     int  length = (int)getLength();
     int  byte0 = getByteAt(0);
     int  byte1 = getByteAt(1);

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
@@ -98,6 +98,7 @@ public class VM {
   private boolean      isLP64;
   private int          bytesPerLong;
   private int          bytesPerWord;
+  private int          logBytesPerWord;
   private int          objectAlignmentInBytes;
   private int          minObjAlignmentInBytes;
   private int          logMinObjAlignmentInBytes;
@@ -477,6 +478,7 @@ public class VM {
     }
     bytesPerLong = db.lookupIntConstant("BytesPerLong").intValue();
     bytesPerWord = db.lookupIntConstant("BytesPerWord").intValue();
+    logBytesPerWord = db.lookupIntConstant("LogBytesPerWord").intValue();
     heapWordSize = db.lookupIntConstant("HeapWordSize").intValue();
     Flags_DEFAULT = db.lookupIntConstant("JVMFlagOrigin::DEFAULT").intValue();
     Flags_COMMAND_LINE = db.lookupIntConstant("JVMFlagOrigin::COMMAND_LINE").intValue();
@@ -686,6 +688,10 @@ public class VM {
 
   public int getBytesPerWord() {
     return bytesPerWord;
+  }
+
+  public int getLogBytesPerWord() {
+    return logBytesPerWord;
   }
 
   /** Get minimum object alignment in bytes. */


### PR DESCRIPTION
Replace '3' and LogMinObjAlignmentInBytes with LogBytesPerWord (3 for LP64 and 2 for 32 bits).
Hoping git actions will test 32 bits.
Tested with tier1 on all Oracle platforms, but since I didn't change the values for our platforms, no failures expected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267303](https://bugs.openjdk.java.net/browse/JDK-8267303): Replace MinObjectAlignmentSize usages for non-Java heap objects


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to acc23f38d087b0ec4749718afa831fe5770e3b6e
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4675/head:pull/4675` \
`$ git checkout pull/4675`

Update a local copy of the PR: \
`$ git checkout pull/4675` \
`$ git pull https://git.openjdk.java.net/jdk pull/4675/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4675`

View PR using the GUI difftool: \
`$ git pr show -t 4675`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4675.diff">https://git.openjdk.java.net/jdk/pull/4675.diff</a>

</details>
