### PR TITLE
8270894: Use acquire semantics in ObjectSynchronizer::read_stable_mark()

### DIFF
--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -59,6 +59,7 @@ class oopDesc {
 
  public:
   inline markWord  mark()          const;
+  inline markWord  mark_acquire()  const;
   inline markWord* mark_addr() const;
 
   inline void set_mark(markWord m);

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -49,6 +49,11 @@ markWord oopDesc::mark() const {
   return markWord(v);
 }
 
+markWord oopDesc::mark_acquire() const {
+  uintptr_t v = HeapAccess<MO_ACQUIRE>::load_at(as_oop(), mark_offset_in_bytes());
+  return markWord(v);
+}
+
 markWord* oopDesc::mark_addr() const {
   return (markWord*) &_mark;
 }

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -681,14 +681,14 @@ struct SharedGlobals {
 static SharedGlobals GVars;
 
 static markWord read_stable_mark(oop obj) {
-  markWord mark = obj->mark();
+  markWord mark = obj->mark_acquire();
   if (!mark.is_being_inflated()) {
     return mark;       // normal fast-path return
   }
 
   int its = 0;
   for (;;) {
-    markWord mark = obj->mark();
+    markWord mark = obj->mark_acquire();
     if (!mark.is_being_inflated()) {
       return mark;    // normal fast-path return
     }
@@ -722,7 +722,7 @@ static markWord read_stable_mark(oop obj) {
         int YieldThenBlock = 0;
         assert(ix >= 0 && ix < NINFLATIONLOCKS, "invariant");
         gInflationLocks[ix]->lock();
-        while (obj->mark() == markWord::INFLATING()) {
+        while (obj->mark_acquire() == markWord::INFLATING()) {
           // Beware: naked_yield() is advisory and has almost no effect on some platforms
           // so we periodically call current->_ParkEvent->park(1).
           // We use a mixed spin/yield/block mechanism.
@@ -1102,7 +1102,7 @@ static void post_monitor_inflate_event(EventJavaMonitorInflate* event,
 
 // Fast path code shared by multiple functions
 void ObjectSynchronizer::inflate_helper(oop obj) {
-  markWord mark = obj->mark();
+  markWord mark = obj->mark_acquire();
   if (mark.has_monitor()) {
     ObjectMonitor* monitor = mark.monitor();
     markWord dmw = monitor->header();
@@ -1117,7 +1117,7 @@ ObjectMonitor* ObjectSynchronizer::inflate(Thread* current, oop object,
   EventJavaMonitorInflate event;
 
   for (;;) {
-    const markWord mark = object->mark();
+    const markWord mark = object->mark_acquire();
 
     // The mark can be in one of the following states:
     // *  Inflated     - just return


### PR DESCRIPTION
Currently, the object header is read using plain loads in read_stable_mark() (synchronizer.cpp). The matching stores use release semantics in corresponding CAS and release_store(). It seems reasonable to use acquire-semantics for the loads of the object header.

See also discussion here:
https://mail.openjdk.java.net/pipermail/hotspot-runtime-dev/2021-July/050132.html

I propose to use MO_ACQUIRE when reading the object header in read_stable_mark() and some related loads of the header. As discussed in the thread, current_thread_holds_lock() is the only place where we could do without acquire, but it doesn't seem worth to introduce extra complexity just to make this access relaxed, because it does not seem to be used in any place that looks very performance sensitive.

If it were me, I'd probably also change the other mark() calls to MO_ACQUIRE for consistency, but that might be overkill.

Testing:
 - [x] tier1
 - [x] tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270894](https://bugs.openjdk.java.net/browse/JDK-8270894): Use acquire semantics in ObjectSynchronizer::read_stable_mark()


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4829/head:pull/4829` \
`$ git checkout pull/4829`

Update a local copy of the PR: \
`$ git checkout pull/4829` \
`$ git pull https://git.openjdk.java.net/jdk pull/4829/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4829`

View PR using the GUI difftool: \
`$ git pr show -t 4829`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4829.diff">https://git.openjdk.java.net/jdk/pull/4829.diff</a>

</details>
