### PR TITLE
8270875: Deprecate the FilterSpuriousWakeups flag so it can be removed 

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -525,6 +525,7 @@ static SpecialFlag const special_jvm_flags[] = {
   { "InitialRAMFraction",           JDK_Version::jdk(10),  JDK_Version::undefined(), JDK_Version::undefined() },
   { "AllowRedefinitionToAddDeleteMethods", JDK_Version::jdk(13), JDK_Version::undefined(), JDK_Version::undefined() },
   { "FlightRecorder",               JDK_Version::jdk(13), JDK_Version::undefined(), JDK_Version::undefined() },
+  { "FilterSpuriousWakeups",        JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::jdk(20) },
 
   // --- Deprecated alias flags (see also aliased_jvm_flags) - sorted by obsolete_in then expired_in:
   { "DefaultMaxRAMFraction",        JDK_Version::jdk(8),  JDK_Version::undefined(), JDK_Version::undefined() },

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -723,8 +723,8 @@ const intx ObjectAlignmentInBytes = 8;
                "(Unstable) select hashCode generation algorithm")           \
                                                                             \
   product(bool, FilterSpuriousWakeups, true,                                \
-          "When true prevents OS-level spurious, or premature, wakeups "    \
-          "from Object.wait (Ignored for Windows)")                         \
+          "(Deprecated) When true prevents OS-level spurious, or premature,"\
+          " wakeups from Object.wait (Ignored for Windows)")                \
                                                                             \
   product(bool, ReduceSignalUsage, false,                                   \
           "Reduce the use of OS signals in Java and/or the VM")             \


### PR DESCRIPTION
Please review this simple change to deprecate the archaic FilterSpuriousWakeups flag.

See JBS issue for more details.

Testing: manual

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270875](https://bugs.openjdk.java.net/browse/JDK-8270875): Deprecate the FilterSpuriousWakeups flag so it can be removed


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4821/head:pull/4821` \
`$ git checkout pull/4821`

Update a local copy of the PR: \
`$ git checkout pull/4821` \
`$ git pull https://git.openjdk.java.net/jdk pull/4821/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4821`

View PR using the GUI difftool: \
`$ git pr show -t 4821`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4821.diff">https://git.openjdk.java.net/jdk/pull/4821.diff</a>

</details>
