### PR TITLE
8270096: Shenandoah: Optimize gc/shenandoah/TestRefprocSanity.java for interpreter mode

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/TestRefprocSanity.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestRefprocSanity.java
@@ -27,16 +27,16 @@
  * @summary Test that null references/referents work fine
  * @requires vm.gc.Shenandoah
  *
- * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ * @run main/othervm -Xmx128m -Xms128m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC
  *      -XX:+ShenandoahVerify
  *      TestRefprocSanity
  *
- * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ * @run main/othervm -Xmx128m -Xms128m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC
  *      TestRefprocSanity
  *
- * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ * @run main/othervm -Xmx128m -Xms128m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
  *      TestRefprocSanity
  */
@@ -46,16 +46,16 @@
  * @summary Test that null references/referents work fine
  * @requires vm.gc.Shenandoah
  *
- * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ * @run main/othervm -Xmx128m -Xms128m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu
  *      -XX:+ShenandoahVerify
  *      TestRefprocSanity
  *
- * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ * @run main/othervm -Xmx128m -Xms128m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu
  *      TestRefprocSanity
  *
- * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ * @run main/othervm -Xmx128m -Xms128m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive
  *      TestRefprocSanity
  */
@@ -64,13 +64,15 @@ import java.lang.ref.*;
 
 public class TestRefprocSanity {
 
-    static final long TARGET_MB = Long.getLong("target", 10_000); // 10 Gb allocation
+    static final long TARGET_MB = Long.getLong("target", 1_000); // 1 Gb allocation
     static final int WINDOW = 10_000;
 
     static final Reference<MyObject>[] refs = new Reference[WINDOW];
 
+    static Object sink;
+
     public static void main(String[] args) throws Exception {
-        long count = TARGET_MB * 1024 * 1024 / 32;
+        long count = TARGET_MB * 1024 * 1024 / 128;
         int rIdx = 0;
 
         ReferenceQueue rq = new ReferenceQueue();
@@ -87,7 +89,12 @@ public class TestRefprocSanity {
             if (rIdx >= WINDOW) {
                 rIdx = 0;
             }
-            while (rq.poll() != null); // drain
+
+            // Do allocations to force GCs
+            sink = new byte[100];
+
+            // Drain the refqueue
+            while (rq.poll() != null);
         }
     }
 

--- a/test/hotspot/jtreg/gc/shenandoah/TestRefprocSanity.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestRefprocSanity.java
@@ -65,7 +65,7 @@ import java.lang.ref.*;
 public class TestRefprocSanity {
 
     static final long TARGET_MB = Long.getLong("target", 1_000); // 1 Gb allocation
-    static final int WINDOW = 10_000;
+    static final int WINDOW = 1_000;
 
     static final Reference<MyObject>[] refs = new Reference[WINDOW];
 


### PR DESCRIPTION
Found this while testing Shenandoah with Zero. This configuration takes a lot of time, and eventually times out:

```
$ time CONF=linux-x86_64-server-fastdebug make run-test TEST=gc/shenandoah/TestRefprocSanity.java TEST_OPTS="JAVA_OPTIONS=-Xint"
<timeout after 1200 seconds>
```

With these fixes, the run time with `-Xint` is under 1 minute:

```
real	0m51.472s
user	3m0.366s
sys	0m5.473s
```

In default mode, the run time is now under 20 seconds:

```
real	0m20.584s
user	1m8.693s
sys	0m5.030s
```

This also passes with Zero (plus some Zero fixes) now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270096](https://bugs.openjdk.java.net/browse/JDK-8270096): Shenandoah: Optimize gc/shenandoah/TestRefprocSanity.java for interpreter mode


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4725/head:pull/4725` \
`$ git checkout pull/4725`

Update a local copy of the PR: \
`$ git checkout pull/4725` \
`$ git pull https://git.openjdk.java.net/jdk pull/4725/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4725`

View PR using the GUI difftool: \
`$ git pr show -t 4725`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4725.diff">https://git.openjdk.java.net/jdk/pull/4725.diff</a>

</details>
