### PR TITLE
8270453: [JVMCI] remove duplicates in vmStructs_jvmci.cpp

### DIFF
--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -496,13 +496,6 @@
   declare_constant(vmIntrinsics::_invokeGeneric)                          \
   declare_constant(vmIntrinsics::_compiledLambdaForm)                     \
                                                                           \
-  declare_constant(CollectedHeap::Serial)                                 \
-  declare_constant(CollectedHeap::Parallel)                               \
-  declare_constant(CollectedHeap::G1)                                     \
-  declare_constant(CollectedHeap::Epsilon)                                \
-  declare_constant(CollectedHeap::Z)                                      \
-  declare_constant(CollectedHeap::Shenandoah)                             \
-                                                                          \
   declare_constant(ConstantPool::CPCACHE_INDEX_TAG)                       \
   declare_constant(ConstantPool::_has_dynamic_constant)                   \
                                                                           \


### PR DESCRIPTION
Removes some duplicate exports in vmStructs_jvmci.cpp.

I've tested by comparing the output of `java -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:+EagerJVMCI -Djvmci.PrintConfig=true -version` before and after this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270453](https://bugs.openjdk.java.net/browse/JDK-8270453): [JVMCI] remove duplicates in vmStructs_jvmci.cpp


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4779/head:pull/4779` \
`$ git checkout pull/4779`

Update a local copy of the PR: \
`$ git checkout pull/4779` \
`$ git pull https://git.openjdk.java.net/jdk pull/4779/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4779`

View PR using the GUI difftool: \
`$ git pr show -t 4779`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4779.diff">https://git.openjdk.java.net/jdk/pull/4779.diff</a>

</details>
