### PR TITLE
8270533: AArch64: size_fits_all_mem_uses should return false if its output is a CAS

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -2634,6 +2634,13 @@ const RegMask Matcher::method_handle_invoke_SP_save_mask() {
 bool size_fits_all_mem_uses(AddPNode* addp, int shift) {
   for (DUIterator_Fast imax, i = addp->fast_outs(imax); i < imax; i++) {
     Node* u = addp->fast_out(i);
+    if (u->is_LoadStore()) {
+      // On AArch64, LoadStoreNodes (i.e. compare and swap
+      // instructions) only take register indirect as an operand, so
+      // any attempt to use an AddPNode as an input to a LoadStoreNode
+      // must fail.
+      return false;
+    }
     if (u->is_Mem()) {
       int opsize = u->as_Mem()->memory_size();
       assert(opsize > 0, "unexpected memory operand size");


### PR DESCRIPTION
`size_fits_all_mem_uses(AddPNode)` is used to determine if an add with shift expression can be used as an input to a MemNode. However, it is not correct when one of its outputs is a CAS. This causes a crash when a single AddPNode feeds a CAS and an ordinary MemNode.

This bug is probably latent in the current HotSpot because `pd_clone_address_expressions()` clones AddPNodes that are used as inputs to MemNodes, so `size_fits_all_mem_uses()` never sees a CAS as one of its outputs. The matcher for a CompareAndSwapX node doesn't call `size_fits_all_mem_uses()`, so this can only happen when the same expression feeds both an ordinary MemNode and a CompareAndSwapX.

This bug has been back-ported to JDK 8u, so it must be fixed there. Even though the bug is latent in current HotSpot, it should be fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270533](https://bugs.openjdk.java.net/browse/JDK-8270533): AArch64: size_fits_all_mem_uses should return false if its output is a CAS


### Reviewers
 * [Andrew Dinn](https://openjdk.java.net/census#adinn) (@adinn - **Reviewer**)
 * [Nick Gasson](https://openjdk.java.net/census#ngasson) (@nick-arm - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4790/head:pull/4790` \
`$ git checkout pull/4790`

Update a local copy of the PR: \
`$ git checkout pull/4790` \
`$ git pull https://git.openjdk.java.net/jdk pull/4790/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4790`

View PR using the GUI difftool: \
`$ git pr show -t 4790`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4790.diff">https://git.openjdk.java.net/jdk/pull/4790.diff</a>

</details>
