### PR TITLE
8270939: ProblemList java/lang/invoke/RicochetTest.java until JDK-8251969 is fixed

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -553,6 +553,7 @@ java/lang/ProcessHandle/InfoTest.java                           8211847 aix-ppc6
 java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java        8151492 generic-all
 java/lang/invoke/LFCaching/LFGarbageCollectedTest.java          8078602 generic-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java    8249079 linux-x64
+java/lang/invoke/RicochetTest.java                              8251969 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Please review the following patch that problem lists RicochetTest.java until [JDK-8251969](https://bugs.openjdk.java.net/browse/JDK-8251969) is fixed.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270939](https://bugs.openjdk.java.net/browse/JDK-8270939): ProblemList java/lang/invoke/RicochetTest.java until JDK-8251969 is fixed


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4838/head:pull/4838` \
`$ git checkout pull/4838`

Update a local copy of the PR: \
`$ git checkout pull/4838` \
`$ git pull https://git.openjdk.java.net/jdk pull/4838/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4838`

View PR using the GUI difftool: \
`$ git pr show -t 4838`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4838.diff">https://git.openjdk.java.net/jdk/pull/4838.diff</a>

</details>
