### PR TITLE
8271722: [TESTBUG] gc/g1/TestMixedGCLiveThreshold.java can fail if G1 Full GC uses >1 workers

### DIFF
--- a/test/hotspot/jtreg/gc/g1/TestMixedGCLiveThreshold.java
+++ b/test/hotspot/jtreg/gc/g1/TestMixedGCLiveThreshold.java
@@ -99,6 +99,8 @@ public class TestMixedGCLiveThreshold {
                                        "-XX:+UnlockDiagnosticVMOptions",
                                        "-XX:+UnlockExperimentalVMOptions",
                                        "-XX:+WhiteBoxAPI",
+                                       // Parallel full gc can distribute live objects into different regions.
+                                       "-XX:ParallelGCThreads=1",
                                        "-Xlog:gc+remset+tracking=trace",
                                        "-Xms10M",
                                        "-Xmx10M"});

--- a/test/hotspot/jtreg/gc/g1/TestMixedGCLiveThreshold.java
+++ b/test/hotspot/jtreg/gc/g1/TestMixedGCLiveThreshold.java
@@ -24,14 +24,36 @@
 package gc.g1;
 
 /*
- * @test TestMixedGCLiveThreshold
- * @summary Test G1MixedGCLiveThresholdPercent. Fill up a region to at least 1/3 region-size,
- * the region should not be selected for mixed GC cycle if liveness is above threshold.
+ * @test id=0percent
+ * @summary Test G1MixedGCLiveThresholdPercent=0. Fill up a region to at least 33 percent,
+ * the region should not be selected for mixed GC cycle.
  * @requires vm.gc.G1
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- * @run driver gc.g1.TestMixedGCLiveThreshold
+ * @run driver gc.g1.TestMixedGCLiveThreshold 0 false
+ */
+
+/*
+ * @test id=25percent
+ * @summary Test G1MixedGCLiveThresholdPercent=25. Fill up a region to at least 33 percent,
+ * the region should not be selected for mixed GC cycle.
+ * @requires vm.gc.G1
+ * @library /test/lib
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run driver gc.g1.TestMixedGCLiveThreshold 25 false
+ */
+
+/*
+ * @test id=100percent
+ * @summary Test G1MixedGCLiveThresholdPercent=100. Fill up a region to at least 33 percent,
+ * the region should be selected for mixed GC cycle.
+ * @requires vm.gc.G1
+ * @library /test/lib
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run driver gc.g1.TestMixedGCLiveThreshold 100 true
  */
 
 import java.util.ArrayList;
@@ -48,14 +70,9 @@ public class TestMixedGCLiveThreshold {
     private static final String pattern = "Remembered Set Tracking update regions total ([0-9]+), selected ([0-9]+)$";
 
     public static void main(String[] args) throws Exception {
-        // -XX:G1MixedGCLiveThresholdPercent=0
-        testMixedGCLiveThresholdPercent(0, false);
-
-        // -XX:G1MixedGCLiveThresholdPercent=25
-        testMixedGCLiveThresholdPercent(25, false);
-
-        // -XX:G1MixedGCLiveThresholdPercent=100
-        testMixedGCLiveThresholdPercent(100, true);
+        int liveThresholdPercent = Integer.parseInt(args[0]);
+        boolean expectRebuild = Boolean.parseBoolean(args[1]);
+        testMixedGCLiveThresholdPercent(liveThresholdPercent, expectRebuild);
     }
 
     private static void testMixedGCLiveThresholdPercent(int liveThresholdPercent, boolean expectedRebuild) throws Exception {
@@ -71,6 +88,7 @@ public class TestMixedGCLiveThreshold {
                              " no regions should be selected")
                             );
         output.shouldHaveExitValue(0);
+        output.reportDiagnosticSummary();
     }
 
     private static OutputAnalyzer testWithMixedGCLiveThresholdPercent(int percent) throws Exception {


### PR DESCRIPTION
I tried to make this pr is dependent on #4968. Hope this works...

The change fixes a test issue in gc/g1/TestMixedGCLiveThreshold.java by adding
the option `-XX:ParallelGCThreads=1`. This prevents the full gc from running
with more than one worker because if it would do that, live data could be
distributed into several regions and one of them could be selected for
collection which is unexpected with `-XX:G1MixedGCLiveThresholdPercent=25`.

Please refer to the JBS-Item for more details.

Thanks, Richard.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271722](https://bugs.openjdk.java.net/browse/JDK-8271722): [TESTBUG] gc/g1/TestMixedGCLiveThreshold.java can fail if G1 Full GC uses >1 workers


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Committer) ⚠️ Review applies to 7d7599757c2fdb4768619b2dece6730cb8f5789a
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 7d7599757c2fdb4768619b2dece6730cb8f5789a


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4971/head:pull/4971` \
`$ git checkout pull/4971`

Update a local copy of the PR: \
`$ git checkout pull/4971` \
`$ git pull https://git.openjdk.java.net/jdk pull/4971/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4971`

View PR using the GUI difftool: \
`$ git pr show -t 4971`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4971.diff">https://git.openjdk.java.net/jdk/pull/4971.diff</a>

</details>
