### PR TITLE
8270155: ARM32: Improve register dump in hs_err

### DIFF
--- a/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
+++ b/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
@@ -468,9 +468,8 @@ void os::print_register_info(outputStream *st, const void *context) {
   st->print_cr("Register to memory mapping:");
   st->cr();
   for (int r = 0; r < ARM_REGS_IN_CONTEXT; r++) {
-    st->print_cr("  %-3s = " INTPTR_FORMAT, as_Register(r)->name(), reg_area[r]);
+    st->print("  %-3s = ", as_Register(r)->name());
     print_location(st, reg_area[r]);
-    st->cr();
   }
   st->cr();
 }


### PR DESCRIPTION
Noticed that ARM32 hs_errs are formatted weirdly, there is a newline after register value, and it prints the register value twice. `print_location` already prints the value and does the CR for us, so we should just delegate there.

Excerpt tefore:

```
Register to memory mapping:

  r0 = 0xb6b54430
0xb6b54430: <offset 0x00e69430> in /jdk/lib/server/libjvm.so at 0xb5ceb000

  r1 = 0x00000501
0x00000501 is an unknown value

  r2 = 0xb6b54ef8
0xb6b54ef8: <offset 0x00e69ef8> in /jdk/lib/server/libjvm.so at 0xb5ceb000

  r3 = 0xb6b54eb4
0xb6b54eb4: <offset 0x00e69eb4> in /jdk/lib/server/libjvm.so at 0xb5ceb000

  r4 = 0xb6f54000
0xb6f54000 points into unknown readable memory: 0x00000058 | 58 00 00 00
```

Excerpt after:

```
Register to memory mapping:

  r0  = 0xb6b3fa70: <offset 0x013f5a70> in /home/pi/shipilev-jdk/build/linux-arm-server-fastdebug/images/jdk/lib/server/libjvm.so at 0xb574a000
  r1  = 0x00000501 is an unknown value
  r2  = 0xb6b40544: <offset 0x013f6544> in /home/pi/shipilev-jdk/build/linux-arm-server-fastdebug/images/jdk/lib/server/libjvm.so at 0xb574a000
  r3  = 0xb6b40500: <offset 0x013f6500> in /home/pi/shipilev-jdk/build/linux-arm-server-fastdebug/images/jdk/lib/server/libjvm.so at 0xb574a000
  r4  = 0x70d6a83c points into unknown readable memory: 0xb6ce8b64 | 64 8b ce b6
```

Additional testing:
 - [x] Eyeballing ARM32 crash logs

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270155](https://bugs.openjdk.java.net/browse/JDK-8270155): ARM32: Improve register dump in hs_err


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4739/head:pull/4739` \
`$ git checkout pull/4739`

Update a local copy of the PR: \
`$ git checkout pull/4739` \
`$ git pull https://git.openjdk.java.net/jdk pull/4739/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4739`

View PR using the GUI difftool: \
`$ git pr show -t 4739`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4739.diff">https://git.openjdk.java.net/jdk/pull/4739.diff</a>

</details>
