### PR TITLE
8268635: Corrupt oop in ClassLoaderData

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -806,6 +806,7 @@ void ClassLoaderData::init_handle_locked(OopHandle& dest, Handle h) {
   if (dest.resolve() != NULL) {
     return;
   } else {
+    record_modified_oops();
     dest = _handles.add(h());
   }
 }


### PR DESCRIPTION
We worked on writing a test for this but weren't successful.  Based on analysis by @stefank this missing call may have been the cause of the crash.
Tested with tier1-3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268635](https://bugs.openjdk.java.net/browse/JDK-8268635): Corrupt oop in ClassLoaderData


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to 1f43b13d27c1903d5e4af5c2d6977a71fd7c24b0
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4701/head:pull/4701` \
`$ git checkout pull/4701`

Update a local copy of the PR: \
`$ git checkout pull/4701` \
`$ git pull https://git.openjdk.java.net/jdk pull/4701/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4701`

View PR using the GUI difftool: \
`$ git pr show -t 4701`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4701.diff">https://git.openjdk.java.net/jdk/pull/4701.diff</a>

</details>
