### PR TITLE
JDK-8270060: (jdeprscan) tools/jdeprscan/tests/jdk/jdeprscan/TestRelease.java failed with class file for jdk.internal.util.random.RandomSupport not found

### DIFF
--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -72,4 +72,3 @@ tools/sjavac/ClasspathDependencies.java                                         
 #
 # jdeps
 
-tools/jdeprscan/tests/jdk/jdeprscan/TestRelease.java                            8270060    generic-all    java.util.SplittableRandom extends a non-exported class


### PR DESCRIPTION
The base problem for the test failure was:
https://bugs.openjdk.java.net/browse/JDK-8270075

As that was fixed, and the change was propagated to the ct.sym historical data, the test should be passing again, and it no longer needs to be problem listed. So this patch removes the test from the `ProblemList.txt`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270060](https://bugs.openjdk.java.net/browse/JDK-8270060): (jdeprscan) tools/jdeprscan/tests/jdk/jdeprscan/TestRelease.java failed with class file for jdk.internal.util.random.RandomSupport not found


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - **Reviewer**)
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4933/head:pull/4933` \
`$ git checkout pull/4933`

Update a local copy of the PR: \
`$ git checkout pull/4933` \
`$ git pull https://git.openjdk.java.net/jdk pull/4933/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4933`

View PR using the GUI difftool: \
`$ git pr show -t 4933`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4933.diff">https://git.openjdk.java.net/jdk/pull/4933.diff</a>

</details>
