### PR TITLE
8270282: Semantically rename reference processing subphases

### DIFF
--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -477,7 +477,7 @@ public:
                OopClosure* keep_alive,
                VoidClosure* complete_gc) override {
     ResourceMark rm;
-    RefProcWorkerTimeTracker t(_phase_times->SoftWeakFinalRefsPhase_worker_time_sec(), tracker_id(worker_id));
+    RefProcWorkerTimeTracker t(_phase_times->soft_weak_final_refs_phase_worker_time_sec(), tracker_id(worker_id));
     {
       RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::ProcessSoftRefSubPhase, _phase_times, tracker_id(worker_id));
       run_phase(worker_id, _ref_processor._discoveredSoftRefs, is_alive, keep_alive, true /* do_enqueue_and_clear */, REF_SOFT);

--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -199,17 +199,17 @@ ReferenceProcessorStats ReferenceProcessor::process_discovered_references(RefPro
   update_soft_ref_master_clock();
 
   {
-    RefProcTotalPhaseTimesTracker tt(RefPhase2, &phase_times);
+    RefProcTotalPhaseTimesTracker tt(SoftWeakFinalRefsPhase, &phase_times);
     process_soft_weak_final_refs(proxy_task, phase_times);
   }
 
   {
-    RefProcTotalPhaseTimesTracker tt(RefPhase3, &phase_times);
+    RefProcTotalPhaseTimesTracker tt(KeepAliveFinalRefsPhase, &phase_times);
     process_final_keep_alive(proxy_task, phase_times);
   }
 
   {
-    RefProcTotalPhaseTimesTracker tt(RefPhase4, &phase_times);
+    RefProcTotalPhaseTimesTracker tt(PhantomRefsPhase, &phase_times);
     process_phantom_refs(proxy_task, phase_times);
   }
 
@@ -452,8 +452,8 @@ size_t ReferenceProcessor::total_reference_count(ReferenceType type) const {
 }
 
 
-class RefProcPhase2Task: public RefProcTask {
-  void run_phase2(uint worker_id,
+class RefProcSoftWeakFinalPhaseTask: public RefProcTask {
+  void run_phase(uint worker_id,
                   DiscoveredList list[],
                   BoolObjectClosure* is_alive,
                   OopClosure* keep_alive,
@@ -467,8 +467,8 @@ class RefProcPhase2Task: public RefProcTask {
   }
 
 public:
-  RefProcPhase2Task(ReferenceProcessor& ref_processor,
-                    ReferenceProcessorPhaseTimes* phase_times)
+  RefProcSoftWeakFinalPhaseTask(ReferenceProcessor& ref_processor,
+                                ReferenceProcessorPhaseTimes* phase_times)
     : RefProcTask(ref_processor,
                   phase_times) {}
 
@@ -477,18 +477,18 @@ public:
                OopClosure* keep_alive,
                VoidClosure* complete_gc) override {
     ResourceMark rm;
-    RefProcWorkerTimeTracker t(_phase_times->phase2_worker_time_sec(), tracker_id(worker_id));
+    RefProcWorkerTimeTracker t(_phase_times->SoftWeakFinalRefsPhase_worker_time_sec(), tracker_id(worker_id));
     {
-      RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::SoftRefSubPhase2, _phase_times, tracker_id(worker_id));
-      run_phase2(worker_id, _ref_processor._discoveredSoftRefs, is_alive, keep_alive, true /* do_enqueue_and_clear */, REF_SOFT);
+      RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::ProcessSoftRefSubPhase, _phase_times, tracker_id(worker_id));
+      run_phase(worker_id, _ref_processor._discoveredSoftRefs, is_alive, keep_alive, true /* do_enqueue_and_clear */, REF_SOFT);
     }
     {
-      RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::WeakRefSubPhase2, _phase_times, tracker_id(worker_id));
-      run_phase2(worker_id, _ref_processor._discoveredWeakRefs, is_alive, keep_alive, true /* do_enqueue_and_clear */, REF_WEAK);
+      RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::ProcessWeakRefSubPhase, _phase_times, tracker_id(worker_id));
+      run_phase(worker_id, _ref_processor._discoveredWeakRefs, is_alive, keep_alive, true /* do_enqueue_and_clear */, REF_WEAK);
     }
     {
-      RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::FinalRefSubPhase2, _phase_times, tracker_id(worker_id));
-      run_phase2(worker_id, _ref_processor._discoveredFinalRefs, is_alive, keep_alive, false /* do_enqueue_and_clear */, REF_FINAL);
+      RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::ProcessFinalRefSubPhase, _phase_times, tracker_id(worker_id));
+      run_phase(worker_id, _ref_processor._discoveredFinalRefs, is_alive, keep_alive, false /* do_enqueue_and_clear */, REF_FINAL);
     }
     // Close the reachable set; needed for collectors which keep_alive_closure do
     // not immediately complete their work.
