### PR TITLE
8271140: Fix native frame handling in vframeStream::asJavaVFrame()

### DIFF
--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/IterateFramesNative.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/IterateFramesNative.java
@@ -25,11 +25,7 @@
  * @test
  * @bug 8269592
  *
- * @requires vm.jvmci & vm.compMode == "Xmixed"
- * @requires vm.opt.final.EliminateAllocations == true
- *
- * @comment no "-Xcomp -XX:-TieredCompilation" combination allowed until JDK-8140018 is resolved
- * @requires vm.opt.TieredCompilation == null | vm.opt.TieredCompilation == true
+ * @requires vm.jvmci
  *
  * @library / /test/lib
  * @library ../common/patches
@@ -46,21 +42,25 @@
  * @run main/othervm -Xbatch -Xbootclasspath/a:.
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI
- *                   -XX:+DoEscapeAnalysis -XX:-UseCounterDecay
+ *                   compiler.jvmci.compilerToVM.IterateFramesNative
+ * @run main/othervm -Xcomp -Xbootclasspath/a:.
+ *                   -XX:CompileOnly=compiler.jvmci.compilerToVM.IterateFramesNative::callerNative
+ *                   -XX:CompileOnly=jdk.vm.ci.hotspot.CompilerToVM::iterateFrames
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI
+ *                   -Dcompiler.jvmci.compilerToVM.IterateFramesNative.checkCompiled=true
  *                   compiler.jvmci.compilerToVM.IterateFramesNative
  */
 
 package compiler.jvmci.compilerToVM;
 
 import compiler.jvmci.common.CTVMUtilities;
-import compiler.testlibrary.CompilerUtils;
 import compiler.whitebox.CompilerWhiteBoxTest;
 import jdk.test.lib.Asserts;
-import jdk.vm.ci.code.stack.InspectedFrame;
+import jdk.vm.ci.code.stack.InspectedFrameVisitor;
 import jdk.vm.ci.hotspot.CompilerToVMHelper;
 import jdk.vm.ci.hotspot.HotSpotStackFrameReference;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
-import jtreg.SkippedException;
 import sun.hotspot.WhiteBox;
 
 import java.lang.reflect.Method;
