### PR TITLE
8271352: Extend jcc erratum mitigation to additional processors

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1789,6 +1789,10 @@ bool VM_Version::compute_has_intel_jcc_erratum() {
     // 06_9EH | D | 9th Generation Intel® Core™ Processor Family based on microarchitecturecode name Coffee Lake H (8+2)
     // 06_9EH | D | 9th Generation Intel® Core™ Processor Family based on microarchitecture code name Coffee Lake S (8+2)
     return _stepping == 0x9 || _stepping == 0xA || _stepping == 0xB || _stepping == 0xD;
+  case 0xA5:
+    // Not in Intel documentation.
+    // 06_A5H |    | 10th Generation Intel® Core™ Processor Family based on microarchitecture code name Comet Lake S/H
+    return true;
   case 0xA6:
     // 06_A6H | 0  | 10th Generation Intel® Core™ Processor Family based on microarchitecture code name Comet Lake U62
     return _stepping == 0x0;


### PR DESCRIPTION
Please review this change to default enable the Intel jcc erratum
performance mitigation for family 6 model 165 (0xA5). This seems to reduce
the frequency of an issue that is still under investigation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271352](https://bugs.openjdk.java.net/browse/JDK-8271352): Extend jcc erratum mitigation to additional processors


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4922/head:pull/4922` \
`$ git checkout pull/4922`

Update a local copy of the PR: \
`$ git checkout pull/4922` \
`$ git pull https://git.openjdk.java.net/jdk pull/4922/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4922`

View PR using the GUI difftool: \
`$ git pr show -t 4922`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4922.diff">https://git.openjdk.java.net/jdk/pull/4922.diff</a>

</details>
