### PR TITLE
8211002: test/jdk/java/lang/Math/PowTests.java skips testing for non-corner-case values

### DIFF
--- a/test/jdk/java/lang/Math/PowTests.java
+++ b/test/jdk/java/lang/Math/PowTests.java
@@ -60,16 +60,10 @@ public class PowTests {
     static int testStrictVsNonstrictPowCase(double input1, double input2) {
         double smResult = StrictMath.pow(input1, input2);
         double mResult = Math.pow(input1, input2);
-        int failures = 0;
-        if (Double.isNaN(smResult)) {
-            if (!Double.isNaN(mResult)) failures = 1;
-        } else {
-            failures += Tests.testUlpDiff(
-                "StrictMath.pow(double, double) vs Math.pow(double, double)",
-                input1, input2, mResult, smResult, 1.0
-            );
-        }
-        return failures;
+        return Tests.testUlpDiff(
+            "StrictMath.pow(double, double) vs Math.pow(double, double)",
+            input1, input2, mResult, smResult, 2.0
+        );
     }
 
     /*

--- a/test/jdk/java/lang/Math/PowTests.java
+++ b/test/jdk/java/lang/Math/PowTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,6 +54,21 @@ public class PowTests {
         int failures = 0;
         failures += Tests.test("Math.pow(double, double)", input1, input2,
                                Math.pow(input1, input2), expected);
+        return failures;
+    }
+
+    static int testStrictVsNonstrictPowCase(double input1, double input2) {
+        double smResult = StrictMath.pow(input1, input2);
+        double mResult = Math.pow(input1, input2);
+        int failures = 0;
+        if (Double.isNaN(smResult)) {
+            if (!Double.isNaN(mResult)) failures = 1;
+        } else {
+            failures += Tests.testUlpDiff(
+                "StrictMath.pow(double, double) vs Math.pow(double, double)",
+                input1, input2, mResult, smResult, 1.0
+            );
+        }
         return failures;
     }
 
@@ -206,8 +221,10 @@ public class PowTests {
                     assert y != 0.0;
                     failures += testStrictPowCase(x, y, f3(x, y));
                     failures += testNonstrictPowCase(x, y, f3ns(x, y));
+                    failures += testStrictVsNonstrictPowCase(x, y);
                     continue;
                 } else {
+                    failures += testStrictVsNonstrictPowCase(x, y);
                     // go to next iteration
                     expected = NaN;
                     continue;


### PR DESCRIPTION
Please consider this proposal to add some test coverage comparing `Math` and `StrictMath` results of `pow()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8211002](https://bugs.openjdk.java.net/browse/JDK-8211002): test/jdk/java/lang/Math/PowTests.java skips testing for non-corner-case values


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4758/head:pull/4758` \
`$ git checkout pull/4758`

Update a local copy of the PR: \
`$ git checkout pull/4758` \
`$ git pull https://git.openjdk.java.net/jdk pull/4758/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4758`

View PR using the GUI difftool: \
`$ git pr show -t 4758`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4758.diff">https://git.openjdk.java.net/jdk/pull/4758.diff</a>

</details>
