### PR TITLE
8270553: Tests should not use (real, in-use, routable) 1.1.1.1 as dummy IP value

### DIFF
--- a/test/jdk/java/net/HttpURLConnection/HttpURLConWithProxy.java
+++ b/test/jdk/java/net/HttpURLConnection/HttpURLConWithProxy.java
@@ -55,7 +55,8 @@ public class HttpURLConWithProxy {
         // Remove the default nonProxyHosts to use localhost for testing
         System.setProperty("http.nonProxyHosts", "");
 
-        System.setProperty("http.proxyHost", "1.1.1.1");
+        // 240.0.0.0/4 is unallocated and "reserved for future use" (RFC 1112, Section 4)
+        System.setProperty("http.proxyHost", "240.0.0.1");
         System.setProperty("http.proxyPort", "1111");
 
         // Use the logger to help verify the Proxy was used
@@ -131,8 +132,9 @@ class MyProxySelector extends ProxySelector {
     List<Proxy> proxies = new ArrayList<>();
 
     MyProxySelector() {
-        Proxy p1 = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("2.2.2.2", 2222));
-        Proxy p2 = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("3.3.3.3", 3333));
+        // 240.0.0.0/4 is unallocated and "reserved for future use" (RFC 1112, Section 4)
+        Proxy p1 = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("240.0.0.2", 2222));
+        Proxy p2 = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("240.0.0.3", 3333));
         proxies.add(p1);
         proxies.add(p2);
     }


### PR DESCRIPTION
The tests `test/jdk/java/net/HttpURLConnection/HttpURLConWithProxy.java` uses the IP address "1.1.1.1" as a value. I think at the time the address was picked, the assumption was the address was not valid / not routable. Since April 2018 the address is part of CloudFlare's "Free" DNS product: <https://en.wikipedia.org/wiki/1.1.1.1>. (this test was originally written in 2016, before the service was launched)

I've verified using local packet captures that running the test does result in IP traffic being sent to 1.1.1.1. (Several other tests in JDK use 1.1.1.1 as a placeholder IP. I've checked them all and none of the others connect out to the IP like this one)
 
This PR substitutes that IP address value (and two others) for ones from a reserved IP range (240.0.0.0/4 according to RFC 6761) which will not result in runners of the test suit inadvertently sending IP packets to the CloudFlare service. 

This could be invalidated again if that address range is allocated at some point in the future. A more future-proof fix would be to bind to random ports on localhost for each dummy proxy (as done for the target HTTP server in the test already). I can do that if preferred.

<https://bugs.openjdk.java.net/browse/JDK-8270553>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270553](https://bugs.openjdk.java.net/browse/JDK-8270553): Tests should not use (real, in-use, routable) 1.1.1.1 as dummy IP value


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4806/head:pull/4806` \
`$ git checkout pull/4806`

Update a local copy of the PR: \
`$ git checkout pull/4806` \
`$ git pull https://git.openjdk.java.net/jdk pull/4806/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4806`

View PR using the GUI difftool: \
`$ git pr show -t 4806`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4806.diff">https://git.openjdk.java.net/jdk/pull/4806.diff</a>

</details>
