### PR TITLE
8270540 G1: Refactor range checking in G1BlockOffsetTablePart::block_start* to asserts

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
@@ -32,22 +32,16 @@
 #include "runtime/atomic.hpp"
 
 inline HeapWord* G1BlockOffsetTablePart::block_start(const void* addr) {
-  if (addr >= _hr->bottom() && addr < _hr->end()) {
-    HeapWord* q = block_at_or_preceding(addr);
-    return forward_to_block_containing_addr(q, addr);
-  } else {
-    return NULL;
-  }
+  assert(addr >= _hr->bottom() && addr < _hr->top(), "invalid address");
+  HeapWord* q = block_at_or_preceding(addr);
+  return forward_to_block_containing_addr(q, addr);
 }
 
 inline HeapWord* G1BlockOffsetTablePart::block_start_const(const void* addr) const {
-  if (addr >= _hr->bottom() && addr < _hr->end()) {
-    HeapWord* q = block_at_or_preceding(addr);
-    HeapWord* n = q + block_size(q);
-    return forward_to_block_containing_addr_const(q, n, addr);
-  } else {
-    return NULL;
-  }
+  assert(addr >= _hr->bottom() && addr < _hr->top(), "invalid address");
+  HeapWord* q = block_at_or_preceding(addr);
+  HeapWord* n = q + block_size(q);
+  return forward_to_block_containing_addr_const(q, n, addr);
 }
 
 u_char G1BlockOffsetTable::offset_array(size_t index) const {


### PR DESCRIPTION
Hi all,

Please review this clean-up to replace range checking with asserts. 

Testing: tier 1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270540](https://bugs.openjdk.java.net/browse/JDK-8270540): G1: Refactor range checking in G1BlockOffsetTablePart::block_start* to asserts


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Committer)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4794/head:pull/4794` \
`$ git checkout pull/4794`

Update a local copy of the PR: \
`$ git checkout pull/4794` \
`$ git pull https://git.openjdk.java.net/jdk pull/4794/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4794`

View PR using the GUI difftool: \
`$ git pr show -t 4794`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4794.diff">https://git.openjdk.java.net/jdk/pull/4794.diff</a>

</details>
