### PR TITLE
8269637: javax/swing/JFileChooser/FileSystemView/SystemIconTest.java fails on windows

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
@@ -30,6 +30,7 @@ import java.awt.Toolkit;
 import java.awt.image.AbstractMultiResolutionImage;
 import java.awt.image.BufferedImage;
 import java.awt.image.ImageObserver;
+import java.awt.image.MultiResolutionImage;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -1160,10 +1161,17 @@ final class Win32ShellFolder2 extends ShellFolder {
                                 getRelativePIDL(), s, true);
                         if (hIcon <= 0) {
                             if (isDirectory()) {
-                                return getShell32Icon(FOLDER_ICON_ID, size);
+                                newIcon = getShell32Icon(FOLDER_ICON_ID, size);
                             } else {
-                                return getShell32Icon(FILE_ICON_ID, size);
+                                newIcon = getShell32Icon(FILE_ICON_ID, size);
                             }
+                            if (newIcon == null) {
+                                return null;
+                            }
+                            if (!(newIcon instanceof MultiResolutionImage)) {
+                                newIcon = new MultiResolutionIconImage(size, newIcon);
+                            }
+                            return newIcon;
                         }
                     }
                     newIcon = makeIcon(hIcon);

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -742,7 +742,6 @@ javax/swing/Popup/TaskbarPositionTest.java 8065097 macosx-all,linux-all
 javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
 javax/swing/JPopupMenu/4634626/bug4634626.java 8017175 macosx-all
-javax/swing/JFileChooser/FileSystemView/SystemIconTest.java 8268280 windows-x64
 
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8225012 windows-all,macosx-all
 sanity/client/SwingSet/src/ScrollPaneDemoTest.java 8225013 linux-all


### PR DESCRIPTION
Make fallback code for inaccessible file to return multiresolution icon
Remove test from ProblemList

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269637](https://bugs.openjdk.java.net/browse/JDK-8269637): javax/swing/JFileChooser/FileSystemView/SystemIconTest.java fails on windows


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4777/head:pull/4777` \
`$ git checkout pull/4777`

Update a local copy of the PR: \
`$ git checkout pull/4777` \
`$ git pull https://git.openjdk.java.net/jdk pull/4777/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4777`

View PR using the GUI difftool: \
`$ git pr show -t 4777`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4777.diff">https://git.openjdk.java.net/jdk/pull/4777.diff</a>

</details>
