### PR TITLE
8267281: Call prepare_for_dynamic_dumping for jcmd dynamic_dump

### DIFF
--- a/src/hotspot/share/cds/dynamicArchive.cpp
+++ b/src/hotspot/share/cds/dynamicArchive.cpp
@@ -346,10 +346,10 @@ public:
   }
 };
 
-void DynamicArchive::prepare_for_dynamic_dumping_at_exit() {
+void DynamicArchive::prepare_for_dynamic_dumping() {
   EXCEPTION_MARK;
   ResourceMark rm(THREAD);
-  MetaspaceShared::link_and_cleanup_shared_classes(THREAD);
+  MetaspaceShared::link_shared_classes(THREAD);
   if (HAS_PENDING_EXCEPTION) {
     log_error(cds)("ArchiveClassesAtExit has failed");
     log_error(cds)("%s: %s", PENDING_EXCEPTION->klass()->external_name(),
@@ -365,6 +365,7 @@ void DynamicArchive::dump(const char* archive_name, TRAPS) {
   assert(ArchiveClassesAtExit == nullptr, "already checked in arguments.cpp?");
   ArchiveClassesAtExit = archive_name;
   if (Arguments::init_shared_archive_paths()) {
+    prepare_for_dynamic_dumping();
     dump(CHECK);
   } else {
     ArchiveClassesAtExit = nullptr;

--- a/src/hotspot/share/cds/dynamicArchive.cpp
+++ b/src/hotspot/share/cds/dynamicArchive.cpp
@@ -351,7 +351,7 @@ void DynamicArchive::prepare_for_dynamic_dumping() {
   ResourceMark rm(THREAD);
   MetaspaceShared::link_shared_classes(THREAD);
   if (HAS_PENDING_EXCEPTION) {
-    log_error(cds)("ArchiveClassesAtExit has failed");
+    log_error(cds)("Dynamic dump has failed");
     log_error(cds)("%s: %s", PENDING_EXCEPTION->klass()->external_name(),
                    java_lang_String::as_utf8_string(java_lang_Throwable::message(PENDING_EXCEPTION)));
     // We cannot continue to dump the archive anymore.
@@ -366,7 +366,9 @@ void DynamicArchive::dump(const char* archive_name, TRAPS) {
   ArchiveClassesAtExit = archive_name;
   if (Arguments::init_shared_archive_paths()) {
     prepare_for_dynamic_dumping();
-    dump(CHECK);
+    if (DynamicDumpSharedSpaces) {
+      dump(CHECK);
+    }
   } else {
     ArchiveClassesAtExit = nullptr;
     THROW_MSG(vmSymbols::java_lang_RuntimeException(),

--- a/src/hotspot/share/cds/dynamicArchive.hpp
+++ b/src/hotspot/share/cds/dynamicArchive.hpp
@@ -59,7 +59,7 @@ public:
 
 class DynamicArchive : AllStatic {
 public:
-  static void prepare_for_dynamic_dumping_at_exit();
+  static void prepare_for_dynamic_dumping();
   static void dump(const char* archive_name, TRAPS);
   static void dump(TRAPS);
   static bool is_mapped() { return FileMapInfo::dynamic_info() != NULL; }

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -592,7 +592,7 @@ bool MetaspaceShared::link_class_for_cds(InstanceKlass* ik, TRAPS) {
   return res;
 }
 
-void MetaspaceShared::link_and_cleanup_shared_classes(TRAPS) {
+void MetaspaceShared::link_shared_classes(TRAPS) {
   // Collect all loaded ClassLoaderData.
   ResourceMark rm;
 
@@ -726,7 +726,7 @@ void MetaspaceShared::preload_and_dump_impl(TRAPS) {
   // were not explicitly specified in the classlist. E.g., if an interface implemented by class K
   // fails verification, all other interfaces that were not specified in the classlist but
   // are implemented by K are not verified.
-  link_and_cleanup_shared_classes(CHECK);
+  link_shared_classes(CHECK);
   log_info(cds)("Rewriting and linking classes: done");
 
 #if INCLUDE_CDS_JAVA_HEAP

--- a/src/hotspot/share/cds/metaspaceShared.hpp
+++ b/src/hotspot/share/cds/metaspaceShared.hpp
@@ -129,7 +129,7 @@ public:
   }
 
   static bool try_link_class(JavaThread* current, InstanceKlass* ik);
-  static void link_and_cleanup_shared_classes(TRAPS) NOT_CDS_RETURN;
+  static void link_shared_classes(TRAPS) NOT_CDS_RETURN;
   static bool link_class_for_cds(InstanceKlass* ik, TRAPS) NOT_CDS_RETURN_(false);
   static bool linking_required(InstanceKlass* ik) NOT_CDS_RETURN_(false);
 

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -424,7 +424,7 @@ JVM_ENTRY_NO_ENV(void, JVM_BeforeHalt())
 #if INCLUDE_CDS
   // Link all classes for dynamic CDS dumping before vm exit.
   if (DynamicDumpSharedSpaces) {
-    DynamicArchive::prepare_for_dynamic_dumping_at_exit();
+    DynamicArchive::prepare_for_dynamic_dumping();
   }
 #endif
   EventShutdown event;

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -3258,7 +3258,7 @@ void JavaThread::invoke_shutdown_hooks() {
   HandleMark hm(this);
 
   // We could get here with a pending exception, if so clear it now or
-  // it will cause MetaspaceShared::link_and_cleanup_shared_classes to
+  // it will cause MetaspaceShared::link_shared_classes to
   // fail for dynamic dump.
   if (this->has_pending_exception()) {
     this->clear_pending_exception();
@@ -3269,7 +3269,7 @@ void JavaThread::invoke_shutdown_hooks() {
   // Same operation is being done in JVM_BeforeHalt for handling the
   // case where the application calls System.exit().
   if (DynamicDumpSharedSpaces) {
-    DynamicArchive::prepare_for_dynamic_dumping_at_exit();
+    DynamicArchive::prepare_for_dynamic_dumping();
   }
 #endif
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestDynamicDumpAtOom.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestDynamicDumpAtOom.java
@@ -53,7 +53,7 @@ public class TestDynamicDumpAtOom extends DynamicArchiveTestBase {
              jarFile,
              mainClass,
              "1024").assertAbnormalExit(output -> {
-                 output.shouldContain("ArchiveClassesAtExit has failed")
+                 output.shouldContain("Dynamic dump has failed")
                        .shouldContain("java.lang.OutOfMemoryError: Java heap space");
              });
     }


### PR DESCRIPTION
Hi, Please review

  When using 'jcmd VM.cds dynamic_dump' to dump dynamic archive, we did not call MetaspaceShared::link_and_cleanup_shared_classes, which is linking linkable shared classes before dump. The classes should be those loaded but not yet linked or loaded during verification. It also will regenerate the lambda form invoker holder classes (those recorded in static archive plus loaded during app run time). For static dump, a separate process spawned to dump the static archive, and for dynamic dump without using jcmd, after dump the process will exit, so this function only called once.  
  With jcmd, we can do multiple dumps to same live process (See bug 8264735) so we need to check if calling this function is safe (do not change runtime data consistency). The lambda form invoker holder classes will be generated every time this function is called either.
  The function name is renamed to link_shared_classes, since the cleanup work is no longer done by this function.

  Tests: tier1,tier3,tier4 (going on to finish, without failure found). 
   
Thanks
Yumin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267281](https://bugs.openjdk.java.net/browse/JDK-8267281): Call prepare_for_dynamic_dumping for jcmd dynamic_dump


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4736/head:pull/4736` \
`$ git checkout pull/4736`

Update a local copy of the PR: \
`$ git checkout pull/4736` \
`$ git pull https://git.openjdk.java.net/jdk pull/4736/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4736`

View PR using the GUI difftool: \
`$ git pr show -t 4736`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4736.diff">https://git.openjdk.java.net/jdk/pull/4736.diff</a>

</details>
