### PR TITLE
8271611: Use SecurityConstants.ACCESS_PERMISSION in MethodHandles

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -230,7 +230,7 @@ public class MethodHandles {
 
         @SuppressWarnings("removal")
         SecurityManager sm = System.getSecurityManager();
-        if (sm != null) sm.checkPermission(ACCESS_PERMISSION);
+        if (sm != null) sm.checkPermission(SecurityConstants.ACCESS_PERMISSION);
         if (targetClass.isPrimitive())
             throw new IllegalArgumentException(targetClass + " is a primitive class");
         if (targetClass.isArray())
@@ -443,13 +443,10 @@ public class MethodHandles {
     public static <T extends Member> T reflectAs(Class<T> expected, MethodHandle target) {
         @SuppressWarnings("removal")
         SecurityManager smgr = System.getSecurityManager();
-        if (smgr != null)  smgr.checkPermission(ACCESS_PERMISSION);
+        if (smgr != null)  smgr.checkPermission(SecurityConstants.ACCESS_PERMISSION);
         Lookup lookup = Lookup.IMPL_LOOKUP;  // use maximally privileged lookup
         return lookup.revealDirect(target).reflectAs(expected, lookup);
     }
-    // Copied from AccessibleObject, as used by Method.setAccessible, etc.:
-    private static final java.security.Permission ACCESS_PERMISSION =
-        new ReflectPermission("suppressAccessChecks");
 
     /**
      * A <em>lookup object</em> is a factory for creating method handles,


### PR DESCRIPTION
Reusing SecurityConstants.ACCESS_PERMISSION (which was moved from AccessibleObject by JDK-8202419) avoids initialization of ReflectPermission when no SecurityManager is installed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271611](https://bugs.openjdk.java.net/browse/JDK-8271611): Use SecurityConstants.ACCESS_PERMISSION in MethodHandles


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4957/head:pull/4957` \
`$ git checkout pull/4957`

Update a local copy of the PR: \
`$ git checkout pull/4957` \
`$ git pull https://git.openjdk.java.net/jdk pull/4957/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4957`

View PR using the GUI difftool: \
`$ git pr show -t 4957`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4957.diff">https://git.openjdk.java.net/jdk/pull/4957.diff</a>

</details>
