### PR TITLE
8270794: Avoid loading Klass* twice in TypeArrayKlass::oop_size()

### DIFF
--- a/src/hotspot/share/oops/typeArrayKlass.cpp
+++ b/src/hotspot/share/oops/typeArrayKlass.cpp
@@ -230,7 +230,7 @@ Klass* TypeArrayKlass::array_klass_or_null() {
 int TypeArrayKlass::oop_size(oop obj) const {
   assert(obj->is_typeArray(),"must be a type array");
   typeArrayOop t = typeArrayOop(obj);
-  return t->object_size();
+  return t->object_size(this);
 }
 
 void TypeArrayKlass::initialize(TRAPS) {

--- a/src/hotspot/share/oops/typeArrayOop.hpp
+++ b/src/hotspot/share/oops/typeArrayOop.hpp
@@ -131,7 +131,7 @@ private:
   }
 
  public:
-  inline int object_size();
+  inline int object_size(const TypeArrayKlass* tk) const;
 };
 
 #endif // SHARE_OOPS_TYPEARRAYOOP_HPP

--- a/src/hotspot/share/oops/typeArrayOop.inline.hpp
+++ b/src/hotspot/share/oops/typeArrayOop.inline.hpp
@@ -31,8 +31,7 @@
 #include "oops/oop.inline.hpp"
 #include "oops/arrayOop.hpp"
 
-int typeArrayOopDesc::object_size() {
-  TypeArrayKlass* tk = TypeArrayKlass::cast(klass());
+int typeArrayOopDesc::object_size(const TypeArrayKlass* tk) const {
   return object_size(tk->layout_helper(), length());
 }
 

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -302,7 +302,7 @@ JRT_BLOCK_ENTRY(void, OptoRuntime::new_array_nozero_C(Klass* array_type, int len
   if ((len > 0) && (result != NULL) &&
       is_deoptimized_caller_frame(current)) {
     // Zero array here if the caller is deoptimized.
-    int size = ((typeArrayOop)result)->object_size();
+    int size = TypeArrayKlass::cast(array_type)->oop_size(result);
     BasicType elem_type = TypeArrayKlass::cast(array_type)->element_type();
     const size_t hs = arrayOopDesc::header_size(elem_type);
     // Align to next 8 bytes to avoid trashing arrays's length.


### PR DESCRIPTION
TypeArrayKlass::oop_size() calls into TypoArrayOopDesc::object_size() which loads the Klass* from the object, but this is not necessary because we're coming from TypeArrayKlass.

Note: This came up in Lilliput, where we need to be careful how to load the Klass, and must figure out the object size using oopDesc::size_given_klass() without blindly re-loading the Klass*. Outside of Lilliput I consider this a cosmetic change (i.e. no substantial performance improvement expected because most cases should be covered by layout-helper).

Testing:
 - [x] tier1
 - [x] tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270794](https://bugs.openjdk.java.net/browse/JDK-8270794): Avoid loading Klass* twice in TypeArrayKlass::oop_size()


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4799/head:pull/4799` \
`$ git checkout pull/4799`

Update a local copy of the PR: \
`$ git checkout pull/4799` \
`$ git pull https://git.openjdk.java.net/jdk pull/4799/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4799`

View PR using the GUI difftool: \
`$ git pr show -t 4799`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4799.diff">https://git.openjdk.java.net/jdk/pull/4799.diff</a>

</details>
