### PR TITLE
8270837: fix typos in test TestSigParse.java

### DIFF
--- a/test/hotspot/jtreg/runtime/verifier/TestSigParse.java
+++ b/test/hotspot/jtreg/runtime/verifier/TestSigParse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8129579
+ * @bug 8219579
  * @summary Test that signatures are properly parsed when verification of local
  *          classes is requested but verification of remote classes is not.
  * @compile BadSignatures.jcod
@@ -33,7 +33,7 @@
 public class TestSigParse {
 
     public static void main(String args[]) throws Throwable {
-        System.out.println("Regression test for bug 819579");
+        System.out.println("Regression test for bug 8219579");
 
         // Test a FieldRef with a bad signature.
         try {


### PR DESCRIPTION
Please review this trivial fix for JDK-8270837.  The modified test was tested by running Mach5 tier1 on Linux, Mac OS, and Windows and by running the test locally on Linux x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270837](https://bugs.openjdk.java.net/browse/JDK-8270837): fix typos in test TestSigParse.java


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4812/head:pull/4812` \
`$ git checkout pull/4812`

Update a local copy of the PR: \
`$ git checkout pull/4812` \
`$ git pull https://git.openjdk.java.net/jdk pull/4812/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4812`

View PR using the GUI difftool: \
`$ git pr show -t 4812`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4812.diff">https://git.openjdk.java.net/jdk/pull/4812.diff</a>

</details>
