### PR TITLE
8267585: JavaThread::set_thread_state generally needs release semantics

### DIFF
--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -512,7 +512,7 @@ bool HandshakeState::possibly_can_process_handshake() {
   if (_handshakee->is_terminated()) {
     return true;
   }
-  switch (_handshakee->thread_state()) {
+  switch (_handshakee->thread_state_acquire()) {
   case _thread_in_native:
     // native threads are safe if they have no java stack or have walkable stack
     return !_handshakee->has_last_Java_frame() || _handshakee->frame_anchor()->walkable();

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -605,7 +605,7 @@ void vm_perform_shutdown_actions() {
       // Must always be walkable or have no last_Java_frame when in
       // thread_in_native
       jt->frame_anchor()->make_walkable(jt);
-      jt->set_thread_state(_thread_in_native);
+      jt->release_set_thread_state(_thread_in_native);
     }
   }
   notify_vm_shutdown();

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1834,7 +1834,7 @@ void JavaThread::verify_not_published() {
 // Note only the native==>Java barriers can call this function when thread state
 // is _thread_in_native_trans.
 void JavaThread::check_special_condition_for_native_trans(JavaThread *thread) {
-  assert(thread->thread_state() == _thread_in_native_trans, "wrong state");
+  assert(thread->thread_state_acquire() == _thread_in_native_trans, "wrong state");
   assert(!thread->has_last_Java_frame() || thread->frame_anchor()->walkable(), "Unwalkable stack in native->Java transition");
 
   // Enable WXWrite: called directly from interpreter native wrapper.

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1091,7 +1091,9 @@ class JavaThread: public Thread {
 
   // Safepoint support
   inline JavaThreadState thread_state() const;
+  inline JavaThreadState thread_state_acquire() const; // read state with acquire semantics
   inline void set_thread_state(JavaThreadState s);
+  inline void release_set_thread_state(JavaThreadState s); // release before setting thread state
   inline void set_thread_state_fence(JavaThreadState s);  // fence after setting thread state
   inline ThreadSafepointState* safepoint_state() const;
   inline void set_safepoint_state(ThreadSafepointState* state);


### PR DESCRIPTION
Please review this small change to try and tidy up some of the memory ordering issues around the use of  `JavaThread::set_thread_state()` and `JavaThread::thread_state()`.

- Added: `release_set_thread_state()` and `thread_state_acquire()`
- Replaced use of storestore barrier before `set_thread_state()` with `release_set_thread_state()`
- Added missing release semantics in  ` vm_perform_shutdown_actions()`
- Changed uses of `thread_state()` prior to checking `walkable()` to use acquire semantics, to match the release semantics used after `make_walkable()`
- Use Atomic load/store instead of plain accesses on `_thread_state`
- Removed unnecessary casts in the use of the Atomic and OrderAccess API's.

This makes some of the semantics clearer and removes redundant barriers on PPC64 and Aarch64 in some cases.

I question whether acquire/release semantics are needed by default on PPC64/Aarch64. I couldn't find any discussion related to that decision. But I can see that reasoning about when they are, and are not needed is quite difficult. So I didn't try to change that.

Testing:
 - tiers 1-4 builds (as sanity check for cast removal etc)
 - GHA (in progress)

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8267585](https://bugs.openjdk.java.net/browse/JDK-8267585): JavaThread::set_thread_state generally needs release semantics


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4825/head:pull/4825` \
`$ git checkout pull/4825`

Update a local copy of the PR: \
`$ git checkout pull/4825` \
`$ git pull https://git.openjdk.java.net/jdk pull/4825/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4825`

View PR using the GUI difftool: \
`$ git pr show -t 4825`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4825.diff">https://git.openjdk.java.net/jdk/pull/4825.diff</a>

</details>
