### PR TITLE
8270057: Use Objects.checkFromToIndex for j.u.c.CopyOnWriteArrayList

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/CopyOnWriteArrayList.java
+++ b/src/java.base/share/classes/java/util/concurrent/CopyOnWriteArrayList.java
@@ -561,8 +561,7 @@ public class CopyOnWriteArrayList<E>
             Object[] es = getArray();
             int len = es.length;
 
-            if (fromIndex < 0 || toIndex > len || toIndex < fromIndex)
-                throw new IndexOutOfBoundsException();
+            Objects.checkFromToIndex(fromIndex, toIndex, len);
             int newlen = len - (toIndex - fromIndex);
             int numMoved = len - toIndex;
             if (numMoved == 0)
@@ -1173,8 +1172,7 @@ public class CopyOnWriteArrayList<E>
             Object[] es = getArray();
             int len = es.length;
             int size = toIndex - fromIndex;
-            if (fromIndex < 0 || toIndex > len || size < 0)
-                throw new IndexOutOfBoundsException();
+            Objects.checkFromToIndex(fromIndex, toIndex, len);
             return new COWSubList(es, fromIndex, size);
         }
     }
@@ -1457,8 +1455,7 @@ public class CopyOnWriteArrayList<E>
         public List<E> subList(int fromIndex, int toIndex) {
             synchronized (lock) {
                 checkForComodification();
-                if (fromIndex < 0 || toIndex > size || fromIndex > toIndex)
-                    throw new IndexOutOfBoundsException();
+                Objects.checkFromToIndex(fromIndex, toIndex, size);
                 return new COWSubList(expectedArray, fromIndex + offset, toIndex - fromIndex);
             }
         }


### PR DESCRIPTION
After JDK-8265518(#3615), it's possible to replace all variants of checkIndex by Objects.checkIndex/Objects.checkFromToIndex/Objects.checkFromIndexSize in the whole JDK codebase.

As Mandy suggested, I create this PR for changes involving  JUC changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8270057](https://bugs.openjdk.java.net/browse/JDK-8270057): Use Objects.checkFromToIndex for j.u.c.CopyOnWriteArrayList


### Reviewers
 * @stsypanov (no known github.com user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4723/head:pull/4723` \
`$ git checkout pull/4723`

Update a local copy of the PR: \
`$ git checkout pull/4723` \
`$ git pull https://git.openjdk.java.net/jdk pull/4723/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4723`

View PR using the GUI difftool: \
`$ git pr show -t 4723`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4723.diff">https://git.openjdk.java.net/jdk/pull/4723.diff</a>

</details>
