### PR TITLE
8270187: G1: Remove ConcGCThreads constraint

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -377,7 +377,7 @@ G1ConcurrentMark::G1ConcurrentMark(G1CollectedHeap* g1h,
   // _finger set in set_non_marking_state
 
   _worker_id_offset(G1DirtyCardQueueSet::num_par_ids() + G1ConcRefinementThreads),
-  _max_num_tasks(ParallelGCThreads),
+  _max_num_tasks(MAX2(ConcGCThreads, ParallelGCThreads)),
   // _num_active_tasks set in set_non_marking_state()
   // _tasks set inside the constructor
 

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -148,7 +148,6 @@
                                                                             \
   product(uint, ConcGCThreads, 0,                                           \
           "Number of threads concurrent gc will use")                       \
-          constraint(ConcGCThreadsConstraintFunc,AfterErgo)                 \
                                                                             \
   product(bool, AlwaysTenure, false,                                        \
           "Always tenure objects in eden (ParallelGC only)")                \

--- a/src/hotspot/share/gc/shared/jvmFlagConstraintsGC.cpp
+++ b/src/hotspot/share/gc/shared/jvmFlagConstraintsGC.cpp
@@ -67,21 +67,6 @@ JVMFlag::Error ParallelGCThreadsConstraintFunc(uint value, bool verbose) {
   return status;
 }
 
-// As ConcGCThreads should be smaller than ParallelGCThreads,
-// we need constraint function.
-JVMFlag::Error ConcGCThreadsConstraintFunc(uint value, bool verbose) {
-  // G1 GC use ConcGCThreads.
-  if (GCConfig::is_gc_selected(CollectedHeap::G1) && (value > ParallelGCThreads)) {
-    JVMFlag::printError(verbose,
-                        "ConcGCThreads (" UINT32_FORMAT ") must be "
-                        "less than or equal to ParallelGCThreads (" UINT32_FORMAT ")\n",
-                        value, ParallelGCThreads);
-    return JVMFlag::VIOLATES_CONSTRAINT;
-  }
-
-  return JVMFlag::SUCCESS;
-}
-
 static JVMFlag::Error MinPLABSizeBounds(const char* name, size_t value, bool verbose) {
   if ((GCConfig::is_gc_selected(CollectedHeap::G1) || GCConfig::is_gc_selected(CollectedHeap::Parallel)) &&
       (value < PLAB::min_size())) {

--- a/src/hotspot/share/gc/shared/jvmFlagConstraintsGC.hpp
+++ b/src/hotspot/share/gc/shared/jvmFlagConstraintsGC.hpp
@@ -42,7 +42,6 @@
  */
 #define SHARED_GC_CONSTRAINTS(f)                               \
  f(uint,   ParallelGCThreadsConstraintFunc)                    \
- f(uint,   ConcGCThreadsConstraintFunc)                        \
  f(size_t, YoungPLABSizeConstraintFunc)                        \
  f(size_t, OldPLABSizeConstraintFunc)                          \
  f(uintx,  MinHeapFreeRatioConstraintFunc)                     \

--- a/test/hotspot/jtreg/gc/g1/TestMarkStackSizes.java
+++ b/test/hotspot/jtreg/gc/g1/TestMarkStackSizes.java
@@ -81,7 +81,7 @@ public class TestMarkStackSizes {
 
         runTest(true, "-XX:ConcGCThreads=3", "-XX:ParallelGCThreads=3");
         runTest(true, "-XX:ConcGCThreads=0", "-XX:ParallelGCThreads=3");
-        runTest(false, "-XX:ConcGCThreads=4", "-XX:ParallelGCThreads=3");
+        runTest(true, "-XX:ConcGCThreads=4", "-XX:ParallelGCThreads=3");
 
         // With that high ParallelGCThreads the default ergonomics would calculate
         // a mark stack size higher than maximum mark stack size.


### PR DESCRIPTION
Removing `ConcGCThreads <= ParallelGCThreads` constraint for G1.

Tested: hotspot_gc with `-XX:ConcGCThreads=3 -XX:ParallelGCThreads=2`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270187](https://bugs.openjdk.java.net/browse/JDK-8270187): G1: Remove ConcGCThreads constraint


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4756/head:pull/4756` \
`$ git checkout pull/4756`

Update a local copy of the PR: \
`$ git checkout pull/4756` \
`$ git pull https://git.openjdk.java.net/jdk pull/4756/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4756`

View PR using the GUI difftool: \
`$ git pr show -t 4756`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4756.diff">https://git.openjdk.java.net/jdk/pull/4756.diff</a>

</details>
