### PR TITLE
8270341: Test serviceability/dcmd/gc/HeapDumpAllTest.java timed-out

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -118,7 +118,7 @@ serviceability/sa/ClhsdbFindPC.java#id1 8269982 macosx-aarch64
 serviceability/sa/ClhsdbFindPC.java#id3 8269982 macosx-aarch64
 serviceability/sa/ClhsdbPstack.java#id1 8269982 macosx-aarch64
 
-serviceability/dcmd/gc/HeapDumpAllTest.java 8270341 generic-x64
+#serviceability/dcmd/gc/HeapDumpAllTest.java 8270341 generic-x64
 
 #############################################################################
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -118,8 +118,6 @@ serviceability/sa/ClhsdbFindPC.java#id1 8269982 macosx-aarch64
 serviceability/sa/ClhsdbFindPC.java#id3 8269982 macosx-aarch64
 serviceability/sa/ClhsdbPstack.java#id1 8269982 macosx-aarch64
 
-#serviceability/dcmd/gc/HeapDumpAllTest.java 8270341 generic-x64
-
 #############################################################################
 
 # :hotspot_misc

--- a/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpAllTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpAllTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@
  *          java.compiler
  *          java.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
- * @run testng HeapDumpAllTest
+ * @run testng/timeout=240 HeapDumpAllTest
  */
 public class HeapDumpAllTest extends HeapDumpTest {
     public HeapDumpAllTest() {
@@ -39,4 +39,3 @@ public class HeapDumpAllTest extends HeapDumpTest {
 
     /* See HeapDumpTest for test cases */
 }
-


### PR DESCRIPTION
[JDK-8267666](https://bugs.openjdk.java.net/browse/JDK-8267666) added a 2nd test case, which doubles the run time of this test. As a result it occasionally times out. This change double the timeout to 240 seconds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270341](https://bugs.openjdk.java.net/browse/JDK-8270341): Test serviceability/dcmd/gc/HeapDumpAllTest.java timed-out


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4935/head:pull/4935` \
`$ git checkout pull/4935`

Update a local copy of the PR: \
`$ git checkout pull/4935` \
`$ git pull https://git.openjdk.java.net/jdk pull/4935/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4935`

View PR using the GUI difftool: \
`$ git pr show -t 4935`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4935.diff">https://git.openjdk.java.net/jdk/pull/4935.diff</a>

</details>
