### PR TITLE
8270911: Don't use Access API to access object header word

### DIFF
--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -412,17 +412,18 @@ void HeapShared::copy_roots() {
   HeapWord* mem = G1CollectedHeap::heap()->archive_mem_allocate(size);
 
   memset(mem, 0, size * BytesPerWord);
+  oop obj = cast_to_oop(mem);
   {
     // This is copied from MemAllocator::finish
-    oopDesc::set_mark(mem, markWord::prototype());
-    oopDesc::release_set_klass(mem, k);
+    obj->set_mark(markWord::prototype());
+    obj->release_set_klass(k);
   }
   {
     // This is copied from ObjArrayAllocator::initialize
-    arrayOopDesc::set_length(mem, length);
+    arrayOop(obj)->set_length(length);
   }
 
-  _roots = OopHandle(Universe::vm_global(), cast_to_oop(mem));
+  _roots = OopHandle(Universe::vm_global(), obj);
   for (int i = 0; i < length; i++) {
     roots()->obj_at_put(i, _pending_roots->at(i));
   }

--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -383,12 +383,13 @@ void MemAllocator::mem_clear(HeapWord* mem) const {
 oop MemAllocator::finish(HeapWord* mem) const {
   assert(mem != NULL, "NULL object pointer");
   // May be bootstrapping
-  oopDesc::set_mark(mem, markWord::prototype());
+  oop obj = cast_to_oop(mem);
+  obj->set_mark(markWord::prototype());
   // Need a release store to ensure array/class length, mark word, and
   // object zeroing are visible before setting the klass non-NULL, for
   // concurrent collectors.
-  oopDesc::release_set_klass(mem, _klass);
-  return cast_to_oop(mem);
+  obj->release_set_klass(_klass);
+  return obj;
 }
 
 oop ObjAllocator::initialize(HeapWord* mem) const {
@@ -413,7 +414,7 @@ oop ObjArrayAllocator::initialize(HeapWord* mem) const {
   if (_do_zero) {
     mem_clear(mem);
   }
-  arrayOopDesc::set_length(mem, _length);
+  arrayOop(cast_to_oop(mem))->set_length(_length);
   return finish(mem);
 }
 

--- a/src/hotspot/share/oops/arrayOop.hpp
+++ b/src/hotspot/share/oops/arrayOop.hpp
@@ -118,10 +118,6 @@ class arrayOopDesc : public oopDesc {
     return length_addr_impl(this);
   }
 
-  static void set_length(HeapWord* mem, int length) {
-    *length_addr_impl(mem) = length;
-  }
-
   // Should only be called with constants as argument
   // (will not constant fold otherwise)
   // Returns the header size in words aligned to the requirements of the

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -62,11 +62,8 @@ class oopDesc {
   inline markWord* mark_addr() const;
 
   inline void set_mark(markWord m);
-  static inline void set_mark(HeapWord* mem, markWord m);
-
   inline void release_set_mark(markWord m);
-  inline markWord cas_set_mark(markWord new_mark, markWord old_mark);
-  inline markWord cas_set_mark(markWord new_mark, markWord old_mark, atomic_memory_order order);
+  inline markWord cas_set_mark(markWord new_mark, markWord old_mark, atomic_memory_order order = memory_order_conservative);
 
   // Used only to re-initialize the mark word (e.g., of promoted
   // objects during a GC) -- requires a valid klass pointer
@@ -78,7 +75,7 @@ class oopDesc {
 
   void set_narrow_klass(narrowKlass nk) NOT_CDS_JAVA_HEAP_RETURN;
   inline void set_klass(Klass* k);
-  static inline void release_set_klass(HeapWord* mem, Klass* k);
+  inline void release_set_klass(Klass* k);
 
   // For klass field compression
   inline int klass_gap() const;


### PR DESCRIPTION
Back when Shenandoah required read- and write-barriers on all object accesses, we introduced using the HeapAccess API to access object header words, too. Since JDK 13 (introduction of Shenandoah LRB), this is no longer necessary. I propose to simplify header access by not using the Access API but use ordinary C++ instead.

(N.b: do we want to get rid of all primitive Access API, too? I would do it.)

Testing:
 - [x] tier1
 - [ ] tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8270911](https://bugs.openjdk.java.net/browse/JDK-8270911): Don't use Access API to access object header word


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4827/head:pull/4827` \
`$ git checkout pull/4827`

Update a local copy of the PR: \
`$ git checkout pull/4827` \
`$ git pull https://git.openjdk.java.net/jdk pull/4827/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4827`

View PR using the GUI difftool: \
`$ git pr show -t 4827`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4827.diff">https://git.openjdk.java.net/jdk/pull/4827.diff</a>

</details>
