### PR TITLE
8269806: Emoji rendering on Linux

### DIFF
--- a/src/java.desktop/share/classes/sun/font/GlyphList.java
+++ b/src/java.desktop/share/classes/sun/font/GlyphList.java
@@ -502,7 +502,7 @@ public final class GlyphList {
     }
 
     public static boolean canContainColorGlyphs() {
-        return FontUtilities.isMacOSX;
+        return FontUtilities.isMacOSX || FontUtilities.isLinux;
     }
 
     public boolean isColorGlyph(int glyphIndex) {

--- a/src/java.desktop/unix/classes/sun/font/XRTextRenderer.java
+++ b/src/java.desktop/unix/classes/sun/font/XRTextRenderer.java
@@ -78,13 +78,20 @@ public class XRTextRenderer extends GlyphListPipe {
                 advY += 0.5f;
             }
 
-            XRGlyphCacheEntry[] cachedGlyphs = glyphCache.cacheGlyphs(gl);
+            XRGlyphCacheEntry[] cachedGlyphs =
+                    glyphCache.cacheGlyphs(gl, x11sd.getXid());
             boolean containsLCDGlyphs = false;
-            int activeGlyphSet = cachedGlyphs[0].getGlyphSet();
+            /* Do not initialize it to cachedGlyphs[0].getGlyphSet(),
+             * as it may cause NPE */
+            int activeGlyphSet = 0;
 
             int eltIndex = -1;
             gl.startGlyphIteration();
             float[] positions = gl.getPositions();
+            /* Accumulated advances are used to adjust glyph positions
+             * when mixing BGRA and standard glyphs as they have
+             * completely different methods of rendering. */
+            float accumulatedXEltAdvanceX = 0, accumulatedXEltAdvanceY = 0;
             for (int i = 0; i < gl.getNumGlyphs(); i++) {
                 gl.setGlyphIndex(i);
                 XRGlyphCacheEntry cacheEntry = cachedGlyphs[i];
@@ -92,8 +99,18 @@ public class XRTextRenderer extends GlyphListPipe {
                     continue;
                 }
 
-                eltList.getGlyphs().addInt(cacheEntry.getGlyphID());
                 int glyphSet = cacheEntry.getGlyphSet();
+
+                if (glyphSet == XRGlyphCache.BGRA_GLYPH_SET) {
+                    /* BGRA glyphs store pointers to BGRAGlyphInfo
+                     * struct instead of glyph index */
+                    eltList.getGlyphs().addInt(
+                            (int) (cacheEntry.getBgraGlyphInfoPtr() >> 32));
+                    eltList.getGlyphs().addInt(
+                            (int) cacheEntry.getBgraGlyphInfoPtr());
+                } else {
+                    eltList.getGlyphs().addInt(cacheEntry.getGlyphID());
+                }
 
                 containsLCDGlyphs |= (glyphSet == glyphCache.lcdGlyphSet);
 
@@ -103,7 +120,11 @@ public class XRTextRenderer extends GlyphListPipe {
                         || cacheEntry.getYAdvance() != ((float) cacheEntry.getYOff())
                         || glyphSet != activeGlyphSet
                         || eltIndex < 0
-                        || eltList.getCharCnt(eltIndex) == MAX_ELT_GLYPH_COUNT) {
+                        /* We don't care about number of glyphs when
+                         * rendering BGRA glyphs because they are not rendered
+                         * using XRenderCompositeText. */
+                        || (glyphSet != XRGlyphCache.BGRA_GLYPH_SET &&
+                            eltList.getCharCnt(eltIndex) == MAX_ELT_GLYPH_COUNT)) {
 
                     eltIndex = eltList.getNextIndex();
                     eltList.setCharCnt(eltIndex, 1);
@@ -136,16 +157,30 @@ public class XRTextRenderer extends GlyphListPipe {
                         advY += (cacheEntry.getYAdvance() - cacheEntry.getYOff());
                     }
 
-                    // Offset of the current glyph is the difference
-                    // to the last glyph and this one
-                    eltList.setXOff(eltIndex, (posX - oldPosX));
-                    eltList.setYOff(eltIndex, (posY - oldPosY));
-
-                    oldPosX = posX;
-                    oldPosY = posY;
+                    if (glyphSet == XRGlyphCache.BGRA_GLYPH_SET) {
+                        // BGRA glyphs use absolute positions
+                        eltList.setXOff(eltIndex,
+                                        (int) (accumulatedXEltAdvanceX + posX));
+                        eltList.setYOff(eltIndex,
+                                        (int) (accumulatedXEltAdvanceY + posY));
+                    } else {
+                        // Offset of the current glyph is the difference
+                        // to the last glyph and this one
+                        eltList.setXOff(eltIndex, (posX - oldPosX));
+                        eltList.setYOff(eltIndex, (posY - oldPosY));
+                        oldPosX = posX;
+                        oldPosY = posY;
+                    }
 
                 } else {
                     eltList.setCharCnt(eltIndex, eltList.getCharCnt(eltIndex) + 1);
+                }
+                if (glyphSet == XRGlyphCache.BGRA_GLYPH_SET) {
+                    advX += cacheEntry.getXAdvance();
+                    advY += cacheEntry.getYAdvance();
+                } else {
+                    accumulatedXEltAdvanceX += cacheEntry.getXAdvance();
+                    accumulatedXEltAdvanceY += cacheEntry.getYAdvance();
                 }
             }
 

--- a/src/java.desktop/unix/classes/sun/java2d/xr/XRBackend.java
+++ b/src/java.desktop/unix/classes/sun/java2d/xr/XRBackend.java
@@ -94,6 +94,11 @@ public interface XRBackend {
 
     public void XRenderFreeGlyphs(int glyphSet, int[] gids);
 
+    public void addBGRAGlyphImages(int drawable,
+                                   List<XRGlyphCacheEntry> cacheEntries);
+
+    public void freeBGRAGlyphImages(long[] glyphInfoPointers, int glyphCount);
+
     public void XRenderCompositeText(byte op, int src, int dst,
                                      int maskFormatID,
                                      int xSrc, int ySrc, int xDst, int yDst,

--- a/src/java.desktop/unix/classes/sun/java2d/xr/XRBackendNative.java
+++ b/src/java.desktop/unix/classes/sun/java2d/xr/XRBackendNative.java
@@ -250,6 +250,26 @@ public class XRBackendNative implements XRBackend {
     private static native void XRFreeGlyphsNative(int glyphSet,
                                                   int[] gids, int idCnt);
 
+    public void addBGRAGlyphImages(int drawable,
+                                   List<XRGlyphCacheEntry> cacheEntries) {
+        long[] glyphInfoPtrs = getGlyphInfoPtrs(cacheEntries);
+        addBGRAGlyphImagesNative(drawable, glyphInfoPtrs,
+                                 glyphInfoPtrs.length, FMTPTR_ARGB32);
+        /* addBGRAGlyphImagesNative replaced values in
+         * glyphInfoPtrs with pointers to BGRAGlyphInfo structs, save them */
+        int i = 0;
+        for (XRGlyphCacheEntry cacheEntry : cacheEntries) {
+            cacheEntry.setBgraGlyphInfoPtr(glyphInfoPtrs[i++]);
+        }
+    }
+
+    private native void addBGRAGlyphImagesNative(int drawable,
+                                                 long[] glyphInfoPtrs,
+                                                 int glyphCnt, long format32);
+
+    public native void freeBGRAGlyphImages(long[] glyphInfoPointers,
+                                           int glyphCount);
+
     private static native void
         XRenderCompositeTextNative(int op, int src, int dst,
                                    int srcX, int srcY, long maskFormat,

--- a/test/jdk/java/awt/font/Emoji.java
+++ b/test/jdk/java/awt/font/Emoji.java
@@ -24,12 +24,12 @@
 /*
  * @test
  * @key headful
- * @bug 8263583
+ * @bug 8263583 8269806
  * @summary Checks that emoji character has a non-empty and identical
  *          representation when rendered to different types of images,
  *          including an accelerated (OpenGL or Metal) surface.
- * @requires (os.family == "mac")
- * @run main/othervm -Dsun.java2d.uiScale=1 MacEmoji
+ * @requires (os.family == "mac" | os.family == "linux")
+ * @run main/othervm -Dsun.java2d.uiScale=1 Emoji
  */
 
 import java.awt.*;
@@ -37,9 +37,12 @@ import java.awt.image.BufferedImage;
 import java.awt.image.VolatileImage;
 import java.util.List;
 
-public class MacEmoji {
+public class Emoji {
     private static final int IMG_WIDTH = 20;
     private static final int IMG_HEIGHT = 20;
+    private static final Font FONT = new Font(
+            System.getProperty("os.name").toLowerCase().contains("linux") ?
+                    "Noto Color Emoji" : Font.DIALOG, Font.PLAIN, 12);
 
     public static void main(String[] args) {
         GraphicsConfiguration cfg
@@ -101,7 +104,7 @@ public class MacEmoji {
         Graphics g = img.getGraphics();
         g.setColor(Color.white);
         g.fillRect(0, 0, IMG_WIDTH, IMG_HEIGHT);
-        g.setFont(new Font(Font.DIALOG, Font.PLAIN, 12));
+        g.setFont(FONT);
         g.drawString("\uD83D\uDE00" /* U+1F600 'GRINNING FACE' */, 2, 15);
         g.dispose();
     }


### PR DESCRIPTION
It was implemented in JetBrains Runtime a year ago and was ported & refactored for this PR
It includes:
- Bitmap glyph loading via Freetype
- Manual scaling & transformation of bitmap glyphs with nearest-neighbor or bilinear-mipmap style algorithms depending on the text antialiasing hint
- Storing BGRA glyphs in glyph cache & rendering them as plain images, as currently used XRender text drawing functions doesn't support colored glyphs
- Small fixes in related code like null-checks which could cause NPE & comment typos