### PR TITLE
8270083: -Wnonnull errors happen with GCC 11.1.1

### DIFF
--- a/make/hotspot/lib/JvmOverrideFiles.gmk
+++ b/make/hotspot/lib/JvmOverrideFiles.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ ifeq ($(TOOLCHAIN_TYPE), gcc)
   BUILD_LIBJVM_assembler_x86.cpp_CXXFLAGS := -Wno-maybe-uninitialized
   BUILD_LIBJVM_cardTableBarrierSetAssembler_x86.cpp_CXXFLAGS := -Wno-maybe-uninitialized
   BUILD_LIBJVM_interp_masm_x86.cpp_CXXFLAGS := -Wno-uninitialized
+  BUILD_LIBJVM_ad_$(HOTSPOT_TARGET_CPU_ARCH).cpp_CXXFLAGS := -Wno-nonnull
   ifeq ($(DEBUG_LEVEL), release)
     # Need extra inlining to collapse shared marking code into the hot marking loop
     BUILD_LIBJVM_shenandoahMark.cpp_CXXFLAGS := --param inline-unit-growth=1000

--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -7427,6 +7427,10 @@ void Assembler::evprolq(XMMRegister dst, XMMRegister src, int shift, int vector_
   emit_int24(0x72, (0xC0 | encode), shift & 0xFF);
 }
 
