### PR TITLE
8270021: Incorrect log decorators in gc/g1/plab/TestPLABEvacuationFailure.java

### DIFF
--- a/test/hotspot/jtreg/gc/g1/plab/TestPLABEvacuationFailure.java
+++ b/test/hotspot/jtreg/gc/g1/plab/TestPLABEvacuationFailure.java
@@ -68,7 +68,7 @@ public class TestPLABEvacuationFailure {
             "failure wasted"));
 
     private static final String[] COMMON_OPTIONS = {
-        "-Xlog:gc=debug,gc+phases=trace",
+        "-Xlog:gc,gc+plab=debug",
         "-XX:+UseG1GC",
         "-XX:InitiatingHeapOccupancyPercent=100",
         "-XX:-G1UseAdaptiveIHOP",

--- a/test/hotspot/jtreg/gc/g1/plab/lib/LogParser.java
+++ b/test/hotspot/jtreg/gc/g1/plab/lib/LogParser.java
@@ -190,13 +190,17 @@ final public class LogParser {
     }
 
     private Map<Long, PlabInfo> getSpecifiedStats(List<Long> gcIds, LogParser.ReportType type, List<String> fieldNames, boolean extractId) {
-        return new HashMap<>(
-                getEntries().entryStream()
-                .filter(gcLogItem -> extractId == gcIds.contains(gcLogItem.getKey()))
-                .collect(Collectors.toMap(gcLogItem -> gcLogItem.getKey(),
-                                gcLogItem -> gcLogItem.getValue().get(type).filter(fieldNames)
+        var map = new HashMap<>(
+                        getEntries().entryStream()
+                        .filter(gcLogItem -> extractId == gcIds.contains(gcLogItem.getKey()))
+                        .collect(Collectors.toMap(gcLogItem -> gcLogItem.getKey(),
+                                        gcLogItem -> gcLogItem.getValue().get(type).filter(fieldNames)
+                                )
                         )
-                )
-        );
+                 );
+        if (map.isEmpty()) {
+            throw new RuntimeException("Cannot find relevant PLAB statistics in the log");
+        }
+        return map;
     }
 }


### PR DESCRIPTION
Fixed the log decorator, and added checks for non-empty statistics.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270021](https://bugs.openjdk.java.net/browse/JDK-8270021): Incorrect log decorators in gc/g1/plab/TestPLABEvacuationFailure.java


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4707/head:pull/4707` \
`$ git checkout pull/4707`

Update a local copy of the PR: \
`$ git checkout pull/4707` \
`$ git pull https://git.openjdk.java.net/jdk pull/4707/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4707`

View PR using the GUI difftool: \
`$ git pr show -t 4707`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4707.diff">https://git.openjdk.java.net/jdk/pull/4707.diff</a>

</details>
