### PR TITLE
8269935: ProblemList runtime/jni/checked/TestPrimitiveArrayCriticalWithBadParam.java on windows

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -99,6 +99,8 @@ runtime/os/TestTracePageSizes.java#with-G1 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#with-Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#with-Serial 8267460 linux-aarch64
 
+runtime/jni/checked/TestPrimitiveArrayCriticalWithBadParam.java 8269923 windows-x64
+
 #############################################################################
 
 # :hotspot_serviceability


### PR DESCRIPTION
A trivial fix to ProblemList runtime/jni/checked/TestPrimitiveArrayCriticalWithBadParam.java on windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269935](https://bugs.openjdk.java.net/browse/JDK-8269935): ProblemList runtime/jni/checked/TestPrimitiveArrayCriticalWithBadParam.java on windows


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4692/head:pull/4692` \
`$ git checkout pull/4692`

Update a local copy of the PR: \
`$ git checkout pull/4692` \
`$ git pull https://git.openjdk.java.net/jdk pull/4692/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4692`

View PR using the GUI difftool: \
`$ git pr show -t 4692`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4692.diff">https://git.openjdk.java.net/jdk/pull/4692.diff</a>

</details>
