### PR TITLE
JDK-8270468: TestRangeCheckEliminated fails because methods are not compiled

### DIFF
--- a/test/hotspot/jtreg/compiler/c1/TestRangeCheckEliminated.java
+++ b/test/hotspot/jtreg/compiler/c1/TestRangeCheckEliminated.java
@@ -50,6 +50,7 @@ public class TestRangeCheckEliminated {
             "-XX:TieredStopAtLevel=1",
             "-XX:+TraceRangeCheckElimination",
             "-XX:-BackgroundCompilation",
+            "-XX:CompileThreshold=500",
             test_constant_array.class.getName()
          };
 
@@ -69,6 +70,7 @@ public class TestRangeCheckEliminated {
             "-XX:TieredStopAtLevel=1",
             "-XX:+TraceRangeCheckElimination",
             "-XX:-BackgroundCompilation",
+            "-XX:CompileThreshold=500",
             test_multi_constant_array.class.getName()
         };
 
@@ -88,6 +90,7 @@ public class TestRangeCheckEliminated {
             "-XX:TieredStopAtLevel=1",
             "-XX:+TraceRangeCheckElimination",
             "-XX:-BackgroundCompilation",
+            "-XX:CompileThreshold=500",
             test_multi_new_array.class.getName()
          };
 


### PR DESCRIPTION
Hi,

please review this small change to the TestRangeCheckEliminated test case, which ensures that the required methods are compiled on every platform, by setting the CompileThreshold explicitly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270468](https://bugs.openjdk.java.net/browse/JDK-8270468): TestRangeCheckEliminated fails because methods are not compiled


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4781/head:pull/4781` \
`$ git checkout pull/4781`

Update a local copy of the PR: \
`$ git checkout pull/4781` \
`$ git pull https://git.openjdk.java.net/jdk pull/4781/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4781`

View PR using the GUI difftool: \
`$ git pr show -t 4781`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4781.diff">https://git.openjdk.java.net/jdk/pull/4781.diff</a>

</details>
