### PR TITLE
8271186: Add UL option to replace newline char

### DIFF
--- a/src/hotspot/share/logging/logFileOutput.cpp
+++ b/src/hotspot/share/logging/logFileOutput.cpp
@@ -195,7 +195,16 @@ bool LogFileOutput::parse_options(const char* options, outputStream* errstream) 
     char* value_str = equals_pos + 1;
     *equals_pos = '\0';
 
-    if (strcmp(FileCountOptionKey, key) == 0) {
+    if (strcmp(NewLineOptionKey, key) == 0) {
+      // We need to pass <key>=<value> style option to LogFileStreamOutput::initialize().
+      // Thus we restore '=' temporally.
+      *equals_pos = '=';
+      success = LogFileStreamOutput::initialize(pos, errstream);
+      *equals_pos = '\0';
+      if (!success) {
+        break;
+      }
+    } else if (strcmp(FileCountOptionKey, key) == 0) {
       size_t value = parse_value(value_str);
       if (value > MaxRotationFileCount) {
         errstream->print_cr("Invalid option: %s must be in range [0, %u]",

--- a/src/hotspot/share/logging/logFileStreamOutput.hpp
+++ b/src/hotspot/share/logging/logFileStreamOutput.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,12 +41,16 @@ static LogFileStreamInitializer log_stream_initializer;
 // Base class for all FileStream-based log outputs.
 class LogFileStreamOutput : public LogOutput {
  private:
+  char*               _new_line;
   bool                _write_error_is_shown;
+
+  int write_internal(const char* msg);
  protected:
+  static const char* const NewLineOptionKey;
   FILE*               _stream;
   size_t              _decorator_padding[LogDecorators::Count];
 
-  LogFileStreamOutput(FILE *stream) : _write_error_is_shown(false), _stream(stream) {
+  LogFileStreamOutput(FILE *stream) : _new_line(NULL), _write_error_is_shown(false), _stream(stream) {
     for (size_t i = 0; i < LogDecorators::Count; i++) {
       _decorator_padding[i] = 0;
     }
@@ -56,6 +60,14 @@ class LogFileStreamOutput : public LogOutput {
   bool flush();
 
  public:
+
+  virtual ~LogFileStreamOutput() {
+    if (_new_line != NULL) {
+      os::free(_new_line);
+    }
+  }
+
+  virtual bool initialize(const char* options, outputStream* errstream);
   virtual int write(const LogDecorations& decorations, const char* msg);
   virtual int write(LogMessageBuffer::Iterator msg_iterator);
 };

--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -4391,8 +4391,8 @@ selected.
 \f[I]output\-options\f[R] is
 .RS
 .PP
-\f[CB]filecount=\f[R]\f[I]file\-count\f[R] \f[CB]filesize=\f[R]\f[I]file size
-with optional K, M or G suffix\f[R]
+\f[CB]filecount=\f[R]\f[I]file\-count\f[R] \f[CB]filesize=\f[R]\f[I]<file size
+with optional K, M or G suffix>\f[R] \f[CB]newline=\f[R]\f[I]<chars to replace newline char (\\n)>\f[R]
 .RE
 .RE
 .SS Default Configuration


### PR DESCRIPTION
Most of UL entries would print log in one line, however some categories (e.g. `exceptions`) have multiline entries as following:

```
[0.157s][info][exceptions] Exception <a 'java/lang/NullPointerException'{0x000000008b918f70}: test>
 thrown in interpreter method <{method} {0x00007f8335000248} 'main' '([Ljava/lang/String;)V' in 'Test'>
 at bci 9 for thread 0x00007f8330017160 (main)
```

It is ease to parse with log shipper (Fluent Bit, Logstash, and more) if UL can print all logs in one line.
Famous log shippers support multiline logs of course, but its configuration tends to be complex, and also some input plugins (e.g. TCP on Fluent Bit) do not support multiline logs.

So I want to introduce new UL option newline to replace `\n` to other chars. For example, the user specifies `newline=\\n` to UL output, newline char (`\n`) will replace `\\n`.

After this patch, we can get following logs with `newline=\\n`:

```
[0.166s][info][exceptions] Exception <a 'java/lang/NullPointerException'{0x000000008b918f70}: test>\n thrown in interpreter method <{method} {0x00007fbc81000248} 'main' '([Ljava/lang/String;)V' in 'Test'>\n at bci 9 for thread 0x00007fbc9c0171a0 (main)
```

I've also filed [CSR](https://bugs.openjdk.java.net/browse/JDK-8271188) for this issue, please review it.