### PR TITLE
8270204: [macos11] JTabbedPane selected tab text is barely legible (again)

### DIFF
--- a/src/java.desktop/macosx/classes/apple/laf/JRSUIUtils.java
+++ b/src/java.desktop/macosx/classes/apple/laf/JRSUIUtils.java
@@ -36,10 +36,13 @@ public final class JRSUIUtils {
 
     static boolean isLeopard = isMacOSXLeopard();
     static boolean isSnowLeopardOrBelow = isMacOSXSnowLeopardOrBelow();
-    static boolean isBigSurOrAbove = isMacOSXBigSurOrAbove();
 
     public static boolean isMacOSXBigSurOrAbove() {
-        return currentMacOSXVersionMatchesGivenVersionRange(16, true, false, true);
+        String version = System.getProperty("os.version");
+        if (version.startsWith("11.")) {
+            return true;
+        }
+        return false;
     }
 
     static boolean isMacOSXLeopard() {

--- a/src/java.desktop/macosx/classes/apple/laf/JRSUIUtils.java
+++ b/src/java.desktop/macosx/classes/apple/laf/JRSUIUtils.java
@@ -38,8 +38,16 @@ public final class JRSUIUtils {
     static boolean isSnowLeopardOrBelow = isMacOSXSnowLeopardOrBelow();
 
     public static boolean isMacOSXBigSurOrAbove() {
-        String version = System.getProperty("os.version");
-        if (version.startsWith("11.")) {
+        @SuppressWarnings("removal")
+        String version = AccessController.doPrivileged(new GetPropertyAction("os.version"));
+        version = version.subString(0, version.indexOf("."));
+        int ver = 0;
+        try {
+            ver = Integer.parseInt(version);
+        } catch (NumberFormatException e) {
+            // was not an integer
+        }
+        if (ver >= 11) {
             return true;
         }
         return false;


### PR DESCRIPTION
The JTabbedPane background color was fixed in JDK-8251377 but it actually relies on os.version being returned by JVM as 10.16. However, JVM has been modified since to return 11.x for MacOSX Bigsur release so we need to update code to rely on modified version.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8270204](https://bugs.openjdk.java.net/browse/JDK-8270204): [macos11] JTabbedPane selected tab text is barely legible (again)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4824/head:pull/4824` \
`$ git checkout pull/4824`

Update a local copy of the PR: \
`$ git checkout pull/4824` \
`$ git pull https://git.openjdk.java.net/jdk pull/4824/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4824`

View PR using the GUI difftool: \
`$ git pr show -t 4824`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4824.diff">https://git.openjdk.java.net/jdk/pull/4824.diff</a>

</details>
