### PR TITLE
8269923: runtime/jni/checked/TestPrimitiveArrayCriticalWithBadParam.java failed with "FATAL ERROR in native method: Primitive type array expected but not received for JNI array operation"

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -99,8 +99,6 @@ runtime/os/TestTracePageSizes.java#with-G1 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#with-Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#with-Serial 8267460 linux-aarch64
 
-runtime/jni/checked/TestPrimitiveArrayCriticalWithBadParam.java 8269923 windows-x64
-
 #############################################################################
 
 # :hotspot_serviceability

--- a/test/hotspot/jtreg/runtime/jni/checked/TestPrimitiveArrayCriticalWithBadParam.java
+++ b/test/hotspot/jtreg/runtime/jni/checked/TestPrimitiveArrayCriticalWithBadParam.java
@@ -65,7 +65,7 @@ public class TestPrimitiveArrayCriticalWithBadParam {
 
             // -Xcheck:jni should warn the bad parameter
             analyzer.shouldContain("FATAL ERROR in native method: Primitive type array expected but not received for JNI array operation");
-            analyzer.shouldHaveExitValue(134);
+            analyzer.shouldNotHaveExitValue(0);
         } catch (IOException e) {
             throw  new RuntimeException(e);
         }


### PR DESCRIPTION
On Posix compatible platforms, when abort with code dump, it exits with os:abort(), which has exit code 134.
```
  if (dump_core) {
    LINUX_ONLY(if (DumpPrivateMappingsInCore) ClassLoader::close_jrt_image();)
    ::abort(); // dump core
  }

```
but not on Windows, where it still exits with 1.

```
  CloseHandle(dumpFile);
  win32::exit_process_or_thread(win32::EPT_PROCESS, 1);
```

The test expects exit code 134 when jni check fails, so it fails on Windows. Maybe we should have Windows also to return 134 for consistence?

The fix changes the check to non-zero exit code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269923](https://bugs.openjdk.java.net/browse/JDK-8269923): runtime/jni/checked/TestPrimitiveArrayCriticalWithBadParam.java failed with "FATAL ERROR in native method: Primitive type array expected but not received for JNI array operation"


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4696/head:pull/4696` \
`$ git checkout pull/4696`

Update a local copy of the PR: \
`$ git checkout pull/4696` \
`$ git pull https://git.openjdk.java.net/jdk pull/4696/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4696`

View PR using the GUI difftool: \
`$ git pr show -t 4696`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4696.diff">https://git.openjdk.java.net/jdk/pull/4696.diff</a>

</details>
