### PR TITLE
8270058: Use Objects.check{Index,FromIndexSize} for java.desktop

### DIFF
--- a/src/java.desktop/share/classes/com/sun/media/sound/AudioFloatInputStream.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/AudioFloatInputStream.java
@@ -82,7 +82,7 @@ public abstract class AudioFloatInputStream {
         public int read(float[] b, int off, int len) throws IOException {
             if (b == null)
                 throw new NullPointerException();
-            Objects.checkFromIndexSize(len, off, b.length);
+            Objects.checkFromIndexSize(off, len, b.length);
             if (pos >= buffer_len)
                 return -1;
             if (len == 0)

--- a/src/java.desktop/share/classes/com/sun/media/sound/AudioFloatInputStream.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/AudioFloatInputStream.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.Objects;
 
 import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.AudioInputStream;
@@ -81,8 +82,7 @@ public abstract class AudioFloatInputStream {
         public int read(float[] b, int off, int len) throws IOException {
             if (b == null)
                 throw new NullPointerException();
-            if (off < 0 || len < 0 || len > b.length - off)
-                throw new IndexOutOfBoundsException();
+            Objects.checkFromIndexSize(len, off, b.length);
             if (pos >= buffer_len)
                 return -1;
             if (len == 0)

--- a/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
@@ -45,6 +45,7 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Locale;
+import java.util.Objects;
 
 import javax.accessibility.Accessible;
 import javax.accessibility.AccessibleComponent;
@@ -1789,9 +1790,7 @@ public class JTabbedPane extends JComponent
     }
 
     private void checkIndex(int index) {
-        if (index < 0 || index >= pages.size()) {
-            throw new IndexOutOfBoundsException("Index: "+index+", Tab count: "+pages.size());
-        }
+        Objects.checkIndex(index, pages.size());
     }
 
 

--- a/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
@@ -1790,7 +1790,9 @@ public class JTabbedPane extends JComponent
     }
 
     private void checkIndex(int index) {
-        Objects.checkIndex(index, pages.size());
+        if (index < 0 || index >= pages.size()) {
+            throw new IndexOutOfBoundsException("Index: " + index + ", Tab count: " + pages.size());
+        }
     }
 
 

--- a/test/jdk/java/awt/print/PrinterJob/ImagePrinting/ClippedImages.java
+++ b/test/jdk/java/awt/print/PrinterJob/ImagePrinting/ClippedImages.java
@@ -29,6 +29,7 @@
  */
 
 import java.io.*;
+import java.util.Objects;
 import java.awt.*;
 import java.awt.geom.*;
 import java.awt.event.*;
@@ -196,10 +197,7 @@ class ClippedImageCanvas extends Component implements Printable, Pageable {
 
     public PageFormat getPageFormat(int pageIndex)
         throws IndexOutOfBoundsException {
-
-        if (pageIndex < 0 || pageIndex >= getNumberOfPages()) {
-            throw new IndexOutOfBoundsException();
-        }
+        Objects.checkIndex(pageIndex, getNumberOfPages());
 
         PageFormat pf = myPrinterJob.defaultPage();
         switch (pageIndex % 2) {
@@ -225,10 +223,8 @@ class ClippedImageCanvas extends Component implements Printable, Pageable {
 
     public Printable getPrintable(int pageIndex)
         throws IndexOutOfBoundsException {
+        Objects.checkIndex(pageIndex, getNumberOfPages());
 
-        if (pageIndex < 0 || pageIndex >= getNumberOfPages()) {
-            throw new IndexOutOfBoundsException();
-        }
         if (pageIndex < 2) {
             paintSquares = true;
         } else {

--- a/test/jdk/javax/imageio/AppletResourceTest.java
+++ b/test/jdk/javax/imageio/AppletResourceTest.java
@@ -37,6 +37,7 @@ import java.util.Iterator;
 import java.util.ListResourceBundle;
 import java.util.Locale;
 import java.util.MissingResourceException;
+import java.util.Objects;
 import java.util.Vector;
 
 import javax.imageio.IIOException;
@@ -114,8 +115,7 @@ public class AppletResourceTest {
         public int getWidth(int imageIndex) throws IOException {
             if (input == null)
                 throw new IllegalStateException();
-            if (imageIndex >= 5 || imageIndex < 0)
-                throw new IndexOutOfBoundsException();
+            Objects.checkIndex(imageIndex, 5);
 
             return 10;
         }
@@ -123,8 +123,7 @@ public class AppletResourceTest {
         public int getHeight(int imageIndex) throws IOException {
             if (input == null)
                 throw new IllegalStateException();
-            if (imageIndex >= 5 || imageIndex < 0)
-                throw new IndexOutOfBoundsException();
+            Objects.checkIndex(imageIndex, 5);
 
             return 15;
         }
@@ -132,8 +131,7 @@ public class AppletResourceTest {
         public Iterator getImageTypes(int imageIndex) throws IOException {
             if (input == null)
                 throw new IllegalStateException();
-            if (imageIndex >= 5 || imageIndex < 0)
-                throw new IndexOutOfBoundsException();
+            Objects.checkIndex(imageIndex, 5);
 
             Vector imageTypes = new Vector();
             imageTypes.add(ImageTypeSpecifier.createFromBufferedImageType
@@ -150,8 +148,7 @@ public class AppletResourceTest {
 
             if (input == null)
                 throw new IllegalStateException();
-            if (imageIndex >= 5 || imageIndex < 0)
-                throw new IndexOutOfBoundsException();
+            Objects.checkIndex(imageIndex, 5);
             if (seekForwardOnly) {
                 if (imageIndex < minIndex)
                     throw new IndexOutOfBoundsException();
@@ -165,8 +162,7 @@ public class AppletResourceTest {
           throws IOException {
             if (input == null)
                 throw new IllegalStateException();
-            if (imageIndex >= 5 || imageIndex < 0)
-                throw new IndexOutOfBoundsException();
+            Objects.checkIndex(imageIndex, 5);
             if (seekForwardOnly) {
                 if (imageIndex < minIndex)
                     throw new IndexOutOfBoundsException();

--- a/test/jdk/javax/imageio/ImageReaderReadAll.java
+++ b/test/jdk/javax/imageio/ImageReaderReadAll.java
@@ -32,6 +32,7 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.Vector;
 
 import javax.imageio.IIOImage;
@@ -87,8 +88,7 @@ public class ImageReaderReadAll {
           throws IOException {
             if (input == null)
                 throw new IllegalStateException();
-            if (imageIndex >= 1 || imageIndex < 0)
-                throw new IndexOutOfBoundsException();
+            Objects.checkIndex(imageIndex, 1);
             if (seekForwardOnly) {
                 if (imageIndex < minIndex)
                     throw new IndexOutOfBoundsException();
@@ -101,8 +101,7 @@ public class ImageReaderReadAll {
         public Iterator getImageTypes(int imageIndex) throws IOException {
             if (input == null)
                 throw new IllegalStateException();
-            if (imageIndex >= 1 || imageIndex < 0)
-                throw new IndexOutOfBoundsException();
+            Objects.checkIndex(imageIndex, 1);
 
             Vector imageTypes = new Vector();
             imageTypes.add(ImageTypeSpecifier.createFromBufferedImageType

--- a/test/jdk/javax/imageio/metadata/IIOMetadataFormat/UserPluginMetadataFormatTest.java
+++ b/test/jdk/javax/imageio/metadata/IIOMetadataFormat/UserPluginMetadataFormatTest.java
@@ -39,7 +39,7 @@ import java.util.Iterator;
 import java.util.ListResourceBundle;
 import java.util.Locale;
 import java.util.MissingResourceException;
-import java.util.Obejcts;
+import java.util.Objects;
 import java.util.Vector;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;

--- a/test/jdk/javax/imageio/metadata/IIOMetadataFormat/UserPluginMetadataFormatTest.java
+++ b/test/jdk/javax/imageio/metadata/IIOMetadataFormat/UserPluginMetadataFormatTest.java
@@ -39,6 +39,7 @@ import java.util.Iterator;
 import java.util.ListResourceBundle;
 import java.util.Locale;
 import java.util.MissingResourceException;
+import java.util.Obejcts;
 import java.util.Vector;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
@@ -115,8 +116,7 @@ public class UserPluginMetadataFormatTest implements MetadataTest {
         public int getWidth(int imageIndex) throws IOException {
             if (input == null)
                 throw new IllegalStateException();
-            if (imageIndex >= 5 || imageIndex < 0)
-                throw new IndexOutOfBoundsException();
+            Objects.checkIndex(imageIndex, 5);
 
             return 10;
         }
@@ -124,8 +124,7 @@ public class UserPluginMetadataFormatTest implements MetadataTest {
         public int getHeight(int imageIndex) throws IOException {
             if (input == null)
                 throw new IllegalStateException();
-            if (imageIndex >= 5 || imageIndex < 0)
-                throw new IndexOutOfBoundsException();
+            Objects.checkIndex(imageIndex, 5);
 
             return 15;
         }
@@ -133,8 +132,7 @@ public class UserPluginMetadataFormatTest implements MetadataTest {
         public Iterator getImageTypes(int imageIndex) throws IOException {
             if (input == null)
                 throw new IllegalStateException();
-            if (imageIndex >= 5 || imageIndex < 0)
-                throw new IndexOutOfBoundsException();
+            Objects.checkIndex(imageIndex, 5);
 
             Vector imageTypes = new Vector();
             imageTypes.add(ImageTypeSpecifier.createFromBufferedImageType
@@ -150,8 +148,7 @@ public class UserPluginMetadataFormatTest implements MetadataTest {
 
             if (input == null)
                 throw new IllegalStateException();
-            if (imageIndex >= 5 || imageIndex < 0)
-                throw new IndexOutOfBoundsException();
+            Objects.checkIndex(imageIndex, 5);
             if (seekForwardOnly) {
                 if (imageIndex < minIndex)
                     throw new IndexOutOfBoundsException();
@@ -169,8 +166,7 @@ public class UserPluginMetadataFormatTest implements MetadataTest {
           throws IOException {
             if (input == null)
                 throw new IllegalStateException();
-            if (imageIndex >= 5 || imageIndex < 0)
-                throw new IndexOutOfBoundsException();
+            Objects.checkIndex(imageIndex, 5);
             if (seekForwardOnly) {
                 if (imageIndex < minIndex)
                     throw new IndexOutOfBoundsException();


### PR DESCRIPTION
After JDK-8265518(#3615), it's possible to replace all variants of checkIndex by Objects.checkIndex/Objects.checkFromToIndex/Objects.checkFromIndexSize in the whole JDK codebase.

As Mandy suggested, I create this PR for changes involving client code:

src/java.desktop/share/classes/com/sun/media/sound/AudioFloatInputStream.java
src/java.desktop/share/classes/javax/swing/JTabbedPane.java
test/jdk/java/awt/print/PrinterJob/ImagePrinting/ClippedImages.java
test/jdk/javax/imageio/AppletResourceTest.java
test/jdk/javax/imageio/ImageReaderReadAll.java
test/jdk/javax/imageio/metadata/IIOMetadataFormat/UserPluginMetadataFormatTest.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270058](https://bugs.openjdk.java.net/browse/JDK-8270058): Use Objects.check{Index,FromIndexSize} for java.desktop


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**) ⚠️ Review applies to 1db9e872733d44d538fb8af818541220347de94e
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**) ⚠️ Review applies to 1db9e872733d44d538fb8af818541220347de94e
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4718/head:pull/4718` \
`$ git checkout pull/4718`

Update a local copy of the PR: \
`$ git checkout pull/4718` \
`$ git pull https://git.openjdk.java.net/jdk pull/4718/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4718`

View PR using the GUI difftool: \
`$ git pr show -t 4718`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4718.diff">https://git.openjdk.java.net/jdk/pull/4718.diff</a>

</details>
