### PR TITLE
8270064: Problem list tools/jdeprscan/tests/jdk/jdeprscan/TestRelease.java due to JDK-8270060

### DIFF
--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -72,4 +72,4 @@ tools/sjavac/ClasspathDependencies.java                                         
 #
 # jdeps
 
-tools/jdeprscan/tests/jdk/jdeprscan/TestRelease.java                            8270064    generic-all    java.util.SplittableRandom extends a non-exported class
+tools/jdeprscan/tests/jdk/jdeprscan/TestRelease.java                            8270060    generic-all    java.util.SplittableRandom extends a non-exported class

--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -72,3 +72,4 @@ tools/sjavac/ClasspathDependencies.java                                         
 #
 # jdeps
 
+tools/jdeprscan/tests/jdk/jdeprscan/TestRelease.java                            8270064    generic-all    java.util.SplittableRandom extends a non-exported class


### PR DESCRIPTION
I don't think we can fix JDK-8270060 very quick, so proposing to problem list the test for now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270064](https://bugs.openjdk.java.net/browse/JDK-8270064): Problem list tools/jdeprscan/tests/jdk/jdeprscan/TestRelease.java due to JDK-8270060


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4716/head:pull/4716` \
`$ git checkout pull/4716`

Update a local copy of the PR: \
`$ git checkout pull/4716` \
`$ git pull https://git.openjdk.java.net/jdk pull/4716/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4716`

View PR using the GUI difftool: \
`$ git pr show -t 4716`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4716.diff">https://git.openjdk.java.net/jdk/pull/4716.diff</a>

</details>
