### PR TITLE
8270801: Print VM arguments with java -Xlog:arguments

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3989,6 +3989,11 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
 
   apply_debugger_ergo();
 
+  if (log_is_enabled(Info, arguments)) {
+    LogStream st(Log(arguments)::info());
+    Arguments::print_on(&st);
+  }
+
   return JNI_OK;
 }
 


### PR DESCRIPTION
It's useful to print VM arguments to the log file, especially when you are logging several JVM invocations:

```
$ java -cp foo -Xlog:gc:file=a.log -Xcomp com.Foo
$ java -cp foo -Xlog:gc:file=b.log -Xint com.Foo
```

After a while, you may forget which process created a.log and which created b.log. Adding vm arguments into the log file will help distinguishing them:

```
$ java -cp foo -Xlog:gc,arguments:file=a.log -Xcomp com.Foo
$ java -cp foo -Xlog:gc,arguments:file=b.log -Xint com.Foo

$ grep jvm_args a.log b.log
a.log:[0.015s][info][arguments] jvm_args: -Xlog:gc,arguments:file=a.log -Xint
b.log:[0.001s][info][arguments] jvm_args: -Xlog:gc,arguments:file=b.log -Xcomp
```

Here's an example of what the log looks like:

```
$ java -Xlog:arguments -Xshare:on -cp ~/tmp -Dxx=yy -esa HelloWorld 1 2 3
[0.001s][info][arguments] VM Arguments:
[0.001s][info][arguments] jvm_args: -Xlog:arguments -Xshare:on -Dxx=yy -esa
[0.001s][info][arguments] java_command: HelloWorld 1 2 3
[0.001s][info][arguments] java_class_path (initial): /home/user/tmp
[0.001s][info][arguments] Launcher Type: SUN_STANDARD
Hello World
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270801](https://bugs.openjdk.java.net/browse/JDK-8270801): Print VM arguments with java -Xlog:arguments


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Xin Liu](https://openjdk.java.net/census#xliu) (@navyxliu - Committer)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4801/head:pull/4801` \
`$ git checkout pull/4801`

Update a local copy of the PR: \
`$ git checkout pull/4801` \
`$ git pull https://git.openjdk.java.net/jdk pull/4801/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4801`

View PR using the GUI difftool: \
`$ git pr show -t 4801`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4801.diff">https://git.openjdk.java.net/jdk/pull/4801.diff</a>

</details>
