### PR TITLE
8269113: Javac throws when compiling switch (null)

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -370,7 +370,7 @@ public class TransPatterns extends TreeTranslator {
             ListBuffer<JCStatement> statements = new ListBuffer<>();
             VarSymbol temp = new VarSymbol(Flags.SYNTHETIC,
                     names.fromString("selector" + tree.pos + target.syntheticNameChar() + "temp"),
-                    seltype,
+                    seltype.hasTag(BOT) ? syms.objectType : seltype,
                     currentMethodSym);
             boolean hasNullCase = cases.stream()
                                        .flatMap(c -> c.labels.stream())

--- a/test/langtools/tools/javac/patterns/Switches.java
+++ b/test/langtools/tools/javac/patterns/Switches.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
 
 /*
  * @test
- * @bug 8262891 8268333 8268896
+ * @bug 8262891 8268333 8268896 8269113
  * @summary Check behavior of pattern switches.
  * @compile --enable-preview -source ${jdk.version} Switches.java
  * @run main/othervm --enable-preview Switches
@@ -44,6 +44,7 @@ public class Switches {
         run(this::testBooleanSwitchExpression);
         assertFalse(testNullSwitch(null));
         assertTrue(testNullSwitch(""));
+        assertFalse(testNullSelector());
         runArrayTypeTest(this::testArrayTypeStatement);
         runArrayTypeTest(this::testArrayTypeExpression);
         runDefaultTest(this::testDefaultDoesNotDominateStatement);
@@ -64,6 +65,7 @@ public class Switches {
         runFallThrough(this::testFallThroughExpression);
         npeTest(this::npeTestStatement);
         npeTest(this::npeTestExpression);
+        npeTest(this::npeTestNullSelector);
         exhaustiveStatementSane("");
         exhaustiveStatementSane(null);
     }
@@ -162,6 +164,13 @@ public class Switches {
 
     boolean testNullSwitch(Object o) {
         return switch (o) {
+            case null -> false;
+            default -> true;
+        };
+    }
+
+    boolean testNullSelector() {
+        return switch (null) {
             case null -> false;
             default -> true;
         };
@@ -352,6 +361,12 @@ public class Switches {
             case A a -> 0;
             case B b -> 1;
         };
+    }
+
+    void npeTestNullSelector(Object o) {
+        switch (null) {
+            default:
+        }
     }
 
     void exhaustiveStatementSane(Object o) {


### PR DESCRIPTION
Hi all,

When we use `switch(null)` in the source code, the type of the selector is `BottomType`.
So the statement `Type seltype = selector.type;` of the method `TransPatterns::handleSwitch` will get a `BottomType`.
Then compiler mistakenly uses this `BottomType` to construct a new `VarSymbol`.

```
            VarSymbol temp = new VarSymbol(Flags.SYNTHETIC,
                    names.fromString("selector" + tree.pos + target.syntheticNameChar() + "temp"),
                    seltype,     // <--------here is a BottomType
                    currentMethodSym);
```

At last, when the compiler uses the new `VarSymbol temp` to construct a new `JCVariableDecl`(the code shown as below), it crashes at the method `TreeMaker::Type` because the method `TreeMaker::Type` can't handle the type `BottomType`.

```
statements.append(make.at(tree.pos).VarDef(temp, !hasNullCase ? attr.makeNullCheck(selector)
                                                                          : selector));
```

This patch changes the type from `BottomType` to `syms.objectType` and adds the corresponding test.
Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269113](https://bugs.openjdk.java.net/browse/JDK-8269113): Javac throws when compiling switch (null)


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4679/head:pull/4679` \
`$ git checkout pull/4679`

Update a local copy of the PR: \
`$ git checkout pull/4679` \
`$ git pull https://git.openjdk.java.net/jdk pull/4679/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4679`

View PR using the GUI difftool: \
`$ git pr show -t 4679`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4679.diff">https://git.openjdk.java.net/jdk/pull/4679.diff</a>

</details>
