### PR TITLE
8270082: Remove unnecessary gc_timer null check in ReferenceProcessorPhaseTimes

### DIFF
--- a/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
@@ -117,9 +117,7 @@ RefProcPhaseTimeBaseTracker::RefProcPhaseTimeBaseTracker(const char* title,
   assert(_phase_times != NULL, "Invariant");
 
   _start_ticks.stamp();
-  if (_phase_times->gc_timer() != NULL) {
-    _phase_times->gc_timer()->register_gc_phase_start(title, _start_ticks);
-  }
+  _phase_times->gc_timer()->register_gc_phase_start(title, _start_ticks);
 }
 
 Ticks RefProcPhaseTimeBaseTracker::end_ticks() {
@@ -138,10 +136,8 @@ double RefProcPhaseTimeBaseTracker::elapsed_time() {
 }
 
 RefProcPhaseTimeBaseTracker::~RefProcPhaseTimeBaseTracker() {
-  if (_phase_times->gc_timer() != NULL) {
-    Ticks ticks = end_ticks();
-    _phase_times->gc_timer()->register_gc_phase_end(ticks);
-  }
+  Ticks ticks = end_ticks();
+  _phase_times->gc_timer()->register_gc_phase_end(ticks);
 }
 
 RefProcBalanceQueuesTimeTracker::RefProcBalanceQueuesTimeTracker(ReferenceProcessor::RefProcPhases phase_number,
@@ -175,7 +171,7 @@ RefProcTotalPhaseTimesTracker::~RefProcTotalPhaseTimesTracker() {
 
 ReferenceProcessorPhaseTimes::ReferenceProcessorPhaseTimes(GCTimer* gc_timer, uint max_gc_threads) :
   _processing_is_mt(false), _gc_timer(gc_timer) {
-
+  assert(gc_timer != nullptr, "pre-condition");
   for (uint i = 0; i < ReferenceProcessor::RefSubPhaseMax; i++) {
     _sub_phases_worker_time_sec[i] = new WorkerDataArray<double>(NULL, SubPhasesParWorkTitle[i], max_gc_threads);
   }


### PR DESCRIPTION
Simple change of removing a null check.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270082](https://bugs.openjdk.java.net/browse/JDK-8270082): Remove unnecessary gc_timer null check in ReferenceProcessorPhaseTimes


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4720/head:pull/4720` \
`$ git checkout pull/4720`

Update a local copy of the PR: \
`$ git checkout pull/4720` \
`$ git pull https://git.openjdk.java.net/jdk pull/4720/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4720`

View PR using the GUI difftool: \
`$ git pr show -t 4720`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4720.diff">https://git.openjdk.java.net/jdk/pull/4720.diff</a>

</details>
