### PR TITLE
8267940: [macos] java/awt/print/Dialog/DialogOwnerTest.java fails

### DIFF
--- a/test/jdk/java/awt/print/Dialog/DialogOwnerTest.java
+++ b/test/jdk/java/awt/print/Dialog/DialogOwnerTest.java
@@ -98,8 +98,7 @@ public class DialogOwnerTest extends JPanel {
        "window, or on top of all windows.\n" +
        "For Owned tests the window titled 'Owner Window' should always \n" +
        "stay behind the print dialog.\n" +
-       "For On Top tests the print dialog should stay above \n" +
-       " the window titled 'Owner window'.\n" +
+       "For On Top tests all windows should stay behind the print dialog \n" +
        "This test tracks if you have checked all the scenarios and will\n" +
        "not allow the test to pass unless you have visited them all.\n";
 

--- a/test/jdk/java/awt/print/Dialog/DialogOwnerTest.java
+++ b/test/jdk/java/awt/print/Dialog/DialogOwnerTest.java
@@ -98,7 +98,8 @@ public class DialogOwnerTest extends JPanel {
        "window, or on top of all windows.\n" +
        "For Owned tests the window titled 'Owner Window' should always \n" +
        "stay behind the print dialog.\n" +
-       "For On Top tests all windows should stay behind the owner window.\n" +
+       "For On Top tests the print dialog should stay above \n" +
+       " the window titled 'Owner window'.\n" +
        "This test tracks if you have checked all the scenarios and will\n" +
        "not allow the test to pass unless you have visited them all.\n";
 


### PR DESCRIPTION
This test fails to follow the test instruction which says ""On Top" print dialogs should stay behind the "Owner Window" 
but it seems to be the behaviour right from jdk11b18 where DialogOwner class and this test was inducted via JDK-8203796 not only in mac but in windows too ie,
"On Top" print dialogs should stay behind the "Owner Window" as per instruction but is not.
On Top print dialogs actually stay above the "owner window"

I guess there is some ambiguity in test instruction or clarity in understanding test instructions is not there
because Test instructions says "For On Top tests all windows should stay *behind* the owner window."
but "Owner Window" instruction says "For tests that are 'Owned' or 'On Top' the dialog must always stay *above* this window. " 

Rectified the test instruction to be same as owner window instruction

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267940](https://bugs.openjdk.java.net/browse/JDK-8267940): [macos] java/awt/print/Dialog/DialogOwnerTest.java fails


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4823/head:pull/4823` \
`$ git checkout pull/4823`

Update a local copy of the PR: \
`$ git checkout pull/4823` \
`$ git pull https://git.openjdk.java.net/jdk pull/4823/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4823`

View PR using the GUI difftool: \
`$ git pr show -t 4823`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4823.diff">https://git.openjdk.java.net/jdk/pull/4823.diff</a>

</details>
