### PR TITLE
8271118: C2: StressGCM should have higher priority than frequency-based policy

### DIFF
--- a/src/hotspot/share/opto/block.hpp
+++ b/src/hotspot/share/opto/block.hpp
@@ -435,6 +435,12 @@ class PhaseCFG : public Phase {
   // Compute the instruction global latency with a backwards walk
   void compute_latencies_backwards(VectorSet &visited, Node_Stack &stack);
 
+  // Check if a block between early and LCA block of uses is cheaper by
+  // frequency-based policy, latency-based policy and random-based policy
+  bool is_cheaper_block(Block* LCA, Node* self, uint target_latency,
+                        uint end_latency, double least_freq,
+                        int cand_cnt, bool in_latency);
+
   // Pick a block between early and late that is a cheaper alternative
   // to late. Helper for schedule_late.
   Block* hoist_to_cheaper_block(Block* LCA, Block* early, Node* self);

--- a/src/hotspot/share/opto/gcm.cpp
+++ b/src/hotspot/share/opto/gcm.cpp
@@ -1130,11 +1130,42 @@ void PhaseCFG::latency_from_uses(Node *n) {
   set_latency_for_node(n, latency);
 }
 
+//------------------------------is_cheaper_block-------------------------
+// Check if a block between early and LCA block of uses is cheaper by
+// frequency-based policy, latency-based policy and random-based policy
+bool PhaseCFG::is_cheaper_block(Block* LCA, Node* self, uint target_latency,
+                                uint end_latency, double least_freq,
+                                int cand_cnt, bool in_latency) {
+  if (StressGCM && C->randomized_select(cand_cnt)) {
+    // Should be randomly accepted in stress mode
+    return true;
+  }
+
+  if (!StressGCM) {
+    // Better Frequency
+    if (LCA->_freq < least_freq) {
+      return true;
+    }
+    // Otherwise, choose with latency
+    const double delta = 1 + PROB_UNLIKELY_MAG(4);
+    if (!in_latency                     &&  // No block containing latency
+        LCA->_freq < least_freq * delta &&  // No worse frequency
+        target_latency >= end_latency   &&  // within latency range
+        !self->is_iteratively_computed()    // But don't hoist IV increments
+             // because they may end up above other uses of their phi forcing
+             // their result register to be different from their input.
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 //------------------------------hoist_to_cheaper_block-------------------------
 // Pick a block for node self, between early and LCA block of uses, that is a
 // cheaper alternative to LCA.
 Block* PhaseCFG::hoist_to_cheaper_block(Block* LCA, Block* early, Node* self) {
-  const double delta = 1+PROB_UNLIKELY_MAG(4);
   Block* least       = LCA;
   double least_freq  = least->_freq;
   uint target        = get_latency_for_node(self);
@@ -1206,16 +1237,7 @@ Block* PhaseCFG::hoist_to_cheaper_block(Block* LCA, Block* early, Node* self) {
     }
 #endif
     cand_cnt++;
-    if ((StressGCM && C->randomized_select(cand_cnt)) ||  // Should be randomly accepted in stress mode
-        LCA_freq < least_freq           ||    // Better Frequency
-         (!StressGCM                    &&    // Otherwise, choose with latency
-          !in_latency                   &&    // No block containing latency
-          LCA_freq < least_freq * delta &&    // No worse frequency
-          target >= end_lat             &&    // within latency range
-          !self->is_iteratively_computed() )  // But don't hoist IV increments
-             // because they may end up above other uses of their phi forcing
-             // their result register to be different from their input.
-       ) {
+    if (is_cheaper_block(LCA, self, target, end_lat, least_freq, cand_cnt, in_latency)) {
       least = LCA;            // Found cheaper block
       least_freq = LCA_freq;
       start_latency = start_lat;


### PR DESCRIPTION
I think StressGCM should have higher priority than frequency-based policy, otherwise StressGCM has no chance to choose because the frequency-based policy would choose block first if appropriately.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271118](https://bugs.openjdk.java.net/browse/JDK-8271118): C2: StressGCM should have higher priority than frequency-based policy


### Reviewers
 * [Igor Veresov](https://openjdk.java.net/census#iveresov) (@veresov - **Reviewer**) ⚠️ Review applies to a16a65841ff8a218e40cc897e24df9ba629bf019
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4865/head:pull/4865` \
`$ git checkout pull/4865`

Update a local copy of the PR: \
`$ git checkout pull/4865` \
`$ git pull https://git.openjdk.java.net/jdk pull/4865/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4865`

View PR using the GUI difftool: \
`$ git pr show -t 4865`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4865.diff">https://git.openjdk.java.net/jdk/pull/4865.diff</a>

</details>
