### PR TITLE
8271224: runtime/EnclosingMethodAttr/EnclMethodAttr.java doesn't check exit code

### DIFF
--- a/test/hotspot/jtreg/runtime/EnclosingMethodAttr/EnclMethodAttr.java
+++ b/test/hotspot/jtreg/runtime/EnclosingMethodAttr/EnclMethodAttr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,7 @@ public class EnclMethodAttr {
         System.out.println("Regression test for bug 8044738");
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("EnclMethTest");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldNotHaveExitValue(0);
         output.shouldContain("java.lang.ClassFormatError: Wrong EnclosingMethod");
     }
 }


### PR DESCRIPTION
Hi all,

could you please review this small patch?

Thanks,
-- Igor

PS migrated from  openjdk/jdk17#284

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271224](https://bugs.openjdk.java.net/browse/JDK-8271224): runtime/EnclosingMethodAttr/EnclMethodAttr.java doesn't check exit code


### Reviewers
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4974/head:pull/4974` \
`$ git checkout pull/4974`

Update a local copy of the PR: \
`$ git checkout pull/4974` \
`$ git pull https://git.openjdk.java.net/jdk pull/4974/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4974`

View PR using the GUI difftool: \
`$ git pr show -t 4974`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4974.diff">https://git.openjdk.java.net/jdk/pull/4974.diff</a>

</details>
