### PR TITLE
8271726: JFR: should use equal() to check event fields in tests

### DIFF
--- a/test/jdk/jdk/jfr/event/diagnostics/TestHeapDump.java
+++ b/test/jdk/jdk/jfr/event/diagnostics/TestHeapDump.java
@@ -63,8 +63,8 @@ public class TestHeapDump {
             RecordedEvent e = events.get(0);
             Events.assertField(e, "destination").equal(path.toString());
             Events.assertField(e, "gcBeforeDump").equal(true);
-            Events.assertField(e, "onOutOfMemoryError").equals(false);
-            Events.assertField(e, "size").equals(Files.size(path));
+            Events.assertField(e, "onOutOfMemoryError").equal(false);
+            Events.assertField(e, "size").equal(Files.size(path));
             System.out.println(e);
         }
     }


### PR DESCRIPTION
Hi,

Please help review this trivial test fix.

In TestHeapDump.java, we should use EventField.equal() to check fields, but there are two lines that didn't abide by this rule(I think it's a typo).

No other similar mistake was found in other jfr tests.

Thanks,
Denghui

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271726](https://bugs.openjdk.java.net/browse/JDK-8271726): JFR: should use equal() to check event fields in tests


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4970/head:pull/4970` \
`$ git checkout pull/4970`

Update a local copy of the PR: \
`$ git checkout pull/4970` \
`$ git pull https://git.openjdk.java.net/jdk pull/4970/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4970`

View PR using the GUI difftool: \
`$ git pr show -t 4970`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4970.diff">https://git.openjdk.java.net/jdk/pull/4970.diff</a>

</details>
