### PR TITLE
8269342: CICrashAt=1 does not always catch first Java method

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -140,6 +140,7 @@ CompileLog** CompileBroker::_compiler2_logs = NULL;
 // These counters are used to assign an unique ID to each compilation.
 volatile jint CompileBroker::_compilation_id     = 0;
 volatile jint CompileBroker::_osr_compilation_id = 0;
+volatile jint CompileBroker::_native_compilation_id = 0;
 
 // Performance counters
 PerfCounter* CompileBroker::_perf_total_compilation = NULL;
@@ -1588,7 +1589,7 @@ int CompileBroker::assign_compile_id(const methodHandle& method, int osr_bci) {
     assert(!is_osr, "can't be osr");
     // Adapters, native wrappers and method handle intrinsics
     // should be generated always.
-    return Atomic::add(&_compilation_id, 1);
+    return Atomic::add(CICountNative ? &_native_compilation_id : &_compilation_id, 1);
   } else if (CICountOSR && is_osr) {
     id = Atomic::add(&_osr_compilation_id, 1);
     if (CIStartOSR <= id && id < CIStopOSR) {
@@ -2474,6 +2475,8 @@ void CompileBroker::update_compile_perf_data(CompilerThread* thread, const metho
   int last_compile_type = normal_compile;
   if (CICountOSR && is_osr) {
     last_compile_type = osr_compile;
+  } else if (CICountNative && method->is_native()) {
+    last_compile_type = native_compile;
   }
 
   CompilerCounters* counters = thread->counters();

--- a/src/hotspot/share/compiler/compileBroker.hpp
+++ b/src/hotspot/share/compiler/compileBroker.hpp
@@ -174,6 +174,7 @@ class CompileBroker: AllStatic {
   // These counters are used for assigning id's to each compilation
   static volatile jint _compilation_id;
   static volatile jint _osr_compilation_id;
+  static volatile jint _native_compilation_id;
 
   static CompileQueue* _c2_compile_queue;
   static CompileQueue* _c1_compile_queue;

--- a/src/hotspot/share/compiler/compiler_globals.hpp
+++ b/src/hotspot/share/compiler/compiler_globals.hpp
@@ -72,6 +72,10 @@
   develop(bool, CICountOSR, false,                                          \
           "use a separate counter when assigning ids to osr compilations")  \
                                                                             \
+  develop(bool, CICountNative, false,                                       \
+          "use a separate counter when assigning ids to native "            \
+          "compilations")                                                   \
+                                                                            \
   develop(bool, CICompileNatives, true,                                     \
           "compile native methods if supported by the compiler")            \
                                                                             \

--- a/test/hotspot/jtreg/compiler/ciReplay/CiReplayBase.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/CiReplayBase.java
@@ -68,17 +68,23 @@ public abstract class CiReplayBase {
         "-XX:CompilerThreadStackSize=512", "-XX:ParallelGCThreads=1", "-XX:CICompilerCount=2",
         "-XX:-BackgroundCompilation", "-XX:CompileCommand=inline,java.io.PrintStream::*",
         "-XX:+IgnoreUnrecognizedVMOptions", "-XX:TypeProfileLevel=222", // extra profile data as a stress test
-        "-XX:CICrashAt=1", "-XX:+DumpReplayDataOnError",
-        "-XX:+PreferInterpreterNativeStubs", REPLAY_FILE_OPTION};
+        "-XX:+CICountNative", "-XX:CICrashAt=1", "-XX:+DumpReplayDataOnError",
+        REPLAY_FILE_OPTION};
     private static final String[] REPLAY_OPTIONS = new String[]{DISABLE_COREDUMP_ON_CRASH,
         "-XX:+IgnoreUnrecognizedVMOptions", "-XX:TypeProfileLevel=222",
         "-XX:+ReplayCompiles", REPLAY_FILE_OPTION};
     protected final Optional<Boolean> runServer;
     private static int dummy;
 
+    static interface Lambda {
+        int value();
+    }
+
     public static class TestMain {
         public static void main(String[] args) {
-            for (int i = 0; i < 20_000; i++) {
+            Lambda start = () -> 0;
+
+            for (int i = start.value(); i < 20_000; i++) {
                 test(i);
             }
         }

--- a/test/hotspot/jtreg/compiler/ciReplay/CiReplayBase.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/CiReplayBase.java
@@ -82,6 +82,7 @@ public abstract class CiReplayBase {
 
     public static class TestMain {
         public static void main(String[] args) {
+            // explicitly trigger native compilation
             Lambda start = () -> 0;
 
             for (int i = start.value(); i < 20_000; i++) {


### PR DESCRIPTION
This change reintroduces the CICountNative flag, so that -XX:+CICountNative -XX:CICrashAt=1 can reliably crash the first compiled Java method without worrying about native method wrappers and method handle intrinsics.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269342](https://bugs.openjdk.java.net/browse/JDK-8269342): CICrashAt=1 does not always catch first Java method


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to ba0569e2dab579a6b5a0e75d5d1522ad50ff3d10
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4897/head:pull/4897` \
`$ git checkout pull/4897`

Update a local copy of the PR: \
`$ git checkout pull/4897` \
`$ git pull https://git.openjdk.java.net/jdk pull/4897/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4897`

View PR using the GUI difftool: \
`$ git pr show -t 4897`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4897.diff">https://git.openjdk.java.net/jdk/pull/4897.diff</a>

</details>
