### PR TITLE
8270832: Aarch64: Update algorithm annotations for MacroAssembler::fill_words

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -4809,6 +4809,13 @@ void MacroAssembler::fill_words(Register base, Register cnt, Register value)
 {
 //  Algorithm:
 //
+//    if (cnt == 0) {
+//      return;
+//    }
+//    if ((p & 8) != 0) {
+//      *p++ = v;
+//    }
+//
 //    scratch1 = cnt & 14;
 //    cnt -= scratch1;
 //    p += scratch1;
@@ -4831,8 +4838,8 @@ void MacroAssembler::fill_words(Register base, Register cnt, Register value)
 //          p += 16;
 //      } while (cnt);
 //    }
-//    if (cnt & 1 == 1) {
-//      p[0] = v;
+//    if ((cnt & 1) == 1) {
+//      *p++ = v;
 //    }
 
   assert_different_registers(base, cnt, value, rscratch1, rscratch2);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -4809,23 +4809,30 @@ void MacroAssembler::fill_words(Register base, Register cnt, Register value)
 {
 //  Algorithm:
 //
-//    scratch1 = cnt & 7;
+//    scratch1 = cnt & 14;
 //    cnt -= scratch1;
 //    p += scratch1;
-//    switch (scratch1) {
+//    switch (scratch1 / 2) {
 //      do {
-//        cnt -= 8;
-//          p[-8] = v;
+//        cnt -= 16;
+//          p[-16] = v;
+//          p[-15] = v;
 //        case 7:
-//          p[-7] = v;
+//          p[-14] = v;
+//          p[-13] = v;
 //        case 6:
-//          p[-6] = v;
+//          p[-12] = v;
+//          p[-11] = v;
 //          // ...
 //        case 1:
+//          p[-2] = v;
 //          p[-1] = v;
 //        case 0:
-//          p += 8;
+//          p += 16;
 //      } while (cnt);
+//    }
+//    if (cnt & 1 == 1) {
+//      p[0] = v;
 //    }
 
   assert_different_registers(base, cnt, value, rscratch1, rscratch2);


### PR DESCRIPTION
It is found that the comments of `MacroAssembler::fill_words` is not right here. Let's fix that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270832](https://bugs.openjdk.java.net/browse/JDK-8270832): Aarch64: Update algorithm annotations for MacroAssembler::fill_words


### Reviewers
 * [Nick Gasson](https://openjdk.java.net/census#ngasson) (@nick-arm - **Reviewer**)
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Contributors
 * Wang Huang `<whuang@openjdk.org>`
 * Miu Zhuojun `<mouzhuojun@huawei.com>`
 * Wu Yan `<wuyan@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4809/head:pull/4809` \
`$ git checkout pull/4809`

Update a local copy of the PR: \
`$ git checkout pull/4809` \
`$ git pull https://git.openjdk.java.net/jdk pull/4809/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4809`

View PR using the GUI difftool: \
`$ git pr show -t 4809`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4809.diff">https://git.openjdk.java.net/jdk/pull/4809.diff</a>

</details>
