### PR TITLE
8267625: AARCH64: typo in LIR_Assembler::emit_profile_type 

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -2833,7 +2833,7 @@ void LIR_Assembler::emit_profile_type(LIR_OpProfileType* op) {
         }
 #endif
         // first time here. Set profile type.
-        __ ldr(tmp, mdo_addr);
+        __ str(tmp, mdo_addr);
       } else {
         assert(ciTypeEntries::valid_ciklass(current_klass) != NULL &&
                ciTypeEntries::valid_ciklass(current_klass) != exact_klass, "inconsistent");


### PR DESCRIPTION
This code is generated when C1 is profiling types but it is known statically that there should only be one possible class at this point. It's supposed to then store the klass pointer into the method data when the expected class is actually observed but currently it does a load instead of a store.

I've attached a simple example to the JBS entry that shows the correct method data after changing LDR to STR. Also tested tier1 on AArch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267625](https://bugs.openjdk.java.net/browse/JDK-8267625): AARCH64: typo in LIR_Assembler::emit_profile_type


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4686/head:pull/4686` \
`$ git checkout pull/4686`

Update a local copy of the PR: \
`$ git checkout pull/4686` \
`$ git pull https://git.openjdk.java.net/jdk pull/4686/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4686`

View PR using the GUI difftool: \
`$ git pr show -t 4686`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4686.diff">https://git.openjdk.java.net/jdk/pull/4686.diff</a>

</details>
