### PR TITLE
JDK-8266565: Spec of ForwardingJavaFileManager/ForwardingFileObject/ForwardingJavaFileObject methods should mention delegation instead of being copied

### DIFF
--- a/src/java.compiler/share/classes/javax/tools/ForwardingFileObject.java
+++ b/src/java.compiler/share/classes/javax/tools/ForwardingFileObject.java
@@ -38,6 +38,9 @@ import java.util.Objects;
  * might override some of these methods and might also provide
  * additional fields and methods.
  *
+ * <p>Unless stated otherwise, references in this class to "<em>this file object</em>"
+ * should be interpreted as referring indirectly to the {@link #fileObject delegate file object}.
+ *
  * @param <F> the kind of file object forwarded to by this object
  * @author Peter von der Ah&eacute;
  * @since 1.6
@@ -45,7 +48,7 @@ import java.util.Objects;
 public class ForwardingFileObject<F extends FileObject> implements FileObject {
 
     /**
-     * The file object which all methods are delegated to.
+     * The file object to which all methods are delegated.
      */
     protected final F fileObject;
 

--- a/src/java.compiler/share/classes/javax/tools/ForwardingJavaFileManager.java
+++ b/src/java.compiler/share/classes/javax/tools/ForwardingJavaFileManager.java
@@ -37,6 +37,9 @@ import javax.tools.JavaFileObject.Kind;
  * might override some of these methods and might also provide
  * additional fields and methods.
  *
+ * <p>Unless stated otherwise, references in this class to "<em>this file manager</em>"
+ * should be interpreted as referring indirectly to the {@link #fileManager delegate file manager}.
+ *
  * @param <M> the kind of file manager forwarded to by this object
  * @author Peter von der Ah&eacute;
  * @since 1.6
@@ -44,7 +47,7 @@ import javax.tools.JavaFileObject.Kind;
 public class ForwardingJavaFileManager<M extends JavaFileManager> implements JavaFileManager {
 
     /**
-     * The file manager which all methods are delegated to.
+     * The file manager to which all methods are delegated.
      */
     protected final M fileManager;
 

--- a/src/java.compiler/share/classes/javax/tools/ForwardingJavaFileObject.java
+++ b/src/java.compiler/share/classes/javax/tools/ForwardingJavaFileObject.java
@@ -33,6 +33,9 @@ import javax.lang.model.element.NestingKind;
  * might override some of these methods and might also provide
  * additional fields and methods.
  *
+ * <p>Unless stated otherwise, references in this class to "<em>this file object</em>"
+ * should be interpreted as referring indirectly to the {@link #fileObject delegate file object}.
+ *
  * @param <F> the kind of file object forwarded to by this object
  * @author Peter von der Ah&eacute;
  * @since 1.6


### PR DESCRIPTION
Please review a simple doc-only clarification to the spec for the `Forwarding...` classes in `javax.tools`.

The change is as in the CSR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266565](https://bugs.openjdk.java.net/browse/JDK-8266565): Spec of ForwardingJavaFileManager/ForwardingFileObject/ForwardingJavaFileObject methods should mention delegation instead of being copied


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4735/head:pull/4735` \
`$ git checkout pull/4735`

Update a local copy of the PR: \
`$ git checkout pull/4735` \
`$ git pull https://git.openjdk.java.net/jdk pull/4735/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4735`

View PR using the GUI difftool: \
`$ git pr show -t 4735`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4735.diff">https://git.openjdk.java.net/jdk/pull/4735.diff</a>

</details>
