### PR TITLE
8271203: C2: assert(iff->Opcode() == Op_If || iff->Opcode() == Op_CountedLoopEnd || iff->Opcode() == Op_RangeCheck) failed: Check this code when new subtype is added

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -233,8 +233,13 @@ void PhaseIdealLoop::dominated_by( Node *prevdom, Node *iff, bool flip, bool exc
   if (VerifyLoopOptimizations && PrintOpto) { tty->print_cr("dominating test"); }
 
   // prevdom is the dominating projection of the dominating test.
-  assert( iff->is_If(), "" );
-  assert(iff->Opcode() == Op_If || iff->Opcode() == Op_CountedLoopEnd || iff->Opcode() == Op_RangeCheck, "Check this code when new subtype is added");
+  assert(iff->is_If(), "must be");
+  assert(iff->Opcode() == Op_If ||
+         iff->Opcode() == Op_CountedLoopEnd ||
+         iff->Opcode() == Op_LongCountedLoopEnd ||
+         iff->Opcode() == Op_RangeCheck,
+        "Check this code when new subtype is added");
+
   int pop = prevdom->Opcode();
   assert( pop == Op_IfFalse || pop == Op_IfTrue, "" );
   if (flip) {

--- a/test/hotspot/jtreg/compiler/c2/LongCountedLoopAsUnswitchIff.java
+++ b/test/hotspot/jtreg/compiler/c2/LongCountedLoopAsUnswitchIff.java
@@ -26,7 +26,7 @@
  * @test
  * @bug 8271203
  * @summary C2: assert(iff->Opcode() == Op_If || iff->Opcode() == Op_CountedLoopEnd || iff->Opcode() == Op_RangeCheck) failed: Check this code when new subtype is added
- * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:CompileOnly=LongCountedLoopAsUnswitchIff::test compiler.c2.LongCountedLoopAsUnswitchIff
+ * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:CompileOnly=compiler.c2.LongCountedLoopAsUnswitchIff::test compiler.c2.LongCountedLoopAsUnswitchIff
  */
 
 package compiler.c2;

--- a/test/hotspot/jtreg/compiler/c2/LongCountedLoopAsUnswitchIff.java
+++ b/test/hotspot/jtreg/compiler/c2/LongCountedLoopAsUnswitchIff.java
@@ -26,13 +26,12 @@
  * @test
  * @bug 8271203
  * @summary C2: assert(iff->Opcode() == Op_If || iff->Opcode() == Op_CountedLoopEnd || iff->Opcode() == Op_RangeCheck) failed: Check this code when new subtype is added
- * @library /test/lib
- * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:CompileOnly=UnswitchingLongCountedLoop compiler.c2.UnswitchingLongCountedLoop
+ * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:CompileOnly=LongCountedLoopAsUnswitchIff::test compiler.c2.LongCountedLoopAsUnswitchIff
  */
 
 package compiler.c2;
 
-public class UnswitchingLongCountedLoop {
+public class LongCountedLoopAsUnswitchIff {
     static int iArrFld[] = new int[400];
 
     public static void main(String[] strArr) {

--- a/test/hotspot/jtreg/compiler/c2/UnswitchingLongCountedLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/UnswitchingLongCountedLoop.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8271203
+ * @summary C2: assert(iff->Opcode() == Op_If || iff->Opcode() == Op_CountedLoopEnd || iff->Opcode() == Op_RangeCheck) failed: Check this code when new subtype is added
+ * @library /test/lib
+ * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:CompileOnly=UnswitchingLongCountedLoop compiler.c2.UnswitchingLongCountedLoop
+ */
+
+package compiler.c2;
+
+public class UnswitchingLongCountedLoop {
+    static int iArrFld[] = new int[400];
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 10; i++) {
+            test();
+        }
+    }
+
+    static void test() {
+        int i = 56, i2 = 22257;
+
+        do {
+            do {
+                int i24 = 1;
+                while (++i24 < 2) {
+                }
+                for (long l1 = i; l1 < 2; ++l1) {
+                    iArrFld[0] += 5;
+                }
+            } while ((i2 -= 2) > 0);
+            for (long l3 = 8; l3 < 194; ++l3) {
+            }
+        } while (--i > 0);
+    }
+}


### PR DESCRIPTION
Hi, I'm trying to fix [JDK-8271203](https://bugs.openjdk.java.net/browse/JDK-8271203). It's reasonable to unswitch LongCountedLoop, so relax it.

![image](https://user-images.githubusercontent.com/5010047/127302280-0faa90bb-add7-4639-8c63-49668901f267.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271203](https://bugs.openjdk.java.net/browse/JDK-8271203): C2: assert(iff->Opcode() == Op_If || iff->Opcode() == Op_CountedLoopEnd || iff->Opcode() == Op_RangeCheck) failed: Check this code when new subtype is added


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to c2d47b2e14717b4a5bca2f0561876bc6eb7c43d4
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**) ⚠️ Review applies to c2d47b2e14717b4a5bca2f0561876bc6eb7c43d4
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4920/head:pull/4920` \
`$ git checkout pull/4920`

Update a local copy of the PR: \
`$ git checkout pull/4920` \
`$ git pull https://git.openjdk.java.net/jdk pull/4920/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4920`

View PR using the GUI difftool: \
`$ git pr show -t 4920`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4920.diff">https://git.openjdk.java.net/jdk/pull/4920.diff</a>

</details>
