### PR TITLE
8271601: Math.floorMod(int, int) and Math.floorMod(long, long) differ in their logic

### DIFF
--- a/src/java.base/share/classes/java/lang/Math.java
+++ b/src/java.base/share/classes/java/lang/Math.java
@@ -1398,7 +1398,7 @@ public final class Math {
     public static int floorMod(int x, int y) {
         int mod = x % y;
         // if the signs are different and modulo not zero, adjust result
-        if ((mod ^ y) < 0 && mod != 0) {
+        if ((x ^ y) < 0 && mod != 0) {
             mod += y;
         }
         return mod;


### PR DESCRIPTION
Hello,

please review this tiny change in the implementation of j.l.Math.floorMod(int, int).

While the results are unaffected, all of
    floorDiv(int, int)
    floorDiv(long, long)
    floorMod(long, long)
use x ^ y in the tests to correct the result if needed.

Not only is the proposed change more consistent with the other methods, but it might benefit later stages in the cpu to proceed with the evaluation of x ^ y in parallel with the previous x % y and, depending of the outcome, even further down.


Greetings
Raffaello

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271601](https://bugs.openjdk.java.net/browse/JDK-8271601): Math.floorMod(int, int) and Math.floorMod(long, long) differ in their logic


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4962/head:pull/4962` \
`$ git checkout pull/4962`

Update a local copy of the PR: \
`$ git checkout pull/4962` \
`$ git pull https://git.openjdk.java.net/jdk pull/4962/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4962`

View PR using the GUI difftool: \
`$ git pr show -t 4962`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4962.diff">https://git.openjdk.java.net/jdk/pull/4962.diff</a>

</details>
