### PR TITLE
8271293: Monitor class should use ThreadBlockInVMPreprocess

### DIFF
--- a/src/hotspot/share/prims/jvmtiRawMonitor.cpp
+++ b/src/hotspot/share/prims/jvmtiRawMonitor.cpp
@@ -332,7 +332,7 @@ void JvmtiRawMonitor::raw_enter(Thread* self) {
     for (;;) {
       ExitOnSuspend eos(this);
       {
-        ThreadBlockInVMPreprocess<ExitOnSuspend> tbivmp(jt, eos);
+        ThreadBlockInVMPreprocess<ExitOnSuspend> tbivmp(jt, eos, true /* allow_suspend */);
         simple_enter(jt);
       }
       if (!eos.monitor_exited()) {
@@ -384,7 +384,7 @@ int JvmtiRawMonitor::raw_wait(jlong millis, Thread* self) {
     for (;;) {
       ExitOnSuspend eos(this);
       {
-        ThreadBlockInVMPreprocess<ExitOnSuspend> tbivmp(jt, eos);
+        ThreadBlockInVMPreprocess<ExitOnSuspend> tbivmp(jt, eos, true /* allow_suspend */);
         simple_enter(jt);
       }
       if (!eos.monitor_exited()) {

--- a/src/hotspot/share/runtime/interfaceSupport.inline.hpp
+++ b/src/hotspot/share/runtime/interfaceSupport.inline.hpp
@@ -239,13 +239,13 @@ class ThreadToNativeFromVM : public ThreadStateTransition {
 // SafepointMechanism::process_if_requested when returning to the VM. This allows us
 // to perform an "undo" action if we might block processing a safepoint/handshake operation
 // (such as thread suspension).
-template <typename PRE_PROC>
+template <typename PRE_PROC = void(JavaThread*)>
 class ThreadBlockInVMPreprocess : public ThreadStateTransition {
  private:
   PRE_PROC& _pr;
   bool _allow_suspend;
  public:
-  ThreadBlockInVMPreprocess(JavaThread* thread, PRE_PROC& pr, bool allow_suspend = true)
+  ThreadBlockInVMPreprocess(JavaThread* thread, PRE_PROC& pr = emptyOp, bool allow_suspend = false)
     : ThreadStateTransition(thread), _pr(pr), _allow_suspend(allow_suspend) {
     assert(thread->thread_state() == _thread_in_vm, "coming from wrong thread state");
     thread->check_possible_safepoint();
@@ -266,33 +266,12 @@ class ThreadBlockInVMPreprocess : public ThreadStateTransition {
 
     _thread->set_thread_state(_thread_in_vm);
   }
+
+  static void emptyOp(JavaThread* current) {}
 };
 
-class InFlightMutexRelease {
- private:
-  Mutex** _in_flight_mutex_addr;
- public:
-  InFlightMutexRelease(Mutex** in_flight_mutex_addr) : _in_flight_mutex_addr(in_flight_mutex_addr) {}
-  void operator()(JavaThread* current) {
-    if (_in_flight_mutex_addr != NULL && *_in_flight_mutex_addr != NULL) {
-      (*_in_flight_mutex_addr)->release_for_safepoint();
-      *_in_flight_mutex_addr = NULL;
-    }
-  }
-};
+typedef ThreadBlockInVMPreprocess<> ThreadBlockInVM;
 
-// Parameter in_flight_mutex_addr is only used by class Mutex to avoid certain deadlock
-// scenarios while making transitions that might block for a safepoint or handshake.
-// It's the address of a pointer to the mutex we are trying to acquire. This will be used to
-// access and release said mutex when transitioning back from blocked to vm (destructor) in
-// case we need to stop for a safepoint or handshake.
-class ThreadBlockInVM {
-  InFlightMutexRelease _ifmr;
-  ThreadBlockInVMPreprocess<InFlightMutexRelease> _tbivmpp;
- public:
-  ThreadBlockInVM(JavaThread* thread, Mutex** in_flight_mutex_addr = NULL)
-    : _ifmr(in_flight_mutex_addr), _tbivmpp(thread, _ifmr, /* allow_suspend= */ false) {}
-};
 
 // Debug class instantiated in JRT_ENTRY macro.
 // Can be used to verify properties on enter/exit of the VM.

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -430,7 +430,7 @@ bool ObjectMonitor::enter(JavaThread* current) {
     for (;;) {
       ExitOnSuspend eos(this);
       {
-        ThreadBlockInVMPreprocess<ExitOnSuspend> tbivs(current, eos);
+        ThreadBlockInVMPreprocess<ExitOnSuspend> tbivs(current, eos, true /* allow_suspend */);
         EnterI(current);
         current->set_current_pending_monitor(NULL);
         // We can go to a safepoint at the end of this block. If we
@@ -975,7 +975,7 @@ void ObjectMonitor::ReenterI(JavaThread* current, ObjectWaiter* currentNode) {
 
       {
         ClearSuccOnSuspend csos(this);
-        ThreadBlockInVMPreprocess<ClearSuccOnSuspend> tbivs(current, csos);
+        ThreadBlockInVMPreprocess<ClearSuccOnSuspend> tbivs(current, csos, true /* allow_suspend */);
         current->_ParkEvent->park();
       }
     }
@@ -1536,7 +1536,7 @@ void ObjectMonitor::wait(jlong millis, bool interruptible, TRAPS) {
 
     {
       ClearSuccOnSuspend csos(this);
-      ThreadBlockInVMPreprocess<ClearSuccOnSuspend> tbivs(current, csos);
+      ThreadBlockInVMPreprocess<ClearSuccOnSuspend> tbivs(current, csos, true /* allow_suspend */);
       if (interrupted || HAS_PENDING_EXCEPTION) {
         // Intentionally empty
       } else if (node._notified == 0) {


### PR DESCRIPTION
Hi,

Please review the following small patch which changes the Monitor class to use the more appropriate ThreadBlockInVMPreprocess transition wrapper instead of ThreadBlockInVM. This allows to remove the embedded InFlightMutexRelease object from ThreadBlockInVM and to move it, along with the definition of the InFlightMutexRelease class, to mutex.cpp where they belong.

I also changed the default value of allow_suspend to false, even though more users set it to true, to make it consistent with the fact that ThreadBlockInVM doesn't process suspend requests. This avoids having to think twice when looking at a ThreadBlockInVM* object as to whether it processes suspend requests or not. Suspend requests are never processed unless explicitly allowed.

I also changed ThreadBlockInVM to be a typedef to avoid declaring a wrapper class of ThreadBlockInVMPreprocess. 

Testing in mach5 tiers 1-3.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271293](https://bugs.openjdk.java.net/browse/JDK-8271293): Monitor class should use ThreadBlockInVMPreprocess


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4978/head:pull/4978` \
`$ git checkout pull/4978`

Update a local copy of the PR: \
`$ git checkout pull/4978` \
`$ git pull https://git.openjdk.java.net/jdk pull/4978/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4978`

View PR using the GUI difftool: \
`$ git pr show -t 4978`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4978.diff">https://git.openjdk.java.net/jdk/pull/4978.diff</a>

</details>
