### PR TITLE
8270094: Shenandoah: Provide human-readable labels for test configurations

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/TestAllocHumongousFragment.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestAllocHumongousFragment.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestAllocHumongousFragment
+ * @test id=passive
  * @summary Make sure Shenandoah can recover from humongous allocation fragmentation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -51,7 +51,7 @@
  */
 
 /*
- * @test TestAllocHumongousFragment
+ * @test id=aggressive
  * @summary Make sure Shenandoah can recover from humongous allocation fragmentation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -79,7 +79,7 @@
  */
 
 /*
- * @test TestAllocHumongousFragment
+ * @test id=adaptive
  * @summary Make sure Shenandoah can recover from humongous allocation fragmentation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -96,7 +96,7 @@
  */
 
 /*
- * @test TestAllocHumongousFragment
+ * @test id=static
  * @summary Make sure Shenandoah can recover from humongous allocation fragmentation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -108,7 +108,7 @@
  */
 
 /*
- * @test TestAllocHumongousFragment
+ * @test id=compact
  * @summary Make sure Shenandoah can recover from humongous allocation fragmentation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -120,7 +120,7 @@
  */
 
 /*
- * @test TestAllocHumongousFragment
+ * @test id=iu-aggressive
  * @summary Make sure Shenandoah can recover from humongous allocation fragmentation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -148,7 +148,7 @@
  */
 
 /*
- * @test TestAllocHumongousFragment
+ * @test id=iu
  * @summary Make sure Shenandoah can recover from humongous allocation fragmentation
  * @key randomness
  * @requires vm.gc.Shenandoah

--- a/test/hotspot/jtreg/gc/shenandoah/TestAllocIntArrays.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestAllocIntArrays.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestAllocIntArrays
+ * @test id=passive
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -51,7 +51,7 @@
  */
 
 /*
- * @test TestAllocIntArrays
+ * @test id=aggressive
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -83,7 +83,7 @@
  */
 
 /*
- * @test TestAllocIntArrays
+ * @test id=adaptive
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -100,7 +100,7 @@
  */
 
 /*
- * @test TestAllocIntArrays
+ * @test id=static
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -112,7 +112,7 @@
  */
 
 /*
- * @test TestAllocIntArrays
+ * @test id=compact
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -124,7 +124,7 @@
  */
 
 /*
- * @test TestAllocIntArrays
+ * @test id=no-tlab
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -137,7 +137,7 @@
  */
 
 /*
- * @test TestAllocIntArrays
+ * @test id=iu-aggressive
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -169,7 +169,7 @@
  */
 
 /*
- * @test TestAllocIntArrays
+ * @test id=iu
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
  * @requires vm.gc.Shenandoah

--- a/test/hotspot/jtreg/gc/shenandoah/TestAllocObjectArrays.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestAllocObjectArrays.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestAllocObjectArrays
+ * @test id=passive
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -51,7 +51,7 @@
  */
 
 /*
- * @test TestAllocObjectArrays
+ * @test id=aggressive
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -83,7 +83,7 @@
  */
 
 /*
- * @test TestAllocObjectArrays
+ * @test id=adaptive
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -100,7 +100,7 @@
  */
 
 /*
- * @test TestAllocObjectArrays
+ * @test id=static
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -112,7 +112,7 @@
  */
 
 /*
- * @test TestAllocObjectArrays
+ * @test id=compact
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -124,7 +124,7 @@
  */
 
 /*
- * @test TestAllocObjectArrays
+ * @test id=no-tlab
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -137,7 +137,7 @@
  */
 
 /*
- * @test TestAllocObjectArrays
+ * @test id=iu-aggressive
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -169,7 +169,7 @@
  */
 
 /*
- * @test TestAllocObjectArrays
+ * @test id=iu
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
  * @requires vm.gc.Shenandoah

--- a/test/hotspot/jtreg/gc/shenandoah/TestAllocObjects.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestAllocObjects.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestAllocObjects
+ * @test id=passive
  * @summary Acceptance tests: collector can withstand allocation
  * @requires vm.gc.Shenandoah
  *
@@ -49,7 +49,7 @@
  */
 
 /*
- * @test TestAllocObjects
+ * @test id=aggressive
  * @summary Acceptance tests: collector can withstand allocation
  * @requires vm.gc.Shenandoah
  *
@@ -85,7 +85,7 @@
  */
 
 /*
- * @test TestAllocObjects
+ * @test id=adaptive
  * @summary Acceptance tests: collector can withstand allocation
  * @requires vm.gc.Shenandoah
  *
@@ -105,7 +105,7 @@
  */
 
 /*
- * @test TestAllocObjects
+ * @test id=static
  * @summary Acceptance tests: collector can withstand allocation
  * @requires vm.gc.Shenandoah
  *
@@ -120,7 +120,7 @@
  */
 
 /*
- * @test TestAllocObjects
+ * @test id=compact
  * @summary Acceptance tests: collector can withstand allocation
  * @requires vm.gc.Shenandoah
  *
@@ -135,7 +135,7 @@
  */
 
 /*
- * @test TestAllocObjects
+ * @test id=iu-aggressive
  * @summary Acceptance tests: collector can withstand allocation
  * @requires vm.gc.Shenandoah
  *
@@ -165,7 +165,7 @@
  */
 
 /*
- * @test TestAllocObjects
+ * @test id=iu
  * @summary Acceptance tests: collector can withstand allocation
  * @requires vm.gc.Shenandoah
  *

--- a/test/hotspot/jtreg/gc/shenandoah/TestArrayCopyCheckCast.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestArrayCopyCheckCast.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestArrayCopyCheckCast
+ * @test
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:TieredStopAtLevel=0 -Xmx16m TestArrayCopyCheckCast

--- a/test/hotspot/jtreg/gc/shenandoah/TestArrayCopyStress.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestArrayCopyStress.java
@@ -26,7 +26,7 @@ import java.util.Random;
 import jdk.test.lib.Utils;
 
 /*
- * @test TestArrayCopyStress
+ * @test
  * @key randomness
  * @requires vm.gc.Shenandoah
  * @library /test/lib

--- a/test/hotspot/jtreg/gc/shenandoah/TestDynamicSoftMaxHeapSize.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestDynamicSoftMaxHeapSize.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestDynamicSoftMaxHeapSize
+ * @test id=passive
  * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
@@ -41,7 +41,7 @@
  */
 
 /*
- * @test TestDynamicSoftMaxHeapSize
+ * @test id=aggressive
  * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
@@ -52,7 +52,7 @@
  */
 
 /*
- * @test TestDynamicSoftMaxHeapSize
+ * @test id=adaptive
  * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
@@ -63,7 +63,7 @@
  */
 
 /*
- * @test TestDynamicSoftMaxHeapSize
+ * @test id=static
  * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
@@ -74,7 +74,7 @@
  */
 
 /*
- * @test TestDynamicSoftMaxHeapSize
+ * @test id=compact
  * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
@@ -85,7 +85,7 @@
  */
 
 /*
- * @test TestDynamicSoftMaxHeapSize
+ * @test id=iu-aggressive
  * @requires vm.gc.Shenandoah
  * @library /test/lib
  *
@@ -96,7 +96,7 @@
  */
 
 /*
- * @test TestDynamicSoftMaxHeapSize
+ * @test id=iu
  * @requires vm.gc.Shenandoah
  * @library /test/lib
  *

--- a/test/hotspot/jtreg/gc/shenandoah/TestElasticTLAB.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestElasticTLAB.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestElasticTLAB
+ * @test
  * @key randomness
  * @summary Test that Shenandoah is able to work with elastic TLABs
  * @requires vm.gc.Shenandoah

--- a/test/hotspot/jtreg/gc/shenandoah/TestEvilSyncBug.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestEvilSyncBug.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestEvilSyncBug
+ * @test
  * @summary Tests for crash/assert when attaching init thread during shutdown
  * @requires vm.gc.Shenandoah
  * @library /test/lib

--- a/test/hotspot/jtreg/gc/shenandoah/TestGCThreadGroups.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestGCThreadGroups.java
@@ -23,7 +23,7 @@
  */
 
 /**
- * @test TestGCThreadGroups
+ * @test id=passive
  * @summary Test Shenandoah GC uses concurrent/parallel threads correctly
  * @requires vm.gc.Shenandoah
  *
@@ -35,7 +35,7 @@
  */
 
 /**
- * @test TestGCThreadGroups
+ * @test id=default
  * @summary Test Shenandoah GC uses concurrent/parallel threads correctly
  * @requires vm.gc.Shenandoah
  *
@@ -77,7 +77,7 @@
  */
 
 /**
- * @test TestGCThreadGroups
+ * @test id=iu
  * @summary Test Shenandoah GC uses concurrent/parallel threads correctly
  * @requires vm.gc.Shenandoah
  *

--- a/test/hotspot/jtreg/gc/shenandoah/TestHeapUncommit.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestHeapUncommit.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestHeapUncommit
+ * @test id=passive
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -51,7 +51,7 @@
  */
 
 /*
- * @test TestHeapUncommit
+ * @test id=adaptive
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -85,7 +85,7 @@
  */
 
 /*
- * @test TestHeapUncommit
+ * @test id=iu
  * @summary Acceptance tests: collector can withstand allocation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -106,7 +106,7 @@
  */
 
 /*
- * @test TestHeapUncommit
+ * @test id=default-lp
  * @key randomness
  * @requires vm.gc.Shenandoah
  * @requires vm.bits == "64"

--- a/test/hotspot/jtreg/gc/shenandoah/TestHumongousThreshold.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestHumongousThreshold.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestHumongousThreshold
+ * @test id=default
  * @key randomness
  * @requires vm.gc.Shenandoah
  * @library /test/lib
@@ -69,7 +69,7 @@
  */
 
 /*
- * @test TestHumongousThreshold
+ * @test id=16b
  * @key randomness
  * @requires vm.gc.Shenandoah
  * @requires vm.bits == "64"

--- a/test/hotspot/jtreg/gc/shenandoah/TestLargeObjectAlignment.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestLargeObjectAlignment.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestLargeObjectAlignment
+ * @test
  * @summary Shenandoah crashes with -XX:ObjectAlignmentInBytes=16
  * @key randomness
  * @requires vm.gc.Shenandoah

--- a/test/hotspot/jtreg/gc/shenandoah/TestLotsOfCycles.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestLotsOfCycles.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestLotsOfCycles
+ * @test id=passive
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -40,7 +40,7 @@
  */
 
 /*
- * @test TestLotsOfCycles
+ * @test id=aggressive
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -62,7 +62,7 @@
  */
 
 /*
- * @test TestLotsOfCycles
+ * @test id=adaptive
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -72,7 +72,7 @@
  */
 
 /*
- * @test TestLotsOfCycles
+ * @test id=static
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -82,7 +82,7 @@
  */
 
 /*
- * @test TestLotsOfCycles
+ * @test id=compact
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -92,7 +92,7 @@
  */
 
 /*
- * @test TestLotsOfCycles
+ * @test id=iu-aggressive
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
@@ -114,7 +114,7 @@
  */
 
 /*
- * @test TestLotsOfCycles
+ * @test id=iu
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions

--- a/test/hotspot/jtreg/gc/shenandoah/TestObjItrWithHeapDump.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestObjItrWithHeapDump.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestObjIterWithHeapDump
+ * @test
  * @summary Test heap dump triggered heap object iteration
  * @bug 8225014
  * @requires vm.gc.Shenandoah

--- a/test/hotspot/jtreg/gc/shenandoah/TestParallelRefprocSanity.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestParallelRefprocSanity.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestParallelRefprocSanity
+ * @test
  * @summary Test that reference processing works with both parallel and non-parallel variants.
  * @requires vm.gc.Shenandoah
  *

--- a/test/hotspot/jtreg/gc/shenandoah/TestPeriodicGC.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestPeriodicGC.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestPeriodicGC
+ * @test
  * @summary Test that periodic GC is working
  * @requires vm.gc.Shenandoah
  * @library /test/lib

--- a/test/hotspot/jtreg/gc/shenandoah/TestReferenceRefersToShenandoah.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestReferenceRefersToShenandoah.java
@@ -23,7 +23,7 @@
 
 package gc.shenandoah;
 
-/* @test
+/* @test id=satb
  * @requires vm.gc.Shenandoah
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
@@ -35,7 +35,7 @@ package gc.shenandoah;
  *      gc.shenandoah.TestReferenceRefersToShenandoah
  */
 
