### PR TITLE
JDK-8270308: Arena::Amalloc may return misaligned address on 32-bit

### DIFF
--- a/src/hotspot/share/memory/arena.cpp
+++ b/src/hotspot/share/memory/arena.cpp
@@ -357,7 +357,8 @@ size_t Arena::used() const {
 // Grow a new Chunk
 void* Arena::grow(size_t x, AllocFailType alloc_failmode) {
   // Get minimal required size.  Either real big, or even bigger for giant objs
-  size_t len = MAX2(x, (size_t) Chunk::size);
+  // (Note: all chunk sizes have to be 64-bit aligned)
+  size_t len = MAX2(ARENA_ALIGN(x), (size_t) Chunk::size);
 
   Chunk *k = _chunk;            // Get filled-up chunk address
   _chunk = new (alloc_failmode, len) Chunk(len);

--- a/src/hotspot/share/memory/arena.cpp
+++ b/src/hotspot/share/memory/arena.cpp
@@ -171,13 +171,30 @@ class ChunkPoolCleaner : public PeriodicTask {
 //--------------------------------------------------------------------------------------
 // Chunk implementation
 
-void* Chunk::operator new (size_t requested_size, AllocFailType alloc_failmode, size_t length) throw() {
-  // requested_size is equal to sizeof(Chunk) but in order for the arena
-  // allocations to come out aligned as expected the size must be aligned
-  // to expected arena alignment.
-  // expect requested_size but if sizeof(Chunk) doesn't match isn't proper size we must align it.
-  assert(ARENA_ALIGN(requested_size) == aligned_overhead_size(), "Bad alignment");
-  size_t bytes = ARENA_ALIGN(requested_size) + length;
+void* Chunk::operator new (size_t sizeofChunk, AllocFailType alloc_failmode, size_t length) throw() {
+
+  // - requested_size = sizeof(Chunk)
+  // - length = payload size
+  // We must ensure that the boundaries of the payload (C and D) are aligned to 64-bit:
+  //
+  // +-----------+--+--------------------------------------------+
+  // |           |g |                                            |
+  // | Chunk     |a |               Payload                      |
+  // |           |p |                                            |
+  // +-----------+--+--------------------------------------------+
+  // A           B  C                                            D
+  //
+  // - The Chunk is allocated from C-heap, therefore its start address (A) should be
+  //   64-bit aligned on all our platforms, including 32-bit.
+  // - sizeof(Chunk) (B) may not be aligned to 64-bit, and we have to take that into
+  //   account when calculating the Payload bottom (C) (see Chunk::bottom())
+  // - the payload size (length) must be aligned to 64-bit, which takes care of 64-bit
+  //   aligning (D)
+
+  assert(sizeofChunk == sizeof(Chunk), "weird request size");
+  assert(is_aligned(length, BytesPerLong), "chunk payload length not 64-bit aligned: "
+                                           SIZE_FORMAT ".", length);
+  size_t bytes = ARENA_ALIGN(sizeofChunk) + length;
   switch (length) {
    case Chunk::size:        return ChunkPool::large_pool()->allocate(bytes, alloc_failmode);
    case Chunk::medium_size: return ChunkPool::medium_pool()->allocate(bytes, alloc_failmode);
@@ -188,6 +205,7 @@ void* Chunk::operator new (size_t requested_size, AllocFailType alloc_failmode, 
      if (p == NULL && alloc_failmode == AllocFailStrategy::EXIT_OOM) {
        vm_exit_out_of_memory(bytes, OOM_MALLOC_ERROR, "Chunk::new");
      }
+     assert(is_aligned(p, BytesPerLong), "Chunk start address not malloc aligned?");
      return p;
    }
   }
@@ -239,8 +257,7 @@ void Chunk::start_chunk_pool_cleaner_task() {
 //------------------------------Arena------------------------------------------
 
 Arena::Arena(MEMFLAGS flag, size_t init_size) : _flags(flag), _size_in_bytes(0)  {
-  size_t round_size = (sizeof (char *)) - 1;
-  init_size = (init_size+round_size) & ~round_size;
+  init_size = ARENA_ALIGN(init_size);
   _first = _chunk = new (AllocFailStrategy::EXIT_OOM, init_size) Chunk(init_size);
   _hwm = _chunk->bottom();      // Save the cached hwm, max
   _max = _chunk->top();

--- a/src/hotspot/share/memory/arena.hpp
+++ b/src/hotspot/share/memory/arena.hpp
@@ -138,8 +138,10 @@ protected:
     // allocation was AmallocWords. Note though that padding plays havoc with arenas holding packed arrays,
     // like HandleAreas. Those areas should never mix Amalloc.. calls with differing alignment.
 #ifndef LP64 // Since this is a hot path, and on 64-bit Amalloc and AmallocWords are identical, restrict this alignment to 32-bit.
-    _hwm = ARENA_ALIGN(_hwm);
-    _hwm = MIN2(_hwm, _max); // _max is not guaranteed to be 64 bit aligned.
+    if (x > 0) {
+      _hwm = ARENA_ALIGN(_hwm);
+      _hwm = MIN2(_hwm, _max); // _max is not guaranteed to be 64 bit aligned.
+    }
 #endif // !LP64
     return internal_amalloc(x, alloc_failmode);
   }

--- a/src/hotspot/share/memory/arena.hpp
+++ b/src/hotspot/share/memory/arena.hpp
@@ -133,11 +133,14 @@ protected:
   // on both 32 and 64 bit platforms. Required for atomic jlong operations on 32 bits.
   void* Amalloc(size_t x, AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM) {
     x = ARENA_ALIGN(x);  // note for 32 bits this should align _hwm as well.
-#ifndef LP64 // Since this is a hot path, do this only if really needed.
+    debug_only(if (UseMallocOnly) return malloc(x);)
+    // JDK-8270308: Amalloc guarantees 64-bit alignment and we need to ensure that in case the preceding
+    // allocation was AmallocWords. Note though that padding plays havoc with arenas holding packed arrays,
+    // like HandleAreas. Those areas should never mix Amalloc.. calls with differing alignment.
+#ifndef LP64 // Since this is a hot path, and on 64-bit Amalloc and AmallocWords are identical, restrict this alignment to 32-bit.
     _hwm = ARENA_ALIGN(_hwm);
     _hwm = MIN2(_hwm, _max); // _max is not guaranteed to be 64 bit aligned.
 #endif // !LP64
-    debug_only(if (UseMallocOnly) return malloc(x);)
     return internal_amalloc(x, alloc_failmode);
   }
 

--- a/src/hotspot/share/memory/arena.hpp
+++ b/src/hotspot/share/memory/arena.hpp
@@ -52,11 +52,12 @@ class Chunk: CHeapObj<mtChunk> {
   enum {
     // default sizes; make them slightly smaller than 2**k to guard against
     // buddy-system style malloc implementations
+    // Note: please keep these constants 64-bit aligned.
 #ifdef _LP64
     slack      = 40,            // [RGV] Not sure if this is right, but make it
                                 //       a multiple of 8.
 #else
-    slack      = 20,            // suspected sizeof(Chunk) + internal malloc headers
+    slack      = 24,            // suspected sizeof(Chunk) + internal malloc headers
 #endif
 
     tiny_size  =  256  - slack, // Size of first chunk (tiny)
@@ -134,15 +135,11 @@ protected:
   void* Amalloc(size_t x, AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM) {
     x = ARENA_ALIGN(x);  // note for 32 bits this should align _hwm as well.
     debug_only(if (UseMallocOnly) return malloc(x);)
-    // JDK-8270308: Amalloc guarantees 64-bit alignment and we need to ensure that in case the preceding
-    // allocation was AmallocWords. Note though that padding plays havoc with arenas holding packed arrays,
-    // like HandleAreas. Those areas should never mix Amalloc.. calls with differing alignment.
-#ifndef LP64 // Since this is a hot path, and on 64-bit Amalloc and AmallocWords are identical, restrict this alignment to 32-bit.
-    if (x > 0) {
-      _hwm = ARENA_ALIGN(_hwm);
-      _hwm = MIN2(_hwm, _max); // _max is not guaranteed to be 64 bit aligned.
-    }
-#endif // !LP64
+    // Amalloc guarantees 64-bit alignment and we need to ensure that in case the preceding
+    // allocation was AmallocWords. Only needed on 32-bit - on 64-bit Amalloc and AmallocWords are
+    // identical.
+    assert(is_aligned(_max, ARENA_AMALLOC_ALIGNMENT), "chunk end unaligned?");
+    NOT_LP64(_hwm = ARENA_ALIGN(_hwm));
     return internal_amalloc(x, alloc_failmode);
   }
 

--- a/src/hotspot/share/memory/arena.hpp
+++ b/src/hotspot/share/memory/arena.hpp
@@ -133,6 +133,10 @@ protected:
   // on both 32 and 64 bit platforms. Required for atomic jlong operations on 32 bits.
   void* Amalloc(size_t x, AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM) {
     x = ARENA_ALIGN(x);  // note for 32 bits this should align _hwm as well.
+#ifndef LP64 // Since this is a hot path, do this only if really needed.
+    _hwm = ARENA_ALIGN(_hwm);
+    _hwm = MIN2(_hwm, _max); // _max is not guaranteed to be 64 bit aligned.
+#endif // !LP64
     debug_only(if (UseMallocOnly) return malloc(x);)
     return internal_amalloc(x, alloc_failmode);
   }

--- a/test/hotspot/gtest/memory/test_arena.cpp
+++ b/test/hotspot/gtest/memory/test_arena.cpp
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 SAP SE. All rights reserved.
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +25,8 @@
 
 #include "precompiled.hpp"
 #include "memory/arena.hpp"
+#include "utilities/align.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include "unittest.hpp"
 
 #ifndef LP64
@@ -36,7 +40,7 @@ TEST_VM(Arena, mixed_alignment_allocation) {
   void* p1 = ar.AmallocWords(BytesPerWord);
   void* p2 = ar.Amalloc(BytesPerLong);
   ASSERT_TRUE(is_aligned(p1, BytesPerWord));
-  ASSERT_TRUE(is_aligned(p2, BytesPerLong));
+  ASSERT_TRUE(is_aligned(p2, ARENA_AMALLOC_ALIGNMENT));
 }
 
 TEST_VM(Arena, Arena_with_crooked_initial_size) {
@@ -46,7 +50,7 @@ TEST_VM(Arena, Arena_with_crooked_initial_size) {
   void* p1 = ar.AmallocWords(BytesPerWord);
   void* p2 = ar.Amalloc(BytesPerLong);
   ASSERT_TRUE(is_aligned(p1, BytesPerWord));
-  ASSERT_TRUE(is_aligned(p2, BytesPerLong));
+  ASSERT_TRUE(is_aligned(p2, ARENA_AMALLOC_ALIGNMENT));
 }
 
 TEST_VM(Arena, Arena_grows_large_unaligned) {
@@ -57,7 +61,7 @@ TEST_VM(Arena, Arena_grows_large_unaligned) {
   // something should assert at some point.
   Arena ar(mtTest, 100); // first chunk is small
   void* p = ar.AmallocWords(Chunk::size + BytesPerWord); // if Arena::grow() misaligns, this asserts
-  ASSERT_TRUE(is_aligned(p, BytesPerLong));
+  // some more allocations for good measure
   for (int i = 0; i < 100; i ++) {
     ar.Amalloc(1);
   }

--- a/test/hotspot/gtest/memory/test_arena.cpp
+++ b/test/hotspot/gtest/memory/test_arena.cpp
@@ -25,10 +25,20 @@
 #include "memory/arena.hpp"
 #include "unittest.hpp"
 
-TEST(Arena, mixed_alignment_allocation) {
+TEST_VM(Arena, mixed_alignment_allocation) {
   // Test that mixed alignment allocations work and provide allocations with the correct
   // alignment
   Arena ar(mtTest);
+  void* p1 = ar.AmallocWords(BytesPerWord);
+  void* p2 = ar.Amalloc(BytesPerLong);
+  ASSERT_TRUE(is_aligned(p1, BytesPerWord));
+  ASSERT_TRUE(is_aligned(p2, BytesPerLong));
+}
+
+TEST_VM(Arena, Arena_with_crooked_initial_size) {
+  // Test that an arena with a crooked, not 64-bit aligned initial size
+  // works
+  Arena ar(mtTest, 4097);
   void* p1 = ar.AmallocWords(BytesPerWord);
   void* p2 = ar.Amalloc(BytesPerLong);
   ASSERT_TRUE(is_aligned(p1, BytesPerWord));

--- a/test/hotspot/gtest/memory/test_arena.cpp
+++ b/test/hotspot/gtest/memory/test_arena.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "precompiled.hpp"
+#include "memory/arena.hpp"
+#include "unittest.hpp"
+
+TEST(Arena, mixed_alignment_allocation) {
+  // Test that mixed alignment allocations work and provide allocations with the correct
+  // alignment
+  Arena ar(mtTest);
+  void* p1 = ar.AmallocWords(BytesPerWord);
+  void* p2 = ar.Amalloc(BytesPerLong);
+  ASSERT_TRUE(is_aligned(p1, BytesPerWord));
+  ASSERT_TRUE(is_aligned(p2, BytesPerLong));
+}


### PR DESCRIPTION
Hi,

may I please have reviews for this fix. This fixes an issue with arena allocation alignment which can only happen on 32-bit. 

The underlying problem is that even though Arenas offer ways to allocate with different alignment (Amalloc and AmallocWords), allocation alignment is not guaranteed. This sequence will not work on 32-bit:

```
Arena ar;
p1 = ar.AmallocWords();  // return 32bit aligned address
p2 = ar.Amalloc();       // supposed to return 64bit aligned address but does not.
```

This patch is the bare minimum needed to fix the specific problem; I proposed a larger patch before which redid arena alignment handling but it was found too complex: https://github.com/openjdk/jdk/pull/4784 . 

This fix is limited to `Amalloc()` and aligns `_hwm` to be 64bit aligned before allocation. But since chunk boundaries are not guaranteed to be 64-bit aligned either, additional care must be taken to not overflow `_max`.  Since this adds instructions into a hot allocation path, I restricted this code to 32 bit - it is only needed there.

Remaining issues:

- `Amalloc...` align the allocation size in an attempt to ensure allocation alignment. This is not needed nor sufficient, we could just remove that code. I left it untouched to keep the patch minimal. I also left the `// ... for 32 bits this should align _hwm as well.` comment in `Amalloc()` though I think it is wrong.
- The chunk dimensions are not guaranteed to be 64-bit aligned:
	1) Chunk bottom depends on Chunk start. We currently align the header size, but if the chunk starts at an unaligned address, this is not sufficient. It's not a real issue though as long as Chunks are C-heap allocated since malloc alignment is at least 64bit on our 32bit platforms. More of a beauty spot, since this is an implicit assumption which we don't really check.
	2) Chunk top and hence Arena::_max are not guaranteed to be 64-bit aligned either. They depend on the input chunk length, which is not even aligned for the standard chunk sizes used in ChunkPool. And users can hand in any size they want. Fixing this would require more widespread changes to the ChunkPool logic though, so I left it as it is.
	3) similarly, we cannot just align Arena::_max, because that is set in many places and we need to cover all of that; it ties in with Arena rollback as well.

Because of (2) and (3), I had to add the overflow check into `Amalloc()` - any other way to solve this would result in more widespread changes.
	
-----

Tests:

- I tested the provided gtest on both 64-bit and 32-bit platforms (with and without the fix, without it shows the expected problem)
- GHA
- Tests are scheduled at SAP.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270308](https://bugs.openjdk.java.net/browse/JDK-8270308): Arena::Amalloc may return misaligned address on 32-bit


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4835/head:pull/4835` \
`$ git checkout pull/4835`

Update a local copy of the PR: \
`$ git checkout pull/4835` \
`$ git pull https://git.openjdk.java.net/jdk pull/4835/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4835`

View PR using the GUI difftool: \
`$ git pr show -t 4835`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4835.diff">https://git.openjdk.java.net/jdk/pull/4835.diff</a>

</details>
