### PR TITLE
8271060: Merge G1CollectedHeap::determine_start_concurrent_mark_gc and G1Policy::decide_on_conc_mark_initiation

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1782,6 +1782,10 @@ jint G1CollectedHeap::initialize() {
   return JNI_OK;
 }
 
+bool G1CollectedHeap::concurrent_mark_is_terminating() const {
+  return _cm_thread->should_terminate();
+}
+
 void G1CollectedHeap::stop() {
   // Stop all concurrent threads. We do this to make sure these threads
   // do not continue to execute and access resources (e.g. logging)
@@ -3001,24 +3005,6 @@ public:
   }
 };
 
-bool G1CollectedHeap::determine_start_concurrent_mark_gc(){
-  // We should not be doing concurrent start unless the concurrent mark thread is running
-  if (!_cm_thread->should_terminate()) {
-    // This call will decide whether this pause is a concurrent start
-    // pause. If it is, in_concurrent_start_gc() will return true
-    // for the duration of this pause.
-    policy()->decide_on_conc_mark_initiation();
-  }
-
-  // We do not allow concurrent start to be piggy-backed on a mixed GC.
-  assert(!collector_state()->in_concurrent_start_gc() ||
-         collector_state()->in_young_only_phase(), "sanity");
-  // We also do not allow mixed GCs during marking.
-  assert(!collector_state()->mark_or_rebuild_in_progress() || collector_state()->in_young_only_phase(), "sanity");
-
-  return collector_state()->in_concurrent_start_gc();
-}
-
 void G1CollectedHeap::set_young_collection_default_active_worker_threads(){
   uint active_workers = WorkerPolicy::calc_active_workers(workers()->total_workers(),
                                                           workers()->active_workers(),
@@ -3058,7 +3044,7 @@ void G1CollectedHeap::do_collection_pause_at_safepoint_helper(double target_paus
   // Record whether this pause may need to trigger a concurrent operation. Later,
   // when we signal the G1ConcurrentMarkThread, the collector state has already
   // been reset for the next pause.
-  bool should_start_concurrent_mark_operation = determine_start_concurrent_mark_gc();
+  bool should_start_concurrent_mark_operation = policy()->decide_on_concurrent_start_pause();
   bool concurrent_operation_is_full_mark = false;
 
   // Verification may use the gang workers, so they must be set up before.

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -801,8 +801,6 @@ private:
 
   void set_young_collection_default_active_worker_threads();
 
-  bool determine_start_concurrent_mark_gc();
-
   void prepare_tlabs_for_mutator();
 
   void retire_tlabs();
@@ -1003,6 +1001,9 @@ public:
   // maximum sizes and remembered and barrier sets
   // specified by the policy object.
   jint initialize();
+
+  // Returns whether concurrent mark threads (and the VM) are about to terminate.
+  bool concurrent_mark_is_terminating() const;
 
   virtual void stop();
   virtual void safepoint_synchronize_begin();

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1046,7 +1046,7 @@ void G1Policy::initiate_conc_mark() {
   collector_state()->set_initiate_conc_mark_if_possible(false);
 }
 
-void G1Policy::decide_on_conc_mark_initiation() {
+bool G1Policy::decide_on_concurrent_start_pause() {
   // We are about to decide on whether this pause will be a
   // concurrent start pause.
 
@@ -1055,6 +1055,12 @@ void G1Policy::decide_on_conc_mark_initiation() {
   // the end of the pause (it's only set for the duration of a
   // concurrent start pause).
   assert(!collector_state()->in_concurrent_start_gc(), "pre-condition");
+
+  // We should not be starting a concurrent start pause if the concurrent mark
+  // thread is terminating.
+  if (_g1h->concurrent_mark_is_terminating()) {
+    return false;
+  }
 
   if (collector_state()->initiate_conc_mark_if_possible()) {
     // We had noticed on a previous pause that the heap occupancy has
@@ -1104,6 +1110,14 @@ void G1Policy::decide_on_conc_mark_initiation() {
       log_debug(gc, ergo)("Do not initiate concurrent cycle (concurrent cycle already in progress)");
     }
   }
+  // Result consistency checks.
+  // We do not allow concurrent start to be piggy-backed on a mixed GC.
+  assert(!collector_state()->in_concurrent_start_gc() ||
+         collector_state()->in_young_only_phase(), "sanity");
+  // We also do not allow mixed GCs during marking.
+  assert(!collector_state()->mark_or_rebuild_in_progress() || collector_state()->in_young_only_phase(), "sanity");
+
+  return collector_state()->in_concurrent_start_gc();
 }
 
 void G1Policy::record_concurrent_mark_cleanup_end(bool has_rebuilt_remembered_sets) {

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -373,13 +373,14 @@ public:
   // progress or not is stable.
   bool force_concurrent_start_if_outside_cycle(GCCause::Cause gc_cause);
 
-  // This is called at the very beginning of an evacuation pause (it
-  // has to be the first thing that the pause does). If
-  // initiate_conc_mark_if_possible() is true, and the concurrent
-  // marking thread has completed its work during the previous cycle,
-  // it will set in_concurrent_start_gc() to so that the pause does
-  // the concurrent start work and start a marking cycle.
-  void decide_on_conc_mark_initiation();
+  // Decide whether this garbage collection pause should be a concurrent start
+  // pause. This must be called at the very beginning of an evacuation pause.
+  // If initiate_conc_mark_if_possible() is true, and the concurrent
+  // marking thread has completed its work for the previous cycle, and we are
+  // not shutting down the VM this method will return that this should be a
+  // concurrent start pause.
+  // It also updates the collector state accordingly.
+  bool decide_on_concurrent_start_pause();
 
   size_t young_list_target_length() const { return _young_list_target_length; }
 

--- a/src/hotspot/share/gc/g1/g1VMOperations.cpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.cpp
@@ -74,7 +74,7 @@ void VM_G1TryInitiateConcMark::doit() {
   GCCauseSetter x(g1h, _gc_cause);
 
   // Record for handling by caller.
-  _terminating = g1h->_cm_thread->should_terminate();
+  _terminating = g1h->concurrent_mark_is_terminating();
 
   if (_terminating && GCCause::is_user_requested_gc(_gc_cause)) {
     // When terminating, the request to initiate a concurrent cycle will be


### PR DESCRIPTION
Hi all,

  can I have reviews for this merge of two methods that have the same purpose: determine whether this pause should be a concurrent start pause. The reason for this merge is that `G1CollectedHeap::determine_start_concurrent_mark_gc` just calls the other, and
  - is the only caller
  - only adds another condition of the same type that `G1Policy::decide_on_conc_mark_initiation` does at the beginning
  - adds some return value checking and return value
which all imho fit into `G1Policy::decide_on_conc_mark_initiation` too.

It also reduces `G1CollectedHeap` a bit. The main reason for me to put this in the new location is basically that that additional condition in  `G1CollectedHeap::determine_start_concurrent_mark_gc` makes all conditions for that decision be located closer together.

If you think otherwise and this is a bad idea, I will close this PR.

Testing: manual gc/g1 runs

Thanks,
  Thomas