### PR TITLE
8075806: divideExact is missing in java.lang.Math

### DIFF
--- a/src/java.base/share/classes/java/lang/Math.java
+++ b/src/java.base/share/classes/java/lang/Math.java
@@ -91,13 +91,8 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * will not overflow the range of values of the computation.
  * The best practice is to choose the primitive type and algorithm to avoid
  * overflow. In cases where the size is {@code int} or {@code long} and
- * overflow errors need to be detected, the methods {@code addExact},
- * {@code subtractExact}, {@code multiplyExact}, {@code toIntExact},
- * {@code incrementExact}, {@code decrementExact} and {@code negateExact}
- * throw an {@code ArithmeticException} when the results overflow.
- * For the arithmetic operations divide and absolute value, overflow
- * occurs only with a specific minimum or maximum value and
- * should be checked against the minimum or maximum as appropriate.
+ * overflow errors need to be detected, the methods whose names end with
+ * {@code Exact} throw an {@code ArithmeticException} when the results overflow.
  *
  * <h2><a id=Ieee754RecommendedOps>IEEE 754 Recommended
  * Operations</a></h2>
@@ -1005,6 +1000,53 @@ public final class Math {
             }
         }
         return r;
+    }
+
+    /**
+     * Returns the quotient of the arguments, throwing an exception if the
+     * result overflows an {@code int}.  Such overflow can occur if and only
+     * if either {@code y} is zero, or both {@code x} is
+     * {@link Integer#MIN_VALUE} and {@code y} is {@code -1}.  In contrast,
+     * if {@code Integer.MIN_VALUE / -1} were evaluated directly, the result
+     * would be {@code Integer.MIN_VALUE} and no exception would be thrown.
+     *
+     * @param x the dividend
+     * @param y the divisor
+     * @return the quotient {@code x / y}
+     * @throws ArithmeticException if the quotient overflows an int
+     * @jls 15.17.2 Division Operator /
+     * @since 18
+     */
+    public static int divideExact(int x, int y) {
+        // * This conditional is slower than the straightfoward one below.
+        // HD 2nd. Ed. p. 44 section 2-13 Overflow Detection: Division
+        // int z = (x ^ Integer.MIN_VALUE) | (y + 1);
+        // if (((y | -y) & (z | -z)) >= 0)
+
+        if (x == Integer.MIN_VALUE && y == -1)
+            throw new ArithmeticException("integer overflow");
+        return x / y; // if y == 0, ArithmeticException is thrown here
+    }
+
+    /**
+     * Returns the quotient of the arguments, throwing an exception if the
+     * result overflows a {@code long}.  Such overflow can occur if and only
+     * if either {@code y} is zero, or both {@code x} is
+     * {@link Long#MIN_VALUE} and {@code y} is {@code -1}.  In contrast,
+     * if {@code Long.MIN_VALUE / -1} were evaluated directly, the result
+     * would be {@code Long.MIN_VALUE} and no exception would be thrown.
+     *
+     * @param x the dividend
+     * @param y the divisor
+     * @return the quotient {@code x / y}
+     * @throws ArithmeticException if the quotient overflows a long
+     * @jls 15.17.2 Division Operator /
+     * @since 18
+     */
+    public static long divideExact(long x, long y) {
+        if (x == Long.MIN_VALUE && y == -1L)
+            throw new ArithmeticException("long overflow");
+        return x / y; // if y == 0, ArithmeticException is thrown here
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Math.java
+++ b/src/java.base/share/classes/java/lang/Math.java
@@ -1010,13 +1010,14 @@ public final class Math {
      * the result would be {@code Integer.MIN_VALUE} and no exception would be
      * thrown.
      * <p>
-     * If {@code y} is zero, overflow also occurs as in direct evaluation and
-     * an exception is thrown as usual.
+     * If {@code y} is zero, an {@code ArithmeticException} is thrown
+     * (JLS {@jls 15.17.2}).
      *
      * @param x the dividend
      * @param y the divisor
      * @return the quotient {@code x / y}
-     * @throws ArithmeticException if the quotient overflows an int
+     * @throws ArithmeticException if {@code y} is zero or the quotient
+     * overflows an int
      * @jls 15.17.2 Division Operator /
      * @since 18
      */
@@ -1036,13 +1037,14 @@ public final class Math {
      * the result would be {@code Long.MIN_VALUE} and no exception would be
      * thrown.
      * <p>
-     * If {@code y} is zero, overflow also occurs as in direct evaluation and
-     * an exception is thrown as usual.
+     * If {@code y} is zero, an {@code ArithmeticException} is thrown
+     * (JLS {@jls 15.17.2}).
      *
      * @param x the dividend
      * @param y the divisor
      * @return the quotient {@code x / y}
-     * @throws ArithmeticException if the quotient overflows a long
+     * @throws ArithmeticException if {@code y} is zero or the quotient
+     * overflows a long
      * @jls 15.17.2 Division Operator /
      * @since 18
      */

--- a/src/java.base/share/classes/java/lang/Math.java
+++ b/src/java.base/share/classes/java/lang/Math.java
@@ -1004,11 +1004,14 @@ public final class Math {
 
     /**
      * Returns the quotient of the arguments, throwing an exception if the
-     * result overflows an {@code int}.  Such overflow can occur if and only
-     * if either {@code y} is zero, or both {@code x} is
-     * {@link Integer#MIN_VALUE} and {@code y} is {@code -1}.  In contrast,
-     * if {@code Integer.MIN_VALUE / -1} were evaluated directly, the result
-     * would be {@code Integer.MIN_VALUE} and no exception would be thrown.
+     * result overflows an {@code int}.  Such overflow occurs in this method if
+     * {@code x} is {@link Integer#MIN_VALUE} and {@code y} is {@code -1}.
+     * In contrast, if {@code Integer.MIN_VALUE / -1} were evaluated directly,
+     * the result would be {@code Integer.MIN_VALUE} and no exception would be
+     * thrown.
+     * <p>
+     * If {@code y} is zero, overflow also occurs as in direct evaluation and
+     * an exception is thrown as usual.
      *
      * @param x the dividend
      * @param y the divisor
@@ -1018,23 +1021,23 @@ public final class Math {
      * @since 18
      */
     public static int divideExact(int x, int y) {
-        // * This conditional is slower than the straightfoward one below.
-        // HD 2nd. Ed. p. 44 section 2-13 Overflow Detection: Division
-        // int z = (x ^ Integer.MIN_VALUE) | (y + 1);
-        // if (((y | -y) & (z | -z)) >= 0)
-
-        if (x == Integer.MIN_VALUE && y == -1)
-            throw new ArithmeticException("integer overflow");
-        return x / y; // if y == 0, ArithmeticException is thrown here
+        int q = x / y;
+        if ((x & y & q) >= 0) {
+            return q;
+        }
+        throw new ArithmeticException("integer overflow");
     }
 
     /**
      * Returns the quotient of the arguments, throwing an exception if the
-     * result overflows a {@code long}.  Such overflow can occur if and only
-     * if either {@code y} is zero, or both {@code x} is
-     * {@link Long#MIN_VALUE} and {@code y} is {@code -1}.  In contrast,
-     * if {@code Long.MIN_VALUE / -1} were evaluated directly, the result
-     * would be {@code Long.MIN_VALUE} and no exception would be thrown.
+     * result overflows a {@code long}.  Such overflow occurs in this method if
+     * {@code x} is {@link Long#MIN_VALUE} and {@code y} is {@code -1}.
+     * In contrast, if {@code Long.MIN_VALUE / -1} were evaluated directly,
+     * the result would be {@code Long.MIN_VALUE} and no exception would be
+     * thrown.
+     * <p>
+     * If {@code y} is zero, overflow also occurs as in direct evaluation and
+     * an exception is thrown as usual.
      *
      * @param x the dividend
      * @param y the divisor
@@ -1044,9 +1047,11 @@ public final class Math {
      * @since 18
      */
     public static long divideExact(long x, long y) {
-        if (x == Long.MIN_VALUE && y == -1L)
-            throw new ArithmeticException("long overflow");
-        return x / y; // if y == 0, ArithmeticException is thrown here
+        long q = x / y;
+        if ((x & y & q) >= 0) {
+            return q;
+        }
+        throw new ArithmeticException("long overflow");
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/StrictMath.java
+++ b/src/java.base/share/classes/java/lang/StrictMath.java
@@ -861,13 +861,14 @@ public final class StrictMath {
      * the result would be {@code Integer.MIN_VALUE} and no exception would be
      * thrown.
      * <p>
-     * If {@code y} is zero, overflow also occurs as in direct evaluation and
-     * an exception is thrown as usual.
+     * If {@code y} is zero, an {@code ArithmeticException} is thrown
+     * (JLS {@jls 15.17.2}).
      *
      * @param x the dividend
      * @param y the divisor
      * @return the quotient {@code x / y}
-     * @throws ArithmeticException if the quotient overflows an int
+     * @throws ArithmeticException if {@code y} is zero or the quotient
+     * overflows an int
      * @jls 15.17.2 Division Operator /
      * @see Math#divideExact(int,int)
      * @since 18
@@ -884,13 +885,14 @@ public final class StrictMath {
      * the result would be {@code Long.MIN_VALUE} and no exception would be
      * thrown.
      * <p>
-     * If {@code y} is zero, overflow also occurs as in direct evaluation and
-     * an exception is thrown as usual.
+     * If {@code y} is zero, an {@code ArithmeticException} is thrown
+     * (JLS {@jls 15.17.2}).
      *
      * @param x the dividend
      * @param y the divisor
      * @return the quotient {@code x / y}
-     * @throws ArithmeticException if the quotient overflows a long
+     * @throws ArithmeticException if {@code y} is zero or the quotient
+     * overflows a long
      * @jls 15.17.2 Division Operator /
      * @see Math#divideExact(long,long)
      * @since 18

--- a/src/java.base/share/classes/java/lang/StrictMath.java
+++ b/src/java.base/share/classes/java/lang/StrictMath.java
@@ -66,13 +66,8 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * will not overflow the range of values of the computation.
  * The best practice is to choose the primitive type and algorithm to avoid
  * overflow. In cases where the size is {@code int} or {@code long} and
- * overflow errors need to be detected, the methods {@code addExact},
- * {@code subtractExact}, {@code multiplyExact}, {@code toIntExact},
- * {@code incrementExact}, {@code decrementExact} and {@code negateExact}
- * throw an {@code ArithmeticException} when the results overflow.
- * For the arithmetic operations divide and absolute value, overflow
- * occurs only with a specific minimum or maximum value and
- * should be checked against the minimum or maximum as appropriate.
+ * overflow errors need to be detected, the methods whose names end with
+ * {@code Exact} throw an {@code ArithmeticException} when the results overflow.
  *
  * <h2><a id=Ieee754RecommendedOps>IEEE 754 Recommended
  * Operations</a></h2>
@@ -856,6 +851,52 @@ public final class StrictMath {
      */
     public static long multiplyExact(long x, long y) {
         return Math.multiplyExact(x, y);
+    }
+
+    /**
+     * Returns the quotient of the arguments, throwing an exception if the
+     * result overflows an {@code int}.  Such overflow occurs in this method if
+     * {@code x} is {@link Integer#MIN_VALUE} and {@code y} is {@code -1}.
+     * In contrast, if {@code Integer.MIN_VALUE / -1} were evaluated directly,
+     * the result would be {@code Integer.MIN_VALUE} and no exception would be
+     * thrown.
+     * <p>
+     * If {@code y} is zero, overflow also occurs as in direct evaluation and
+     * an exception is thrown as usual.
+     *
+     * @param x the dividend
+     * @param y the divisor
+     * @return the quotient {@code x / y}
+     * @throws ArithmeticException if the quotient overflows an int
+     * @jls 15.17.2 Division Operator /
+     * @see Math#divideExact(int,int)
+     * @since 18
+     */
+    public static int divideExact(int x, int y) {
+        return Math.divideExact(x, y);
+    }
+
+    /**
+     * Returns the quotient of the arguments, throwing an exception if the
+     * result overflows a {@code long}.  Such overflow occurs in this method if
+     * {@code x} is {@link Long#MIN_VALUE} and {@code y} is {@code -1}.
+     * In contrast, if {@code Long.MIN_VALUE / -1} were evaluated directly,
+     * the result would be {@code Long.MIN_VALUE} and no exception would be
+     * thrown.
+     * <p>
+     * If {@code y} is zero, overflow also occurs as in direct evaluation and
+     * an exception is thrown as usual.
+     *
+     * @param x the dividend
+     * @param y the divisor
+     * @return the quotient {@code x / y}
+     * @throws ArithmeticException if the quotient overflows a long
+     * @jls 15.17.2 Division Operator /
+     * @see Math#divideExact(long,long)
+     * @since 18
+     */
+    public static long divideExact(long x, long y) {
+        return Math.divideExact(x, y);
     }
 
     /**

--- a/test/jdk/java/lang/Math/ExactArithTests.java
+++ b/test/jdk/java/lang/Math/ExactArithTests.java
@@ -56,8 +56,9 @@ public class ExactArithTests {
     }
 
     /**
-     * Test Math.addExact, multiplyExact, subtractExact, incrementExact,
-     * decrementExact, negateExact methods with {@code int} arguments.
+     * Test Math.addExact, multiplyExact, divideExact, subtractExact,
+     * incrementExact, decrementExact, negateExact methods with
+     * {@code int} arguments.
      */
     static void testIntegerExact() {
         testIntegerExact(0, 0);
@@ -215,8 +216,9 @@ public class ExactArithTests {
     }
 
     /**
-     * Test Math.addExact, multiplyExact, subtractExact, incrementExact,
-     * decrementExact, negateExact, toIntExact methods with {@code long} arguments.
+     * Test Math.addExact, multiplyExact, divideExact, subtractExact,
+     * incrementExact, decrementExact, negateExact, toIntExact methods
+     * with {@code long} arguments.
      */
     static void testLongExact() {
         testLongExactTwice(0, 0);

--- a/test/jdk/java/lang/Math/ExactArithTests.java
+++ b/test/jdk/java/lang/Math/ExactArithTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@ import java.math.BigInteger;
 
 /**
  * @test Test for Math.*Exact integer and long methods.
- * @bug 6708398
+ * @bug 6708398 8075806
  * @summary Basic tests for Math exact arithmetic operations.
  *
  * @author Roger Riggs
@@ -129,6 +129,39 @@ public class ExactArithTests {
             long m2 = (long) x * (long) y;
             if ((int) m2 == m2) {
                 fail("FAIL: int Math.multiplyExact(" + x + " * " + y + ")" + "; Unexpected exception: " + ex);
+            }
+        }
+
+        boolean exceptionExpected = false;
+        try {
+            // Test divideExact
+            BigInteger q = null;
+            try {
+                q = BigInteger.valueOf(x).divide(BigInteger.valueOf(y));
+            } catch (ArithmeticException e) {
+                exceptionExpected = true;
+            }
+            int quotient = 0;
+            if (q != null) {
+                try {
+                    quotient = q.intValueExact();
+                } catch (ArithmeticException e) {
+                    exceptionExpected = true;
+                }
+            }
+            int z = Math.divideExact(x, y);
+            if (exceptionExpected) {
+                fail("FAIL: int Math.divideExact(" + x + " / " + y + ")" +
+                    "; expected ArithmeticException not thrown");
+            }
+            if (z != quotient) {
+                fail("FAIL: int Math.divideExact(" + x + " / " + y + ") = " +
+                    z + "; expected: " + quotient);
+            }
+        } catch (ArithmeticException ex) {
+            if (!exceptionExpected) {
+                fail("FAIL: int Math.divideExact(" + x + " / " + y + ")" +
+                    "; Unexpected exception: " + ex);
             }
         }
 
@@ -266,6 +299,26 @@ public class ExactArithTests {
         } catch (ArithmeticException ex) {
             if (inLongRange(resultBig)) {
                 fail("FAIL: long Math.multiplyExact(" + x + " * " + y + ")" + "; Unexpected exception: " + ex);
+            }
+        }
+
+        try {
+            // Test divideExact
+            resultBig = null;
+            try {
+                resultBig = xBig.divide(yBig);
+            } catch (ArithmeticException ex) {
+            }
+            long quotient = Math.divideExact(x, y);
+            if (resultBig == null) {
+                fail("FAIL: long Math.divideExact(" + x + " / " + y + ")" +
+                    "; expected ArithmeticException not thrown");
+            }
+            checkResult("long Math.divideExact", x, y, quotient, resultBig);
+        } catch (ArithmeticException ex) {
+            if (resultBig != null && inLongRange(resultBig)) {
+                fail("FAIL: long Math.divideExact(" + x + " / " + y + ")" +
+                    "; Unexpected exception: " + ex);
             }
         }
 


### PR DESCRIPTION
Please consider this proposal to add `divideExact()` methods for integral data types to `java.lang.Math` thereby rounding out "exact" support to all four basic arithmetic operations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8075806](https://bugs.openjdk.java.net/browse/JDK-8075806): divideExact is missing in java.lang.Math


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to 5093a2e877adcaff76b0aa65d5a9b290170f2882


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4770/head:pull/4770` \
`$ git checkout pull/4770`

Update a local copy of the PR: \
`$ git checkout pull/4770` \
`$ git pull https://git.openjdk.java.net/jdk pull/4770/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4770`

View PR using the GUI difftool: \
`$ git pr show -t 4770`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4770.diff">https://git.openjdk.java.net/jdk/pull/4770.diff</a>

</details>
