### PR TITLE
8271215: Fix data races in G1PeriodicGCTask

### DIFF
--- a/src/hotspot/share/gc/g1/g1PeriodicGCTask.cpp
+++ b/src/hotspot/share/gc/g1/g1PeriodicGCTask.cpp
@@ -27,12 +27,16 @@
 #include "gc/g1/g1ConcurrentMark.inline.hpp"
 #include "gc/g1/g1ConcurrentMarkThread.inline.hpp"
 #include "gc/g1/g1PeriodicGCTask.hpp"
+#include "gc/shared/suspendibleThreadSet.hpp"
 #include "logging/log.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/os.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 bool G1PeriodicGCTask::should_start_periodic_gc() {
+  // Ensure no GC safepoints while we're doing the checks, to avoid data races.
+  SuspendibleThreadSetJoiner sts;
+
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
   // If we are currently in a concurrent mark we are going to uncommit memory soon.
   if (g1h->concurrent_mark()->cm_thread()->in_progress()) {


### PR DESCRIPTION
Please review this small change to G1PeriodicGCTask, eliminating unlikely
but possible data races with a concurrently running GC pause.  An STS-joiner
is used to ensure there isn't a GC pause while doing the checks to decide
whether to perform a periodic GC.

Testing:
mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271215](https://bugs.openjdk.java.net/browse/JDK-8271215): Fix data races in G1PeriodicGCTask


### Reviewers
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4899/head:pull/4899` \
`$ git checkout pull/4899`

Update a local copy of the PR: \
`$ git checkout pull/4899` \
`$ git pull https://git.openjdk.java.net/jdk pull/4899/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4899`

View PR using the GUI difftool: \
`$ git pr show -t 4899`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4899.diff">https://git.openjdk.java.net/jdk/pull/4899.diff</a>

</details>
