### PR TITLE
8271624: Avoid unnecessary ThreadGroup.checkAccess calls when creating Threads

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -417,14 +417,14 @@ public class Thread implements Runnable {
             }
         }
 
-        /* checkAccess regardless of whether or not threadgroup is
-           explicitly passed in. */
-        g.checkAccess();
-
         /*
          * Do we have the required permissions?
          */
         if (security != null) {
+            /* checkAccess regardless of whether or not threadgroup is
+               explicitly passed in. */
+            security.checkAccess(g);
+
             if (isCCLOverridden(getClass())) {
                 security.checkPermission(
                         SecurityConstants.SUBCLASS_IMPLEMENTATION_PERMISSION);


### PR DESCRIPTION
Trivially avoid some redundant calls when creating threads. (ThreadGroup.checkAccess is final, and all it does is call security.checkAccess(g) if there's a SM installed)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271624](https://bugs.openjdk.java.net/browse/JDK-8271624): Avoid unnecessary ThreadGroup.checkAccess calls when creating Threads


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4959/head:pull/4959` \
`$ git checkout pull/4959`

Update a local copy of the PR: \
`$ git checkout pull/4959` \
`$ git pull https://git.openjdk.java.net/jdk pull/4959/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4959`

View PR using the GUI difftool: \
`$ git pr show -t 4959`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4959.diff">https://git.openjdk.java.net/jdk/pull/4959.diff</a>

</details>