-/* @test
+/* @test id=iu
  * @requires vm.gc.Shenandoah
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
@@ -47,7 +47,7 @@ package gc.shenandoah;
  *      gc.shenandoah.TestReferenceRefersToShenandoah
  */
 
-/* @test
+/* @test id=satb-100
  * @requires vm.gc.Shenandoah
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
@@ -60,7 +60,7 @@ package gc.shenandoah;
  *      gc.shenandoah.TestReferenceRefersToShenandoah
  */
 
-/* @test
+/* @test id=iu-100
  * @requires vm.gc.Shenandoah
  * @library /test/lib
  * @build sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/gc/shenandoah/TestReferenceShortcutCycle.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestReferenceShortcutCycle.java
@@ -23,7 +23,7 @@
 
 package gc.shenandoah;
 
-/* @test
+/* @test id=satb-100
  * @requires vm.gc.Shenandoah
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
@@ -36,7 +36,7 @@ package gc.shenandoah;
  *      gc.shenandoah.TestReferenceShortcutCycle
  */
 
-/* @test
+/* @test id=iu-100
  * @requires vm.gc.Shenandoah
  * @library /test/lib
  * @build sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/gc/shenandoah/TestRefprocSanity.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestRefprocSanity.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestRefprocSanity
+ * @test id=default
  * @summary Test that null references/referents work fine
  * @requires vm.gc.Shenandoah
  *
@@ -42,7 +42,7 @@
  */
 
 /*
- * @test TestRefprocSanity
+ * @test id=iu
  * @summary Test that null references/referents work fine
  * @requires vm.gc.Shenandoah
  *

--- a/test/hotspot/jtreg/gc/shenandoah/TestRegionSampling.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestRegionSampling.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestRegionSampling
+ * @test id=passive
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+ShenandoahRegionSampling
@@ -38,7 +38,7 @@
  */
 
 /*
- * @test TestRegionSampling
+ * @test id=adaptive
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+ShenandoahRegionSampling
@@ -47,7 +47,7 @@
  */
 
 /*
- * @test TestRegionSampling
+ * @test id=static
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+ShenandoahRegionSampling
@@ -56,7 +56,7 @@
  */
 
 /*
- * @test TestRegionSampling
+ * @test id=compact
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+ShenandoahRegionSampling
@@ -65,7 +65,7 @@
  */
 
 /*
- * @test TestRegionSampling
+ * @test id=aggressive
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+ShenandoahRegionSampling
@@ -74,7 +74,7 @@
  */
 
 /*
- * @test TestRegionSampling
+ * @test id=iu-aggressive
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+ShenandoahRegionSampling
@@ -83,7 +83,7 @@
  */
 
 /*
- * @test TestRegionSampling
+ * @test id=iu
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+ShenandoahRegionSampling

--- a/test/hotspot/jtreg/gc/shenandoah/TestResizeTLAB.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestResizeTLAB.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestResizeTLAB
+ * @test id=passive
  * @key randomness
  * @summary Test that Shenandoah is able to work with(out) resizeable TLABs
  * @requires vm.gc.Shenandoah
@@ -59,7 +59,7 @@
  */
 
 /*
- * @test TestResizeTLAB
+ * @test id=aggressive
  * @key randomness
  * @summary Test that Shenandoah is able to work with(out) resizeable TLABs
  * @requires vm.gc.Shenandoah
@@ -79,7 +79,7 @@
  */
 
 /*
- * @test TestResizeTLAB
+ * @test id=adaptive
  * @key randomness
  * @summary Test that Shenandoah is able to work with(out) resizeable TLABs
  * @requires vm.gc.Shenandoah
@@ -99,7 +99,7 @@
  */
 
 /*
- * @test TestResizeTLAB
+ * @test id=static
  * @key randomness
  * @summary Test that Shenandoah is able to work with(out) resizeable TLABs
  * @requires vm.gc.Shenandoah
@@ -119,7 +119,7 @@
  */
 
 /*
- * @test TestResizeTLAB
+ * @test id=compact
  * @key randomness
  * @summary Test that Shenandoah is able to work with(out) resizeable TLABs
  * @requires vm.gc.Shenandoah
@@ -139,7 +139,7 @@
  */
 
 /*
- * @test TestResizeTLAB
+ * @test id=iu-aggressive
  * @key randomness
  * @summary Test that Shenandoah is able to work with(out) resizeable TLABs
  * @requires vm.gc.Shenandoah
@@ -159,7 +159,7 @@
  */
 
 /*
- * @test TestResizeTLAB
+ * @test id=iu
  * @key randomness
  * @summary Test that Shenandoah is able to work with(out) resizeable TLABs
  * @requires vm.gc.Shenandoah

--- a/test/hotspot/jtreg/gc/shenandoah/TestRetainObjects.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestRetainObjects.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestRetainObjects
+ * @test id=passive
  * @summary Acceptance tests: collector can deal with retained objects
  * @requires vm.gc.Shenandoah
  *
@@ -49,7 +49,7 @@
  */
 
 /*
- * @test TestRetainObjects
+ * @test id=aggressive
  * @summary Acceptance tests: collector can deal with retained objects
  * @requires vm.gc.Shenandoah
  *
@@ -69,7 +69,7 @@
  */
 
 /*
- * @test TestRetainObjects
+ * @test id=adaptive
  * @summary Acceptance tests: collector can deal with retained objects
  * @requires vm.gc.Shenandoah
  *
@@ -84,7 +84,7 @@
  */
 
 /*
- * @test TestRetainObjects
+ * @test id=static
  * @summary Acceptance tests: collector can deal with retained objects
  * @requires vm.gc.Shenandoah
  *
@@ -94,7 +94,7 @@
  */
 
 /*
- * @test TestRetainObjects
+ * @test id=compact
  * @summary Acceptance tests: collector can deal with retained objects
  * @requires vm.gc.Shenandoah
  *
@@ -104,7 +104,7 @@
  */
 
 /*
- * @test TestRetainObjects
+ * @test id=no-tlab
  * @summary Acceptance tests: collector can deal with retained objects
  * @requires vm.gc.Shenandoah
  *
@@ -115,7 +115,7 @@
  */
 
 /*
- * @test TestRetainObjects
+ * @test id=iu-aggressive
  * @summary Acceptance tests: collector can deal with retained objects
  * @requires vm.gc.Shenandoah
  *
@@ -135,7 +135,7 @@
  */
 
 /*
- * @test TestRetainObjects
+ * @test id=iu
  * @summary Acceptance tests: collector can deal with retained objects
  * @requires vm.gc.Shenandoah
  *

--- a/test/hotspot/jtreg/gc/shenandoah/TestSieveObjects.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestSieveObjects.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestSieveObjects
+ * @test id=passive
  * @summary Acceptance tests: collector can deal with retained objects
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -51,7 +51,7 @@
  */
 
 /*
- * @test TestSieveObjects
+ * @test id=aggressive
  * @summary Acceptance tests: collector can deal with retained objects
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -73,7 +73,7 @@
  */
 
 /*
- * @test TestSieveObjects
+ * @test id=adaptive
  * @summary Acceptance tests: collector can deal with retained objects
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -91,7 +91,7 @@
  */
 
 /*
- * @test TestSieveObjects
+ * @test id=static
  * @summary Acceptance tests: collector can deal with retained objects
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -103,7 +103,7 @@
  */
 
 /*
- * @test TestSieveObjects
+ * @test id=compact
  * @summary Acceptance tests: collector can deal with retained objects
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -115,7 +115,7 @@
  */
 
 /*
- * @test TestSieveObjects
+ * @test id=no-tlab
  * @summary Acceptance tests: collector can deal with retained objects
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -128,7 +128,7 @@
  */
 
 /*
- * @test TestSieveObjects
+ * @test id=iu-aggressive
  * @summary Acceptance tests: collector can deal with retained objects
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -150,7 +150,7 @@
  */
 
 /*
- * @test TestSieveObjects
+ * @test id=iu
  * @summary Acceptance tests: collector can deal with retained objects
  * @key randomness
  * @requires vm.gc.Shenandoah

--- a/test/hotspot/jtreg/gc/shenandoah/TestSmallHeap.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestSmallHeap.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestSmallHeap
+ * @test
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC         TestSmallHeap

--- a/test/hotspot/jtreg/gc/shenandoah/TestStringDedup.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestStringDedup.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestStringDedup
+ * @test id=passive
  * @summary Test Shenandoah string deduplication implementation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -44,7 +44,7 @@
  */
 
 /*
- * @test TestStringDedup
+ * @test id=default
  * @summary Test Shenandoah string deduplication implementation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -67,7 +67,7 @@
  */
 
 /*
- * @test TestStringDedup
+ * @test id=iu
  * @summary Test Shenandoah string deduplication implementation
  * @key randomness
  * @requires vm.gc.Shenandoah

--- a/test/hotspot/jtreg/gc/shenandoah/TestStringDedupStress.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestStringDedupStress.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestStringDedupStress
+ * @test id=passive
  * @summary Test Shenandoah string deduplication implementation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -44,7 +44,7 @@
  */
 
 /*
- * @test TestStringDedupStress
+ * @test id=default
  * @summary Test Shenandoah string deduplication implementation
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -75,7 +75,7 @@
  */
 
  /*
- * @test TestStringDedupStress
+ * @test id=iu
  * @summary Test Shenandoah string deduplication implementation
  * @key randomness
  * @requires vm.gc.Shenandoah

--- a/test/hotspot/jtreg/gc/shenandoah/TestStringInternCleanup.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestStringInternCleanup.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestStringInternCleanup
+ * @test id=passive
  * @summary Check that Shenandoah cleans up interned strings
  * @requires vm.gc.Shenandoah
  *
@@ -49,7 +49,7 @@
  */
 
 /*
- * @test TestStringInternCleanup
+ * @test id=default
  * @summary Check that Shenandoah cleans up interned strings
  * @requires vm.gc.Shenandoah
  *
@@ -76,7 +76,7 @@
  */
 
 /*
- * @test TestStringInternCleanup
+ * @test id=iu
  * @summary Check that Shenandoah cleans up interned strings
  * @requires vm.gc.Shenandoah
  *

--- a/test/hotspot/jtreg/gc/shenandoah/TestVerifyJCStress.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestVerifyJCStress.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestVerifyJCStress
+ * @test id=passive
  * @summary Tests that we pass at least one jcstress-like test with all verification turned on
  * @requires vm.gc.Shenandoah
  * @modules java.base/jdk.internal.misc
@@ -41,7 +41,7 @@
  */
 
 /*
- * @test TestVerifyJCStress
+ * @test id=default
  * @summary Tests that we pass at least one jcstress-like test with all verification turned on
  * @requires vm.gc.Shenandoah
  * @modules java.base/jdk.internal.misc
@@ -59,7 +59,7 @@
  */
 
 /*
- * @test TestVerifyJCStress
+ * @test id=iu
  * @summary Tests that we pass at least one jcstress-like test with all verification turned on
  * @requires vm.gc.Shenandoah
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/shenandoah/TestVerifyLevels.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestVerifyLevels.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestVerifyLevels
+ * @test
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:+UnlockDiagnosticVMOptions -Xmx128m -XX:+ShenandoahVerify -XX:ShenandoahVerifyLevel=0 TestVerifyLevels

--- a/test/hotspot/jtreg/gc/shenandoah/TestWithLogLevel.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestWithLogLevel.java
@@ -23,7 +23,7 @@
  */
 
  /*
- * @test TestWithLogLevel
+ * @test
  * @summary Test Shenandoah with different log levels
  * @requires vm.gc.Shenandoah
  *

--- a/test/hotspot/jtreg/gc/shenandoah/TestWrongArrayMember.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestWrongArrayMember.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestWrongArrayMember
+ * @test
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx128m -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC                         TestWrongArrayMember

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/FoldIfAfterExpansion.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/FoldIfAfterExpansion.java
@@ -22,7 +22,8 @@
  */
 
 /**
- * @test 8238385
+ * @test
+ * @bug 8238385
  * @summary CTW: C2 (Shenandoah) compilation fails with "Range check dependent CastII node was not removed"
  * @requires vm.gc.Shenandoah
  * @modules java.base/jdk.internal.misc:+open

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestC1ArrayCopyNPE.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestC1ArrayCopyNPE.java
@@ -22,7 +22,7 @@
  *
  */
 
