### PR TITLE
8271163: G1 uses wrong degree of MT processing since JDK-8270169

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1848,8 +1848,10 @@ void G1CollectedHeap::ref_processing_init() {
   _ref_processor_cm =
     new ReferenceProcessor(&_is_subject_to_discovery_cm,
                            ParallelGCThreads,                              // degree of mt processing
-                           (ConcGCThreads > 1),                            // mt discovery
-                           ConcGCThreads,                                  // degree of mt discovery
+                           // We discover with the gc worker threads during Remark, so both
+                           // thread counts must be considered for discovery.
+                           (ParallelGCThreads > 1) || (ConcGCThreads > 1), // mt discovery
+                           MAX2(ParallelGCThreads, ConcGCThreads),         // degree of mt discovery
                            false,                                          // Reference discovery is not atomic
                            &_is_alive_closure_cm);                         // is alive closure
 


### PR DESCRIPTION
Hi all,

  JDK-8270169 changed the amount of resources supplied by the CM reference processor, assuming that the CM ref processor is only ever used with the marking threads.
This is unfortunately not true, the CM reference processor is also used by the Remark pause for discovery using the parallel gc worker threads.

This causes crashes because of the code assuming single threaded operation while it is not.

The solution proposed here is to just revert JDK-8270169 which introduced  that change. Applies cleanly.

I also added a comment in the reference processor constructor to why we need to consider both thread counts.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271163](https://bugs.openjdk.java.net/browse/JDK-8271163): G1 uses wrong degree of MT processing since JDK-8270169


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4888/head:pull/4888` \
`$ git checkout pull/4888`

Update a local copy of the PR: \
`$ git checkout pull/4888` \
`$ git pull https://git.openjdk.java.net/jdk pull/4888/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4888`

View PR using the GUI difftool: \
`$ git pr show -t 4888`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4888.diff">https://git.openjdk.java.net/jdk/pull/4888.diff</a>

</details>
