### PR TITLE
8270091: The path of JFR emergency dump should be able to specified by the user

### DIFF
--- a/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp
@@ -105,7 +105,14 @@ static void close_emergency_dump_file() {
 static const char* create_emergency_dump_path() {
   assert(is_path_empty(), "invariant");
 
-  const size_t path_len = get_current_directory();
+  size_t path_len = 0;
+  if (JFREmergencyDumpPath == NULL) {
+    path_len = get_current_directory();
+  } else {
+    if (strlen(JFREmergencyDumpPath) < (sizeof(_path_buffer) - 1)) {
+      path_len = jio_snprintf(_path_buffer, sizeof(_path_buffer), "%s%s", JFREmergencyDumpPath, os::file_separator());
+    }
+  }
   if (path_len == 0) {
     return NULL;
   }

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2035,6 +2035,11 @@ const intx ObjectAlignmentInBytes = 8;
   JFR_ONLY(product(ccstr, StartFlightRecording, NULL,                       \
           "Start flight recording with options"))                           \
                                                                             \
+  JFR_ONLY(product(ccstr, JFREmergencyDumpPath, NULL,                       \
+          "The path for JFR emergency dump. "                               \
+          "Flight record will be dumped there "                             \
+          "when the error (OOM, stack overflow, crash) happens."))          \
+                                                                            \
   product(bool, UseFastUnorderedTimeStamps, false, EXPERIMENTAL,            \
           "Use platform unstable time where supported for timestamps only") \
                                                                             \


### PR DESCRIPTION
JFR will dump the recording to the file as hs_err_pid<PID>.jfr if JVM encountered fatal errors (e.g. crash). It will be dumped to current directory, and we cannot specify dump path.

In other dumps (hs_err log, heap dump, replay & inline data for JIT) can be specified it.

This is useful especially in the container application if we can specify it in JFR.

I've filed [CSR](https://bugs.openjdk.java.net/browse/JDK-8270093) for this RFE, please review it too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ The change requires a CSR request to be approved.

### Issue
 * [JDK-8270091](https://bugs.openjdk.java.net/browse/JDK-8270091): The path of JFR emergency dump should be able to specified by the user


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4724/head:pull/4724` \
`$ git checkout pull/4724`

Update a local copy of the PR: \
`$ git checkout pull/4724` \
`$ git pull https://git.openjdk.java.net/jdk pull/4724/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4724`

View PR using the GUI difftool: \
`$ git pr show -t 4724`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4724.diff">https://git.openjdk.java.net/jdk/pull/4724.diff</a>

</details>
