### PR TITLE
8271202: C1: assert(false) failed: live_in set of first block must be empty

### DIFF
--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -830,12 +830,14 @@ bool BlockBegin::try_merge(ValueStack* new_state) {
           if (existing_phi == NULL) {
             return false; // BAILOUT in caller
           }
-          // Invalidate the phi function here. This case is very rare except for
-          // JVMTI capability "can_access_local_variables".
-          // In really rare cases we will bail out in LIRGenerator::move_to_phi.
-          existing_phi->make_illegal();
-          existing_state->invalidate_local(index);
-          TRACE_PHI(tty->print_cr("invalidating local %d because of type mismatch", index));
+          if (new_value != NULL) {
+            // Invalidate the phi function here. This case is very rare except for
+            // JVMTI capability "can_access_local_variables".
+            // In really rare cases we will bail out in LIRGenerator::move_to_phi.
+            existing_phi->make_illegal();
+            existing_state->invalidate_local(index);
+            TRACE_PHI(tty->print_cr("invalidating local %d because of type mismatch", index));
+          }
         }
       }
 

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -832,6 +832,18 @@ void LinearScan::compute_global_live_sets() {
   if (!ir()->start()->live_in().is_same(live_in_args)) {
 #ifdef ASSERT
     tty->print_cr("Error: live_in set of first block must be empty (when this fails, virtual registers are used before they are defined)");
+    for (int i = num_blocks - 1; i >= 0; i--) {
+      BlockBegin* block = block_at(i);
+      tty->print_cr("Block %d", block->block_id());
+      tty->print_cr("live_in:");
+      print_bitmap(block->live_in());
+      tty->print_cr("live_out:");
+      print_bitmap(block->live_out());
+      tty->print_cr("live_gen:");
+      print_bitmap(block->live_gen());
+      tty->print_cr("live_kill:");
+      print_bitmap(block->live_kill());
+    }
     tty->print_cr("affected registers:");
     print_bitmap(ir()->start()->live_in());
 

--- a/test/hotspot/jtreg/compiler/c1/ExtendLocalVarLifetime.java
+++ b/test/hotspot/jtreg/compiler/c1/ExtendLocalVarLifetime.java
@@ -48,7 +48,7 @@ public class ExtendLocalVarLifetime {
         int counter = 0;
         int i2, i26, i29, iArr[] = new int[400];
         boolean b3 = true;
-       
+
         for (int smallinvoc = 0; smallinvoc < 139; smallinvoc++) {
         }
         for (i2 = 13; i2 < 1000; i2++) {

--- a/test/hotspot/jtreg/compiler/c1/ExtendLocalVarLifetime.java
+++ b/test/hotspot/jtreg/compiler/c1/ExtendLocalVarLifetime.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8271202
+ * @summary extending local var lifetime by DeoptimizeALot
+ * @requires vm.compiler1.enabled
+ * @library /test/lib
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+DeoptimizeALot
+ *                   compiler.c1.ExtendLocalVarLifetime
+ */
+
+package compiler.c1;
+
+public class ExtendLocalVarLifetime {
+    public static void main(String[] strArr) {
+        try {
+            test();
+        } catch (Exception e) {
+            // Expected
+        }
+    }
+
+    static void test() {
+        long l6 = 10L;
+        int counter = 0;
+        int i2, i26, i29, iArr[] = new int[400];
+        boolean b3 = true;
+       
+        for (int smallinvoc = 0; smallinvoc < 139; smallinvoc++) {
+        }
+        for (i2 = 13; i2 < 1000; i2++) {
+            for (i26 = 2; i26 < 114; l6 += 2) {
+                // Infinite loop
+                if (b3) {
+                    for (i29 = 1; i29 < 2; i29++) {
+                        try {
+                            iArr[i26] = 0;
+                        } catch (ArithmeticException a_e) {
+                        }
+                    }
+                }
+                counter++;
+                if (counter == 100000) {
+                    throw new RuntimeException("expected");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi, I'm trying to fix [JDK-8271202](https://bugs.openjdk.java.net/browse/JDK-8271202). A local variable(smallinvoc) is defined in B3 and only used in B14, so it oughts to have a short lifetime. But its lifetime has been unconditionally extended since -XX:+DeoptimizeALot(**Just removing this may be also a simpler and safer fix? Not sure if it's acceptable**), making it propagate to almost the whole remaing IR.

https://github.com/openjdk/jdk/blob/ecd445562f8355704a041f9eca0e87dc85a7f44c/src/hotspot/share/ci/ciMethod.cpp#L373-L379

![image](https://user-images.githubusercontent.com/5010047/127277954-2a64d87e-2981-4d74-8001-c7efeb000a10.png)


A virtual register(v603) that represents this variable is located in B13 live_in set, which propagated to B1 live_out set.

When B1 merges state with B16 and B19, it found that this variable in new_state(B16) was empty, so B1 invalidates the corresponding local slot.

https://github.com/openjdk/jdk/blob/ecd445562f8355704a041f9eca0e87dc85a7f44c/src/hotspot/share/c1/c1_Instruction.cpp#L826-L838

I think we should invalidate this slot only when their types are mismatched. Otherwise, Phi will not be generated, B19 live_gen set will not contain this variable, because of which this variable is alive in B1 live_in. B1 live_in will eventually backward propagate to B20 live_in set, it avoids being killed by B19 live_gen, which causes the crash.

```
Block 1
live_in:
603 616 617 618 619 620 621 622 
live_out:
603 616 617 618 619 620 621 622 
live_gen:
620 
live_kill:
648 649 650

Block 16
live_in:
603 616 617 618 619 620 621 622 
live_out:
603 616 617 618 619 620 621 622 
live_gen:
616 617 618 619 620 621 622 
live_kill:
620 654 655 656 657 

Block 19
live_in:
603 
live_out:
603 616 617 618 619 620 621 622 
live_gen:

live_kill:
0 1 616 617 618 619 620 621 622 623 624 625 626 627 628 629 630 631 632 633 634 635 636 637 638 639 640 641 642 643 644 645 646 647 


Block 20
live_in:
603 
live_out:
603 
live_gen:

live_kill:
577 578
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271202](https://bugs.openjdk.java.net/browse/JDK-8271202): C1: assert(false) failed: live_in set of first block must be empty


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4916/head:pull/4916` \
`$ git checkout pull/4916`

Update a local copy of the PR: \
`$ git checkout pull/4916` \
`$ git pull https://git.openjdk.java.net/jdk pull/4916/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4916`

View PR using the GUI difftool: \
`$ git pr show -t 4916`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4916.diff">https://git.openjdk.java.net/jdk/pull/4916.diff</a>

</details>
