### PR TITLE
8270100: Fix some inaccurate GC logging

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -313,14 +313,14 @@ bool DefNewGeneration::expand(size_t bytes) {
   return success;
 }
 
-size_t DefNewGeneration::adjust_for_thread_increase(size_t new_size_candidate,
-                                                    size_t new_size_before,
-                                                    size_t alignment) const {
+size_t DefNewGeneration::adjust_for_thread_increase(size_t  new_size_candidate,
+                                                    size_t  new_size_before,
+                                                    size_t  alignment,
+                                                    int&    threads_count,
+                                                    size_t& thread_increase_size) const {
   size_t desired_new_size = new_size_before;
 
   if (NewSizeThreadIncrease > 0) {
-    int threads_count;
-    size_t thread_increase_size = 0;
 
     // 1. Check an overflow at 'threads_count * NewSizeThreadIncrease'.
     threads_count = Threads::number_of_non_daemon_threads();
@@ -370,7 +370,8 @@ void DefNewGeneration::compute_new_size() {
   size_t new_size_candidate = old_size / NewRatio;
   // Compute desired new generation size based on NewRatio and NewSizeThreadIncrease
   // and reverts to previous value if any overflow happens
-  size_t desired_new_size = adjust_for_thread_increase(new_size_candidate, new_size_before, alignment);
+  size_t desired_new_size = adjust_for_thread_increase(new_size_candidate, new_size_before, alignment,
+                                                       threads_count, thread_increase_size);
 
   // Adjust new generation size
   desired_new_size = clamp(desired_new_size, min_new_size, max_new_size);

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -339,9 +339,11 @@ protected:
 
   // Return adjusted new size for NewSizeThreadIncrease.
   // If any overflow happens, revert to previous new size.
-  size_t adjust_for_thread_increase(size_t new_size_candidate,
-                                    size_t new_size_before,
-                                    size_t alignment) const;
+  size_t adjust_for_thread_increase(size_t  new_size_candidate,
+                                    size_t  new_size_before,
+                                    size_t  alignment,
+                                    int&    threads_count,
+                                    size_t& thread_increase_size) const;
 
 
   // Scavenge support

--- a/src/hotspot/share/gc/shared/cardGeneration.cpp
+++ b/src/hotspot/share/gc/shared/cardGeneration.cpp
@@ -272,8 +272,8 @@ void CardGeneration::compute_new_size() {
                                initial_size() / (double) K, maximum_desired_capacity / (double) K);
       log_trace(gc, heap)("    shrink_bytes: %.1fK  current_shrink_factor: " SIZE_FORMAT "  new shrink factor: " SIZE_FORMAT "  _min_heap_delta_bytes: %.1fK",
                                shrink_bytes / (double) K,
-                               current_shrink_factor,
-                               _shrink_factor,
+                               ShrinkHeapInSteps ? current_shrink_factor : 100,
+                               ShrinkHeapInSteps ? _shrink_factor : 100,
                                _min_heap_delta_bytes / (double) K);
     }
   }


### PR DESCRIPTION
If running with `-Xlog:gc+heap*=trace` the JVM will print the extra per thread amount which is added to the new generation on resize:
```
[0,105s][debug][gc,ergo,heap ] GC(0) New generation size 34112K->34176K [eden=27392K,survivor=3392K]
[0,105s][trace][gc,ergo,heap ] GC(0) [allowed 0K extra for 0 threads]
```
Currently this will always print "0K extra for 0 threads" no matter how much extra space was added.

Also, the shrink factor will always be printed to be 0%, even if we run with `-XX:-ShrinkHeapInSteps` which pins the shrink factor at 100%:
```
[13,213s][trace][gc,heap ] GC(34) shrink_bytes: 463564,0K current_shrink_factor: 0 new shrink factor: 0 _min_heap_delta_bytes: 192,0K
[13,239s][trace][gc,heap ] GC(34) Shrinking tenured generation from 531852K to 68288K
```

The fix is trivial.