### PR TITLE
8269886: Inaccurate error message for compressed hprof test

### DIFF
--- a/test/lib/jdk/test/lib/hprof/parser/Reader.java
+++ b/test/lib/jdk/test/lib/hprof/parser/Reader.java
@@ -160,7 +160,7 @@ public abstract class Reader {
                         fos.write(buffer, 0, len);
                     }
                 } catch (Exception e) {
-                    throw new IOException("Can not decompress the compressed hprof file", e);
+                    throw new IOException("Cannot decompress the compressed hprof file", e);
                 }
                 // Check dump data header and print stack trace.
                 try {
@@ -173,9 +173,11 @@ public abstract class Reader {
                                               true, debugLevel);
                         r.read();
                         return r.printStackTraces();
+                    } else {
+                        throw new IOException("Unrecognized magic number of decompressed data: " + i);
                     }
                 } catch (Exception e) {
-                    throw new IOException("Can not get stack trace from the compressed hprof file", e);
+                    throw new IOException("Cannot get stack trace from the compressed hprof file", e);
                 }
                 out.delete();
             } else {

--- a/test/lib/jdk/test/lib/hprof/parser/Reader.java
+++ b/test/lib/jdk/test/lib/hprof/parser/Reader.java
@@ -177,8 +177,6 @@ public abstract class Reader {
                     } else {
                         throw new IOException("Unrecognized magic number of decompressed data: " + i);
                     }
-                } catch (Exception e) {
-                    throw new IOException("Cannot get stack trace from the compressed hprof file", e);
                 } finally {
                     out.delete();
                 }

--- a/test/lib/jdk/test/lib/hprof/parser/Reader.java
+++ b/test/lib/jdk/test/lib/hprof/parser/Reader.java
@@ -175,7 +175,7 @@ public abstract class Reader {
                         r.read();
                         return r.printStackTraces();
                     } else {
-                        throw new IOException("Unrecognized magic number of decompressed data: " + i);
+                        throw new IOException("Unrecognized magic number found in decompressed data: " + i);
                     }
                 } finally {
                     out.delete();

--- a/test/lib/jdk/test/lib/hprof/parser/Reader.java
+++ b/test/lib/jdk/test/lib/hprof/parser/Reader.java
@@ -171,7 +171,7 @@ public abstract class Reader {
                         return r.printStackTraces();
                     }
                 } catch (Exception e) {
-                    throw new IOException("Can not decompress the compressed hprof file", e);
+                    throw new IOException("Can not get stack trace from the compressed hprof file", e);
                 }
                 out.delete();
             } else {

--- a/test/lib/jdk/test/lib/hprof/parser/Reader.java
+++ b/test/lib/jdk/test/lib/hprof/parser/Reader.java
@@ -159,7 +159,11 @@ public abstract class Reader {
                     while ((len = gis.read(buffer)) > 0) {
                         fos.write(buffer, 0, len);
                     }
-                    // Check dump data header and print stack trace.
+                } catch (Exception e) {
+                    throw new IOException("Can not decompress the compressed hprof file", e);
+                }
+                // Check dump data header and print stack trace.
+                try {
                     PositionDataInputStream in2 = new PositionDataInputStream(
                         new BufferedInputStream(new FileInputStream(out)));
                     i = in2.readInt();

--- a/test/lib/jdk/test/lib/hprof/parser/Reader.java
+++ b/test/lib/jdk/test/lib/hprof/parser/Reader.java
@@ -160,6 +160,7 @@ public abstract class Reader {
                         fos.write(buffer, 0, len);
                     }
                 } catch (Exception e) {
+                    out.delete();
                     throw new IOException("Cannot decompress the compressed hprof file", e);
                 }
                 // Check dump data header and print stack trace.
@@ -172,14 +173,14 @@ public abstract class Reader {
                             = new HprofReader(deCompressedFile, in2, dumpNumber,
                                               true, debugLevel);
                         r.read();
-                        out.delete();
                         return r.printStackTraces();
                     } else {
                         throw new IOException("Unrecognized magic number of decompressed data: " + i);
                     }
                 } catch (Exception e) {
-                    out.delete();
                     throw new IOException("Cannot get stack trace from the compressed hprof file", e);
+                } finally {
+                    out.delete();
                 }
             } else {
                 throw new IOException("Unrecognized magic number: " + i);

--- a/test/lib/jdk/test/lib/hprof/parser/Reader.java
+++ b/test/lib/jdk/test/lib/hprof/parser/Reader.java
@@ -172,18 +172,18 @@ public abstract class Reader {
                             = new HprofReader(deCompressedFile, in2, dumpNumber,
                                               true, debugLevel);
                         r.read();
+                        out.delete();
                         return r.printStackTraces();
                     } else {
                         throw new IOException("Unrecognized magic number of decompressed data: " + i);
                     }
                 } catch (Exception e) {
+                    out.delete();
                     throw new IOException("Cannot get stack trace from the compressed hprof file", e);
                 }
-                out.delete();
             } else {
                 throw new IOException("Unrecognized magic number: " + i);
             }
         }
-        return null;
     }
 }


### PR DESCRIPTION
The current implementation of hprof Reader for testing always prompts "Can not decompress the compressed hprof file" when there is error for testing gzipped heap dump. This is inaccurate if the gzipped file was decompressed successfully but the hprof file format is incorrect. So the inaccurate error message could be misleading for issue analysis.

This trivial PR refine the error message by simply print "Can not get stack trace from the compressed hprof file", the underlying exception from GZIPInputStream() or HprofReader() would give accurate error info.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269886](https://bugs.openjdk.java.net/browse/JDK-8269886): Inaccurate error message for compressed hprof test


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4685/head:pull/4685` \
`$ git checkout pull/4685`

Update a local copy of the PR: \
`$ git checkout pull/4685` \
`$ git pull https://git.openjdk.java.net/jdk pull/4685/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4685`

View PR using the GUI difftool: \
`$ git pr show -t 4685`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4685.diff">https://git.openjdk.java.net/jdk/pull/4685.diff</a>

</details>
