### PR TITLE
8271605: Update JMH devkit to 1.32

### DIFF
--- a/make/devkit/createJMHBundle.sh
+++ b/make/devkit/createJMHBundle.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 # Create a bundle in the build directory, containing what's needed to
 # build and run JMH microbenchmarks from the OpenJDK build.
 
-JMH_VERSION=1.28
+JMH_VERSION=1.32
 COMMONS_MATH3_VERSION=3.2
 JOPT_SIMPLE_VERSION=4.6
 


### PR DESCRIPTION
It is currently at 1.28, and thus misses a bunch of fixes and improvements. 1.32 is the latest version, and probably the last version before enabling the automatic detection of compiler blackholes (CODETOOLS-7903004), the change that would affect benchmarks performance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271605](https://bugs.openjdk.java.net/browse/JDK-8271605): Update JMH devkit to 1.32


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Eric Caspole](https://openjdk.java.net/census#ecaspole) (@ericcaspole - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4954/head:pull/4954` \
`$ git checkout pull/4954`

Update a local copy of the PR: \
`$ git checkout pull/4954` \
`$ git pull https://git.openjdk.java.net/jdk pull/4954/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4954`

View PR using the GUI difftool: \
`$ git pr show -t 4954`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4954.diff">https://git.openjdk.java.net/jdk/pull/4954.diff</a>

</details>
