### PR TITLE
6506405: Math.abs(float) is slow

### DIFF
--- a/src/java.base/share/classes/java/lang/Math.java
+++ b/src/java.base/share/classes/java/lang/Math.java
@@ -1527,7 +1527,7 @@ public final class Math {
      */
     @IntrinsicCandidate
     public static float abs(float a) {
-        return (a <= 0.0F) ? 0.0F - a : a;
+        return Float.intBitsToFloat(Float.floatToRawIntBits(a) & 0x7fffffff);
     }
 
     /**
@@ -1552,7 +1552,8 @@ public final class Math {
      */
     @IntrinsicCandidate
     public static double abs(double a) {
-        return (a <= 0.0D) ? 0.0D - a : a;
+        return Double.longBitsToDouble(Double.doubleToRawLongBits(a) & 0x7fffffffffffffffL);
+
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Math.java
+++ b/src/java.base/share/classes/java/lang/Math.java
@@ -1527,7 +1527,8 @@ public final class Math {
      */
     @IntrinsicCandidate
     public static float abs(float a) {
-        return Float.intBitsToFloat(Float.floatToRawIntBits(a) & 0x7fffffff);
+        // Convert to bit field form, zero the sign bit, and convert back
+        return Float.intBitsToFloat(Float.floatToRawIntBits(a) & FloatConsts.MAG_BIT_MASK);
     }
 
     /**
@@ -1552,7 +1553,8 @@ public final class Math {
      */
     @IntrinsicCandidate
     public static double abs(double a) {
-        return Double.longBitsToDouble(Double.doubleToRawLongBits(a) & 0x7fffffffffffffffL);
+        // Convert to bit field form, zero the sign bit, and convert back
+        return Double.longBitsToDouble(Double.doubleToRawLongBits(a) & DoubleConsts.MAG_BIT_MASK);
 
     }
 

--- a/src/java.base/share/classes/jdk/internal/math/DoubleConsts.java
+++ b/src/java.base/share/classes/jdk/internal/math/DoubleConsts.java
@@ -86,7 +86,7 @@ public class DoubleConsts {
                (((SIGN_BIT_MASK & EXP_BIT_MASK) == 0L) &&
                 ((SIGN_BIT_MASK & SIGNIF_BIT_MASK) == 0L) &&
                 ((EXP_BIT_MASK & SIGNIF_BIT_MASK) == 0L)) &&
-                ((SIGN_BIT_MASK | MAG_BIT_MASK) == ~0));
+                ((SIGN_BIT_MASK | MAG_BIT_MASK) == ~0L));
 
     }
 }

--- a/src/java.base/share/classes/jdk/internal/math/DoubleConsts.java
+++ b/src/java.base/share/classes/jdk/internal/math/DoubleConsts.java
@@ -73,12 +73,20 @@ public class DoubleConsts {
      */
     public static final long    SIGNIF_BIT_MASK = 0x000FFFFFFFFFFFFFL;
 
+    /**
+     * Bit mask to isolate the magnitude bits (combined exponent and
+     * significand fields) of a {@code double}.
+     */
+    public static final long    MAG_BIT_MASK = 0x7FFFFFFFFFFFFFFFL;
+
     static {
         // verify bit masks cover all bit positions and that the bit
         // masks are non-overlapping
         assert(((SIGN_BIT_MASK | EXP_BIT_MASK | SIGNIF_BIT_MASK) == ~0L) &&
                (((SIGN_BIT_MASK & EXP_BIT_MASK) == 0L) &&
                 ((SIGN_BIT_MASK & SIGNIF_BIT_MASK) == 0L) &&
-                ((EXP_BIT_MASK & SIGNIF_BIT_MASK) == 0L)));
+                ((EXP_BIT_MASK & SIGNIF_BIT_MASK) == 0L)) &&
+                ((SIGN_BIT_MASK | MAG_BIT_MASK) == ~0));
+
     }
 }

--- a/src/java.base/share/classes/jdk/internal/math/DoubleConsts.java
+++ b/src/java.base/share/classes/jdk/internal/math/DoubleConsts.java
@@ -77,7 +77,7 @@ public class DoubleConsts {
      * Bit mask to isolate the magnitude bits (combined exponent and
      * significand fields) of a {@code double}.
      */
-    public static final long    MAG_BIT_MASK = 0x7FFFFFFFFFFFFFFFL;
+    public static final long    MAG_BIT_MASK = ~SIGN_BIT_MASK;
 
     static {
         // verify bit masks cover all bit positions and that the bit

--- a/src/java.base/share/classes/jdk/internal/math/FloatConsts.java
+++ b/src/java.base/share/classes/jdk/internal/math/FloatConsts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,12 +73,19 @@ public class FloatConsts {
      */
     public static final int     SIGNIF_BIT_MASK = 0x007FFFFF;
 
+    /**
+     * Bit mask to isolate the magnitude bits (combined exponent and
+     * significand fields) of a {@code float}.
+     */
+    public static final int     MAG_BIT_MASK = 0x7FFFFFFF;
+
     static {
         // verify bit masks cover all bit positions and that the bit
         // masks are non-overlapping
         assert(((SIGN_BIT_MASK | EXP_BIT_MASK | SIGNIF_BIT_MASK) == ~0) &&
                (((SIGN_BIT_MASK & EXP_BIT_MASK) == 0) &&
                 ((SIGN_BIT_MASK & SIGNIF_BIT_MASK) == 0) &&
-                ((EXP_BIT_MASK & SIGNIF_BIT_MASK) == 0)));
+                ((EXP_BIT_MASK & SIGNIF_BIT_MASK) == 0)) &&
+                ((SIGN_BIT_MASK | MAG_BIT_MASK) == ~0));
     }
 }

--- a/src/java.base/share/classes/jdk/internal/math/FloatConsts.java
+++ b/src/java.base/share/classes/jdk/internal/math/FloatConsts.java
@@ -77,7 +77,7 @@ public class FloatConsts {
      * Bit mask to isolate the magnitude bits (combined exponent and
      * significand fields) of a {@code float}.
      */
-    public static final int     MAG_BIT_MASK = 0x7FFFFFFF;
+    public static final int     MAG_BIT_MASK = ~SIGN_BIT_MASK;
 
     static {
         // verify bit masks cover all bit positions and that the bit


### PR DESCRIPTION
Please consider this change to make the `float` and `double` versions of `java.lang.Math.abs()` branch-free.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-6506405](https://bugs.openjdk.java.net/browse/JDK-6506405): Math.abs(float) is slow


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4711/head:pull/4711` \
`$ git checkout pull/4711`

Update a local copy of the PR: \
`$ git checkout pull/4711` \
`$ git pull https://git.openjdk.java.net/jdk pull/4711/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4711`

View PR using the GUI difftool: \
`$ git pr show -t 4711`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4711.diff">https://git.openjdk.java.net/jdk/pull/4711.diff</a>

</details>
