### PR TITLE
8268894: forged ASTs can provoke an AIOOBE at com.sun.tools.javac.jvm.ClassWriter::writePosition

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotationPosition.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotationPosition.java
@@ -297,7 +297,6 @@ public class TypeAnnotationPosition {
 
     public void updatePosOffset(int to) {
         offset = to;
-        lvarOffset = new int[]{to};
         isValidOffset = true;
     }
 

--- a/test/langtools/tools/javac/annotations/typeAnnotations/position/TypeAnnotationPositionProcessor.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/position/TypeAnnotationPositionProcessor.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.util.TreeScanner;
+import com.sun.source.util.Trees;
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.JCTree.*;
+
+import javax.annotation.processing.*;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.ElementFilter;
+import java.util.Set;
+
+@SupportedAnnotationTypes("*")
+public class TypeAnnotationPositionProcessor extends AbstractProcessor {
+    private Trees trees;
+    private boolean processed = false;
+
+    @Override
+    public void init(ProcessingEnvironment pe) {
+        super.init(pe);
+        trees = Trees.instance(pe);
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        if (processed) {
+            return false;
+        } else {
+            processed = true;
+        }
+        Set<? extends Element> elements = roundEnv.getRootElements();
+        TypeElement typeElement = null;
+        for (TypeElement te : ElementFilter.typesIn(elements)) {
+            if ("TypeAnnotationPositionTest".equals(te.getSimpleName().toString())) {
+                typeElement = te;
+                break;
+            }
+        }
+        for (ExecutableElement m : ElementFilter.methodsIn(typeElement.getEnclosedElements())) {
+            if ("test".equals(m.getSimpleName().toString())) {
+                MethodTree methodTree = trees.getTree(m);
+                new PositionVisitor().scan(methodTree, ((JCMethodDecl) methodTree).pos);
+            }
+        }
+        return false;
+    }
+
+    private static class PositionVisitor extends TreeScanner<Void, Integer> {
+        @Override
+        public Void scan(Tree tree, Integer p) {
+            if (tree != null) ((JCTree) tree).pos = p;
+            return super.scan(tree, p);
+        }
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latest();
+    }
+}

--- a/test/langtools/tools/javac/annotations/typeAnnotations/position/TypeAnnotationPositionTest.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/position/TypeAnnotationPositionTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8268894
+ * @summary Updating the type annotation position offset causes ArrayIndexOutOfBoundsException in ClassWriter
+ * @modules jdk.compiler/com.sun.tools.javac.tree
+ * @compile TypeAnnotationPositionProcessor.java
+ * @compile -processor TypeAnnotationPositionProcessor TypeAnnotationPositionTest.java
+ */
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+public class TypeAnnotationPositionTest {
+    TypeAnnotationPositionTest(char @MyTest [] bar) { }
+
+    @Target({ElementType.TYPE_USE})
+    @interface MyTest {
+    }
+
+    TypeAnnotationPositionTest test() {
+        char @MyTest [] val = new char[]{'1'};
+        return new TypeAnnotationPositionTest(val);
+    }
+}


### PR DESCRIPTION
Hi all,

The method `TypeAnnotationPosition.updatePosOffset` sets the `lvarOffset` unnecessarily. After invoking `TypeAnnotationPosition.updatePosOffset`, the lengths of (`lvarOffset`, `lvarLength`, `lvarIndex`) are respectively (1, 0, 0). Then `Code.fillLocalVarPosition` fills the `lvarOffset`, `lvarLength`, `lvarIndex` which make their lengths become (N, N-1, N-1). At last, the method `ClassWrite.writePosition` uses these three arrays whose lengths are not the same so that the `ArrayIndexOutOfBoundsException` occurs.

The `lvarOffset` should be always changed along with `lvarLength` and `lvarIndex` so that their lengths can be the same.

This patch removes the unnecessary `lvarOffset = new int[]{to};` of the method  `TypeAnnotationPosition.updatePosOffset` and add a corresponding test.

---
Steps to reproduce the issue:

1. Construct a annotation processor which set the `pos` of the method sub-tree nodes to the same position. Please see the file `TypeAnnotationPositionProcessor.java` for more details.
2. Compile the code which has the corresponding method with the annotated local variable by using the annotation processor generated at the step 1. Please see the file `TypeAnnotationPositionTest.java` for more details.
3. Then the crash occurs.

Actually, this bug may never occur if the users use the compiler friendly. Because the method `TypeAnnotationPosition.updatePosOffset`, which we mentioned at the beginning, may never be invoked at the situation that the different trees has different and right position.

The lib `lombok` constructs some new tree nodes by using the internal method of the compiler. But it doesn't set the `pos` correctly and uses the same fake position. The unfriendly code of the `lombok` is in the method [JavacHandlerUtil.setGeneratedBy](https://github.com/projectlombok/lombok/blob/master/src/core/lombok/javac/handlers/JavacHandlerUtil.java#L167). At much time, the fake same position works well, but this time, it crashes the compiler.

---
A brief history:

According to the git's records, I found the code `ta.position.lvarOffset = new int[] { code.cp };` was firstly added at [8006775: JSR 308: Compiler changes in JDK8](http://hg.openjdk.java.net/jdk8/jdk8/langtools/rev/71f35e4b93a5#l52.35) .

Then, [8013852: update reference impl for type-annotations](http://hg.openjdk.java.net/jdk8/jdk8/langtools/rev/ddb4a2bfcd82#l8.52) moved the code to `TypeAnnotationPosition.updatePosOffset`.

The bug didn't occur at that time, because the old [Code.fillLocalVarPosition](http://hg.openjdk.java.net/jdk8/jdk8/langtools/rev/71f35e4b93a5#l51.21) always created a new array instead of using the old array.

But later, [8231826: Implement javac changes for pattern matching for instanceof](https://hg.openjdk.java.net/jdk/jdk/rev/7799a51dbe30#l24.27) revised the method `Code.fillLocalVarPosition` to reuse the old array so that the bug occurs.

Concluded, this is an issue introduced at JDK8 when implementing the type annotation. But it was hidden by other code at the past. 

---

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268894](https://bugs.openjdk.java.net/browse/JDK-8268894): forged ASTs can provoke an AIOOBE at com.sun.tools.javac.jvm.ClassWriter::writePosition


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4749/head:pull/4749` \
`$ git checkout pull/4749`

Update a local copy of the PR: \
`$ git checkout pull/4749` \
`$ git pull https://git.openjdk.java.net/jdk pull/4749/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4749`

View PR using the GUI difftool: \
`$ git pr show -t 4749`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4749.diff">https://git.openjdk.java.net/jdk/pull/4749.diff</a>

</details>
