### PR TITLE
8247351: [aarch64] NullPointerException during stack walking (clhsdb "where -a")

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/RegisterMap.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/RegisterMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -146,7 +146,7 @@ public abstract class RegisterMap implements Cloneable {
       Assert.that(0 <= i && i < regCount, "sanity check");
       Assert.that(0 <= index && index < locationValidSize, "sanity check");
     }
-    if ((locationValid[index] & (1 << i % locationValidTypeSize)) != 0) {
+    if ((locationValid[index] & (1L << i % locationValidTypeSize)) != 0) {
       return location[i];
     } else {
       return getLocationPD(reg);
@@ -162,7 +162,7 @@ public abstract class RegisterMap implements Cloneable {
       Assert.that(updateMap, "updating map that does not need updating");
     }
     location[i]          = loc;
-    locationValid[index] |= (1 << (i % locationValidTypeSize));
+    locationValid[index] |= (1L << (i % locationValidTypeSize));
   }
 
   public boolean getIncludeArgumentOops() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/aarch64/AARCH64Frame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/aarch64/AARCH64Frame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2015, 2019, Red Hat Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -70,7 +70,7 @@ public class AARCH64Frame extends Frame {
   // Native frames
   private static final int NATIVE_FRAME_INITIAL_PARAM_OFFSET =  2;
 
-  private static VMReg fp = new VMReg(29);
+  private static VMReg fp = new VMReg(29 << 1);
 
   static {
     VM.registerVMInitializedObserver(new Observer() {


### PR DESCRIPTION
Running the jtreg test serviceability/sa/ClhsdbWhere.java with -Xcomp
-XX:-TieredCompilation fails with the following exception:

  Error: java.lang.NullPointerException: Cannot invoke "sun.jvm.hotspot.debugger.Address.getJLongAt(long)" because "valueAddr" is null
  java.lang.NullPointerException: Cannot invoke "sun.jvm.hotspot.debugger.Address.getJLongAt(long)" because "valueAddr" is null
          at jdk.hotspot.agent/sun.jvm.hotspot.runtime.CompiledVFrame.createStackValue(CompiledVFrame.java:270)
          at jdk.hotspot.agent/sun.jvm.hotspot.runtime.CompiledVFrame.getLocals(CompiledVFrame.java:107)
          at jdk.hotspot.agent/sun.jvm.hotspot.ui.classbrowser.HTMLGenerator.genHTMLForJavaStackTrace(HTMLGenerator.java:1937)
          at jdk.hotspot.agent/sun.jvm.hotspot.CommandProcessor$43.doit(CommandProcessor.java:1573)
          at jdk.hotspot.agent/sun.jvm.hotspot.CommandProcessor.executeCommand(CommandProcessor.java:2090)
          at jdk.hotspot.agent/sun.jvm.hotspot.CommandProcessor.executeCommand(CommandProcessor.java:2060)

The oop map for the frame being inspected is:

   ScopeDesc(pc=0x0000ffff8957e000 offset=140):
   jdk.test.lib.apps.LingeredApp::steadyState@7 (line 536)
   Locals
    - l0: empty
    - l1: reg rfp [58],oop
    - l2: empty
   Monitor stack
    - @0: monitor{reg rfp [58],oop,stack[16]}

But RegisterMap::getLocation() returns a null Address for register
58 (=RFP).

This patch fixes two problems: the fp VMReg value used in
AARCH64Frame::updateMapWithSavedLink should be 29<<1 not 29 because a
VMReg has two slots in a 64-bit VM.  The other bug is that
RegisterMap::setLocation and getLocation calculate the long
locationValid mask using (1 << (i % locationValidTypeSize)) where i and
locationValidTypeSize are both int.  We need to do this calculation as a
long if i % locationValidTypeSize can be > 32.  There's no failure on
x86_64 because that only has 16 integer registers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8247351](https://bugs.openjdk.java.net/browse/JDK-8247351): [aarch64] NullPointerException during stack walking (clhsdb "where -a")


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4737/head:pull/4737` \
`$ git checkout pull/4737`

Update a local copy of the PR: \
`$ git checkout pull/4737` \
`$ git pull https://git.openjdk.java.net/jdk pull/4737/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4737`

View PR using the GUI difftool: \
`$ git pr show -t 4737`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4737.diff">https://git.openjdk.java.net/jdk/pull/4737.diff</a>

</details>
