### PR TITLE
8271165: ProblemList serviceability/dcmd/gc/HeapDumpAllTest.java on X64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -116,6 +116,8 @@ serviceability/sa/ClhsdbFindPC.java#id1 8269982 macosx-aarch64
 serviceability/sa/ClhsdbFindPC.java#id3 8269982 macosx-aarch64
 serviceability/sa/ClhsdbPstack.java#id1 8269982 macosx-aarch64
 
+serviceability/dcmd/gc/HeapDumpAllTest.java 8270341 generic-x64
+
 #############################################################################
 
 # :hotspot_misc

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -100,6 +100,8 @@ runtime/os/TestTracePageSizes.java#with-G1 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#with-Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#with-Serial 8267460 linux-aarch64
 
+applications/jcstress/copy.java 8229852 linux-x64
+
 #############################################################################
 
 # :hotspot_serviceability


### PR DESCRIPTION
Trivial fixes:
JDK-8271165 ProblemList serviceability/dcmd/gc/HeapDumpAllTest.java on X64
JDK-8271166 ProblemList applications/jcstress/copy.java on Linux-X64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8271165](https://bugs.openjdk.java.net/browse/JDK-8271165): ProblemList serviceability/dcmd/gc/HeapDumpAllTest.java on X64
 * [JDK-8271166](https://bugs.openjdk.java.net/browse/JDK-8271166): ProblemList applications/jcstress/copy.java on Linux-X64


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4881/head:pull/4881` \
`$ git checkout pull/4881`

Update a local copy of the PR: \
`$ git checkout pull/4881` \
`$ git pull https://git.openjdk.java.net/jdk pull/4881/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4881`

View PR using the GUI difftool: \
`$ git pr show -t 4881`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4881.diff">https://git.openjdk.java.net/jdk/pull/4881.diff</a>

</details>
