### PR TITLE
8270869: G1ServiceThread may not terminate

### DIFF
--- a/src/hotspot/share/gc/g1/g1ServiceThread.cpp
+++ b/src/hotspot/share/gc/g1/g1ServiceThread.cpp
@@ -112,12 +112,10 @@ void G1ServiceThread::notify() {
 }
 
 void G1ServiceThread::sleep_before_next_cycle() {
+  MonitorLocker ml(&_monitor, Mutex::_no_safepoint_check_flag);
   if (should_terminate()) {
     return;
-  }
-
-  MonitorLocker ml(&_monitor, Mutex::_no_safepoint_check_flag);
-  if (_task_queue.is_empty()) {
+  } else if (_task_queue.is_empty()) {
     // Sleep until new task is registered if no tasks available.
     log_trace(gc, task)("G1 Service Thread (wait for new tasks)");
     ml.wait(0);


### PR DESCRIPTION
Please review this fix of a rare race in G1ServiceThread termination that
can lead to the thread not terminating in a timely manner.

Testing:
mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270869](https://bugs.openjdk.java.net/browse/JDK-8270869): G1ServiceThread may not terminate


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Committer) ⚠️ Review applies to e065a5150968e46659e76ec0583253eae3b74b00
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to e065a5150968e46659e76ec0583253eae3b74b00


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4819/head:pull/4819` \
`$ git checkout pull/4819`

Update a local copy of the PR: \
`$ git checkout pull/4819` \
`$ git pull https://git.openjdk.java.net/jdk pull/4819/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4819`

View PR using the GUI difftool: \
`$ git pr show -t 4819`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4819.diff">https://git.openjdk.java.net/jdk/pull/4819.diff</a>

</details>
