### PR TITLE
8270961: [TESTBUG] Move GotWrongOOMEException into vm.share.gc package

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/common/StressHierarchyBaseClass.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/common/StressHierarchyBaseClass.java
@@ -110,11 +110,6 @@ abstract public class StressHierarchyBaseClass extends TestBase {
             System.out.println("Whole test took " + ((System.currentTimeMillis() - startTimeStamp)/1000/60.0) +" min");
             log.info("Test PASSED");
         } catch (HeapOOMEException e) {
-            /**
-             * Usually this means that we got OOME:heap while trying to gain OOME:metaspace.
-             * We pass test in this case as this breaks test logic. We have dedicated test configurations
-             * for OOME:heap provoking class unloading, that why we are not missing test coverage here.
-             */
             log.info("HeapOOMEException: " + e.getMessage());
             log.info("Got wrong type of OOME. We are passing test as it breaks test logic. We have dedicated test configurations" +
             " for each OOME type provoking class unloading, that's why we are not missing test coverage here.");

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/common/StressHierarchyBaseClass.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/common/StressHierarchyBaseClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import vm.share.gc.TriggerUnloadingWithWhiteBox;
 
 import metaspace.stressHierarchy.common.classloader.tree.Node;
 import metaspace.stressHierarchy.common.classloader.tree.Tree;
-import metaspace.stressHierarchy.common.exceptions.GotWrongOOMEException;
+import vm.share.gc.HeapOOMEException;
 import metaspace.stressHierarchy.common.exceptions.TimeIsOverException;
 import metaspace.stressHierarchy.common.generateHierarchy.GenerateHierarchyHelper;
 import metaspace.stressHierarchy.common.generateHierarchy.GenerateHierarchyHelper.Type;
@@ -109,7 +109,12 @@ abstract public class StressHierarchyBaseClass extends TestBase {
 
             System.out.println("Whole test took " + ((System.currentTimeMillis() - startTimeStamp)/1000/60.0) +" min");
             log.info("Test PASSED");
-        } catch (GotWrongOOMEException e) {
+        } catch (HeapOOMEException e) {
+            /**
+             * Usually this means that we got OOME:heap while trying to gain OOME:metaspace.
+             * We pass test in this case as this breaks test logic. We have dedicated test configurations
+             * for OOME:heap provoking class unloading, that why we are not missing test coverage here.
+             */
             log.info("GotWrongOOMEExc: " + e.getMessage());
             log.info("Got wrong type of OOME. We are passing test as it breaks test logic. We have dedicated test configurations" +
             " for each OOME type provoking class unloading, that's why we are not missing test coverage here.");

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/common/StressHierarchyBaseClass.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/common/StressHierarchyBaseClass.java
@@ -24,13 +24,13 @@ package metaspace.stressHierarchy.common;
 
 import java.net.MalformedURLException;
 
+import vm.share.gc.HeapOOMEException;
 import vm.share.gc.TriggerUnloadingByFillingMetaspace;
 import vm.share.gc.TriggerUnloadingHelper;
 import vm.share.gc.TriggerUnloadingWithWhiteBox;
 
 import metaspace.stressHierarchy.common.classloader.tree.Node;
 import metaspace.stressHierarchy.common.classloader.tree.Tree;
-import vm.share.gc.HeapOOMEException;
 import metaspace.stressHierarchy.common.exceptions.TimeIsOverException;
 import metaspace.stressHierarchy.common.generateHierarchy.GenerateHierarchyHelper;
 import metaspace.stressHierarchy.common.generateHierarchy.GenerateHierarchyHelper.Type;

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/common/StressHierarchyBaseClass.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/common/StressHierarchyBaseClass.java
@@ -115,7 +115,7 @@ abstract public class StressHierarchyBaseClass extends TestBase {
              * We pass test in this case as this breaks test logic. We have dedicated test configurations
              * for OOME:heap provoking class unloading, that why we are not missing test coverage here.
              */
-            log.info("GotWrongOOMEExc: " + e.getMessage());
+            log.info("HeapOOMEException: " + e.getMessage());
             log.info("Got wrong type of OOME. We are passing test as it breaks test logic. We have dedicated test configurations" +
             " for each OOME type provoking class unloading, that's why we are not missing test coverage here.");
         } catch (OutOfMemoryError e) {

--- a/test/hotspot/jtreg/vmTestbase/vm/share/gc/HeapOOMEException.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/share/gc/HeapOOMEException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,18 +20,16 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package metaspace.stressHierarchy.common.exceptions;
+package vm.share.gc;
 
 /**
- * Usually this means that we got OOME:heap while trying to gain OOME:metaspace.
- * We pass test in this case as this breaks test logic. We have dedicated test configurations
- * for OOME:heap provoking class unloading, that why we are not missing test coverage here.
+ * This class is used to differ OOME in metaspace and heap when trigger class unloading.
  */
-public class GotWrongOOMEException extends RuntimeException {
+public class HeapOOMEException extends RuntimeException {
 
     private static final long serialVersionUID = 1L;
 
-    public GotWrongOOMEException(String string) {
+    public HeapOOMEException(String string) {
         super(string);
     }
 

--- a/test/hotspot/jtreg/vmTestbase/vm/share/gc/HeapOOMEException.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/share/gc/HeapOOMEException.java
@@ -23,7 +23,7 @@
 package vm.share.gc;
 
 /**
- * This class is used to differ OOME in metaspace and heap when trigger class unloading.
+ * This class is used to distinguish between OOME in metaspace and OOME in heap when triggering class unloading.
  */
 public class HeapOOMEException extends RuntimeException {
 

--- a/test/hotspot/jtreg/vmTestbase/vm/share/gc/TriggerUnloadingByFillingMetaspace.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/share/gc/TriggerUnloadingByFillingMetaspace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,6 @@
 package vm.share.gc;
 
 import nsk.share.test.ExecutionController;
-import metaspace.stressHierarchy.common.exceptions.GotWrongOOMEException;
 import nsk.share.gc.gp.classload.GeneratedClassProducer;
 
 public class TriggerUnloadingByFillingMetaspace implements
@@ -50,7 +49,7 @@ public class TriggerUnloadingByFillingMetaspace implements
                 generatedClassProducer.get().create(-100500); //argument is not used.
             } catch (Throwable oome) {
                 if (!isInMetaspace(oome)) {
-                    throw new GotWrongOOMEException("Got OOME in heap while triggering OOME in metaspace. Test result can't be valid.");
+                    throw new HeapOOMEException("Got OOME in heap while triggering OOME in metaspace. Test result can't be valid.");
                 }
                 gotOOME = true;
             }


### PR DESCRIPTION
The small refactoring which consolidates shared code in the shared library. Make project more IDE-friendly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270961](https://bugs.openjdk.java.net/browse/JDK-8270961): [TESTBUG] Move GotWrongOOMEException into vm.share.gc package


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to 990bff2f0ab70fe1a0aaa3a1bb6fd3b5f9523258
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4844/head:pull/4844` \
`$ git checkout pull/4844`

Update a local copy of the PR: \
`$ git checkout pull/4844` \
`$ git pull https://git.openjdk.java.net/jdk pull/4844/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4844`

View PR using the GUI difftool: \
`$ git pr show -t 4844`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4844.diff">https://git.openjdk.java.net/jdk/pull/4844.diff</a>

</details>
