### PR TITLE
JDK-8269774: doclint reports missing javadoc comments for JavaFX properties if the docs are on the property method

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/MemberSummaryBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/MemberSummaryBuilder.java
@@ -486,7 +486,7 @@ public abstract class MemberSummaryBuilder extends AbstractMemberBuilder {
                                         VariableElement field,
                                         ExecutableElement getter,
                                         ExecutableElement setter) {
-            if (field == null || builder.utils.getDocCommentTree(field) == null) {
+            if (field == null || !builder.utils.hasDocCommentTree(field)) {
                 addToPropertiesMap(propertyMethod, propertyMethod);
                 addToPropertiesMap(getter, propertyMethod);
                 addToPropertiesMap(setter, propertyMethod);

--- a/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFXMissingPropComments.java
+++ b/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFXMissingPropComments.java
@@ -54,10 +54,10 @@ public class TestJavaFXMissingPropComments extends JavadocTester {
                 public class C {
                     /** Dummy class. */
                     public static class BooleanProperty { }
-                    
+
                     // no comment
                     private BooleanProperty value;
-                    
+
                     /**
                      * The value property (property method comment).
                      * @return the property object
@@ -65,7 +65,7 @@ public class TestJavaFXMissingPropComments extends JavadocTester {
                     public BooleanProperty valueProperty() {
                         return value;
                     }
-                    
+
                     // no comment
                     public boolean getValue() {
                         return true;
@@ -110,10 +110,10 @@ public class TestJavaFXMissingPropComments extends JavadocTester {
                 public class C {
                     /** Dummy class. */
                     public static class BooleanProperty { }
-                    
+
                     /** The value property (field comment). */
                     private BooleanProperty value;
-                    
+
                     /**
                      * The value property (property method comment).
                      * @return the property object
@@ -121,7 +121,7 @@ public class TestJavaFXMissingPropComments extends JavadocTester {
                     public BooleanProperty valueProperty() {
                         return value;
                     }
-                    
+
                     // no comment
                     public boolean getValue() {
                         return true;

--- a/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFXMissingPropComments.java
+++ b/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFXMissingPropComments.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8269774
+ * @summary doclint reports missing javadoc comments for JavaFX properties if the docs are on the property method
+ * @library /tools/lib ../../lib
+ * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ * @build toolbox.ToolBox javadoc.tester.*
+ * @run main TestJavaFXMissingPropComments
+ */
+
+import java.nio.file.Path;
+
+import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
+
+public class TestJavaFXMissingPropComments extends JavadocTester {
+
+    public static void main(String... args) throws Exception {
+        TestJavaFXMissingPropComments tester = new TestJavaFXMissingPropComments();
+        tester.runTests(m -> new Object[] { Path.of(m.getName()) });
+    }
+
+    ToolBox tb = new ToolBox();
+
+    @Test
+    public void testMissingFieldComments(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src, """
+                package p;
+                /** Class comment. */
+                public class C {
+                    /** Dummy class. */
+                    public static class BooleanProperty { }
+                    
+                    // no comment
+                    private BooleanProperty value;
+                    
+                    /**
+                     * The value property (property method comment).
+                     * @return the property object
+                     */
+                    public BooleanProperty valueProperty() {
+                        return value;
+                    }
+                    
+                    // no comment
+                    public boolean getValue() {
+                        return true;
+                    }
+                }
+                """);
+
+        javadoc("-d", base.resolve("api").toString(),
+                "--javafx",
+                "--disable-javafx-strict-checks",
+                "-sourcepath", src.toString(),
+                "p"
+                );
+        checkExit(Exit.OK);
+
+        // no warnings for any missing comments
+        checkOutput(Output.OUT, false,
+                "warning: no comment");
+
+        checkOutput("p/C.html", true,
+                """
+                    <section class="detail" id="getValue()">
+                    <h3>getValue</h3>
+                    <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
+                    lass="return-type">boolean</span>&nbsp;<span class="element-name">getValue</span\
+                    >()</div>
+                    <div class="block">Gets the value of the property value.</div>
+                    <dl class="notes">
+                    <dt>Property description:</dt>
+                    <dd>The value property (property method comment).</dd>
+                    </dl>
+                    </section>"""
+                );
+    }
+
+    @Test
+    public void testWithFieldComments(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src, """
+                package p;
+                /** Class comment. */
+                public class C {
+                    /** Dummy class. */
+                    public static class BooleanProperty { }
+                    
+                    /** The value property (field comment). */
+                    private BooleanProperty value;
+                    
+                    /**
+                     * The value property (property method comment).
+                     * @return the property object
+                     */
+                    public BooleanProperty valueProperty() {
+                        return value;
+                    }
+                    
+                    // no comment
+                    public boolean getValue() {
+                        return true;
+                    }
+                }
+                """);
+
+        javadoc("-d", base.resolve("api").toString(),
+                "--javafx",
+                "--disable-javafx-strict-checks",
+                "-sourcepath", src.toString(),
+                "p"
+        );
+        checkExit(Exit.OK);
+
+        // no warnings for any missing comments
+        checkOutput(Output.OUT, false,
+                "warning: no comment");
+
+        checkOutput("p/C.html", true,
+                """
+                    <section class="detail" id="getValue()">
+                    <h3>getValue</h3>
+                    <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
+                    lass="return-type">boolean</span>&nbsp;<span class="element-name">getValue</span\
+                    >()</div>
+                    <div class="block">Gets the value of the property value.</div>
+                    <dl class="notes">
+                    <dt>Property description:</dt>
+                    <dd>The value property (field comment).</dd>
+                    </dl>
+                    </section>"""
+        );
+    }
+}


### PR DESCRIPTION
Please review a simple change to the code for generating docs for JavaFX properties, in order to suppress an inappropriate
"missing comment" warning.

The change is to use `hasDocCommentTree` instead of `getDocCommentTree`.

A new test is added, that runs javadoc on similar classes, with and without a comment on the field for a property. In both cases, no warnings about missing comments should be generated, and when the comment is available, it is used as expected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269774](https://bugs.openjdk.java.net/browse/JDK-8269774): doclint reports missing javadoc comments for JavaFX properties if the docs are on the property method


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Author)
 * [Hannes Wallnöfer](https://openjdk.java.net/census#hannesw) (@hns - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4747/head:pull/4747` \
`$ git checkout pull/4747`

Update a local copy of the PR: \
`$ git checkout pull/4747` \
`$ git pull https://git.openjdk.java.net/jdk pull/4747/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4747`

View PR using the GUI difftool: \
`$ git pr show -t 4747`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4747.diff">https://git.openjdk.java.net/jdk/pull/4747.diff</a>

</details>
