### PR TITLE
JDK-8271149: remove unreferenced functions from EncodingSupport_md.c

### DIFF
--- a/src/java.instrument/unix/native/libinstrument/EncodingSupport_md.c
+++ b/src/java.instrument/unix/native/libinstrument/EncodingSupport_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,22 +104,6 @@ utfInitialize(void)
 }
 
 /*
- * Terminate all utf processing
- */
-static void
-utfTerminate(void)
-{
-    if ( iconvFromPlatform!=(iconv_t)-1 ) {
-        (void)iconv_close(iconvFromPlatform);
-    }
-    if ( iconvToPlatform!=(iconv_t)-1 ) {
-        (void)iconv_close(iconvToPlatform);
-    }
-    iconvToPlatform   = (iconv_t)-1;
-    iconvFromPlatform = (iconv_t)-1;
-}
-
-/*
  * Do iconv() conversion.
  *    Returns length or -1 if output overflows.
  */
@@ -174,16 +158,6 @@ static int
 utf8ToPlatform(char *utf8, int len, char *output, int outputMaxLen)
 {
     return iconvConvert(iconvToPlatform, utf8, len, output, outputMaxLen);
-}
-
-/*
- * Convert Platform Encoding to UTF-8.
- *    Returns length or -1 if output overflows.
- */
-static int
-platformToUtf8(char *str, int len, char *output, int outputMaxLen)
-{
-    return iconvConvert(iconvFromPlatform, str, len, output, outputMaxLen);
 }
 
 int


### PR DESCRIPTION
Please review this small change.
I was running into those 2 warnings in EncodingSupport_md.c
function "utfTerminate" was declared but never referenced
function "platformToUtf8" was declared but never referenced

Probably those 2 functions can and should be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271149](https://bugs.openjdk.java.net/browse/JDK-8271149): remove unreferenced functions from EncodingSupport_md.c


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4875/head:pull/4875` \
`$ git checkout pull/4875`

Update a local copy of the PR: \
`$ git checkout pull/4875` \
`$ git pull https://git.openjdk.java.net/jdk pull/4875/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4875`

View PR using the GUI difftool: \
`$ git pr show -t 4875`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4875.diff">https://git.openjdk.java.net/jdk/pull/4875.diff</a>

</details>
