### PR TITLE
JDK-8265888: StandardJavaFileManager::setLocationForModule specification misses 'Implementation Requirements:'

### DIFF
--- a/src/java.compiler/share/classes/javax/tools/StandardJavaFileManager.java
+++ b/src/java.compiler/share/classes/javax/tools/StandardJavaFileManager.java
@@ -372,6 +372,9 @@ public interface StandardJavaFileManager extends JavaFileManager {
      * {@linkplain #setLocation setLocation} or
      * {@linkplain #setLocationFromPaths setLocationFromPaths}.
      *
+     * @implSpec
+     * The default implementation throws {@link UnsupportedOperationException}.
+     *
      * @throws IllegalStateException if the location is not a module-oriented
      *  or output location.
      * @throws UnsupportedOperationException if this operation is not supported by


### PR DESCRIPTION
Please review a simple `no-reg` doc fix to add an `@implSpec` to StandardJavaFileManager::setLocationForModule.

The change is as for the CSR. There is no functional change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265888](https://bugs.openjdk.java.net/browse/JDK-8265888): StandardJavaFileManager::setLocationForModule specification misses 'Implementation Requirements:'


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4785/head:pull/4785` \
`$ git checkout pull/4785`

Update a local copy of the PR: \
`$ git checkout pull/4785` \
`$ git pull https://git.openjdk.java.net/jdk pull/4785/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4785`

View PR using the GUI difftool: \
`$ git pr show -t 4785`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4785.diff">https://git.openjdk.java.net/jdk/pull/4785.diff</a>

</details>
