### PR TITLE
8271711: Remove WorkArounds.isSynthetic

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -1830,8 +1830,8 @@ public class HtmlDocletWriter {
             HtmlLinkInfo linkInfo = new HtmlLinkInfo(configuration,
                                                      HtmlLinkInfo.Kind.ANNOTATION, annotationElement);
             Map<? extends ExecutableElement, ? extends AnnotationValue> pairs = aDesc.getElementValues();
-            // If the annotation is synthesized, do not print the container.
-            if (utils.configuration.workArounds.isSynthesized(aDesc)) {
+            // If the annotation is mandated, do not print the container.
+            if (utils.configuration.workArounds.isMandated(aDesc)) {
                 for (ExecutableElement ee : pairs.keySet()) {
                     AnnotationValue annotationValue = pairs.get(ee);
                     List<AnnotationValue> annotationTypeValues = new ArrayList<>();

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/WorkArounds.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/WorkArounds.java
@@ -122,9 +122,8 @@ public class WorkArounds {
         return false;
     }
 
-    // TODO: fix jx.l.m add this method.
-    public boolean isSynthesized(AnnotationMirror aDesc) {
-        return ((Attribute)aDesc).isSynthesized();
+    public boolean isMandated(AnnotationMirror aDesc) {
+        return elementUtils.getOrigin(null, aDesc) == Elements.Origin.MANDATED;
     }
 
     // TODO: DocTrees: Trees.getPath(Element e) is slow a factor 4-5 times.


### PR DESCRIPTION
Switch out logic in WorkArounds for a different expression implemented using javax.lang.model.Elements logic.

Langtools regression test suite passes with the changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271711](https://bugs.openjdk.java.net/browse/JDK-8271711): Remove WorkArounds.isSynthetic


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4967/head:pull/4967` \
`$ git checkout pull/4967`

Update a local copy of the PR: \
`$ git checkout pull/4967` \
`$ git pull https://git.openjdk.java.net/jdk pull/4967/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4967`

View PR using the GUI difftool: \
`$ git pr show -t 4967`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4967.diff">https://git.openjdk.java.net/jdk/pull/4967.diff</a>

</details>
