### PR TITLE
8232066: Remove outdated code/methods from PKIX implementation

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/certpath/DistributionPointFetcher.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/DistributionPointFetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,44 +62,6 @@ public class DistributionPointFetcher {
      * Private instantiation only.
      */
     private DistributionPointFetcher() {}
-
-    /**
-     * Return the X509CRLs matching this selector. The selector must be
-     * an X509CRLSelector with certificateChecking set.
-     */
-    public static Collection<X509CRL> getCRLs(X509CRLSelector selector,
-            boolean signFlag, PublicKey prevKey, String provider,
-            List<CertStore> certStores, boolean[] reasonsMask,
-            Set<TrustAnchor> trustAnchors, Date validity, String variant)
-            throws CertStoreException
-    {
-        return getCRLs(selector, signFlag, prevKey, null, provider, certStores,
-                reasonsMask, trustAnchors, validity, variant, null);
-    }
-    /**
-     * Return the X509CRLs matching this selector. The selector must be
-     * an X509CRLSelector with certificateChecking set.
-     */
-    // Called by com.sun.deploy.security.RevocationChecker
-    public static Collection<X509CRL> getCRLs(X509CRLSelector selector,
-                                              boolean signFlag,
-                                              PublicKey prevKey,
-                                              String provider,
-                                              List<CertStore> certStores,
-                                              boolean[] reasonsMask,
-                                              Set<TrustAnchor> trustAnchors,
-                                              Date validity)
-        throws CertStoreException
-    {
-        if (trustAnchors.isEmpty()) {
-            throw new CertStoreException(
-                "at least one TrustAnchor must be specified");
-        }
-        TrustAnchor anchor = trustAnchors.iterator().next();
-        return getCRLs(selector, signFlag, prevKey, null, provider, certStores,
-                reasonsMask, trustAnchors, validity,
-                Validator.VAR_PLUGIN_CODE_SIGNING, anchor);
-    }
 
     /**
      * Return the X509CRLs matching this selector. The selector must be

--- a/src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
@@ -38,7 +38,6 @@ import java.security.cert.Extension;
 import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
 import java.util.Base64;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -97,67 +96,6 @@ public final class OCSP {
     }
 
     private OCSP() {}
-
-
-    /**
-     * Obtains the revocation status of a certificate using OCSP.
-     *
-     * @param cert the certificate to be checked
-     * @param issuerCert the issuer certificate
-     * @param responderURI the URI of the OCSP responder
-     * @param responderCert the OCSP responder's certificate
-     * @param date the time the validity of the OCSP responder's certificate
-     *    should be checked against. If null, the current time is used.
-     * @return the RevocationStatus
-     * @throws IOException if there is an exception connecting to or
-     *    communicating with the OCSP responder
-     * @throws CertPathValidatorException if an exception occurs while
-     *    encoding the OCSP Request or validating the OCSP Response
-     */
-
-    // Called by com.sun.deploy.security.TrustDecider
-    public static RevocationStatus check(X509Certificate cert,
-                                         X509Certificate issuerCert,
-                                         URI responderURI,
-                                         X509Certificate responderCert,
-                                         Date date)
-        throws IOException, CertPathValidatorException
-    {
-        return check(cert, issuerCert, responderURI, responderCert, date,
-                     Collections.<Extension>emptyList(),
-                     Validator.VAR_PLUGIN_CODE_SIGNING);
-    }
-
-
-    public static RevocationStatus check(X509Certificate cert,
-            X509Certificate issuerCert, URI responderURI,
-            X509Certificate responderCert, Date date, List<Extension> extensions,
-            String variant)
-        throws IOException, CertPathValidatorException
-    {
-        return check(cert, responderURI, null, issuerCert, responderCert, date,
-                extensions, variant);
-    }
-
-    public static RevocationStatus check(X509Certificate cert,
-            URI responderURI, TrustAnchor anchor, X509Certificate issuerCert,
-            X509Certificate responderCert, Date date,
-            List<Extension> extensions, String variant)
-            throws IOException, CertPathValidatorException
-    {
-        CertId certId;
-        try {
-            X509CertImpl certImpl = X509CertImpl.toImpl(cert);
-            certId = new CertId(issuerCert, certImpl.getSerialNumberObject());
-        } catch (CertificateException | IOException e) {
-            throw new CertPathValidatorException
-                ("Exception while encoding OCSPRequest", e);
-        }
-        OCSPResponse ocspResponse = check(Collections.singletonList(certId),
-                responderURI, new OCSPResponse.IssuerInfo(anchor, issuerCert),
-                responderCert, date, extensions, variant);
-        return (RevocationStatus) ocspResponse.getSingleResponse(certId);
-    }
 
     /**
      * Checks the revocation status of a list of certificates using OCSP.

--- a/src/java.base/share/classes/sun/security/provider/certpath/PKIX.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/PKIX.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -159,8 +159,7 @@ class PKIX {
                 // use timestamp if checking signed code that is
                 // timestamped, otherwise use date parameter
                 if (timestamp != null &&
-                    (variant.equals(Validator.VAR_CODE_SIGNING) ||
-                     variant.equals(Validator.VAR_PLUGIN_CODE_SIGNING))) {
+                    variant.equals(Validator.VAR_CODE_SIGNING)) {
                     date = timestamp.getTimestamp();
                 } else {
                     date = params.getDate();

--- a/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -805,7 +805,6 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
                         break;
                     case "signedjar":
                         match =
-                            variant.equals(Validator.VAR_PLUGIN_CODE_SIGNING) ||
                             variant.equals(Validator.VAR_CODE_SIGNING) ||
                             variant.equals(Validator.VAR_TSA_SERVER);
                         break;

--- a/src/java.base/share/classes/sun/security/validator/EndEntityChecker.java
+++ b/src/java.base/share/classes/sun/security/validator/EndEntityChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,10 +52,6 @@ import sun.security.x509.NetscapeCertTypeExtension;
  * providers had incorrect extensions. In this mode the checks
  * are relaxed compared to standard code signing checks in order to
  * allow these certificates to pass.
- *
- * <li>Plugin code signing. WebStart and Plugin require their own variant
- * which is equivalent to VAR_CODE_SIGNING with additional checks for
- * compatibility/special cases. See also PKIXValidator.
  *
  * <li>TSA Server (see RFC 3161, section 2.3).
  *
@@ -155,8 +151,6 @@ class EndEntityChecker {
         } else if (variant.equals(Validator.VAR_CODE_SIGNING)) {
             checkCodeSigning(chain[0], exts);
         } else if (variant.equals(Validator.VAR_JCE_SIGNING)) {
-            checkCodeSigning(chain[0], exts);
-        } else if (variant.equals(Validator.VAR_PLUGIN_CODE_SIGNING)) {
             checkCodeSigning(chain[0], exts);
         } else if (variant.equals(Validator.VAR_TSA_SERVER)) {
             checkTSAServer(chain[0], exts);

--- a/src/java.base/share/classes/sun/security/validator/PKIXValidator.java
+++ b/src/java.base/share/classes/sun/security/validator/PKIXValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,9 @@
 
 package sun.security.validator;
 
-import java.util.*;
-
 import java.security.*;
 import java.security.cert.*;
-
+import java.util.*;
 import javax.security.auth.x500.X500Principal;
 import sun.security.action.GetBooleanAction;
 import sun.security.provider.certpath.AlgorithmChecker;
@@ -81,8 +79,6 @@ public final class PKIXValidator extends Validator {
     private final Map<X500Principal, List<PublicKey>> trustedSubjects;
     private final CertificateFactory factory;
 
-    private final boolean plugin;
-
     PKIXValidator(String variant, Collection<X509Certificate> trustedCerts) {
         super(TYPE_PKIX, variant);
         this.trustedCerts = (trustedCerts instanceof Set) ?
@@ -104,7 +100,6 @@ public final class PKIXValidator extends Validator {
         }
 
         setDefaultParameters(variant);
-        plugin = variant.equals(VAR_PLUGIN_CODE_SIGNING);
 
         trustedSubjects = setTrustedSubjects();
     }
@@ -125,8 +120,6 @@ public final class PKIXValidator extends Validator {
         } catch (CertificateException e) {
             throw new RuntimeException("Internal error", e);
         }
-
-        plugin = variant.equals(VAR_PLUGIN_CODE_SIGNING);
 
         trustedSubjects = setTrustedSubjects();
     }
@@ -270,56 +263,12 @@ public final class PKIXValidator extends Validator {
         X509Certificate last = chain[chain.length - 1];
         X500Principal issuer = last.getIssuerX500Principal();
         X500Principal subject = last.getSubjectX500Principal();
-        if (trustedSubjects.containsKey(issuer) &&
-                isSignatureValid(trustedSubjects.get(issuer), last)) {
+        if (trustedSubjects.containsKey(issuer)) {
             return doValidate(chain, pkixParameters);
         }
 
-        // don't fallback to builder if called from plugin/webstart
-        if (plugin) {
-            // Validate chain even if no trust anchor is found. This
-            // allows plugin/webstart to make sure the chain is
-            // otherwise valid
-            if (chain.length > 1) {
-                X509Certificate[] newChain =
-                    new X509Certificate[chain.length-1];
-                System.arraycopy(chain, 0, newChain, 0, newChain.length);
-
-                // temporarily set last cert as sole trust anchor
-                try {
-                    pkixParameters.setTrustAnchors
-                        (Collections.singleton(new TrustAnchor
-                            (chain[chain.length-1], null)));
-                } catch (InvalidAlgorithmParameterException iape) {
-                    // should never occur, but ...
-                    throw new CertificateException(iape);
-                }
-                doValidate(newChain, pkixParameters);
-            }
-            // if the rest of the chain is valid, throw exception
-            // indicating no trust anchor was found
-            throw new ValidatorException
-                (ValidatorException.T_NO_TRUST_ANCHOR);
-        }
         // otherwise, fall back to builder
-
         return doBuild(chain, otherCerts, pkixParameters);
-    }
-
-    private boolean isSignatureValid(List<PublicKey> keys,
-            X509Certificate sub) {
-        if (plugin) {
-            for (PublicKey key: keys) {
-                try {
-                    sub.verify(key);
-                    return true;
-                } catch (Exception ex) {
-                    continue;
-                }
-            }
-            return false;
-        }
-        return true; // only check if PLUGIN is set
     }
 
     private static X509Certificate[] toArray(CertPath path, TrustAnchor anchor)

--- a/src/java.base/share/classes/sun/security/validator/Validator.java
+++ b/src/java.base/share/classes/sun/security/validator/Validator.java
@@ -167,9 +167,6 @@ public abstract class Validator {
      */
     public static Validator getInstance(String type, String variant,
             Collection<X509Certificate> trustedCerts) {
-        if (variant == null) {
-            throw new NullPointerException("variant cannot be null");
-        }
         if (type.equals(TYPE_SIMPLE)) {
             return new SimpleValidator(variant, trustedCerts);
         } else if (type.equals(TYPE_PKIX)) {
@@ -186,9 +183,6 @@ public abstract class Validator {
      */
     public static Validator getInstance(String type, String variant,
             PKIXBuilderParameters params) {
-        if (variant == null) {
-            throw new NullPointerException("variant cannot be null");
-        }
         if (type.equals(TYPE_PKIX) == false) {
             throw new IllegalArgumentException
                 ("getInstance(PKIXBuilderParameters) can only be used "

--- a/src/java.base/share/classes/sun/security/validator/Validator.java
+++ b/src/java.base/share/classes/sun/security/validator/Validator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,6 @@ import java.security.cert.*;
  * <li>VAR_CODE_SIGNING (code signing specific checks).
  * <li>VAR_JCE_SIGNING (JCE code signing specific checks).
  * <li>VAR_TSA_SERVER (TSA server specific checks).
- * <li>VAR_PLUGIN_CODE_SIGNING (Plugin/WebStart code signing specific checks).
  * </ul>
  * See EndEntityChecker for more information.
  * <p>
@@ -136,13 +135,6 @@ public abstract class Validator {
      */
     public static final String VAR_TSA_SERVER = "tsa server";
 
-    /**
-     * Constant for a Code Signing variant of a validator for use by
-     * the J2SE Plugin/WebStart code.
-     * @see #getInstance
-     */
-    public static final String VAR_PLUGIN_CODE_SIGNING = "plugin code signing";
-
     private final String type;
     final EndEntityChecker endEntityChecker;
     final String variant;
@@ -175,6 +167,9 @@ public abstract class Validator {
      */
     public static Validator getInstance(String type, String variant,
             Collection<X509Certificate> trustedCerts) {
+        if (variant == null) {
+            throw new NullPointerException("variant cannot be null");
+        }
         if (type.equals(TYPE_SIMPLE)) {
             return new SimpleValidator(variant, trustedCerts);
         } else if (type.equals(TYPE_PKIX)) {
@@ -191,6 +186,9 @@ public abstract class Validator {
      */
     public static Validator getInstance(String type, String variant,
             PKIXBuilderParameters params) {
+        if (variant == null) {
+            throw new NullPointerException("variant cannot be null");
+        }
         if (type.equals(TYPE_PKIX) == false) {
             throw new IllegalArgumentException
                 ("getInstance(PKIXBuilderParameters) can only be used "

--- a/test/jdk/sun/security/validator/ConstructorTest.java
+++ b/test/jdk/sun/security/validator/ConstructorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -404,21 +404,6 @@ public class ConstructorTest {
         valNoGood = Validator.getInstance(Validator.TYPE_PKIX,
                 "BogusVariant", certSet);
         System.out.println("\tSuccessful construction [PASS]");
-
-        // Case 6: Provide a null variant
-        // Expected result: throw NullPointerException
-        System.out.println("Constructor test 6: null variant");
-        try {
-            valNoGood = Validator.getInstance(Validator.TYPE_PKIX, null,
-                    certSet);
-            // Throw something non Runtime-related to indicate we shouldn't
-            // have succeeded on construction.
-            throw new IOException(
-                    "Constructor did not throw NullPointerException");
-        } catch (NullPointerException npe) {
-            System.out.println("\tCaught RuntimeException (" + npe.toString() +
-                    ") [PASS])");
-        }
     }
 
     public static void testCtorByPKIXBuilderParams(Set<X509Certificate> certSet)
@@ -429,9 +414,9 @@ public class ConstructorTest {
         X509Certificate[] chain = new X509Certificate[1];
         Set<X509Certificate> intermeds = new HashSet<>();
 
-        // Case 7: Make a PKIXValidator with valid arguments
+        // Case 6: Make a PKIXValidator with valid arguments
         // Expected result: Well-formed PKIXValidator object
-        System.out.println("Constructor test 7: Valid inputs");
+        System.out.println("Constructor test 6: Valid inputs");
 
         // Set up the PKIXBuilderParameters
         X509CertSelector sel = new X509CertSelector();
@@ -450,9 +435,9 @@ public class ConstructorTest {
 
         showValidatedChain(valOK, chain, intermeds);
 
-        // Case 8: Make a PKIXValidator but provide a null PKIXBuilderParameters
+        // Case 7: Make a PKIXValidator but provide a null PKIXBuilderParameters
         // Expected result: throw NullPointerException
-        System.out.println("Constructor test 8: null params");
+        System.out.println("Constructor test 7: null params");
         try {
             valNoGood = Validator.getInstance(Validator.TYPE_PKIX,
                     Validator.VAR_GENERIC, (PKIXBuilderParameters)null);


### PR DESCRIPTION
Please review this fix to remove the Validator.VAR_PLUGIN_CODE_SIGNING variant and related code that is no longer needed in the PKIX implementation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8232066](https://bugs.openjdk.java.net/browse/JDK-8232066): Remove outdated code/methods from PKIX implementation


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**) ⚠️ Review applies to 52be3dd262e0cb693af85a8ec2b164210b96d032


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4934/head:pull/4934` \
`$ git checkout pull/4934`

Update a local copy of the PR: \
`$ git checkout pull/4934` \
`$ git pull https://git.openjdk.java.net/jdk pull/4934/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4934`

View PR using the GUI difftool: \
`$ git pr show -t 4934`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4934.diff">https://git.openjdk.java.net/jdk/pull/4934.diff</a>

</details>
