### PR TITLE
8269753: Misplaced caret in PatternSyntaxException's detail message

### DIFF
--- a/src/java.base/share/classes/java/util/regex/PatternSyntaxException.java
+++ b/src/java.base/share/classes/java/util/regex/PatternSyntaxException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/regex/PatternSyntaxException.java
+++ b/src/java.base/share/classes/java/util/regex/PatternSyntaxException.java
@@ -107,7 +107,9 @@ public class PatternSyntaxException
         sb.append(pattern);
         if (index >= 0 && pattern != null && index < pattern.length()) {
             sb.append(System.lineSeparator());
-            for (int i = 0; i < index; i++) sb.append(' ');
+            for (int i = 0; i < index; i++) {
+                sb.append((pattern.charAt(i) == '\t') ? '\t' : ' ');
+            }
             sb.append('^');
         }
         return sb.toString();

--- a/test/jdk/java/util/regex/RegExTest.java
+++ b/test/jdk/java/util/regex/RegExTest.java
@@ -36,7 +36,7 @@
  * 8151481 4867170 7080302 6728861 6995635 6736245 4916384 6328855 6192895
  * 6345469 6988218 6693451 7006761 8140212 8143282 8158482 8176029 8184706
  * 8194667 8197462 8184692 8221431 8224789 8228352 8230829 8236034 8235812
- * 8216332 8214245 8237599 8241055 8247546 8258259 8037397
+ * 8216332 8214245 8237599 8241055 8247546 8258259 8037397 8269753
  *
  * @library /test/lib
  * @library /lib/testlibrary/java/lang
@@ -198,6 +198,7 @@ public class RegExTest {
         caseInsensitivePMatch();
         surrogatePairOverlapRegion();
         droppedClassesWithIntersection();
+        errorMessageCaretIndentation();
 
 
         if (failure) {
@@ -5289,5 +5290,23 @@ public class RegExTest {
             System.out.println("Compiling intersection pattern is matching digits where it should not");
         }
 
+    }
+
+    //This test is for 8269753
+    private static void errorMessageCaretIndentation() {
+        String pattern = "\t**";
+
+        try {
+            var res = Pattern.compile(pattern);
+        } catch (PatternSyntaxException e) {
+            var message = e.getMessage();
+            var sep = System.lineSeparator();
+            if(message.contains(sep + "\t ^")){
+                return;
+            }
+        }
+        failCount++;
+
+        report("Correct caret indentation for patterns with tabs");
     }
 }

--- a/test/jdk/java/util/regex/RegExTest.java
+++ b/test/jdk/java/util/regex/RegExTest.java
@@ -5290,6 +5290,8 @@ public class RegExTest {
             System.out.println("Compiling intersection pattern is matching digits where it should not");
         }
 
+        report("Dropped classes with intersection.");
+
     }
 
     //This test is for 8269753
@@ -5301,12 +5303,10 @@ public class RegExTest {
         } catch (PatternSyntaxException e) {
             var message = e.getMessage();
             var sep = System.lineSeparator();
-            if(message.contains(sep + "\t ^")){
-                return;
+            if (!message.contains(sep + "\t ^")){
+                failCount++;
             }
         }
-        failCount++;
-
         report("Correct caret indentation for patterns with tabs");
     }
 }


### PR DESCRIPTION
Fixes a bug where carets aren't indented correctly in PatternSyntaxException messages because tab characters are converted to spaces in their indentation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269753](https://bugs.openjdk.java.net/browse/JDK-8269753): Misplaced caret in PatternSyntaxException's detail message


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4906/head:pull/4906` \
`$ git checkout pull/4906`

Update a local copy of the PR: \
`$ git checkout pull/4906` \
`$ git pull https://git.openjdk.java.net/jdk pull/4906/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4906`

View PR using the GUI difftool: \
`$ git pr show -t 4906`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4906.diff">https://git.openjdk.java.net/jdk/pull/4906.diff</a>

</details>
