### PR TITLE
8269636: Change outputStream's print_raw() and print_raw_cr() second parameter to size_t type

### DIFF
--- a/src/hotspot/share/compiler/disassembler.cpp
+++ b/src/hotspot/share/compiler/disassembler.cpp
@@ -684,7 +684,7 @@ static int printf_to_env(void* env_pv, const char* format, ...) {
     raw = format+1;
   }
   if (raw != NULL) {
-    st->print_raw(raw, (int) flen);
+    st->print_raw(raw, flen);
     return (int) flen;
   }
   va_list ap;

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1116,7 +1116,7 @@ void Arguments::print_on(outputStream* st) {
     if (len == 0) {
       st->print_raw_cr("<not set>");
     } else {
-      st->print_raw_cr(path, (int)len);
+      st->print_raw_cr(path, len);
     }
   }
   st->print_cr("Launcher Type: %s", _sun_java_launcher);

--- a/src/hotspot/share/utilities/ostream.hpp
+++ b/src/hotspot/share/utilities/ostream.hpp
@@ -97,9 +97,9 @@ class outputStream : public ResourceObj {
    void vprint(const char *format, va_list argptr) ATTRIBUTE_PRINTF(2, 0);
    void vprint_cr(const char* format, va_list argptr) ATTRIBUTE_PRINTF(2, 0);
    void print_raw(const char* str)            { write(str, strlen(str)); }
-   void print_raw(const char* str, int len)   { write(str,         len); }
+   void print_raw(const char* str, size_t len)   { write(str,         len); }
    void print_raw_cr(const char* str)         { write(str, strlen(str)); cr(); }
-   void print_raw_cr(const char* str, int len){ write(str,         len); cr(); }
+   void print_raw_cr(const char* str, size_t len){ write(str,         len); cr(); }
    void print_data(void* data, size_t len, bool with_ascii);
    void put(char ch);
    void sp(int count = 1);


### PR DESCRIPTION
Please review this small cleanup so that the callers of outputStream's `print_raw()` don't need to typecast the second arg to int.

Testing:
- [x] Tiers1,2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269636](https://bugs.openjdk.java.net/browse/JDK-8269636): Change outputStream's print_raw() and print_raw_cr() second parameter to size_t type


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4814/head:pull/4814` \
`$ git checkout pull/4814`

Update a local copy of the PR: \
`$ git checkout pull/4814` \
`$ git pull https://git.openjdk.java.net/jdk pull/4814/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4814`

View PR using the GUI difftool: \
`$ git pr show -t 4814`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4814.diff">https://git.openjdk.java.net/jdk/pull/4814.diff</a>

</details>
