### PR TITLE
8269851: OperatingSystemMXBean getProcessCpuLoad reports incorrect process cpu usage in containers

### DIFF
--- a/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
+++ b/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
@@ -130,7 +130,7 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
             return (int[] cpuSet) -> {
                 int totalCPUs = getHostOnlineCpuCount0();
                 int containerCPUs = getAvailableProcessors();
-                return getProcessCpuLoad0() * totalCPUs / containerCPUs;
+                return Math.min(1.0, getProcessCpuLoad0() * totalCPUs / containerCPUs);
             };
         }
 

--- a/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
+++ b/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
@@ -44,6 +44,9 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
     private final Metrics containerMetrics;
     private long usageTicks = 0; // used for cpu load calculation
     private long totalTicks = 0; // used for cpu load calculation
+    private long processUsageTicks = 0; // used for process cpu load calculation
+    private long processTotalTicks = 0; // used for process cpu load calculation
+
 
     OperatingSystemImpl(VMManagement vm) {
         super(vm);
@@ -217,7 +220,45 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
         return getCpuLoad0();
     }
 
+    private double getProcessUsageDividesTotal(long usageTicks, long totalTicks) {
+        if (usageTicks < 0 || totalTicks <= 0) {
+            return -1;
+        }
+        long distance = usageTicks - this.processUsageTicks;
+        this.processUsageTicks = usageTicks;
+        long totalDistance = totalTicks - this.processTotalTicks;
+        this.processTotalTicks = totalTicks;
+
+        double processLoad = 0.0;
+        if (distance > 0 && totalDistance > 0) {
+            processLoad = ((double)distance) / totalDistance;
+        }
+        // Ensure the return value is in the range 0.0 -> 1.0
+        processLoad = Math.max(0.0, processLoad);
+        processLoad = Math.min(1.0, processLoad);
+        return processLoad;
+    }
+
     public double getProcessCpuLoad() {
+        if (containerMetrics != null) {
+            long quota = containerMetrics.getCpuQuota();
+            long share = containerMetrics.getCpuShares();
+            long usageNanos = getProcessCpuTime();
+            if (quota > 0) {
+                long numPeriods = containerMetrics.getCpuNumPeriods();
+                long quotaNanos = TimeUnit.MICROSECONDS.toNanos(quota * numPeriods);
+                return getProcessUsageDividesTotal(usageNanos, quotaNanos);
+            } else if (share > 0) {
+                long hostTicks = getHostTotalCpuTicks0();
+                int totalCPUs = getHostOnlineCpuCount0();
+                int containerCPUs = getAvailableProcessors();
+                // scale the total host load to the actual container cpus
+                hostTicks = hostTicks * containerCPUs / totalCPUs;
+                return getProcessUsageDividesTotal(usageNanos, hostTicks);
+            } else {
+                return getProcessCpuLoad0();
+            }
+        }
         return getProcessCpuLoad0();
     }
 

--- a/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
+++ b/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
@@ -47,7 +47,6 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
     private long processUsageTicks = 0; // used for process cpu load calculation
     private long processTotalTicks = 0; // used for process cpu load calculation
 
-
     OperatingSystemImpl(VMManagement vm) {
         super(vm);
         this.containerMetrics = jdk.internal.platform.Container.metrics();

--- a/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
+++ b/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
@@ -46,7 +46,7 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
     private CpuTicks processLoadTicks = new CpuTicks();
 
     private class CpuTicks {
-        long usageTicks = 0; 
+        long usageTicks = 0;
         long totalTicks = 0;
     }
 


### PR DESCRIPTION
…ocess cpu usage in containers

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269851](https://bugs.openjdk.java.net/browse/JDK-8269851): OperatingSystemMXBean getProcessCpuLoad reports incorrect process cpu usage in containers


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)


### Contributors
 * Severin Gehwolf `<sgehwolf@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4702/head:pull/4702` \
`$ git checkout pull/4702`

Update a local copy of the PR: \
`$ git checkout pull/4702` \
`$ git pull https://git.openjdk.java.net/jdk pull/4702/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4702`

View PR using the GUI difftool: \
`$ git pr show -t 4702`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4702.diff">https://git.openjdk.java.net/jdk/pull/4702.diff</a>

</details>
