### PR TITLE
8270446: Remove the MemBarNode that has been optimized from the current block

### DIFF
--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1684,8 +1684,15 @@ void PhaseOutput::fill_buffer(CodeBuffer* cb, uint* blk_starts) {
 
       // "Normal" instruction case
       DEBUG_ONLY(uint instr_offset = cb->insts_size());
+      uint pre_offset = cb->insts_size();
       n->emit(*cb, C->regalloc());
       current_offset = cb->insts_size();
+
+      if (n->is_MachMemBar() && ((current_offset - pre_offset) == 0)) {
+          block->remove_node(j);
+          --last_inst;
+          continue;
+      }
 
       // Above we only verified that there is enough space in the instruction section.
       // However, the instruction may emit stubs that cause code buffer expansion.


### PR DESCRIPTION
Hi all,
aarch64 and mips64 also had an optimization to merge two memory barrier instructions. But when I use the args -XX:+UnlockDiagnosticVMOptions -XX:+PrintOptoAssembly, I see some information like the following 

1a0 membar_release 
            dmb ish 
1a4 membar_release 
            dmb ish 
1a4 spill R19 -> R0 # spill size = 64 


Here, "1a4 membar_release" is actually optimized out . so I think it should be better to display it like this 


1a0 membar_release 
            dmb ish 
1a4 spill R19 -> R0 # spill size = 64

Please review this trivial change.

Thanks,
Sun Guoyun

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8270446](https://bugs.openjdk.java.net/browse/JDK-8270446): Remove the MemBarNode that has been optimized from the current block


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4774/head:pull/4774` \
`$ git checkout pull/4774`

Update a local copy of the PR: \
`$ git checkout pull/4774` \
`$ git pull https://git.openjdk.java.net/jdk pull/4774/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4774`

View PR using the GUI difftool: \
`$ git pr show -t 4774`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4774.diff">https://git.openjdk.java.net/jdk/pull/4774.diff</a>

</details>
