### PR TITLE
8271744: mark hotspot runtime/getSysPackage tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/getSysPackage/GetPackageXbootclasspath.java
+++ b/test/hotspot/jtreg/runtime/getSysPackage/GetPackageXbootclasspath.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8187436
  * @summary Test that getPackage() works with a class loaded via -Xbootclasspath/a.
+ * @requires vm.flagless
  * @library /test/lib
  * @run driver GetPackageXbootclasspath
  */

--- a/test/hotspot/jtreg/runtime/getSysPackage/GetSysPkgTest.java
+++ b/test/hotspot/jtreg/runtime/getSysPackage/GetSysPkgTest.java
@@ -26,6 +26,7 @@
  * @modules java.base/jdk.internal.misc
  * @modules java.base/jdk.internal.loader
  *          java.logging
+ * @requires vm.flagless
  * @library /test/lib
  * @run driver GetSysPkgTest
  */


### PR DESCRIPTION
Hi all,

could you please review this test-only patch that adds `@requires vm.flagless` to two `runtime/getSysPackage` tests?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271744](https://bugs.openjdk.java.net/browse/JDK-8271744): mark hotspot runtime/getSysPackage tests which ignore external VM flags


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4977/head:pull/4977` \
`$ git checkout pull/4977`

Update a local copy of the PR: \
`$ git checkout pull/4977` \
`$ git pull https://git.openjdk.java.net/jdk pull/4977/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4977`

View PR using the GUI difftool: \
`$ git pr show -t 4977`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4977.diff">https://git.openjdk.java.net/jdk/pull/4977.diff</a>

</details>
