### PR TITLE
JDK-8271142: package help is not displayed for missing X11/extensions/Xrandr.h

### DIFF
--- a/make/autoconf/help.m4
+++ b/make/autoconf/help.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -42,21 +42,21 @@ AC_DEFUN([HELP_MSG_MISSING_DEPENDENCY],
     PKGHANDLER_COMMAND=
 
     case $PKGHANDLER in
-      apt-get)
+      *apt-get)
         apt_help     $MISSING_DEPENDENCY ;;
-      yum)
+      *yum)
         yum_help     $MISSING_DEPENDENCY ;;
-      brew)
+      *brew)
         brew_help    $MISSING_DEPENDENCY ;;
-      port)
+      *port)
         port_help    $MISSING_DEPENDENCY ;;
-      pkgutil)
+      *pkgutil)
         pkgutil_help $MISSING_DEPENDENCY ;;
-      pkgadd)
+      *pkgadd)
         pkgadd_help  $MISSING_DEPENDENCY ;;
-      *zypper*)
+      *zypper)
         zypper_help  $MISSING_DEPENDENCY ;;
-      pacman)
+      *pacman)
         pacman_help  $MISSING_DEPENDENCY ;;
     esac
 

--- a/make/autoconf/help.m4
+++ b/make/autoconf/help.m4
@@ -54,7 +54,7 @@ AC_DEFUN([HELP_MSG_MISSING_DEPENDENCY],
         pkgutil_help $MISSING_DEPENDENCY ;;
       pkgadd)
         pkgadd_help  $MISSING_DEPENDENCY ;;
-      zypper)
+      *zypper*)
         zypper_help  $MISSING_DEPENDENCY ;;
       pacman)
         pacman_help  $MISSING_DEPENDENCY ;;


### PR DESCRIPTION
Please review the following change.
On SUSE Linux 15 configure was running into this error, because of a missing X11 header :

checking for X11/extensions/Xrandr.h... no
configure: error: Could not find all X11 headers (shape.h Xrender.h Xrandr.h XTest.h Intrinsic.h).

I wondered about the missing package help output, we should display some hint what packages are missing.
In help.m4,  PKGHANDLER was detected as /usr/bin/zypper .
However only the exact string zypper is checked, this should be relaxed.
Afterwards, the package - help  was working nicely :

checking for X11/extensions/Xrandr.h... no
configure: error: Could not find all X11 headers (shape.h Xrender.h Xrandr.h XTest.h Intrinsic.h).
You might be able to fix this by running 'sudo zypper install libX11-devel libXext-devel libXrender-devel libXrandr-devel libXtst-devel libXt-devel libXi-devel'.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271142](https://bugs.openjdk.java.net/browse/JDK-8271142): package help is not displayed for missing X11/extensions/Xrandr.h


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4873/head:pull/4873` \
`$ git checkout pull/4873`

Update a local copy of the PR: \
`$ git checkout pull/4873` \
`$ git pull https://git.openjdk.java.net/jdk pull/4873/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4873`

View PR using the GUI difftool: \
`$ git pr show -t 4873`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4873.diff">https://git.openjdk.java.net/jdk/pull/4873.diff</a>

</details>
