### PR TITLE
8270086: ARM32-softfp: Do not load CONSTANT_double using the condy helper methods in the interpreter

### DIFF
--- a/src/hotspot/cpu/arm/templateTable_arm.cpp
+++ b/src/hotspot/cpu/arm/templateTable_arm.cpp
@@ -496,18 +496,27 @@ void TemplateTable::ldc2_w() {
   __ cmp(Rtemp, JVM_CONSTANT_Double);
   __ b(NotDouble, ne);
   __ ldr_double(D0_tos, Address(Rbase, base_offset));
-
   __ push(dtos);
   __ b(exit);
-  __ bind(NotDouble);
-#endif
 
+  __ bind(NotDouble);
   __ cmp(Rtemp, JVM_CONSTANT_Long);
   __ b(Condy, ne);
   __ ldr(R0_tos_lo, Address(Rbase, base_offset + 0 * wordSize));
   __ ldr(R1_tos_hi, Address(Rbase, base_offset + 1 * wordSize));
   __ push(ltos);
   __ b(exit);
+#else // !__ABI_HARD__
+  __ cmp(Rtemp, JVM_CONSTANT_Long);
+  __ cond_cmp(Rtemp, JVM_CONSTANT_Double, ne);
+  __ b(Condy, ne);
+  __ ldr(R0_tos_lo, Address(Rbase, base_offset + 0 * wordSize));
+  __ ldr(R1_tos_hi, Address(Rbase, base_offset + 1 * wordSize));
+  // doubles and longs are placed on the stack in the same way
+  // without VFP, we can push(ltos) to transfer a double value
+  __ push(ltos);
+  __ b(exit);
+#endif // __ABI_HARD__
 
   __ bind(Condy);
   condy_helper(exit);

--- a/src/hotspot/cpu/arm/templateTable_arm.cpp
+++ b/src/hotspot/cpu/arm/templateTable_arm.cpp
@@ -490,38 +490,30 @@ void TemplateTable::ldc2_w() {
   __ add(Rtemp, Rtags, tags_offset);
   __ ldrb(Rtemp, Address(Rtemp, Rindex));
 
-  Label Condy, exit;
-#ifdef __ABI_HARD__
-  Label NotDouble;
+  Label Done, NotLong, NotDouble;
   __ cmp(Rtemp, JVM_CONSTANT_Double);
   __ b(NotDouble, ne);
+#ifdef __SOFTFP__
+  __ ldr(R0_tos_lo, Address(Rbase, base_offset + 0 * wordSize));
+  __ ldr(R1_tos_hi, Address(Rbase, base_offset + 1 * wordSize));
+#else // !__SOFTFP__
   __ ldr_double(D0_tos, Address(Rbase, base_offset));
+#endif // __SOFTFP__
   __ push(dtos);
-  __ b(exit);
-
+  __ b(Done);
   __ bind(NotDouble);
+
   __ cmp(Rtemp, JVM_CONSTANT_Long);
-  __ b(Condy, ne);
+  __ b(NotLong, ne);
   __ ldr(R0_tos_lo, Address(Rbase, base_offset + 0 * wordSize));
   __ ldr(R1_tos_hi, Address(Rbase, base_offset + 1 * wordSize));
   __ push(ltos);
-  __ b(exit);
-#else // !__ABI_HARD__
-  __ cmp(Rtemp, JVM_CONSTANT_Long);
-  __ cond_cmp(Rtemp, JVM_CONSTANT_Double, ne);
-  __ b(Condy, ne);
-  __ ldr(R0_tos_lo, Address(Rbase, base_offset + 0 * wordSize));
-  __ ldr(R1_tos_hi, Address(Rbase, base_offset + 1 * wordSize));
-  // doubles and longs are placed on the stack in the same way
-  // without VFP, we can push(ltos) to transfer a double value
-  __ push(ltos);
-  __ b(exit);
-#endif // __ABI_HARD__
+  __ b(Done);
+  __ bind(NotLong);
 
-  __ bind(Condy);
-  condy_helper(exit);
+  condy_helper(Done);
 
-  __ bind(exit);
+  __ bind(Done);
 }
 
 


### PR DESCRIPTION
Hi,

please review this fix for the template interpreter for ARM32-softfp.

With the introduction of condy, the interpreter started to load double constants using the condy_helper, which is unnecessary. Also, the [resolve_ldc](https://github.com/openjdk/jdk/blob/8973867fb9568a3a527b763c9ce10cebdfb306d0/src/hotspot/share/interpreter/interpreterRuntime.cpp#L148) implementation of the interpreter runtime might not be designed to load constant values. It should only load strings and condy.

https://github.com/openjdk/jdk/blob/2ee56fd1cf4acd634e19cc77b7c9a6858e1c315a/src/hotspot/cpu/arm/templateTable_arm.cpp#L515-L560

I refactored the ldc2_w bytecode imlpementation. Now, the ifdef between soft and hard float covers both types, CONSTANT_Long and CONSTANT_Double. I did this, because for the softfp, we can use a conditional cmp, since double and long are both placed on the stack in the same way. The same is also done for CONSTANT_Integer and CONSTANT_Float in the ldc bytecode implementation. Also, I think it is easier to follow the code this way.

Old ldc2_w implementation (before condy was implemented for ARM32):

https://github.com/openjdk/jdk/blob/7101b28dc3903be27cb46a00781f4d74f81f1114/src/hotspot/cpu/arm/templateTable_arm.cpp#L497-L537

Testing: ARMv7-A (hardfp) hotspot tier1, ARMv5TE (softfp) hotspot tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270086](https://bugs.openjdk.java.net/browse/JDK-8270086): ARM32-softfp: Do not load CONSTANT_double using the condy helper methods in the interpreter


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4767/head:pull/4767` \
`$ git checkout pull/4767`

Update a local copy of the PR: \
`$ git checkout pull/4767` \
`$ git pull https://git.openjdk.java.net/jdk pull/4767/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4767`

View PR using the GUI difftool: \
`$ git pr show -t 4767`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4767.diff">https://git.openjdk.java.net/jdk/pull/4767.diff</a>

</details>
