### PR TITLE
8265443: IGV: disambiguate groups by emiting additional properties

### DIFF
--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -48,6 +48,8 @@ const char *IdealGraphPrinter::NODE_ELEMENT = "node";
 const char *IdealGraphPrinter::NODES_ELEMENT = "nodes";
 const char *IdealGraphPrinter::REMOVE_EDGE_ELEMENT = "removeEdge";
 const char *IdealGraphPrinter::REMOVE_NODE_ELEMENT = "removeNode";
+const char *IdealGraphPrinter::COMPILATION_ID_PROPERTY = "compilationId";
+const char *IdealGraphPrinter::COMPILATION_OSR_PROPERTY = "osr";
 const char *IdealGraphPrinter::METHOD_NAME_PROPERTY = "name";
 const char *IdealGraphPrinter::METHOD_IS_PUBLIC_PROPERTY = "public";
 const char *IdealGraphPrinter::METHOD_IS_STATIC_PROPERTY = "static";
@@ -312,6 +314,12 @@ void IdealGraphPrinter::begin_method() {
   if (method->flags().is_static()) {
     print_prop(METHOD_IS_STATIC_PROPERTY, TRUE_VALUE);
   }
+
+  if (C->is_osr_compilation()) {
+      print_prop(COMPILATION_OSR_PROPERTY, TRUE_VALUE);
+  }
+
+  print_prop(COMPILATION_ID_PROPERTY, C->compile_id());
 
   tail(PROPERTIES_ELEMENT);
 

--- a/src/hotspot/share/opto/idealGraphPrinter.hpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.hpp
@@ -57,6 +57,8 @@ class IdealGraphPrinter : public CHeapObj<mtCompiler> {
   static const char *CONTROL_FLOW_ELEMENT;
   static const char *REMOVE_EDGE_ELEMENT;
   static const char *REMOVE_NODE_ELEMENT;
+  static const char *COMPILATION_ID_PROPERTY;
+  static const char *COMPILATION_OSR_PROPERTY;
   static const char *METHOD_NAME_PROPERTY;
   static const char *BLOCK_NAME_PROPERTY;
   static const char *BLOCK_DOMINATOR_PROPERTY;


### PR DESCRIPTION
Added compilation id and whether the compilation is OSR or not to the IdealGraphPrinter's output. Are there any other properties that should also be emitted?

Here is a screenshot of how the properties appear in IGV: 
![image](https://user-images.githubusercontent.com/85193727/125358968-9fe19680-e337-11eb-8d00-eb744c4f3e30.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265443](https://bugs.openjdk.java.net/browse/JDK-8265443): IGV: disambiguate groups by emiting additional properties


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4743/head:pull/4743` \
`$ git checkout pull/4743`

Update a local copy of the PR: \
`$ git checkout pull/4743` \
`$ git pull https://git.openjdk.java.net/jdk pull/4743/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4743`

View PR using the GUI difftool: \
`$ git pr show -t 4743`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4743.diff">https://git.openjdk.java.net/jdk/pull/4743.diff</a>

</details>
