### PR TITLE
8270993: Missing forward declaration of ZeroFrame

### DIFF
--- a/src/hotspot/share/runtime/javaFrameAnchor.hpp
+++ b/src/hotspot/share/runtime/javaFrameAnchor.hpp
@@ -34,6 +34,7 @@
 //
 class JavaThread;
 class MacroAssembler;
+class ZeroFrame;
 
 class JavaFrameAnchor {
 // Too many friends...


### PR DESCRIPTION
Zero-specific portions of the `JavaFrameAnchor` class use the `ZeroFrame` type:

https://github.com/openjdk/jdk/blob/38694aa970be73d269cb444ea80ebe7085bd9e90/src/hotspot/cpu/zero/javaFrameAnchor_zero.hpp#L26-L30

javaFrameAnchor_zero.hpp is included in the middle of the declaration of `JavaFrameAnchor`, so we can't declare `ZeroFrame` in javaFrameAnchor_zero.hpp (or else we would be declaring a nested type `JavaFrameAnchor::ZeroFrame`.

The least painful way is to simply do the forward declaration in javaFrameAnchor.hpp

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8270993](https://bugs.openjdk.java.net/browse/JDK-8270993): Missing forward declaration of ZeroFrame


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4846/head:pull/4846` \
`$ git checkout pull/4846`

Update a local copy of the PR: \
`$ git checkout pull/4846` \
`$ git pull https://git.openjdk.java.net/jdk pull/4846/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4846`

View PR using the GUI difftool: \
`$ git pr show -t 4846`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4846.diff">https://git.openjdk.java.net/jdk/pull/4846.diff</a>

</details>
