### PR TITLE
8271308: (fc) FileChannel.transferTo() transfers no more than Integer.MAX_VALUE bytes in one call

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -65,6 +65,9 @@ public class FileChannelImpl
     private static final JavaIOFileDescriptorAccess fdAccess =
         SharedSecrets.getJavaIOFileDescriptorAccess();
 
+    // Maximum direct transfer size
+    private static final int MAX_DIRECT_TRANSFER_SIZE = maxDirectTransferSize0();
+
     // Used to make native read and write calls
     private final FileDispatcher nd;
 
@@ -678,7 +681,7 @@ public class FileChannelImpl
 
         // Attempt a direct transfer, if the kernel supports it, limiting
         // the number of bytes according to which platform
-        int icount = (int)Math.min(count, maxDirectTransferSize0());
+        int icount = (int)Math.min(count, MAX_DIRECT_TRANSFER_SIZE);
         long n;
         if ((n = transferToDirectly(position, icount, target)) >= 0)
             return n;
@@ -1350,7 +1353,7 @@ public class FileChannelImpl
                                     long count, FileDescriptor dst);
 
     // Retrieves the maximum size of a transfer
-    private native int maxDirectTransferSize0();
+    private static native int maxDirectTransferSize0();
 
     // Caches fieldIDs
     private static native long initIDs();

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -66,7 +66,7 @@ public class FileChannelImpl
         SharedSecrets.getJavaIOFileDescriptorAccess();
 
     // Maximum direct transfer size
-    private static final int MAX_DIRECT_TRANSFER_SIZE = maxDirectTransferSize0();
+    private static final int MAX_DIRECT_TRANSFER_SIZE;
 
     // Used to make native read and write calls
     private final FileDispatcher nd;
@@ -1361,5 +1361,6 @@ public class FileChannelImpl
     static {
         IOUtil.load();
         allocationGranularity = initIDs();
+        MAX_DIRECT_TRANSFER_SIZE = maxDirectTransferSize0();
     }
 }

--- a/src/java.base/unix/native/libnio/ch/FileChannelImpl.c
+++ b/src/java.base/unix/native/libnio/ch/FileChannelImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -252,3 +252,12 @@ Java_sun_nio_ch_FileChannelImpl_transferTo0(JNIEnv *env, jobject this,
 #endif
 }
 
+JNIEXPORT jlong JNICALL
+Java_sun_nio_ch_FileChannelImpl_maxTransferSize0(JNIEnv* env, jobject this)
+{
+#if defined(LINUX)
+    return 0x7ffff000; // 2,147,479,552 maximum for sendfile()
+#else
+    return java_lang_Integer_MAX_VALUE;
+#endif
+}

--- a/src/java.base/unix/native/libnio/ch/FileChannelImpl.c
+++ b/src/java.base/unix/native/libnio/ch/FileChannelImpl.c
@@ -252,8 +252,8 @@ Java_sun_nio_ch_FileChannelImpl_transferTo0(JNIEnv *env, jobject this,
 #endif
 }
 
