### PR TITLE
8269738: AssertionError when combining pattern matching and function closure

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -816,7 +816,7 @@ public class TransPatterns extends TreeTranslator {
         VarSymbol bindingDeclared(BindingSymbol varSymbol) {
             VarSymbol res = parent.bindingDeclared(varSymbol);
             if (res == null) {
-                res = new VarSymbol(varSymbol.flags(), varSymbol.name, varSymbol.type, varSymbol.owner);
+                res = new VarSymbol(varSymbol.flags(), varSymbol.name, varSymbol.type, currentMethodSym);
                 res.setTypeAttributes(varSymbol.getRawTypeAttributes());
                 hoistedVarMap.put(varSymbol, res);
             }

--- a/test/langtools/tools/javac/patterns/LambdaCannotCapturePatternVariables.java
+++ b/test/langtools/tools/javac/patterns/LambdaCannotCapturePatternVariables.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8267610
+ * @bug 8267610 8269738
  * @summary LambdaToMethod cannot capture pattern variables. So the TransPatterns should
  *          transform the pattern variables and symbols to normal variables and symbols.
  * @compile --enable-preview -source ${jdk.version} LambdaCannotCapturePatternVariables.java
@@ -34,11 +34,24 @@ import java.util.function.Supplier;
 
 public class LambdaCannotCapturePatternVariables {
 
+    static Number num1 = 1;
+    static Number num2 = null;
+    static Number staticNum1 = (num1 instanceof Integer i) ? ((Supplier<Integer>) () -> i).get() : null;
+    static Number staticNum2 = (num2 instanceof Integer i) ? ((Supplier<Integer>) () -> i).get() : null;
+    Number instanceNum1 = (num1 instanceof Integer i) ? ((Supplier<Integer>) () -> i).get() : null;
+    Number instanceNum2 = (num2 instanceof Integer i) ? ((Supplier<Integer>) () -> i).get() : null;
+
     public static void main(String[] args) {
         var testVar = new LambdaCannotCapturePatternVariables();
         testVar.testInstanceOfPatternVariable(Integer.valueOf(1));
         testVar.testSwitchPatternVariable(Integer.valueOf(1));
         testVar.test(Integer.valueOf(1));
+        assertTrue(staticNum1 != null, "staticNum1 is null unexpectedly");
+        assertTrue(staticNum2 == null, "staticNum1 is not null unexpectedly");
+        assertTrue(testVar.instanceNum1 != null, "instanceNum1 is null unexpectedly");
+        assertTrue(testVar.instanceNum2 == null, "instanceNum2 is not null unexpectedly");
+        assertTrue(staticNum1.intValue() == 1, "staticNum1.intValue() is not equal to 1");
+        assertTrue(testVar.instanceNum1.intValue() == 1, "instanceNum1.intValue() is not equal to 1");
     }
 
     public Integer testInstanceOfPatternVariable(Object x) {
@@ -68,5 +81,10 @@ public class LambdaCannotCapturePatternVariables {
                 ((Supplier<Integer>) (() -> {
                     return ((y instanceof Integer z) ? z : bar);
                 })).get() : bar);
+    }
+
+    static void assertTrue(boolean cond, String info) {
+        if (!cond)
+            throw new AssertionError(info);
     }
 }


### PR DESCRIPTION
Hi all,

The method `TransPatterns.BasicBindingContext::bindingDeclared` uses `varSymbol.owner` to construct a new `VarSymbol`. 

```
     res = new VarSymbol(varSymbol.flags(), varSymbol.name, varSymbol.type, varSymbol.owner);
```

But the `varSymbol.owner` may be also a `VarSymbol` when it is at the `init` clause of the static variables or instance variables.
You can see the following code. The `owner` of the `Interger i` is `staticNum1` or `instanceNum1` which is `VarSymbol`.

```
    static Number num1 = 1;
    static Number staticNum1 = (num1 instanceof Integer i) ? ((Supplier<Integer>) () -> i).get() : null;
    Number instanceNum1 = (num1 instanceof Integer i) ? ((Supplier<Integer>) () -> i).get() : null;
```

Then, the class `LambdaToMethod` can't capture the expected variables `Integer i` and the following phases such as `Gen` may fail or throw exceptions.

This patch uses the `currentMethodSym` which means a class or instance field initializer to replace `varSymbol.owner` and adds the corresponding test.

---

And I have a problem:

> The `owner` of the `Interger i` is `staticNum1` or `instanceNum1` which is `VarSymbol`.

The statement above means the `env.info.scope.owner` in the method `Attr::visitBindingPattern` is a `VarSymbol`. Is it a expected result? Or the original `env.info.scope.owner` should be modified to a class or instance field initializer which the following phases need.

```
    // Attr.java
    public void visitBindingPattern(JCBindingPattern tree) {
        ......
        BindingSymbol v = new BindingSymbol(tree.var.mods.flags, tree.var.name, tree.var.vartype.type, env.info.scope.owner);
        ......
    }
```

---

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269738](https://bugs.openjdk.java.net/browse/JDK-8269738): AssertionError when combining pattern matching and function closure


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4678/head:pull/4678` \
`$ git checkout pull/4678`

Update a local copy of the PR: \
`$ git checkout pull/4678` \
`$ git pull https://git.openjdk.java.net/jdk pull/4678/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4678`

View PR using the GUI difftool: \
`$ git pr show -t 4678`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4678.diff">https://git.openjdk.java.net/jdk/pull/4678.diff</a>

</details>
