### PR TITLE
JDK-8270820: remove unused stiFileTableIndex from SDE.c

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/SDE.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/SDE.c
@@ -731,10 +731,6 @@ private jboolean isValid(void);
         return -1;
     }
 
-    private int stiFileTableIndex(int sti, int lti) {
-        return fileTableIndex(sti, lineTable[lti].fileId);
-    }
-
     private jboolean isValid(void) {
         return sourceMapIsValid;
     }


### PR DESCRIPTION
Hello, please review this very small change. While checking compiler warnings of the type : "function 'xyz' was declared but never referenced" I came across stiFileTableIndex from SDE.c that generated such a warning and can be removed.

Thanks, Matthias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270820](https://bugs.openjdk.java.net/browse/JDK-8270820): remove unused stiFileTableIndex from SDE.c


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4805/head:pull/4805` \
`$ git checkout pull/4805`

Update a local copy of the PR: \
`$ git checkout pull/4805` \
`$ git pull https://git.openjdk.java.net/jdk pull/4805/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4805`

View PR using the GUI difftool: \
`$ git pr show -t 4805`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4805.diff">https://git.openjdk.java.net/jdk/pull/4805.diff</a>

</details>
