### PR TITLE
8270903: sun.net.httpserver.HttpConnection: Improve toString

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/HttpConnection.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/HttpConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,11 +66,13 @@ class HttpConnection {
     volatile State state;
 
     public String toString() {
-        String s = null;
+        final var sb = new StringBuilder(HttpConnection.class.getSimpleName());
         if (chan != null) {
-            s = chan.toString();
+            sb.append(" (");
+            sb.append(chan);
+            sb.append(")");
         }
-        return s;
+        return sb.toString();
     }
 
     HttpConnection () {


### PR DESCRIPTION
This is a minor change that updates `sun.net.httpserver.HttpConnection::toString` to never return null.

Testing: tier 1-3 all clear

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270903](https://bugs.openjdk.java.net/browse/JDK-8270903): sun.net.httpserver.HttpConnection: Improve toString


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)
 * [Vyom Tewari](https://openjdk.java.net/census#vtewari) (@vyommani - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4928/head:pull/4928` \
`$ git checkout pull/4928`

Update a local copy of the PR: \
`$ git checkout pull/4928` \
`$ git pull https://git.openjdk.java.net/jdk pull/4928/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4928`

View PR using the GUI difftool: \
`$ git pr show -t 4928`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4928.diff">https://git.openjdk.java.net/jdk/pull/4928.diff</a>

</details>
