### PR TITLE
8270169: G1: Incorrect reference discovery MT degree in concurrent marking

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1845,8 +1845,8 @@ void G1CollectedHeap::ref_processing_init() {
   _ref_processor_cm =
     new ReferenceProcessor(&_is_subject_to_discovery_cm,
                            ParallelGCThreads,                              // degree of mt processing
-                           (ParallelGCThreads > 1) || (ConcGCThreads > 1), // mt discovery
-                           MAX2(ParallelGCThreads, ConcGCThreads),         // degree of mt discovery
+                           (ConcGCThreads > 1),                            // mt discovery
+                           ConcGCThreads,                                  // degree of mt discovery
                            false,                                          // Reference discovery is not atomic
                            &_is_alive_closure_cm);                         // is alive closure
 


### PR DESCRIPTION
Simple change of ref discovery MT degree in concurrent marking.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270169](https://bugs.openjdk.java.net/browse/JDK-8270169): G1: Incorrect reference discovery MT degree in concurrent marking


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4741/head:pull/4741` \
`$ git checkout pull/4741`

Update a local copy of the PR: \
`$ git checkout pull/4741` \
`$ git pull https://git.openjdk.java.net/jdk pull/4741/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4741`

View PR using the GUI difftool: \
`$ git pr show -t 4741`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4741.diff">https://git.openjdk.java.net/jdk/pull/4741.diff</a>

</details>
