### PR TITLE
8215948: [TESTBUG] gtest pseudo-JavaThreads could be more regular JavaThreads

### DIFF
--- a/test/hotspot/gtest/threadHelper.inline.hpp
+++ b/test/hotspot/gtest/threadHelper.inline.hpp
@@ -26,6 +26,7 @@
 
 #include "runtime/mutex.hpp"
 #include "runtime/semaphore.hpp"
+#include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/thread.inline.hpp"
 #include "runtime/vmThread.hpp"
 #include "runtime/vmOperations.hpp"
@@ -44,38 +45,36 @@ public:
 
 // This class and thread keep the non-safepoint op running while we do our testing.
 class VMThreadBlocker : public JavaThread {
-public:
   Semaphore _ready;
   Semaphore _unblock;
-  VMThreadBlocker() {}
-  virtual ~VMThreadBlocker() {}
-  const char* get_thread_name_string(char* buf, int buflen) const {
-    return "VMThreadBlocker";
+
+  static VMThreadBlocker* cast(JavaThread* thread) {
+    return static_cast<VMThreadBlocker*>(thread);
   }
-  void run() {
-    this->set_thread_state(_thread_in_vm);
-    {
-      MutexLocker ml(Threads_lock);
-      Threads::add(this);
-    }
-    VM_StopSafepoint ss(&_ready, &_unblock);
+
+  static void blocker_thread_entry(JavaThread* thread, TRAPS) {
+    VMThreadBlocker* t = cast(thread);
+    VM_StopSafepoint ss(&t->_ready, &t->_unblock);
     VMThread::execute(&ss);
   }
 
-  // Override as JavaThread::post_run() calls JavaThread::exit which
-  // expects a valid thread object oop.
-  virtual void post_run() {
-    Threads::remove(this, false);
-    this->smr_delete();
+  VMThreadBlocker() : JavaThread(&blocker_thread_entry) {};
+
+  virtual ~VMThreadBlocker() {}
+
+public:
+  static VMThreadBlocker* start() {
+    EXCEPTION_MARK;
+    ThreadInVMfromNative tivfn(THREAD);
+    HandleMark hm(THREAD);
+    const char* name = "VMThreadBlocker";
+    Handle thread_oop = JavaThread::create_system_thread_object(name, false /* not visible */, CHECK_NULL);
+    VMThreadBlocker* thread = new VMThreadBlocker();
+    JavaThread::vm_exit_on_osthread_failure(thread);
+    JavaThread::start_internal_daemon(THREAD, thread, thread_oop, NoPriority);
+    return thread;
   }
 
-  void doit() {
-    if (os::create_thread(this, os::os_thread)) {
-      os::start_thread(this);
-    } else {
-      ASSERT_TRUE(false);
-    }
-  }
   void ready() {
     _ready.wait();
   }
@@ -86,52 +85,57 @@ public:
 
 // For testing in a real JavaThread.
 class JavaTestThread : public JavaThread {
-public:
   Semaphore* _post;
+
+  static JavaTestThread* cast(JavaThread* thread) {
+    return static_cast<JavaTestThread*>(thread);
+  }
+
+protected:
   JavaTestThread(Semaphore* post)
-    : _post(post) {
+    : JavaThread(&test_thread_entry), _post(post) {
+    JavaThread::vm_exit_on_osthread_failure(this);
   }
   virtual ~JavaTestThread() {}
 
-  const char* get_thread_name_string(char* buf, int buflen) const {
-    return "JavaTestThread";
+public:
+  static JavaTestThread* start(JavaTestThread* thread) {
+    EXCEPTION_MARK;
+    HandleMark hm(THREAD);
+    const char* name = "JavaTestThread";
+    Handle thread_oop;
+
+    // This code can be called from the main thread, which is _thread_in_native,
+    // or by an existing JavaTestThread, which is _thread_in_vm.
+    if (THREAD->thread_state() == _thread_in_native) {
+      ThreadInVMfromNative tivfn(THREAD);
+      thread_oop = JavaThread::create_system_thread_object(name, false /* not visible */, CHECK_NULL);
+      JavaThread::start_internal_daemon(THREAD, thread, thread_oop, NoPriority);
+    } else {
+      thread_oop = JavaThread::create_system_thread_object(name, false /* not visible */, CHECK_NULL);
+      JavaThread::start_internal_daemon(THREAD, thread, thread_oop, NoPriority);
+    }
+    return thread;
   }
 
-  void pre_run() {
-    this->set_thread_state(_thread_in_vm);
-    {
-      MutexLocker ml(Threads_lock);
-      Threads::add(this);
-    }
+  // simplified starting for subclass instances
+  void doit() {
+    start(this);
   }
 
   virtual void main_run() = 0;
 
-  void run() {
-    main_run();
-  }
-
-  // Override as JavaThread::post_run() calls JavaThread::exit which
-  // expects a valid thread object oop. And we need to call signal.
-  void post_run() {
-    Threads::remove(this, false);
-    _post->signal();
-    this->smr_delete();
-  }
-
-  void doit() {
-    if (os::create_thread(this, os::os_thread)) {
-      os::start_thread(this);
-    } else {
-      ASSERT_TRUE(false);
-    }
+  static void test_thread_entry(JavaThread* thread, TRAPS) {
+    JavaTestThread* t = cast(thread);
+    t->main_run();
+    t->_post->signal();
   }
 };
 
 template <typename FUNC>
 class SingleTestThread : public JavaTestThread {
-public:
   FUNC& _f;
+public:
   SingleTestThread(Semaphore* post, FUNC& f)
     : JavaTestThread(post), _f(f) {
   }
@@ -147,8 +151,8 @@ template <typename TESTFUNC>
 static void nomt_test_doer(TESTFUNC &f) {
   Semaphore post;
 
-  VMThreadBlocker* blocker = new VMThreadBlocker();
-  blocker->doit();
+  VMThreadBlocker* blocker = VMThreadBlocker::start();
+
   blocker->ready();
 
   SingleTestThread<TESTFUNC>* stt = new SingleTestThread<TESTFUNC>(&post, f);
@@ -162,8 +166,8 @@ template <typename RUNNER>
 static void mt_test_doer() {
   Semaphore post;
 
-  VMThreadBlocker* blocker = new VMThreadBlocker();
-  blocker->doit();
+  VMThreadBlocker* blocker = VMThreadBlocker::start();
+
   blocker->ready();
 
   RUNNER* runner = new RUNNER(&post);


### PR DESCRIPTION
Please review this change to the gtest infrastructure that makes the test JavaThreads more regular JavaThreads, with the same lifecycle methods and having a regular j.l.Thread object.

One test had to be modified slightly to create and start the threads outside of a code region where a Mutex is held.

Testing: tiers 1-3, GHA

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8215948](https://bugs.openjdk.java.net/browse/JDK-8215948): [TESTBUG] gtest pseudo-JavaThreads could be more regular JavaThreads


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4703/head:pull/4703` \
`$ git checkout pull/4703`

Update a local copy of the PR: \
`$ git checkout pull/4703` \
`$ git pull https://git.openjdk.java.net/jdk pull/4703/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4703`

View PR using the GUI difftool: \
`$ git pr show -t 4703`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4703.diff">https://git.openjdk.java.net/jdk/pull/4703.diff</a>

</details>
