### PR TITLE
8171382: java.time.Duration missing isPositive method

### DIFF
--- a/src/java.base/share/classes/java/time/Duration.java
+++ b/src/java.base/share/classes/java/time/Duration.java
@@ -583,6 +583,20 @@ public final class Duration
 
     //-----------------------------------------------------------------------
     /**
+     * Checks if this duration is positive, excluding zero.
+     * <p>
+     * A {@code Duration} represents a directed distance between two points on
+     * the time-line and can therefore be positive, zero or negative.
+     * This method checks whether the length is greater than zero.
+     *
+     * @return true if this duration has a total length greater than zero
+     * @since 18
+     */
+    public boolean isPositive() {
+        return (seconds | nanos) > 0;
+    }
+
+    /**
      * Checks if this duration is zero length.
      * <p>
      * A {@code Duration} represents a directed distance between two points on

--- a/test/jdk/java/time/tck/java/time/TCKDuration.java
+++ b/test/jdk/java/time/tck/java/time/TCKDuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -909,15 +909,31 @@ public class TCKDuration extends AbstractTCKTest {
     }
 
     @Test
+    public void test_isPositive() {
+        assertEquals(Duration.ofNanos(0).isPositive(), false);
+        assertEquals(Duration.ofSeconds(0).isPositive(), false);
+        assertEquals(Duration.ofNanos(1).isPositive(), true);
+        assertEquals(Duration.ofSeconds(1).isPositive(), true);
+        assertEquals(Duration.ofSeconds(1, 1).isPositive(), true);
+        assertEquals(Duration.ofSeconds(Long.MAX_VALUE, 999_999_999).isPositive(), true);
+        assertEquals(Duration.ofNanos(-1).isPositive(), false);
+        assertEquals(Duration.ofSeconds(-1).isPositive(), false);
+        assertEquals(Duration.ofSeconds(-1, -1).isPositive(), false);
+        assertEquals(Duration.ofSeconds(Long.MIN_VALUE).isPositive(), false);
+    }
+
+    @Test
     public void test_isNegative() {
         assertEquals(Duration.ofNanos(0).isNegative(), false);
         assertEquals(Duration.ofSeconds(0).isNegative(), false);
         assertEquals(Duration.ofNanos(1).isNegative(), false);
         assertEquals(Duration.ofSeconds(1).isNegative(), false);
         assertEquals(Duration.ofSeconds(1, 1).isNegative(), false);
+        assertEquals(Duration.ofSeconds(Long.MAX_VALUE, 999_999_999).isNegative(), false);
         assertEquals(Duration.ofNanos(-1).isNegative(), true);
         assertEquals(Duration.ofSeconds(-1).isNegative(), true);
         assertEquals(Duration.ofSeconds(-1, -1).isNegative(), true);
+        assertEquals(Duration.ofSeconds(Long.MIN_VALUE).isNegative(), true);
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
Please review this PR to introduce `java.time.Duration.isPositive()` method. A CSR is also drafted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8171382](https://bugs.openjdk.java.net/browse/JDK-8171382): java.time.Duration missing isPositive method


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Stephen Colebourne](https://openjdk.java.net/census#scolebourne) (@jodastephen - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4892/head:pull/4892` \
`$ git checkout pull/4892`

Update a local copy of the PR: \
`$ git checkout pull/4892` \
`$ git pull https://git.openjdk.java.net/jdk pull/4892/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4892`

View PR using the GUI difftool: \
`$ git pr show -t 4892`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4892.diff">https://git.openjdk.java.net/jdk/pull/4892.diff</a>

</details>
