### PR TITLE
8264908: Investigate adding BOT range check in G1BlockOffsetTablePart::block_at_or_preceding

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
@@ -32,7 +32,7 @@
 #include "runtime/atomic.hpp"
 
 inline HeapWord* G1BlockOffsetTablePart::block_start(const void* addr) {
-  if (addr >= _hr->bottom() && addr < _hr->end()) {
+  if (addr >= _hr->bottom() && addr < _hr->top()) {
     HeapWord* q = block_at_or_preceding(addr);
     return forward_to_block_containing_addr(q, addr);
   } else {
@@ -41,7 +41,7 @@ inline HeapWord* G1BlockOffsetTablePart::block_start(const void* addr) {
 }
 
 inline HeapWord* G1BlockOffsetTablePart::block_start_const(const void* addr) const {
-  if (addr >= _hr->bottom() && addr < _hr->end()) {
+  if (addr >= _hr->bottom() && addr < _hr->top()) {
     HeapWord* q = block_at_or_preceding(addr);
     HeapWord* n = q + block_size(q);
     return forward_to_block_containing_addr_const(q, n, addr);
@@ -115,9 +115,8 @@ inline HeapWord* G1BlockOffsetTablePart::block_at_or_preceding(const void* addr)
          "Object crossed region boundary, found offset %u instead of 0",
          (uint) _bot->offset_array(_bot->index_for(_hr->bottom())));
   size_t index = _bot->index_for(addr);
-  // We must make sure that the offset table entry we use is valid.  If
-  // "addr" is past the end, start at the last valid index.
-  index = MIN2(index, _next_offset_index - 1);
+  // We must make sure that the offset table entry we use is valid.
+  assert(index < _next_offset_index, "Precondition");
 
   HeapWord* q = _bot->address_for_index(index);
 

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
@@ -32,7 +32,7 @@
 #include "runtime/atomic.hpp"
 
 inline HeapWord* G1BlockOffsetTablePart::block_start(const void* addr) {
-  if (addr >= _hr->bottom() && addr < _hr->top()) {
+  if (addr >= _hr->bottom() && addr < _hr->end()) {
     HeapWord* q = block_at_or_preceding(addr);
     return forward_to_block_containing_addr(q, addr);
   } else {
@@ -41,7 +41,7 @@ inline HeapWord* G1BlockOffsetTablePart::block_start(const void* addr) {
 }
 
 inline HeapWord* G1BlockOffsetTablePart::block_start_const(const void* addr) const {
-  if (addr >= _hr->bottom() && addr < _hr->top()) {
+  if (addr >= _hr->bottom() && addr < _hr->end()) {
     HeapWord* q = block_at_or_preceding(addr);
     HeapWord* n = q + block_size(q);
     return forward_to_block_containing_addr_const(q, n, addr);

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -734,61 +734,6 @@ void HeapRegion::verify(VerifyOption vo,
     return;
   }
 
-  HeapWord* the_end = end();
-  // Do some extra BOT consistency checking for addresses in the
-  // range [top, end). BOT look-ups in this range should yield
-  // top. No point in doing that if top == end (there's nothing there).
-  if (p < the_end) {
-    // Look up top
-    HeapWord* addr_1 = p;
-    HeapWord* b_start_1 = block_start_const(addr_1);
-    if (b_start_1 != p) {
-      log_error(gc, verify)("BOT look up for top: " PTR_FORMAT " "
-                            " yielded " PTR_FORMAT ", expecting " PTR_FORMAT,
-                            p2i(addr_1), p2i(b_start_1), p2i(p));
-      *failures = true;
-      return;
-    }
-
-    // Look up top + 1
-    HeapWord* addr_2 = p + 1;
-    if (addr_2 < the_end) {
-      HeapWord* b_start_2 = block_start_const(addr_2);
-      if (b_start_2 != p) {
-        log_error(gc, verify)("BOT look up for top + 1: " PTR_FORMAT " "
-                              " yielded " PTR_FORMAT ", expecting " PTR_FORMAT,
-                              p2i(addr_2), p2i(b_start_2), p2i(p));
-        *failures = true;
-        return;
-      }
-    }
-
-    // Look up an address between top and end
-    size_t diff = pointer_delta(the_end, p) / 2;
-    HeapWord* addr_3 = p + diff;
-    if (addr_3 < the_end) {
-      HeapWord* b_start_3 = block_start_const(addr_3);
-      if (b_start_3 != p) {
-        log_error(gc, verify)("BOT look up for top + diff: " PTR_FORMAT " "
-                              " yielded " PTR_FORMAT ", expecting " PTR_FORMAT,
-                              p2i(addr_3), p2i(b_start_3), p2i(p));
-        *failures = true;
-        return;
-      }
-    }
-
-    // Look up end - 1
-    HeapWord* addr_4 = the_end - 1;
-    HeapWord* b_start_4 = block_start_const(addr_4);
-    if (b_start_4 != p) {
-      log_error(gc, verify)("BOT look up for end - 1: " PTR_FORMAT " "
-                            " yielded " PTR_FORMAT ", expecting " PTR_FORMAT,
-                            p2i(addr_4), p2i(b_start_4), p2i(p));
-      *failures = true;
-      return;
-    }
-  }
-
   verify_strong_code_roots(vo, failures);
 }
 


### PR DESCRIPTION
Hi all,

Please review this cleanup change to add an assert to G1BlockOffsetTablePart::block_at_or_preceding. Additionally, remove code that attempts to read beyond the _next_offset_index threshold. 

Testing: Tier 1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264908](https://bugs.openjdk.java.net/browse/JDK-8264908): Investigate adding BOT range check in G1BlockOffsetTablePart::block_at_or_preceding


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Committer)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4775/head:pull/4775` \
`$ git checkout pull/4775`

Update a local copy of the PR: \
`$ git checkout pull/4775` \
`$ git pull https://git.openjdk.java.net/jdk pull/4775/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4775`

View PR using the GUI difftool: \
`$ git pr show -t 4775`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4775.diff">https://git.openjdk.java.net/jdk/pull/4775.diff</a>

</details>
