### PR TITLE
8268744: Improve sinking algorithm in partial peeling to avoid redundant clones

### DIFF
--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1378,19 +1378,24 @@ public:
   Node* adjust_limit(bool reduce, Node* scale, Node* offset, Node* rc_limit, Node* old_limit, Node* pre_ctrl, bool round);
 
   // Partially peel loop up through last_peel node.
-  bool partial_peel( IdealLoopTree *loop, Node_List &old_new );
+  bool partial_peel(IdealLoopTree* loop, Node_List& old_new);
 
+  // Move non-pinned data nodes into the not-peel region if possible.
+  bool move_nodes_to_not_peel(IdealLoopTree* loop, const IfNode* new_peel_if, uint estimate, VectorSet& peel, VectorSet& not_peel,
+                              Node_List& peel_list, Node_List& worklist, Node_List& sink_list, uint& cloned_for_outside_use);
   // Create a scheduled list of nodes control dependent on ctrl set.
-  void scheduled_nodelist( IdealLoopTree *loop, VectorSet& ctrl, Node_List &sched );
-  // Has a use in the vector set
-  bool has_use_in_set( Node* n, VectorSet& vset );
-  // Has use internal to the vector set (ie. not in a phi at the loop head)
-  bool has_use_internal_to_set( Node* n, VectorSet& vset, IdealLoopTree *loop );
-  // clone "n" for uses that are outside of loop
-  int  clone_for_use_outside_loop( IdealLoopTree *loop, Node* n, Node_List& worklist );
-  // clone "n" for special uses that are in the not_peeled region
-  void clone_for_special_use_inside_loop( IdealLoopTree *loop, Node* n,
-                                          VectorSet& not_peel, Node_List& sink_list, Node_List& worklist );
+  static void scheduled_nodelist(IdealLoopTree* loop, VectorSet& ctrl, Node_List& sched);
+  // Has a use in the vector set?
+  static bool has_use_in_set(Node* n, VectorSet& vset);
+  // Has use internal to the vector set (i.e. not in a phi at the loop head)?
+  static bool has_use_internal_to_set(Node* n, VectorSet& vset, IdealLoopTree* loop);
+  // Clone "n" for uses that are outside of loop.
+  int clone_for_use_outside_loop(IdealLoopTree* loop, Node* n, Node_List& worklist, Node_Array& initial_outside_uses_map);
+  // Return a new or cached clone for the outside of the loop use.
+  Node* get_clone_for_outside_use(const Node* n, Node* outside_use, Node_Array& outside_uses_map, Node_List& clones_of_n_for_use);
+  // Clone "n" for special uses that are in the not_peeled region.
+  void clone_for_special_use_inside_loop(IdealLoopTree* loop, Node* n, VectorSet& not_peel, Node_List& sink_list,
+                                         Node_List& worklist);
   // Insert phi(lp_entry_val, back_edge_val) at use->in(idx) for loop lp if phi does not already exist
   void insert_phi_for_loop( Node* use, uint idx, Node* lp_entry_val, Node* back_edge_val, LoopNode* lp );
 #ifdef ASSERT

--- a/test/hotspot/jtreg/compiler/loopopts/TestPartialPeelingSinkNodes.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestPartialPeelingSinkNodes.java
@@ -24,11 +24,11 @@
 
 /*
  * @test
- * @bug 8256934
+ * @bug 8256934 8268744
  * @summary Sinking of nodes in partial peeling creates too many clones resulting in a live node limit exceeded assertion failure.
  * @requires vm.compiler2.enabled
  * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileCommand=compileonly,compiler.loopopts.TestPartialPeelingSinkNodes::test
- *                   compiler.loopopts.TestPartialPeelingSinkNodes
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure compiler.loopopts.TestPartialPeelingSinkNodes
  */
 
 package compiler.loopopts;
@@ -42,6 +42,9 @@ public class TestPartialPeelingSinkNodes {
     }
 
     // The algorithm in partial peeling creates ~90000 nodes for this method which triggers the assertion failure.
+    // Edit 8268744: When increasing the node limit (default limit will bailout with 8256934), the old algorithm needs
+    // significantly more time to execute where the new algorithm is much faster and only requires ~140 new nodes.
+    // There is no compilation bailout anymore and -XX:+AbortVMOnCompilationFailure does not abort the VM.
     public static void test() {
         for (int i = 0; i < 2480; i++) {
             int i2 = -37052, i3 = 39651, i4 = -37052;


### PR DESCRIPTION
The algorithm in step 2 in partial peeling to move data nodes from the peel section to the non-peel section uses a straight forward cloning algorithm which creates redundant clones when the IR contains one ore more diamonds of data nodes to be cloned. The number of clones grows exponentially which could lead to a bailout (added by [JDK-8256934](https://bugs.openjdk.java.net/browse/JDK-8256934) for JDK 17 with a testcase). This RFE improves this algorithm to handle node diamonds more efficiently to avoid unnecessary cloning. The testcase for JDK-8256934 does not bail out anymore and uses only few clones.

The main idea is to first find all outside of the loop uses `u` of the nodes in the initial peel region to be moved into the non-peel region. We then only need to clone any data node during the algorithm at most `u` times, once for each initial outside of the loop use. If we process a node diamond (following inputs), we can use an already cloned node for the top node of the diamond (node A in the example below). An example with 1 initial outside of the loop use and 4 nodes to be cloned, forming a diamond, is shown as comment in the code:
https://github.com/openjdk/jdk/blob/8ae0e1a06558a1678521dcb4ed32708a1821b47d/src/hotspot/share/opto/loopopts.cpp#L3605-L3635

The algorithm is explained in more details in the comments in the code (starting in method `move_nodes_to_not_peel()`).

I also cleaned up the code for step 2 of partial peeling. I left the bailout code added by JDK-8256934 in place which I think is still required if we enter partial peeling with a huge number of live nodes (quite rare though).

I additionally ran some standard benchmarks which did not show any improvements but also no regressions. I think it is rather an edge case where the old algorithm creates a huge number of redundant clones. Nevertheless, I think this improved algorithm is still worth to have to handle the more uncommon case of node diamonds. What do you think?

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8268744](https://bugs.openjdk.java.net/browse/JDK-8268744): Improve sinking algorithm in partial peeling to avoid redundant clones


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4923/head:pull/4923` \
`$ git checkout pull/4923`

Update a local copy of the PR: \
`$ git checkout pull/4923` \
`$ git pull https://git.openjdk.java.net/jdk pull/4923/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4923`

View PR using the GUI difftool: \
`$ git pr show -t 4923`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4923.diff">https://git.openjdk.java.net/jdk/pull/4923.diff</a>

</details>
