### PR TITLE
8137101: [TEST_BUG] javax/swing/plaf/basic/BasicHTML/4251579/bug4251579.java failure due to timing

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -745,8 +745,6 @@ javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
 javax/swing/JPopupMenu/4634626/bug4634626.java 8017175 macosx-all
 
-javax/swing/plaf/basic/BasicHTML/4251579/bug4251579.java 8137101 linux-x64
-
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8225012 windows-all,macosx-all
 sanity/client/SwingSet/src/ScrollPaneDemoTest.java 8225013 linux-all
 sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java 8265770 macosx-all

--- a/test/jdk/javax/swing/plaf/basic/BasicHTML/4251579/bug4251579.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicHTML/4251579/bug4251579.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2008, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,21 +27,27 @@
  * @key headful
  * @bug 4251579
  * @summary  Tests if style sheets are working in JLabel
- * @author Denis Sharypov
  * @run main bug4251579
  */
-import java.awt.*;
-import javax.swing.*;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Robot;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.JLabel;
 
 public class bug4251579 {
 
     private static JLabel htmlComponent;
+    private static JFrame mainFrame;
 
     public static void main(String[] args) throws Exception {
         final Robot robot = new Robot();
-        robot.setAutoDelay(50);
 
-        SwingUtilities.invokeAndWait(new Runnable() {
+        try {
+            SwingUtilities.invokeAndWait(new Runnable() {
 
             @Override
             public void run() {
@@ -50,6 +56,7 @@ public class bug4251579 {
         });
 
         robot.waitForIdle();
+        robot.delay(1000);
 
         SwingUtilities.invokeAndWait(new Runnable() {
 
@@ -75,6 +82,13 @@ public class bug4251579 {
 
             }
         });
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (mainFrame != null) {
+                    mainFrame.dispose();
+                }
+            });
+        }
     }
 
     private static void createAndShowGUI() {
@@ -86,12 +100,13 @@ public class bug4251579 {
                 + "<P class=\"blue\"> should be rendered with BLUE class definition</P>"
                 + "</body>";
 
-        JFrame mainFrame = new JFrame("bug4251579");
+        mainFrame = new JFrame("bug4251579");
         mainFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
         htmlComponent = new JLabel(htmlText);
         mainFrame.getContentPane().add(htmlComponent);
 
+        mainFrame.setLocationRelativeTo(null);
         mainFrame.pack();
         mainFrame.setVisible(true);
     }

--- a/test/jdk/javax/swing/plaf/basic/BasicHTML/4251579/bug4251579.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicHTML/4251579/bug4251579.java
@@ -49,39 +49,39 @@ public class bug4251579 {
         try {
             SwingUtilities.invokeAndWait(new Runnable() {
 
-            @Override
-            public void run() {
-                createAndShowGUI();
-            }
-        });
+                @Override
+                public void run() {
+                    createAndShowGUI();
+                }
+            });
 
-        robot.waitForIdle();
-        robot.delay(1000);
+            robot.waitForIdle();
+            robot.delay(1000);
 
-        SwingUtilities.invokeAndWait(new Runnable() {
+            SwingUtilities.invokeAndWait(new Runnable() {
 
-            @Override
-            public void run() {
-                boolean passed = false;
+                @Override
+                public void run() {
+                    boolean passed = false;
 
-                Point p = htmlComponent.getLocationOnScreen();
-                Dimension d = htmlComponent.getSize();
-                int x0 = p.x;
-                int y = p.y + d.height / 2;
+                    Point p = htmlComponent.getLocationOnScreen();
+                    Dimension d = htmlComponent.getSize();
+                    int x0 = p.x;
+                    int y = p.y + d.height / 2;
 
-                for (int x = x0; x < x0 + d.width; x++) {
-                    if (robot.getPixelColor(x, y).equals(Color.blue)) {
-                        passed = true;
-                        break;
+                    for (int x = x0; x < x0 + d.width; x++) {
+                        if (robot.getPixelColor(x, y).equals(Color.blue)) {
+                            passed = true;
+                            break;
+                        }
                     }
-                }
 
-                if (!passed) {
-                    throw new RuntimeException("Test failed.");
-                }
+                    if (!passed) {
+                        throw new RuntimeException("Test failed.");
+                    }
 
-            }
-        });
+                }
+            });
         } finally {
             SwingUtilities.invokeAndWait(() -> {
                 if (mainFrame != null) {


### PR DESCRIPTION
This test was failing in CI test run due to timing issue. Adjusted robot delay..Also, made frame to show in middle of screen and dispose of frame at end.
CI test run is green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8137101](https://bugs.openjdk.java.net/browse/JDK-8137101): [TEST_BUG] javax/swing/plaf/basic/BasicHTML/4251579/bug4251579.java failure due to timing


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4918/head:pull/4918` \
`$ git checkout pull/4918`

Update a local copy of the PR: \
`$ git checkout pull/4918` \
`$ git pull https://git.openjdk.java.net/jdk pull/4918/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4918`

View PR using the GUI difftool: \
`$ git pr show -t 4918`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4918.diff">https://git.openjdk.java.net/jdk/pull/4918.diff</a>

</details>
