### PR TITLE
8270009: Factor out and shuffle methods in G1CollectedHeap::do_collection_pause_at_safepoint_helper

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3053,6 +3053,11 @@ void G1CollectedHeap::do_collection_pause_at_safepoint_helper(double target_paus
 
     G1HeapPrinterMark hpm(this);
 
+    // Wait for root region scan here to make sure that it is done before any
+    // use of the STW work gang to maximize cpu use (i.e. all cores are available
+    // just to do that).
+    wait_for_root_region_scanning();
+
     G1HeapVerifier::G1VerifyType verify_type = young_collection_verify_type();
     verify_before_young_collection(verify_type);
     {
@@ -3539,8 +3544,6 @@ void G1CollectedHeap::pre_evacuate_collection_set(G1EvacuationInfo* evacuation_i
 
   _expand_heap_after_alloc_failure = true;
   Atomic::store(&_num_regions_failed_evacuation, 0u);
-
-  wait_for_root_region_scanning();
 
   gc_prologue(false);
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2570,24 +2570,6 @@ void G1CollectedHeap::gc_prologue(bool full) {
   if (full || collector_state()->in_concurrent_start_gc()) {
     increment_old_marking_cycles_started();
   }
-
-  // Fill TLAB's and such
-  {
-    Ticks start = Ticks::now();
-    ensure_parsability(true);
-    Tickspan dt = Ticks::now() - start;
-    phase_times()->record_prepare_tlab_time_ms(dt.seconds() * MILLIUNITS);
-  }
-
-  if (!full) {
-    // Flush dirty card queues to qset, so later phases don't need to account
-    // for partially filled per-thread queues and such.  Not needed for full
-    // collections, which ignore those logs.
-    Ticks start = Ticks::now();
-    G1BarrierSet::dirty_card_queue_set().concatenate_logs();
-    Tickspan dt = Ticks::now() - start;
-    phase_times()->record_concatenate_dirty_card_logs_time_ms(dt.seconds() * MILLIUNITS);
-  }
 }
 
 void G1CollectedHeap::gc_epilogue(bool full) {
@@ -2600,10 +2582,6 @@ void G1CollectedHeap::gc_epilogue(bool full) {
 #if COMPILER2_OR_JVMCI
   assert(DerivedPointerTable::is_empty(), "derived pointer present");
 #endif
-
-  double start = os::elapsedTime();
-  resize_all_tlabs();
-  phase_times()->record_resize_tlab_time_ms((os::elapsedTime() - start) * 1000.0);
 
   // We have just completed a GC. Update the soft reference
   // policy with the new heap occupancy
@@ -2798,6 +2776,9 @@ void G1CollectedHeap::start_new_collection_set() {
 }
 
 void G1CollectedHeap::calculate_collection_set(G1EvacuationInfo* evacuation_info, double target_pause_time_ms) {
+  // Forget the current allocation region (we might even choose it to be part
+  // of the collection set!) before finalizing the collection set.
+  _allocator->release_mutator_alloc_regions();
 
   _collection_set.finalize_initial_collection_set(target_pause_time_ms, &_survivor);
   evacuation_info->set_collectionset_regions(collection_set()->region_length() +
@@ -2988,16 +2969,7 @@ public:
   }
 };
 
-void G1CollectedHeap::do_collection_pause_at_safepoint_helper(double target_pause_time_ms) {
-  GCIdMark gc_id_mark;
-
-  SvcGCMarker sgcm(SvcGCMarker::MINOR);
-  ResourceMark rm;
-
-  policy()->note_gc_start();
-
-  wait_for_root_region_scanning();
-
+bool G1CollectedHeap::determine_start_concurrent_mark_gc(){
   // We should not be doing concurrent start unless the concurrent mark thread is running
   if (!_cm_thread->should_terminate()) {
     // This call will decide whether this pause is a concurrent start
@@ -3012,24 +2984,61 @@ void G1CollectedHeap::do_collection_pause_at_safepoint_helper(double target_paus
   // We also do not allow mixed GCs during marking.
   assert(!collector_state()->mark_or_rebuild_in_progress() || collector_state()->in_young_only_phase(), "sanity");
 
+  return collector_state()->in_concurrent_start_gc();
+}
+
+void G1CollectedHeap::set_default_active_worker_threads(){
+  uint active_workers = WorkerPolicy::calc_active_workers(workers()->total_workers(),
+          workers()->active_workers(),
+          Threads::number_of_non_daemon_threads());
+  active_workers = workers()->update_active_workers(active_workers);
+  log_info(gc,task)("Using %u workers of %u for evacuation", active_workers, workers()->total_workers());
+}
+
+void G1CollectedHeap::prepare_tlabs_for_mutator() {
+  Ticks start = Ticks::now();
+
+  _survivor_evac_stats.adjust_desired_plab_sz();
+  _old_evac_stats.adjust_desired_plab_sz();
+
+  allocate_dummy_regions();
+
+  _allocator->init_mutator_alloc_regions();
+
+  resize_all_tlabs();
+
+  phase_times()->record_resize_tlab_time_ms((Ticks::now() - start).seconds() * 1000.0);
+}
+
+void G1CollectedHeap::retire_tlabs() {
+  ensure_parsability(true);
+}
+
+void G1CollectedHeap::do_collection_pause_at_safepoint_helper(double target_pause_time_ms) {
+  ResourceMark rm;
+
+  IsGCActiveMark active_gc_mark;
+  GCIdMark gc_id_mark;
+  SvcGCMarker sgcm(SvcGCMarker::MINOR);
+
+  GCTraceCPUTime tcpu;
+
   // Record whether this pause may need to trigger a concurrent operation. Later,
   // when we signal the G1ConcurrentMarkThread, the collector state has already
   // been reset for the next pause.
-  bool should_start_concurrent_mark_operation = collector_state()->in_concurrent_start_gc();
+  bool should_start_concurrent_mark_operation = determine_start_concurrent_mark_gc();
   bool concurrent_operation_is_full_mark = false;
 
-  // Inner scope for scope based logging, timers, and stats collection
-  {
-    GCTraceCPUTime tcpu;
+  // Verification may use the gang workers, so they must be set up before.
+  set_default_active_worker_threads();
 
+  {
+    // The G1YoungGCTraceTime message depends on collector state, so must come after
+    // determining collector state.
     G1YoungGCTraceTime tm(gc_cause());
 
-    uint active_workers = WorkerPolicy::calc_active_workers(workers()->total_workers(),
-                                                            workers()->active_workers(),
-                                                            Threads::number_of_non_daemon_threads());
-    active_workers = workers()->update_active_workers(active_workers);
-    log_info(gc,task)("Using %u workers of %u for evacuation", active_workers, workers()->total_workers());
-
+    // Young GC internal timing
+    policy()->note_gc_start();
     // JFR
     G1YoungGCJFRTracerMark jtm(_gc_timer_stw, _gc_tracer_stw, gc_cause());
     // JStat/MXBeans
@@ -3039,75 +3048,44 @@ void G1CollectedHeap::do_collection_pause_at_safepoint_helper(double target_paus
 
     G1HeapPrinterMark hpm(this);
 
+    G1HeapVerifier::G1VerifyType verify_type = young_collection_verify_type();
+    verify_before_young_collection(verify_type);
     {
-      IsGCActiveMark x;
-      gc_prologue(false);
+      double sample_start_time_sec = os::elapsedTime();
+      policy()->record_collection_pause_start(sample_start_time_sec);
 
-      G1HeapVerifier::G1VerifyType verify_type = young_collection_verify_type();
-      verify_before_young_collection(verify_type);
-      {
-        // The elapsed time induced by the start time below deliberately elides
-        // the possible verification above.
-        double sample_start_time_sec = os::elapsedTime();
+      calculate_collection_set(jtm.evacuation_info(), target_pause_time_ms);
 
-        // Please see comment in g1CollectedHeap.hpp and
-        // G1CollectedHeap::ref_processing_init() to see how
-        // reference processing currently works in G1.
-        _ref_processor_stw->start_discovery(false /* always_clear */);
+      G1RedirtyCardsQueueSet rdcqs(G1BarrierSet::dirty_card_queue_set().allocator());
+      G1ParScanThreadStateSet per_thread_states(this,
+                                                &rdcqs,
+                                                workers()->active_workers(),
+                                                collection_set()->young_region_length(),
+                                                collection_set()->optional_region_length());
+      pre_evacuate_collection_set(jtm.evacuation_info(), &per_thread_states);
 
-        policy()->record_collection_pause_start(sample_start_time_sec);
+      bool may_do_optional_evacuation = _collection_set.optional_region_length() != 0;
+      // Actually do the work...
+      evacuate_initial_collection_set(&per_thread_states, may_do_optional_evacuation);
 
-        // Forget the current allocation region (we might even choose it to be part
-        // of the collection set!).
-        _allocator->release_mutator_alloc_regions();
-
-        calculate_collection_set(jtm.evacuation_info(), target_pause_time_ms);
-
-        G1RedirtyCardsQueueSet rdcqs(G1BarrierSet::dirty_card_queue_set().allocator());
-        G1ParScanThreadStateSet per_thread_states(this,
-                                                  &rdcqs,
-                                                  workers()->active_workers(),
-                                                  collection_set()->young_region_length(),
-                                                  collection_set()->optional_region_length());
-        pre_evacuate_collection_set(jtm.evacuation_info(), &per_thread_states);
-
-        bool may_do_optional_evacuation = _collection_set.optional_region_length() != 0;
-        // Actually do the work...
-        evacuate_initial_collection_set(&per_thread_states, may_do_optional_evacuation);
-
-        if (may_do_optional_evacuation) {
-          evacuate_optional_collection_set(&per_thread_states);
-        }
-        post_evacuate_collection_set(jtm.evacuation_info(), &rdcqs, &per_thread_states);
-
-        start_new_collection_set();
-
-        _survivor_evac_stats.adjust_desired_plab_sz();
-        _old_evac_stats.adjust_desired_plab_sz();
-
-        allocate_dummy_regions();
-
-        _allocator->init_mutator_alloc_regions();
-
-        expand_heap_after_young_collection();
-
-        // Refine the type of a concurrent mark operation now that we did the
-        // evacuation, eventually aborting it.
-        concurrent_operation_is_full_mark = policy()->concurrent_operation_is_full_mark("Revise IHOP");
-
-        // Need to report the collection pause now since record_collection_pause_end()
-        // modifies it to the next state.
-        jtm.report_pause_type(collector_state()->young_gc_pause_type(concurrent_operation_is_full_mark));
-
-        double sample_end_time_sec = os::elapsedTime();
-        double pause_time_ms = (sample_end_time_sec - sample_start_time_sec) * MILLIUNITS;
-        policy()->record_collection_pause_end(pause_time_ms, concurrent_operation_is_full_mark);
+      if (may_do_optional_evacuation) {
+        evacuate_optional_collection_set(&per_thread_states);
       }
+      post_evacuate_collection_set(jtm.evacuation_info(), &rdcqs, &per_thread_states);
 
-      verify_after_young_collection(verify_type);
+      // Refine the type of a concurrent mark operation now that we did the
+      // evacuation, eventually aborting it.
+      concurrent_operation_is_full_mark = policy()->concurrent_operation_is_full_mark("Revise IHOP");
 
-      gc_epilogue(false);
+      // Need to report the collection pause now since record_collection_pause_end()
+      // modifies it to the next state.
+      jtm.report_pause_type(collector_state()->young_gc_pause_type(concurrent_operation_is_full_mark));
+
+      double sample_end_time_sec = os::elapsedTime();
+      double pause_time_ms = (sample_end_time_sec - sample_start_time_sec) * MILLIUNITS;
+      policy()->record_collection_pause_end(pause_time_ms, concurrent_operation_is_full_mark);
     }
+    verify_after_young_collection(verify_type);
 
     policy()->print_phases();
 
@@ -3117,7 +3095,6 @@ void G1CollectedHeap::do_collection_pause_at_safepoint_helper(double target_paus
   // It should now be safe to tell the concurrent mark thread to start
   // without its logging output interfering with the logging output
   // that came from the pause.
-
   if (should_start_concurrent_mark_operation) {
     // CAUTION: after the start_concurrent_cycle() call below, the concurrent marking
     // thread(s) could be running concurrently with us. Make sure that anything
@@ -3544,10 +3521,34 @@ public:
 };
 
 void G1CollectedHeap::pre_evacuate_collection_set(G1EvacuationInfo* evacuation_info, G1ParScanThreadStateSet* per_thread_states) {
+  // Please see comment in g1CollectedHeap.hpp and
+  // G1CollectedHeap::ref_processing_init() to see how
+  // reference processing currently works in G1.
+  _ref_processor_stw->start_discovery(false /* always_clear */);
+
   _bytes_used_during_gc = 0;
 
   _expand_heap_after_alloc_failure = true;
   Atomic::store(&_num_regions_failed_evacuation, 0u);
+
+  wait_for_root_region_scanning();
+
+  gc_prologue(false);
+
+  {
+    Ticks start = Ticks::now();
+    retire_tlabs();
+    phase_times()->record_prepare_tlab_time_ms((Ticks::now() - start).seconds() * 1000.0);
+  }
+
+  {
+    // Flush dirty card queues to qset, so later phases don't need to account
+    // for partially filled per-thread queues and such.
+    Ticks start = Ticks::now();
+    G1BarrierSet::dirty_card_queue_set().concatenate_logs();
+    Tickspan dt = Ticks::now() - start;
+    phase_times()->record_concatenate_dirty_card_logs_time_ms(dt.seconds() * MILLIUNITS);
+  }
 
   _regions_failed_evacuation.clear();
 
@@ -3842,6 +3843,14 @@ void G1CollectedHeap::post_evacuate_collection_set(G1EvacuationInfo* evacuation_
 
   evacuation_info->set_collectionset_used_before(collection_set()->bytes_used_before());
   evacuation_info->set_bytes_used(_bytes_used_during_gc);
+
+  start_new_collection_set();
+
+  prepare_tlabs_for_mutator();
+
+  gc_epilogue(false);
+
+  expand_heap_after_young_collection();
 }
 
 void G1CollectedHeap::record_obj_copy_mem_stats() {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -800,7 +800,7 @@ private:
   // of the incremental collection pause, executed by the vm thread.
   void do_collection_pause_at_safepoint_helper(double target_pause_time_ms);
 
-  void set_default_active_worker_threads();
+  void set_young_collection_default_active_worker_threads();
 
   bool determine_start_concurrent_mark_gc();
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -800,6 +800,14 @@ private:
   // of the incremental collection pause, executed by the vm thread.
   void do_collection_pause_at_safepoint_helper(double target_pause_time_ms);
 
+  void set_default_active_worker_threads();
+
+  bool determine_start_concurrent_mark_gc();
+
+  void prepare_tlabs_for_mutator();
+
+  void retire_tlabs();
+
   G1HeapVerifier::G1VerifyType young_collection_verify_type() const;
   void verify_before_young_collection(G1HeapVerifier::G1VerifyType type);
   void verify_after_young_collection(G1HeapVerifier::G1VerifyType type);
@@ -1451,7 +1459,6 @@ private:
   void print_regions_on(outputStream* st) const;
 
 public:
-
   virtual void print_on(outputStream* st) const;
   virtual void print_extended_on(outputStream* st) const;
   virtual void print_on_error(outputStream* st) const;

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -174,6 +174,7 @@ void G1FullCollector::prepare_collection() {
   _heap->verify_before_full_collection(scope()->is_explicit_gc());
 
   _heap->gc_prologue(true);
+  _heap->retire_tlabs();
   _heap->prepare_heap_for_full_collection();
 
   PrepareRegionsClosure cl(this);
@@ -213,12 +214,12 @@ void G1FullCollector::complete_collection() {
 
   _heap->prepare_heap_for_mutators();
 
+  _heap->resize_all_tlabs();
+
   _heap->policy()->record_full_collection_end();
   _heap->gc_epilogue(true);
 
   _heap->verify_after_full_collection();
-
-  _heap->print_heap_after_full_collection();
 }
 
 void G1FullCollector::before_marking_update_attribute_table(HeapRegion* hr) {


### PR DESCRIPTION
Hi all,

  can I get reviews for this change that factors out a few methods from `do_collection_pause_at_safepoint_helper` and reshuffles code from `gc_prologue`/`gc_epilogue` to be able to put those into parallel phase(s) later.

Testing: tier1-5

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270009](https://bugs.openjdk.java.net/browse/JDK-8270009): Factor out and shuffle methods in G1CollectedHeap::do_collection_pause_at_safepoint_helper


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Committer) ⚠️ Review applies to b28374175398bea24588ef0c64161b4d9be876c5


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4744/head:pull/4744` \
`$ git checkout pull/4744`

Update a local copy of the PR: \
`$ git checkout pull/4744` \
`$ git pull https://git.openjdk.java.net/jdk pull/4744/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4744`

View PR using the GUI difftool: \
`$ git pr show -t 4744`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4744.diff">https://git.openjdk.java.net/jdk/pull/4744.diff</a>

</details>
