### PR TITLE
8270912: Clean up G1CollectedHeap::process_discovered_references()

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3278,8 +3278,8 @@ public:
     pss->set_ref_discoverer(nullptr);
 
     G1STWIsAliveClosure is_alive(&_g1h);
-    G1CopyingKeepAliveClosure keep_alive(&_g1h, _pss.state_for_worker(index));
-    G1ParEvacuateFollowersClosure complete_gc(&_g1h, _pss.state_for_worker(index), &_task_queues, _tm == RefProcThreadModel::Single ? nullptr : &_terminator, G1GCPhaseTimes::ObjCopy);
+    G1CopyingKeepAliveClosure keep_alive(&_g1h, pss);
+    G1ParEvacuateFollowersClosure complete_gc(&_g1h, pss, &_task_queues, _tm == RefProcThreadModel::Single ? nullptr : &_terminator, G1GCPhaseTimes::ObjCopy);
     _rp_task->rp_work(worker_id, &is_alive, &keep_alive, &complete_gc);
 
     // We have completed copying any necessary live referent objects.

--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -569,6 +569,7 @@ void ReferenceProcessor::log_reflist_counts(DiscoveredList ref_lists[], uint num
 #endif
 
 void ReferenceProcessor::set_active_mt_degree(uint v) {
+  assert(v <= max_num_queues(), "Mt degree %u too high, maximum %u", v,  max_num_queues());
   _num_queues = v;
   _next_id = 0;
 }


### PR DESCRIPTION
Hi all,

  can I have reviews for this cleanup of `G1CollectedHeap::process_discovered_references()`, cleaning out obsolete or duplicate code and moving asserts?

Testing: tier1-5

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270912](https://bugs.openjdk.java.net/browse/JDK-8270912): Clean up G1CollectedHeap::process_discovered_references()


### Reviewers
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer) ⚠️ Review applies to 97b1e81af0afd073478524ffb3cbbae9ccd326c1
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to 97b1e81af0afd073478524ffb3cbbae9ccd326c1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4857/head:pull/4857` \
`$ git checkout pull/4857`

Update a local copy of the PR: \
`$ git checkout pull/4857` \
`$ git pull https://git.openjdk.java.net/jdk pull/4857/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4857`

View PR using the GUI difftool: \
`$ git pr show -t 4857`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4857.diff">https://git.openjdk.java.net/jdk/pull/4857.diff</a>

</details>