+// Register is a class, but it would be assigned numerical value.
+// "0" is assigned for xmm0. Thus we need to ignore -Wnonnull.
+PRAGMA_DIAG_PUSH
+PRAGMA_NONNULL_IGNORED
 void Assembler::evprord(XMMRegister dst, XMMRegister src, int shift, int vector_len) {
   assert(VM_Version::supports_evex(), "requires EVEX support");
   assert(vector_len == Assembler::AVX_512bit || VM_Version::supports_avx512vl(), "requires VL support");
@@ -7444,6 +7448,7 @@ void Assembler::evprorq(XMMRegister dst, XMMRegister src, int shift, int vector_
   int encode = vex_prefix_and_encode(xmm0->encoding(), dst->encoding(), src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int24(0x72, (0xC0 | encode), shift & 0xFF);
 }
+PRAGMA_DIAG_POP
 
 void Assembler::evprolvd(XMMRegister dst, XMMRegister src, XMMRegister shift, int vector_len) {
   assert(VM_Version::supports_evex(), "requires EVEX support");

--- a/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
@@ -318,7 +318,11 @@ enum reg_save_layout {
 // expensive.  The deopt blob is the only thing which needs to
 // describe FPU registers.  In all other cases it should be sufficient
 // to simply save their current value.
-
+//
+// Register is a class, but it would be assigned numerical value.
+// "0" is assigned for rax. Thus we need to ignore -Wnonnull.
+PRAGMA_DIAG_PUSH
+PRAGMA_NONNULL_IGNORED
 static OopMap* generate_oop_map(StubAssembler* sasm, int num_rt_args,
                                 bool save_fpu_registers = true) {
 
@@ -418,6 +422,7 @@ static OopMap* generate_oop_map(StubAssembler* sasm, int num_rt_args,
 
   return map;
 }
+PRAGMA_DIAG_POP
 
 #define __ this->
 

--- a/src/hotspot/cpu/x86/frame_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.inline.hpp
@@ -227,6 +227,10 @@ inline JavaCallWrapper** frame::entry_frame_call_wrapper_addr() const {
 
 // Compiled frames
 
+// Register is a class, but it would be assigned numerical value.
+// "0" is assigned for rax. Thus we need to ignore -Wnonnull.
+PRAGMA_DIAG_PUSH
+PRAGMA_NONNULL_IGNORED
 inline oop frame::saved_oop_result(RegisterMap* map) const {
   oop* result_adr = (oop *)map->location(rax->as_VMReg());
   guarantee(result_adr != NULL, "bad register save location");
@@ -240,5 +244,6 @@ inline void frame::set_saved_oop_result(RegisterMap* map, oop obj) {
 
   *result_adr = obj;
 }
+PRAGMA_DIAG_POP
 
 #endif // CPU_X86_FRAME_X86_INLINE_HPP

--- a/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
@@ -465,6 +465,10 @@ private:
     _spill_offset += 8;
   }
 
+// Register is a class, but it would be assigned numerical value.
+// "0" is assigned for rax. Thus we need to ignore -Wnonnull.
+PRAGMA_DIAG_PUSH
+PRAGMA_NONNULL_IGNORED
   void initialize(ZLoadBarrierStubC2* stub) {
     // Create mask of caller saved registers that need to
     // be saved/restored if live
@@ -540,6 +544,7 @@ private:
     // Stack pointer must be 16 bytes aligned for the call
     _spill_offset = _spill_size = align_up(xmm_spill_size + gp_spill_size + opmask_spill_size + arg_spill_size, 16);
   }
+PRAGMA_DIAG_POP
 
 public:
   ZSaveLiveRegisters(MacroAssembler* masm, ZLoadBarrierStubC2* stub) :

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -168,6 +168,10 @@ class RegisterSaver {
   static void restore_result_registers(MacroAssembler* masm);
 };
 
+// Register is a class, but it would be assigned numerical value.
+// "0" is assigned for rax. Thus we need to ignore -Wnonnull.
+PRAGMA_DIAG_PUSH
+PRAGMA_NONNULL_IGNORED
 OopMap* RegisterSaver::save_live_registers(MacroAssembler* masm, int additional_frame_words, int* total_frame_words, bool save_vectors) {
   int off = 0;
   int num_xmm_regs = XMMRegisterImpl::number_of_registers;
@@ -360,6 +364,7 @@ OopMap* RegisterSaver::save_live_registers(MacroAssembler* masm, int additional_
 
   return map;
 }
+PRAGMA_DIAG_POP
 
 void RegisterSaver::restore_live_registers(MacroAssembler* masm, bool restore_vectors) {
   int num_xmm_regs = XMMRegisterImpl::number_of_registers;

--- a/src/hotspot/cpu/x86/universalUpcallHandler_x86_64.cpp
+++ b/src/hotspot/cpu/x86/universalUpcallHandler_x86_64.cpp
@@ -580,6 +580,10 @@ struct AuxiliarySaves {
   bool should_detach;
 };
 
+// Register is a class, but it would be assigned numerical value.
+// "0" is assigned for rax and for xmm0. Thus we need to ignore -Wnonnull.
+PRAGMA_DIAG_PUSH
+PRAGMA_NONNULL_IGNORED
 address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiver, Method* entry, jobject jabi, jobject jconv) {
   ResourceMark rm;
   const ABIDescriptor abi = ForeignGlobals::parse_abi_descriptor(jabi);
@@ -844,6 +848,7 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
 
   return blob->code_begin();
 }
+PRAGMA_DIAG_POP
 
 bool ProgrammableUpcallHandler::supports_optimized_upcalls() {
   return true;

--- a/src/hotspot/share/utilities/compilerWarnings.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,6 +64,10 @@
 
 #ifndef PRAGMA_STRINGOP_TRUNCATION_IGNORED
 #define PRAGMA_STRINGOP_TRUNCATION_IGNORED
+#endif
+
+#ifndef PRAGMA_NONNULL_IGNORED
+#define PRAGMA_NONNULL_IGNORED
 #endif
 
 #endif // SHARE_UTILITIES_COMPILERWARNINGS_HPP

--- a/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,6 +49,9 @@
 #if !defined(__clang_major__) && (__GNUC__ >= 8)
 #define PRAGMA_STRINGOP_TRUNCATION_IGNORED PRAGMA_DISABLE_GCC_WARNING("-Wstringop-truncation")
 #endif
+
+#define PRAGMA_NONNULL_IGNORED \
+  PRAGMA_DISABLE_GCC_WARNING("-Wnonnull")
 
 #if defined(__clang_major__) && \
       (__clang_major__ >= 4 || \


### PR DESCRIPTION
I attempted to build OpenJDK on Fedora 34 with gcc-11.1.1-3.fc34.x86_64, but I saw following errors:

```
In file included from /home/ysuenaga/github-forked/jdk/src/hotspot/share/runtime/frame.inline.hpp:42,
                 from /home/ysuenaga/github-forked/jdk/src/hotspot/cpu/x86/abstractInterpreter_x86.cpp:29:
/home/ysuenaga/github-forked/jdk/src/hotspot/cpu/x86/frame_x86.inline.hpp: In member function 'oop frame::saved_oop_result(RegisterMap*) const':
/home/ysuenaga/github-forked/jdk/src/hotspot/cpu/x86/frame_x86.inline.hpp:231:42: error: 'this' pointer is null [-Werror=nonnull]
  231 | oop* result_adr = (oop *)map->location(rax->as_VMReg());
      | ^~~
In file included from /home/ysuenaga/github-forked/jdk/src/hotspot/share/code/vmreg.inline.hpp:31,
                 from /home/ysuenaga/github-forked/jdk/src/hotspot/cpu/x86/macroAssembler_x86.hpp:29,
                 from /home/ysuenaga/github-forked/jdk/src/hotspot/share/asm/macroAssembler.hpp:31,
                 from /home/ysuenaga/github-forked/jdk/src/hotspot/share/interpreter/interp_masm.hpp:28,
                 from /home/ysuenaga/github-forked/jdk/src/hotspot/share/interpreter/interpreter.hpp:29,
                 from /home/ysuenaga/github-forked/jdk/src/hotspot/cpu/x86/abstractInterpreter_x86.cpp:27:
/home/ysuenaga/github-forked/jdk/src/hotspot/cpu/x86/vmreg_x86.inline.hpp:28:14: note: in a call to non-static member function 'VMRegImpl* RegisterImpl::as_VMReg()'
   28 | inline VMReg RegisterImpl::as_VMReg() {
      | ^~~~~~~~~~~~
In file included from /home/ysuenaga/github-forked/jdk/src/hotspot/share/runtime/frame.inline.hpp:42,
                 from /home/ysuenaga/github-forked/jdk/src/hotspot/cpu/x86/abstractInterpreter_x86.cpp:29:
/home/ysuenaga/github-forked/jdk/src/hotspot/cpu/x86/frame_x86.inline.hpp: In member function 'void frame::set_saved_oop_result(RegisterMap*, oop)':
/home/ysuenaga/github-forked/jdk/src/hotspot/cpu/x86/frame_x86.inline.hpp:238:42: error: 'this' pointer is null [-Werror=nonnull]
  238 | oop* result_adr = (oop *)map->location(rax->as_VMReg());
      | ^~~
In file included from /home/ysuenaga/github-forked/jdk/src/hotspot/share/code/vmreg.inline.hpp:31,
                 from /home/ysuenaga/github-forked/jdk/src/hotspot/cpu/x86/macroAssembler_x86.hpp:29,
                 from /home/ysuenaga/github-forked/jdk/src/hotspot/share/asm/macroAssembler.hpp:31,
                 from /home/ysuenaga/github-forked/jdk/src/hotspot/share/interpreter/interp_masm.hpp:28,
                 from /home/ysuenaga/github-forked/jdk/src/hotspot/share/interpreter/interpreter.hpp:29,
                 from /home/ysuenaga/github-forked/jdk/src/hotspot/cpu/x86/abstractInterpreter_x86.cpp:27:
/home/ysuenaga/github-forked/jdk/src/hotspot/cpu/x86/vmreg_x86.inline.hpp:28:14: note: in a call to non-static member function 'VMRegImpl* RegisterImpl::as_VMReg()'
   28 | inline VMReg RegisterImpl::as_VMReg() {
      | ^~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

`Register` ( `RegisterImpl` ) is defined as a class, but it is used like numerical value. For example `rax` and `xmm0` are assigned to `0`. It is the cause of this error.

Logically, the code is fine, so we can avoid them to disable `-Wnonnull`.
I guess this issue is since [JDK-8269122](https://bugs.openjdk.java.net/browse/JDK-8269122) because it changes register declaration as numerical value.
https://github.com/openjdk/jdk/commit/4d2412ef3e1068063acc954a00b4db0fa4b5affb#diff-5906c5396c185410f531af49c478163214ddf5f4b3d054c6e43658913d26564fL91-R55

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270083](https://bugs.openjdk.java.net/browse/JDK-8270083): -Wnonnull errors happen with GCC 11.1.1


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4719/head:pull/4719` \
`$ git checkout pull/4719`

Update a local copy of the PR: \
`$ git checkout pull/4719` \
`$ git pull https://git.openjdk.java.net/jdk pull/4719/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4719`

View PR using the GUI difftool: \
`$ git pr show -t 4719`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4719.diff">https://git.openjdk.java.net/jdk/pull/4719.diff</a>

</details>
