### PR TITLE
 8269914: Factor out heap printing for G1 young and full gc

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -317,10 +317,6 @@ private:
   // this method will be found dead by the marking cycle).
   void allocate_dummy_regions() PRODUCT_RETURN;
 
-  // If the HR printer is active, dump the state of the regions in the
-  // heap after a compaction.
-  void print_hrm_post_compaction();
-
   // Create a memory mapper for auxiliary data structures of the given size and
   // translation factor.
   static G1RegionToSpaceMapper* create_aux_memory_mapper(const char* description,
@@ -537,7 +533,7 @@ private:
   void prepare_heap_for_mutators();
   void abort_refinement();
   void verify_after_full_collection();
-  void print_heap_after_full_collection(G1HeapTransition* heap_transition);
+  void print_heap_after_full_collection();
 
   // Helper method for satisfy_failed_allocation()
   HeapWord* satisfy_failed_allocation_helper(size_t word_size,
@@ -1476,6 +1472,8 @@ private:
   void print_regions_on(outputStream* st) const;
 
 public:
+  class G1HeapPrinterMark;
+
   virtual void print_on(outputStream* st) const;
   virtual void print_extended_on(outputStream* st) const;
   virtual void print_on_error(outputStream* st) const;
@@ -1491,6 +1489,15 @@ public:
 
   // Used to print information about locations in the hs_err file.
   virtual bool print_location(outputStream* st, void* addr) const;
+};
+
+class G1CollectedHeap::G1HeapPrinterMark : public StackObj {
+  G1CollectedHeap* _g1h;
+  G1HeapTransition _heap_transition;
+
+public:
+  G1HeapPrinterMark(G1CollectedHeap* g1h);
+  ~G1HeapPrinterMark();
 };
 
 class G1ParEvacuateFollowersClosure : public VoidClosure {

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -170,9 +170,6 @@ public:
 void G1FullCollector::prepare_collection() {
   _heap->policy()->record_full_collection_start();
 
-  _heap->print_heap_before_gc();
-  _heap->print_heap_regions();
-
   _heap->abort_concurrent_cycle();
   _heap->verify_before_full_collection(scope()->is_explicit_gc());
 
@@ -221,7 +218,7 @@ void G1FullCollector::complete_collection() {
 
   _heap->verify_after_full_collection();
 
-  _heap->print_heap_after_full_collection(scope()->heap_transition());
+  _heap->print_heap_after_full_collection();
 }
 
 void G1FullCollector::before_marking_update_attribute_table(HeapRegion* hr) {

--- a/src/hotspot/share/gc/g1/g1FullGCScope.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCScope.cpp
@@ -40,7 +40,7 @@ G1FullGCScope::G1FullGCScope(G1MonitoringSupport* monitoring_support,
     _cpu_time(),
     _soft_refs(clear_soft, _g1h->soft_ref_policy()),
     _monitoring_scope(monitoring_support, true /* full_gc */, true /* all_memory_pools_affected */),
-    _heap_transition(_g1h),
+    _heap_printer(_g1h),
     _region_compaction_threshold(do_maximum_compaction ?
                                  HeapRegion::GrainWords :
                                  (1 - MarkSweepDeadRatio / 100.0) * HeapRegion::GrainWords) {
@@ -71,10 +71,6 @@ STWGCTimer* G1FullGCScope::timer() {
 
 G1FullGCTracer* G1FullGCScope::tracer() {
   return &_tracer;
-}
-
-G1HeapTransition* G1FullGCScope::heap_transition() {
-  return &_heap_transition;
 }
 
 size_t G1FullGCScope::region_compaction_threshold() {

--- a/src/hotspot/share/gc/g1/g1FullGCScope.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCScope.hpp
@@ -52,7 +52,7 @@ class G1FullGCScope : public StackObj {
   GCTraceCPUTime          _cpu_time;
   ClearedAllSoftRefs      _soft_refs;
   G1MonitoringScope       _monitoring_scope;
-  G1HeapTransition        _heap_transition;
+  G1CollectedHeap::G1HeapPrinterMark _heap_printer;
   size_t                  _region_compaction_threshold;
 
 public:


### PR DESCRIPTION
Hi all,

can I have reviews for this change that factors out before/after heap related printing into a single scoped object to be used for both young and full gc code?

There is some minor change in order of unrelated options (COMMIT/UNCOMMIT region state changes vs. other heap printing), during full gc but since this is very low level debugging I do not see a problem to do that.

Based on #4539 .

Thanks,
Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ Dependency #4539 must be integrated first

### Issue
 * [JDK-8269914](https://bugs.openjdk.java.net/browse/JDK-8269914): Factor out heap printing for G1 young and full gc


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4689/head:pull/4689` \
`$ git checkout pull/4689`

Update a local copy of the PR: \
`$ git checkout pull/4689` \
`$ git pull https://git.openjdk.java.net/jdk pull/4689/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4689`

View PR using the GUI difftool: \
`$ git pr show -t 4689`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4689.diff">https://git.openjdk.java.net/jdk/pull/4689.diff</a>

</details>
