### PR TITLE
8271043: Rename G1CollectedHeap::g1mm() 

### DIFF
--- a/src/hotspot/share/gc/g1/g1Allocator.cpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.cpp
@@ -429,7 +429,7 @@ bool G1ArchiveAllocator::alloc_new_region() {
   _max = _bottom + HeapRegion::min_region_size_in_words();
 
   // Since we've modified the old set, call update_sizes.
-  _g1h->g1mm()->update_sizes();
+  _g1h->monitoring_support()->update_sizes();
   return true;
 }
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -347,7 +347,7 @@ HeapWord* G1CollectedHeap::humongous_obj_allocate(size_t word_size) {
     // A successful humongous object allocation changes the used space
     // information of the old generation so we need to recalculate the
     // sizes and update the jstat counters here.
-    g1mm()->update_sizes();
+    monitoring_support()->update_sizes();
   }
 
   _verifier->verify_region_sets_optional();
@@ -1450,7 +1450,7 @@ G1CollectedHeap::G1CollectedHeap() :
   _survivor_evac_stats("Young", YoungPLABSize, PLABWeight),
   _old_evac_stats("Old", OldPLABSize, PLABWeight),
   _expand_heap_after_alloc_failure(true),
-  _g1mm(NULL),
+  _monitoring_support(nullptr),
   _humongous_reclaim_candidates(),
   _num_humongous_objects(0),
   _num_humongous_reclaim_candidates(0),