-/* @test TestC1ArrayCopyNPE
+/* @test
  * @summary test C1 arraycopy intrinsic
  * @requires vm.gc.Shenandoah
  * @run main/othervm -XX:TieredStopAtLevel=1 -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive TestC1ArrayCopyNPE

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestC1VectorizedMismatch.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestC1VectorizedMismatch.java
@@ -22,7 +22,7 @@
  *
  */
 
-/* @test TestC1VectorizedMismatch
+/* @test
  * @summary test C1 vectorized mismatch intrinsic
  * @key randomness
  * @requires vm.gc.Shenandoah

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestClone.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestClone.java
@@ -22,7 +22,7 @@
  */
 
 /*
- * @test TestClone
+ * @test id=default
  * @summary Test clone barriers work correctly
  * @requires vm.gc.Shenandoah
  *
@@ -48,7 +48,7 @@
  */
 
 /*
- * @test TestClone
+ * @test id=default-verify
  * @summary Test clone barriers work correctly
  * @requires vm.gc.Shenandoah
  *
@@ -79,7 +79,7 @@
  */
 
 /*
- * @test TestClone
+ * @test id=aggressive
  * @summary Test clone barriers work correctly
  * @requires vm.gc.Shenandoah
  *
@@ -105,39 +105,7 @@
  */
 
 /*
- * @test TestClone
- * @summary Test clone barriers work correctly
- * @requires vm.gc.Shenandoah
- * @requires vm.bits == "64"
- *
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
- *                   -XX:-UseCompressedOops
- *                   -XX:+UseShenandoahGC
- *                   TestClone
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
- *                   -XX:-UseCompressedOops
- *                   -XX:+UseShenandoahGC
- *                   -Xint
- *                   TestClone
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
- *                   -XX:-UseCompressedOops
- *                   -XX:+UseShenandoahGC
- *                   -XX:-TieredCompilation
- *                   TestClone
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
- *                   -XX:-UseCompressedOops
- *                   -XX:+UseShenandoahGC
- *                   -XX:TieredStopAtLevel=1
- *                   TestClone
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
- *                   -XX:-UseCompressedOops
- *                   -XX:+UseShenandoahGC
- *                   -XX:TieredStopAtLevel=4
- *                   TestClone
- */
-
-/*
- * @test TestClone
+ * @test id=no-coops
  * @summary Test clone barriers work correctly
  * @requires vm.gc.Shenandoah
  * @requires vm.bits == "64"
@@ -145,6 +113,38 @@
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
  *                   -XX:-UseCompressedOops
  *                   -XX:+UseShenandoahGC
+ *                   TestClone
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
+ *                   -XX:-UseCompressedOops
+ *                   -XX:+UseShenandoahGC
+ *                   -Xint
+ *                   TestClone
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
+ *                   -XX:-UseCompressedOops
+ *                   -XX:+UseShenandoahGC
+ *                   -XX:-TieredCompilation
+ *                   TestClone
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
+ *                   -XX:-UseCompressedOops
+ *                   -XX:+UseShenandoahGC
+ *                   -XX:TieredStopAtLevel=1
+ *                   TestClone
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
+ *                   -XX:-UseCompressedOops
+ *                   -XX:+UseShenandoahGC
+ *                   -XX:TieredStopAtLevel=4
+ *                   TestClone
+ */
+
+/*
+ * @test id=no-coops-verify
+ * @summary Test clone barriers work correctly
+ * @requires vm.gc.Shenandoah
+ * @requires vm.bits == "64"
+ *
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
+ *                   -XX:-UseCompressedOops
+ *                   -XX:+UseShenandoahGC
  *                   -XX:+ShenandoahVerify
  *                   TestClone
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xms1g -Xmx1g
@@ -174,7 +174,7 @@
  */
 
 /*
- * @test TestClone
+ * @test id=no-coops-aggressive
  * @summary Test clone barriers work correctly
  * @requires vm.gc.Shenandoah
  * @requires vm.bits == "64"

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestExpandedWBLostNullCheckDep.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestExpandedWBLostNullCheckDep.java
@@ -22,7 +22,7 @@
  */
 
 /**
- * @test TestExpandedWBLostNullCheckDep
+ * @test
  * @key stress randomness
  * @summary Logic that moves a null check in the expanded barrier may cause a memory access that doesn't depend on the barrier to bypass the null check
  * @requires vm.gc.Shenandoah

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestMaybeNullUnsafeAccess.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestMaybeNullUnsafeAccess.java
@@ -22,7 +22,7 @@
  */
 
 /**
- * @test TestMaybeNullUnsafeAccess
+ * @test
  * @summary cast before unsafe access moved in dominating null check null path causes crash
  * @requires vm.gc.Shenandoah
  * @modules java.base/jdk.internal.misc:+open

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestNullCheck.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestNullCheck.java
@@ -22,7 +22,7 @@
  */
 
 /**
- * @test TestNullCheck
+ * @test
  * @summary implicit null check on brooks pointer must not cause crash
  * @requires vm.gc.Shenandoah
  * @requires vm.bits == "64"

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestReferenceCAS.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestReferenceCAS.java
@@ -27,7 +27,7 @@
  */
 
 /*
- * @test TestReferenceCAS
+ * @test id=default
  * @summary Shenandoah reference CAS test
  * @requires vm.gc.Shenandoah
  * @modules java.base/jdk.internal.misc:+open
@@ -40,7 +40,7 @@
  */
 
 /*
- * @test TestReferenceCAS
+ * @test id=no-coops
  * @summary Shenandoah reference CAS test
  * @requires vm.gc.Shenandoah
  * @requires vm.bits == "64"

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestUnsafeOffheapSwap.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestUnsafeOffheapSwap.java
@@ -22,7 +22,7 @@
  */
 
 /**
- * @test TestUnsafeOffheapSwap
+ * @test
  * @summary Miscompilation in Unsafe off-heap swap routines
  * @requires vm.gc.Shenandoah
  * @modules java.base/jdk.internal.misc:+open

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestWriteBarrierClearControl.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestWriteBarrierClearControl.java
@@ -22,7 +22,7 @@
  */
 
 /**
- * @test TestWriteBarrierClearControl
+ * @test
  * @key stress randomness
  * @summary Clearing control during final graph reshape causes memory barrier to loose dependency on null check
  * @requires vm.gc.Shenandoah

--- a/test/hotspot/jtreg/gc/shenandoah/jni/TestJNICritical.java
+++ b/test/hotspot/jtreg/gc/shenandoah/jni/TestJNICritical.java
@@ -22,7 +22,7 @@
  *
  */
 
