### PR TITLE
8269908: Move MemoryService::track_memory_usage call into G1MonitoringScope

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2618,7 +2618,6 @@ void G1CollectedHeap::gc_epilogue(bool full) {
   resize_all_tlabs();
   phase_times()->record_resize_tlab_time_ms((os::elapsedTime() - start) * 1000.0);
 
-  MemoryService::track_memory_usage();
   // We have just completed a GC. Update the soft reference
   // policy with the new heap occupancy
   Universe::heap()->update_capacity_and_used_at_gc();
@@ -2970,6 +2969,8 @@ void G1CollectedHeap::do_collection_pause_at_safepoint_helper(double target_paus
                                                             Threads::number_of_non_daemon_threads());
     active_workers = workers()->update_active_workers(active_workers);
     log_info(gc,task)("Using %u workers of %u for evacuation", active_workers, workers()->total_workers());
+
+    // JStat/MXBeans
     G1MonitoringScope ms(g1mm(),
                          false /* full_gc */,
                          collector_state()->in_mixed_phase() /* all_memory_pools_affected */);

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
@@ -350,6 +350,7 @@ G1MonitoringScope::G1MonitoringScope(G1MonitoringSupport* g1mm, bool full_gc, bo
 }
 
 G1MonitoringScope::~G1MonitoringScope() {
-  MemoryService::track_memory_usage();
   _g1mm->update_sizes();
+  // Needs to be called after updating pool sizes.
+  MemoryService::track_memory_usage();
 }

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
@@ -350,5 +350,6 @@ G1MonitoringScope::G1MonitoringScope(G1MonitoringSupport* g1mm, bool full_gc, bo
 }
 
 G1MonitoringScope::~G1MonitoringScope() {
+  MemoryService::track_memory_usage();
   _g1mm->update_sizes();
 }


### PR DESCRIPTION
Hi all,

  can I have reviews for this tiny change that moves the `MemoryService::track_memory_usage()` call into the destructor of `G1MonitoringScope` so that all jstat/mxbeans related reporting is handled by that single place?

Testing: tier1-3

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269908](https://bugs.openjdk.java.net/browse/JDK-8269908): Move MemoryService::track_memory_usage call into G1MonitoringScope


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Committer)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4687/head:pull/4687` \
`$ git checkout pull/4687`

Update a local copy of the PR: \
`$ git checkout pull/4687` \
`$ git pull https://git.openjdk.java.net/jdk pull/4687/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4687`

View PR using the GUI difftool: \
`$ git pr show -t 4687`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4687.diff">https://git.openjdk.java.net/jdk/pull/4687.diff</a>

</details>
