### PR TITLE
JDK-8270949: Make dynamically generated classes with the class file version of the current release

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
+++ b/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
@@ -621,7 +621,7 @@ abstract class ClassSpecializer<T,K,S extends ClassSpecializer<T,K,S>.SpeciesDat
 
             final ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS + ClassWriter.COMPUTE_FRAMES);
             final int NOT_ACC_PUBLIC = 0;  // not ACC_PUBLIC
-            cw.visit(V1_6, NOT_ACC_PUBLIC + ACC_FINAL + ACC_SUPER, className, null, superClassName, null);
+            cw.visit(CLASSFILE_VERSION, NOT_ACC_PUBLIC + ACC_FINAL + ACC_SUPER, className, null, superClassName, null);
 
             final String sourceFile = className.substring(className.lastIndexOf('.')+1);
             cw.visitSource(sourceFile, null);

--- a/src/java.base/share/classes/java/lang/invoke/GenerateJLIClassesHelper.java
+++ b/src/java.base/share/classes/java/lang/invoke/GenerateJLIClassesHelper.java
@@ -39,6 +39,7 @@ import java.util.TreeSet;
 import java.util.stream.Stream;
 
 import static java.lang.invoke.LambdaForm.BasicType.*;
+import static java.lang.invoke.MethodHandleStatics.CLASSFILE_VERSION;
 import static java.lang.invoke.MethodTypeForm.*;
 import static java.lang.invoke.LambdaForm.Kind.*;
 