-/* @test TestJNICritical
+/* @test
  * @summary test JNI critical arrays support in Shenandoah
  * @key randomness
  * @requires vm.gc.Shenandoah

--- a/test/hotspot/jtreg/gc/shenandoah/jni/TestJNIGlobalRefs.java
+++ b/test/hotspot/jtreg/gc/shenandoah/jni/TestJNIGlobalRefs.java
@@ -22,7 +22,7 @@
  *
  */
 
-/* @test TestJNIGlobalRefs
+/* @test id=aggressive-verify
  * @summary Test JNI Global Refs with Shenandoah
  * @requires vm.gc.Shenandoah
  *
@@ -32,7 +32,7 @@
  *      TestJNIGlobalRefs
  */
 
-/* @test TestJNIGlobalRefs
+/* @test id=aggressive
  * @summary Test JNI Global Refs with Shenandoah
  * @requires vm.gc.Shenandoah
  *

--- a/test/hotspot/jtreg/gc/shenandoah/jni/TestPinnedGarbage.java
+++ b/test/hotspot/jtreg/gc/shenandoah/jni/TestPinnedGarbage.java
@@ -22,7 +22,7 @@
  *
  */
 
-/* @test TestPinnedGarbage
+/* @test id=passive
  * @summary Test that garbage in the pinned region does not crash VM
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -39,7 +39,7 @@
  *      TestPinnedGarbage
  */
 
