### PR TITLE
8270027: ProblemList jdk/jfr/event/oldobject/TestObjectSize.java on macOS-x64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -822,6 +822,7 @@ jdk/jfr/event/os/TestThreadContextSwitches.java                 8247776 windows-
 jdk/jfr/startupargs/TestStartName.java                          8214685 windows-x64
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
 jdk/jfr/api/consumer/streaming/TestLatestEvent.java             8268297 windows-x64
+jdk/jfr/event/oldobject/TestObjectSize.java                     8269418 macosx-x64
 
 ############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList jdk/jfr/event/oldobject/TestObjectSize.java on macOS-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270027](https://bugs.openjdk.java.net/browse/JDK-8270027): ProblemList jdk/jfr/event/oldobject/TestObjectSize.java on macOS-x64


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4709/head:pull/4709` \
`$ git checkout pull/4709`

Update a local copy of the PR: \
`$ git checkout pull/4709` \
`$ git pull https://git.openjdk.java.net/jdk pull/4709/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4709`

View PR using the GUI difftool: \
`$ git pr show -t 4709`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4709.diff">https://git.openjdk.java.net/jdk/pull/4709.diff</a>

</details>
