### PR TITLE
8270901: Typo PHASE_CPP in CompilerPhaseType

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2221,7 +2221,7 @@ void Compile::Optimize() {
     TracePhase tp("ccp", &timers[_t_ccp]);
     ccp.do_transform();
   }
-  print_method(PHASE_CPP1, 2);
+  print_method(PHASE_CCP1, 2);
 
   assert( true, "Break here to ccp.dump_old2new_map()");
 

--- a/src/hotspot/share/opto/phasetype.hpp
+++ b/src/hotspot/share/opto/phasetype.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/opto/phasetype.hpp
+++ b/src/hotspot/share/opto/phasetype.hpp
@@ -44,7 +44,7 @@ enum CompilerPhaseType {
   PHASE_PHASEIDEALLOOP1,
   PHASE_PHASEIDEALLOOP2,
   PHASE_PHASEIDEALLOOP3,
-  PHASE_CPP1,
+  PHASE_CCP1,
   PHASE_ITER_GVN2,
   PHASE_PHASEIDEALLOOP_ITERATIONS,
   PHASE_OPTIMIZE_FINISHED,
@@ -95,7 +95,7 @@ class CompilerPhaseTypeHelper {
       case PHASE_PHASEIDEALLOOP1:            return "PhaseIdealLoop 1";
       case PHASE_PHASEIDEALLOOP2:            return "PhaseIdealLoop 2";
       case PHASE_PHASEIDEALLOOP3:            return "PhaseIdealLoop 3";
-      case PHASE_CPP1:                       return "PhaseCPP 1";
+      case PHASE_CCP1:                       return "PhaseCCP 1";
       case PHASE_ITER_GVN2:                  return "Iter GVN 2";
       case PHASE_PHASEIDEALLOOP_ITERATIONS:  return "PhaseIdealLoop iterations";
       case PHASE_OPTIMIZE_FINISHED:          return "Optimize finished";

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/opto/CompilerPhaseType.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/opto/CompilerPhaseType.java
@@ -38,7 +38,7 @@ public enum CompilerPhaseType {
   PHASE_PHASEIDEALLOOP1 ("PhaseIdealLoop 1"),
   PHASE_PHASEIDEALLOOP2 ("PhaseIdealLoop 2"),
   PHASE_PHASEIDEALLOOP3 ("PhaseIdealLoop 3"),
-  PHASE_CPP1 ("PhaseCPP 1"),
+  PHASE_CCP1 ("PhaseCCP 1"),
   PHASE_ITER_GVN2 ("Iter GVN 2"),
   PHASE_PHASEIDEALLOOP_ITERATIONS ("PhaseIdealLoop iterations"),
   PHASE_OPTIMIZE_FINISHED ("Optimize finished"),

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/opto/CompilerPhaseType.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/opto/CompilerPhaseType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Should be PHASE_CCP instead of PHASE_CPP, it also affects dumped ideal graph XML.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270901](https://bugs.openjdk.java.net/browse/JDK-8270901): Typo PHASE_CPP in CompilerPhaseType


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**) ⚠️ Review applies to f556d064e0ee8e631f4d7e4e2964805b96150b32


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4917/head:pull/4917` \
`$ git checkout pull/4917`

Update a local copy of the PR: \
`$ git checkout pull/4917` \
`$ git pull https://git.openjdk.java.net/jdk pull/4917/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4917`

View PR using the GUI difftool: \
`$ git pr show -t 4917`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4917.diff">https://git.openjdk.java.net/jdk/pull/4917.diff</a>

</details>