-/* @test TestPinnedGarbage
+/* @test id=aggressive
  * @summary Test that garbage in the pinned region does not crash VM
  * @key randomness
  * @requires vm.gc.Shenandoah
@@ -48,7 +48,13 @@
  * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx128m
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
  *      TestPinnedGarbage
- *
+ */
+
+/* @test id=verify
+ * @summary Test that garbage in the pinned region does not crash VM
+ * @key randomness
+ * @requires vm.gc.Shenandoah
+ * @library /test/lib
  * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx128m
  *      -XX:+UseShenandoahGC
  *      -XX:+ShenandoahVerify

--- a/test/hotspot/jtreg/gc/shenandoah/jvmti/TestHeapDump.java
+++ b/test/hotspot/jtreg/gc/shenandoah/jvmti/TestHeapDump.java
@@ -23,32 +23,44 @@
  */
 
 /**
- * @test TestHeapDump
+ * @test id=aggressive
  * @summary Tests JVMTI heap dumps
  * @requires vm.gc.Shenandoah
  * @requires vm.jvmti
  * @compile TestHeapDump.java
- * @run main/othervm/native/timeout=300 -agentlib:TestHeapDump -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -Xmx128m -XX:ShenandoahGCHeuristics=aggressive                        TestHeapDump
+ * @run main/othervm/native/timeout=300 -agentlib:TestHeapDump
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ *      -XX:+UseShenandoahGC -Xmx128m
+ *      -XX:ShenandoahGCHeuristics=aggressive
+ *      TestHeapDump
  *
  */
 
 /**
- * @test TestHeapDump
+ * @test id=no-coops-aggressive
  * @summary Tests JVMTI heap dumps
  * @requires vm.gc.Shenandoah
  * @requires vm.jvmti
  * @requires vm.bits == "64"
  * @compile TestHeapDump.java
- * @run main/othervm/native/timeout=300 -agentlib:TestHeapDump -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -Xmx128m -XX:ShenandoahGCHeuristics=aggressive -XX:-UseCompressedOops TestHeapDump
+ * @run main/othervm/native/timeout=300 -agentlib:TestHeapDump
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ *      -XX:+UseShenandoahGC -Xmx128m
+ *      -XX:ShenandoahGCHeuristics=aggressive
+ *      -XX:-UseCompressedOops TestHeapDump
  */
 
 /**
- * @test TestHeapDump
+ * @test id=aggressive-strdedup
  * @summary Tests JVMTI heap dumps
  * @requires vm.gc.Shenandoah
  * @requires vm.jvmti
  * @compile TestHeapDump.java
- * @run main/othervm/native/timeout=300 -agentlib:TestHeapDump -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -Xmx128m -XX:ShenandoahGCHeuristics=aggressive                         -XX:+UseStringDeduplication TestHeapDump
+ * @run main/othervm/native/timeout=300 -agentlib:TestHeapDump
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ *      -XX:+UseShenandoahGC -Xmx128m
+ *      -XX:ShenandoahGCHeuristics=aggressive
+ *      -XX:+UseStringDeduplication TestHeapDump
  */
 
 import java.lang.ref.Reference;