@@ -496,10 +496,10 @@ public:
   }
 };
 
-class RefProcPhase3Task: public RefProcTask {
+class RefProcKeepAliveFinalPhaseTask: public RefProcTask {
 public:
-  RefProcPhase3Task(ReferenceProcessor& ref_processor,
-                    ReferenceProcessorPhaseTimes* phase_times)
+  RefProcKeepAliveFinalPhaseTask(ReferenceProcessor& ref_processor,
+                                 ReferenceProcessorPhaseTimes* phase_times)
     : RefProcTask(ref_processor,
                   phase_times) {}
 
@@ -508,15 +508,15 @@ public:
                OopClosure* keep_alive,
                VoidClosure* complete_gc) override {
     ResourceMark rm;
-    RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::FinalRefSubPhase3, _phase_times, tracker_id(worker_id));
+    RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::KeepAliveFinalRefsSubPhase, _phase_times, tracker_id(worker_id));
     _ref_processor.process_final_keep_alive_work(_ref_processor._discoveredFinalRefs[worker_id], keep_alive, complete_gc);
   }
 };
 
-class RefProcPhase4Task: public RefProcTask {
+class RefProcPhantomPhaseTask: public RefProcTask {
 public:
-  RefProcPhase4Task(ReferenceProcessor& ref_processor,
-                    ReferenceProcessorPhaseTimes* phase_times)
+  RefProcPhantomPhaseTask(ReferenceProcessor& ref_processor,
+                          ReferenceProcessorPhaseTimes* phase_times)
     : RefProcTask(ref_processor,
                   phase_times) {}
 
@@ -525,7 +525,7 @@ public:
                OopClosure* keep_alive,
                VoidClosure* complete_gc) override {
     ResourceMark rm;
-    RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::PhantomRefSubPhase4, _phase_times, tracker_id(worker_id));
+    RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::ProcessPhantomRefsSubPhase, _phase_times, tracker_id(worker_id));
     size_t const removed = _ref_processor.process_phantom_refs_work(_ref_processor._discoveredPhantomRefs[worker_id],
                                                                     is_alive,
                                                                     keep_alive,
@@ -720,31 +720,31 @@ void ReferenceProcessor::process_soft_weak_final_refs(RefProcProxyTask& proxy_ta
   phase_times.set_processing_is_mt(processing_is_mt());
 
   if (num_total_refs == 0) {
-    log_debug(gc, ref)("Skipped phase 2 of Reference Processing: no references");
+    log_debug(gc, ref)("Skipped SoftWeakFinalRefsPhase of Reference Processing: no references");
     return;
   }
 
-  RefProcMTDegreeAdjuster a(this, RefPhase2, num_total_refs);
+  RefProcMTDegreeAdjuster a(this, SoftWeakFinalRefsPhase, num_total_refs);
 
   if (processing_is_mt()) {
-    RefProcBalanceQueuesTimeTracker tt(RefPhase2, &phase_times);
+    RefProcBalanceQueuesTimeTracker tt(SoftWeakFinalRefsPhase, &phase_times);
     maybe_balance_queues(_discoveredSoftRefs);
     maybe_balance_queues(_discoveredWeakRefs);
     maybe_balance_queues(_discoveredFinalRefs);
   }
 
-  RefProcPhaseTimeTracker tt(RefPhase2, &phase_times);
+  RefProcPhaseTimeTracker tt(SoftWeakFinalRefsPhase, &phase_times);
 
-  log_reflist("Phase 2 Soft before", _discoveredSoftRefs, _max_num_queues);
-  log_reflist("Phase 2 Weak before", _discoveredWeakRefs, _max_num_queues);
-  log_reflist("Phase 2 Final before", _discoveredFinalRefs, _max_num_queues);
+  log_reflist("SoftWeakFinalRefsPhase Soft before", _discoveredSoftRefs, _max_num_queues);
+  log_reflist("SoftWeakFinalRefsPhase Weak before", _discoveredWeakRefs, _max_num_queues);
+  log_reflist("SoftWeakFinalRefsPhase Final before", _discoveredFinalRefs, _max_num_queues);
 
-  RefProcPhase2Task phase2(*this, &phase_times);
-  run_task(phase2, proxy_task, false);
+  RefProcSoftWeakFinalPhaseTask phase_task(*this, &phase_times);
+  run_task(phase_task, proxy_task, false);
 
   verify_total_count_zero(_discoveredSoftRefs, "SoftReference");
   verify_total_count_zero(_discoveredWeakRefs, "WeakReference");
-  log_reflist("Phase 2 Final after", _discoveredFinalRefs, _max_num_queues);
+  log_reflist("SoftWeakFinalRefsPhase Final after", _discoveredFinalRefs, _max_num_queues);
 }
 
 void ReferenceProcessor::process_final_keep_alive(RefProcProxyTask& proxy_task,
@@ -754,22 +754,21 @@ void ReferenceProcessor::process_final_keep_alive(RefProcProxyTask& proxy_task,
   phase_times.set_processing_is_mt(processing_is_mt());
 
   if (num_final_refs == 0) {
-    log_debug(gc, ref)("Skipped phase 3 of Reference Processing: no references");
+    log_debug(gc, ref)("Skipped KeepAliveFinalRefsPhase of Reference Processing: no references");
     return;
   }
 
-  RefProcMTDegreeAdjuster a(this, RefPhase3, num_final_refs);
+  RefProcMTDegreeAdjuster a(this, KeepAliveFinalRefsPhase, num_final_refs);
 
   if (processing_is_mt()) {
-    RefProcBalanceQueuesTimeTracker tt(RefPhase3, &phase_times);
+    RefProcBalanceQueuesTimeTracker tt(KeepAliveFinalRefsPhase, &phase_times);
     maybe_balance_queues(_discoveredFinalRefs);
   }
 
-  // Phase 3:
-  // . Traverse referents of final references and keep them and followers alive.
-  RefProcPhaseTimeTracker tt(RefPhase3, &phase_times);
-  RefProcPhase3Task phase3(*this, &phase_times);
-  run_task(phase3, proxy_task, true);
+  // Traverse referents of final references and keep them and followers alive.
+  RefProcPhaseTimeTracker tt(KeepAliveFinalRefsPhase, &phase_times);
+  RefProcKeepAliveFinalPhaseTask phase_task(*this, &phase_times);
+  run_task(phase_task, proxy_task, true);
 
   verify_total_count_zero(_discoveredFinalRefs, "FinalReference");
 }
@@ -782,24 +781,24 @@ void ReferenceProcessor::process_phantom_refs(RefProcProxyTask& proxy_task,
   phase_times.set_processing_is_mt(processing_is_mt());
 
   if (num_phantom_refs == 0) {
-    log_debug(gc, ref)("Skipped phase 4 of Reference Processing: no references");
+    log_debug(gc, ref)("Skipped PhantomRefsPhase of Reference Processing: no references");
     return;
   }
 
-  RefProcMTDegreeAdjuster a(this, RefPhase4, num_phantom_refs);
+  RefProcMTDegreeAdjuster a(this, PhantomRefsPhase, num_phantom_refs);
 
   if (processing_is_mt()) {
-    RefProcBalanceQueuesTimeTracker tt(RefPhase4, &phase_times);
+    RefProcBalanceQueuesTimeTracker tt(PhantomRefsPhase, &phase_times);
     maybe_balance_queues(_discoveredPhantomRefs);
   }
 
-  // Phase 4: Walk phantom references appropriately.
-  RefProcPhaseTimeTracker tt(RefPhase4, &phase_times);
+  // Walk phantom references appropriately.
+  RefProcPhaseTimeTracker tt(PhantomRefsPhase, &phase_times);
 
-  log_reflist("Phase 4 Phantom before", _discoveredPhantomRefs, _max_num_queues);
+  log_reflist("PhantomRefsPhase Phantom before", _discoveredPhantomRefs, _max_num_queues);
 
-  RefProcPhase4Task phase4(*this, &phase_times);
-  run_task(phase4, proxy_task, false);
+  RefProcPhantomPhaseTask phase_task(*this, &phase_times);
+  run_task(phase_task, proxy_task, false);
 
   verify_total_count_zero(_discoveredPhantomRefs, "PhantomReference");
 }
@@ -1190,7 +1189,7 @@ uint RefProcMTDegreeAdjuster::ergo_proc_thread_count(size_t ref_count,
 
 bool RefProcMTDegreeAdjuster::use_max_threads(RefProcPhases phase) const {
   // Even a small number of references in this phase could produce large amounts of work.
-  return phase == ReferenceProcessor::RefPhase3;
+  return phase == ReferenceProcessor::KeepAliveFinalRefsPhase;
 }
 
 RefProcMTDegreeAdjuster::RefProcMTDegreeAdjuster(ReferenceProcessor* rp,

--- a/src/hotspot/share/gc/shared/referenceProcessor.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.hpp
@@ -160,26 +160,26 @@ public:
 // straightforward manner in a general, non-generational, non-contiguous generation
 // (or heap) setting.
 class ReferenceProcessor : public ReferenceDiscoverer {
-  friend class RefProcPhase2Task;
-  friend class RefProcPhase3Task;
-  friend class RefProcPhase4Task;
+  friend class RefProcSoftWeakFinalPhaseTask;
+  friend class RefProcKeepAliveFinalPhaseTask;
+  friend class RefProcPhantomPhaseTask;
 public:
   // Names of sub-phases of reference processing. Indicates the type of the reference
   // processed and the associated phase number at the end.
   enum RefProcSubPhases {
-    SoftRefSubPhase2,
-    WeakRefSubPhase2,
-    FinalRefSubPhase2,
-    FinalRefSubPhase3,
-    PhantomRefSubPhase4,
+    ProcessSoftRefSubPhase,
+    ProcessWeakRefSubPhase,
+    ProcessFinalRefSubPhase,
+    KeepAliveFinalRefsSubPhase,
+    ProcessPhantomRefsSubPhase,
     RefSubPhaseMax
   };
 
   // Main phases of reference processing.
   enum RefProcPhases {
-    RefPhase2,
-    RefPhase3,
-    RefPhase4,
+    SoftWeakFinalRefsPhase,
+    KeepAliveFinalRefsPhase,
+    PhantomRefsPhase,
     RefPhaseMax
   };
 
@@ -234,16 +234,16 @@ private:
 
   void run_task(RefProcTask& task, RefProcProxyTask& proxy_task, bool marks_oops_alive);
 
-  // Phase 2: Drop Soft/Weak/Final references with a NULL or live referent, and clear
+  // Drop Soft/Weak/Final references with a NULL or live referent, and clear
   // and enqueue non-Final references.
   void process_soft_weak_final_refs(RefProcProxyTask& proxy_task,
                                     ReferenceProcessorPhaseTimes& phase_times);
 
-  // Phase 3: Keep alive followers of Final references, and enqueue.
+  // Keep alive followers of Final references, and enqueue.
   void process_final_keep_alive(RefProcProxyTask& proxy_task,
                                 ReferenceProcessorPhaseTimes& phase_times);
 
-  // Phase 4: Drop and keep alive live Phantom references, or clear and enqueue if dead.
+  // Drop and keep alive live Phantom references, or clear and enqueue if dead.
   void process_phantom_refs(RefProcProxyTask& proxy_task,
                             ReferenceProcessorPhaseTimes& phase_times);
 

--- a/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
@@ -172,7 +172,7 @@ ReferenceProcessorPhaseTimes::ReferenceProcessorPhaseTimes(GCTimer* gc_timer, ui
   for (uint i = 0; i < ReferenceProcessor::RefSubPhaseMax; i++) {
     _sub_phases_worker_time_sec[i] = new WorkerDataArray<double>(NULL, SubPhasesParWorkTitle[i], max_gc_threads);
   }
-  _SoftWeakFinalRefsPhase_worker_time_sec = new WorkerDataArray<double>(NULL, SoftWeakFinalRefsPhaseParWorkTitle, max_gc_threads);
+  _soft_weak_final_refs_phase_worker_time_sec = new WorkerDataArray<double>(NULL, SoftWeakFinalRefsPhaseParWorkTitle, max_gc_threads);
 
   reset();
 }
@@ -208,7 +208,7 @@ void ReferenceProcessorPhaseTimes::reset() {
     _balance_queues_time_ms[i] = uninitialized();
   }
 
-  _SoftWeakFinalRefsPhase_worker_time_sec->reset();
+  _soft_weak_final_refs_phase_worker_time_sec->reset();
 
   for (int i = 0; i < number_of_subclasses_of_ref; i++) {
     _ref_cleared[i] = 0;
@@ -224,7 +224,7 @@ ReferenceProcessorPhaseTimes::~ReferenceProcessorPhaseTimes() {
   for (int i = 0; i < ReferenceProcessor::RefSubPhaseMax; i++) {
     delete _sub_phases_worker_time_sec[i];
   }
-  delete _SoftWeakFinalRefsPhase_worker_time_sec;
+  delete _soft_weak_final_refs_phase_worker_time_sec;
 }
 
 double ReferenceProcessorPhaseTimes::sub_phase_total_time_ms(ReferenceProcessor::RefProcSubPhases sub_phase) const {
@@ -340,7 +340,7 @@ void ReferenceProcessorPhaseTimes::print_phase(ReferenceProcessor::RefProcPhases
         ShouldNotReachHere();
     }
     if (phase == ReferenceProcessor::SoftWeakFinalRefsPhase) {
-      print_worker_time(&ls, _SoftWeakFinalRefsPhase_worker_time_sec, SoftWeakFinalRefsPhaseSerWorkTitle, indent + 1);
+      print_worker_time(&ls, _soft_weak_final_refs_phase_worker_time_sec, SoftWeakFinalRefsPhaseSerWorkTitle, indent + 1);
     }
   }
 }

--- a/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
@@ -36,11 +36,11 @@
 #define ASSERT_REF_TYPE(ref_type) assert((ref_type) >= REF_SOFT && (ref_type) <= REF_PHANTOM, \
                                          "Invariant (%d)", (int)ref_type)
 
-#define ASSERT_PHASE(phase) assert((phase) >= ReferenceProcessor::RefPhase2 && \
+#define ASSERT_PHASE(phase) assert((phase) >= ReferenceProcessor::SoftWeakFinalRefsPhase && \
                                    (phase) < ReferenceProcessor::RefPhaseMax,  \
                                    "Invariant (%d)", (int)phase);
 
-#define ASSERT_SUB_PHASE(phase) assert((phase) >= ReferenceProcessor::SoftRefSubPhase2 && \
+#define ASSERT_SUB_PHASE(phase) assert((phase) >= ReferenceProcessor::ProcessSoftRefSubPhase && \
                                        (phase) < ReferenceProcessor::RefSubPhaseMax, \
                                        "Invariant (%d)", (int)phase);
 
@@ -52,7 +52,7 @@ static const char* SubPhasesParWorkTitle[ReferenceProcessor::RefSubPhaseMax] = {
        "PhantomRef (ms):"
        };
 
-static const char* Phase2ParWorkTitle = "Total (ms):";
+static const char* SoftWeakFinalRefsPhaseParWorkTitle = "Total (ms):";
 
 static const char* SubPhasesSerWorkTitle[ReferenceProcessor::RefSubPhaseMax] = {
        "SoftRef:",
@@ -62,7 +62,7 @@ static const char* SubPhasesSerWorkTitle[ReferenceProcessor::RefSubPhaseMax] = {
        "PhantomRef:"
        };
 
-static const char* Phase2SerWorkTitle = "Total:";
+static const char* SoftWeakFinalRefsPhaseSerWorkTitle = "Total:";
 
 static const char* Indents[6] = {"", "  ", "    ", "      ", "        ", "          "};
 
@@ -172,7 +172,7 @@ ReferenceProcessorPhaseTimes::ReferenceProcessorPhaseTimes(GCTimer* gc_timer, ui
   for (uint i = 0; i < ReferenceProcessor::RefSubPhaseMax; i++) {
     _sub_phases_worker_time_sec[i] = new WorkerDataArray<double>(NULL, SubPhasesParWorkTitle[i], max_gc_threads);
   }
-  _phase2_worker_time_sec = new WorkerDataArray<double>(NULL, Phase2ParWorkTitle, max_gc_threads);
+  _SoftWeakFinalRefsPhase_worker_time_sec = new WorkerDataArray<double>(NULL, SoftWeakFinalRefsPhaseParWorkTitle, max_gc_threads);
 
   reset();
 }
@@ -208,7 +208,7 @@ void ReferenceProcessorPhaseTimes::reset() {
     _balance_queues_time_ms[i] = uninitialized();
   }
 
-  _phase2_worker_time_sec->reset();
+  _SoftWeakFinalRefsPhase_worker_time_sec->reset();
 
   for (int i = 0; i < number_of_subclasses_of_ref; i++) {
     _ref_cleared[i] = 0;
@@ -224,7 +224,7 @@ ReferenceProcessorPhaseTimes::~ReferenceProcessorPhaseTimes() {
   for (int i = 0; i < ReferenceProcessor::RefSubPhaseMax; i++) {
     delete _sub_phases_worker_time_sec[i];
   }
-  delete _phase2_worker_time_sec;
+  delete _SoftWeakFinalRefsPhase_worker_time_sec;
 }
 
 double ReferenceProcessorPhaseTimes::sub_phase_total_time_ms(ReferenceProcessor::RefProcSubPhases sub_phase) const {
@@ -272,9 +272,9 @@ void ReferenceProcessorPhaseTimes::print_all_references(uint base_indent, bool p
   }
 
   uint next_indent = base_indent + 1;
-  print_phase(ReferenceProcessor::RefPhase2, next_indent);
-  print_phase(ReferenceProcessor::RefPhase3, next_indent);
-  print_phase(ReferenceProcessor::RefPhase4, next_indent);
+  print_phase(ReferenceProcessor::SoftWeakFinalRefsPhase, next_indent);
+  print_phase(ReferenceProcessor::KeepAliveFinalRefsPhase, next_indent);
+  print_phase(ReferenceProcessor::PhantomRefsPhase, next_indent);
 
   print_reference(REF_SOFT, next_indent);
   print_reference(REF_WEAK, next_indent);
@@ -325,22 +325,22 @@ void ReferenceProcessorPhaseTimes::print_phase(ReferenceProcessor::RefProcPhases
     }
 
     switch (phase) {
-      case ReferenceProcessor::RefPhase2:
-        print_sub_phase(&ls, ReferenceProcessor::SoftRefSubPhase2, indent + 1);
-        print_sub_phase(&ls, ReferenceProcessor::WeakRefSubPhase2, indent + 1);
-        print_sub_phase(&ls, ReferenceProcessor::FinalRefSubPhase2, indent + 1);
+      case ReferenceProcessor::SoftWeakFinalRefsPhase:
+        print_sub_phase(&ls, ReferenceProcessor::ProcessSoftRefSubPhase, indent + 1);
+        print_sub_phase(&ls, ReferenceProcessor::ProcessWeakRefSubPhase, indent + 1);
+        print_sub_phase(&ls, ReferenceProcessor::ProcessFinalRefSubPhase, indent + 1);
         break;
-      case ReferenceProcessor::RefPhase3:
-        print_sub_phase(&ls, ReferenceProcessor::FinalRefSubPhase3, indent + 1);
+      case ReferenceProcessor::KeepAliveFinalRefsPhase:
+        print_sub_phase(&ls, ReferenceProcessor::KeepAliveFinalRefsSubPhase, indent + 1);
         break;
-      case ReferenceProcessor::RefPhase4:
-        print_sub_phase(&ls, ReferenceProcessor::PhantomRefSubPhase4, indent + 1);
+      case ReferenceProcessor::PhantomRefsPhase:
+        print_sub_phase(&ls, ReferenceProcessor::ProcessPhantomRefsSubPhase, indent + 1);
         break;
       default:
         ShouldNotReachHere();
     }
-    if (phase == ReferenceProcessor::RefPhase2) {
-      print_worker_time(&ls, _phase2_worker_time_sec, Phase2SerWorkTitle, indent + 1);
+    if (phase == ReferenceProcessor::SoftWeakFinalRefsPhase) {
+      print_worker_time(&ls, _SoftWeakFinalRefsPhase_worker_time_sec, SoftWeakFinalRefsPhaseSerWorkTitle, indent + 1);
     }
   }
 }

--- a/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.hpp
@@ -49,7 +49,7 @@ class ReferenceProcessorPhaseTimes : public CHeapObj<mtGC> {
   // Records total queue balancing for each phase.
   double                   _balance_queues_time_ms[ReferenceProcessor::RefPhaseMax];
 
-  WorkerDataArray<double>* _SoftWeakFinalRefsPhase_worker_time_sec;
+  WorkerDataArray<double>* _soft_weak_final_refs_phase_worker_time_sec;
 
   // Total spent time for reference processing.
   double                   _total_time_ms;
@@ -80,7 +80,7 @@ public:
   ReferenceProcessorPhaseTimes(GCTimer* gc_timer, uint max_gc_threads);
   ~ReferenceProcessorPhaseTimes();
 
-  WorkerDataArray<double>* SoftWeakFinalRefsPhase_worker_time_sec() const { return _SoftWeakFinalRefsPhase_worker_time_sec; }
+  WorkerDataArray<double>* soft_weak_final_refs_phase_worker_time_sec() const { return _soft_weak_final_refs_phase_worker_time_sec; }
   WorkerDataArray<double>* sub_phase_worker_time_sec(ReferenceProcessor::RefProcSubPhases phase) const;
   void set_phase_time_ms(ReferenceProcessor::RefProcPhases phase, double par_phase_time_ms);
 

--- a/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.hpp
@@ -49,7 +49,7 @@ class ReferenceProcessorPhaseTimes : public CHeapObj<mtGC> {
   // Records total queue balancing for each phase.
   double                   _balance_queues_time_ms[ReferenceProcessor::RefPhaseMax];
 
-  WorkerDataArray<double>* _phase2_worker_time_sec;
+  WorkerDataArray<double>* _SoftWeakFinalRefsPhase_worker_time_sec;
 
   // Total spent time for reference processing.
   double                   _total_time_ms;
@@ -80,7 +80,7 @@ public:
   ReferenceProcessorPhaseTimes(GCTimer* gc_timer, uint max_gc_threads);
   ~ReferenceProcessorPhaseTimes();
 
-  WorkerDataArray<double>* phase2_worker_time_sec() const { return _phase2_worker_time_sec; }
+  WorkerDataArray<double>* SoftWeakFinalRefsPhase_worker_time_sec() const { return _SoftWeakFinalRefsPhase_worker_time_sec; }
   WorkerDataArray<double>* sub_phase_worker_time_sec(ReferenceProcessor::RefProcSubPhases phase) const;
   void set_phase_time_ms(ReferenceProcessor::RefProcPhases phase, double par_phase_time_ms);
 


### PR DESCRIPTION
Simple rename of phase{2,3,4} to something with semantic meaning.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270282](https://bugs.openjdk.java.net/browse/JDK-8270282): Semantically rename reference processing subphases


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to 49a4e277a3b16f5340ab1142205686e835e544b3
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 49a4e277a3b16f5340ab1142205686e835e544b3


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4752/head:pull/4752` \
`$ git checkout pull/4752`

Update a local copy of the PR: \
`$ git checkout pull/4752` \
`$ git pull https://git.openjdk.java.net/jdk pull/4752/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4752`

View PR using the GUI difftool: \
`$ git pr show -t 4752`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4752.diff">https://git.openjdk.java.net/jdk/pull/4752.diff</a>

</details>
