### PR TITLE
8261236: C2: ClhsdbJstackXcompStress test fails when StressGCM is enabled

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/compiler/OopMapStream.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/compiler/OopMapStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,24 +29,13 @@ import sun.jvm.hotspot.code.*;
 public class OopMapStream {
   private CompressedReadStream stream;
   private ImmutableOopMap oopMap;
-  private int mask;
   private int size;
   private int position;
   private OopMapValue omv;
   private boolean omvValid;
 
   public OopMapStream(ImmutableOopMap oopMap) {
-    this(oopMap, (OopMapValue.OopTypes[]) null);
-  }
-
-  public OopMapStream(ImmutableOopMap oopMap, OopMapValue.OopTypes type) {
-    this(oopMap, (OopMapValue.OopTypes[]) null);
-    mask = type.getValue();
-  }
-
-  public OopMapStream(ImmutableOopMap oopMap, OopMapValue.OopTypes[] types) {
     stream = new CompressedReadStream(oopMap.getData());
-    mask = computeMask(types);
     size = (int) oopMap.getCount();
     position = 0;
     omv = new OopMapValue();
@@ -72,23 +61,11 @@ public class OopMapStream {
   // Internals only below this point
   //
 
-  private int computeMask(OopMapValue.OopTypes[] types) {
-    mask = 0;
-    if (types != null) {
-      for (int i = 0; i < types.length; i++) {
-        mask |= types[i].getValue();
-      }
-    }
-    return mask;
-  }
-
   private void findNext() {
-    while (position++ < size) {
+    if (position++ < size) {
       omv.readFrom(stream);
-      if ((omv.getType().getValue() & mask) > 0) {
-        omvValid = true;
-        return;
-      }
+      omvValid = true;
+      return;
     }
     omvValid = false;
   }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/classbrowser/HTMLGenerator.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/classbrowser/HTMLGenerator.java
@@ -1180,7 +1180,8 @@ public class HTMLGenerator implements /* imports */ ClassConstants {
       Formatter buf = new Formatter(genHTML);
 
       final class OopMapValueIterator {
-         final Formatter iterate(OopMapStream oms, String type, boolean printContentReg) {
+         final Formatter iterate(OopMapStream oms, String type, boolean printContentReg,
+                                 OopMapValue.OopTypes filter) {
             Formatter tmpBuf = new Formatter(genHTML);
             boolean found = false;
             tmpBuf.beginTag("tr");
@@ -1188,7 +1189,7 @@ public class HTMLGenerator implements /* imports */ ClassConstants {
             tmpBuf.append(type);
             for (; ! oms.isDone(); oms.next()) {
                OopMapValue omv = oms.getCurrent();
-               if (omv == null) {
+               if (omv == null || omv.getType() != filter) {
                   continue;
                }
                found = true;
@@ -1224,17 +1225,21 @@ public class HTMLGenerator implements /* imports */ ClassConstants {
       buf.beginTable(0);
 
       OopMapValueIterator omvIterator = new OopMapValueIterator();
-      OopMapStream oms = new OopMapStream(map, OopMapValue.OopTypes.OOP_VALUE);
-      buf.append(omvIterator.iterate(oms, "Oops:", false));
+      OopMapStream oms = new OopMapStream(map);
+      buf.append(omvIterator.iterate(oms, "Oops:", false,
+                                     OopMapValue.OopTypes.OOP_VALUE));
 
-      oms = new OopMapStream(map, OopMapValue.OopTypes.NARROWOOP_VALUE);
-      buf.append(omvIterator.iterate(oms, "NarrowOops:", false));
+      oms = new OopMapStream(map);
+      buf.append(omvIterator.iterate(oms, "NarrowOops:", false,
+                                     OopMapValue.OopTypes.NARROWOOP_VALUE));
 
-      oms = new OopMapStream(map, OopMapValue.OopTypes.CALLEE_SAVED_VALUE);
-      buf.append(omvIterator.iterate(oms, "Callee saved:",  true));
+      oms = new OopMapStream(map);
+      buf.append(omvIterator.iterate(oms, "Callee saved:", true,
+                                     OopMapValue.OopTypes.CALLEE_SAVED_VALUE));
 
-      oms = new OopMapStream(map, OopMapValue.OopTypes.DERIVED_OOP_VALUE);
-      buf.append(omvIterator.iterate(oms, "Derived oops:", true));
+      oms = new OopMapStream(map);
+      buf.append(omvIterator.iterate(oms, "Derived oops:", true,
+                                     OopMapValue.OopTypes.DERIVED_OOP_VALUE));
 
       buf.endTag("table");
       return buf.toString();


### PR DESCRIPTION
The clhsdb jstack command crashes when the debugged program is run with `-Xcomp -XX:+StressGCM -XX:StressSeed=2` on AArch64:

```
  sun.jvm.hotspot.utilities.AssertionFailure: sanity check
  at jdk.hotspot.agent/sun.jvm.hotspot.utilities.Assert.that(Assert.java:32)
  at jdk.hotspot.agent/sun.jvm.hotspot.runtime.RegisterMap.setLocation(RegisterMap.java:160)
  at jdk.hotspot.agent/sun.jvm.hotspot.compiler.ImmutableOopMapSet.updateRegisterMap(ImmutableOopMapSet.java:303)
  at jdk.hotspot.agent/sun.jvm.hotspot.runtime.aarch64.AARCH64Frame.senderForCompiledFrame(AARCH64Frame.java:407)
```

The assertion failure here is:

```
  Assert.that(0 <= i && i < regCount, "sanity check");
```

I.e. there's an invalid register in the oop map.

The problem seems to be caused by the changes in JDK-8231586 which changed `OopMapValue::oop_types` from a bit mask to normal integer enum. However the changes in the C++ code weren't mirrored in SA's OopMapStream which still treats OopTypes as a bit mask.

The particular oop map this is crashing on looks like this:

```
  ImmutableOopMap {[24]=Oop [32]=Oop [40]=Derived_oop_[24] } pc offsets: 324
```

The code is looking for callee saved values (type=2) by AND-ing with each oop value type in the set, so it wrongly interprets the derived oop [40] (type=3) as a callee saved register.

This patch just mirrors the changes to the C++ code into the corresponding SA classes.  The C++ OopMapStream constructor no longer takes a type filter argument and callers are expected filter themselves, so I've made the same change to the Java code.

This bug can also be seen using the clhsdb "disassemble" command.  For example the above oop map is currently printed incorrectly as:

```
  OopMap:
  NarrowOops:[40]
  Callee saved:[40] = [24]
  Derived oops:[40] = [24]
```

With this patch it becomes:

```
  OopMap:
  Oops:[24]  [32]
  Derived oops:[40] = [24]
```

This bug was reported on AArch64 but it seems to be just luck that we don't see it on other platforms.

Tested tier1 and hotspot_serviceability on AArch64 and x86.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261236](https://bugs.openjdk.java.net/browse/JDK-8261236): C2: ClhsdbJstackXcompStress test fails when StressGCM is enabled


### Reviewers
 * [Tom Rodriguez](https://openjdk.java.net/census#never) (@tkrodriguez - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4807/head:pull/4807` \
`$ git checkout pull/4807`

Update a local copy of the PR: \
`$ git checkout pull/4807` \
`$ git pull https://git.openjdk.java.net/jdk pull/4807/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4807`

View PR using the GUI difftool: \
`$ git pr show -t 4807`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4807.diff">https://git.openjdk.java.net/jdk/pull/4807.diff</a>

</details>
