### PR TITLE
8269598: Regressions up to 5% on aarch64 seems due to JDK-8268858

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -2591,6 +2591,14 @@ uint Matcher::int_pressure_limit()
   // a high register pressure area of the code so that split_DEF can
   // generate DefinitionSpillCopy for the derived pointer.
   uint default_int_pressure_threshold = _NO_SPECIAL_REG32_mask.Size() - 1;
+  if (!PreserveFramePointer) {
+    // When PreserveFramePointer is off, frame pointer is allocatable,
+    // but different from other SOC registers, it is excluded from
+    // fatproj's mask because its save type is No-Save. Decrease 1 to
+    // ensure high pressure at fatproj when PreserveFramePointer is off.
+    // See check_pressure_at_fatproj().
+    default_int_pressure_threshold--;
+  }
   return (INTPRESSURE == -1) ? default_int_pressure_threshold : INTPRESSURE;
 }
 


### PR DESCRIPTION
Hi,

Please review this change.
It fixes the SPECjvm2008 regression on aarch64 caused by JDK-8268858.

Compressor::compress() in case "compress" of SPECjvm2008 performed
degraded by 5% due to extra spillings. There existed an LRG that covered
almost the entire function, hence it interfered with more live ranges.
These interferences caused the LRG no freedom and lastly RA had to spill
it to stack. After the fix, the LRG is split into two shorter live
ranges. Both LRGs are assigned to registers due to fewer interferences.

See details at: http://cr.openjdk.java.net/~jzhu/8269598/analysis.pdf
OptoAssembly: http://cr.openjdk.java.net/~jzhu/8269598/

The root cause is:
When PreserveFramePointer is off, frame pointer is allocatable, but
different from other SOC registers, it is excluded from fatproj's mask
because its save type is No-Save. Therefore fatproj was not treated as
high-pressure transition point in the previous int_pressure_limit()
computation. This fix ensures high pressure at fatproj when
PreserveFramePointer is off. See check_pressure_at_fatproj() [1].

After this fix, the regression disappeared.
The result of regression cases in SPECjvm2008:
    http://cr.openjdk.java.net/~jzhu/8269598/Book1.pdf

[1] https://github.com/openjdk/jdk/blob/375fc2a2b29c454b36d3ae068a080b28f6ec04e9/src/hotspot/share/opto/chaitin.hpp#L620

Best Regards,
Joshua

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269598](https://bugs.openjdk.java.net/browse/JDK-8269598): Regressions up to 5% on aarch64 seems due to JDK-8268858


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4766/head:pull/4766` \
`$ git checkout pull/4766`

Update a local copy of the PR: \
`$ git checkout pull/4766` \
`$ git pull https://git.openjdk.java.net/jdk pull/4766/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4766`

View PR using the GUI difftool: \
`$ git pr show -t 4766`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4766.diff">https://git.openjdk.java.net/jdk/pull/4766.diff</a>

</details>
