### PR TITLE
8271743: mark hotspot runtime/jni tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/jni/CalleeSavedRegisters/FPRegs.java
+++ b/test/hotspot/jtreg/runtime/jni/CalleeSavedRegisters/FPRegs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/jni/CalleeSavedRegisters/FPRegs.java
+++ b/test/hotspot/jtreg/runtime/jni/CalleeSavedRegisters/FPRegs.java
@@ -28,6 +28,7 @@
  * @comment Test uses custom launcher that starts VM in primordial thread. This is
  *          not possible on aix.
  * @requires os.family != "aix"
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @run main/native FPRegs

--- a/test/hotspot/jtreg/runtime/jni/checked/TestCheckedReleaseArrayElements.java
+++ b/test/hotspot/jtreg/runtime/jni/checked/TestCheckedReleaseArrayElements.java
@@ -24,6 +24,7 @@
 /* @test
  * @bug 8258077
  * @summary verify multiple release calls on a copied array work when checked
+ * @requires vm.flagless
  * @library /test/lib
  * @run main/native TestCheckedReleaseArrayElements launch
  */


### PR DESCRIPTION
Hi all,

could you please review this small patch?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271743](https://bugs.openjdk.java.net/browse/JDK-8271743): mark hotspot runtime/jni tests which ignore external VM flags


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4976/head:pull/4976` \
`$ git checkout pull/4976`

Update a local copy of the PR: \
`$ git checkout pull/4976` \
`$ git pull https://git.openjdk.java.net/jdk pull/4976/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4976`

View PR using the GUI difftool: \
`$ git pr show -t 4976`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4976.diff">https://git.openjdk.java.net/jdk/pull/4976.diff</a>

</details>
