### PR TITLE
8271219: [REDO] JDK-8271063 Print injected fields for InstanceKlass

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -1007,6 +1007,7 @@ public:
   void do_local_static_fields(FieldClosure* cl);
   void do_nonstatic_fields(FieldClosure* cl); // including inherited fields
   void do_local_static_fields(void f(fieldDescriptor*, Handle, TRAPS), Handle, TRAPS);
+  void print_nonstatic_fields(FieldClosure* cl); // including inherited and injected fields
 
   void methods_do(void f(Method* method));
   void array_klasses_do(void f(Klass* k));

--- a/src/hotspot/share/runtime/fieldDescriptor.cpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.cpp
@@ -110,8 +110,6 @@ void fieldDescriptor::reinitialize(InstanceKlass* ik, int index) {
     assert(field_holder() == ik, "must be already initialized to this class");
   }
   FieldInfo* f = ik->field(index);
-  assert(!f->is_internal(), "regular Java fields only");
-
   _access_flags = accessFlags_from(f->access_flags());
   guarantee(f->name_index() != 0 && f->signature_index() != 0, "bad constant pool index for fieldDescriptor");
   _index = index;
@@ -125,7 +123,8 @@ void fieldDescriptor::verify() const {
     assert(_index == badInt, "constructor must be called");  // see constructor
   } else {
     assert(_index >= 0, "good index");
-    assert(_index < field_holder()->java_fields_count(), "oob");
+    assert(access_flags().is_internal() ||
+           _index < field_holder()->java_fields_count(), "oob");
   }
 }
 
@@ -133,6 +132,7 @@ void fieldDescriptor::verify() const {
 
 void fieldDescriptor::print_on(outputStream* st) const {
   access_flags().print_on(st);
+  if (access_flags().is_internal()) st->print("internal ");
   name()->print_value_on(st);
   st->print(" ");
   signature()->print_value_on(st);

--- a/test/hotspot/gtest/oops/test_instanceKlass.cpp
+++ b/test/hotspot/gtest/oops/test_instanceKlass.cpp
@@ -22,9 +22,11 @@
  */
 
 #include "precompiled.hpp"
+#include "classfile/systemDictionary.hpp"
 #include "classfile/vmClasses.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/instanceKlass.hpp"
+#include "oops/klass.inline.hpp"
 #include "unittest.hpp"
 
 // Tests for InstanceKlass::is_class_loader_instance_klass() function
@@ -36,4 +38,27 @@ TEST_VM(InstanceKlass, class_loader_class) {
 TEST_VM(InstanceKlass, string_klass) {
   InstanceKlass* klass = vmClasses::String_klass();
   ASSERT_TRUE(!klass->is_class_loader_instance_klass());
+}
+
+TEST_VM(InstanceKlass, class_loader_printer) {
+  ResourceMark rm;
+  oop loader = SystemDictionary::java_platform_loader();
+  stringStream st;
+  loader->print_on(&st);
+  // See if injected loader_data field is printed in string
+  ASSERT_TRUE(strstr(st.as_string(), "internal 'loader_data'") != NULL) << "Must contain internal fields";
+  st.reset();
+  // See if mirror injected fields are printed.
+  oop mirror = vmClasses::ClassLoader_klass()->java_mirror();
+  mirror->print_on(&st);
+  ASSERT_TRUE(strstr(st.as_string(), "internal 'protection_domain'") != NULL) << "Must contain internal fields";
+  // We should test other printing functions too.
+#ifndef PRODUCT
+  st.reset();
+  // method printing is non-product
+  Method* method = vmClasses::ClassLoader_klass()->methods()->at(0);  // we know there's a method here!
+  method->print_on(&st);
+  ASSERT_TRUE(strstr(st.as_string(), "method holder:") != NULL) << "Must contain method_holder field";
+  ASSERT_TRUE(strstr(st.as_string(), "'java/lang/ClassLoader'") != NULL) << "Must be in ClassLoader";
+#endif
 }


### PR DESCRIPTION
There was a test bug in the JDK-8271063.  I thought I'd check the output of Method->print() except it's only available in debug mode.  The basic diff is line 56 and 63 in the gtest.  Retested with mach5 tier1 on 5 Oracle platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271219](https://bugs.openjdk.java.net/browse/JDK-8271219): [REDO] JDK-8271063 Print injected fields for InstanceKlass


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4894/head:pull/4894` \
`$ git checkout pull/4894`

Update a local copy of the PR: \
`$ git checkout pull/4894` \
`$ git pull https://git.openjdk.java.net/jdk pull/4894/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4894`

View PR using the GUI difftool: \
`$ git pr show -t 4894`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4894.diff">https://git.openjdk.java.net/jdk/pull/4894.diff</a>

</details>
