### PR TITLE
8269849: vmTestbase/gc/gctests/PhantomReference/phantom002/TestDescription.java failed with "OutOfMemoryError: Java heap space: failed reallocation of scalar replaced objects"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/phantom001/phantom001.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/phantom001/phantom001.java
@@ -94,7 +94,7 @@ public class phantom001 extends ThreadedGCTest implements GarbageProducerAware, 
     }
 
     // The class implements the logic of the testcase
-    class Test implements Runnable {
+    class Test implements Runnable, OOMStress {
 
         int iteration;
         private volatile boolean finalized;

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/SoftReference/soft001/soft001.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/SoftReference/soft001/soft001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021test/hotspot/jtreg/vmTestbase/gc/gctests/SoftReference/soft001/soft001.java, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,6 +62,7 @@ import java.lang.ref.SoftReference;
 
 import nsk.share.gc.GC;
 import nsk.share.gc.NonbranchyTree;
+import nsk.share.gc.OOMStress;
 import nsk.share.gc.ThreadedGCTest;
 import nsk.share.gc.gp.GarbageProducer;
 import nsk.share.gc.gp.GarbageProducerAware;
@@ -99,7 +100,7 @@ public class soft001 extends ThreadedGCTest implements GarbageProducerAware, Mem
     }
 
     // The class implements the logic of the testcase
-    class Test implements Runnable {
+    class Test implements Runnable, OOMStress {
 
         int iteration;
 

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/SoftReference/soft001/soft001.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/SoftReference/soft001/soft001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021test/hotspot/jtreg/vmTestbase/gc/gctests/SoftReference/soft001/soft001.java, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/SoftReference/soft003/soft003.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/SoftReference/soft003/soft003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ import java.lang.ref.SoftReference;
  */
 public class soft003 extends ThreadedGCTest {
 
-    class Worker implements Runnable {
+    class Worker implements Runnable, OOMStress {
 
         private int arrayLength;
         private int objectSize = 100;

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/SoftReference/soft004/soft004.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/SoftReference/soft004/soft004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ import java.lang.ref.SoftReference;
  */
 public class soft004 extends ThreadedGCTest {
 
-    class Worker implements Runnable {
+    class Worker implements Runnable, OOMStress {
 
         private int arrayLength;
         private int objectSize = 100;

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/SoftReference/soft005/soft005.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/SoftReference/soft005/soft005.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ import java.lang.ref.SoftReference;
  */
 public class soft005 extends ThreadedGCTest {
 
-    class Worker implements Runnable {
+    class Worker implements Runnable, OOMStress {
 
         private int length = 10000;
         private int objectSize = 10000;

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/WeakReference/weak001/weak001.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/WeakReference/weak001/weak001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,6 +62,7 @@ import java.lang.ref.WeakReference;
 
 import nsk.share.gc.GC;
 import nsk.share.gc.NonbranchyTree;
+import nsk.share.gc.OOMStress;
 import nsk.share.gc.ThreadedGCTest;
 import nsk.share.gc.gp.GarbageProducer;
 import nsk.share.gc.gp.GarbageProducerAware;
@@ -99,7 +100,7 @@ public class weak001 extends ThreadedGCTest implements GarbageProducerAware, Mem
     }
 
     // The class implements the logic of the testcase
-    class Test implements Runnable {
+    class Test implements Runnable, OOMStress {
 
         int iteration;
 

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/WeakReference/weak003/weak003.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/WeakReference/weak003/weak003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@ import java.lang.ref.WeakReference;
  */
 public class weak003 extends ThreadedGCTest {
 
-    class Worker implements Runnable {
+    class Worker implements Runnable, OOMStress {
 
         private int arrayLength;
         private int objectSize = 100;

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/WeakReference/weak004/weak004.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/WeakReference/weak004/weak004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ import java.lang.ref.WeakReference;
  */
 public class weak004 extends ThreadedGCTest {
 
-    class Worker implements Runnable {
+    class Worker implements Runnable, OOMStress {
 
         private int arrayLength;
         private int objectSize = 100;

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/WeakReference/weak005/weak005.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/WeakReference/weak005/weak005.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ import java.lang.ref.WeakReference;
  */
 public class weak005 extends ThreadedGCTest {
 
-    class Worker implements Runnable {
+    class Worker implements Runnable, OOMStress {
 
         private int length = 10000;
         private int objectSize = 10000;

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/WeakReference/weak006/weak006.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/WeakReference/weak006/weak006.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ import java.lang.ref.Reference;
  */
 public class weak006 extends ThreadedGCTest {
 
-    class Worker implements Runnable {
+    class Worker implements Runnable, OOMStress {
 
         private int length;
         private int objectSize = 100;

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/WeakReference/weak007/weak007.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/WeakReference/weak007/weak007.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ import java.lang.ref.Reference;
  */
 public class weak007 extends ThreadedGCTest {
 
-    class Worker implements Runnable {
+    class Worker implements Runnable, OOMStress {
 
         private int length = 10000;
         private int objectSize = 10000;


### PR DESCRIPTION
Test failed because caught OOME outside of 
try{
...
}/catch( OutOfMemoryError e) {}

because of deoptimization even if no objects are allocated. The OOMStress is used to put the whole iteration into try/catch and ignore OOME. 

I verified that test doesn't fail anymore and updated all similar tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269849](https://bugs.openjdk.java.net/browse/JDK-8269849): vmTestbase/gc/gctests/PhantomReference/phantom002/TestDescription.java failed with "OutOfMemoryError: Java heap space: failed reallocation of scalar replaced objects"


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4843/head:pull/4843` \
`$ git checkout pull/4843`

Update a local copy of the PR: \
`$ git checkout pull/4843` \
`$ git pull https://git.openjdk.java.net/jdk pull/4843/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4843`

View PR using the GUI difftool: \
`$ git pr show -t 4843`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4843.diff">https://git.openjdk.java.net/jdk/pull/4843.diff</a>

</details>
