### PR TITLE
8268284: javax/swing/JComponent/7154030/bug7154030.java fails with "Exception: Failed to hide opaque button"

### DIFF
--- a/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
+++ b/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
@@ -57,7 +57,7 @@ public class bug7154030 {
 
     private static JButton button = null;
     private static JFrame frame;
-    private static int locx, locy, frw, frh;
+    private static volatile int locx, locy, frw, frh;
 
     public static void main(String[] args) throws Exception {
         try {
@@ -103,12 +103,14 @@ public class bug7154030 {
 
             Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
             Rectangle screen = new Rectangle(0, 0, (int) screenSize.getWidth(), (int) screenSize.getHeight());
-            Rectangle bounds = frame.getBounds();
-            Insets insets = frame.getInsets();
-            locx = bounds.x + insets.left;
-            locy = bounds.y + insets.top;
-            frw = bounds.width - insets.left - insets.right;
-            frh = bounds.height - insets.top - insets.bottom;
+            SwingUtilities.invokeAndWait(() -> {
+                        Rectangle bounds = frame.getBounds();
+                        Insets insets = frame.getInsets();
+                        locx = bounds.x + insets.left;
+                        locy = bounds.y + insets.top;
+                        frw = bounds.width - insets.left - insets.right;
+                        frh = bounds.height - insets.top - insets.bottom;
+                    });
 
             BufferedImage fullScreen = robot.createScreenCapture(screen);
             Graphics g = fullScreen.getGraphics();

--- a/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
+++ b/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
@@ -107,7 +107,7 @@ public class bug7154030 {
             locx = bounds.x + insets.left;
             locy = bounds.y + insets.top;
             frw = bounds.width - insets.left - insets.right;
-            frh = bounds.height - insets.top - insets.bottom;
+            frh = bounds.height - insets.top - insets.bottom - 25;
 
             BufferedImage fullScreen = robot.createScreenCapture(screen);
             Graphics g = fullScreen.getGraphics();

--- a/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
+++ b/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
@@ -76,6 +76,7 @@ public class bug7154030 {
                     JDesktopPane desktop = new JDesktopPane();
                     button = new JButton("button");
                     frame = new JFrame();
+                    frame.setUndecorated(true);
 
                     button.setSize(200, 200);
                     button.setLocation(100, 100);
@@ -107,7 +108,7 @@ public class bug7154030 {
             locx = bounds.x + insets.left;
             locy = bounds.y + insets.top;
             frw = bounds.width - insets.left - insets.right;
-            frh = bounds.height - insets.top - insets.bottom - 25;
+            frh = bounds.height - insets.top - insets.bottom;
 
             BufferedImage fullScreen = robot.createScreenCapture(screen);
             Graphics g = fullScreen.getGraphics();


### PR DESCRIPTION
Reducing the height of the analyzed area to get rid of the rounded edges
at the botom of the frame. Apparently shadow outside of it being
rendered by Mac OS X Big Sur inconsistently which gives random test
failures on M1 macs with Big Sur.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268284](https://bugs.openjdk.java.net/browse/JDK-8268284): javax/swing/JComponent/7154030/bug7154030.java fails with "Exception: Failed to hide opaque button"


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4792/head:pull/4792` \
`$ git checkout pull/4792`

Update a local copy of the PR: \
`$ git checkout pull/4792` \
`$ git pull https://git.openjdk.java.net/jdk pull/4792/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4792`

View PR using the GUI difftool: \
`$ git pr show -t 4792`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4792.diff">https://git.openjdk.java.net/jdk/pull/4792.diff</a>

</details>
