### PR TITLE
8270554: Shenandoah: Optimize heap scan loop

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -65,7 +65,7 @@ inline oop ShenandoahBarrierSet::load_reference_barrier_mutator(oop obj, T* load
            "evac should be in progress");
     Thread* const t = Thread::current();
     ShenandoahEvacOOMScope scope(t);
-    fwd = _heap->evacuate_object(obj, t);
+    _heap->evacuate_object(fwd, t);
   }
 
   if (load_addr != NULL && fwd != obj) {
@@ -92,7 +92,7 @@ inline oop ShenandoahBarrierSet::load_reference_barrier(oop obj) {
     if (obj == fwd && _heap->is_evacuation_in_progress()) {
        Thread* t = Thread::current();
       ShenandoahEvacOOMScope oom_evac_scope(t);
-      return _heap->evacuate_object(obj, t);
+      _heap->evacuate_object(fwd, t);
     }
     return fwd;
   }
@@ -355,7 +355,7 @@ void ShenandoahBarrierSet::arraycopy_work(T* src, size_t count) {
       if (HAS_FWD && cset->is_in(obj)) {
         oop fwd = resolve_forwarded_not_null(obj);
         if (EVAC && obj == fwd) {
-          fwd = _heap->evacuate_object(obj, thread);
+          _heap->evacuate_object(fwd, thread);
         }
         assert(obj != fwd || _heap->cancelled_gc(), "must be forwarded");
         ShenandoahHeap::atomic_update_oop(fwd, elem_ptr, o);

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetClone.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetClone.inline.hpp
@@ -51,7 +51,7 @@ private:
       if (HAS_FWD && _cset->is_in(obj)) {
         oop fwd = _bs->resolve_forwarded_not_null(obj);
         if (EVAC && obj == fwd) {
-          fwd = _heap->evacuate_object(obj, _thread);
+          _heap->evacuate_object(fwd, _thread);
         }
         assert(obj != fwd || _heap->cancelled_gc(), "must be forwarded");
         ShenandoahHeap::atomic_update_oop(fwd, p, o);

--- a/src/hotspot/share/gc/shenandoah/shenandoahClosures.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahClosures.inline.hpp
@@ -124,7 +124,7 @@ void ShenandoahEvacuateUpdateMetadataClosure<MO>::do_oop_work(T* p) {
       shenandoah_assert_marked(p, obj);
       oop resolved = ShenandoahBarrierSet::resolve_forwarded_not_null(obj);
       if (resolved == obj) {
-        resolved = _heap->evacuate_object(obj, _thread);
+        _heap->evacuate_object(resolved, _thread);
       }
       RawAccess<IS_NOT_NULL | MO>::oop_store(p, resolved);
     }
@@ -159,7 +159,7 @@ void ShenandoahEvacuateUpdateRootsClosure::do_oop_work(T* p, Thread* t) {
       shenandoah_assert_marked(p, obj);
       oop resolved = ShenandoahBarrierSet::resolve_forwarded_not_null(obj);
       if (resolved == obj) {
-        resolved = _heap->evacuate_object(obj, t);
+        _heap->evacuate_object(resolved, t);
       }
       ShenandoahHeap::atomic_update_oop(resolved, p, o);
     }

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -690,7 +690,7 @@ void ShenandoahEvacUpdateCleanupOopStorageRootsClosure::do_oop(oop* p) {
     } else if (_evac_in_progress && _heap->in_collection_set(obj)) {
       oop resolved = ShenandoahBarrierSet::resolve_forwarded_not_null(obj);
       if (resolved == obj) {
-        resolved = _heap->evacuate_object(obj, _thread);
+        _heap->evacuate_object(resolved, _thread);
       }
       ShenandoahHeap::atomic_update_oop(resolved, p, obj);
       assert(_heap->cancelled_gc() ||

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -941,7 +941,7 @@ MetaWord* ShenandoahHeap::satisfy_failed_metadata_allocation(ClassLoaderData* lo
   return NULL;
 }
 
-class ShenandoahConcurrentEvacuateRegionObjectClosure : public ObjectClosure {
+class ShenandoahConcurrentEvacuateRegionObjectClosure {
 private:
   ShenandoahHeap* const _heap;
   Thread* const _thread;
@@ -949,10 +949,18 @@ public:
   ShenandoahConcurrentEvacuateRegionObjectClosure(ShenandoahHeap* heap) :
     _heap(heap), _thread(Thread::current()) {}
 
-  void do_object(oop p) {
+  inline void do_object(oop p) {
     shenandoah_assert_marked(NULL, p);
     if (!p->is_forwarded()) {
       _heap->evacuate_object(p, _thread);
+    }
+  }
+  inline int do_object_size(oop p) {
+    shenandoah_assert_marked(NULL, p);
+    if (!p->is_forwarded()) {
+      return _heap->evacuate_object(p, _thread);
+    } else {
+      return p->size();
     }
   }
 };

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -618,9 +618,9 @@ public:
   // Checks if location is in the collection set. Can be interior pointer, not the oop itself.
   inline bool in_collection_set_loc(void* loc) const;
 
-  // Evacuates object src. Returns the evacuated object, either evacuated
-  // by this thread, or by some other thread.
-  inline oop evacuate_object(oop src, Thread* thread);
+  // Evacuates the object obj. Updates reference to the evacuated object, either evacuated
+  // by this thread, or by some other thread. Returns size of the object.
+  inline int evacuate_object(oop& obj, Thread* thread);
 
   // Call before/after evacuation.
   inline void enter_evacuation(Thread* t);

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -265,7 +265,13 @@ class oopDesc {
   inline void oop_iterate(OopClosureType* cl);
 
   template <typename OopClosureType>
+  inline void oop_iterate(OopClosureType* cl, Klass* klass);
+
+  template <typename OopClosureType>
   inline void oop_iterate(OopClosureType* cl, MemRegion mr);
+
+  template <typename OopClosureType>
+  inline void oop_iterate(OopClosureType* cl, MemRegion mr, Klass* klass);
 
   template <typename OopClosureType>
   inline int oop_iterate_size(OopClosureType* cl);

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -326,8 +326,18 @@ void oopDesc::oop_iterate(OopClosureType* cl) {
 }
 
 template <typename OopClosureType>
+void oopDesc::oop_iterate(OopClosureType* cl, Klass* klass) {
+  OopIteratorClosureDispatch::oop_oop_iterate(cl, this, klass);
+}
+
+template <typename OopClosureType>
 void oopDesc::oop_iterate(OopClosureType* cl, MemRegion mr) {
   OopIteratorClosureDispatch::oop_oop_iterate(cl, this, klass(), mr);
+}
+
+template <typename OopClosureType>
+void oopDesc::oop_iterate(OopClosureType* cl, MemRegion mr, Klass* klass) {
+  OopIteratorClosureDispatch::oop_oop_iterate(cl, this, klass, mr);
 }
 
 template <typename OopClosureType>


### PR DESCRIPTION
This is a fall-out from Lilliput. I noticed that in the heap scan loop, we load the size of objects in the size-based object scanner, even though all of the object closures already load the size, or at least in some cases, the Klass* which is necessary to determine the size. We can optimize that by making the scan loop co-operate with the closures. In other words, this changes the loop to avoid double-loading the Klass* in most cases in the size-based part of the scan loop.

Note: the motivation in Lilliput is not performance, but correctness, because there loading the Klass* means loading the header, and this needs to be done carefully because of concurrent evacuation and concurrent locking code both messing with the header, and thus depends a lot on the actual closures to do it correctly. 

Implementation notes:
- SH::evacuate_object() has been changed so that it can return both the forwardee and the size. I opted to return the size as return-value because otherwise I'd have to null check an incoming pointer in the cases when we're not interested in the size. The way it is done, it can simply be ignored (and optimized-out) by the compiler.
- I added a do_object_size() variant to all affected iterators. I tried to do it with templates, but could not figure out how to please the compiler.
- While I was at it, I marked all do_object() methods as 'inline'.
- I ran some benchmarks. I think I see consistent but small improvements in evac and update-refs times, but it's not large enough to say that it is a definite improvement.

Testing:
 - [x] hotspot_gc_shenandoah
 - [ ] tier1 (+UseShenandoahGC)
 - [x] specjvm testing
 