### PR TITLE
8269870: PS: Membar in PSPromotionManager::copy_unmarked_to_survivor_space could be relaxed

### DIFF
--- a/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
@@ -248,15 +248,14 @@ inline oop PSPromotionManager::copy_unmarked_to_survivor_space(oop o,
 
   assert(new_obj != NULL, "allocation should have succeeded");
 
-  // Copy obj
-  Copy::aligned_disjoint_words(cast_from_oop<HeapWord*>(o), cast_from_oop<HeapWord*>(new_obj), new_obj_size);
-
   // Now we have to CAS in the header.
-  // Make copy visible to threads reading the forwardee.
-  oop forwardee = o->forward_to_atomic(new_obj, test_mark, memory_order_release);
+  oop forwardee = o->forward_to_atomic(new_obj, test_mark, memory_order_relaxed);
   if (forwardee == NULL) {  // forwardee is NULL when forwarding is successful
     // We won any races, we "own" this object.
     assert(new_obj == o->forwardee(), "Sanity");
+
+    // Copy obj
+    Copy::aligned_disjoint_words(cast_from_oop<HeapWord*>(o), cast_from_oop<HeapWord*>(new_obj), new_obj_size);
 
     // Increment age if obj still in new generation. Now that
     // we're dealing with a markWord that cannot change, it is

--- a/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
@@ -248,14 +248,14 @@ inline oop PSPromotionManager::copy_unmarked_to_survivor_space(oop o,
 
   assert(new_obj != NULL, "allocation should have succeeded");
 
+  // Copy obj
+  Copy::aligned_disjoint_words(cast_from_oop<HeapWord*>(o), cast_from_oop<HeapWord*>(new_obj), new_obj_size);
+
   // Now we have to CAS in the header.
   oop forwardee = o->forward_to_atomic(new_obj, test_mark, memory_order_relaxed);
   if (forwardee == NULL) {  // forwardee is NULL when forwarding is successful
     // We won any races, we "own" this object.
     assert(new_obj == o->forwardee(), "Sanity");
-
-    // Copy obj
-    Copy::aligned_disjoint_words(cast_from_oop<HeapWord*>(o), cast_from_oop<HeapWord*>(new_obj), new_obj_size);
 
     // Increment age if obj still in new generation. Now that
     // we're dealing with a markWord that cannot change, it is


### PR DESCRIPTION
Membar in PSPromotionManager::copy_unmarked_to_survivor_space could be relaxed.
( Please also refer to the similar membar relaxed in G1ParScanThreadState::do_copy_to_survivor_space )

Per the specjbb2015 test results, it has about 8% improvement in critical.
https://bugs.openjdk.java.net/secure/attachment/95445/jdk17_default_options.v2.png

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8269870](https://bugs.openjdk.java.net/browse/JDK-8269870): PS: Membar in PSPromotionManager::copy_unmarked_to_survivor_space could be relaxed


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4751/head:pull/4751` \
`$ git checkout pull/4751`

Update a local copy of the PR: \
`$ git checkout pull/4751` \
`$ git pull https://git.openjdk.java.net/jdk pull/4751/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4751`

View PR using the GUI difftool: \
`$ git pr show -t 4751`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4751.diff">https://git.openjdk.java.net/jdk/pull/4751.diff</a>

</details>
