### PR TITLE
8269993: [Test]: java/net/httpclient/DigestEchoClientSSL.java contains redundant @run tags

### DIFF
--- a/test/jdk/java/net/httpclient/DigestEchoClientSSL.java
+++ b/test/jdk/java/net/httpclient/DigestEchoClientSSL.java
@@ -39,12 +39,6 @@
  * @run main/othervm/timeout=300
  *          DigestEchoClientSSL SSL
  * @run main/othervm/timeout=300
- *          DigestEchoClientSSL SSL
- * @run main/othervm/timeout=300
- *          -Djdk.http.auth.proxying.disabledSchemes=
- *          -Djdk.http.auth.tunneling.disabledSchemes=
- *          DigestEchoClientSSL SSL PROXY
- * @run main/othervm/timeout=300
  *          -Djdk.http.auth.proxying.disabledSchemes=
  *          -Djdk.http.auth.tunneling.disabledSchemes=
  *          DigestEchoClientSSL SSL PROXY


### PR DESCRIPTION
Hi,

Please review this simple change to remove redundancy of @run tags. The test "java/net/httpclient/DigestEchoClientSSL.java" contains a couple of redundant @run tags:

 * @run main/othervm/timeout=300
 * DigestEchoClientSSL SSL
 * @run main/othervm/timeout=300
 * DigestEchoClientSSL SSL
 * @run main/othervm/timeout=300
 * -Djdk.http.auth.proxying.disabledSchemes=
 * -Djdk.http.auth.tunneling.disabledSchemes=
 * DigestEchoClientSSL SSL PROXY
 * @run main/othervm/timeout=300
 * -Djdk.http.auth.proxying.disabledSchemes=
 * -Djdk.http.auth.tunneling.disabledSchemes=
 * DigestEchoClientSSL SSL PROXY

This change is to remove the redundancy. I have run the test and verified that it passes on all platforms following the change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269993](https://bugs.openjdk.java.net/browse/JDK-8269993): [Test]: java/net/httpclient/DigestEchoClientSSL.java contains redundant @run tags


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Vyom Tewari](https://openjdk.java.net/census#vtewari) (@vyommani - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4706/head:pull/4706` \
`$ git checkout pull/4706`

Update a local copy of the PR: \
`$ git checkout pull/4706` \
`$ git pull https://git.openjdk.java.net/jdk pull/4706/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4706`

View PR using the GUI difftool: \
`$ git pr show -t 4706`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4706.diff">https://git.openjdk.java.net/jdk/pull/4706.diff</a>

</details>
