### PR TITLE
8270925: replay dump using CICrashAt does not include inlining data

### DIFF
--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -599,7 +599,7 @@ Compilation::Compilation(AbstractCompiler* compiler, ciEnv* env, ciMethod* metho
 
 Compilation::~Compilation() {
   // simulate crash during compilation
-  assert(_env->compile_id() != CICrashAt, "just as planned");
+  assert(CICrashAt < 0 || (uintx)_env->compile_id() != (uintx)CICrashAt, "just as planned");
 
   _env->set_compiler_data(NULL);
 }

--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -598,6 +598,9 @@ Compilation::Compilation(AbstractCompiler* compiler, ciEnv* env, ciMethod* metho
 }
 
 Compilation::~Compilation() {
+  // simulate crash during compilation
+  assert(_env->compile_id() != CICrashAt, "just as planned");
+
   _env->set_compiler_data(NULL);
 }
 

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2126,8 +2126,6 @@ void CompileBroker::post_compile(CompilerThread* thread, CompileTask* task, bool
       fatal("Never compilable: %s", failure_reason);
     }
   }
-  // simulate crash during compilation
-  assert(task->compile_id() != CICrashAt, "just as planned");
 }
 
 static void post_compilation_event(EventCompilation& event, CompileTask* task) {

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -475,6 +475,9 @@ CompileWrapper::CompileWrapper(Compile* compile) : _compile(compile) {
   _compile->clone_map().set_debug(_compile->has_method() && _compile->directive()->CloneMapDebugOption);
 }
 CompileWrapper::~CompileWrapper() {
+  // simulate crash during compilation
+  assert(_compile->compile_id() != CICrashAt, "just as planned");
+
   _compile->end_method();
   _compile->env()->set_compiler_data(NULL);
 }

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -476,7 +476,7 @@ CompileWrapper::CompileWrapper(Compile* compile) : _compile(compile) {
 }
 CompileWrapper::~CompileWrapper() {
   // simulate crash during compilation
-  assert(_compile->compile_id() != CICrashAt, "just as planned");
+  assert(CICrashAt < 0 || _compile->compile_id() != CICrashAt, "just as planned");
 
   _compile->end_method();
   _compile->env()->set_compiler_data(NULL);

--- a/test/hotspot/jtreg/compiler/ciReplay/TestInlining.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/TestInlining.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8011675
+ * @library / /test/lib
+ * @summary testing of ciReplay with inlining
+ * @requires vm.flightRecorder != true & vm.compMode != "Xint" & vm.debug == true & vm.compiler2.enabled
+ * @modules java.base/jdk.internal.misc
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      compiler.ciReplay.TestInlining
+ */
+
+package compiler.ciReplay;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.StringTokenizer;
+import jdk.test.lib.Asserts;
+
+public class TestInlining extends CiReplayBase {
+    public static void main(String args[]) {
+        new TestInlining().runTest(false, TIERED_DISABLED_VM_OPTION);
+    }
+
+    @Override
+    public void testAction() {
+        try {
+            Path replayFilePath = Paths.get(REPLAY_FILE_NAME);
+            List<String> replayContent = Files.readAllLines(replayFilePath);
+            boolean found = false;
+            for (int i = 0; i < replayContent.size(); i++) {
+                String line = replayContent.get(i);
+                if (line.startsWith("compile ")) {
+                    StringTokenizer tokenizer = new StringTokenizer(line, " ");
+                    Asserts.assertEQ(tokenizer.nextToken(), "compile");
+                    tokenizer.nextToken(); // class
+                    tokenizer.nextToken(); // method
+                    tokenizer.nextToken(); // signature
+                    tokenizer.nextToken(); // bci
+                    Asserts.assertEQ(tokenizer.nextToken(), "4"); // level
+                    Asserts.assertEQ(tokenizer.nextToken(), "inline");
+                    found = true;
+                }
+            }
+            Asserts.assertEQ(found, true);
+        } catch (IOException ioe) {
+            throw new Error("Failed to read/write replay data: " + ioe, ioe);
+        }
+    }
+}
+

--- a/test/hotspot/jtreg/compiler/ciReplay/TestInlining.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/TestInlining.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8011675
+ * @bug 8270925
  * @library / /test/lib
  * @summary testing of ciReplay with inlining
  * @requires vm.flightRecorder != true & vm.compMode != "Xint" & vm.debug == true & vm.compiler2.enabled


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270925](https://bugs.openjdk.java.net/browse/JDK-8270925): replay dump using CICrashAt does not include inlining data


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4908/head:pull/4908` \
`$ git checkout pull/4908`

Update a local copy of the PR: \
`$ git checkout pull/4908` \
`$ git pull https://git.openjdk.java.net/jdk pull/4908/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4908`

View PR using the GUI difftool: \
`$ git pr show -t 4908`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4908.diff">https://git.openjdk.java.net/jdk/pull/4908.diff</a>

</details>
