### PR TITLE
8270908: TestParallelRefProc fails on single core machines

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestParallelRefProc.java
+++ b/test/hotspot/jtreg/gc/arguments/TestParallelRefProc.java
@@ -51,7 +51,9 @@ public class TestParallelRefProc {
         }
         if (GC.Parallel.isSupported()) {
             noneGCSupported = false;
-            testFlag(new String[] { "-XX:+UseParallelGC" }, true);
+            testFlag(new String[] { "-XX:+UseParallelGC", "-XX:ParallelGCThreads=1" }, false);
+            testFlag(new String[] { "-XX:+UseParallelGC", "-XX:ParallelGCThreads=2" }, true);
+            testFlag(new String[] { "-XX:+UseParallelGC", "-XX:-ParallelRefProcEnabled", "-XX:ParallelGCThreads=2" }, false);
         }
         if (GC.G1.isSupported()) {
             noneGCSupported = false;


### PR DESCRIPTION
Hi,

please review this small fix for the test case TestParallelRefProc.
I changed the way the ParallelGC is tested to the same way G1GC is tested, since the test failed on single core machines. Ergo configures only 1 parallel GC thread on single core machines and with only 1 thread, ergo does not enable `ParallelRefProcEnabled`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8270908](https://bugs.openjdk.java.net/browse/JDK-8270908): TestParallelRefProc fails on single core machines


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4837/head:pull/4837` \
`$ git checkout pull/4837`

Update a local copy of the PR: \
`$ git checkout pull/4837` \
`$ git pull https://git.openjdk.java.net/jdk pull/4837/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4837`

View PR using the GUI difftool: \
`$ git pr show -t 4837`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4837.diff">https://git.openjdk.java.net/jdk/pull/4837.diff</a>

</details>