@@ -68,38 +68,38 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class IterateFramesNative {
     private static final WhiteBox WB;
-    private static final int COMPILE_THRESHOLD;
+    private static final Method NATIVE_METHOD;
+    private static final Method ITERATE_FRAMES_METHOD;
     private static final ResolvedJavaMethod NATIVE_METHOD_RESOLVED;
     private static final ResolvedJavaMethod NATIVE_CALLBACK_METHOD_RESOLVED;
+    private static final boolean CHECK_COMPILED;
 
     static {
-        Method nativeMethod;
         Method nativeCallbackMethod;
         WB = WhiteBox.getWhiteBox();
         try {
-            nativeMethod = IterateFramesNative.class.getDeclaredMethod("callerNative",
+            NATIVE_METHOD = IterateFramesNative.class.getDeclaredMethod("callerNative",
                     Runnable.class);
             nativeCallbackMethod = IterateFramesNative.class.getDeclaredMethod("testNativeFrameCallback",
                     Helper.class, int.class);
+            ITERATE_FRAMES_METHOD = CompilerToVMHelper.CompilerToVMClass().getDeclaredMethod(
+                    "iterateFrames",
+                    ResolvedJavaMethod[].class,
+                    ResolvedJavaMethod[].class,
+                    int.class,
+                    InspectedFrameVisitor.class);
         } catch (NoSuchMethodException e) {
             throw new Error("Can't get executable for test method", e);
         }
-        NATIVE_METHOD_RESOLVED = CTVMUtilities.getResolvedMethod(nativeMethod);
+        NATIVE_METHOD_RESOLVED = CTVMUtilities.getResolvedMethod(NATIVE_METHOD);
         NATIVE_CALLBACK_METHOD_RESOLVED = CTVMUtilities.getResolvedMethod(nativeCallbackMethod);
-        COMPILE_THRESHOLD = WB.getBooleanVMFlag("TieredCompilation")
-                ? CompilerWhiteBoxTest.THRESHOLD
-                : CompilerWhiteBoxTest.THRESHOLD * 2;
+        CHECK_COMPILED = Boolean.getBoolean(
+                "compiler.jvmci.compilerToVM.IterateFramesNative.checkCompiled");
 
         loadNativeLibrary();
     }
 
     public static void main(String[] args) {
-        int levels[] = CompilerUtils.getAvailableCompilationLevels();
-        // we need compilation level 4 to use EscapeAnalysis
-        if (levels.length < 1 || levels[levels.length - 1] != 4) {
-            throw new SkippedException("Test needs compilation level 4");
-        }
-
         new IterateFramesNative().test();
     }
 
@@ -116,17 +116,38 @@ public class IterateFramesNative {
         System.loadLibrary("IterateFramesNative");
     }
 
+    public static native void callerNative(Runnable runnable);
+
     private void testNativeFrame(String str, int iteration) {
-        Helper innerHelper = new Helper("foo");
+        Helper innerHelper = new Helper(str);
+
         callerNative(() -> testNativeFrameCallback(innerHelper, iteration));
 
         Asserts.assertEQ(innerHelper.string, NATIVE_METHOD_RESOLVED.getName(),
             "Native frame not found?: " + NATIVE_METHOD_RESOLVED.getName());
+
+        if (CHECK_COMPILED) {
+            Asserts.assertTrue(WB.isMethodCompiled(ITERATE_FRAMES_METHOD),
+                "Expected native method to be compiled: " + ITERATE_FRAMES_METHOD);
+            Asserts.assertTrue(WB.isMethodCompiled(NATIVE_METHOD),
+                "Expected native method to be compiled: " + NATIVE_METHOD);
+        }
     }
 
-    public static native void callerNative(Runnable runnable);
-
     private void testNativeFrameCallback(Helper helper, int iteration) {
+        HotSpotStackFrameReference initialFrame = CompilerToVMHelper.iterateFrames(
+            null,
+            null,
+            0,
+            f -> {
+                HotSpotStackFrameReference frame = (HotSpotStackFrameReference) f;
+                Asserts.assertNotNull(frame, "got null frame for native method");
+                return frame;
+            });
+        Asserts.assertNotNull(initialFrame, "frame must not be null");
+        Asserts.assertEQ(initialFrame.getMethod().getName(), "iterateFrames",
+            "Expected initial frame method to be CompilerToVM.iterateFrames");
+
         AtomicInteger frameCounter = new AtomicInteger();
         ResolvedJavaMethod[] methods = new ResolvedJavaMethod[] {NATIVE_METHOD_RESOLVED, NATIVE_CALLBACK_METHOD_RESOLVED};
         CompilerToVMHelper.iterateFrames(


### PR DESCRIPTION
Follow-up to https://github.com/openjdk/jdk/pull/4625 ([JDK-8269592](https://bugs.openjdk.java.net/browse/JDK-8269592)) which added support for native frames to `vframeStreamCommon::asJavaVFrame()`. This change was not correct when `asJavaVFrame()` is called for a native frame that is the last frame on the stack (i.e. the first frame in the stream), in which case there's no `_prev_frame` yet. We don't actually need the extended frame information for native frames, so the fix is to just use the vframeStream's `_frame` and `_reg_map` for native frames.
Extended the test from JDK-8269592 to cover this case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271140](https://bugs.openjdk.java.net/browse/JDK-8271140): Fix native frame handling in vframeStream::asJavaVFrame()


### Reviewers
 * [Doug Simon](https://openjdk.java.net/census#dnsimon) (@dougxc - Committer) ⚠️ Review applies to 04992d7258da71ecd8edc908994d86b1a9f92ead
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tom Rodriguez](https://openjdk.java.net/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4872/head:pull/4872` \
`$ git checkout pull/4872`

Update a local copy of the PR: \
`$ git checkout pull/4872` \
`$ git pull https://git.openjdk.java.net/jdk pull/4872/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4872`

View PR using the GUI difftool: \
`$ git pr show -t 4872`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4872.diff">https://git.openjdk.java.net/jdk/pull/4872.diff</a>

</details>
