### PR TITLE
8264543: Cross modify fence optimization for x86

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_ext_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_ext_x86.hpp
@@ -27,6 +27,7 @@
 
 #include "runtime/vm_version.hpp"
 #include "utilities/macros.hpp"
+#include "utilities/sizes.hpp"
 
 class VM_Version_Ext : public VM_Version {
 

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -25,9 +25,9 @@
 #ifndef CPU_X86_VM_VERSION_X86_HPP
 #define CPU_X86_VM_VERSION_X86_HPP
 
-#include "memory/universe.hpp"
 #include "runtime/abstract_vm_version.hpp"
 #include "utilities/macros.hpp"
+#include "utilities/sizes.hpp"
 
 class VM_Version : public Abstract_VM_Version {
   friend class VMStructs;
@@ -261,7 +261,9 @@ class VM_Version : public Abstract_VM_Version {
       uint32_t             : 2,
              avx512_4vnniw : 1,
              avx512_4fmaps : 1,
-                           : 28;
+                           : 10,
+                 serialize : 1,
+                           : 17;
     } bits;
   };
 
@@ -359,7 +361,8 @@ protected:
                                                      \
     decl(AVX512_VBMI2,      "avx512_vbmi2",      44) /* VBMI2 shift left double instructions */ \
     decl(AVX512_VBMI,       "avx512_vbmi",       45) /* Vector BMI instructions */ \
-    decl(HV,                "hv",                46) /* Hypervisor instructions */
+    decl(HV,                "hv",                46) /* Hypervisor instructions */ \
+    decl(SERIALIZE,         "serialize",         47) /* CPU SERIALIZE */
 
 #define DECLARE_CPU_FEATURE_FLAG(id, name, bit) CPU_##id = (1ULL << bit),
     CPU_FEATURE_FLAGS(DECLARE_CPU_FEATURE_FLAG)
@@ -646,6 +649,8 @@ enum Extended_Family {
       if (_cpuid_info.sef_cpuid7_ebx.bits.clwb != 0) {
         result |= CPU_CLWB;
       }
+      if (_cpuid_info.sef_cpuid7_edx.bits.serialize != 0)
+        result |= CPU_SERIALIZE;
     }
 
     // ZX features.
@@ -896,6 +901,7 @@ public:
   static bool supports_avx512_vbmi()  { return (_features & CPU_AVX512_VBMI) != 0; }
   static bool supports_avx512_vbmi2() { return (_features & CPU_AVX512_VBMI2) != 0; }
   static bool supports_hv()           { return (_features & CPU_HV) != 0; }
+  static bool supports_serialize()    { return (_features & CPU_SERIALIZE) != 0; }
 
   // Intel features
   static bool is_intel_family_core() { return is_intel() &&
@@ -1027,19 +1033,8 @@ public:
   // and trailing StoreStore fences.
 
 #ifdef _LP64
-  static bool supports_clflush() {
-    // clflush should always be available on x86_64
-    // if not we are in real trouble because we rely on it
-    // to flush the code cache.
-    // Unfortunately, Assembler::clflush is currently called as part
-    // of generation of the code cache flush routine. This happens
-    // under Universe::init before the processor features are set
-    // up. Assembler::flush calls this routine to check that clflush
-    // is allowed. So, we give the caller a free pass if Universe init
-    // is still in progress.
-    assert ((!Universe::is_fully_initialized() || (_features & CPU_FLUSH) != 0), "clflush should be available");
-    return true;
-  }
+
+  static bool supports_clflush(); // Can't inline due to header file conflict
 #else
   static bool supports_clflush() { return  ((_features & CPU_FLUSH) != 0); }
 #endif // _LP64

--- a/src/hotspot/os_cpu/linux_x86/orderAccess_linux_x86.hpp
+++ b/src/hotspot/os_cpu/linux_x86/orderAccess_linux_x86.hpp
@@ -25,6 +25,7 @@
 #ifndef OS_CPU_LINUX_X86_ORDERACCESS_LINUX_X86_HPP
 #define OS_CPU_LINUX_X86_ORDERACCESS_LINUX_X86_HPP
 
+#include OS_HEADER_INLINE(os)
 // Included in orderAccess.hpp header file.
 
 // Compiler version last used for testing: gcc 4.8.2
@@ -56,14 +57,18 @@ inline void OrderAccess::fence() {
 }
 
 inline void OrderAccess::cross_modify_fence_impl() {
-  int idx = 0;
+  if (VM_Version::supports_serialize()) {
+    __asm__ volatile (".byte 0x0f, 0x01, 0xe8\n\t" : : :); //serialize
+  } else {
+    int idx = 0;
 #ifdef AMD64
-  __asm__ volatile ("cpuid " : "+a" (idx) : : "ebx", "ecx", "edx", "memory");
+    __asm__ volatile ("cpuid " : "+a" (idx) : : "ebx", "ecx", "edx", "memory");
 #else
-  // On some x86 systems EBX is a reserved register that cannot be
-  // clobbered, so we must protect it around the CPUID.
-  __asm__ volatile ("xchg %%esi, %%ebx; cpuid; xchg %%esi, %%ebx " : "+a" (idx) : : "esi", "ecx", "edx", "memory");
+    // On some x86 systems EBX is a reserved register that cannot be
+    // clobbered, so we must protect it around the CPUID.
+    __asm__ volatile ("xchg %%esi, %%ebx; cpuid; xchg %%esi, %%ebx " : "+a" (idx) : : "esi", "ecx", "edx", "memory");
 #endif
+  }
 }
 
 #endif // OS_CPU_LINUX_X86_ORDERACCESS_LINUX_X86_HPP

--- a/src/hotspot/os_cpu/windows_x86/orderAccess_windows_x86.hpp
+++ b/src/hotspot/os_cpu/windows_x86/orderAccess_windows_x86.hpp
@@ -28,6 +28,7 @@
 // Included in orderAccess.hpp header file.
 
 #include <intrin.h>
+#include <immintrin.h>
 
 // Compiler version last used for testing: Microsoft Visual Studio 2010
 // Please update this information when this file changes
@@ -59,8 +60,12 @@ inline void OrderAccess::fence() {
 }
 
 inline void OrderAccess::cross_modify_fence_impl() {
-  int regs[4];
-  __cpuid(regs, 0);
+  if (VM_Version::supports_serialize()) {
+    _serialize();
+  } else {
+    int regs[4];
+    __cpuid(regs, 0);
+  }
 }
 
 #endif // OS_CPU_WINDOWS_X86_ORDERACCESS_WINDOWS_X86_HPP

--- a/src/hotspot/share/runtime/orderAccess.hpp
+++ b/src/hotspot/share/runtime/orderAccess.hpp
@@ -26,6 +26,7 @@
 #define SHARE_RUNTIME_ORDERACCESS_HPP
 
 #include "memory/allocation.hpp"
+#include "runtime/vm_version.hpp"
 #include "utilities/macros.hpp"
 
 //                Memory Access Ordering Model

--- a/src/hotspot/share/runtime/vm_version.hpp
+++ b/src/hotspot/share/runtime/vm_version.hpp
@@ -25,6 +25,7 @@
 #ifndef SHARE_RUNTIME_VM_VERSION_HPP
 #define SHARE_RUNTIME_VM_VERSION_HPP
 
+#include "runtime/globals.hpp"
 #include "utilities/macros.hpp"  // for CPU_HEADER() macro.
 #include CPU_HEADER(vm_version)
 


### PR DESCRIPTION
Intel introduced a new instruction “serialize” which ensures that all modifications to flags, registers, and memory by previous instructions are completed and all buffered writes are drained to memory before the next instruction is fetched and executed. It is a serializing instruction and can be used to implement cross modify fence (OrderAccess::cross_modify_fence_impl) more efficiently than using “cpuid” on supported 32-bit and 64-bit x86 platforms.

The availability of the SERIALIZE instruction is indicated by the presence of the CPUID feature flag SERIALIZE, bit 14 of the EDX register in sub-leaf CPUID:7H.0H.

https://software.intel.com/content/www/us/en/develop/download/intel-architecture-instruction-set-extensions-programming-reference.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ Executable files are not allowed (file: src/hotspot/os_cpu/windows_x86/orderAccess_windows_x86.hpp)

### Issue
 * [JDK-8264543](https://bugs.openjdk.java.net/browse/JDK-8264543): Cross modify fence optimization for x86


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4841/head:pull/4841` \
`$ git checkout pull/4841`

Update a local copy of the PR: \
`$ git checkout pull/4841` \
`$ git pull https://git.openjdk.java.net/jdk pull/4841/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4841`

View PR using the GUI difftool: \
`$ git pr show -t 4841`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4841.diff">https://git.openjdk.java.net/jdk/pull/4841.diff</a>

</details>
