### PR TITLE
8268019: C2: assert(no_dead_loop) failed: dead loop detected

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/TestDeadLoopSplitIfLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/TestDeadLoopSplitIfLoop.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key stress randomness
+ * @requires vm.compiler2.enabled
+ * @bug 8268019
+ * @summary Splitting an If through a dying loop header region that is not a LoopNode, yet, results in a dead data loop.
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileCommand=compileonly,compiler.c2.TestDeadLoopSplitIfLoop::test -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+StressIGVN -XX:StressSeed=2382674767 -XX:CompileCommand=dontinline,compiler.c2.TestDeadLoopSplitIfLoop::test
+ *                   compiler.c2.TestDeadLoopSplitIfLoop
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileCommand=compileonly,compiler.c2.TestDeadLoopSplitIfLoop::test -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+StressIGVN -XX:CompileCommand=dontinline,compiler.c2.TestDeadLoopSplitIfLoop::test
+ *                   compiler.c2.TestDeadLoopSplitIfLoop
+ */
+package compiler.c2;
+
+public class TestDeadLoopSplitIfLoop {
+    int a;
+    int b;
+    boolean c;
+
+    public static void main(String[] g) {
+        TestDeadLoopSplitIfLoop h = new TestDeadLoopSplitIfLoop();
+        h.test();
+    }
+
+    void test() {
+        int e = 4;
+        long f[] = new long[a];
+        if (c) {
+        } else if (c) {
+            // Dead path is removed after parsing which results in a dead data loop for certain node orderings in IGVN.
+            switch (126) {
+                case 126:
+                    do {
+                        f[e] = b;
+                        switch (6) {
+                            case 7:
+                                f = f;
+                        }
+                    } while (e++ < 93);
+            }
+        }
+    }
+}


### PR DESCRIPTION
In the testcase, a path containing a loop is found to be dead. These nodes are then removed during IGVN after parsing (before loop opts). One of these nodes is a loop header region through which an `If` is split. Splitting an `If` through a loop header region is not intended and was disabled by [JDK-8232539](https://bugs.openjdk.java.net/browse/JDK-8232539). However, the bailouts in the current code are not enough to prevent the split if optimization for this dying loop header node due to the following reasons:
- The region is not a `LoopNode`, yet, and we do not bail out at:
https://github.com/openjdk/jdk/blob/cd8783c08ee18167f15df621e997015b971bfb01/src/hotspot/share/opto/ifnode.cpp#L119
- The loop header region has only one phi left (the other phis were already killed) and we do not bail out at:
https://github.com/openjdk/jdk/blob/cd8783c08ee18167f15df621e997015b971bfb01/src/hotspot/share/opto/ifnode.cpp#L143-L148
- The phi merges a `ConP` constant (dead path) and a `CastPP` node which is also allowed as constant:
https://github.com/openjdk/jdk/blob/cd8783c08ee18167f15df621e997015b971bfb01/src/hotspot/share/opto/ifnode.cpp#L98-L101
- The loop entry was already replaced by top and thus no predicates can be found to bail out:
https://github.com/openjdk/jdk/blob/cd8783c08ee18167f15df621e997015b971bfb01/src/hotspot/share/opto/ifnode.cpp#L244-L247

These conditions let the split if optimization to be applied without a bailout. The `CastPP` node is a use of the phi and is thus rewired in the process. The problem now is that the `CastPP` node is an input *and* output of the loop phi while being a constant to be merged:
![before_split_if](https://user-images.githubusercontent.com/17833009/126507548-62583105-b746-4551-8037-aba1b15b1d5a.png)

This lets the split if optimization to create a data loop by setting the input of the `CastPP` to itself.

This scenario is rare and highly depends on the order in which IGVN processes the nodes. As a fix, I propose to extend the bailout checks for loop header regions to catch this edge case. The new check looks at all inputs of the region and bail out if only one path is non-top. This also avoids unnecessary splits through regions which are dying anyways.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268019](https://bugs.openjdk.java.net/browse/JDK-8268019): C2: assert(no_dead_loop) failed: dead loop detected


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4860/head:pull/4860` \
`$ git checkout pull/4860`

Update a local copy of the PR: \
`$ git checkout pull/4860` \
`$ git pull https://git.openjdk.java.net/jdk pull/4860/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4860`

View PR using the GUI difftool: \
`$ git pr show -t 4860`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4860.diff">https://git.openjdk.java.net/jdk/pull/4860.diff</a>

</details>
