### PR TITLE
8253178: Replace LinkedList Impl in net.http.FilterFactory

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/FilterFactory.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/FilterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,20 +25,20 @@
 
 package jdk.internal.net.http;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 class FilterFactory {
 
     // Strictly-ordered list of filters.
-    final LinkedList<Class<? extends HeaderFilter>> filterClasses = new LinkedList<>();
+    final List<Class<? extends HeaderFilter>> filterClasses = new ArrayList<>(3);
 
     public void addFilter(Class<? extends HeaderFilter> type) {
         filterClasses.add(type);
     }
 
-    LinkedList<HeaderFilter> getFilterChain() {
-        LinkedList<HeaderFilter> l = new LinkedList<>();
+    List<HeaderFilter> getFilterChain() {
+        List<HeaderFilter> l = new ArrayList<>();
         for (Class<? extends HeaderFilter> clazz : filterClasses) {
             try {
                 // Requires a public no arg constructor.

--- a/src/java.net.http/share/classes/jdk/internal/net/http/FilterFactory.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/FilterFactory.java
@@ -38,7 +38,7 @@ class FilterFactory {
     }
 
     List<HeaderFilter> getFilterChain() {
-        List<HeaderFilter> l = new ArrayList<>();
+        List<HeaderFilter> l = new ArrayList<>(filterClasses.size());
         for (Class<? extends HeaderFilter> clazz : filterClasses) {
             try {
                 // Requires a public no arg constructor.

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
@@ -56,14 +56,12 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -1206,7 +1204,7 @@ final class HttpClientImpl extends HttpClient implements Trackable {
         filters.addFilter(f);
     }
 
-    final LinkedList<HeaderFilter> filterChain() {
+    final List<HeaderFilter> filterChain() {
         return filters.getFilterChain();
     }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/MultiExchange.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/MultiExchange.java
@@ -30,9 +30,9 @@ import java.lang.ref.WeakReference;
 import java.net.ConnectException;
 import java.net.http.HttpConnectTimeoutException;
 import java.time.Duration;
-import java.util.Iterator;
-import java.util.LinkedList;
 import java.security.AccessControlContext;
+import java.util.List;
+import java.util.ListIterator;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CancellationException;
@@ -100,7 +100,7 @@ class MultiExchange<T> implements Cancelable {
             "jdk.httpclient.redirects.retrylimit", DEFAULT_MAX_ATTEMPTS
     );
 
-    private final LinkedList<HeaderFilter> filters;
+    private final List<HeaderFilter> filters;
     ResponseTimerEvent responseTimerEvent;
     volatile boolean cancelled;
     AtomicReference<CancellationException> interrupted = new AtomicReference<>();
@@ -241,9 +241,9 @@ class MultiExchange<T> implements Cancelable {
     private HttpRequestImpl responseFilters(Response response) throws IOException
     {
         Log.logTrace("Applying response filters");
-        Iterator<HeaderFilter> reverseItr = filters.descendingIterator();
-        while (reverseItr.hasNext()) {
-            HeaderFilter filter = reverseItr.next();
+        ListIterator<HeaderFilter> reverseItr = filters.listIterator(filters.size());
+        while (reverseItr.hasPrevious()) {
+            HeaderFilter filter = reverseItr.previous();
             Log.logTrace("Applying {0}", filter);
             HttpRequestImpl newreq = filter.response(response);
             if (newreq != null) {


### PR DESCRIPTION
This patch replaces a LinkedList data structure used in the net.http.FilterFactory class with an ArrayList. This issue relates to [JDK-8246048: Replace LinkedList with ArrayLists in java.net.](https://bugs.openjdk.java.net/browse/JDK-8246048).

The list created once per HttpClient and filled with upfront known values (3 of them in the jdk.internal.net.http.HttpClientImpl#initFilters: AuthenticationFilter.class, RedirectFilter.class and depending on the presence of a cookieHandler - a CookieFilter.class).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253178](https://bugs.openjdk.java.net/browse/JDK-8253178): Replace LinkedList Impl in net.http.FilterFactory


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4721/head:pull/4721` \
`$ git checkout pull/4721`

Update a local copy of the PR: \
`$ git checkout pull/4721` \
`$ git pull https://git.openjdk.java.net/jdk pull/4721/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4721`

View PR using the GUI difftool: \
`$ git pr show -t 4721`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4721.diff">https://git.openjdk.java.net/jdk/pull/4721.diff</a>

</details>
