### PR TITLE
8270320: JDK-8270110 committed invalid copyright headers

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/jni/TestStringCriticalWithDedup.java
+++ b/test/hotspot/jtreg/gc/shenandoah/jni/TestStringCriticalWithDedup.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as

--- a/test/hotspot/jtreg/gc/shenandoah/jni/libTestStringCriticalWithDedup.c
+++ b/test/hotspot/jtreg/gc/shenandoah/jni/libTestStringCriticalWithDedup.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as


### PR DESCRIPTION
The fix for JDK-8270110 added two new files with copyright headers that do not follow the prescribed format.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270320](https://bugs.openjdk.java.net/browse/JDK-8270320): JDK-8270110 committed invalid copyright headers


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4757/head:pull/4757` \
`$ git checkout pull/4757`

Update a local copy of the PR: \
`$ git checkout pull/4757` \
`$ git pull https://git.openjdk.java.net/jdk pull/4757/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4757`

View PR using the GUI difftool: \
`$ git pr show -t 4757`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4757.diff">https://git.openjdk.java.net/jdk/pull/4757.diff</a>

</details>
