### PR TITLE
8271353: PerfDataManager::destroy crashes in VM_Exit

### DIFF
--- a/src/hotspot/share/runtime/perfData.cpp
+++ b/src/hotspot/share/runtime/perfData.cpp
@@ -277,7 +277,8 @@ void PerfDataManager::destroy() {
   os::naked_short_sleep(1);  // 1ms sleep to let other thread(s) run
 
   log_debug(perf, datacreation)("Total = %d, Sampled = %d, Constants = %d",
-                                _all->length(), _sampled->length(), _constants->length());
+                                _all->length(), _sampled == NULL ? -1 : _sampled->length(),
+                                _constants == NULL ? -1 : _constants->length());
 
   for (int index = 0; index < _all->length(); index++) {
     PerfData* p = _all->at(index);

--- a/src/hotspot/share/runtime/perfData.cpp
+++ b/src/hotspot/share/runtime/perfData.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -277,8 +277,8 @@ void PerfDataManager::destroy() {
   os::naked_short_sleep(1);  // 1ms sleep to let other thread(s) run
 
   log_debug(perf, datacreation)("Total = %d, Sampled = %d, Constants = %d",
-                                _all->length(), _sampled == NULL ? -1 : _sampled->length(),
-                                _constants == NULL ? -1 : _constants->length());
+                                _all->length(), _sampled == NULL ? 0 : _sampled->length(),
+                                _constants == NULL ? 0 : _constants->length());
 
   for (int index = 0; index < _all->length(); index++) {
     PerfData* p = _all->at(index);


### PR DESCRIPTION
This patch check PerfDataManager::_sampled and _constants is NULL. if it is,
return -1. 

When the user enables UL `-Xlog:perf+datacreation=debug`, it may crash in
PerfDataManager::destroy(). The following line will crash when _sampled is NULL.

```
  log_debug(perf, datacreation)("Total = %d, Sampled = %d, Constants = %d",
                                _all->length(), _sampled->length(), _constants->length());
```

This only happens when UsePerfData is on and PerfDataManager::destroy() is invoked before
StatSampler::initialize() which initializes PerfDataManager::_sampled.
PerfDataManager::destroy() is called by VM_Exit which can be triggered by SIGINT on Linux anytime.

A reproducible: invoke the following command and keep pressing Ctrl-c.
$perf stat -r 100 java -Xlog:perf+datacreation=debug --version

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271353](https://bugs.openjdk.java.net/browse/JDK-8271353): PerfDataManager::destroy crashes in VM_Exit


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to d94c9d35097018c3c7bfa82ce13e80eef3ef4457
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4913/head:pull/4913` \
`$ git checkout pull/4913`

Update a local copy of the PR: \
`$ git checkout pull/4913` \
`$ git pull https://git.openjdk.java.net/jdk pull/4913/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4913`

View PR using the GUI difftool: \
`$ git pr show -t 4913`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4913.diff">https://git.openjdk.java.net/jdk/pull/4913.diff</a>

</details>
