### PR TITLE
8271014: Refactor HeapShared::is_archived_object()

### DIFF
--- a/src/hotspot/share/cds/archiveUtils.cpp
+++ b/src/hotspot/share/cds/archiveUtils.cpp
@@ -39,6 +39,7 @@
 #include "oops/compressedOops.inline.hpp"
 #include "runtime/arguments.hpp"
 #include "utilities/bitMap.inline.hpp"
+#include "utilities/formatBuffer.hpp"
 
 CHeapBitMap* ArchivePtrMarker::_ptrmap = NULL;
 VirtualSpace* ArchivePtrMarker::_vs;

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -119,7 +119,7 @@ OopHandle HeapShared::_roots;
 #ifdef ASSERT
 bool HeapShared::is_archived_object_during_dumptime(oop p) {
   assert(HeapShared::is_heap_object_archiving_allowed(), "must be");
-  assert(DumpSharedSpaces, "must be called during dump time only");
+  assert(DumpSharedSpaces, "this function is only used with -Xshare:dump");
   return Universe::heap()->is_archived_object(p);
 }
 #endif

--- a/src/hotspot/share/cds/heapShared.hpp
+++ b/src/hotspot/share/cds/heapShared.hpp
@@ -376,7 +376,7 @@ private:
 
   static void fixup_mapped_regions() NOT_CDS_JAVA_HEAP_RETURN;
 
-  inline static bool is_archived_object(oop p) NOT_CDS_JAVA_HEAP_RETURN_(false);
+  static bool is_archived_object_during_dumptime(oop p) NOT_CDS_JAVA_HEAP_RETURN_(false);
 
   static void resolve_classes(JavaThread* THREAD) NOT_CDS_JAVA_HEAP_RETURN;
   static void initialize_from_archived_subgraph(Klass* k, JavaThread* THREAD) NOT_CDS_JAVA_HEAP_RETURN;

--- a/src/hotspot/share/cds/heapShared.inline.hpp
+++ b/src/hotspot/share/cds/heapShared.inline.hpp
@@ -26,16 +26,10 @@
 #define SHARE_CDS_HEAPSHARED_INLINE_HPP
 
 #include "cds/heapShared.hpp"
-
-#include "gc/shared/collectedHeap.inline.hpp"
 #include "oops/compressedOops.inline.hpp"
 #include "utilities/align.hpp"
 
 #if INCLUDE_CDS_JAVA_HEAP
-
-bool HeapShared::is_archived_object(oop p) {
-  return Universe::heap()->is_archived_object(p);
-}
 
 inline oop HeapShared::decode_from_archive(narrowOop v) {
   assert(!CompressedOops::is_null(v), "narrow oop value can never be zero");

--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -720,7 +720,7 @@ oop StringTable::lookup_shared(const jchar* name, int len) {
 oop StringTable::create_archived_string(oop s) {
   assert(DumpSharedSpaces, "this function is only used with -Xshare:dump");
   assert(java_lang_String::is_instance(s), "sanity");
-  assert(!HeapShared::is_archived_object(s), "sanity");
+  assert(!HeapShared::is_archived_object_during_dumptime(s), "sanity");
 
   oop new_s = NULL;
   typeArrayOop v = java_lang_String::value_no_keepalive(s);

--- a/src/hotspot/share/oops/oop.cpp
+++ b/src/hotspot/share/oops/oop.cpp
@@ -23,9 +23,10 @@
  */
 
 #include "precompiled.hpp"
-#include "cds/heapShared.inline.hpp"
 #include "classfile/altHashing.hpp"
 #include "classfile/javaClasses.inline.hpp"
+#include "gc/shared/collectedHeap.inline.hpp"
+#include "gc/shared/gc_globals.hpp"
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
 #include "oops/access.inline.hpp"
@@ -218,7 +219,7 @@ void oopDesc::release_double_field_put(int offset, jdouble value)     { HeapAcce
 #ifdef ASSERT
 void oopDesc::verify_forwardee(oop forwardee) {
 #if INCLUDE_CDS_JAVA_HEAP
-  assert(!HeapShared::is_archived_object(forwardee) && !HeapShared::is_archived_object(this),
+  assert(!Universe::heap()->is_archived_object(forwardee) && !Universe::heap()->is_archived_object(this),
          "forwarding archive object");
 #endif
 }

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1933,7 +1933,7 @@ WB_END
 
 WB_ENTRY(jboolean, WB_IsShared(JNIEnv* env, jobject wb, jobject obj))
   oop obj_oop = JNIHandles::resolve(obj);
-  return HeapShared::is_archived_object(obj_oop);
+  return Universe::heap()->is_archived_object(obj_oop);
 WB_END
 
 WB_ENTRY(jboolean, WB_IsSharedClass(JNIEnv* env, jobject wb, jclass clazz))


### PR DESCRIPTION
(This PR is in preparation of [JDK-8270489](https://bugs.openjdk.java.net/browse/JDK-8270489) - Support archived heap objects in EpsilonGC)

We have the following function that's used ONLY in asserts and WhiteBox tests.

```
bool HeapShared::is_archived_object(oop p) {
  return Universe::heap()->is_archived_object(p);
}
```

This function is used for two completely different purposes:

[1] During dump time, is `p` an object that's about to be written into the archived heap?
[2] During runtime, is `p` an object in an archive region?

To support archived objects in other types of GCs that do not support archive regions, we should refactor this code to distinguish between the two use cases. This will make the code easier to understand.

=========

[0] Remove HeapShared::is_archived_object()
[1] -> add new function `HeapShared::is_archived_object_during_dumptime()`
[2] -> rewrite the code to call `Universe::heap()->is_archived_object(p)` instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271014](https://bugs.openjdk.java.net/browse/JDK-8271014): Refactor HeapShared::is_archived_object()


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**) ⚠️ Review applies to a03a7ab306d60f3fdd22542eaa5a1030119225fc


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4855/head:pull/4855` \
`$ git checkout pull/4855`

Update a local copy of the PR: \
`$ git checkout pull/4855` \
`$ git pull https://git.openjdk.java.net/jdk pull/4855/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4855`

View PR using the GUI difftool: \
`$ git pr show -t 4855`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4855.diff">https://git.openjdk.java.net/jdk/pull/4855.diff</a>

</details>
