### PR TITLE
8271609: Misleading message for AbortVMOnVMOperationTimeoutDelay

### DIFF
--- a/src/hotspot/share/runtime/vmThread.cpp
+++ b/src/hotspot/share/runtime/vmThread.cpp
@@ -60,7 +60,7 @@ void VMOperationTimeoutTask::task() {
   if (is_armed()) {
     jlong delay = nanos_to_millis(os::javaTimeNanos() - _arm_time);
     if (delay > AbortVMOnVMOperationTimeoutDelay) {
-      fatal("VM operation took too long: " JLONG_FORMAT " ms (timeout: " INTX_FORMAT " ms)",
+      fatal("VM operation took too long: " JLONG_FORMAT " ms elapsed since VM-op start (timeout: " INTX_FORMAT " ms)",
             delay, AbortVMOnVMOperationTimeoutDelay);
     }
   }


### PR DESCRIPTION
Simple amendment to `AbortVMOnVMOperationTimeoutDelay` message to avoid misinterpretation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271609](https://bugs.openjdk.java.net/browse/JDK-8271609): Misleading message for AbortVMOnVMOperationTimeoutDelay


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4955/head:pull/4955` \
`$ git checkout pull/4955`

Update a local copy of the PR: \
`$ git checkout pull/4955` \
`$ git pull https://git.openjdk.java.net/jdk pull/4955/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4955`

View PR using the GUI difftool: \
`$ git pr show -t 4955`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4955.diff">https://git.openjdk.java.net/jdk/pull/4955.diff</a>

</details>
