### PR TITLE
8270609: [TESTBUG] java/awt/print/Dialog/DialogCopies.java does not show instruction

### DIFF
--- a/test/jdk/java/awt/print/Dialog/DialogCopies.java
+++ b/test/jdk/java/awt/print/Dialog/DialogCopies.java
@@ -46,7 +46,6 @@ public class DialogCopies {
                 number of copies and press OK/Cancel button.""";
 
         TextArea instructionTextArea = new TextArea(instruction);
-        instructionTextArea.setText(instruction);
         instructionTextArea.setEditable(false);
 
         Frame instructionFrame = new Frame();

--- a/test/jdk/java/awt/print/Dialog/DialogCopies.java
+++ b/test/jdk/java/awt/print/Dialog/DialogCopies.java
@@ -37,13 +37,15 @@ public class DialogCopies {
 
     private static Frame createInstructionUI() {
         final String instruction = """
-                This test requires that you have a printer. In case if the test
-                system has a virtual printers such as Microsoft Print to PDF or
-                Microsoft XPS Document Writer is installed. Press Cancel
-                button since neither Microsoft Print to PDF or Microsoft XPS
-                Document Writer does not allow setting copies to anything but 1.
-                If printer is installed then PrintDialog is visible increase the
-                number of copies and press OK/Cancel button.""";
+                This test requires that you have a printer.
+
+                Press Cancel if your system has only virtual printers such as
+                Microsoft Print to PDF or Microsoft XPS Document Writer since
+                neither allows setting copies to anything but 1.
+
+                If a real printer is installed, select it from the drop-down
+                list in the Print dialog and increase the number of copies,
+                then press OK button.""";
 
         TextArea instructionTextArea = new TextArea(instruction);
         instructionTextArea.setEditable(false);

--- a/test/jdk/java/awt/print/Dialog/DialogCopies.java
+++ b/test/jdk/java/awt/print/Dialog/DialogCopies.java
@@ -28,33 +28,286 @@
  * @run main/manual DialogCopies
  */
 
-import java.awt.print.*;
+import java.awt.Frame;
+import java.awt.Button;
+import java.awt.TextArea;
+import java.awt.Dialog;
+import java.awt.Panel;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.print.PrinterJob;
 
 public class DialogCopies {
 
-  static String[] instructions = {
-     "This test assumes and requires that you have a printer installed",
-     "When the dialog appears, increment the number of copies then press OK.",
-     "The test will throw an exception if you fail to do this, since",
-     "it cannot distinguish that from a failure",
-     ""
-  };
+    private static void init() {
+        String[] instructions = {
+                "This test assumes and requires that you have a printer installed",
+                "When the dialog appears, increment the number of copies then press OK.",
+        };
+        String[] errorMessage = {
+                "Since you did not increase the number of copies in the print dialog the testcase is failed. " +
+                "Please click fail button."
+        };
 
-  public static void main(String[] args) {
+        String[] successMessage = {
+                "You have increased the number of copies in the print dialog the testcase is passed. " +
+                "Please click pass button"
+        };
+        Sysout.createDialog();
+        Sysout.printInstructions(instructions);
 
-      for (int i=0;i<instructions.length;i++) {
-         System.out.println(instructions[i]);
-      }
+        PrinterJob job = PrinterJob.getPrinterJob();
+        if (job.getPrintService() == null || !job.printDialog()) {
+            return;
+        }
+        if (job.getCopies() == 1) {
+            Sysout.printInstructions(errorMessage);
+        }
 
-      PrinterJob job = PrinterJob.getPrinterJob();
-      if (job.getPrintService() == null || !job.printDialog()) {
-         return;
-      }
+        if (job.getCopies() > 1) {
+            Sysout.printInstructions(successMessage);
+        }
+    }
 
-      System.out.println("Job copies is " + job.getCopies());
+    /*****************************************************
+     Standard Test Machinery Section
+     DO NOT modify anything in this section -- it's a
+     standard chunk of code which has all of the
+     synchronisation necessary for the test harness.
+     By keeping it the same in all tests, it is easier
+     to read and understand someone else's test, as
+     well as insuring that all tests behave correctly
+     with the test harness.
+     There is a section following this for test-defined
+     classes
+     ******************************************************/
+    private static boolean theTestPassed = false;
+    private static boolean testGeneratedInterrupt = false;
+    private static String failureMessage = "";
 
-      if (job.getCopies() == 1) {
-            throw new RuntimeException("Copies not incremented");
-      }
-   }
+    private static Thread mainThread = null;
+
+    private static int sleepTime = 300000;
+
+    public static void main(String args[]) throws InterruptedException {
+        mainThread = Thread.currentThread();
+        try {
+            init();
+        } catch (TestPassedException e) {
+            //The test passed, so just return from main and harness will interpret this return as a pass
+            return;
+        }
+
+        /*
+            At this point, neither test passed nor test failed has been
+            called -- either would have thrown an exception and ended the
+            test, so we know we have multiple threads.
+            Test involves other threads, so sleep and wait for them to
+            called pass() or fail()
+         */
+        try {
+            Thread.sleep(sleepTime);
+            //Timed out, so fail the test
+            throw new RuntimeException("Timed out after " + sleepTime / 1000 + " seconds");
+        } catch (InterruptedException e) {
+            if (!testGeneratedInterrupt) throw e;
+
+            //reset flag in case hit this code more than once for some reason (just safety)
+            testGeneratedInterrupt = false;
+            if (theTestPassed == false) {
+                throw new RuntimeException(failureMessage);
+            }
+        }
+
+    }
+
+    public static synchronized void setTimeoutTo(int seconds) {
+        sleepTime = seconds * 1000;
+    }
+
+    public static synchronized void pass() {
+        Sysout.println("The test passed.");
+        Sysout.println("The test is over, hit  Ctl-C to stop Java VM");
+
+        // first check if this is executing in main thread
+        if (mainThread == Thread.currentThread()) {
+            /*
+             * Still in the main thread, so set the flag just for kicks,
+             * and throw a test passed exception which will be caught
+             * and end the test.
+             */
+            theTestPassed = true;
+            throw new TestPassedException();
+        }
+        /*
+         * pass was called from a different thread, so set the flag and interrupt the main thead.
+         */
+        theTestPassed = true;
+        testGeneratedInterrupt = true;
+        mainThread.interrupt();
+    }
+
+    public static synchronized void fail() {
+        // test writer didn't specify why test failed, so give generic
+        fail("it just plain failed! :-)");
+    }
+
+    public static synchronized void fail(String whyFailed) {
+        Sysout.println("The test failed: " + whyFailed);
+        Sysout.println("The test is over, hit  Ctl-C to stop Java VM");
+        //check if this called from main thread
+        if (mainThread == Thread.currentThread()) {
+            //If main thread, fail now 'cause not sleeping
+            throw new RuntimeException(whyFailed);
+        }
+        theTestPassed = false;
+        testGeneratedInterrupt = true;
+        failureMessage = whyFailed;
+        mainThread.interrupt();
+    }
 }
+
+/**
+ * This exception is used to exit from any level of call nesting
+ * when it's determined that the test has passed, and immediately
+ * end the test.
+ */
+class TestPassedException extends RuntimeException {
+}
+
+/****************************************************
+ Standard Test Machinery
+ DO NOT modify anything below -- it's a standard
+ chunk of code whose purpose is to make user
+ interaction uniform, and thereby make it simpler
+ to read and understand someone else's test.
+ ****************************************************/
+
+/**
+ * This is part of the standard test machinery.
+ * It creates a dialog (with the instructions), and is the interface
+ * for sending text messages to the user.
+ * To print the instructions, send an array of strings to Sysout.createDialog
+ * WithInstructions method.  Put one line of instructions per array entry.
+ * To display a message for the tester to see, simply call Sysout.println
+ * with the string to be displayed.
+ * This mimics System.out.println but works within the test harness as well
+ * as standalone.
+ */
+
+class Sysout {
+    private static TestDialog dialog;
+
+    public static void createDialogWithInstructions(String[] instructions) {
+        dialog = new TestDialog(new Frame(), "Instructions");
+        dialog.printInstructions(instructions);
+        dialog.show();
+        println("Any messages for the tester will display here.");
+    }
+
+    public static void createDialog() {
+        dialog = new TestDialog(new Frame(), "Instructions");
+        String[] defInstr = {"Instructions will appear here. ", ""};
+        dialog.printInstructions(defInstr);
+        dialog.show();
+        println("Any messages for the tester will display here.");
+    }
+
+    public static void printInstructions(String[] instructions) {
+        dialog.printInstructions(instructions);
+    }
+
+    public static void println(String messageIn) {
+        dialog.displayMessage(messageIn);
+    }
+}
+
+/**
+ * This is part of the standard test machinery.  It provides a place for the
+ * test instructions to be displayed, and a place for interactive messages
+ * to the user to be displayed.
+ * To have the test instructions displayed, see Sysout.
+ * To have a message to the user be displayed, see Sysout.
+ * Do not call anything in this dialog directly.
+ */
+class TestDialog extends Dialog implements ActionListener {
+
+    TextArea instructionsText;
+    TextArea messageText;
+    int maxStringLength = 80;
+    Panel buttonP = new Panel();
+    Button passB = new Button("pass");
+    Button failB = new Button("fail");
+
+    //DO NOT call this directly, go through Sysout
+    public TestDialog(Frame frame, String name) {
+        super(frame, name);
+        int scrollBoth = TextArea.SCROLLBARS_BOTH;
+        instructionsText = new TextArea("", 15, maxStringLength, scrollBoth);
+        add("North", instructionsText);
+
+        messageText = new TextArea("", 5, maxStringLength, scrollBoth);
+        add("Center", messageText);
+
+        passB = new Button("pass");
+        passB.setActionCommand("pass");
+        passB.addActionListener(this);
+        buttonP.add("East", passB);
+
+        failB = new Button("fail");
+        failB.setActionCommand("fail");
+        failB.addActionListener(this);
+        buttonP.add("West", failB);
+
+        add("South", buttonP);
+        pack();
+        setVisible(true);
+    }
+
+    //DO NOT call this directly, go through Sysout
+    public void printInstructions(String[] instructions) {
+        instructionsText.setText("");
+
+        String printStr, remainingStr;
+        for (int i = 0; i < instructions.length; i++) {
+            //chop up each into pieces maxSringLength long
+            remainingStr = instructions[i];
+            while (remainingStr.length() > 0) {
+                //if longer than max then chop off first max chars to print
+                if (remainingStr.length() >= maxStringLength) {
+                    //Try to chop on a word boundary
+                    int posOfSpace = remainingStr.
+                            lastIndexOf(' ', maxStringLength - 1);
+
+                    if (posOfSpace <= 0) posOfSpace = maxStringLength - 1;
+
+                    printStr = remainingStr.substring(0, posOfSpace + 1);
+                    remainingStr = remainingStr.substring(posOfSpace + 1);
+                } else {
+                    printStr = remainingStr;
+                    remainingStr = "";
+                }
+
+                instructionsText.append(printStr + "\n");
+            }
+        }
+    }
+
+    //DO NOT call this directly, go through Sysout
+    public void displayMessage(String messageIn) {
+        messageText.append(messageIn + "\n");
+    }
+
+    /**
+     * Catch presses of the passed and failed buttons. Wimply call the standard pass() or fail()
+     * static methods of XparColor
+     */
+    public void actionPerformed(ActionEvent e) {
+        if (e.getActionCommand() == "pass") {
+            DialogCopies.pass();
+        } else {
+            DialogCopies.fail();
+        }
+    }
+}
+

--- a/test/jdk/java/awt/print/Dialog/DialogCopies.java
+++ b/test/jdk/java/awt/print/Dialog/DialogCopies.java
@@ -41,7 +41,7 @@ public class DialogCopies {
 
                 Press Cancel if your system has only virtual printers such as
                 Microsoft Print to PDF or Microsoft XPS Document Writer since
-                neither allows setting copies to anything but 1.
+                they don't allow setting copies to anything but 1.
 
                 If a real printer is installed, select it from the drop-down
                 list in the Print dialog and increase the number of copies,

--- a/test/jdk/java/awt/print/Dialog/DialogCopies.java
+++ b/test/jdk/java/awt/print/Dialog/DialogCopies.java
@@ -30,7 +30,6 @@
 
 import java.awt.Frame;
 import java.awt.TextArea;
-import java.awt.Panel;
 import java.awt.BorderLayout;
 import java.awt.print.PrinterJob;
 
@@ -38,20 +37,20 @@ public class DialogCopies {
 
     private static Frame createInstructionUI() {
         final String instruction = """
-                This test assumes and requires that you have a printer / PDF printer
-                / XPS writer is installed. If none of them is installed and user sees
-                PrintDialog press Cancel button. If printer/PDF printer / XPS writer
-                is installed & when the Print Dialog appears increment the number of
-                copies then press OK/Print.""";
+                This test requires that you have a printer. In case if the test
+                system has a virtual printers such as Microsoft Print to PDF or
+                Microsoft XPS Document Writer is installed. Press Cancel
+                button since neither Microsoft Print to PDF or Microsoft XPS
+                Document Writer does not allow setting copies to anything but 1.
+                If printer is installed then PrintDialog is visible increase the
+                number of copies and press OK/Cancel button.""";
 
-        Panel mainControlPanel = new Panel(new BorderLayout());
-        TextArea instructionTextArea = new TextArea();
+        TextArea instructionTextArea = new TextArea(instruction);
         instructionTextArea.setText(instruction);
         instructionTextArea.setEditable(false);
 
         Frame instructionFrame = new Frame();
-        mainControlPanel.add(instructionTextArea, BorderLayout.CENTER);
-        instructionFrame.add(mainControlPanel);
+        instructionFrame.add(instructionTextArea, BorderLayout.CENTER);
         instructionFrame.pack();
         instructionFrame.setLocationRelativeTo(null);
         instructionFrame.setVisible(true);
@@ -62,7 +61,7 @@ public class DialogCopies {
         PrinterJob job = PrinterJob.getPrinterJob();
         if (job.getPrintService() == null) {
             System.out.println("Looks like printer is not configured. Please install printer " +
-                    "/ PDF printer, XPS writer and re-run the test case.");
+                    " and re-run the test case.");
             return;
         }
         checkNoOfCopies(job, job.printDialog());
@@ -78,11 +77,7 @@ public class DialogCopies {
                 System.out.println("Total number of copies : " + copies);
             }
         } else {
-            /*
-                Treat pressing Cancel button as pass. This is need in case if printer / PDF printers / XPS writer
-                is not installed
-             */
-            System.out.println("User has selected Cancel button on the PrintDialog");
+            System.out.println("User has selected Cancel button on the PrintDialog.");
         }
     }
 


### PR DESCRIPTION
1) When the test is executed via jtreg user can see only print dialog with no instruction to the user. User has to see the test case to see the instruction and perform the test . 
2) With this fix User is instructed what he/she has to do with the print dialog.
3) I have added both success instruction as well as failure instruction.

@shurymury

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270609](https://bugs.openjdk.java.net/browse/JDK-8270609): [TESTBUG] java/awt/print/Dialog/DialogCopies.java does not show instruction


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4850/head:pull/4850` \
`$ git checkout pull/4850`

Update a local copy of the PR: \
`$ git checkout pull/4850` \
`$ git pull https://git.openjdk.java.net/jdk pull/4850/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4850`

View PR using the GUI difftool: \
`$ git pr show -t 4850`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4850.diff">https://git.openjdk.java.net/jdk/pull/4850.diff</a>

</details>
