### PR TITLE
8213714: AttachingConnector/attach/attach001 failed due to "bind failed: Address already in use"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attach/attach001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attach/attach001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import jdk.test.lib.JDWP;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
@@ -69,9 +70,6 @@ public class attach001 {
     }
 
     private int runIt(String argv[], PrintStream out) {
-        String port;
-        String listenPort;
-        Process proc;
         ArgumentHandler argHandler = new ArgumentHandler(argv);
 
 // pass if "com.sun.jdi.SocketAttach" is not implemented
@@ -96,19 +94,17 @@ public class attach001 {
         long timeout = argHandler.getWaitTime() * 60 * 1000;
         attempts = (int)(timeout / delay);
 
-        port = argHandler.getTransportPort();
-        listenPort = argHandler.getTransportPort();
-
         String java = argHandler.getLaunchExecPath()
                         + " " + argHandler.getLaunchOptions();
-        String cmd = java +
-                " -Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,address=" +
-                listenPort + " " + DEBUGEE_CLASS;
+        String cmd = java
+                + " -Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,address=0"
+                + " " + DEBUGEE_CLASS;
 
         Binder binder = new Binder(argHandler, log);
         log.display("command: " + cmd);
         Debugee debugee = binder.startLocalDebugee(cmd);
-        debugee.redirectOutput(log);
+        JDWP.ListenAddress listenAddress = debugee.redirectOutputAndDetectListeningAddress(log);
+        String port = listenAddress.address();
 
         if ((vm = attachTarget(argHandler.getTestHost(), port)) == null) {
             log.complain("TEST: Unable to attach the debugee VM");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attachnosuspend/attachnosuspend001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attachnosuspend/attachnosuspend001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import jdk.test.lib.JDWP;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
@@ -69,9 +70,6 @@ public class attachnosuspend001 {
     }
 
     private int runIt(String argv[], PrintStream out) {
-        String port;
-        String listenPort;
-        Process proc;
         ArgumentHandler argHandler = new ArgumentHandler(argv);
 
 // pass if "com.sun.jdi.SocketAttach" is not implemented
@@ -96,19 +94,17 @@ public class attachnosuspend001 {
         long timeout = argHandler.getWaitTime() * 60 * 1000;
         attempts = (int)(timeout / delay);
 
-        port = argHandler.getTransportPort();
-        listenPort = argHandler.getTransportPort();
-
         String java = argHandler.getLaunchExecPath()
                         + " " + argHandler.getLaunchOptions();
-        String cmd = java +
-                " -Xdebug -Xnoagent -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=" +
-                listenPort + " " + DEBUGEE_CLASS;
+        String cmd = java
+                + " -Xdebug -Xnoagent -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0"
+                + " " + DEBUGEE_CLASS;
 
         Binder binder = new Binder(argHandler, log);
         log.display("command: " + cmd);
         Debugee debugee = binder.startLocalDebugee(cmd);
-        debugee.redirectOutput(log);
+        JDWP.ListenAddress listenAddress = debugee.redirectOutputAndDetectListeningAddress(log);
+        String port = listenAddress.address();
 
         if ((vm = attachTarget(argHandler.getTestHost(), port)) == null) {
             log.complain("TEST: Unable to attach the debugee VM");

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/IORedirector.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/IORedirector.java
@@ -24,6 +24,9 @@
 package nsk.share;
 
 import java.io.*;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * This class implements a thread transfering bytes from
@@ -31,13 +34,7 @@ import java.io.*;
  */
 public class IORedirector extends Thread {
     private BufferedReader bin  = null;
-    private PrintStream    pout = null;
-    private Log            log  = null;
-
-    /**
-     * Few symbols to precede every text line being redirected.
-     */
-    private String prefix = "";
+    private List<Consumer<String>> processors = new LinkedList<>();
 
     /**
      * Input and output streams must be specified.
@@ -54,10 +51,16 @@ public class IORedirector extends Thread {
      * @see #IORedirector(BufferedReader,Log,String)
      */
     @Deprecated
-    public IORedirector(InputStream in, OutputStream out) {
+    public IORedirector(InputStream in, OutputStream out, String prefix) {
         this();
         bin  = new BufferedReader(new InputStreamReader(in));
-        pout = new PrintStream(out);
+        PrintStream pout = new PrintStream(out);
+        addProcessor(s -> {
+            synchronized (pout) {
+                pout.println(prefix + s);
+                pout.flush();
+            }
+        });
     }
 
     /**
@@ -67,16 +70,16 @@ public class IORedirector extends Thread {
      */
     public IORedirector(BufferedReader in, Log log, String prefix) {
         this();
-        this.prefix = prefix;
         this.bin  = in;
-        this.log = log;
+        addProcessor( s -> log.println(prefix + s));
     }
 
-    /**
-     * Set the prefix for redirected messages;
-     */
-    public void setPrefix(String prefix) {
-        this.prefix = prefix;
+    public void addProcessor(Consumer<String> lineProcessor) {
+        processors.add(lineProcessor);
+    }
+
+    private void processLine(String line) {
+        processors.stream().forEach(processor -> processor.accept(line));
     }
 
     private boolean cancelled = false;
@@ -104,39 +107,20 @@ public class IORedirector extends Thread {
      */
     public void run () {
         started = true;
-        String logPrefix = "IORedirector-" + prefix;
-        if (bin == null || (pout == null && log == null))
+        if (bin == null || processors.isEmpty()) {
             return;
+        }
         try {
             while (!cancelled) {
                 String line = bin.readLine();
                 if (line == null)
                     break; //EOF
-                String message = prefix + line;
-                if (log != null) {
-                    // It's synchronized and auto-flushed:
-                    log.println(message);
-                } else if (pout != null) {
-                    synchronized (pout) {
-                        pout.println(message);
-                        pout.flush();
-                    }
-                }
+                processLine(line);
             }
         } catch (IOException e) {
             // e.printStackTrace(log.getOutStream());
             String msg = "# WARNING: Caught IOException while redirecting output stream:\n\t" + e;
-            if (log != null) {
-                log.println(msg);
-            } else if (pout != null) {
-                synchronized (pout) {
-                    pout.println(msg);
-                    pout.flush();
-                }
-            } else {
-                System.err.println(msg);
-                System.err.flush();
-            }
+            processLine(msg);
         };
         stopped = true;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/IORedirector.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/IORedirector.java
@@ -71,7 +71,7 @@ public class IORedirector extends Thread {
     public IORedirector(BufferedReader in, Log log, String prefix) {
         this();
         this.bin  = in;
-        addProcessor( s -> log.println(prefix + s));
+        addProcessor(s -> log.println(prefix + s));
     }
 
     public void addProcessor(Consumer<String> lineProcessor) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeProcess.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeProcess.java
@@ -304,8 +304,7 @@ abstract public class DebugeeProcess extends FinalizableObject {
 
     /**
      * Start thread redirecting the debugee's stdout to the
-     * given <code>out</code> stream. If the debugee's stdout
-     * was already redirected, the TestBug exception is thrown.
+     * given <code>out</code> stream.
      *
      * @deprecated Use redirectStdout(Log, String) instead.
      */
@@ -314,7 +313,6 @@ abstract public class DebugeeProcess extends FinalizableObject {
         if (stdoutRedirector != null) {
             return;
         }
-//            throw new TestBug("Debugee's stdout is already redirected");
         stdoutRedirector = new IORedirector(getOutPipe(), out, DEBUGEE_STDOUT_LOG_PREFIX);
         stdoutRedirector.setName("IORedirector for stdout");
         stdoutRedirector.setDaemon(true);
@@ -323,8 +321,7 @@ abstract public class DebugeeProcess extends FinalizableObject {
 
     /**
      * Start thread redirecting the debugee's stdout to the
-     * given <code>Log</code>. If the debugee's stdout
-     * was already redirected, the TestBug exception is thrown.
+     * given <code>Log</code>.
      */
     public void redirectStdout(Log log, String prefix) {
         redirectStdout(log, prefix, null);
@@ -332,9 +329,7 @@ abstract public class DebugeeProcess extends FinalizableObject {
 
     private void redirectStdout(Log log, String prefix, Consumer<String> stdoutProcessor) {
         if (stdoutRedirector != null) {
-//            stdoutRedirector.setPrefix(prefix);
             return;
-//            throw new TestBug("the debugee's stdout is already redirected");
         }
         stdoutRedirector = new IORedirector(new BufferedReader(new InputStreamReader(getOutPipe())), log, prefix);
         if (stdoutProcessor != null) {
@@ -347,8 +342,7 @@ abstract public class DebugeeProcess extends FinalizableObject {
 
     /**
      * Start thread redirecting the debugee's stderr to the
-     * given <code>err</code> stream. If the debugee's stderr
-     * was already redirected, the TestBug exception is thrown.
+     * given <code>err</code> stream.
      *
      * @deprecated Use redirectStderr(Log, String) instead.
      */
@@ -357,7 +351,6 @@ abstract public class DebugeeProcess extends FinalizableObject {
         if (stderrRedirector != null) {
             return;
         }
-//            throw new TestBug("Debugee's stderr is already redirected");
         stderrRedirector = new IORedirector(getErrPipe(), err, DEBUGEE_STDERR_LOG_PREFIX);
         stdoutRedirector.setName("IORedirector for stderr");
         stderrRedirector.setDaemon(true);
@@ -366,14 +359,11 @@ abstract public class DebugeeProcess extends FinalizableObject {
 
     /**
      * Start thread redirecting the debugee's stderr to the
-     * given <code>Log</code>. If the debugee's stderr
-     * was already redirected, the TestBug exception is thrown.
+     * given <code>Log</code>.
      */
     public void redirectStderr(Log log, String prefix) {
         if (stderrRedirector != null) {
-//            stderrRedirector.setPrefix(prefix);
             return;
-//            throw new TestBug("Debugee's stderr is already redirected");
         }
         stderrRedirector = new IORedirector(new BufferedReader(new InputStreamReader(getErrPipe())), log, prefix);
         stdoutRedirector.setName("IORedirector for stderr");
@@ -384,8 +374,6 @@ abstract public class DebugeeProcess extends FinalizableObject {
     /**
      * Start thread redirecting the debugee's stdout/stderr to the
      * given <code>Log</code> using standard prefixes.
-     * If the debugee's stdout/stderr were already redirected,
-     * the TestBug exception is thrown.
      */
     public void redirectOutput(Log log) {
         redirectStdout(log, DEBUGEE_STDOUT_LOG_PREFIX);

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeProcess.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeProcess.java
@@ -23,9 +23,11 @@
 
 package nsk.share.jpda;
 
+import jdk.test.lib.JDWP;
 import nsk.share.*;
 import java.io.*;
 import java.net.*;
+import java.util.function.Consumer;
 
 /**
  * This class is used to control debugee VM process.
@@ -313,8 +315,7 @@ abstract public class DebugeeProcess extends FinalizableObject {
             return;
         }
 //            throw new TestBug("Debugee's stdout is already redirected");
-        stdoutRedirector = new IORedirector(getOutPipe(),out);
-        stdoutRedirector.setPrefix(DEBUGEE_STDOUT_LOG_PREFIX);
+        stdoutRedirector = new IORedirector(getOutPipe(), out, DEBUGEE_STDOUT_LOG_PREFIX);
         stdoutRedirector.setName("IORedirector for stdout");
         stdoutRedirector.setDaemon(true);
         stdoutRedirector.start();
@@ -326,12 +327,19 @@ abstract public class DebugeeProcess extends FinalizableObject {
      * was already redirected, the TestBug exception is thrown.
      */
     public void redirectStdout(Log log, String prefix) {
+        redirectStdout(log, prefix, null);
+    }
+
+    private void redirectStdout(Log log, String prefix, Consumer<String> stdoutProcessor) {
         if (stdoutRedirector != null) {
 //            stdoutRedirector.setPrefix(prefix);
             return;
 //            throw new TestBug("the debugee's stdout is already redirected");
         }
         stdoutRedirector = new IORedirector(new BufferedReader(new InputStreamReader(getOutPipe())), log, prefix);
+        if (stdoutProcessor != null) {
+            stdoutRedirector.addProcessor(stdoutProcessor);
+        }
         stdoutRedirector.setName("IORedirector for stdout");
         stdoutRedirector.setDaemon(true);
         stdoutRedirector.start();
@@ -350,8 +358,7 @@ abstract public class DebugeeProcess extends FinalizableObject {
             return;
         }
 //            throw new TestBug("Debugee's stderr is already redirected");
-        stderrRedirector = new IORedirector(getErrPipe(),err);
-        stderrRedirector.setPrefix(DEBUGEE_STDERR_LOG_PREFIX);
+        stderrRedirector = new IORedirector(getErrPipe(), err, DEBUGEE_STDERR_LOG_PREFIX);
         stdoutRedirector.setName("IORedirector for stderr");
         stderrRedirector.setDaemon(true);
         stderrRedirector.start();
@@ -381,9 +388,48 @@ abstract public class DebugeeProcess extends FinalizableObject {
      * the TestBug exception is thrown.
      */
     public void redirectOutput(Log log) {
-        redirectStdout(log, "debugee.stdout> ");
-        redirectStderr(log, "debugee.stderr> ");
+        redirectStdout(log, DEBUGEE_STDOUT_LOG_PREFIX);
+        redirectStderr(log, DEBUGEE_STDERR_LOG_PREFIX);
     }
+
+    /**
+     * Starts redirecting of the debugee's stdout/stderr to the
+     * given <code>Log</code> using standard prefixes
+     * and detects listening address from the debuggee stdout.
+     */
+    public JDWP.ListenAddress redirectOutputAndDetectListeningAddress(Log log) {
+        JDWP.ListenAddress listenAddress[] = new JDWP.ListenAddress[1];
+        Consumer<String> stdoutProcessor = line -> {
+            JDWP.ListenAddress addr = JDWP.parseListenAddress(line);
+            if (addr != null) {
+                synchronized (listenAddress) {
+                    listenAddress[0] = addr;
+                    listenAddress.notifyAll();
+                }
+            }
+        };
+
+        redirectStdout(log, DEBUGEE_STDOUT_LOG_PREFIX, stdoutProcessor);
+        redirectStderr(log, DEBUGEE_STDERR_LOG_PREFIX);
+
+        synchronized (listenAddress) {
+            while (!terminated() && listenAddress[0] == null) {
+                try {
+                    listenAddress.wait(500);
+                } catch (InterruptedException e) {
+                    // ignore
+                }
+            }
+        }
+        if (terminated()) {
+            throw new Failure("Failed to detect debuggee listening port");
+        }
+
+        log.display("Debuggee is listening on port " + listenAddress[0].address());
+
+        return listenAddress[0];
+    }
+
     // --------------------------------------------------- //
 
     /**


### PR DESCRIPTION
The fix updates the tests to use dynamic port launching debuggee and get the listening port from the debugee output

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8213714](https://bugs.openjdk.java.net/browse/JDK-8213714): AttachingConnector/attach/attach001 failed due to "bind failed: Address already in use"


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4817/head:pull/4817` \
`$ git checkout pull/4817`

Update a local copy of the PR: \
`$ git checkout pull/4817` \
`$ git pull https://git.openjdk.java.net/jdk pull/4817/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4817`

View PR using the GUI difftool: \
`$ git pr show -t 4817`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4817.diff">https://git.openjdk.java.net/jdk/pull/4817.diff</a>

</details>
