### PR TITLE
8271209: Fix doc comment typos in JavadocTokenizer

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavadocTokenizer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavadocTokenizer.java
@@ -36,7 +36,7 @@ import java.util.regex.Pattern;
 /**
  * An extension to the base lexical analyzer (JavaTokenizer) that
  * captures and processes the contents of doc comments. It does
- * so by stripping the leading whitespace and comment starts from
+ * so by stripping the leading whitespace and comment stars from
  * each line of the Javadoc comment.
  *
  *  <p><b>This is NOT part of any supported API.
@@ -89,7 +89,7 @@ public class JavadocTokenizer extends JavaTokenizer {
      */
     protected static class JavadocComment extends BasicComment {
         /**
-         * Pattern used to detect a well formed @deprecated tag in a JaavDoc
+         * Pattern used to detect a well formed @deprecated tag in a Javadoc
          * comment.
          */
         private static final Pattern DEPRECATED_PATTERN =


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271209](https://bugs.openjdk.java.net/browse/JDK-8271209): Fix doc comment typos in JavadocTokenizer


### Reviewers
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4889/head:pull/4889` \
`$ git checkout pull/4889`

Update a local copy of the PR: \
`$ git checkout pull/4889` \
`$ git pull https://git.openjdk.java.net/jdk pull/4889/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4889`

View PR using the GUI difftool: \
`$ git pr show -t 4889`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4889.diff">https://git.openjdk.java.net/jdk/pull/4889.diff</a>

</details>
