### PR TITLE
8268824: Remove unused jdk.accessibility APIs deprecated for removal in JDK 9

### DIFF
--- a/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/AWTEventMonitor.java
+++ b/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/AWTEventMonitor.java
@@ -50,165 +50,22 @@ public class AWTEventMonitor {
      */
     public AWTEventMonitor() {}
 
-    /**
-     * The current component with keyboard focus.
-     *
-     * @see #getComponentWithFocus
-     *
-     * @deprecated This field is unused; to get the component with focus use the
-     * getComponentWithFocus method.
-     */
-    @Deprecated(since="8", forRemoval=true)
-    static protected Component componentWithFocus = null;
-
     static private Component componentWithFocus_private = null;
 
     // Low-level listeners
-    /**
-     * The current list of registered ComponentListener classes.
-     *
-     * @see #addComponentListener
-     * @see #removeComponentListener
-     *
-     * @deprecated This field is unused.
-     */
-    @Deprecated(since="8", forRemoval=true)
-    static protected ComponentListener     componentListener     = null;
-
     static private ComponentListener componentListener_private = null;
-
-    /**
-     * The current list of registered ContainerListener classes.
-     *
-     * @see #addContainerListener
-     * @see #removeContainerListener
-     *
-     * @deprecated This field is unused.
-     */
-    @Deprecated(since="8", forRemoval=true)
-    static protected ContainerListener     containerListener     = null;
-
     static private ContainerListener containerListener_private = null;
-
-    /**
-     * The current list of registered FocusListener classes.
-     *
-     * @see #addFocusListener
-     * @see #removeFocusListener
-     *
-     * @deprecated This field is unused.
-     */
-    @Deprecated(since="8", forRemoval=true)
-    static protected FocusListener         focusListener         = null;
-
     static private FocusListener focusListener_private = null;
-
-    /**
-     * The current list of registered KeyListener classes.
-     *
-     * @see #addKeyListener
-     * @see #removeKeyListener
-     *
-     * @deprecated This field is unused.
-     */
-    @Deprecated(since="8", forRemoval=true)
-    static protected KeyListener           keyListener           = null;
-
     static private KeyListener keyListener_private = null;
-
-    /**
-     * The current list of registered MouseListener classes.
-     *
-     * @see #addMouseListener
-     * @see #removeMouseListener
-     *
-     * @deprecated This field is unused.
-     */
-    @Deprecated(since="8", forRemoval=true)
-    static protected MouseListener         mouseListener         = null;
-
     static private MouseListener mouseListener_private = null;
-
-    /**
-     * The current list of registered MouseMotionListener classes.
-     *
-     * @see #addMouseMotionListener
-     * @see #removeMouseMotionListener
-     *
-     * @deprecated This field is unused.
-     */
-    @Deprecated(since="8", forRemoval=true)
-    static protected MouseMotionListener   mouseMotionListener   = null;
-
     static private MouseMotionListener mouseMotionListener_private = null;
-
-    /**
-     * The current list of registered WindowListener classes.
-     *
-     * @see #addWindowListener
-     * @see #removeWindowListener
-     *
-     * @deprecated This field is unused.
-     */
-    @Deprecated(since="8", forRemoval=true)
-    static protected WindowListener        windowListener        = null;
-
     static private WindowListener windowListener_private = null;
 
-
     // Semantic listeners
-    /**
-     * The current list of registered ActionListener classes.
-     *
-     * @see #addActionListener
-     * @see #removeActionListener
-     *
-     * @deprecated This field is unused.
-     */
-    @Deprecated(since="8", forRemoval=true)
-    static protected ActionListener        actionListener        = null;
-
     static private ActionListener actionListener_private = null;
-
-    /**
-     * The current list of registered AdjustmentListener classes.
-     *
-     * @see #addAdjustmentListener
-     * @see #removeAdjustmentListener
-     *
-     * @deprecated This field is unused.
-     */
-    @Deprecated(since="8", forRemoval=true)
-    static protected AdjustmentListener    adjustmentListener    = null;
-
     static private AdjustmentListener adjustmentListener_private = null;
-
-    /**
-     * The current list of registered ItemListener classes.
-     *
-     * @see #addItemListener
-     * @see #removeItemListener
-     *
-     * @deprecated This field is unused.
-     */
-    @Deprecated(since="8", forRemoval=true)
-    static protected ItemListener          itemListener          = null;
-
     static private ItemListener itemListener_private = null;
-
-    /**
-     * The current list of registered TextListener classes.
-     *
-     * @see #addTextListener
-     * @see #removeTextListener
-     *
-     * @deprecated This field is unused.
-     */
-    @Deprecated(since="8", forRemoval=true)
-    static protected TextListener          textListener          = null;
-
     static private TextListener textListener_private = null;
-
 
     /**
      * The actual listener that is installed on the component instances.

--- a/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/AWTEventMonitor.java
+++ b/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/AWTEventMonitor.java
@@ -50,22 +50,22 @@ public class AWTEventMonitor {
      */
     public AWTEventMonitor() {}
 
-    static private Component componentWithFocus_private = null;
+    static private Component componentWithFocus = null;
 
     // Low-level listeners
-    static private ComponentListener componentListener_private = null;
-    static private ContainerListener containerListener_private = null;
-    static private FocusListener focusListener_private = null;
-    static private KeyListener keyListener_private = null;
-    static private MouseListener mouseListener_private = null;
-    static private MouseMotionListener mouseMotionListener_private = null;
-    static private WindowListener windowListener_private = null;
+    static private ComponentListener componentListener = null;
+    static private ContainerListener containerListener = null;
+    static private FocusListener focusListener = null;
+    static private KeyListener keyListener = null;
+    static private MouseListener mouseListener = null;
+    static private MouseMotionListener mouseMotionListener = null;
+    static private WindowListener windowListener = null;
 
     // Semantic listeners
-    static private ActionListener actionListener_private = null;
-    static private AdjustmentListener adjustmentListener_private = null;
-    static private ItemListener itemListener_private = null;
-    static private TextListener textListener_private = null;
+    static private ActionListener actionListener = null;
+    static private AdjustmentListener adjustmentListener = null;
+    static private ItemListener itemListener = null;
+    static private TextListener textListener = null;
 
     /**
      * The actual listener that is installed on the component instances.
@@ -82,7 +82,7 @@ public class AWTEventMonitor {
      * @return the component that has keyboard focus
      */
     static public Component getComponentWithFocus() {
-        return componentWithFocus_private;
+        return componentWithFocus;
     }
 
     /*
@@ -107,11 +107,11 @@ public class AWTEventMonitor {
      * @see #removeComponentListener
      */
     static public void addComponentListener(ComponentListener l) {
-        if (componentListener_private == null) {
+        if (componentListener == null) {
             checkInstallPermission();
             awtListener.installListeners(EventID.COMPONENT);
         }
-        componentListener_private = AWTEventMulticaster.add(componentListener_private, l);
+        componentListener = AWTEventMulticaster.add(componentListener, l);
     }
 
     /**
@@ -122,8 +122,8 @@ public class AWTEventMonitor {
      * @see #addComponentListener
      */
     static public void removeComponentListener(ComponentListener l) {
-        componentListener_private = AWTEventMulticaster.remove(componentListener_private, l);
-        if (componentListener_private == null) {
+        componentListener = AWTEventMulticaster.remove(componentListener, l);
+        if (componentListener == null) {
             awtListener.removeListeners(EventID.COMPONENT);
         }
     }
@@ -139,7 +139,7 @@ public class AWTEventMonitor {
      * @see #removeContainerListener
      */
     static public void addContainerListener(ContainerListener l) {
-        containerListener_private = AWTEventMulticaster.add(containerListener_private, l);
+        containerListener = AWTEventMulticaster.add(containerListener, l);
     }
 
     /**
@@ -150,7 +150,7 @@ public class AWTEventMonitor {
      * @see #addContainerListener
      */
     static public void removeContainerListener(ContainerListener l) {
-        containerListener_private = AWTEventMulticaster.remove(containerListener_private, l);
+        containerListener = AWTEventMulticaster.remove(containerListener, l);
     }
 
     /**
@@ -164,7 +164,7 @@ public class AWTEventMonitor {
      * @see #removeFocusListener
      */
     static public void addFocusListener(FocusListener l) {
-        focusListener_private = AWTEventMulticaster.add(focusListener_private, l);
+        focusListener = AWTEventMulticaster.add(focusListener, l);
     }
 
     /**
@@ -175,7 +175,7 @@ public class AWTEventMonitor {
      * @see #addFocusListener
      */
     static public void removeFocusListener(FocusListener l) {
-        focusListener_private = AWTEventMulticaster.remove(focusListener_private, l);
+        focusListener = AWTEventMulticaster.remove(focusListener, l);
     }
 
     /**
@@ -189,11 +189,11 @@ public class AWTEventMonitor {
      * @see #removeKeyListener
      */
     static public void addKeyListener(KeyListener l) {
-        if (keyListener_private == null) {
+        if (keyListener == null) {
             checkInstallPermission();
             awtListener.installListeners(EventID.KEY);
         }
-        keyListener_private = AWTEventMulticaster.add(keyListener_private, l);
+        keyListener = AWTEventMulticaster.add(keyListener, l);
     }
 
     /**
@@ -204,8 +204,8 @@ public class AWTEventMonitor {
      * @see #addKeyListener
      */
     static public void removeKeyListener(KeyListener l) {
-        keyListener_private = AWTEventMulticaster.remove(keyListener_private, l);
-        if (keyListener_private == null)  {
+        keyListener = AWTEventMulticaster.remove(keyListener, l);
+        if (keyListener == null)  {
             awtListener.removeListeners(EventID.KEY);
         }
     }
@@ -221,11 +221,11 @@ public class AWTEventMonitor {
      * @see #removeMouseListener
      */
     static public void addMouseListener(MouseListener l) {
-        if (mouseListener_private == null) {
+        if (mouseListener == null) {
             checkInstallPermission();
             awtListener.installListeners(EventID.MOUSE);
         }
-        mouseListener_private = AWTEventMulticaster.add(mouseListener_private, l);
+        mouseListener = AWTEventMulticaster.add(mouseListener, l);
     }
 
     /**
@@ -236,8 +236,8 @@ public class AWTEventMonitor {
      * @see #addMouseListener
      */
     static public void removeMouseListener(MouseListener l) {
-        mouseListener_private = AWTEventMulticaster.remove(mouseListener_private, l);
-        if (mouseListener_private == null) {
+        mouseListener = AWTEventMulticaster.remove(mouseListener, l);
+        if (mouseListener == null) {
             awtListener.removeListeners(EventID.MOUSE);
         }
     }
@@ -253,11 +253,11 @@ public class AWTEventMonitor {
      * @see #removeMouseMotionListener
      */
     static public void addMouseMotionListener(MouseMotionListener l) {
-        if (mouseMotionListener_private == null) {
+        if (mouseMotionListener == null) {
             checkInstallPermission();
             awtListener.installListeners(EventID.MOTION);
         }
-        mouseMotionListener_private = AWTEventMulticaster.add(mouseMotionListener_private, l);
+        mouseMotionListener = AWTEventMulticaster.add(mouseMotionListener, l);
     }
 
     /**
@@ -268,8 +268,8 @@ public class AWTEventMonitor {
      * @see #addMouseMotionListener
      */
     static public void removeMouseMotionListener(MouseMotionListener l) {
-        mouseMotionListener_private = AWTEventMulticaster.remove(mouseMotionListener_private, l);
-        if (mouseMotionListener_private == null) {
+        mouseMotionListener = AWTEventMulticaster.remove(mouseMotionListener, l);
+        if (mouseMotionListener == null) {
             awtListener.removeListeners(EventID.MOTION);
         }
     }
@@ -285,11 +285,11 @@ public class AWTEventMonitor {
      * @see #removeWindowListener
      */
     static public void addWindowListener(WindowListener l) {
-        if (windowListener_private == null) {
+        if (windowListener == null) {
             checkInstallPermission();
             awtListener.installListeners(EventID.WINDOW);
         }
-        windowListener_private = AWTEventMulticaster.add(windowListener_private, l);
+        windowListener = AWTEventMulticaster.add(windowListener, l);
     }
 
     /**
@@ -300,8 +300,8 @@ public class AWTEventMonitor {
      * @see #addWindowListener
      */
     static public void removeWindowListener(WindowListener l) {
-        windowListener_private = AWTEventMulticaster.remove(windowListener_private, l);
-        if (windowListener_private == null) {
+        windowListener = AWTEventMulticaster.remove(windowListener, l);
+        if (windowListener == null) {
             awtListener.removeListeners(EventID.WINDOW);
         }
     }
@@ -317,11 +317,11 @@ public class AWTEventMonitor {
      * @see #removeActionListener
      */
     static public void addActionListener(ActionListener l) {
-        if (actionListener_private == null) {
+        if (actionListener == null) {
             checkInstallPermission();
             awtListener.installListeners(EventID.ACTION);
         }
-        actionListener_private = AWTEventMulticaster.add(actionListener_private, l);
+        actionListener = AWTEventMulticaster.add(actionListener, l);
     }
 
     /**
@@ -332,8 +332,8 @@ public class AWTEventMonitor {
      * @see #addActionListener
      */
     static public void removeActionListener(ActionListener l) {
-        actionListener_private = AWTEventMulticaster.remove(actionListener_private, l);
-        if (actionListener_private == null) {
+        actionListener = AWTEventMulticaster.remove(actionListener, l);
+        if (actionListener == null) {
             awtListener.removeListeners(EventID.ACTION);
         }
     }
@@ -350,11 +350,11 @@ public class AWTEventMonitor {
      * @see #removeAdjustmentListener
      */
     static public void addAdjustmentListener(AdjustmentListener l) {
-        if (adjustmentListener_private == null) {
+        if (adjustmentListener == null) {
             checkInstallPermission();
             awtListener.installListeners(EventID.ADJUSTMENT);
         }
-        adjustmentListener_private = AWTEventMulticaster.add(adjustmentListener_private, l);
+        adjustmentListener = AWTEventMulticaster.add(adjustmentListener, l);
     }
 
     /**
@@ -365,8 +365,8 @@ public class AWTEventMonitor {
      * @see #addAdjustmentListener
      */
     static public void removeAdjustmentListener(AdjustmentListener l) {
-        adjustmentListener_private = AWTEventMulticaster.remove(adjustmentListener_private, l);
-        if (adjustmentListener_private == null) {
+        adjustmentListener = AWTEventMulticaster.remove(adjustmentListener, l);
+        if (adjustmentListener == null) {
             awtListener.removeListeners(EventID.ADJUSTMENT);
         }
     }
@@ -382,11 +382,11 @@ public class AWTEventMonitor {
      * @see #removeItemListener
      */
     static public void addItemListener(ItemListener l) {
-        if (itemListener_private == null) {
+        if (itemListener == null) {
             checkInstallPermission();
             awtListener.installListeners(EventID.ITEM);
         }
-        itemListener_private = AWTEventMulticaster.add(itemListener_private, l);
+        itemListener = AWTEventMulticaster.add(itemListener, l);
     }
 
     /**
@@ -397,8 +397,8 @@ public class AWTEventMonitor {
      * @see #addItemListener
      */
     static public void removeItemListener(ItemListener l) {
-        itemListener_private = AWTEventMulticaster.remove(itemListener_private, l);
-        if (itemListener_private == null) {
+        itemListener = AWTEventMulticaster.remove(itemListener, l);
+        if (itemListener == null) {
             awtListener.removeListeners(EventID.ITEM);
         }
     }
@@ -414,11 +414,11 @@ public class AWTEventMonitor {
      * @see #removeTextListener
      */
     static public void addTextListener(TextListener l) {
-        if (textListener_private == null) {
+        if (textListener == null) {
             checkInstallPermission();
             awtListener.installListeners(EventID.TEXT);
         }
-        textListener_private = AWTEventMulticaster.add(textListener_private, l);
+        textListener = AWTEventMulticaster.add(textListener, l);
     }
 
     /**
@@ -429,8 +429,8 @@ public class AWTEventMonitor {
      * @see #addTextListener
      */
     static public void removeTextListener(TextListener l) {
-        textListener_private = AWTEventMulticaster.remove(textListener_private, l);
-        if (textListener_private == null) {
+        textListener = AWTEventMulticaster.remove(textListener, l);
+        if (textListener == null) {
             awtListener.removeListeners(EventID.TEXT);
         }
     }
@@ -569,34 +569,34 @@ public class AWTEventMonitor {
 
             // conditionally install low-level listeners
             //
-            if (AWTEventMonitor.componentListener_private != null) {
+            if (AWTEventMonitor.componentListener != null) {
                 installListeners(c,EventID.COMPONENT);
             }
-            if (AWTEventMonitor.keyListener_private != null) {
+            if (AWTEventMonitor.keyListener != null) {
                 installListeners(c,EventID.KEY);
             }
-            if (AWTEventMonitor.mouseListener_private != null) {
+            if (AWTEventMonitor.mouseListener != null) {
                 installListeners(c,EventID.MOUSE);
             }
-            if (AWTEventMonitor.mouseMotionListener_private != null) {
+            if (AWTEventMonitor.mouseMotionListener != null) {
                 installListeners(c,EventID.MOTION);
             }
-            if (AWTEventMonitor.windowListener_private != null) {
+            if (AWTEventMonitor.windowListener != null) {
                 installListeners(c,EventID.WINDOW);
             }
 
             // conditionally install Semantic listeners
             //
-            if (AWTEventMonitor.actionListener_private != null) {
+            if (AWTEventMonitor.actionListener != null) {
                 installListeners(c,EventID.ACTION);
             }
-            if (AWTEventMonitor.adjustmentListener_private != null) {
+            if (AWTEventMonitor.adjustmentListener != null) {
                 installListeners(c,EventID.ADJUSTMENT);
             }
-            if (AWTEventMonitor.itemListener_private != null) {
+            if (AWTEventMonitor.itemListener != null) {
                 installListeners(c,EventID.ITEM);
             }
-            if (AWTEventMonitor.textListener_private != null) {
+            if (AWTEventMonitor.textListener != null) {
                 installListeners(c,EventID.TEXT);
             }
         }
@@ -625,15 +625,15 @@ public class AWTEventMonitor {
                         last instanceof JMenu) {
                         // This is a popup with nothing in the popup
                         // selected. The menu itself is selected.
-                        componentWithFocus_private = last;
+                        componentWithFocus = last;
                     } else if (penult instanceof JPopupMenu) {
                         // This is a popup with an item selected
-                        componentWithFocus_private = penult;
+                        componentWithFocus = penult;
                     }
                 }
             } else {
                 // The focus owner has the selection.
-                componentWithFocus_private = focusOwner;
+                componentWithFocus = focusOwner;
             }
         }
 
@@ -822,34 +822,34 @@ public class AWTEventMonitor {
 
             // conditionally remove low-level listeners
             //
-            if (AWTEventMonitor.componentListener_private != null) {
+            if (AWTEventMonitor.componentListener != null) {
                 removeListeners(c,EventID.COMPONENT);
             }
-            if (AWTEventMonitor.keyListener_private != null) {
+            if (AWTEventMonitor.keyListener != null) {
                 removeListeners(c,EventID.KEY);
             }
-            if (AWTEventMonitor.mouseListener_private != null) {
+            if (AWTEventMonitor.mouseListener != null) {
                 removeListeners(c,EventID.MOUSE);
             }
-            if (AWTEventMonitor.mouseMotionListener_private != null) {
+            if (AWTEventMonitor.mouseMotionListener != null) {
                 removeListeners(c,EventID.MOTION);
             }
-            if (AWTEventMonitor.windowListener_private != null) {
+            if (AWTEventMonitor.windowListener != null) {
                 removeListeners(c,EventID.WINDOW);
             }
 
             // Remove semantic listeners
             //
-            if (AWTEventMonitor.actionListener_private != null) {
+            if (AWTEventMonitor.actionListener != null) {
                 removeListeners(c,EventID.ACTION);
             }
-            if (AWTEventMonitor.adjustmentListener_private != null) {
+            if (AWTEventMonitor.adjustmentListener != null) {
                 removeListeners(c,EventID.ADJUSTMENT);
             }
-            if (AWTEventMonitor.itemListener_private != null) {
+            if (AWTEventMonitor.itemListener != null) {
                 removeListeners(c,EventID.ITEM);
             }
-            if (AWTEventMonitor.textListener_private != null) {
+            if (AWTEventMonitor.textListener != null) {
                 removeListeners(c,EventID.TEXT);
             }
         }
@@ -1025,8 +1025,8 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addActionListener
          */
         public void actionPerformed(ActionEvent e) {
-            if (AWTEventMonitor.actionListener_private != null) {
-                AWTEventMonitor.actionListener_private.actionPerformed(e);
+            if (AWTEventMonitor.actionListener != null) {
+                AWTEventMonitor.actionListener.actionPerformed(e);
             }
         }
 
@@ -1038,8 +1038,8 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addAdjustmentListener
          */
         public void adjustmentValueChanged(AdjustmentEvent e) {
-            if (AWTEventMonitor.adjustmentListener_private != null) {
-                AWTEventMonitor.adjustmentListener_private.adjustmentValueChanged(e);
+            if (AWTEventMonitor.adjustmentListener != null) {
+                AWTEventMonitor.adjustmentListener.adjustmentValueChanged(e);
             }
         }
 
@@ -1051,8 +1051,8 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addComponentListener
          */
         public void componentHidden(ComponentEvent e) {
-            if (AWTEventMonitor.componentListener_private != null) {
-                AWTEventMonitor.componentListener_private.componentHidden(e);
+            if (AWTEventMonitor.componentListener != null) {
+                AWTEventMonitor.componentListener.componentHidden(e);
             }
         }
 
@@ -1062,8 +1062,8 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addComponentListener
          */
         public void componentMoved(ComponentEvent e) {
-            if (AWTEventMonitor.componentListener_private != null) {
-                AWTEventMonitor.componentListener_private.componentMoved(e);
+            if (AWTEventMonitor.componentListener != null) {
+                AWTEventMonitor.componentListener.componentMoved(e);
             }
         }
 
@@ -1073,8 +1073,8 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addComponentListener
          */
         public void componentResized(ComponentEvent e) {
-            if (AWTEventMonitor.componentListener_private != null) {
-                AWTEventMonitor.componentListener_private.componentResized(e);
+            if (AWTEventMonitor.componentListener != null) {
+                AWTEventMonitor.componentListener.componentResized(e);
             }
         }
 
@@ -1084,8 +1084,8 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addComponentListener
          */
         public void componentShown(ComponentEvent e) {
-            if (AWTEventMonitor.componentListener_private != null) {
-                AWTEventMonitor.componentListener_private.componentShown(e);
+            if (AWTEventMonitor.componentListener != null) {
+                AWTEventMonitor.componentListener.componentShown(e);
             }
         }
 
@@ -1098,8 +1098,8 @@ public class AWTEventMonitor {
          */
         public void componentAdded(ContainerEvent e) {
             installListeners(e.getChild());
-            if (AWTEventMonitor.containerListener_private != null) {
-                AWTEventMonitor.containerListener_private.componentAdded(e);
+            if (AWTEventMonitor.containerListener != null) {
+                AWTEventMonitor.containerListener.componentAdded(e);
             }
         }
 
@@ -1110,8 +1110,8 @@ public class AWTEventMonitor {
          */
         public void componentRemoved(ContainerEvent e) {
             removeListeners(e.getChild());
-            if (AWTEventMonitor.containerListener_private != null) {
-                AWTEventMonitor.containerListener_private.componentRemoved(e);
+            if (AWTEventMonitor.containerListener != null) {
+                AWTEventMonitor.containerListener.componentRemoved(e);
             }
         }
 
@@ -1123,9 +1123,9 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addFocusListener
          */
         public void focusGained(FocusEvent e) {
-            AWTEventMonitor.componentWithFocus_private = (Component) e.getSource();
-            if (AWTEventMonitor.focusListener_private != null) {
-                AWTEventMonitor.focusListener_private.focusGained(e);
+            AWTEventMonitor.componentWithFocus = (Component) e.getSource();
+            if (AWTEventMonitor.focusListener != null) {
+                AWTEventMonitor.focusListener.focusGained(e);
             }
         }
 
@@ -1135,9 +1135,9 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addFocusListener
          */
         public void focusLost(FocusEvent e) {
-            AWTEventMonitor.componentWithFocus_private = null;
-            if (AWTEventMonitor.focusListener_private != null) {
-                AWTEventMonitor.focusListener_private.focusLost(e);
+            AWTEventMonitor.componentWithFocus = null;
+            if (AWTEventMonitor.focusListener != null) {
+                AWTEventMonitor.focusListener.focusLost(e);
             }
         }
 
@@ -1149,8 +1149,8 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addItemListener
          */
         public void itemStateChanged(ItemEvent e) {
-            if (AWTEventMonitor.itemListener_private != null) {
-                AWTEventMonitor.itemListener_private.itemStateChanged(e);
+            if (AWTEventMonitor.itemListener != null) {
+                AWTEventMonitor.itemListener.itemStateChanged(e);
             }
         }
 
@@ -1162,8 +1162,8 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addKeyListener
          */
         public void keyPressed(KeyEvent e) {
-            if (AWTEventMonitor.keyListener_private != null) {
-                AWTEventMonitor.keyListener_private.keyPressed(e);
+            if (AWTEventMonitor.keyListener != null) {
+                AWTEventMonitor.keyListener.keyPressed(e);
             }
         }
 
@@ -1173,8 +1173,8 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addKeyListener
          */
         public void keyReleased(KeyEvent e) {
-            if (AWTEventMonitor.keyListener_private != null) {
-                AWTEventMonitor.keyListener_private.keyReleased(e);
+            if (AWTEventMonitor.keyListener != null) {
+                AWTEventMonitor.keyListener.keyReleased(e);
             }
         }
 
@@ -1184,8 +1184,8 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addKeyListener
          */
         public void keyTyped(KeyEvent e) {
-            if (AWTEventMonitor.keyListener_private != null) {
-                AWTEventMonitor.keyListener_private.keyTyped(e);
+            if (AWTEventMonitor.keyListener != null) {
+                AWTEventMonitor.keyListener.keyTyped(e);
             }
         }
 
@@ -1197,8 +1197,8 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addMouseListener
          */
         public void mouseClicked(MouseEvent e) {
-            if (AWTEventMonitor.mouseListener_private != null) {
-                AWTEventMonitor.mouseListener_private.mouseClicked(e);
+            if (AWTEventMonitor.mouseListener != null) {
+                AWTEventMonitor.mouseListener.mouseClicked(e);
             }
         }
 
@@ -1208,8 +1208,8 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addMouseListener
          */
         public void mouseEntered(MouseEvent e) {
-            if (AWTEventMonitor.mouseListener_private != null) {
-                AWTEventMonitor.mouseListener_private.mouseEntered(e);
+            if (AWTEventMonitor.mouseListener != null) {
+                AWTEventMonitor.mouseListener.mouseEntered(e);
             }
         }
 
@@ -1219,8 +1219,8 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addMouseListener
          */
         public void mouseExited(MouseEvent e) {
-            if (AWTEventMonitor.mouseListener_private != null) {
-                AWTEventMonitor.mouseListener_private.mouseExited(e);
+            if (AWTEventMonitor.mouseListener != null) {
+                AWTEventMonitor.mouseListener.mouseExited(e);
             }
         }
 
@@ -1230,8 +1230,8 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addMouseListener
          */
         public void mousePressed(MouseEvent e) {
-            if (AWTEventMonitor.mouseListener_private != null) {
-                AWTEventMonitor.mouseListener_private.mousePressed(e);
+            if (AWTEventMonitor.mouseListener != null) {
+                AWTEventMonitor.mouseListener.mousePressed(e);
             }
         }
 
@@ -1241,8 +1241,8 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addMouseListener
          */
         public void mouseReleased(MouseEvent e) {
-            if (AWTEventMonitor.mouseListener_private != null) {
-                AWTEventMonitor.mouseListener_private.mouseReleased(e);
+            if (AWTEventMonitor.mouseListener != null) {
+                AWTEventMonitor.mouseListener.mouseReleased(e);
             }
         }
 
@@ -1254,8 +1254,8 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addMouseMotionListener
          */
         public void mouseDragged(MouseEvent e) {
-            if (AWTEventMonitor.mouseMotionListener_private != null) {
-                AWTEventMonitor.mouseMotionListener_private.mouseDragged(e);
+            if (AWTEventMonitor.mouseMotionListener != null) {
+                AWTEventMonitor.mouseMotionListener.mouseDragged(e);
             }
         }
 
@@ -1265,8 +1265,8 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addMouseMotionListener
          */
         public void mouseMoved(MouseEvent e) {
-            if (AWTEventMonitor.mouseMotionListener_private != null) {
-                AWTEventMonitor.mouseMotionListener_private.mouseMoved(e);
+            if (AWTEventMonitor.mouseMotionListener != null) {
+                AWTEventMonitor.mouseMotionListener.mouseMoved(e);
             }
         }
 
@@ -1278,8 +1278,8 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addTextListener
          */
         public void textValueChanged(TextEvent e) {
-            if (AWTEventMonitor.textListener_private != null) {
-                AWTEventMonitor.textListener_private.textValueChanged(e);
+            if (AWTEventMonitor.textListener != null) {
+                AWTEventMonitor.textListener.textValueChanged(e);
             }
         }
 
@@ -1291,8 +1291,8 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addWindowListener
          */
         public void windowOpened(WindowEvent e) {
-            if (AWTEventMonitor.windowListener_private != null) {
-                AWTEventMonitor.windowListener_private.windowOpened(e);
+            if (AWTEventMonitor.windowListener != null) {
+                AWTEventMonitor.windowListener.windowOpened(e);
             }
         }
 
@@ -1302,8 +1302,8 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addWindowListener
          */
         public void windowClosing(WindowEvent e) {
-            if (AWTEventMonitor.windowListener_private != null) {
-                AWTEventMonitor.windowListener_private.windowClosing(e);
+            if (AWTEventMonitor.windowListener != null) {
+                AWTEventMonitor.windowListener.windowClosing(e);
             }
         }
 
@@ -1313,8 +1313,8 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addWindowListener
          */
         public void windowClosed(WindowEvent e) {
-            if (AWTEventMonitor.windowListener_private != null) {
-                AWTEventMonitor.windowListener_private.windowClosed(e);
+            if (AWTEventMonitor.windowListener != null) {
+                AWTEventMonitor.windowListener.windowClosed(e);
             }
         }
 
@@ -1324,8 +1324,8 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addWindowListener
          */
         public void windowIconified(WindowEvent e) {
-            if (AWTEventMonitor.windowListener_private != null) {
-                AWTEventMonitor.windowListener_private.windowIconified(e);
+            if (AWTEventMonitor.windowListener != null) {
+                AWTEventMonitor.windowListener.windowIconified(e);
             }
         }
 
@@ -1335,8 +1335,8 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addWindowListener
          */
         public void windowDeiconified(WindowEvent e) {
-            if (AWTEventMonitor.windowListener_private != null) {
-                AWTEventMonitor.windowListener_private.windowDeiconified(e);
+            if (AWTEventMonitor.windowListener != null) {
+                AWTEventMonitor.windowListener.windowDeiconified(e);
             }
         }
 
@@ -1346,8 +1346,8 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addWindowListener
          */
         public void windowActivated(WindowEvent e) {
-            if (AWTEventMonitor.windowListener_private != null) {
-                AWTEventMonitor.windowListener_private.windowActivated(e);
+            if (AWTEventMonitor.windowListener != null) {
+                AWTEventMonitor.windowListener.windowActivated(e);
             }
         }
 
@@ -1357,8 +1357,8 @@ public class AWTEventMonitor {
          * @see AWTEventMonitor#addWindowListener
          */
         public void windowDeactivated(WindowEvent e) {
-            if (AWTEventMonitor.windowListener_private != null) {
-                AWTEventMonitor.windowListener_private.windowDeactivated(e);
+            if (AWTEventMonitor.windowListener != null) {
+                AWTEventMonitor.windowListener.windowDeactivated(e);
             }
         }
     }


### PR DESCRIPTION
These fields
-  have not been used by the implementation since JDK8,
- are not supposed to be used by applications,
- have been deprecated for removal since JDK 9
- are non-standard, JDK not Java, classes
- very few clients are expected to be using these classes : just those implementing ATs


The CSR for this is https://bugs.openjdk.java.net/browse/JDK-8270918

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268824](https://bugs.openjdk.java.net/browse/JDK-8268824): Remove unused jdk.accessibility APIs deprecated for removal in JDK 9


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4845/head:pull/4845` \
`$ git checkout pull/4845`

Update a local copy of the PR: \
`$ git checkout pull/4845` \
`$ git pull https://git.openjdk.java.net/jdk pull/4845/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4845`

View PR using the GUI difftool: \
`$ git pr show -t 4845`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4845.diff">https://git.openjdk.java.net/jdk/pull/4845.diff</a>

</details>
