### PR TITLE
8271821: mark hotspot runtime/MinimalVM tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/MinimalVM/CDS.java
+++ b/test/hotspot/jtreg/runtime/MinimalVM/CDS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/MinimalVM/CDS.java
+++ b/test/hotspot/jtreg/runtime/MinimalVM/CDS.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @requires vm.flavor == "minimal"
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver CDS

--- a/test/hotspot/jtreg/runtime/MinimalVM/CheckJNI.java
+++ b/test/hotspot/jtreg/runtime/MinimalVM/CheckJNI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/MinimalVM/CheckJNI.java
+++ b/test/hotspot/jtreg/runtime/MinimalVM/CheckJNI.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @requires vm.flavor == "minimal"
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver CheckJNI

--- a/test/hotspot/jtreg/runtime/MinimalVM/Instrumentation.java
+++ b/test/hotspot/jtreg/runtime/MinimalVM/Instrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/MinimalVM/Instrumentation.java
+++ b/test/hotspot/jtreg/runtime/MinimalVM/Instrumentation.java
@@ -25,6 +25,7 @@
  * @test
  * @library /test/lib
  * @requires vm.flavor == "minimal"
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.instrument
  * @run driver Instrumentation

--- a/test/hotspot/jtreg/runtime/MinimalVM/JMX.java
+++ b/test/hotspot/jtreg/runtime/MinimalVM/JMX.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/MinimalVM/JMX.java
+++ b/test/hotspot/jtreg/runtime/MinimalVM/JMX.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @requires vm.flavor == "minimal"
+ * @requires vm.flagless
  * @library /test/lib
  * @run main/othervm JMX
  */

--- a/test/hotspot/jtreg/runtime/MinimalVM/JVMTI.java
+++ b/test/hotspot/jtreg/runtime/MinimalVM/JVMTI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/MinimalVM/JVMTI.java
+++ b/test/hotspot/jtreg/runtime/MinimalVM/JVMTI.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @requires vm.flavor == "minimal"
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver JVMTI

--- a/test/hotspot/jtreg/runtime/MinimalVM/NMT.java
+++ b/test/hotspot/jtreg/runtime/MinimalVM/NMT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/MinimalVM/NMT.java
+++ b/test/hotspot/jtreg/runtime/MinimalVM/NMT.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @requires vm.flavor == "minimal"
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver NMT


### PR DESCRIPTION
Hi all,

could you please review this patch that adds `@requires vm.flagless` to `runtime/MinimalVM/` tests as they ignore external VM flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271821](https://bugs.openjdk.java.net/browse/JDK-8271821): mark hotspot runtime/MinimalVM tests which ignore external VM flags


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4979/head:pull/4979` \
`$ git checkout pull/4979`

Update a local copy of the PR: \
`$ git checkout pull/4979` \
`$ git pull https://git.openjdk.java.net/jdk pull/4979/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4979`

View PR using the GUI difftool: \
`$ git pr show -t 4979`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4979.diff">https://git.openjdk.java.net/jdk/pull/4979.diff</a>

</details>
