### PR TITLE
8270991: G1 Full GC always performs heap verification after JDK-8269295 

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1028,6 +1028,9 @@ void G1CollectedHeap::prepare_heap_for_full_collection() {
 void G1CollectedHeap::verify_before_full_collection(bool explicit_gc) {
   assert(!GCCause::is_user_requested_gc(gc_cause()) || explicit_gc, "invariant");
   assert_used_and_recalculate_used_equal(this);
+  if (!VerifyBeforeGC) {
+    return;
+  }
   _verifier->verify_region_sets_optional();
   _verifier->verify_before_gc(G1HeapVerifier::G1VerifyFull);
   _verifier->check_bitmaps("Full GC Start");
@@ -1073,6 +1076,9 @@ void G1CollectedHeap::abort_refinement() {
 }
 
 void G1CollectedHeap::verify_after_full_collection() {
+  if (!VerifyAfterGC) {
+    return;
+  }
   _hrm.verify_optional();
   _verifier->verify_region_sets_optional();
   _verifier->verify_after_gc(G1HeapVerifier::G1VerifyFull);

--- a/test/hotspot/jtreg/gc/arguments/TestVerifyBeforeAndAfterGCFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestVerifyBeforeAndAfterGCFlags.java
@@ -30,7 +30,6 @@ package gc.arguments;
          combinations of -XX:{+|-}Verify{After|Before}GC flags and checks that
          output contain or doesn't contain expected patterns
  * @requires vm.gc != "Z" & vm.gc != "Shenandoah"
-
  * @modules java.base/jdk.internal.misc
  * @modules java.management
  * @library /test/lib
@@ -91,7 +90,7 @@ public class TestVerifyBeforeAndAfterGCFlags {
         Collections.addAll(vmOpts, new String[] {
                                        "-Xbootclasspath/a:.",
                                        "-XX:+UnlockDiagnosticVMOptions",
-                                      "-XX:+WhiteBoxAPI",
+                                       "-XX:+WhiteBoxAPI",
                                        "-Xlog:gc+verify=debug",
                                        "-Xmx5m",
                                        "-Xms5m",

--- a/test/hotspot/jtreg/gc/arguments/TestVerifyBeforeAndAfterGCFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestVerifyBeforeAndAfterGCFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,10 +30,13 @@ package gc.arguments;
          combinations of -XX:{+|-}Verify{After|Before}GC flags and checks that
          output contain or doesn't contain expected patterns
  * @requires vm.gc != "Z" & vm.gc != "Shenandoah"
+
  * @modules java.base/jdk.internal.misc
  * @modules java.management
  * @library /test/lib
  * @library /
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run driver gc.arguments.TestVerifyBeforeAndAfterGCFlags
  */
 
@@ -43,6 +46,8 @@ import java.util.Collections;
 import jdk.test.lib.Utils;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
+
+import sun.hotspot.WhiteBox;
 
 public class TestVerifyBeforeAndAfterGCFlags {
 
@@ -63,30 +68,40 @@ public class TestVerifyBeforeAndAfterGCFlags {
                                                    "-XX:-DisplayVMOutput",
                                                    "VerifyBeforeGC",
                                                    "VerifyAfterGC" });
-        testVerifyFlags(false, false, filteredOpts);
-        testVerifyFlags(true,  true,  filteredOpts);
-        testVerifyFlags(true,  false, filteredOpts);
-        testVerifyFlags(false, true,  filteredOpts);
+        // Young GC
+        testVerifyFlags(false, false, false, filteredOpts);
+        testVerifyFlags(true,  true,  false, filteredOpts);
+        testVerifyFlags(true,  false, false, filteredOpts);
+        testVerifyFlags(false, true,  false, filteredOpts);
+        // Full GC
+        testVerifyFlags(false, false, true, filteredOpts);
+        testVerifyFlags(true,  true,  true, filteredOpts);
+        testVerifyFlags(true,  false, true, filteredOpts);
+        testVerifyFlags(false, true,  true, filteredOpts);
     }
 
     public static void testVerifyFlags(boolean verifyBeforeGC,
                                        boolean verifyAfterGC,
+                                       boolean doFullGC,
                                        String[] opts) throws Exception {
         ArrayList<String> vmOpts = new ArrayList<>();
         if (opts != null && (opts.length > 0)) {
             Collections.addAll(vmOpts, opts);
         }
         Collections.addAll(vmOpts, new String[] {
+                                       "-Xbootclasspath/a:.",
+                                       "-XX:+UnlockDiagnosticVMOptions",
+                                      "-XX:+WhiteBoxAPI",
                                        "-Xlog:gc+verify=debug",
                                        "-Xmx5m",
                                        "-Xms5m",
                                        "-Xmn3m",
-                                       "-XX:+UnlockDiagnosticVMOptions",
                                        (verifyBeforeGC ? "-XX:+VerifyBeforeGC"
                                                        : "-XX:-VerifyBeforeGC"),
                                        (verifyAfterGC ? "-XX:+VerifyAfterGC"
                                                       : "-XX:-VerifyAfterGC"),
-                                       GarbageProducer.class.getName() });
+                                       GarbageProducer.class.getName(),
+                                       doFullGC ? "t" : "f" });
         ProcessBuilder pb = GCArguments.createJavaProcessBuilder(vmOpts);
         OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
 
@@ -111,10 +126,12 @@ public class TestVerifyBeforeAndAfterGCFlags {
         static long[][] garbage = new long[10][];
 
         public static void main(String args[]) {
-            int j = 0;
-            for(int i = 0; i<1000; i++) {
-                garbage[j] = new long[10000];
-                j = (j+1)%garbage.length;
+            WhiteBox wb = WhiteBox.getWhiteBox();
+
+            if (args[0].equals("t")) {
+                wb.fullGC();
+            } else {
+                wb.youngGC();
             }
         }
     }


### PR DESCRIPTION
Hi all,

  can I have reviews for this fix that removes always-on heap verification for g1 full gcs caused by any reason?

JDK-8269295 refactored some code in that area, and existing tests only checked that verification is properly enabled or disabled for young gc only.

This change fixes the problem and improves the existing test accordingly.

Testing: new test case

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270991](https://bugs.openjdk.java.net/browse/JDK-8270991): G1 Full GC always performs heap verification after JDK-8269295


### Reviewers
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4856/head:pull/4856` \
`$ git checkout pull/4856`

Update a local copy of the PR: \
`$ git checkout pull/4856` \
`$ git pull https://git.openjdk.java.net/jdk pull/4856/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4856`

View PR using the GUI difftool: \
`$ git pr show -t 4856`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4856.diff">https://git.openjdk.java.net/jdk/pull/4856.diff</a>

</details>