--- a/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestChurnNotifications.java
+++ b/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestChurnNotifications.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestChurnNotifications
+ * @test id=passive
  * @summary Check that MX notifications are reported for all cycles
  * @library /test/lib /
  * @requires vm.gc.Shenandoah
@@ -40,7 +40,7 @@
  */
 
 /*
- * @test TestChurnNotifications
+ * @test id=aggressive
  * @summary Check that MX notifications are reported for all cycles
  * @library /test/lib /
  * @requires vm.gc.Shenandoah
@@ -52,7 +52,7 @@
  */
 
 /*
- * @test TestChurnNotifications
+ * @test id=adaptive
  * @summary Check that MX notifications are reported for all cycles
  * @library /test/lib /
  * @requires vm.gc.Shenandoah
@@ -64,7 +64,7 @@
  */
 
 /*
- * @test TestChurnNotifications
+ * @test id=static
  * @summary Check that MX notifications are reported for all cycles
  * @library /test/lib /
  * @requires vm.gc.Shenandoah
@@ -76,7 +76,7 @@
  */
 
 /*
- * @test TestChurnNotifications
+ * @test id=compact
  * @summary Check that MX notifications are reported for all cycles
  * @library /test/lib /
  * @requires vm.gc.Shenandoah
@@ -88,7 +88,7 @@
  */
 
 /*
- * @test TestChurnNotifications
+ * @test id=iu
  * @summary Check that MX notifications are reported for all cycles
  * @library /test/lib /
  * @requires vm.gc.Shenandoah

--- a/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestMemoryMXBeans.java
+++ b/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestMemoryMXBeans.java
@@ -23,7 +23,7 @@
  */
 
 /**
- * @test TestMemoryMXBeans
+ * @test
  * @summary Test JMX memory beans
  * @requires vm.gc.Shenandoah
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestMemoryPools.java
+++ b/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestMemoryPools.java
@@ -23,7 +23,7 @@
  */
 
 /**
- * @test TestMemoryPools
+ * @test
  * @summary Test JMX memory pools
  * @requires vm.gc.Shenandoah
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestPauseNotifications.java
+++ b/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestPauseNotifications.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestPauseNotifications
+ * @test id=passive
  * @summary Check that MX notifications are reported for all cycles
  * @library /test/lib /
  * @requires vm.gc.Shenandoah
@@ -40,7 +40,7 @@
  */
 
 /*
- * @test TestPauseNotifications
+ * @test id=aggressive
  * @summary Check that MX notifications are reported for all cycles
  * @library /test/lib /
  * @requires vm.gc.Shenandoah
@@ -51,7 +51,7 @@
  */
 
 /*
- * @test TestPauseNotifications
+ * @test id=adaptive
  * @summary Check that MX notifications are reported for all cycles
  * @library /test/lib /
  * @requires vm.gc.Shenandoah
@@ -62,7 +62,7 @@
  */
 
 /*
- * @test TestPauseNotifications
+ * @test id=static
  * @summary Check that MX notifications are reported for all cycles
  * @library /test/lib /
  * @requires vm.gc.Shenandoah
@@ -73,7 +73,7 @@
  */
 
 /*
- * @test TestPauseNotifications
+ * @test id=compact
  * @summary Check that MX notifications are reported for all cycles
  * @library /test/lib /
  * @requires vm.gc.Shenandoah
@@ -84,7 +84,7 @@
  */
 
 /*
- * @test TestPauseNotifications
+ * @test id=iu
  * @summary Check that MX notifications are reported for all cycles
  * @library /test/lib /
  * @requires vm.gc.Shenandoah

--- a/test/hotspot/jtreg/gc/shenandoah/oom/TestAllocLargeObj.java
+++ b/test/hotspot/jtreg/gc/shenandoah/oom/TestAllocLargeObj.java
@@ -23,7 +23,7 @@
  */
 
 /**
- * @test TestAllocLargeObj
+ * @test
  * @summary Test allocation of small object to result OOM, but not to crash JVM
  * @requires vm.gc.Shenandoah
  * @library /test/lib

--- a/test/hotspot/jtreg/gc/shenandoah/oom/TestAllocLargerThanHeap.java
+++ b/test/hotspot/jtreg/gc/shenandoah/oom/TestAllocLargerThanHeap.java
@@ -23,7 +23,7 @@
  */
 
 /**
- * @test TestAllocLargerThanHeap
+ * @test
  * @summary Test that allocation of the object larger than heap fails predictably
  * @requires vm.gc.Shenandoah
  * @library /test/lib

--- a/test/hotspot/jtreg/gc/shenandoah/oom/TestAllocSmallObj.java
+++ b/test/hotspot/jtreg/gc/shenandoah/oom/TestAllocSmallObj.java
@@ -23,7 +23,7 @@
  */
 
 /**
- * @test TestAllocSmallObj
+ * @test
  * @summary Test allocation of small object to result OOM, but not to crash JVM
  * @requires vm.gc.Shenandoah
  * @library /test/lib

--- a/test/hotspot/jtreg/gc/shenandoah/oom/TestClassLoaderLeak.java
+++ b/test/hotspot/jtreg/gc/shenandoah/oom/TestClassLoaderLeak.java
@@ -23,7 +23,7 @@
  */
 
 /**
- * @test TestClassLoaderLeak
+ * @test
  * @summary Test OOME in due to classloader leak
  * @requires vm.gc.Shenandoah
  * @library /test/lib

--- a/test/hotspot/jtreg/gc/shenandoah/oom/TestThreadFailure.java
+++ b/test/hotspot/jtreg/gc/shenandoah/oom/TestThreadFailure.java
@@ -23,7 +23,7 @@
  */
 
 /**
- * @test TestThreadFailure
+ * @test
  * @summary Test OOME in separate thread is recoverable
  * @requires vm.gc.Shenandoah
  * @library /test/lib

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestAlwaysPreTouch.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestAlwaysPreTouch.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestAlwaysPreTouch
+ * @test
  * @summary Check that Shenandoah's AlwaysPreTouch does not fire asserts
  * @requires vm.gc.Shenandoah
  *

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestArgumentRanges.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestArgumentRanges.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestArgumentRanges
+ * @test
  * @summary Test that Shenandoah arguments are checked for ranges where applicable
  * @requires vm.gc.Shenandoah
  * @library /test/lib

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestClassUnloadingArguments.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestClassUnloadingArguments.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestClassUnloadingArguments
+ * @test
  * @summary Test that loop mining arguments are sane
  * @requires vm.gc.Shenandoah
  * @library /test/lib

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestEnabled.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestEnabled.java
@@ -25,14 +25,14 @@ import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 
 /*
- * @test TestEnabled
+ * @test id=default
  * @requires vm.gc.Shenandoah & vm.gc == "null"
  * @run main/othervm -Dexpected=false -Xmx64m                                                       TestEnabled
  * @run main/othervm -Dexpected=true  -Xmx64m -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC TestEnabled
  */
 
 /*
- * @test TestEnabledAlready
+ * @test id=already
  * @requires vm.gc.Shenandoah & vm.gc == "Shenandoah"
  * @run main/othervm -Dexpected=true -Xmx64m                                                        TestEnabled
  */

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestExplicitGC.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestExplicitGC.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestExplicitGC
+ * @test
  * @summary Test that Shenandoah reacts to explicit GC flags appropriately
  * @requires vm.gc.Shenandoah
  * @library /test/lib

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestExplicitGCNoConcurrent.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestExplicitGCNoConcurrent.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestExplicitGCNoConcurrent
+ * @test
  * @summary Test that Shenandoah reacts to explicit GC flags appropriately
  * @requires vm.gc.Shenandoah
  * @library /test/lib

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestHeuristicsUnlock.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestHeuristicsUnlock.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestHeuristicsUnlock
+ * @test
  * @summary Test that Shenandoah heuristics are unlocked properly
  * @requires vm.gc.Shenandoah
  * @library /test/lib

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestHumongousMoves.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestHumongousMoves.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestHumongousMoves
+ * @test
  * @summary Check Shenandoah reacts on setting humongous moves correctly
  * @key randomness
  * @requires vm.gc.Shenandoah

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestHumongousThresholdArgs.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestHumongousThresholdArgs.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestHumongousThresholdArgs
+ * @test
  * @summary Test that Shenandoah humongous threshold args are checked
  * @requires vm.gc.Shenandoah
  * @library /test/lib

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestLoopMiningArguments.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestLoopMiningArguments.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestLoopMiningArguments
+ * @test
  * @summary Test that loop mining arguments are sane
  * @requires vm.gc.Shenandoah
  * @requires vm.flavor == "server"

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestModeUnlock.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestModeUnlock.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestModeUnlock
+ * @test
  * @summary Test that Shenandoah modes are unlocked properly
  * @requires vm.gc.Shenandoah
  * @library /test/lib

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestObjectAlignment.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestObjectAlignment.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestObjectAlignment
+ * @test id=default
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC          TestObjectAlignment
@@ -37,7 +37,7 @@
  */
 
 /*
- * @test TestObjectAlignment
+ * @test id=16b
  * @requires vm.gc.Shenandoah
  * @requires vm.bits == "64"
  *

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestPacing.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestPacing.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestPacing
+ * @test
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:-ShenandoahPacing -Xmx128m TestPacing

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestParallelRegionStride.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestParallelRegionStride.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestParallelRegionStride
+ * @test
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahParallelRegionStride=1    -Xmx128m TestParallelRegionStride

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestRegionSizeArgs.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestRegionSizeArgs.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestRegionSizeArgs
+ * @test
  * @summary Test that Shenandoah region size args are checked
  * @requires vm.gc.Shenandoah
  * @library /test/lib

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestSelectiveBarrierFlags.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestSelectiveBarrierFlags.java
@@ -22,7 +22,7 @@
  *
  */
 
