### PR TITLE
8271063: Print injected fields for InstanceKlass

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -1662,7 +1662,6 @@ void InstanceKlass::print_nonstatic_fields(FieldClosure* cl) {
   for (AllFieldStream fs(this); !fs.done(); fs.next()) {
     if (!fs.access_flags().is_static()) {
       fd = fs.field_descriptor();
-      // tty->print_cr(" %d %d %s", fd.offset(), fs.offset(), fd.name()->as_C_string());
       F f(fs.offset(), fs.index());
       fields_sorted.push(f);
       i++;

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -1623,11 +1623,6 @@ void InstanceKlass::do_local_static_fields(void f(fieldDescriptor*, Handle, TRAP
   }
 }
 
-
-static int compare_fields_by_offset(int* a, int* b) {
-  return a[0] - b[0];
-}
-
 void InstanceKlass::do_nonstatic_fields(FieldClosure* cl) {
   InstanceKlass* super = superklass();
   if (super != NULL) {
@@ -1635,30 +1630,56 @@ void InstanceKlass::do_nonstatic_fields(FieldClosure* cl) {
   }
   fieldDescriptor fd;
   int length = java_fields_count();
-  // In DebugInfo nonstatic fields are sorted by offset.
-  int* fields_sorted = NEW_C_HEAP_ARRAY(int, 2*(length+1), mtClass);
-  int j = 0;
   for (int i = 0; i < length; i += 1) {
     fd.reinitialize(this, i);
     if (!fd.is_static()) {
-      fields_sorted[j + 0] = fd.offset();
-      fields_sorted[j + 1] = i;
-      j += 2;
-    }
-  }
-  if (j > 0) {
-    length = j;
-    // _sort_Fn is defined in growableArray.hpp.
-    qsort(fields_sorted, length/2, 2*sizeof(int), (_sort_Fn)compare_fields_by_offset);
-    for (int i = 0; i < length; i += 2) {
-      fd.reinitialize(this, fields_sorted[i + 1]);
-      assert(!fd.is_static() && fd.offset() == fields_sorted[i], "only nonstatic fields");
       cl->do_field(&fd);
     }
   }
-  FREE_C_HEAP_ARRAY(int, fields_sorted);
 }
 
+struct F {
+  int _off;
+  int _pos;
+  F(int off, int pos) : _off(off), _pos(pos) {}
+  F() : _off(0), _pos(0) {}
+};
+
+static int compare_fields_by_offset(F* a, F* b) {
+  return a->_off - b->_off;
+}
+
+void InstanceKlass::print_nonstatic_fields(FieldClosure* cl) {
+  InstanceKlass* super = superklass();
+  if (super != NULL) {
+    super->print_nonstatic_fields(cl);
+  }
+  ResourceMark rm;
+  fieldDescriptor fd;
+  // In DebugInfo nonstatic fields are sorted by offset.
+  GrowableArray<F> fields_sorted;
+  int i = 0;
+  for (AllFieldStream fs(this); !fs.done(); fs.next()) {
+    if (!fs.access_flags().is_static()) {
+      fd = fs.field_descriptor();
+      // tty->print_cr(" %d %d %s", fd.offset(), fs.offset(), fd.name()->as_C_string());
+      F f(fs.offset(), fs.index());
+      fields_sorted.push(f);
+      i++;
+    }
+  }
+  if (i > 0) {
+    int length = i;
+    assert(length == fields_sorted.length(), "duh");
+    // _sort_Fn is defined in growableArray.hpp.
+    fields_sorted.sort(compare_fields_by_offset);
+    for (int i = 0; i < length; i++) {
+      fd.reinitialize(this, fields_sorted.at(i)._pos);
+      assert(!fd.is_static() && fd.offset() == fields_sorted.at(i)._off, "only nonstatic fields");
+      cl->do_field(&fd);
+    }
+  }
+}
 
 void InstanceKlass::array_klasses_do(void f(Klass* k, TRAPS), TRAPS) {
   if (array_klasses() != NULL)
@@ -3437,7 +3458,7 @@ void InstanceKlass::print_on(outputStream* st) const {
   st->print_cr(BULLET"---- non-static fields (%d words):", nonstatic_field_size());
   FieldPrinter print_nonstatic_field(st);
   InstanceKlass* ik = const_cast<InstanceKlass*>(this);
-  ik->do_nonstatic_fields(&print_nonstatic_field);
+  ik->print_nonstatic_fields(&print_nonstatic_field);
 
   st->print(BULLET"non-static oop maps: ");
   OopMapBlock* map     = start_of_nonstatic_oop_maps();
@@ -3479,30 +3500,20 @@ void InstanceKlass::oop_print_on(oop obj, outputStream* st) {
       st->print(BULLET"string: ");
       java_lang_String::print(obj, st);
       st->cr();
-      if (!WizardMode)  return;  // that is enough
     }
   }
 
   st->print_cr(BULLET"---- fields (total size %d words):", oop_size(obj));
   FieldPrinter print_field(st, obj);
-  do_nonstatic_fields(&print_field);
+  print_nonstatic_fields(&print_field);
 
   if (this == vmClasses::Class_klass()) {
     st->print(BULLET"signature: ");
     java_lang_Class::print_signature(obj, st);
     st->cr();
-    Klass* mirrored_klass = java_lang_Class::as_Klass(obj);
-    st->print(BULLET"fake entry for mirror: ");
-    Metadata::print_value_on_maybe_null(st, mirrored_klass);
-    st->cr();
-    Klass* array_klass = java_lang_Class::array_klass_acquire(obj);
-    st->print(BULLET"fake entry for array: ");
-    Metadata::print_value_on_maybe_null(st, array_klass);
-    st->cr();
-    st->print_cr(BULLET"fake entry for oop_size: %d", java_lang_Class::oop_size(obj));
-    st->print_cr(BULLET"fake entry for static_oop_field_count: %d", java_lang_Class::static_oop_field_count(obj));
     Klass* real_klass = java_lang_Class::as_Klass(obj);
     if (real_klass != NULL && real_klass->is_instance_klass()) {
+      st->print_cr(BULLET"---- static fields (%d words):", java_lang_Class::static_oop_field_count(obj));
       InstanceKlass::cast(real_klass)->do_local_static_fields(&print_field);
     }
   } else if (this == vmClasses::MethodType_klass()) {

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -1007,6 +1007,7 @@ public:
   void do_local_static_fields(FieldClosure* cl);
   void do_nonstatic_fields(FieldClosure* cl); // including inherited fields
   void do_local_static_fields(void f(fieldDescriptor*, Handle, TRAPS), Handle, TRAPS);
+  void print_nonstatic_fields(FieldClosure* cl); // including inherited and injected fields
 
   void methods_do(void f(Method* method));
   void array_klasses_do(void f(Klass* k));

--- a/src/hotspot/share/runtime/fieldDescriptor.cpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.cpp
@@ -110,8 +110,6 @@ void fieldDescriptor::reinitialize(InstanceKlass* ik, int index) {
     assert(field_holder() == ik, "must be already initialized to this class");
   }
   FieldInfo* f = ik->field(index);
-  assert(!f->is_internal(), "regular Java fields only");
-
   _access_flags = accessFlags_from(f->access_flags());
   guarantee(f->name_index() != 0 && f->signature_index() != 0, "bad constant pool index for fieldDescriptor");
   _index = index;
@@ -125,7 +123,8 @@ void fieldDescriptor::verify() const {
     assert(_index == badInt, "constructor must be called");  // see constructor
   } else {
     assert(_index >= 0, "good index");
-    assert(_index < field_holder()->java_fields_count(), "oob");
+    assert(access_flags().is_internal() ||
+           _index < field_holder()->java_fields_count(), "oob");
   }
 }
 
@@ -133,6 +132,7 @@ void fieldDescriptor::verify() const {
 
 void fieldDescriptor::print_on(outputStream* st) const {
   access_flags().print_on(st);
+  if (access_flags().is_internal()) st->print("internal ");
   name()->print_value_on(st);
   st->print(" ");
   signature()->print_value_on(st);

--- a/test/hotspot/gtest/oops/test_instanceKlass.cpp
+++ b/test/hotspot/gtest/oops/test_instanceKlass.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "precompiled.hpp"
+#include "classfile/systemDictionary.hpp"
 #include "classfile/vmClasses.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/instanceKlass.hpp"
@@ -36,4 +37,24 @@ TEST_VM(InstanceKlass, class_loader_class) {
 TEST_VM(InstanceKlass, string_klass) {
   InstanceKlass* klass = vmClasses::String_klass();
   ASSERT_TRUE(!klass->is_class_loader_instance_klass());
+}
+
+TEST_VM(InstanceKlass, class_loader_printer) {
+  ResourceMark rm;
+  oop loader = SystemDictionary::java_platform_loader();
+  stringStream st;
+  loader->print_on(&st);
+  // See if injected loader_data field is printed in string
+  ASSERT_TRUE(strstr(st.as_string(), "internal 'loader_data'") != NULL) << "Must contain internal fields";
+  st.reset();
+  // See if mirror injected fields are printed.
+  oop mirror = vmClasses::ClassLoader_klass()->java_mirror();
+  mirror->print_on(&st);
+  ASSERT_TRUE(strstr(st.as_string(), "internal 'protection_domain'") != NULL) << "Must contain internal fields";
+  // We should test other printing functions too.
+  st.reset();
+  Method* method = vmClasses::ClassLoader_klass()->methods()->at(0);  // we know there's a method here!
+  method->print_on(&st);
+  ASSERT_TRUE(strstr(st.as_string(), "method holder:") != NULL) << "Must contain method_holder field";
+  ASSERT_TRUE(strstr(st.as_string(), "'java/lang/ClassLoader'") != NULL) << "Must be in ClassLoader";
 }

--- a/test/hotspot/gtest/oops/test_instanceKlass.cpp
+++ b/test/hotspot/gtest/oops/test_instanceKlass.cpp
@@ -26,6 +26,7 @@
 #include "classfile/vmClasses.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/instanceKlass.hpp"
+#include "oops/klass.inline.hpp"
 #include "unittest.hpp"
 
 // Tests for InstanceKlass::is_class_loader_instance_klass() function


### PR DESCRIPTION
I added code to print the injected fields in InstanceKlass.  I also removed field offset sorting for do_nonstatic_fields because it's not necessary when used for purposes other than printing the fields.  I also added a gtest.
Tested with tier1 all Oracle platforms, tier2-3 on linux-x64-debug, windows-x64-debug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271063](https://bugs.openjdk.java.net/browse/JDK-8271063): Print injected fields for InstanceKlass


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer) ⚠️ Review applies to 7f8e7421440baf3223194486e8d6a91931f81c30
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**) ⚠️ Review applies to 7f8e7421440baf3223194486e8d6a91931f81c30
 * [Yi Yang](https://openjdk.java.net/census#yyang) (@kelthuzadx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4858/head:pull/4858` \
`$ git checkout pull/4858`

Update a local copy of the PR: \
`$ git checkout pull/4858` \
`$ git pull https://git.openjdk.java.net/jdk pull/4858/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4858`

View PR using the GUI difftool: \
`$ git pr show -t 4858`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4858.diff">https://git.openjdk.java.net/jdk/pull/4858.diff</a>

</details>