-JNIEXPORT jlong JNICALL
-Java_sun_nio_ch_FileChannelImpl_maxTransferSize0(JNIEnv* env, jobject this)
+JNIEXPORT jint JNICALL
+Java_sun_nio_ch_FileChannelImpl_maxDirectTransferSize0(JNIEnv* env, jobject this)
 {
 #if defined(LINUX)
     return 0x7ffff000; // 2,147,479,552 maximum for sendfile()

--- a/src/java.base/windows/native/libnio/ch/FileChannelImpl.c
+++ b/src/java.base/windows/native/libnio/ch/FileChannelImpl.c
@@ -194,8 +194,8 @@ Java_sun_nio_ch_FileChannelImpl_transferTo0(JNIEnv *env, jobject this,
 }
 
 
-JNIEXPORT jlong JNICALL
-Java_sun_nio_ch_FileChannelImpl_maxTransferSize0(JNIEnv* env, jobject this)
+JNIEXPORT jint JNICALL
+Java_sun_nio_ch_FileChannelImpl_maxDirectTransferSize0(JNIEnv* env, jobject this)
 {
     return MAX_TRANSMIT_SIZE;
 }

--- a/src/java.base/windows/native/libnio/ch/FileChannelImpl.c
+++ b/src/java.base/windows/native/libnio/ch/FileChannelImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -145,6 +145,9 @@ Java_sun_nio_ch_FileChannelImpl_unmap0(JNIEnv *env, jobject this,
     return 0;
 }
 
+// Integer.MAX_VALUE - 1 is the maximum transfer size for TransmitFile()
+#define MAX_TRANSMIT_SIZE (java_lang_Integer_MAX_VALUE - 1)
+
 JNIEXPORT jlong JNICALL
 Java_sun_nio_ch_FileChannelImpl_transferTo0(JNIEnv *env, jobject this,
                                             jobject srcFD,
@@ -156,8 +159,8 @@ Java_sun_nio_ch_FileChannelImpl_transferTo0(JNIEnv *env, jobject this,
     LARGE_INTEGER where;
     HANDLE src = (HANDLE)(handleval(env, srcFD));
     SOCKET dst = (SOCKET)(fdval(env, dstFD));
-    DWORD chunkSize = (count > java_lang_Integer_MAX_VALUE) ?
-        java_lang_Integer_MAX_VALUE : (DWORD)count;
+    DWORD chunkSize = (count > MAX_TRANSMIT_SIZE) ?
+        MAX_TRANSMIT_SIZE : (DWORD)count;
     BOOL result;
 
     where.QuadPart = position;
@@ -188,4 +191,11 @@ Java_sun_nio_ch_FileChannelImpl_transferTo0(JNIEnv *env, jobject this,
         return IOS_THROWN;
     }
     return chunkSize;
+}
+
+
+JNIEXPORT jlong JNICALL
+Java_sun_nio_ch_FileChannelImpl_maxTransferSize0(JNIEnv* env, jobject this)
+{
+    return MAX_TRANSMIT_SIZE;
 }

--- a/test/jdk/java/nio/channels/FileChannel/Transfer2GPlus.java
+++ b/test/jdk/java/nio/channels/FileChannel/Transfer2GPlus.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8271308
+ * @summary Verify that transferTo() copies more than Integer.MAX_VALUE bytes
+ */
+
+import java.io.File;
+import java.io.DataOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.channels.WritableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.Random;
+
+public class Transfer2GPlus {
+    private static final long BASE   = (long)Integer.MAX_VALUE;
+    private static final int  EXTRA  = 1024;
+    private static final long LENGTH = BASE + EXTRA;
+
+    public static void main(String[] args) throws IOException {
+        Path src = Files.createTempFile("src", ".dat");
+        src.toFile().deleteOnExit();
+        byte[] b = createSrcFile(src);
+        testToFileChannel(src, b);
+        testToWritableByteChannel(src, b);
+    }
+
+    // Create a file of size LENGTH with EXTRA random bytes at offset BASE.
+    private static byte[] createSrcFile(Path src)
+        throws IOException {
+        RandomAccessFile raf = new RandomAccessFile(src.toString(), "rw");
+        raf.setLength(LENGTH);
+        raf.seek(BASE);
+        Random r = new Random(System.nanoTime());
+        byte[] b = new byte[EXTRA];
+        r.nextBytes(b);
+        raf.write(b);
+        return b;
+    }
+
+    // Exercises transferToDirectly() on Linux and transferToTrustedChannel()
+    // on macOS and Windows.
+    private static void testToFileChannel(Path src, byte[] expected)
+        throws IOException {
+        Path dst = Files.createTempFile("dst", ".dat");
+        dst.toFile().deleteOnExit();
+        try (FileChannel srcCh = FileChannel.open(src)) {
+            try (FileChannel dstCh = FileChannel.open(dst,
+                 StandardOpenOption.READ, StandardOpenOption.WRITE)) {
+                long n;
+                if ((n = srcCh.transferTo(0, LENGTH, dstCh)) < LENGTH)
+                    throw new RuntimeException("Too few bytes transferred: " +
+                        n + " < " + LENGTH);
+
+                if (dstCh.size() < LENGTH)
+                    throw new RuntimeException("Target file too small: " +
+                        dstCh.size() + " < " + LENGTH);
+
+                System.out.println("Transferred " + n + " bytes");
+
+                dstCh.position(BASE);
+                ByteBuffer bb = ByteBuffer.allocate(EXTRA);
+                dstCh.read(bb);
+                if (!Arrays.equals(bb.array(), expected))
+                    throw new RuntimeException("Unexpected values");
+            }
+        }
+    }
+
+    // Exercises transferToArbitraryChannel() on all platforms.
+    private static void testToWritableByteChannel(Path src, byte[] expected)
+        throws IOException {
+        File file = File.createTempFile("dst", ".dat");
+        file.deleteOnExit();
+        try (FileChannel srcCh = FileChannel.open(src)) {
+            // The FileOutputStream is wrapped so that newChannel() does not
+            // return a FileChannelImpl and so make a faster path be taken.
+            try (DataOutputStream stream =
+                new DataOutputStream(new FileOutputStream(file))) {
+                try (WritableByteChannel wbc = Channels.newChannel(stream)) {
+                    long n;
+                    if ((n = srcCh.transferTo(0, LENGTH, wbc)) < LENGTH)
+                        throw new RuntimeException("Too few bytes transferred: " +
+                            n + " < " + LENGTH);
+
+                    System.out.println("Transferred " + n + " bytes");
+
+                    RandomAccessFile raf = new RandomAccessFile(file, "r");
+                    raf.seek(BASE);
+                    byte[] b = new byte[EXTRA];
+                    raf.read(b);
+                    if (!Arrays.equals(b, expected))
+                        throw new RuntimeException("Unexpected values");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Please consider this request to enhance `java.nio.channels.FileChannel.transferTo()` to be able to transfer more than `Integer.MAX_VALUE` bytes in one call.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271308](https://bugs.openjdk.java.net/browse/JDK-8271308): (fc) FileChannel.transferTo() transfers no more than Integer.MAX_VALUE bytes in one call


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Vyom Tewari](https://openjdk.java.net/census#vtewari) (@vyommani - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4940/head:pull/4940` \
`$ git checkout pull/4940`

Update a local copy of the PR: \
`$ git checkout pull/4940` \
`$ git pull https://git.openjdk.java.net/jdk pull/4940/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4940`

View PR using the GUI difftool: \
`$ git pr show -t 4940`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4940.diff">https://git.openjdk.java.net/jdk/pull/4940.diff</a>

</details>