-/* @test TestSelectiveBarrierFlags
+/* @test
  * @summary Test selective barrier enabling works, by aggressively compiling HelloWorld with combinations
  *          of barrier flags
  * @requires vm.gc.Shenandoah

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestSingleThreaded.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestSingleThreaded.java
@@ -22,7 +22,7 @@
  *
  */
 
-/* @test TestSingleThreaded
+/* @test
  * @summary test single worker threaded Shenandoah
  * @requires vm.gc.Shenandoah
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestSoftMaxHeapSize.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestSoftMaxHeapSize.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestSoftMaxHeapSize
+ * @test
  * @summary Test that Shenandoah checks SoftMaxHeapSize
  * @requires vm.gc.Shenandoah
  * @library /test/lib

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestThreadCounts.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestThreadCounts.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestThreadCounts
+ * @test
  * @summary Test that Shenandoah GC thread counts are handled well
  * @requires vm.gc.Shenandoah
  * @library /test/lib

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestThreadCountsOverride.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestThreadCountsOverride.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestThreadCountsOverride
+ * @test
  * @summary Test that Shenandoah GC thread counts are overridable
  * @requires vm.gc.Shenandoah
  * @library /test/lib

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestWrongBarrierDisable.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestWrongBarrierDisable.java
@@ -22,7 +22,7 @@
  *
  */
 
-/* @test TestWrongBarrierDisable
+/* @test
  * @summary Test that disabling wrong barriers fails early
  * @requires vm.gc.Shenandoah
  * @library /test/lib

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestWrongBarrierEnable.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestWrongBarrierEnable.java
@@ -22,7 +22,7 @@
  *
  */
 
