### PR TITLE
8266988: compiler/jvmci/compilerToVM/IsMatureTest.java fails with Unexpected isMature state for multiple times invoked method: expected false to equal true

### DIFF
--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/IsMatureTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/IsMatureTest.java
@@ -78,10 +78,13 @@ public class IsMatureTest {
                 && compLevel != CompilerWhiteBoxTest.COMP_LEVEL_SIMPLE) {
             Asserts.assertNE(methodData, 0L,
                     "Multiple times invoked method should have method data");
-            /* a method is not mature in Xcomp mode with tiered compilation disabled,
-               see NonTieredCompPolicy::is_mature */
-            Asserts.assertEQ(isMature, !(Platform.isComp() && !TIERED),
-                    "Unexpected isMature state for multiple times invoked method");
+            // The method may or may not be mature if it's compiled with limited profile.
+            if (compLevel != CompilerWhiteBoxTest.COMP_LEVEL_LIMITED_PROFILE) {
+               /* a method is not mature in Xcomp mode with tiered compilation disabled,
+                 see NonTieredCompPolicy::is_mature */
+               Asserts.assertEQ(isMature, !(Platform.isComp() && !TIERED),
+                       "Unexpected isMature state for multiple times invoked method");
+            }
         }
     }
 }


### PR DESCRIPTION
The test doesn't expect to be run with -XX:TieredStopAtLevel=2. While we're going to create an MDO for the test method at level 2, we're not going to profile it. Therefore it may not become "mature".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266988](https://bugs.openjdk.java.net/browse/JDK-8266988): compiler/jvmci/compilerToVM/IsMatureTest.java fails with Unexpected isMature state for multiple times invoked method: expected false to equal true


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4895/head:pull/4895` \
`$ git checkout pull/4895`

Update a local copy of the PR: \
`$ git checkout pull/4895` \
`$ git pull https://git.openjdk.java.net/jdk pull/4895/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4895`

View PR using the GUI difftool: \
`$ git pr show -t 4895`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4895.diff">https://git.openjdk.java.net/jdk/pull/4895.diff</a>

</details>
