### PR TITLE
8269689: Update --release 17 symbol information for JDK 17 build 31

### DIFF
--- a/make/data/symbols/java.base-H.sym.txt
+++ b/make/data/symbols/java.base-H.sym.txt
@@ -209,7 +209,8 @@ header extends java/lang/RuntimeException flags 21
 class name java/lang/runtime/SwitchBootstraps
 header extends java/lang/Object flags 21 classAnnotations @Ljdk/internal/javac/PreviewFeature;(feature=eLjdk/internal/javac/PreviewFeature$Feature;SWITCH_PATTERN_MATCHING;)
 innerclass innerClass java/lang/invoke/MethodHandles$Lookup outerClass java/lang/invoke/MethodHandles innerClassName Lookup flags 19
-method name typeSwitch descriptor (Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;[Ljava/lang/Object;)Ljava/lang/invoke/CallSite; thrownTypes java/lang/Throwable flags 89
+method name typeSwitch descriptor (Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;[Ljava/lang/Object;)Ljava/lang/invoke/CallSite; flags 89
+method name enumSwitch descriptor (Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;[Ljava/lang/Object;)Ljava/lang/invoke/CallSite; flags 89
 
 class name java/net/DatagramSocket
 -method name setDatagramSocketImplFactory descriptor (Ljava/net/DatagramSocketImplFactory;)V
@@ -454,8 +455,7 @@ innerclass innerClass java/io/ObjectInputStream$GetField outerClass java/io/Obje
 innerclass innerClass java/io/ObjectOutputStream$PutField outerClass java/io/ObjectOutputStream innerClassName PutField flags 409
 
 class name java/util/SplittableRandom
-header extends jdk/internal/util/random/RandomSupport$AbstractSplittableGenerator flags 31 runtimeAnnotations @Ljdk/internal/util/random/RandomSupport$RandomGeneratorProperties;(name="SplittableRandom",i=I64,j=I0,k=I0,equidistribution=I1)
-innerclass innerClass jdk/internal/util/random/RandomSupport$AbstractSplittableGenerator outerClass jdk/internal/util/random/RandomSupport innerClassName AbstractSplittableGenerator flags 409
+header extends java/lang/Object implements java/util/random/RandomGenerator,java/util/random/RandomGenerator$SplittableGenerator flags 31 runtimeAnnotations @Ljdk/internal/util/random/RandomSupport$RandomGeneratorProperties;(name="SplittableRandom",i=I64,j=I0,k=I0,equidistribution=I1)
 innerclass innerClass java/util/random/RandomGenerator$SplittableGenerator outerClass java/util/random/RandomGenerator innerClassName SplittableGenerator flags 609
 -method name nextInt descriptor (I)I
 -method name nextInt descriptor (II)I

--- a/make/data/symbols/jdk.javadoc-H.sym.txt
+++ b/make/data/symbols/jdk.javadoc-H.sym.txt
@@ -29,9 +29,9 @@
 class name jdk/javadoc/doclet/Reporter
 header extends java/lang/Object flags 601
 innerclass innerClass javax/tools/Diagnostic$Kind outerClass javax/tools/Diagnostic innerClassName Kind flags 4019
-method name print descriptor (Ljavax/tools/Diagnostic$Kind;Ljavax/tools/FileObject;IIILjava/lang/String;)V flags 401
 method name getStandardWriter descriptor ()Ljava/io/PrintWriter; flags 1
 method name getDiagnosticWriter descriptor ()Ljava/io/PrintWriter; flags 1
+method name print descriptor (Ljavax/tools/Diagnostic$Kind;Ljavax/tools/FileObject;IIILjava/lang/String;)V flags 1
 
 class name jdk/javadoc/doclet/StandardDoclet
 header extends java/lang/Object implements jdk/javadoc/doclet/Doclet flags 21


### PR DESCRIPTION
Usual kind of  updates for the symbol information in JDK 18 to reflect changes in the JDK 17 API. Bug fixes with API changes since JDK 17 b28 include JDK-8266313, JDK-8268972, and JDK-8266269.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269689](https://bugs.openjdk.java.net/browse/JDK-8269689): Update --release 17 symbol information for JDK 17 build 31


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4820/head:pull/4820` \
`$ git checkout pull/4820`

Update a local copy of the PR: \
`$ git checkout pull/4820` \
`$ git pull https://git.openjdk.java.net/jdk pull/4820/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4820`

View PR using the GUI difftool: \
`$ git pr show -t 4820`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4820.diff">https://git.openjdk.java.net/jdk/pull/4820.diff</a>

</details>
