### PR TITLE
8271055: Crash during deoptimization with "assert(bb->is_reachable()) failed: getting result from unreachable basicblock" with -XX:+VerifyStack

### DIFF
--- a/src/hotspot/share/oops/generateOopMap.cpp
+++ b/src/hotspot/share/oops/generateOopMap.cpp
@@ -1171,8 +1171,11 @@ void GenerateOopMap::interp_bb(BasicBlock *bb) {
 }
 
 void GenerateOopMap::do_exception_edge(BytecodeStream* itr) {
-  // Only check exception edge, if bytecode can trap
-  if (!Bytecodes::can_trap(itr->code())) return;
+  // Check exception edge even if bytecode can not trap since some
+  // bytecodes in try-block will never throw an exception, thus handler
+  // basic blocks becomes unreachable. For such cases, these unreachable
+  // basic block confuse later OopMap generation.
+
   switch (itr->code()) {
     case Bytecodes::_aload_0:
       // These bytecodes can trap for rewriting.  We need to assume that

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -784,11 +784,6 @@ JRT_LEAF(BasicType, Deoptimization::unpack_frames(JavaThread* thread, int exec_m
           // a given bytecode or the state after, so we try both
           if (!Bytecodes::is_invoke(cur_code) && cur_code != Bytecodes::_athrow) {
             // Get expression stack size for the next bytecode
-            if(UseNewCode) {
-              if(cur_code == Bytecodes::_goto && next_code ==Bytecodes::_astore_2){
-                tty->print_cr("==");
-              }
-            }
             InterpreterOopMap next_mask;
             OopMapCache::compute_one_oop_map(mh, str.bci(), &next_mask);
             next_mask_expression_stack_size = next_mask.expression_stack_size();

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -784,6 +784,11 @@ JRT_LEAF(BasicType, Deoptimization::unpack_frames(JavaThread* thread, int exec_m
           // a given bytecode or the state after, so we try both
           if (!Bytecodes::is_invoke(cur_code) && cur_code != Bytecodes::_athrow) {
             // Get expression stack size for the next bytecode
+            if(UseNewCode) {
+              if(cur_code == Bytecodes::_goto && next_code ==Bytecodes::_astore_2){
+                tty->print_cr("==");
+              }
+            }
             InterpreterOopMap next_mask;
             OopMapCache::compute_one_oop_map(mh, str.bci(), &next_mask);
             next_mask_expression_stack_size = next_mask.expression_stack_size();

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -1518,6 +1518,11 @@ public class Gen extends JCTree.Visitor {
             int startpc = code.curCP();
             Code.State stateTry = code.state.dup();
             genStat(body, env, CRT_BLOCK);
+            if (startpc == code.curCP()) {
+                // Put an nop into try block even if it is empty because we want
+                // to generate exception table within code attribute.
+                code.emitop0(nop);
+            }
             int endpc = code.curCP();
             List<Integer> gaps = env.info.gaps.toList();
             code.statBegin(TreeInfo.endPos(body));

--- a/test/hotspot/jtreg/compiler/interpreter/VerifyStackWithUnreachableBlock.java
+++ b/test/hotspot/jtreg/compiler/interpreter/VerifyStackWithUnreachableBlock.java
@@ -25,6 +25,7 @@
 /*
  * @test VerifyStackWithUnreachableBlock
  * @bug 8271055
+ * @compile VerifyStackWithUnreachableBlock.java
  * @summary Using VerifyStack for method that contains unreachable basic blocks
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+VerifyStack compiler.interpreter.VerifyStackWithUnreachableBlock
  */

--- a/test/hotspot/jtreg/compiler/interpreter/VerifyStackWithUnreachableBlock.java
+++ b/test/hotspot/jtreg/compiler/interpreter/VerifyStackWithUnreachableBlock.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test VerifyStackWithUnreachableBlock
+ * @bug 8271055
+ * @summary Using VerifyStack for method that contains unreachable basic blocks
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+VerifyStack compiler.interpreter.VerifyStackWithUnreachableBlock
+ */
+
+package compiler.interpreter;
+
+public class VerifyStackWithUnreachableBlock {
+    public static void main(String[] strArr) {
+        VerifyStackWithUnreachableBlock _instance = new VerifyStackWithUnreachableBlock();
+        for (int i = 0; i < 10000; i++) {
+            _instance.test();
+        }
+    }
+
+    void test() {
+        int i8 = 1;
+        try {
+            ;
+        } finally {
+            for (; i8 < 100; i8++) {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi, I'm trying to fix JDK-8271055. The root cause is that some basic blocks are not interpreted because there is no trap bytecode inside them, these basic blocks eventually become unreachable and lead to a crash. Maybe we need to coordinate compiler and hotspot groups to fix this crash.

----

The attached test generates the following bytecode:
```
  void test();
    descriptor: ()V
    flags: (0x0000)
    Code:
      stack=2, locals=3, args_size=1
         0: iconst_1
         1: istore_1
         2: iload_1
         3: bipush        100
         5: if_icmpge     29
         8: iinc          1, 1
        11: goto          2
        14: astore_2
        15: iload_1
        16: bipush        100
        18: if_icmpge     27
        21: iinc          1, 1
        24: goto          15
        27: aload_2
        28: athrow
        29: return

```

Javac generates some unreachable basic blocks(BCI 14 - 28), and there is no exception table for them, VM knows nothing about them. I found the same bug report at JDK-8022186 which was marked as `Fixed`, but I think it was not properly fixed, In some similar cases, javac cannot work well, I have filed https://bugs.openjdk.java.net/browse/JDK-8271254 for another javac bug.

Going back to this bug, the proposed change is to insert a nop in empty try-block so that javac can generate the correct exception table. Now generated bytecodes look like this:
```
  void test();
    descriptor: ()V
    flags: (0x0000)
    Code:
      stack=2, locals=3, args_size=1
         0: iconst_1
         1: istore_1
         2: nop
         3: iload_1
         4: bipush        100
         6: if_icmpge     30
         9: iinc          1, 1
        12: goto          3
        15: astore_2
        16: iload_1
        17: bipush        100
        19: if_icmpge     28
        22: iinc          1, 1
        25: goto          16
        28: aload_2
        29: athrow
        30: return
      Exception table:
         from    to  target type
             2     3    15   any
```

However, this is not the end. Even if the exception table is correctly generated, VM only enters GenerateOopMap::do_exception_edge when the bytecode may be trapped. In order to setup handler block, we need to relax this restriction to allow even bytecodes such as nop to correctly enter GenerateOopMap::do_exception_edge. Otherwise, handler block will not be interpreted, its stack is problematic and finally hits the assertion.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8271055](https://bugs.openjdk.java.net/browse/JDK-8271055): Crash during deoptimization with "assert(bb->is_reachable()) failed: getting result from unreachable basicblock" with -XX:+VerifyStack


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4902/head:pull/4902` \
`$ git checkout pull/4902`

Update a local copy of the PR: \
`$ git checkout pull/4902` \
`$ git pull https://git.openjdk.java.net/jdk pull/4902/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4902`

View PR using the GUI difftool: \
`$ git pr show -t 4902`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4902.diff">https://git.openjdk.java.net/jdk/pull/4902.diff</a>

</details>
