### PR TITLE
8271623: Omit enclosing instance fields from inner classes that don't use it

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -121,7 +121,7 @@ public class Lower extends TreeTranslator {
         debugLower = options.isSet("debuglower");
         pkginfoOpt = PkgInfo.get(options);
         optimizeOuterThis =
-            target.omitUnusedPrivateSyntheticEnclosingInstanceFields() ||
+            target.optimizeOuterThis() ||
             options.getBoolean("optimizeOuterThis", false);
         disableProtectedAccessors = options.isSet("disableProtectedAccessors");
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -2248,12 +2248,11 @@ public class Lower extends TreeTranslator {
             enterSynthetic(tree.pos(), otdef.sym, currentClass.members());
 
            for (JCTree def : tree.defs) {
-                if (!TreeInfo.isInitialConstructor(def)) {
-                    continue;
+                if (TreeInfo.isInitialConstructor(def)) {
+                  JCMethodDecl mdef = (JCMethodDecl) def;
+                  mdef.body.stats = mdef.body.stats.prepend(
+                      initOuterThis(mdef.body.pos, mdef.params.head.sym));
                 }
-                JCMethodDecl mdef = (JCMethodDecl) def;
-                mdef.body.stats = mdef.body.stats.prepend(
-                    initOuterThis(mdef.body.pos, mdef.params.head.sym));
             }
         }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -120,7 +120,9 @@ public class Lower extends TreeTranslator {
         Options options = Options.instance(context);
         debugLower = options.isSet("debuglower");
         pkginfoOpt = PkgInfo.get(options);
-        optimizeOuterThis = options.getBoolean("optimizeOuterThis", true);
+        optimizeOuterThis =
+            target.omitUnusedPrivateSyntheticEnclosingInstanceFields() ||
+            options.getBoolean("optimizeOuterThis", false);
         disableProtectedAccessors = options.isSet("disableProtectedAccessors");
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -98,6 +98,7 @@ public class Lower extends TreeTranslator {
     private final boolean debugLower;
     private final boolean disableProtectedAccessors; // experimental
     private final PkgInfo pkginfoOpt;
+    private final boolean optimizeOuterThis;
 
     protected Lower(Context context) {
         context.put(lowerKey, this);
@@ -119,6 +120,7 @@ public class Lower extends TreeTranslator {
         Options options = Options.instance(context);
         debugLower = options.isSet("debuglower");
         pkginfoOpt = PkgInfo.get(options);
+        optimizeOuterThis = options.getBoolean("optimizeOuterThis", true);
         disableProtectedAccessors = options.isSet("disableProtectedAccessors");
     }
 
@@ -1480,8 +1482,12 @@ public class Lower extends TreeTranslator {
 
     private VarSymbol makeOuterThisVarSymbol(Symbol owner, long flags) {
         Type target = types.erasure(owner.enclClass().type.getEnclosingType());
+        // Set NOOUTERTHIS for all synthetic outer instance variables, and unset
+        // it when the variable is accessed. If the variable is never accessed,
+        // we skip creating an outer instance field and saving the constructor
+        // parameter to it.
         VarSymbol outerThis =
-            new VarSymbol(flags, outerThisName(target, owner), target, owner);
+            new VarSymbol(flags | NOOUTERTHIS, outerThisName(target, owner), target, owner);
         outerThisStack = outerThisStack.prepend(outerThis);
         return outerThis;
     }
@@ -1728,6 +1734,7 @@ public class Lower extends TreeTranslator {
         }
         VarSymbol ot = ots.head;
         JCExpression tree = access(make.at(pos).Ident(ot));
+        ot.flags_field &= ~NOOUTERTHIS;
         TypeSymbol otc = ot.type.tsym;
         while (otc != c) {
             do {
@@ -1745,6 +1752,7 @@ public class Lower extends TreeTranslator {
                 return makeNull();
             }
             tree = access(make.at(pos).Select(tree, ot));
+            ot.flags_field &= ~NOOUTERTHIS;
             otc = ot.type.tsym;
         }
         return tree;
@@ -1784,6 +1792,7 @@ public class Lower extends TreeTranslator {
         }
         VarSymbol ot = ots.head;
         JCExpression tree = access(make.at(pos).Ident(ot));
+        ot.flags_field &= ~NOOUTERTHIS;
         TypeSymbol otc = ot.type.tsym;
         while (!(preciseMatch ? sym.isMemberOf(otc, types) : otc.isSubClass(sym.owner, types))) {
             do {
@@ -1796,6 +1805,7 @@ public class Lower extends TreeTranslator {
                 ot = ots.head;
             } while (ot.owner != otc);
             tree = access(make.at(pos).Select(tree, ot));
+            ot.flags_field &= ~NOOUTERTHIS;
             otc = ot.type.tsym;
         }
         return tree;
@@ -1817,10 +1827,9 @@ public class Lower extends TreeTranslator {
 
     /** Return tree simulating the assignment {@code this.this$n = this$n}.
      */
-    JCStatement initOuterThis(int pos) {
-        VarSymbol rhs = outerThisStack.head;
+    JCStatement initOuterThis(int pos, VarSymbol rhs) {
         Assert.check(rhs.owner.kind == MTH);
-        VarSymbol lhs = outerThisStack.tail.head;
+        VarSymbol lhs = outerThisStack.head;
         Assert.check(rhs.owner.owner == lhs.owner);
         make.at(pos);
         return
@@ -2224,15 +2233,27 @@ public class Lower extends TreeTranslator {
         // Convert name to flat representation, replacing '.' by '$'.
         tree.name = Convert.shortName(currentClass.flatName());
 
-        // Add this$n and free variables proxy definitions to class.
+        // Add free variables proxy definitions to class.
 
         for (List<JCVariableDecl> l = fvdefs; l.nonEmpty(); l = l.tail) {
             tree.defs = tree.defs.prepend(l.head);
             enterSynthetic(tree.pos(), l.head.sym, currentClass.members());
         }
-        if (currentClass.hasOuterInstance()) {
+        // If this$n was accessed, add the field definition and
+        // update initial constructors to initialize it
+        if (currentClass.hasOuterInstance()
+            && (((outerThisStack.head.flags_field & NOOUTERTHIS) == 0) || !optimizeOuterThis)) {
             tree.defs = tree.defs.prepend(otdef);
             enterSynthetic(tree.pos(), otdef.sym, currentClass.members());
+
+           for (JCTree def : tree.defs) {
+                if (!TreeInfo.isInitialConstructor(def)) {
+                    continue;
+                }
+                JCMethodDecl mdef = (JCMethodDecl) def;
+                mdef.body.stats = mdef.body.stats.prepend(
+                    initOuterThis(mdef.body.pos, mdef.params.head.sym));
+            }
         }
 
         proxies = prevProxies;
@@ -2702,11 +2723,6 @@ public class Lower extends TreeTranslator {
                     olderasure.getReturnType(),
                     olderasure.getThrownTypes(),
                     syms.methodClass);
-            }
-            if (currentClass.hasOuterInstance() &&
-                TreeInfo.isInitialConstructor(tree))
-            {
-                added = added.prepend(initOuterThis(tree.body.pos));
             }
 
             // pop local variables from proxy stack

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Target.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Target.java
@@ -207,7 +207,7 @@ public enum Target {
     /** Omit unused enclosing instance fields from inner classes that don't access enclosing
      * instance state.
      */
-    public boolean omitUnusedPrivateSyntheticEnclosingInstanceFields() {
+    public boolean optimizeOuterThis() {
         return compareTo(JDK1_18) >= 0;
     }
 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Target.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Target.java
@@ -203,4 +203,11 @@ public enum Target {
     public boolean obsoleteAccStrict() {
         return compareTo(JDK1_17) >= 0;
     }
+
+    /** Omit unused enclosing instance fields from inner classes that don't access enclosing
+     * instance state.
+     */
+    public boolean omitUnusedPrivateSyntheticEnclosingInstanceFields() {
+        return compareTo(JDK1_18) >= 0;
+    }
 }

--- a/test/langtools/tools/javac/6521805/T6521805d.java
+++ b/test/langtools/tools/javac/6521805/T6521805d.java
@@ -7,6 +7,8 @@
  * @compile/fail/ref=T6521805d.out T6521805d.java -XDrawDiagnostics
  */
 
+import java.util.Objects;
+
 class T6521805 {
 
     static class Inner extends T6521805.Outer {
@@ -25,7 +27,7 @@ class T6521805 {
     class Outer {
         {
             // access enclosing instance so this$0 field is generated
-            T6521805.this.toString();
+            Objects.requireNonNull(T6521805.this);
         }
     }
 

--- a/test/langtools/tools/javac/6521805/T6521805d.java
+++ b/test/langtools/tools/javac/6521805/T6521805d.java
@@ -22,6 +22,11 @@ class T6521805 {
         }
     }
 
-    class Outer {}
+    class Outer {
+        {
+            // access enclosing instance so this$0 field is generated
+            T6521805.this.toString();
+        }
+    }
 
 }

--- a/test/langtools/tools/javac/6521805/T6521805d.out
+++ b/test/langtools/tools/javac/6521805/T6521805d.out
@@ -1,2 +1,2 @@
-T6521805d.java:18:18: compiler.err.cannot.generate.class: T6521805.Inner, (compiler.misc.synthetic.name.conflict: this$0, T6521805.Inner)
+T6521805d.java:20:18: compiler.err.cannot.generate.class: T6521805.Inner, (compiler.misc.synthetic.name.conflict: this$0, T6521805.Inner)
 1 error

--- a/test/langtools/tools/javac/6521805/p/Outer.java
+++ b/test/langtools/tools/javac/6521805/p/Outer.java
@@ -2,11 +2,13 @@
 
 package p;
 
+import java.util.Objects;
+
 class Outer {
     class Super {
         {
             // access enclosing instance so this$0 field is generated
-            Outer.this.toString();
+            Objects.requireNonNull(Outer.this);
         }
     }
 }

--- a/test/langtools/tools/javac/6521805/p/Outer.java
+++ b/test/langtools/tools/javac/6521805/p/Outer.java
@@ -3,5 +3,10 @@
 package p;
 
 class Outer {
-    class Super {}
+    class Super {
+        {
+            // access enclosing instance so this$0 field is generated
+            Outer.this.toString();
+        }
+    }
 }

--- a/test/langtools/tools/javac/ClassFileModifiers/MemberModifiers.out
+++ b/test/langtools/tools/javac/ClassFileModifiers/MemberModifiers.out
@@ -1,8 +1,6 @@
 
 CLASSFILE  MemberModifiers.c
 --- SUPER
-FIELD  this$0
---- FINAL
 METHOD  <init>
 ---
 
@@ -20,8 +18,6 @@ METHOD  m
 
 CLASSFILE  MemberModifiersAux.Foo.c
 --- SUPER
-FIELD  this$1
---- FINAL
 METHOD  <init>
 ---
 
@@ -29,8 +25,6 @@ CLASSFILE  MemberModifiersAux.Foo
 --- FINAL SUPER
 FIELD  f
 ---
-FIELD  this$0
---- FINAL
 METHOD  <init>
 ---
 METHOD  m

--- a/test/langtools/tools/javac/annotations/typeAnnotations/classfile/AnnotatedExtendsTest.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/classfile/AnnotatedExtendsTest.java
@@ -59,7 +59,7 @@ public class AnnotatedExtendsTest {
                 .classes(classPath.toString())
                 .run()
                 .getOutput(Task.OutputKind.DIRECT);
-        if (!javapOut.contains("0: #22(): CLASS_EXTENDS, type_index=65535"))
+        if (!javapOut.contains("0: #20(): CLASS_EXTENDS, type_index=65535"))
             throw new AssertionError("Expected output missing: " + javapOut);
     }
 }

--- a/test/langtools/tools/javac/classfiles/attributes/Synthetic/AccessToPrivateInnerClassConstructorsTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/Synthetic/AccessToPrivateInnerClassConstructorsTest.java
@@ -44,14 +44,11 @@
                 "<init>(AccessToPrivateInnerClassConstructorsTest)",
                 "<init>(AccessToPrivateInnerClassConstructorsTest, " +
                        "AccessToPrivateInnerClassConstructorsTest$1)"},
-        expectedNumberOfSyntheticFields = 1,
         expectedNumberOfSyntheticMethods = 0)
 @ExpectedClass(className = "AccessToPrivateInnerClassConstructorsTest$1Local",
-        expectedMethods = {"<init>(AccessToPrivateInnerClassConstructorsTest)"},
-        expectedNumberOfSyntheticFields = 1)
+        expectedMethods = {"<init>(AccessToPrivateInnerClassConstructorsTest)"})
 @ExpectedClass(className = "AccessToPrivateInnerClassConstructorsTest$2Local",
-        expectedMethods = {"<init>(AccessToPrivateInnerClassConstructorsTest)"},
-        expectedNumberOfSyntheticFields = 1)
+        expectedMethods = {"<init>(AccessToPrivateInnerClassConstructorsTest)"})
 public class AccessToPrivateInnerClassConstructorsTest {
 
     public static void main(String... args) {
@@ -61,33 +58,18 @@ public class AccessToPrivateInnerClassConstructorsTest {
     private class A {
         private A() { }
         private A(AccessToPrivateInnerClassConstructorsTest$1 o) { }
-
-        {
-            // access enclosing instance so this$0 field is generated
-            AccessToPrivateInnerClassConstructorsTest.this.toString();
-        }
     }
 
     void f() {
         new A();
         new A(null);
 
-        class Local {
-            {
-                // access enclosing instance so this$0 field is generated
-                AccessToPrivateInnerClassConstructorsTest.this.toString();
-            }
-        };
+        class Local {};
         new Local();
     }
 
     void g() {
-        class Local {
-            {
-                // access enclosing instance so this$0 field is generated
-                AccessToPrivateInnerClassConstructorsTest.this.toString();
-            }
-        };
+        class Local {};
         new Local();
     }
 }

--- a/test/langtools/tools/javac/classfiles/attributes/Synthetic/AccessToPrivateInnerClassConstructorsTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/Synthetic/AccessToPrivateInnerClassConstructorsTest.java
@@ -61,18 +61,33 @@ public class AccessToPrivateInnerClassConstructorsTest {
     private class A {
         private A() { }
         private A(AccessToPrivateInnerClassConstructorsTest$1 o) { }
+
+        {
+            // access enclosing instance so this$0 field is generated
+            AccessToPrivateInnerClassConstructorsTest.this.toString();
+        }
     }
 
     void f() {
         new A();
         new A(null);
 
-        class Local {};
+        class Local {
+            {
+                // access enclosing instance so this$0 field is generated
+                AccessToPrivateInnerClassConstructorsTest.this.toString();
+            }
+        };
         new Local();
     }
 
     void g() {
-        class Local {};
+        class Local {
+            {
+                // access enclosing instance so this$0 field is generated
+                AccessToPrivateInnerClassConstructorsTest.this.toString();
+            }
+        };
         new Local();
     }
 }

--- a/test/langtools/tools/javac/classfiles/attributes/Synthetic/AccessToPrivateInnerClassMembersTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/Synthetic/AccessToPrivateInnerClassMembersTest.java
@@ -43,15 +43,13 @@
  * 3. access method for private method function().
  * 4. getter/setter for private field staticVar.
  * 5. access method for private method staticFunction().
- * 6. field this in Inner1.
- * 7. constructor for Inner*.
+ * 6. constructor for Inner*.
  */
 @ExpectedClass(className = "AccessToPrivateInnerClassMembersTest",
         expectedMethods = {"<init>()", "<clinit>()"})
 @ExpectedClass(className = "AccessToPrivateInnerClassMembersTest$Inner1",
         expectedMethods = {"<init>(AccessToPrivateInnerClassMembersTest)", "function()"},
-        expectedFields = "var",
-        expectedNumberOfSyntheticFields = 1)
+        expectedFields = "var")
 @ExpectedClass(className = "AccessToPrivateInnerClassMembersTest$Inner2",
         expectedMethods = {"function()", "staticFunction()", "<init>()"},
         expectedFields = {"staticVar", "var"})
@@ -60,10 +58,7 @@ public class AccessToPrivateInnerClassMembersTest {
     private class Inner1 {
         private Inner1() {}
         private int var;
-        private void function() {
-            // access enclosing instance so this$0 field is generated
-            AccessToPrivateInnerClassMembersTest.this.toString();
-        }
+        private void function() {}
     }
 
     {

--- a/test/langtools/tools/javac/classfiles/attributes/Synthetic/AccessToPrivateInnerClassMembersTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/Synthetic/AccessToPrivateInnerClassMembersTest.java
@@ -60,7 +60,10 @@ public class AccessToPrivateInnerClassMembersTest {
     private class Inner1 {
         private Inner1() {}
         private int var;
-        private void function() {}
+        private void function() {
+            // access enclosing instance so this$0 field is generated
+            AccessToPrivateInnerClassMembersTest.this.toString();
+        }
     }
 
     {

--- a/test/langtools/tools/javac/classfiles/attributes/Synthetic/AccessToPrivateSiblingsTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/Synthetic/AccessToPrivateSiblingsTest.java
@@ -43,14 +43,12 @@
  * 3. access method for private method function().
  * 4. getter/setter for private field staticVar.
  * 5. access method for private method staticFunction().
- * 6. field this in Inner1.
- * 7. constructor for Inner*.
+ * 6. constructor for Inner*.
  */
 @ExpectedClass(className = "AccessToPrivateSiblingsTest", expectedMethods = "<init>()")
 @ExpectedClass(className = "AccessToPrivateSiblingsTest$Inner1",
         expectedMethods = {"function()", "<init>(AccessToPrivateSiblingsTest)"},
-        expectedFields = "var",
-        expectedNumberOfSyntheticFields = 1)
+        expectedFields = "var")
 @ExpectedClass(className = "AccessToPrivateSiblingsTest$Inner2",
         expectedMethods = "<init>(AccessToPrivateSiblingsTest)",
         expectedNumberOfSyntheticFields = 1)
@@ -65,10 +63,7 @@ public class AccessToPrivateSiblingsTest {
     private class Inner1 {
         private Inner1() {}
         private int var;
-        private void function() {
-            // access enclosing instance so this$0 field is generated
-            AccessToPrivateSiblingsTest.this.toString();
-        }
+        private void function() {}
 
         {
             Inner3 inner = new Inner3();

--- a/test/langtools/tools/javac/classfiles/attributes/Synthetic/AccessToPrivateSiblingsTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/Synthetic/AccessToPrivateSiblingsTest.java
@@ -65,7 +65,10 @@ public class AccessToPrivateSiblingsTest {
     private class Inner1 {
         private Inner1() {}
         private int var;
-        private void function() {}
+        private void function() {
+            // access enclosing instance so this$0 field is generated
+            AccessToPrivateSiblingsTest.this.toString();
+        }
 
         {
             Inner3 inner = new Inner3();

--- a/test/langtools/tools/javac/classfiles/attributes/Synthetic/BridgeMethodsForLambdaTargetRelease14Test.java
+++ b/test/langtools/tools/javac/classfiles/attributes/Synthetic/BridgeMethodsForLambdaTargetRelease14Test.java
@@ -60,16 +60,19 @@ import java.util.stream.IntStream;
 @ExpectedClass(className = "BridgeMethodsForLambdaTargetRelease14Test$Inner1",
         expectedMethods = {"<init>(BridgeMethodsForLambdaTargetRelease14Test)", "function()", "run()"},
         expectedFields = "lambda1",
-        expectedNumberOfSyntheticMethods = 1)
+        expectedNumberOfSyntheticMethods = 1,
+        expectedNumberOfSyntheticFields = 1)
 @ExpectedClass(className = "BridgeMethodsForLambdaTargetRelease14Test$Inner2",
         expectedMethods = {"<init>()", "staticFunction()"},
         expectedFields = "lambda1",
         expectedNumberOfSyntheticMethods = 1)
 @ExpectedClass(className = "BridgeMethodsForLambdaTargetRelease14Test$Inner3",
-        expectedMethods = {"<init>(BridgeMethodsForLambdaTargetRelease14Test)", "function()"})
+        expectedMethods = {"<init>(BridgeMethodsForLambdaTargetRelease14Test)", "function()"},
+        expectedNumberOfSyntheticFields = 1)
 @ExpectedClass(className = "BridgeMethodsForLambdaTargetRelease14Test$Inner4",
         expectedMethods = {"<init>(BridgeMethodsForLambdaTargetRelease14Test)", "function()"},
-        expectedNumberOfSyntheticMethods = 1)
+        expectedNumberOfSyntheticMethods = 1,
+        expectedNumberOfSyntheticFields = 1)
 public class BridgeMethodsForLambdaTargetRelease14Test {
 
     private class Inner1 implements Runnable {

--- a/test/langtools/tools/javac/classfiles/attributes/Synthetic/BridgeMethodsForLambdaTargetRelease14Test.java
+++ b/test/langtools/tools/javac/classfiles/attributes/Synthetic/BridgeMethodsForLambdaTargetRelease14Test.java
@@ -60,19 +60,16 @@ import java.util.stream.IntStream;
 @ExpectedClass(className = "BridgeMethodsForLambdaTargetRelease14Test$Inner1",
         expectedMethods = {"<init>(BridgeMethodsForLambdaTargetRelease14Test)", "function()", "run()"},
         expectedFields = "lambda1",
-        expectedNumberOfSyntheticMethods = 1,
-        expectedNumberOfSyntheticFields = 1)
+        expectedNumberOfSyntheticMethods = 1)
 @ExpectedClass(className = "BridgeMethodsForLambdaTargetRelease14Test$Inner2",
         expectedMethods = {"<init>()", "staticFunction()"},
         expectedFields = "lambda1",
         expectedNumberOfSyntheticMethods = 1)
 @ExpectedClass(className = "BridgeMethodsForLambdaTargetRelease14Test$Inner3",
-        expectedMethods = {"<init>(BridgeMethodsForLambdaTargetRelease14Test)", "function()"},
-        expectedNumberOfSyntheticFields = 1)
+        expectedMethods = {"<init>(BridgeMethodsForLambdaTargetRelease14Test)", "function()"})
 @ExpectedClass(className = "BridgeMethodsForLambdaTargetRelease14Test$Inner4",
         expectedMethods = {"<init>(BridgeMethodsForLambdaTargetRelease14Test)", "function()"},
-        expectedNumberOfSyntheticMethods = 1,
-        expectedNumberOfSyntheticFields = 1)
+        expectedNumberOfSyntheticMethods = 1)
 public class BridgeMethodsForLambdaTargetRelease14Test {
 
     private class Inner1 implements Runnable {

--- a/test/langtools/tools/javac/classfiles/attributes/Synthetic/BridgeMethodsForLambdaTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/Synthetic/BridgeMethodsForLambdaTest.java
@@ -32,7 +32,7 @@
  * @library /tools/lib /tools/javac/lib ../lib
  * @build toolbox.ToolBox InMemoryFileManager TestResult TestBase
  * @build SyntheticTestDriver ExpectedClass ExpectedClasses
- * @compile -XDdeduplicateLambdas=false BridgeMethodsForLambdaTest.java
+ * @compile BridgeMethodsForLambdaTest.java
  * @run main SyntheticTestDriver BridgeMethodsForLambdaTest
  */
 
@@ -55,19 +55,16 @@ import java.util.stream.IntStream;
 @ExpectedClass(className = "BridgeMethodsForLambdaTest$Inner1",
         expectedMethods = {"<init>(BridgeMethodsForLambdaTest)", "function()", "run()"},
         expectedFields = "lambda1",
-        expectedNumberOfSyntheticMethods = 1,
-        expectedNumberOfSyntheticFields = 1)
+        expectedNumberOfSyntheticMethods = 1)
 @ExpectedClass(className = "BridgeMethodsForLambdaTest$Inner2",
         expectedMethods = {"<init>()", "staticFunction()"},
         expectedFields = "lambda1",
         expectedNumberOfSyntheticMethods = 1)
 @ExpectedClass(className = "BridgeMethodsForLambdaTest$Inner3",
-        expectedMethods = {"<init>(BridgeMethodsForLambdaTest)", "function()"},
-        expectedNumberOfSyntheticFields = 1)
+        expectedMethods = {"<init>(BridgeMethodsForLambdaTest)", "function()"})
 @ExpectedClass(className = "BridgeMethodsForLambdaTest$Inner4",
         expectedMethods = {"<init>(BridgeMethodsForLambdaTest)", "function()"},
-        expectedNumberOfSyntheticMethods = 1,
-        expectedNumberOfSyntheticFields = 1)
+        expectedNumberOfSyntheticMethods = 1)
 public class BridgeMethodsForLambdaTest {
 
     private class Inner1 implements Runnable {
@@ -79,11 +76,6 @@ public class BridgeMethodsForLambdaTest {
         }
         @Override
         public void run() {
-        }
-
-        {
-            // access enclosing instance so this$0 field is generated
-            BridgeMethodsForLambdaTest.this.toString();
         }
     }
 
@@ -97,22 +89,12 @@ public class BridgeMethodsForLambdaTest {
     private class Inner3 {
         public void function() {
         }
-
-        {
-            // access enclosing instance so this$0 field is generated
-            BridgeMethodsForLambdaTest.this.toString();
-        }
     }
 
     private class Inner4 extends Inner3 {
         @Override
         public void function() {
             Runnable r = super::function;
-        }
-
-        {
-            // access enclosing instance so this$0 field is generated
-            BridgeMethodsForLambdaTest.this.toString();
         }
     }
 

--- a/test/langtools/tools/javac/classfiles/attributes/Synthetic/BridgeMethodsForLambdaTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/Synthetic/BridgeMethodsForLambdaTest.java
@@ -32,7 +32,7 @@
  * @library /tools/lib /tools/javac/lib ../lib
  * @build toolbox.ToolBox InMemoryFileManager TestResult TestBase
  * @build SyntheticTestDriver ExpectedClass ExpectedClasses
- * @compile BridgeMethodsForLambdaTest.java
+ * @compile -XDdeduplicateLambdas=false BridgeMethodsForLambdaTest.java
  * @run main SyntheticTestDriver BridgeMethodsForLambdaTest
  */
 

--- a/test/langtools/tools/javac/classfiles/attributes/Synthetic/BridgeMethodsForLambdaTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/Synthetic/BridgeMethodsForLambdaTest.java
@@ -80,6 +80,11 @@ public class BridgeMethodsForLambdaTest {
         @Override
         public void run() {
         }
+
+        {
+            // access enclosing instance so this$0 field is generated
+            BridgeMethodsForLambdaTest.this.toString();
+        }
     }
 
     private static class Inner2 {
@@ -92,12 +97,22 @@ public class BridgeMethodsForLambdaTest {
     private class Inner3 {
         public void function() {
         }
+
+        {
+            // access enclosing instance so this$0 field is generated
+            BridgeMethodsForLambdaTest.this.toString();
+        }
     }
 
     private class Inner4 extends Inner3 {
         @Override
         public void function() {
             Runnable r = super::function;
+        }
+
+        {
+            // access enclosing instance so this$0 field is generated
+            BridgeMethodsForLambdaTest.this.toString();
         }
     }
 

--- a/test/langtools/tools/javac/classfiles/attributes/Synthetic/ThisFieldTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/Synthetic/ThisFieldTest.java
@@ -34,6 +34,8 @@
  * @run main SyntheticTestDriver ThisFieldTest
  */
 
+import java.util.Objects;
+
 /**
  * Synthetic members:
  * 1. fields this$0 for local and anonymous classes.
@@ -51,14 +53,14 @@ public class ThisFieldTest {
         class Local {
             {
                 // access enclosing instance so this$0 field is generated
-                ThisFieldTest.this.toString();
+                Objects.requireNonNull(ThisFieldTest.this);
             }
         }
 
         new Local() {
             {
                 // access enclosing instance so this$0 field is generated
-                ThisFieldTest.this.toString();
+                Objects.requireNonNull(ThisFieldTest.this);
             }
         };
     }

--- a/test/langtools/tools/javac/classfiles/attributes/Synthetic/ThisFieldTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/Synthetic/ThisFieldTest.java
@@ -49,9 +49,17 @@
 public class ThisFieldTest {
     {
         class Local {
+            {
+                // access enclosing instance so this$0 field is generated
+                ThisFieldTest.this.toString();
+            }
         }
 
         new Local() {
+            {
+                // access enclosing instance so this$0 field is generated
+                ThisFieldTest.this.toString();
+            }
         };
     }
 }

--- a/test/langtools/tools/javac/diags/examples/ErrSyntheticNameConflict.java
+++ b/test/langtools/tools/javac/diags/examples/ErrSyntheticNameConflict.java
@@ -24,6 +24,8 @@
 // key: compiler.err.cannot.generate.class
 // key: compiler.misc.synthetic.name.conflict
 
+import java.util.Objects;
+
 class ErrSyntheticNameConflict {
 
     static class Outer {
@@ -33,7 +35,7 @@ class ErrSyntheticNameConflict {
     public class Inner extends Outer {
         {
             // access enclosing instance so this$0 field is generated
-            ErrSyntheticNameConflict.this.toString();
+            Objects.requireNonNull(ErrSyntheticNameConflict.this);
         }
     }
 }

--- a/test/langtools/tools/javac/diags/examples/ErrSyntheticNameConflict.java
+++ b/test/langtools/tools/javac/diags/examples/ErrSyntheticNameConflict.java
@@ -30,5 +30,10 @@ class ErrSyntheticNameConflict {
         ErrSyntheticNameConflict this$0 = null;
     }
 
-    public class Inner extends Outer { }
+    public class Inner extends Outer {
+        {
+            // access enclosing instance so this$0 field is generated
+            ErrSyntheticNameConflict.this.toString();
+        }
+    }
 }

--- a/test/langtools/tools/javac/optimizeOuterThis/DontOptimizeOuterThis.java
+++ b/test/langtools/tools/javac/optimizeOuterThis/DontOptimizeOuterThis.java
@@ -57,6 +57,12 @@ public class DontOptimizeOuterThis extends InnerClasses {
         checkInner(N0.N1.N2.N3.class, true);
         checkInner(N0.N1.N2.N3.N4.class, true);
         checkInner(N0.N1.N2.N3.N4.N5.class, true);
+
+        checkInner(SerializableCapture.class, true);
+        checkInner(SerializableWithSerialVersionUID.class, true);
+        checkInner(SerializableWithInvalidSerialVersionUIDType.class, true);
+        checkInner(SerializableWithInvalidSerialVersionUIDNonFinal.class, true);
+        checkInner(SerializableWithInvalidSerialVersionUIDNonStatic.class, true);
     }
 
     private static void checkInner(Class<?> clazz, boolean expectOuterThis) {

--- a/test/langtools/tools/javac/optimizeOuterThis/DontOptimizeOuterThis.java
+++ b/test/langtools/tools/javac/optimizeOuterThis/DontOptimizeOuterThis.java
@@ -29,39 +29,34 @@ import java.util.Optional;
  * @test
  * @bug 8271623
  *
- * @clean *
- * @compile OptimizeOuterThis.java InnerClasses.java
- * @run main OptimizeOuterThis
- *
- * @clean *
- * @compile -XDoptimizeOuterThis=true --release 17 OptimizeOuterThis.java InnerClasses.java
- * @run main OptimizeOuterThis
+ * @compile --release 17 DontOptimizeOuterThis.java InnerClasses.java
+ * @run main DontOptimizeOuterThis
  */
-public class OptimizeOuterThis extends InnerClasses {
+public class DontOptimizeOuterThis extends InnerClasses {
 
     public static void main(String[] args) {
-        new OptimizeOuterThis().test();
+        new DontOptimizeOuterThis().test();
     }
 
     public void test() {
-        checkInner(localCapturesParameter(0), false);
-        checkInner(localCapturesLocal(), false);
+        checkInner(localCapturesParameter(0), true);
+        checkInner(localCapturesLocal(), true);
         checkInner(localCapturesEnclosing(), true);
 
-        checkInner(anonCapturesParameter(0), false);
-        checkInner(anonCapturesLocal(), false);
+        checkInner(anonCapturesParameter(0), true);
+        checkInner(anonCapturesLocal(), true);
         checkInner(anonCapturesEnclosing(), true);
 
-        checkInner(StaticMemberClass.class, false);
-        checkInner(NonStaticMemberClass.class, false);
+        checkInner(StaticMemberClass.class, false); // static
+        checkInner(NonStaticMemberClass.class, true);
         checkInner(NonStaticMemberClassCapturesEnclosing.class, true);
 
-        checkInner(N0.class, false);
+        checkInner(N0.class, false); // static
         checkInner(N0.N1.class, true);
         checkInner(N0.N1.N2.class, true);
         checkInner(N0.N1.N2.N3.class, true);
-        checkInner(N0.N1.N2.N3.N4.class, false);
-        checkInner(N0.N1.N2.N3.N4.N5.class, false);
+        checkInner(N0.N1.N2.N3.N4.class, true);
+        checkInner(N0.N1.N2.N3.N4.N5.class, true);
     }
 
     private static void checkInner(Class<?> clazz, boolean expectOuterThis) {

--- a/test/langtools/tools/javac/optimizeOuterThis/InnerClasses.java
+++ b/test/langtools/tools/javac/optimizeOuterThis/InnerClasses.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2021, Google LLC. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public class InnerClasses {
+
+    public Class<?> localCapturesParameter(final int x) {
+        class Local {
+            public void f() {
+                System.err.println(x);
+            }
+        }
+        return Local.class;
+    }
+
+    public Class<?> localCapturesLocal() {
+        final int x = 0;
+        class Local {
+            public void f() {
+                System.err.println(x);
+            }
+        }
+        return Local.class;
+    }
+
+    public Class<?> localCapturesEnclosing() {
+        class Local {
+            public void f() {
+                System.err.println(InnerClasses.this);
+            }
+        }
+        return Local.class;
+    }
+
+    public Class<?> anonCapturesParameter(final int x) {
+        return new Object() {
+            public void f() {
+                System.err.println(x);
+            }
+        }.getClass();
+    }
+
+    public Class<?> anonCapturesLocal() {
+        final int x = 0;
+        return new Object() {
+            public void f() {
+                System.err.println(x);
+            }
+        }.getClass();
+    }
+
+    public Class<?> anonCapturesEnclosing() {
+        return new Object() {
+            public void f() {
+                System.err.println(InnerClasses.this);
+            }
+        }.getClass();
+    }
+
+    public static class StaticMemberClass {}
+
+    public class NonStaticMemberClass {}
+
+    public class NonStaticMemberClassCapturesEnclosing {
+        public void f() {
+            System.err.println(InnerClasses.this);
+        }
+    }
+
+    static class N0 {
+        int x;
+
+        class N1 {
+            class N2 {
+                class N3 {
+                    void f() {
+                        System.err.println(x);
+                    }
+
+                    class N4 {
+                        class N5 {}
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/langtools/tools/javac/optimizeOuterThis/InnerClasses.java
+++ b/test/langtools/tools/javac/optimizeOuterThis/InnerClasses.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+import java.io.Serializable;
+
 public class InnerClasses {
 
     public Class<?> localCapturesParameter(final int x) {
@@ -102,5 +104,27 @@ public class InnerClasses {
                 }
             }
         }
+    }
+
+    class SerializableCapture implements Serializable {
+      void f() {
+        System.err.println(InnerClasses.this);
+      }
+    }
+
+    class SerializableWithSerialVersionUID implements Serializable {
+      private static final long serialVersionUID = 0;
+    }
+
+    class SerializableWithInvalidSerialVersionUIDType implements Serializable {
+      private static final int serialVersionUID = 0;
+    }
+
+    class SerializableWithInvalidSerialVersionUIDNonFinal implements Serializable {
+      private static long serialVersionUID = 0;
+    }
+
+    class SerializableWithInvalidSerialVersionUIDNonStatic implements Serializable {
+      private final long serialVersionUID = 0;
     }
 }

--- a/test/langtools/tools/javac/optimizeOuterThis/OptimizeOuterThis.java
+++ b/test/langtools/tools/javac/optimizeOuterThis/OptimizeOuterThis.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2021, Google LLC. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.reflect.Field;
+
+/**
+ * @test
+ * @bug 8271623
+ * @compile OptimizeOuterThis.java
+ * @run main OptimizeOuterThis
+ */
+public class OptimizeOuterThis {
+
+    public static void main(String[] args) {
+        new OptimizeOuterThis().test();
+    }
+
+    public void test() {
+        checkInner(localCapturesParameter(0), false);
+        checkInner(localCapturesLocal(), false);
+        checkInner(localCapturesEnclosing(), true);
+
+        checkInner(anonCapturesParameter(0), false);
+        checkInner(anonCapturesLocal(), false);
+        checkInner(anonCapturesEnclosing(), true);
+
+        checkInner(StaticMemberClass.class, false);
+        checkInner(NonStaticMemberClass.class, false);
+        checkInner(NonStaticMemberClassCapturesEnclosing.class, true);
+    }
+
+    public Class<?> localCapturesParameter(final int x) {
+        class Local {
+            public void f() {
+                System.err.println(x);
+            }
+        }
+        return Local.class;
+    }
+
+    public Class<?> localCapturesLocal() {
+        final int x = 0;
+        class Local {
+            public void f() {
+                System.err.println(x);
+            }
+        }
+        return Local.class;
+    }
+
+    public Class<?> localCapturesEnclosing() {
+        class Local {
+            public void f() {
+                System.err.println(OptimizeOuterThis.this);
+            }
+        }
+        return Local.class;
+    }
+
+    public Class<?> anonCapturesParameter(final int x) {
+        return new Object() {
+            public void f() {
+                System.err.println(x);
+            }
+        }.getClass();
+    }
+
+    public Class<?> anonCapturesLocal() {
+        final int x = 0;
+        return new Object() {
+            public void f() {
+                System.err.println(x);
+            }
+        }.getClass();
+    }
+
+    public Class<?> anonCapturesEnclosing() {
+        return new Object() {
+            public void f() {
+                System.err.println(OptimizeOuterThis.this);
+            }
+        }.getClass();
+    }
+
+    static class StaticMemberClass {}
+
+    class NonStaticMemberClass {}
+
+    class NonStaticMemberClassCapturesEnclosing {
+        public void f() {
+            System.err.println(OptimizeOuterThis.this);
+        }
+    }
+
+    private static void checkInner(Class<?> clazz, boolean expectOuterThis) {
+        Field outerThis;
+        try {
+            outerThis = clazz.getDeclaredField("this$0");
+        } catch (NoSuchFieldException e) {
+            outerThis = null;
+        }
+        if (expectOuterThis) {
+            if (outerThis == null) {
+                throw new AssertionError(
+                        String.format(
+                                "expected %s to have an enclosing instance", clazz.getName()));
+            }
+        } else {
+            if (outerThis != null) {
+                throw new AssertionError(
+                        String.format("%s had an unexpected enclosing instance", clazz.getName()));
+            }
+        }
+    }
+}

--- a/test/langtools/tools/javac/optimizeOuterThis/OptimizeOuterThis.java
+++ b/test/langtools/tools/javac/optimizeOuterThis/OptimizeOuterThis.java
@@ -62,6 +62,12 @@ public class OptimizeOuterThis extends InnerClasses {
         checkInner(N0.N1.N2.N3.class, true);
         checkInner(N0.N1.N2.N3.N4.class, false);
         checkInner(N0.N1.N2.N3.N4.N5.class, false);
+
+        checkInner(SerializableCapture.class, true);
+        checkInner(SerializableWithSerialVersionUID.class, false);
+        checkInner(SerializableWithInvalidSerialVersionUIDType.class, true);
+        checkInner(SerializableWithInvalidSerialVersionUIDNonFinal.class, true);
+        checkInner(SerializableWithInvalidSerialVersionUIDNonStatic.class, true);
     }
 
     private static void checkInner(Class<?> clazz, boolean expectOuterThis) {
@@ -76,7 +82,7 @@ public class OptimizeOuterThis extends InnerClasses {
         } else {
             if (outerThis.isPresent()) {
                 throw new AssertionError(
-                        String.format("%s had an unexpected enclosing instance", clazz.getName()));
+                        String.format("%s had an unexpected enclosing instance %s", clazz.getName(), outerThis.get()));
             }
         }
     }

--- a/test/langtools/tools/javap/AnnoTest.java
+++ b/test/langtools/tools/javap/AnnoTest.java
@@ -49,50 +49,50 @@ public class AnnoTest {
 
         expect(out,
                 "RuntimeVisibleAnnotations:\n" +
-                "  0: #21(#22=B#23)\n" +
+                "  0: #17(#18=B#19)\n" +
                 "    AnnoTest$ByteAnno(\n" +
                 "      value=(byte) 42\n" +
                 "    )\n" +
-                "  1: #24(#22=S#25)\n" +
+                "  1: #20(#18=S#21)\n" +
                 "    AnnoTest$ShortAnno(\n" +
                 "      value=(short) 3\n" +
                 "    )");
         expect(out,
                 "RuntimeInvisibleAnnotations:\n" +
-                "  0: #27(#22=[J#28,J#30,J#32,J#34,J#36])\n" +
+                "  0: #23(#18=[J#24,J#26,J#28,J#30,J#32])\n" +
                 "    AnnoTest$ArrayAnno(\n" +
                 "      value=[1l,2l,3l,4l,5l]\n" +
                 "    )\n" +
-                "  1: #38(#22=Z#39)\n" +
+                "  1: #34(#18=Z#35)\n" +
                 "    AnnoTest$BooleanAnno(\n" +
                 "      value=false\n" +
                 "    )\n" +
-                "  2: #40(#41=c#42)\n" +
+                "  2: #36(#37=c#38)\n" +
                 "    AnnoTest$ClassAnno(\n" +
                 "      type=class Ljava/lang/Object;\n" +
                 "    )\n" +
-                "  3: #43(#44=e#45.#46)\n" +
+                "  3: #39(#40=e#41.#42)\n" +
                 "    AnnoTest$EnumAnno(\n" +
                 "      kind=Ljavax/lang/model/element/ElementKind;.PACKAGE\n" +
                 "    )\n" +
-                "  4: #47(#22=I#48)\n" +
+                "  4: #43(#18=I#44)\n" +
                 "    AnnoTest$IntAnno(\n" +
                 "      value=2\n" +
                 "    )\n" +
-                "  5: #49()\n" +
+                "  5: #45()\n" +
                 "    AnnoTest$IntDefaultAnno\n" +
-                "  6: #50(#51=s#52)\n" +
+                "  6: #46(#47=s#48)\n" +
                 "    AnnoTest$NameAnno(\n" +
                 "      name=\"NAME\"\n" +
                 "    )\n" +
-                "  7: #53(#54=D#55,#57=F#58)\n" +
+                "  7: #49(#50=D#51,#53=F#54)\n" +
                 "    AnnoTest$MultiAnno(\n" +
                 "      d=3.14159d\n" +
                 "      f=2.71828f\n" +
                 "    )\n" +
-                "  8: #59()\n" +
+                "  8: #55()\n" +
                 "    AnnoTest$SimpleAnno\n" +
-                "  9: #60(#22=@#47(#22=I#61))\n" +
+                "  9: #56(#18=@#43(#18=I#57))\n" +
                 "    AnnoTest$AnnoAnno(\n" +
                 "      value=@AnnoTest$IntAnno(\n" +
                 "        value=5\n" +
@@ -100,7 +100,7 @@ public class AnnoTest {
                 "    )");
         expect(out,
                 "RuntimeInvisibleTypeAnnotations:\n" +
-                "  0: #63(): CLASS_EXTENDS, type_index=0\n" +
+                "  0: #59(): CLASS_EXTENDS, type_index=0\n" +
                 "    AnnoTest$TypeAnno");
 
         if (errors > 0)


### PR DESCRIPTION
This change omits the synthetic `this$0` field from inner classes that do not access any enclosing instance state.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271623](https://bugs.openjdk.java.net/browse/JDK-8271623): Omit enclosing instance fields from inner classes that don't use it


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4966/head:pull/4966` \
`$ git checkout pull/4966`

Update a local copy of the PR: \
`$ git checkout pull/4966` \
`$ git pull https://git.openjdk.java.net/jdk pull/4966/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4966`

View PR using the GUI difftool: \
`$ git pr show -t 4966`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4966.diff">https://git.openjdk.java.net/jdk/pull/4966.diff</a>

</details>
