### PR TITLE
4819544: SwingSet2 JTable Demo throws NullPointerException

### DIFF
--- a/src/demo/share/jfc/SwingSet2/TableDemo.java
+++ b/src/demo/share/jfc/SwingSet2/TableDemo.java
@@ -549,7 +549,13 @@ public class TableDemo extends DemoModule {
             public int getRowCount() { return data.length;}
             public Object getValueAt(int row, int col) {return data[row][col];}
             public String getColumnName(int column) {return names[column];}
-            public Class<?> getColumnClass(int c) {return getValueAt(0, c).getClass();}
+            public Class<?> getColumnClass(int c) {
+	        Object obj = getValueAt(0, c);
+                if (obj != null) {
+                    return obj.getClass();
+                }
+                return Object.class;
+            }
             public boolean isCellEditable(int row, int col) {return col != 5;}
             public void setValueAt(Object aValue, int row, int column) { data[row][column] = aValue; }
          };

--- a/src/demo/share/jfc/SwingSet2/TableDemo.java
+++ b/src/demo/share/jfc/SwingSet2/TableDemo.java
@@ -550,7 +550,7 @@ public class TableDemo extends DemoModule {
             public Object getValueAt(int row, int col) {return data[row][col];}
             public String getColumnName(int column) {return names[column];}
             public Class<?> getColumnClass(int c) {
-	        Object obj = getValueAt(0, c);
+                Object obj = getValueAt(0, c);
                 if (obj != null) {
                     return obj.getClass();
                 }

--- a/src/demo/share/jfc/SwingSet2/TableDemo.java
+++ b/src/demo/share/jfc/SwingSet2/TableDemo.java
@@ -551,10 +551,7 @@ public class TableDemo extends DemoModule {
             public String getColumnName(int column) {return names[column];}
             public Class<?> getColumnClass(int c) {
                 Object obj = getValueAt(0, c);
-                if (obj != null) {
-                    return obj.getClass();
-                }
-                return Object.class;
+                return obj != null ? obj.getClass() : Object.class;
             }
             public boolean isCellEditable(int row, int col) {return col != 5;}
             public void setValueAt(Object aValue, int row, int column) { data[row][column] = aValue; }


### PR DESCRIPTION
In the JTable demo, if we double click on the first cell in the Favorite Number column, delete the value and click on some
other cell, a java.lang.NullPointerException is getting thrown.
The flaw is in the TableDemo's TableModel getColumnClass() method which queries the value of cell 0 in the target column, and returns its Class. This logic seems to be flawed - an NPE will be thrown when the value in cell 0 is null.
Fix by checking for null.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-4819544](https://bugs.openjdk.java.net/browse/JDK-4819544): SwingSet2 JTable Demo throws NullPointerException


### Reviewers
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**) ⚠️ Review applies to 5b181beec13ca1e006d9d54eb926624ed7f8e4e1
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**) ⚠️ Review applies to 5b181beec13ca1e006d9d54eb926624ed7f8e4e1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4969/head:pull/4969` \
`$ git checkout pull/4969`

Update a local copy of the PR: \
`$ git checkout pull/4969` \
`$ git pull https://git.openjdk.java.net/jdk pull/4969/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4969`

View PR using the GUI difftool: \
`$ git pr show -t 4969`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4969.diff">https://git.openjdk.java.net/jdk/pull/4969.diff</a>

</details>
