### PR TITLE
8270116: Expand ButtonGroupLayoutTraversalTest.java to run in all LaFs, including Aqua on macOS

### DIFF
--- a/test/jdk/java/awt/Focus/FocusTraversalPolicy/ButtonGroupLayoutTraversal/ButtonGroupLayoutTraversalTest.java
+++ b/test/jdk/java/awt/Focus/FocusTraversalPolicy/ButtonGroupLayoutTraversal/ButtonGroupLayoutTraversalTest.java
@@ -37,6 +37,7 @@ import java.awt.Robot;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
 import java.awt.event.KeyEvent;
+import java.util.Arrays;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
@@ -50,98 +51,113 @@ import javax.swing.UnsupportedLookAndFeelException;
 
 public class ButtonGroupLayoutTraversalTest {
 
-    static int nx = 3;
-    static int ny = 3;
+    private static final int nx = 3;
+    private static final int ny = 3;
 
-    static int focusCnt[] = new int[nx * ny];
+    private static final int[] focusCnt = new int[nx * ny];
+
     private static JFrame window;
+    private static Robot robot;
 
     public static void main(String[] args) throws Exception {
+        robot = new Robot();
+        robot.setAutoDelay(100);
 
-        try {
-            SwingUtilities.invokeAndWait(() -> changeLAF());
-            SwingUtilities.invokeAndWait(() -> initLayout(nx, ny));
-            Robot robot = new Robot();
-            robot.setAutoDelay(100);
+        for (UIManager.LookAndFeelInfo laf : UIManager.getInstalledLookAndFeels()) {
+            try {
+                SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
+                SwingUtilities.invokeAndWait(() -> initLayout(nx, ny));
+                test();
+            } finally {
+                SwingUtilities.invokeAndWait(() -> {
+                    if (window != null) {
+                        window.dispose();
+                    }
+                    window = null;
+                    synchronized (focusCnt) {
+                        Arrays.fill(focusCnt, 0);
+                    }
+                });
+            }
+        }
+    }
+
+
+    private static void test() {
+        robot.waitForIdle();
+        robot.delay(1000);
+
+        for (int i = 0; i < nx * ny - nx * ny / 2 - 1; i++) {
+            robot.keyPress(KeyEvent.VK_RIGHT);
+            robot.keyRelease(KeyEvent.VK_RIGHT);
             robot.waitForIdle();
-            robot.delay(1000);
+        }
 
-            for (int i = 0; i < nx * ny - nx * ny / 2 - 1; i++) {
-                robot.keyPress(KeyEvent.VK_RIGHT);
-                robot.keyRelease(KeyEvent.VK_RIGHT);
-                robot.waitForIdle();
-            }
+        for (int i = 0; i < nx * ny / 2; i++) {
+            robot.keyPress(KeyEvent.VK_TAB);
+            robot.keyRelease(KeyEvent.VK_TAB);
+            robot.waitForIdle();
+        }
 
-            for (int i = 0; i < nx * ny / 2; i++) {
-                robot.keyPress(KeyEvent.VK_TAB);
-                robot.keyRelease(KeyEvent.VK_TAB);
-                robot.waitForIdle();
-            }
+        robot.delay(200);
 
-            robot.delay(200);
-
+        synchronized (focusCnt) {
             for (int i = 0; i < nx * ny; i++) {
                 if (focusCnt[i] < 1) {
                     throw new RuntimeException("Component " + i
-                        + " is not reachable in the forward focus cycle");
+                            + " is not reachable in the forward focus cycle");
                 } else if (focusCnt[i] > 1) {
                     throw new RuntimeException("Component " + i
-                        + " got focus more than once in the forward focus cycle");
+                            + " got focus more than once in the forward focus cycle");
                 }
             }
+        }
 
-            for (int i = 0; i < nx * ny / 2; i++) {
-                robot.keyPress(KeyEvent.VK_SHIFT);
-                robot.keyPress(KeyEvent.VK_TAB);
-                robot.keyRelease(KeyEvent.VK_TAB);
-                robot.keyRelease(KeyEvent.VK_SHIFT);
-                robot.waitForIdle();
-            }
-
-            for (int i = 0; i < nx * ny - nx * ny / 2 - 1; i++) {
-                robot.keyPress(KeyEvent.VK_LEFT);
-                robot.keyRelease(KeyEvent.VK_LEFT);
-                robot.waitForIdle();
-            }
-
+        for (int i = 0; i < nx * ny / 2; i++) {
             robot.keyPress(KeyEvent.VK_SHIFT);
             robot.keyPress(KeyEvent.VK_TAB);
             robot.keyRelease(KeyEvent.VK_TAB);
             robot.keyRelease(KeyEvent.VK_SHIFT);
             robot.waitForIdle();
+        }
 
-            robot.delay(200);
+        for (int i = 0; i < nx * ny - nx * ny / 2 - 1; i++) {
+            robot.keyPress(KeyEvent.VK_LEFT);
+            robot.keyRelease(KeyEvent.VK_LEFT);
+            robot.waitForIdle();
+        }
 
+        robot.keyPress(KeyEvent.VK_SHIFT);
+        robot.keyPress(KeyEvent.VK_TAB);
+        robot.keyRelease(KeyEvent.VK_TAB);
+        robot.keyRelease(KeyEvent.VK_SHIFT);
+        robot.waitForIdle();
+
+        robot.delay(200);
+
+        synchronized (focusCnt) {
             for (int i = 0; i < nx * ny; i++) {
                 if (focusCnt[i] < 2) {
                     throw new RuntimeException("Component " + i
-                        + " is not reachable in the backward focus cycle");
+                            + " is not reachable in the backward focus cycle");
                 } else if (focusCnt[i] > 2) {
                     throw new RuntimeException("Component " + i
-                        + " got focus more than once in the backward focus cycle");
+                            + " got focus more than once in the backward focus cycle");
                 }
             }
