### PR TITLE
8270475: Remove unused G1STWDrainQueueClosure

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3248,29 +3248,6 @@ public:
   }
 };
 
-// Serial drain queue closure. Called as the 'complete_gc'
-// closure for each discovered list in some of the
-// reference processing phases.
-
-class G1STWDrainQueueClosure: public VoidClosure {
-protected:
-  G1CollectedHeap* _g1h;
-  G1ParScanThreadState* _par_scan_state;
-
-  G1ParScanThreadState*   par_scan_state() { return _par_scan_state; }
-
-public:
-  G1STWDrainQueueClosure(G1CollectedHeap* g1h, G1ParScanThreadState* pss) :
-    _g1h(g1h),
-    _par_scan_state(pss)
-  { }
-
-  void do_void() {
-    G1ParScanThreadState* const pss = par_scan_state();
-    pss->trim_queue();
-  }
-};
-
 class G1STWRefProcProxyTask : public RefProcProxyTask {
   G1CollectedHeap& _g1h;
   G1ParScanThreadStateSet& _pss;


### PR DESCRIPTION
Hi all,

  can I have reviews for this removal of unused code?

Testing: local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270475](https://bugs.openjdk.java.net/browse/JDK-8270475): Remove unused G1STWDrainQueueClosure


### Reviewers
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4782/head:pull/4782` \
`$ git checkout pull/4782`

Update a local copy of the PR: \
`$ git checkout pull/4782` \
`$ git pull https://git.openjdk.java.net/jdk pull/4782/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4782`

View PR using the GUI difftool: \
`$ git pr show -t 4782`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4782.diff">https://git.openjdk.java.net/jdk/pull/4782.diff</a>

</details>
