### PR TITLE
8271323: [TESTBUG] serviceability/sa/ClhsdbCDSCore.java fails with -XX:TieredStopAtLevel=1

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbCDSCore.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbCDSCore.java
@@ -125,8 +125,8 @@ public class ClhsdbCDSCore {
 
             List testJavaOpts = Arrays.asList(Utils.getTestJavaOpts());
 
-            if (testJavaOpts.contains("-Xcomp") && testJavaOpts.contains("-XX:TieredStopAtLevel=1")) {
-                // No MDOs are allocated in -XX:TieredStopAtLevel=1 + -Xcomp mode
+            if (testJavaOpts.contains("-XX:TieredStopAtLevel=1")) {
+                // No MDOs are allocated in -XX:TieredStopAtLevel=1
                 // The reason is methods being compiled aren't hot enough
                 // Let's not call printmdo in such scenario
                 cmds = List.of("printall", "jstack -v");


### PR DESCRIPTION
This test fails reliably with `-XX:TieredStopAtLevel=1` since JDK-8251462. MDOs are no longer allocated in this mode so the clhsdb `printmdo -a` command prints nothing.  The failure is basically the same as JDK-8236042 which happened with `-Xcomp -XX:TieredStopAtLevel=1` so the workaround for that just needs to be adjusted slightly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271323](https://bugs.openjdk.java.net/browse/JDK-8271323): [TESTBUG] serviceability/sa/ClhsdbCDSCore.java fails with -XX:TieredStopAtLevel=1


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4910/head:pull/4910` \
`$ git checkout pull/4910`

Update a local copy of the PR: \
`$ git checkout pull/4910` \
`$ git pull https://git.openjdk.java.net/jdk pull/4910/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4910`

View PR using the GUI difftool: \
`$ git pr show -t 4910`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4910.diff">https://git.openjdk.java.net/jdk/pull/4910.diff</a>

</details>