-        } finally {
-            SwingUtilities.invokeAndWait(() -> {
-                if (window != null) {
-                    window.dispose();
-                }
-            });
         }
+
     }
 
-    private static void changeLAF() {
-        String currentLAF = UIManager.getLookAndFeel().toString();
-        currentLAF = currentLAF.toLowerCase();
-        if (currentLAF.contains("aqua") || currentLAF.contains("nimbus")) {
-            try {
-                UIManager.setLookAndFeel("javax.swing.plaf.metal.MetalLookAndFeel");
-            } catch (ClassNotFoundException
-                    | IllegalAccessException
-                    | InstantiationException
-                    | UnsupportedLookAndFeelException ex) {
-                ex.printStackTrace();
-            }
+    private static void setLookAndFeel(UIManager.LookAndFeelInfo laf) {
+        try {
+            UIManager.setLookAndFeel(laf.getClassName());
+            System.out.println(laf.getName());
+        } catch (UnsupportedLookAndFeelException ignored){
+            System.out.println("Unsupported LookAndFeel: " + laf.getClassName());
+        } catch (ClassNotFoundException | InstantiationException |
+                         IllegalAccessException e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -168,16 +184,16 @@ public class ButtonGroupLayoutTraversalTest {
             comp.addFocusListener(new FocusAdapter() {
                 @Override
                 public void focusGained(FocusEvent e) {
-                    focusCnt[fi]++;
-                    if (focusCnt[fi] == 1) {
-                        ((JComponent) e.getSource())
-                                .setBackground(Color.yellow);
-                    } else if (focusCnt[fi] == 2) {
-                        ((JComponent) e.getSource())
-                                .setBackground(Color.green);
-                    } else {
-                        ((JComponent) e.getSource())
-                                .setBackground(Color.red);
+                    synchronized (focusCnt) {
+                        focusCnt[fi]++;
+                        JComponent btn = (JComponent) e.getSource();
+                        if (focusCnt[fi] == 1) {
+                            btn.setBackground(Color.yellow);
+                        } else if (focusCnt[fi] == 2) {
+                            btn.setBackground(Color.green);
+                        } else {
+                            btn.setBackground(Color.red);
+                        }
                     }
                 }
             });

--- a/test/jdk/java/awt/Focus/FocusTraversalPolicy/ButtonGroupLayoutTraversal/ButtonGroupLayoutTraversalTest.java
+++ b/test/jdk/java/awt/Focus/FocusTraversalPolicy/ButtonGroupLayoutTraversal/ButtonGroupLayoutTraversalTest.java
@@ -51,10 +51,10 @@ import javax.swing.UnsupportedLookAndFeelException;
 
 public class ButtonGroupLayoutTraversalTest {
 
-    private static final int nx = 3;
-    private static final int ny = 3;
+    private static final int NX = 3;
+    private static final int NY = 3;
 
-    private static final int[] focusCnt = new int[nx * ny];
+    private static final int[] focusCnt = new int[NX * NY];
 
     private static JFrame window;
     private static Robot robot;
@@ -66,7 +66,7 @@ public class ButtonGroupLayoutTraversalTest {
         for (UIManager.LookAndFeelInfo laf : UIManager.getInstalledLookAndFeels()) {
             try {
                 SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
-                SwingUtilities.invokeAndWait(() -> initLayout(nx, ny));
+                SwingUtilities.invokeAndWait(() -> initLayout(NX, NY));
                 test();
             } finally {
                 SwingUtilities.invokeAndWait(() -> {
@@ -87,13 +87,13 @@ public class ButtonGroupLayoutTraversalTest {
         robot.waitForIdle();
         robot.delay(1000);
 
-        for (int i = 0; i < nx * ny - nx * ny / 2 - 1; i++) {
+        for (int i = 0; i < NX * NY - NX * NY / 2 - 1; i++) {
             robot.keyPress(KeyEvent.VK_RIGHT);
             robot.keyRelease(KeyEvent.VK_RIGHT);
             robot.waitForIdle();
         }
 
-        for (int i = 0; i < nx * ny / 2; i++) {
+        for (int i = 0; i < NX * NY / 2; i++) {
             robot.keyPress(KeyEvent.VK_TAB);
             robot.keyRelease(KeyEvent.VK_TAB);
             robot.waitForIdle();
@@ -102,7 +102,7 @@ public class ButtonGroupLayoutTraversalTest {
         robot.delay(200);
 
         synchronized (focusCnt) {
-            for (int i = 0; i < nx * ny; i++) {
+            for (int i = 0; i < NX * NY; i++) {
                 if (focusCnt[i] < 1) {
                     throw new RuntimeException("Component " + i
                             + " is not reachable in the forward focus cycle");
@@ -113,7 +113,7 @@ public class ButtonGroupLayoutTraversalTest {
             }
         }
 
-        for (int i = 0; i < nx * ny / 2; i++) {
+        for (int i = 0; i < NX * NY / 2; i++) {
             robot.keyPress(KeyEvent.VK_SHIFT);
             robot.keyPress(KeyEvent.VK_TAB);
             robot.keyRelease(KeyEvent.VK_TAB);
@@ -121,7 +121,7 @@ public class ButtonGroupLayoutTraversalTest {
             robot.waitForIdle();
         }
 
-        for (int i = 0; i < nx * ny - nx * ny / 2 - 1; i++) {
+        for (int i = 0; i < NX * NY - NX * NY / 2 - 1; i++) {
             robot.keyPress(KeyEvent.VK_LEFT);
             robot.keyRelease(KeyEvent.VK_LEFT);
             robot.waitForIdle();
@@ -136,7 +136,7 @@ public class ButtonGroupLayoutTraversalTest {
         robot.delay(200);
 
         synchronized (focusCnt) {
-            for (int i = 0; i < nx * ny; i++) {
+            for (int i = 0; i < NX * NY; i++) {
                 if (focusCnt[i] < 2) {
                     throw new RuntimeException("Component " + i
                             + " is not reachable in the backward focus cycle");


### PR DESCRIPTION
Summary: Expanded ButtonGroupLayoutTraversalTest.java to run in all LAFs on all OS. Added synchronization for focusCnt.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270116](https://bugs.openjdk.java.net/browse/JDK-8270116): Expand ButtonGroupLayoutTraversalTest.java to run in all LaFs, including Aqua on macOS


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4937/head:pull/4937` \
`$ git checkout pull/4937`

Update a local copy of the PR: \
`$ git checkout pull/4937` \
`$ git pull https://git.openjdk.java.net/jdk pull/4937/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4937`

View PR using the GUI difftool: \
`$ git pr show -t 4937`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4937.diff">https://git.openjdk.java.net/jdk/pull/4937.diff</a>

</details>
