### PR TITLE
8269924: Shenandoah: Introduce weak/strong marking asserts

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
@@ -316,6 +316,28 @@ void ShenandoahAsserts::assert_marked(void *interior_loc, oop obj, const char *f
   }
 }
 
+void ShenandoahAsserts::assert_marked_weak(void *interior_loc, oop obj, const char *file, int line) {
+  assert_correct(interior_loc, obj, file, line);
+
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  if (!heap->marking_context()->is_marked_weak(obj)) {
+    print_failure(_safe_all, obj, interior_loc, NULL, "Shenandoah assert_marked_weak failed",
+                  "Object should be marked weakly",
+                  file, line);
+  }
+}
+
+void ShenandoahAsserts::assert_marked_strong(void *interior_loc, oop obj, const char *file, int line) {
+  assert_correct(interior_loc, obj, file, line);
+
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  if (!heap->marking_context()->is_marked_strong(obj)) {
+    print_failure(_safe_all, obj, interior_loc, NULL, "Shenandoah assert_marked_strong failed",
+                  "Object should be marked strongly",
+                  file, line);
+  }
+}
+
 void ShenandoahAsserts::assert_in_cset(void* interior_loc, oop obj, const char* file, int line) {
   assert_correct(interior_loc, obj, file, line);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahAsserts.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAsserts.hpp
@@ -61,6 +61,8 @@ public:
   static void assert_forwarded(void* interior_loc, oop obj, const char* file, int line);
   static void assert_not_forwarded(void* interior_loc, oop obj, const char* file, int line);
   static void assert_marked(void* interior_loc, oop obj, const char* file, int line);
+  static void assert_marked_weak(void* interior_loc, oop obj, const char* file, int line);
+  static void assert_marked_strong(void* interior_loc, oop obj, const char* file, int line);
   static void assert_in_cset(void* interior_loc, oop obj, const char* file, int line);
   static void assert_not_in_cset(void* interior_loc, oop obj, const char* file, int line);
   static void assert_not_in_cset_loc(void* interior_loc, const char* file, int line);
@@ -106,6 +108,20 @@ public:
   if (!(exception)) ShenandoahAsserts::assert_marked(interior_loc, obj, __FILE__, __LINE__)
 #define shenandoah_assert_marked(interior_loc, obj) \
                     ShenandoahAsserts::assert_marked(interior_loc, obj, __FILE__, __LINE__)
+
+#define shenandoah_assert_marked_weak_if(interior_loc, obj, condition) \
+  if (condition)    ShenandoahAsserts::assert_marked_weak(interior_loc, obj, __FILE__, __LINE__)
+#define shenandoah_assert_marked_weak_except(interior_loc, obj, exception) \
+  if (!(exception)) ShenandoahAsserts::assert_marked_weak(interior_loc, obj, __FILE__, __LINE__)
+#define shenandoah_assert_marked_weak(interior_loc, obj) \
+                    ShenandoahAsserts::assert_marked_weak(interior_loc, obj, __FILE__, __LINE__)
+
+#define shenandoah_assert_marked_strong_if(interior_loc, obj, condition) \
+  if (condition)    ShenandoahAsserts::assert_marked_strong(interior_loc, obj, __FILE__, __LINE__)
+#define shenandoah_assert_marked_strong_except(interior_loc, obj, exception) \
+  if (!(exception)) ShenandoahAsserts::assert_marked_strong(interior_loc, obj, __FILE__, __LINE__)
+#define shenandoah_assert_marked_strong(interior_loc, obj) \
+                    ShenandoahAsserts::assert_marked_strong(interior_loc, obj, __FILE__, __LINE__)
 
 #define shenandoah_assert_in_cset_if(interior_loc, obj, condition) \
   if (condition)    ShenandoahAsserts::assert_in_cset(interior_loc, obj, __FILE__, __LINE__)
@@ -167,6 +183,14 @@ public:
 #define shenandoah_assert_marked_if(interior_loc, obj, condition)
 #define shenandoah_assert_marked_except(interior_loc, obj, exception)
 #define shenandoah_assert_marked(interior_loc, obj)
+
+#define shenandoah_assert_marked_weak_if(interior_loc, obj, condition)
+#define shenandoah_assert_marked_weak_except(interior_loc, obj, exception)
+#define shenandoah_assert_marked_weak(interior_loc, obj)
+
+#define shenandoah_assert_marked_strong_if(interior_loc, obj, condition)
+#define shenandoah_assert_marked_strong_except(interior_loc, obj, exception)
+#define shenandoah_assert_marked_strong(interior_loc, obj)
 
 #define shenandoah_assert_in_cset_if(interior_loc, obj, condition)
 #define shenandoah_assert_in_cset_except(interior_loc, obj, exception)


### PR DESCRIPTION
For debugging, it is sometimes important to have not only `shenandoah_assert_marked`, but also `shenandoah_assert_marked_(weak|strong)` flavors.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269924](https://bugs.openjdk.java.net/browse/JDK-8269924): Shenandoah: Introduce weak/strong marking asserts


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4691/head:pull/4691` \
`$ git checkout pull/4691`

Update a local copy of the PR: \
`$ git checkout pull/4691` \
`$ git pull https://git.openjdk.java.net/jdk pull/4691/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4691`

View PR using the GUI difftool: \
`$ git pr show -t 4691`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4691.diff">https://git.openjdk.java.net/jdk/pull/4691.diff</a>

</details>
