### PR TITLE
JDK-8265270: Type.getEnclosingType() may fail with CompletionFailure

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -564,7 +564,7 @@ public class ClassReader {
                         public Type getEnclosingType() {
                             if (!completed) {
                                 completed = true;
-                                tsym.complete();
+                                tsym.apiComplete();
                                 Type enclosingType = tsym.type.getEnclosingType();
                                 if (enclosingType != Type.noType) {
                                     List<Type> typeArgs =


### PR DESCRIPTION
The setup is a little bit tricky, but it may happen that user code calls `Type{Mirror}.getEnclosingType()` (or e.g. `Type{Mirror}.toString()` which will in turn invoke `getEnclosingType()`), and the method may throw the `CompletionFailure` (internal) exception. The reason is that the corresponding Symbol is completed using a `complete` method, instead of `apiComplete` method, which is intended to be used in API methods. `apiComplete` does the same as `complete` when running in a javac context, but will suppress the exception when the API method was invoked from a user code, avoiding the exception.

The proposed change is to use `apiComplete`, as it should be done in implementations of API methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Error
&nbsp;⚠️ This PR only contains changes already present in the target

### Issue
 * [JDK-8265270](https://bugs.openjdk.java.net/browse/JDK-8265270): Type.getEnclosingType() may fail with CompletionFailure ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4929/head:pull/4929` \
`$ git checkout pull/4929`

Update a local copy of the PR: \
`$ git checkout pull/4929` \
`$ git pull https://git.openjdk.java.net/jdk pull/4929/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4929`

View PR using the GUI difftool: \
`$ git pr show -t 4929`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4929.diff">https://git.openjdk.java.net/jdk/pull/4929.diff</a>

</details>
