### PR TITLE
8271199: Mutual TLS handshake fails signing client certificate with custom sensitive PKCS11 key

### DIFF
--- a/src/java.base/share/classes/sun/security/rsa/RSAPSSSignature.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAPSSSignature.java
@@ -232,6 +232,26 @@ public class RSAPSSSignature extends SignatureSpi {
                         ("Unrecognized digest algo: " + digestAlgo);
             }
         }
+
+	// validate key attributes
+        try {
+	    if (rsaKey.getModulus().signum() == 0 ||
+                (rsaKey instanceof RSAPrivateKey rsaPrKey &&
+                    (rsaPrKey.getPrivateExponent().signum() == 0 ||
+                        (rsaPrKey instanceof RSAPrivateCrtKey crtKey &&
+                            (crtKey.getPrimeP().signum() == 0 ||
+                             crtKey.getPrimeQ().signum() == 0 ||
+                             crtKey.getPrimeExponentP().signum() == 0 ||
+                             crtKey.getPrimeExponentQ().signum() == 0 ||
+                             crtKey.getCrtCoefficient().signum() == 0 ||
+                             crtKey.getPublicExponent().signum() == 0 )))) ||
+                (rsaKey instanceof RSAPublicKey rsaPubKey &&
+                    rsaPubKey.getPublicExponent().signum() == 0)) {
+                throw new InvalidKeyException("Invalid key attributes");
+            }
+        } catch(Exception ex) {
+            throw new InvalidKeyException("Invalid key attributes", ex);
+        }
         return rsaKey;
     }
 


### PR DESCRIPTION
Hello,

Could you please review the small patch for the issue described in JDK-8271199: Mutual TLS handshake fails signing client certificate with custom sensitive PKCS11 key

I suggest updating the RSAPSSSignature.isValid() method to verify if provided key components can be applied to SunRSASign implementation. 
If not applied, implementation can try to select signer from other providers

Regards
Alexey