### PR TITLE
8271148: static-libs-image target --with-native-debug-symbols=external doesn't produce debug info

### DIFF
--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -526,15 +526,6 @@ define SetupNativeCompilationBody
     # jmods.
     $1_OBJECT_DIR := $$($1_OBJECT_DIR)/static
     $1_OUTPUT_DIR := $$($1_OBJECT_DIR)
-    # For release builds where debug symbols are configured to be moved to
-    # separate debuginfo files, disable debug symbols for static libs instead.
-    # We don't currently support this configuration and we don't want symbol
-    # information in release builds unless explicitly asked to provide it.
-    ifeq ($(DEBUG_LEVEL), release)
-      ifeq ($(COPY_DEBUG_SYMBOLS), true)
-        $1_COMPILE_WITH_DEBUG_SYMBOLS := false
-      endif
-    endif
   endif
 
   ifeq ($$($1_TYPE), EXECUTABLE)


### PR DESCRIPTION
Hi!

Please review this tiny patch which removes the special casing of `--with-native-debug-symbols=external` for the static libs build. I don't see why this is needed. If no debug symbols are wanted `--with-native-debug-symbols=none` can be used to achieve the same effect. Therefore, I propose to remove this hunk.

Testing: Inspecting of the log files and seeing that `-g` switch is there. Run the reproducer test on the resulting static libraries.

Thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8271148](https://bugs.openjdk.java.net/browse/JDK-8271148): static-libs-image target --with-native-debug-symbols=external doesn't produce debug info


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4876/head:pull/4876` \
`$ git checkout pull/4876`

Update a local copy of the PR: \
`$ git checkout pull/4876` \
`$ git pull https://git.openjdk.java.net/jdk pull/4876/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4876`

View PR using the GUI difftool: \
`$ git pr show -t 4876`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4876.diff">https://git.openjdk.java.net/jdk/pull/4876.diff</a>

</details>
