### PR TITLE
8271147: java/nio/file/Path.java javadoc typo

### DIFF
--- a/src/java.base/share/classes/java/nio/file/Path.java
+++ b/src/java.base/share/classes/java/nio/file/Path.java
@@ -413,7 +413,7 @@ public interface Path
      * "{@code foo/bar}" ends with "{@code foo/bar}" and "{@code bar}". It does
      * not end with "{@code r}" or "{@code /bar}". Note that trailing separators
      * are not taken into account, and so invoking this method on the {@code
-     * Path}"{@code foo/bar}" with the {@code String} "{@code bar/}" returns
+     * Path} "{@code foo/bar}" with the {@code String} "{@code bar/}" returns
      * {@code true}.
      *
      * @implSpec


### PR DESCRIPTION
Can I please get a review for this change which fixes the typo noted in https://bugs.openjdk.java.net/browse/JDK-8271147? `make docs-image` worked fine and the generated javadoc looks fine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271147](https://bugs.openjdk.java.net/browse/JDK-8271147): java/nio/file/Path.java javadoc typo


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4884/head:pull/4884` \
`$ git checkout pull/4884`

Update a local copy of the PR: \
`$ git checkout pull/4884` \
`$ git pull https://git.openjdk.java.net/jdk pull/4884/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4884`

View PR using the GUI difftool: \
`$ git pr show -t 4884`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4884.diff">https://git.openjdk.java.net/jdk/pull/4884.diff</a>

</details>
