### PR TITLE
8271506: Add ResourceHashtable support for deleting selected entries

### DIFF
--- a/src/hotspot/share/utilities/resourceHash.hpp
+++ b/src/hotspot/share/utilities/resourceHash.hpp
@@ -56,7 +56,12 @@ class ResourceHashtableBase : public STORAGE {
  private:
   int _number_of_entries;
 
-  Node** bucket_at(unsigned index) const {
+  Node** bucket_at(unsigned index) {
+    Node** t = table();
+    return &t[index];
+  }
+
+  const Node* const* bucket_at(unsigned index) const {
     Node** t = table();
     return &t[index];
   }
@@ -107,7 +112,6 @@ class ResourceHashtableBase : public STORAGE {
  public:
   unsigned table_size() const { return STORAGE::table_size(); }
   int number_of_entries() const { return _number_of_entries; }
-  void decrement_entries() { _number_of_entries--; }
 
   bool contains(K const& key) const {
     return get(key) != NULL;
@@ -216,7 +220,7 @@ class ResourceHashtableBase : public STORAGE {
   // called for each entry in the table.  If do_entry() returns true,
   // the entry is deleted.
   template<class ITER>
-  void unlink(ITER* iter) const {
+  void unlink(ITER* iter) {
     const unsigned sz = table_size();
     for (unsigned index = 0; index < sz; index++) {
       Node** ptr = bucket_at(index);
@@ -229,7 +233,7 @@ class ResourceHashtableBase : public STORAGE {
           if (ALLOC_TYPE == ResourceObj::C_HEAP) {
             delete node;
           }
-          const_cast<ResourceHashtableBase*>(this)->decrement_entries();
+          _number_of_entries --;
         } else {
           ptr = &(node->_next);
         }

--- a/test/hotspot/gtest/utilities/test_resourceHash.cpp
+++ b/test/hotspot/gtest/utilities/test_resourceHash.cpp
@@ -60,6 +60,21 @@ class CommonResourceHashtableTest : public ::testing::Test {
     }
   };
 
+  class DeleterTestIter {
+    int _val;
+   public:
+    DeleterTestIter(int i) : _val(i) {}
+
+    bool do_entry(K const& k, V const& v) {
+      if ((uintptr_t) k == (uintptr_t) _val) {
+        // Delete me!
+        return true;
+      } else {
+        return false; // continue iteration
+      }
+    }
+  };
+
 };
 
 class SmallResourceHashtableTest : public CommonResourceHashtableTest {
@@ -233,6 +248,15 @@ class GenericResourceHashtableTest : public CommonResourceHashtableTest {
         ASSERT_FALSE(rh.remove(as_K(index)));
       }
       rh.iterate(&et);
+
+      // Add more entries in and then delete one.
+      for (uintptr_t i = 10; i > 0; --i) {
+        uintptr_t index = i - 1;
+        ASSERT_TRUE(rh.put(as_K(index), index));
+      }
+      DeleterTestIter dt(5);
+      rh.unlink(&dt);
+      ASSERT_FALSE(rh.get(as_K(5)));
     }
   };
 };


### PR DESCRIPTION
The ResourceHashtable doesn't have a way to delete selected entries based on things like their class has been unloaded, which is needed to replace Hashtable with ResourceHashtable.
The Nodes of the ResourceHashtable has a Key and Value of  template types.
template<typename K, typename V>
class ResourceHashtableNode : public ResourceObj {
public:
  unsigned _hash;
  K _key;
  V _value;
...
But there's no destructor so that ~K and ~V are not called (if I understand C++ correctly).

When instantiated with a value that's not a pointer, calling code does this:

  SourceObjInfo src_info(ref, read_only, follow_mode);
  bool created;
  SourceObjInfo* p = _src_obj_table.put_if_absent(src_obj, src_info, &created);

So if SourceObjInfo has a destructor, it'll have to have a careful assignment operator so that the value copied into the hashtable doesn't get deleted.

In this patch, I assign the responsibility of deleting the Key and Value of the hashtable to the do_entry function, because it's simple.  If we want to use more advanced unreadable C++ code, someone will have to suggest an alternate set of changes, because my C++ is not up to this.

Tested with tier1-3, gtest, and upcoming patch for JDK-8048190.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271506](https://bugs.openjdk.java.net/browse/JDK-8271506): Add ResourceHashtable support for deleting selected entries


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4938/head:pull/4938` \
`$ git checkout pull/4938`

Update a local copy of the PR: \
`$ git checkout pull/4938` \
`$ git pull https://git.openjdk.java.net/jdk pull/4938/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4938`

View PR using the GUI difftool: \
`$ git pr show -t 4938`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4938.diff">https://git.openjdk.java.net/jdk/pull/4938.diff</a>

</details>