@@ -504,7 +505,7 @@ class GenerateJLIClassesHelper {
      */
     private static byte[] generateCodeBytesForLFs(String className, String[] names, LambdaForm[] forms) {
         ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS + ClassWriter.COMPUTE_FRAMES);
-        cw.visit(Opcodes.V1_8, Opcodes.ACC_PRIVATE + Opcodes.ACC_FINAL + Opcodes.ACC_SUPER,
+        cw.visit(CLASSFILE_VERSION, Opcodes.ACC_PRIVATE + Opcodes.ACC_FINAL + Opcodes.ACC_SUPER,
                 className, null, InvokerBytecodeGenerator.INVOKER_SUPER_NAME, null);
         cw.visitSource(className.substring(className.lastIndexOf('/') + 1), null);
 

--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -26,6 +26,7 @@
 package java.lang.invoke;
 
 import jdk.internal.misc.CDS;
+import jdk.internal.misc.VM;
 import jdk.internal.org.objectweb.asm.*;
 import sun.invoke.util.BytecodeDescriptor;
 import sun.invoke.util.VerifyAccess;
@@ -56,7 +57,7 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
  * @see LambdaMetafactory
  */
 /* package */ final class InnerClassLambdaMetafactory extends AbstractValidatingLambdaMetafactory {
-    private static final int CLASSFILE_VERSION = 59;
+    private static final int CLASSFILE_VERSION = VM.classFileVersion();
     private static final String METHOD_DESCRIPTOR_VOID = Type.getMethodDescriptor(Type.VOID_TYPE);
     private static final String JAVA_LANG_OBJECT = "java/lang/Object";
     private static final String NAME_CTOR = "<init>";

--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -340,7 +340,7 @@ class InvokerBytecodeGenerator {
         final int NOT_ACC_PUBLIC = 0;  // not ACC_PUBLIC
         ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS + ClassWriter.COMPUTE_FRAMES);
         setClassWriter(cw);
-        cw.visit(Opcodes.V1_8, NOT_ACC_PUBLIC + Opcodes.ACC_FINAL + Opcodes.ACC_SUPER,
+        cw.visit(CLASSFILE_VERSION, NOT_ACC_PUBLIC + Opcodes.ACC_FINAL + Opcodes.ACC_SUPER,
                 className, null, INVOKER_SUPER_NAME, null);
         cw.visitSource(SOURCE_PREFIX + name, null);
         return cw;

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -1156,7 +1156,7 @@ abstract class MethodHandleImpl {
             //        return vamh.invokeExact(args);
             //     }
             // }
-            cw.visit(52, ACC_PRIVATE | ACC_SUPER, "InjectedInvoker", null, "java/lang/Object", null);
+            cw.visit(CLASSFILE_VERSION, ACC_PRIVATE | ACC_SUPER, "InjectedInvoker", null, "java/lang/Object", null);
 
             MethodVisitor mv = cw.visitMethod(ACC_STATIC, "invoke_V",
                           "(Ljava/lang/invoke/MethodHandle;[Ljava/lang/Object;)Ljava/lang/Object;",

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleStatics.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleStatics.java
@@ -27,6 +27,7 @@ package java.lang.invoke;
 
 import jdk.internal.misc.CDS;
 import jdk.internal.misc.Unsafe;
+import jdk.internal.misc.VM;
 import sun.security.action.GetPropertyAction;
 
 import java.util.Properties;
@@ -46,6 +47,7 @@ class MethodHandleStatics {
     private MethodHandleStatics() { }  // do not instantiate
 
     static final Unsafe UNSAFE = Unsafe.getUnsafe();
+    static final int CLASSFILE_VERSION = VM.classFileVersion();
 
     static final boolean DEBUG_METHOD_HANDLE_NAMES;
     static final boolean DUMP_CLASS_FILES;

--- a/src/java.base/share/classes/java/lang/reflect/ProxyGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/ProxyGenerator.java
@@ -25,6 +25,7 @@
 
 package java.lang.reflect;
 
+import jdk.internal.misc.VM;
 import jdk.internal.org.objectweb.asm.ClassWriter;
 import jdk.internal.org.objectweb.asm.Label;
 import jdk.internal.org.objectweb.asm.MethodVisitor;
@@ -55,7 +56,7 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
  * "generateProxyClass" method.
  */
 final class ProxyGenerator extends ClassWriter {
-
+    private static final int CLASSFILE_VERSION = VM.classFileVersion();
     private static final String JL_CLASS = "java/lang/Class";
     private static final String JL_OBJECT = "java/lang/Object";
     private static final String JL_THROWABLE = "java/lang/Throwable";
@@ -455,7 +456,7 @@ final class ProxyGenerator extends ClassWriter {
      * class file generation process.
      */
     private byte[] generateClassFile() {
-        visit(V14, accessFlags, dotToSlash(className), null,
+        visit(CLASSFILE_VERSION, accessFlags, dotToSlash(className), null,
                 JLR_PROXY, typeNames(interfaces));
 
         /*

--- a/src/java.base/share/classes/jdk/internal/misc/VM.java
+++ b/src/java.base/share/classes/jdk/internal/misc/VM.java
@@ -152,6 +152,14 @@ public class VM {
     private static final int PREVIEW_MINOR_VERSION = 65535;
 
     /**
+     * Returns the class file version of the current release.
+     * @jvms 4.1 Table 4.1-A. class file format major versions
+     */
+    public static int classFileVersion() {
+        return classFileMajorVersion;
+    }
+
+    /**
      * Tests if the given version is a supported {@code class}
      * file version.
      *


### PR DESCRIPTION
Update classes spinned by java.lang.invoke and dynamic proxies to be of the class file version of the current release that will enable them to use the newest features when appropriate for example to support primitive classes in Valhalla repo.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270949](https://bugs.openjdk.java.net/browse/JDK-8270949): Make dynamically generated classes with the class file version of the current release


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4840/head:pull/4840` \
`$ git checkout pull/4840`

Update a local copy of the PR: \
`$ git checkout pull/4840` \
`$ git pull https://git.openjdk.java.net/jdk pull/4840/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4840`

View PR using the GUI difftool: \
`$ git pr show -t 4840`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4840.diff">https://git.openjdk.java.net/jdk/pull/4840.diff</a>

</details>
