### PR TITLE
6350025: API documentation for JOptionPane using deprecated methods.

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JOptionPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JOptionPane.java
@@ -272,7 +272,7 @@ import static javax.swing.ClientPropertyKey.PopupFactory_FORCE_HEAVYWEIGHT_POPUP
  *     JOptionPane pane = new JOptionPane(<i>arguments</i>);
  *     pane.set<i>.Xxxx(...); // Configure</i>
  *     JDialog dialog = pane.createDialog(<i>parentComponent, title</i>);
- *     dialog.show();
+ *     dialog.setVisible(true);
  *     Object selectedValue = pane.getValue();
  *     if(selectedValue == null)
  *       return CLOSED_OPTION;


### PR DESCRIPTION
The method show() in the JOptionPane javadoc example is deprecated. The recommended method to call would be setVisible(true).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-6350025](https://bugs.openjdk.java.net/browse/JDK-6350025): API documentation for JOptionPane using deprecated methods.


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4953/head:pull/4953` \
`$ git checkout pull/4953`

Update a local copy of the PR: \
`$ git checkout pull/4953` \
`$ git pull https://git.openjdk.java.net/jdk pull/4953/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4953`

View PR using the GUI difftool: \
`$ git pr show -t 4953`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4953.diff">https://git.openjdk.java.net/jdk/pull/4953.diff</a>

</details>
