### PR TITLE
8271092: [TESTBUG] Cleanup unused HeapMonitor/MyPackage.HeapMonitorStatObjectCorrectnessTest::statsHaveExpectedNumberSamples

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatObjectCorrectnessTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatObjectCorrectnessTest.java
@@ -40,8 +40,6 @@ public class HeapMonitorStatObjectCorrectnessTest {
   private static final int maxIteration = 200000;
   private static BigObject obj;
 
-  private native static boolean statsHaveExpectedNumberSamples(int expected, int percentError);
-
   private static void allocate() {
     emptyStorage();
 


### PR DESCRIPTION
Simple cleanup.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8271092](https://bugs.openjdk.java.net/browse/JDK-8271092): [TESTBUG] Cleanup unused HeapMonitor/MyPackage.HeapMonitorStatObjectCorrectnessTest::statsHaveExpectedNumberSamples


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4862/head:pull/4862` \
`$ git checkout pull/4862`

Update a local copy of the PR: \
`$ git checkout pull/4862` \
`$ git pull https://git.openjdk.java.net/jdk pull/4862/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4862`

View PR using the GUI difftool: \
`$ git pr show -t 4862`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4862.diff">https://git.openjdk.java.net/jdk/pull/4862.diff</a>

</details>
