### PR TITLE
8270459: Conflict inlining decisions by C1/C2 with the same CompileCommand

### DIFF
--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -351,6 +351,7 @@ static bool resolve_inlining_predicate(enum CompileCommand option, const methodH
     if (v1 && v2) {
       // Conflict options detected
       // Find the last one for that method and return the predicate accordingly
+      // option_list lists options in reverse order. So the first option we find is the last which was specified.
       enum CompileCommand last_one = CompileCommand::Unknown;
       TypedMethodOptionMatcher* current = option_list;
       while (current != NULL) {

--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -341,7 +341,48 @@ bool CompilerOracle::has_option_value(const methodHandle& method, enum CompileCo
   return false;
 }
 
+static bool resolve_inlining_predicate(enum CompileCommand option, const methodHandle& method) {
+  assert(option == CompileCommand::Inline || option == CompileCommand::DontInline, "Sanity");
+  bool v1 = false;
+  bool v2 = false;
+  bool has_inline = CompilerOracle::has_option_value(method, CompileCommand::Inline, v1);
+  bool has_dnotinline = CompilerOracle::has_option_value(method, CompileCommand::DontInline, v2);
+  if (has_inline && has_dnotinline) {
+    if (v1 && v2) {
+      // Conflict options detected
+      // Find the last one for that method and return the predicate accordingly
+      enum CompileCommand last_one = CompileCommand::Unknown;
+      TypedMethodOptionMatcher* current = option_list;
+      while (current != NULL) {
+        last_one = current->option();
+        if (last_one == CompileCommand::Inline || last_one == CompileCommand::DontInline) {
+          if (current->matches(method)) {
+            return last_one == option;
+          }
+        }
+        current = current->next();
+      }
+      ShouldNotReachHere();
+      return false;
+    } else {
+      // No conflicts
+      return option == CompileCommand::Inline ? v1 : v2;
+    }
+  } else {
+    if (option == CompileCommand::Inline) {
+      return has_inline ? v1 : false;
+    } else {
+      return has_dnotinline ? v2 : false;
+    }
+  }
+}
+
 static bool check_predicate(enum CompileCommand option, const methodHandle& method) {
+  // Special handling for Inline and DontInline since conflict options may be specified
+  if (option == CompileCommand::Inline || option == CompileCommand::DontInline) {
+    return resolve_inlining_predicate(option, method);
+  }
+
   bool value = false;
   if (CompilerOracle::has_option_value(method, option, value)) {
     return value;
@@ -395,12 +436,11 @@ bool CompilerOracle::should_exclude(const methodHandle& method) {
 }
 
 bool CompilerOracle::should_inline(const methodHandle& method) {
-  return (check_predicate(CompileCommand::Inline, method) && !check_predicate(CompileCommand::DontInline, method));
+  return (check_predicate(CompileCommand::Inline, method));
 }
 
 bool CompilerOracle::should_not_inline(const methodHandle& method) {
-  return (check_predicate(CompileCommand::DontInline, method) && !check_predicate(CompileCommand::Inline, method))
-         || check_predicate(CompileCommand::Exclude, method);
+  return check_predicate(CompileCommand::DontInline, method) || check_predicate(CompileCommand::Exclude, method);
 }
 
 bool CompilerOracle::should_print(const methodHandle& method) {

--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -395,11 +395,12 @@ bool CompilerOracle::should_exclude(const methodHandle& method) {
 }
 
 bool CompilerOracle::should_inline(const methodHandle& method) {
-  return (check_predicate(CompileCommand::Inline, method));
+  return (check_predicate(CompileCommand::Inline, method) && !check_predicate(CompileCommand::DontInline, method));
 }
 
 bool CompilerOracle::should_not_inline(const methodHandle& method) {
-  return check_predicate(CompileCommand::DontInline, method) || check_predicate(CompileCommand::Exclude, method);
+  return (check_predicate(CompileCommand::DontInline, method) && !check_predicate(CompileCommand::Inline, method))
+         || check_predicate(CompileCommand::Exclude, method);
 }
 
 bool CompilerOracle::should_print(const methodHandle& method) {

--- a/test/hotspot/jtreg/compiler/compilercontrol/TestConflictInlineCommands.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/TestConflictInlineCommands.java
@@ -27,6 +27,7 @@
  * @summary the last specified inlining option should overwrite all previous
  * @library /test/lib
  * @requires vm.flagless
+ * @requires vm.compiler1.enabled | vm.compiler2.enabled
  *
  * @run driver compiler.compilercontrol.TestConflictInlineCommands
  */

--- a/test/hotspot/jtreg/compiler/compilercontrol/TestConflictInlineCommands.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/TestConflictInlineCommands.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8270459
+ * @summary Inlining decisions shouldn't be conflict by the C1/C2 with the same CompileCommand
+ * @library /test/lib
+ * @requires vm.flagless
+ *
+ * @run driver compiler.compilercontrol.TestConflictInlineCommands
+ */
+
+package compiler.compilercontrol;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestConflictInlineCommands {
+    public static void main(String[] args) throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:CompileCommand=inline,*TestConflictInlineCommands::caller",
+                "-XX:CompileCommand=dontinline,*TestConflictInlineCommands::caller",
+                "-XX:CompileCommand=quiet", "-XX:CompileCommand=compileonly,*Launcher::main",
+                "-XX:+PrintCompilation", "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintInlining",
+                Launcher.class.getName());
+
+        OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
+        analyzer.shouldHaveExitValue(0);
+
+        if (analyzer.getStdout().contains("disallowed by CompileCommand") &&
+            analyzer.getStdout().contains("force inline by CompileCommand")) {
+            throw new RuntimeException("Conflict inlining decisions detected:\n" + analyzer.getStdout());
+        }
+    }
+
+    static int sum;
+
+    public static int caller(int a , int b) {
+        return a + b;
+    }
+
+    static class Launcher {
+        public static void main(String[] args) {
+            for (int i = 0; i < 1000; i++) {
+                for (int j = 0; j < 1000; j++) {
+                    sum += caller(i, 0);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

Conflict inlining decisions can be observed by C1/C2 with the same CompileCommand.
And I came across this situation while I was analyzing a performance issue using the jmh, which made me quite confused.

For the example in the JBS.
```
     28    1 %     3       TestInline::main @ 11 (43 bytes)
                              @ 23   TestInline::caller (4 bytes)   disallowed by CompileCommand
     29    2       3       TestInline::main (43 bytes)
                              @ 23   TestInline::caller (4 bytes)   disallowed by CompileCommand
     31    3 %     4       TestInline::main @ 11 (43 bytes)
     33    1 %     3       TestInline::main @ 11 (43 bytes)   made not entrant
                              @ 23   TestInline::caller (4 bytes)   force inline by CompileCommand
```

This can be easily reproduced by specifying both the `inline` and `dontinline` compile commands for a method.
```
   -XX:CompileCommand=inline,TestInline::caller \
   -XX:CompileCommand=dontinline,TestInline::caller \
```

The fix will ignore the inline/not-inline directives if both the `inline` and `dontinline` compile commands are specified for a method.

Effect of the patch:
```
     27    1 %     3       TestInline::main @ 11 (43 bytes)
                              @ 23   TestInline::caller (4 bytes)   inline
     28    2       3       TestInline::main (43 bytes)
                              @ 23   TestInline::caller (4 bytes)   inline
     28    3 %     4       TestInline::main @ 11 (43 bytes)
     30    1 %     3       TestInline::main @ 11 (43 bytes)   made not entrant
                              @ 23   TestInline::caller (4 bytes)   inline (hot)
     31    3 %     4       TestInline::main @ 11 (43 bytes)   made not entrant
```

Testing:
  - tier 1~3 on Linux/x64, no regression

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270459](https://bugs.openjdk.java.net/browse/JDK-8270459): Conflict inlining decisions by C1/C2 with the same CompileCommand


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Xin Liu](https://openjdk.java.net/census#xliu) (@navyxliu - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4780/head:pull/4780` \
`$ git checkout pull/4780`

Update a local copy of the PR: \
`$ git checkout pull/4780` \
`$ git pull https://git.openjdk.java.net/jdk pull/4780/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4780`

View PR using the GUI difftool: \
`$ git pr show -t 4780`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4780.diff">https://git.openjdk.java.net/jdk/pull/4780.diff</a>

</details>