-/* @test TestWrongBarrierEnable
+/* @test
  * @summary Test that disabling wrong barriers fails early
  * @requires vm.gc.Shenandoah
  * @library /test/lib

--- a/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithShenandoah.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithShenandoah.java
@@ -27,7 +27,7 @@ package gc.stress.gcbasher;
 import java.io.IOException;
 
 /*
- * @test TestGCBasherWithShenandoah
+ * @test id=passive
  * @key stress
  * @library /
  * @requires vm.gc.Shenandoah
@@ -46,7 +46,7 @@ import java.io.IOException;
  */
 
 /*
- * @test TestGCBasherWithShenandoah
+ * @test id=aggressive
  * @key stress
  * @library /
  * @requires vm.gc.Shenandoah
@@ -69,7 +69,7 @@ import java.io.IOException;
  */
 
 /*
- * @test TestGCBasherWithShenandoah
+ * @test id=adaptive
  * @key stress
  * @library /
  * @requires vm.gc.Shenandoah
@@ -87,7 +87,7 @@ import java.io.IOException;
  */
 
 /*
- * @test TestGCBasherDeoptWithShenandoah
+ * @test id=compact
  * @key stress
  * @library /
  * @requires vm.gc.Shenandoah
@@ -100,7 +100,7 @@ import java.io.IOException;
  */
 
 /*
- * @test TestGCBasherWithShenandoah
+ * @test id=iu-aggressive
  * @key stress
  * @library /
  * @requires vm.gc.Shenandoah
@@ -123,7 +123,7 @@ import java.io.IOException;
  */
 
 /*
- * @test TestGCBasherWithShenandoah
+ * @test id=iu
  * @key stress
  * @library /
  * @requires vm.gc.Shenandoah
@@ -141,7 +141,7 @@ import java.io.IOException;
  */
 
 /*
- * @test TestGCBasherDeoptWithShenandoah
+ * @test id=passive-deopt-nmethod
  * @key stress
  * @library /
  * @requires vm.gc.Shenandoah
@@ -162,7 +162,7 @@ import java.io.IOException;
  */
 
 /*
- * @test TestGCBasherDeoptWithShenandoah
+ * @test id=aggressive-deopt-nmethod
  * @key stress
  * @library /
  * @requires vm.gc.Shenandoah
@@ -188,7 +188,7 @@ import java.io.IOException;
  */
 
 /*
- * @test TestGCBasherDeoptWithShenandoah
+ * @test id=adaptive-deopt-nmethod
  * @key stress
  * @library /
  * @requires vm.gc.Shenandoah
@@ -208,7 +208,7 @@ import java.io.IOException;
  */
 
 /*
- * @test TestGCBasherDeoptWithShenandoah
+ * @test id=compact-deopt-nmethod
  * @key stress
  * @library /
  * @requires vm.gc.Shenandoah
@@ -222,7 +222,7 @@ import java.io.IOException;
  */
 
 /*
- * @test TestGCBasherDeoptWithShenandoah
+ * @test id=iu-aggressive-deopt-nmethod
  * @key stress
  * @library /
  * @requires vm.gc.Shenandoah
@@ -248,7 +248,7 @@ import java.io.IOException;
  */
 
 /*
- * @test TestGCBasherDeoptWithShenandoah
+ * @test id=iu-deopt-nmethod
  * @key stress
  * @library /
  * @requires vm.gc.Shenandoah

--- a/test/hotspot/jtreg/gc/stress/gclocker/TestGCLockerWithShenandoah.java
+++ b/test/hotspot/jtreg/gc/stress/gclocker/TestGCLockerWithShenandoah.java
@@ -25,7 +25,7 @@
 package gc.stress.gclocker;
 
 /*
- * @test TestGCLockerWithShenandoah
+ * @test id=default
  * @library /
  * @requires vm.gc.Shenandoah
  * @summary Stress Shenandoah's JNI handling by calling GetPrimitiveArrayCritical while concurrently filling up old gen.
@@ -41,7 +41,7 @@ package gc.stress.gclocker;
  */
 
 /*
- * @test TestGCLockerWithShenandoah
+ * @test id=aggressive
  * @library /
  * @requires vm.gc.Shenandoah
  * @summary Stress Shenandoah's JNI handling by calling GetPrimitiveArrayCritical while concurrently filling up old gen.

--- a/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithShenandoah.java
+++ b/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithShenandoah.java
@@ -24,7 +24,7 @@
 package gc.stress.gcold;
 
 /*
- * @test TestGCOldWithShenandoah
+ * @test id=passive
  * @key stress randomness
  * @library / /test/lib
  * @requires vm.gc.Shenandoah
@@ -52,7 +52,7 @@ package gc.stress.gcold;
  */
 
 /*
- * @test TestGCOldWithShenandoah
+ * @test id=aggressive
  * @key stress randomness
  * @library / /test/lib
  * @requires vm.gc.Shenandoah
@@ -74,7 +74,7 @@ package gc.stress.gcold;
  */
 
 /*
- * @test TestGCOldWithShenandoah
+ * @test id=adaptive
  * @key stress randomness
  * @library / /test/lib
  * @requires vm.gc.Shenandoah
@@ -91,7 +91,7 @@ package gc.stress.gcold;
  */
 
 /*
- * @test TestGCOldWithShenandoah
+ * @test id=compact
  * @key stress randomness
  * @library / /test/lib
  * @requires vm.gc.Shenandoah
@@ -103,7 +103,7 @@ package gc.stress.gcold;
  */
 
 /*
- * @test TestGCOldWithShenandoah
+ * @test id=iu-aggressive
  * @key stress randomness
  * @library / /test/lib
  * @requires vm.gc.Shenandoah
@@ -125,7 +125,7 @@ package gc.stress.gcold;
  */
 
 /*
- * @test TestGCOldWithShenandoah
+ * @test id=iu
  * @key stress randomness
  * @library / /test/lib
  * @requires vm.gc.Shenandoah

--- a/test/hotspot/jtreg/gc/stress/systemgc/TestSystemGCWithShenandoah.java
+++ b/test/hotspot/jtreg/gc/stress/systemgc/TestSystemGCWithShenandoah.java
@@ -25,7 +25,7 @@
 package gc.stress.systemgc;
 
 /*
- * @test TestSystemGCWithShenandoah
+ * @test id=default
  * @key stress
  * @library /
  * @requires vm.gc.Shenandoah
@@ -42,7 +42,7 @@ package gc.stress.systemgc;
  */
 
 /*
- * @test TestSystemGCWithShenandoah
+ * @test id=iu
  * @key stress
  * @library /
  * @requires vm.gc.Shenandoah


### PR DESCRIPTION
`hotspot_gc_shenandoah` contains a lot of parallel test configurations, and it would be much nicer to have them named appropriately, rather than just #id1...#id2.

Additional testing:
 - [x] `hotspot_gc_shenandoah`, eyeballing test names

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270094](https://bugs.openjdk.java.net/browse/JDK-8270094): Shenandoah: Provide human-readable labels for test configurations


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4726/head:pull/4726` \
`$ git checkout pull/4726`

Update a local copy of the PR: \
`$ git checkout pull/4726` \
`$ git pull https://git.openjdk.java.net/jdk pull/4726/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4726`

View PR using the GUI difftool: \
`$ git pr show -t 4726`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4726.diff">https://git.openjdk.java.net/jdk/pull/4726.diff</a>

</details>
