### PR TITLE
8269523: runtime/Safepoint/TestAbortOnVMOperationTimeout.java failed when expecting 'VM operation took too long'

### DIFF
--- a/test/hotspot/jtreg/runtime/Safepoint/TestAbortOnVMOperationTimeout.java
+++ b/test/hotspot/jtreg/runtime/Safepoint/TestAbortOnVMOperationTimeout.java
@@ -26,7 +26,7 @@ import jdk.test.lib.process.*;
 
 /*
  * @test TestAbortOnVMOperationTimeout
- * @bug 8181143
+ * @bug 8181143 8269523
  * @summary Check abort on VM timeout is working
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
@@ -51,9 +51,9 @@ public class TestAbortOnVMOperationTimeout {
             testWith(delay, true);
         }
 
-        // These should fail: Serial is not very fast. Traversing 10M objects in 5 ms
-        // means less than 0.5 ns per object, which is not doable.
-        for (int delay : new int[]{0, 1, 5}) {
+        // These should fail: Serial is not very fast but we have seen the test
+        // execute as quickly as 2ms!
+        for (int delay : new int[]{0, 1}) {
             testWith(delay, false);
         }
     }
@@ -66,6 +66,7 @@ public class TestAbortOnVMOperationTimeout {
                 "-Xmx256m",
                 "-XX:+UseSerialGC",
                 "-XX:-CreateCoredumpOnCrash",
+                "-Xlog:gc",
                 "TestAbortOnVMOperationTimeout",
                 "foo"
         );
@@ -77,6 +78,6 @@ public class TestAbortOnVMOperationTimeout {
             output.shouldMatch("VM operation took too long");
             output.shouldNotHaveExitValue(0);
         }
+        output.reportDiagnosticSummary();
     }
 }
-

--- a/test/hotspot/jtreg/runtime/Safepoint/TestAbortOnVMOperationTimeout.java
+++ b/test/hotspot/jtreg/runtime/Safepoint/TestAbortOnVMOperationTimeout.java
@@ -37,10 +37,11 @@ import jdk.test.lib.process.*;
 public class TestAbortOnVMOperationTimeout {
 
     // A static array is unlikely to be optimised away by the JIT.
-    static Object[] arr = new Object[10_000_000];
+    static Object[] arr;
 
     public static void main(String[] args) throws Exception {
         if (args.length > 0) {
+            arr = new Object[10_000_000];
             for (int i = 0; i < arr.length; i++) {
                arr[i] = new Object();
             }

--- a/test/hotspot/jtreg/runtime/Safepoint/TestAbortOnVMOperationTimeout.java
+++ b/test/hotspot/jtreg/runtime/Safepoint/TestAbortOnVMOperationTimeout.java
@@ -36,12 +36,16 @@ import jdk.test.lib.process.*;
 
 public class TestAbortOnVMOperationTimeout {
 
+    // A static array is unlikely to be optimised away by the JIT.
+    static Object[] arr = new Object[10_000_000];
+
     public static void main(String[] args) throws Exception {
         if (args.length > 0) {
-            Object[] arr = new Object[10_000_000];
             for (int i = 0; i < arr.length; i++) {
                arr[i] = new Object();
             }
+            // Try to force at least one full GC cycle.
+            System.gc();
             return;
         }
 


### PR DESCRIPTION
Please review this simple test adjustment:
 - dropped 5ms timeout as we have seen execution as low as 2ms
 - enabled GC logging
 - report output in all cases to allow ease of analysis

Testing: ran 10x on macos/linux/Windows x64 and macos Aarch64 to check execution times and adjusted test accordingly

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269523](https://bugs.openjdk.java.net/browse/JDK-8269523): runtime/Safepoint/TestAbortOnVMOperationTimeout.java failed when expecting 'VM operation took too long'


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4901/head:pull/4901` \
`$ git checkout pull/4901`

Update a local copy of the PR: \
`$ git checkout pull/4901` \
`$ git pull https://git.openjdk.java.net/jdk pull/4901/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4901`

View PR using the GUI difftool: \
`$ git pr show -t 4901`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4901.diff">https://git.openjdk.java.net/jdk/pull/4901.diff</a>

</details>