@@ -1763,7 +1763,7 @@ jint G1CollectedHeap::initialize() {
 
   // Do create of the monitoring and management support so that
   // values in the heap have been properly initialized.
-  _g1mm = new G1MonitoringSupport(this);
+  _monitoring_support = new G1MonitoringSupport(this);
 
   _preserved_marks_set.init(ParallelGCThreads);
 
@@ -3073,7 +3073,7 @@ void G1CollectedHeap::do_collection_pause_at_safepoint_helper(double target_paus
     // JFR
     G1YoungGCJFRTracerMark jtm(_gc_timer_stw, _gc_tracer_stw, gc_cause());
     // JStat/MXBeans
-    G1MonitoringScope ms(g1mm(),
+    G1MonitoringScope ms(monitoring_support(),
                          false /* full_gc */,
                          collector_state()->in_mixed_phase() /* all_memory_pools_affected */);
 
@@ -4171,7 +4171,7 @@ void G1CollectedHeap::retire_mutator_alloc_region(HeapRegion* alloc_region,
   // We update the eden sizes here, when the region is retired,
   // instead of when it's allocated, since this is the point that its
   // used space has been recorded in _summary_bytes_used.
-  g1mm()->update_eden_size();
+  monitoring_support()->update_eden_size();
 }
 
 // Methods for the GC alloc regions
@@ -4371,17 +4371,17 @@ void G1CollectedHeap::rebuild_strong_code_roots() {
 }
 
 void G1CollectedHeap::initialize_serviceability() {
-  _g1mm->initialize_serviceability();
+  _monitoring_support->initialize_serviceability();
 }
 
 MemoryUsage G1CollectedHeap::memory_usage() {
-  return _g1mm->memory_usage();
+  return _monitoring_support->memory_usage();
 }
 
 GrowableArray<GCMemoryManager*> G1CollectedHeap::memory_managers() {
-  return _g1mm->memory_managers();
+  return _monitoring_support->memory_managers();
 }
 
 GrowableArray<MemoryPool*> G1CollectedHeap::memory_pools() {
-  return _g1mm->memory_pools();
+  return _monitoring_support->memory_pools();
 }

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -248,7 +248,7 @@ private:
   bool _expand_heap_after_alloc_failure;
 
   // Helper for monitoring and management support.
-  G1MonitoringSupport* _g1mm;
+  G1MonitoringSupport* _monitoring_support;
 
   // Records whether the region at the given index is (still) a
   // candidate for eager reclaim.  Only valid for humongous start
@@ -577,9 +577,9 @@ public:
     return _verifier;
   }
 
-  G1MonitoringSupport* g1mm() {
-    assert(_g1mm != NULL, "should have been initialized");
-    return _g1mm;
+  G1MonitoringSupport* monitoring_support() {
+    assert(_monitoring_support != nullptr, "should have been initialized");
+    return _monitoring_support;
   }
 
   void resize_heap_if_necessary();

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1309,7 +1309,7 @@ void G1ConcurrentMark::compute_new_sizes() {
 
   // We reclaimed old regions so we should calculate the sizes to make
   // sure we update the old gen/space data.
-  _g1h->g1mm()->update_sizes();
+  _g1h->monitoring_support()->update_sizes();
 }
 
 void G1ConcurrentMark::cleanup() {

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -113,7 +113,7 @@ G1FullCollector::G1FullCollector(G1CollectedHeap* heap,
                                  bool clear_soft_refs,
                                  bool do_maximum_compaction) :
     _heap(heap),
-    _scope(heap->g1mm(), explicit_gc, clear_soft_refs, do_maximum_compaction),
+    _scope(heap->monitoring_support(), explicit_gc, clear_soft_refs, do_maximum_compaction),
     _num_workers(calc_active_workers()),
     _oop_queue_set(_num_workers),
     _array_queue_set(_num_workers),

--- a/src/hotspot/share/gc/g1/g1MemoryPool.cpp
+++ b/src/hotspot/share/gc/g1/g1MemoryPool.cpp
@@ -36,7 +36,7 @@ G1MemoryPoolSuper::G1MemoryPoolSuper(G1CollectedHeap* g1h,
                       init_size,
                       max_size,
                       support_usage_threshold),
-  _g1mm(g1h->g1mm()) {
+  _g1mm(g1h->monitoring_support()) {
   assert(UseG1GC, "sanity");
 }
 

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
@@ -33,23 +33,24 @@
 
 class G1GenerationCounters : public GenerationCounters {
 protected:
-  G1MonitoringSupport* _g1mm;
+  G1MonitoringSupport* _monitoring_support;
 
 public:
-  G1GenerationCounters(G1MonitoringSupport* g1mm,
+  G1GenerationCounters(G1MonitoringSupport* monitoring_support,
                        const char* name, int ordinal, int spaces,
                        size_t min_capacity, size_t max_capacity,
                        size_t curr_capacity)
   : GenerationCounters(name, ordinal, spaces, min_capacity,
-                       max_capacity, curr_capacity), _g1mm(g1mm) { }
+                       max_capacity, curr_capacity),
+    _monitoring_support(monitoring_support) { }
 };
 
 class G1YoungGenerationCounters : public G1GenerationCounters {
 public:
   // We pad the capacity three times given that the young generation
   // contains three spaces (eden and two survivors).
-  G1YoungGenerationCounters(G1MonitoringSupport* g1mm, const char* name, size_t max_size)
-  : G1GenerationCounters(g1mm, name, 0 /* ordinal */, 3 /* spaces */,
+  G1YoungGenerationCounters(G1MonitoringSupport* monitoring_support, const char* name, size_t max_size)
+  : G1GenerationCounters(monitoring_support, name, 0 /* ordinal */, 3 /* spaces */,
                          G1MonitoringSupport::pad_capacity(0, 3) /* min_capacity */,
                          G1MonitoringSupport::pad_capacity(max_size, 3),
                          G1MonitoringSupport::pad_capacity(0, 3) /* curr_capacity */) {
@@ -60,15 +61,15 @@ public:
 
   virtual void update_all() {
     size_t committed =
-              G1MonitoringSupport::pad_capacity(_g1mm->young_gen_committed(), 3);
+              G1MonitoringSupport::pad_capacity(_monitoring_support->young_gen_committed(), 3);
     _current_size->set_value(committed);
   }
 };
 
 class G1OldGenerationCounters : public G1GenerationCounters {
 public:
-  G1OldGenerationCounters(G1MonitoringSupport* g1mm, const char* name, size_t max_size)
-  : G1GenerationCounters(g1mm, name, 1 /* ordinal */, 1 /* spaces */,
+  G1OldGenerationCounters(G1MonitoringSupport* monitoring_support, const char* name, size_t max_size)
+  : G1GenerationCounters(monitoring_support, name, 1 /* ordinal */, 1 /* spaces */,
                          G1MonitoringSupport::pad_capacity(0) /* min_capacity */,
                          G1MonitoringSupport::pad_capacity(max_size),
                          G1MonitoringSupport::pad_capacity(0) /* curr_capacity */) {
@@ -79,7 +80,7 @@ public:
 
   virtual void update_all() {
     size_t committed =
-              G1MonitoringSupport::pad_capacity(_g1mm->old_gen_committed());
+              G1MonitoringSupport::pad_capacity(_monitoring_support->old_gen_committed());
     _current_size->set_value(committed);
   }
 };
@@ -342,15 +343,15 @@ MemoryUsage G1MonitoringSupport::old_gen_memory_usage(size_t initial_size, size_
                      max_size);
 }
 
-G1MonitoringScope::G1MonitoringScope(G1MonitoringSupport* g1mm, bool full_gc, bool all_memory_pools_affected) :
-  _g1mm(g1mm),
-  _tcs(full_gc ? g1mm->_full_collection_counters : g1mm->_incremental_collection_counters),
-  _tms(full_gc ? &g1mm->_full_gc_memory_manager : &g1mm->_incremental_memory_manager,
+G1MonitoringScope::G1MonitoringScope(G1MonitoringSupport* monitoring_support, bool full_gc, bool all_memory_pools_affected) :
+  _monitoring_support(monitoring_support),
+  _tcs(full_gc ? monitoring_support->_full_collection_counters : monitoring_support->_incremental_collection_counters),
+  _tms(full_gc ? &monitoring_support->_full_gc_memory_manager : &monitoring_support->_incremental_memory_manager,
        G1CollectedHeap::heap()->gc_cause(), all_memory_pools_affected) {
 }
 
 G1MonitoringScope::~G1MonitoringScope() {
-  _g1mm->update_sizes();
+  _monitoring_support->update_sizes();
   // Needs to be called after updating pool sizes.
   MemoryService::track_memory_usage();
 }

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
@@ -238,11 +238,11 @@ public:
 
 // Scope object for java.lang.management support.
 class G1MonitoringScope : public StackObj {
-  G1MonitoringSupport* _g1mm;
+  G1MonitoringSupport* _monitoring_support;
   TraceCollectorStats _tcs;
   TraceMemoryManagerStats _tms;
 public:
-  G1MonitoringScope(G1MonitoringSupport* g1mm, bool full_gc, bool all_memory_pools_affected);
+  G1MonitoringScope(G1MonitoringSupport* monitoring_support, bool full_gc, bool all_memory_pools_affected);
   ~G1MonitoringScope();
 };
 

--- a/src/hotspot/share/gc/g1/g1VMOperations.cpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.cpp
@@ -170,7 +170,7 @@ void VM_G1Concurrent::doit() {
   GCTraceTimePauseTimer       timer(_message, g1h->concurrent_mark()->gc_timer_cm());
   GCTraceTimeDriver           t(&logger, &timer);
 
-  TraceCollectorStats tcs(g1h->g1mm()->conc_collection_counters());
+  TraceCollectorStats tcs(g1h->monitoring_support()->conc_collection_counters());
   SvcGCMarker sgcm(SvcGCMarker::CONCURRENT);
   IsGCActiveMark x;
   _cl->do_void();

--- a/src/hotspot/share/gc/g1/vmStructs_g1.hpp
+++ b/src/hotspot/share/gc/g1/vmStructs_g1.hpp
@@ -56,7 +56,7 @@
                                                                               \
   volatile_nonstatic_field(G1CollectedHeap, _summary_bytes_used, size_t)      \
   nonstatic_field(G1CollectedHeap, _hrm,                HeapRegionManager)    \
-  nonstatic_field(G1CollectedHeap, _g1mm,               G1MonitoringSupport*) \
+  nonstatic_field(G1CollectedHeap, _monitoring_support, G1MonitoringSupport*) \
   nonstatic_field(G1CollectedHeap, _old_set,            HeapRegionSetBase)    \
   nonstatic_field(G1CollectedHeap, _archive_set,        HeapRegionSetBase)    \
   nonstatic_field(G1CollectedHeap, _humongous_set,      HeapRegionSetBase)    \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/g1/G1CollectedHeap.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/g1/G1CollectedHeap.java
@@ -53,8 +53,8 @@ public class G1CollectedHeap extends CollectedHeap {
     static private long g1ReservedFieldOffset;
     // size_t _summary_bytes_used;
     static private CIntegerField summaryBytesUsedField;
-    // G1MonitoringSupport* _g1mm;
-    static private AddressField g1mmField;
+    // G1MonitoringSupport* _monitoring_support;
+    static private AddressField monitoringSupportField;
     // HeapRegionSet _old_set;
     static private long oldSetFieldOffset;
     // HeapRegionSet _archive_set;
@@ -75,7 +75,7 @@ public class G1CollectedHeap extends CollectedHeap {
 
         hrmFieldOffset = type.getField("_hrm").getOffset();
         summaryBytesUsedField = type.getCIntegerField("_summary_bytes_used");
-        g1mmField = type.getAddressField("_g1mm");
+        monitoringSupportField = type.getAddressField("_monitoring_support");
         oldSetFieldOffset = type.getField("_old_set").getOffset();
         archiveSetFieldOffset = type.getField("_archive_set").getOffset();
         humongousSetFieldOffset = type.getField("_humongous_set").getOffset();
@@ -99,9 +99,9 @@ public class G1CollectedHeap extends CollectedHeap {
                                                              hrmAddr);
     }
 
-    public G1MonitoringSupport g1mm() {
-        Address g1mmAddr = g1mmField.getValue(addr);
-        return (G1MonitoringSupport) VMObjectFactory.newObject(G1MonitoringSupport.class, g1mmAddr);
+    public G1MonitoringSupport monitoringSupport() {
+        Address monitoringSupportAddr = monitoringSupportField.getValue(addr);
+        return (G1MonitoringSupport) VMObjectFactory.newObject(G1MonitoringSupport.class, monitoringSupportAddr);
     }
 
     public HeapRegionSetBase oldSet() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/HeapSummary.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/HeapSummary.java
@@ -244,9 +244,9 @@ public class HeapSummary extends Tool {
    }
 
    public void printG1HeapSummary(PrintStream tty, G1CollectedHeap g1h) {
-      G1MonitoringSupport g1mm = g1h.g1mm();
-      long edenSpaceRegionNum = g1mm.edenSpaceRegionNum();
-      long survivorSpaceRegionNum = g1mm.survivorSpaceRegionNum();
+      G1MonitoringSupport monitoringSupport = g1h.monitoringSupport();
+      long edenSpaceRegionNum = monitoringSupport.edenSpaceRegionNum();
+      long survivorSpaceRegionNum = monitoringSupport.survivorSpaceRegionNum();
       HeapRegionSetBase oldSet = g1h.oldSet();
       HeapRegionSetBase archiveSet = g1h.archiveSet();
       HeapRegionSetBase humongousSet = g1h.humongousSet();
@@ -255,11 +255,11 @@ public class HeapSummary extends Tool {
                    g1h.used(), g1h.capacity());
       tty.println("G1 Young Generation:");
       printG1Space(tty, "Eden Space:", edenSpaceRegionNum,
-                   g1mm.edenSpaceUsed(), g1mm.edenSpaceCommitted());
+                   monitoringSupport.edenSpaceUsed(), monitoringSupport.edenSpaceCommitted());
       printG1Space(tty, "Survivor Space:", survivorSpaceRegionNum,
-                   g1mm.survivorSpaceUsed(), g1mm.survivorSpaceCommitted());
+                   monitoringSupport.survivorSpaceUsed(), monitoringSupport.survivorSpaceCommitted());
       printG1Space(tty, "G1 Old Generation:", oldGenRegionNum,
-                   g1mm.oldGenUsed(), g1mm.oldGenCommitted());
+                   monitoringSupport.oldGenUsed(), monitoringSupport.oldGenCommitted());
    }
 
    private void printG1Space(PrintStream tty, String spaceName, long regionNum,


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that renames the somewhat cryptic name `g1mm` with `monitoring_support` which sounds much better to me.
Feel free to suggest a better name or if you think it's not worth I can also just drop this change.

Testing: tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271043](https://bugs.openjdk.java.net/browse/JDK-8271043): Rename G1CollectedHeap::g1mm()


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4859/head:pull/4859` \
`$ git checkout pull/4859`

Update a local copy of the PR: \
`$ git checkout pull/4859` \
`$ git pull https://git.openjdk.java.net/jdk pull/4859/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4859`

View PR using the GUI difftool: \
`$ git pr show -t 4859`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4859.diff">https://git.openjdk.java.net/jdk/pull/4859.diff</a>

</details>
