### PR TITLE
8271824: mark hotspot runtime/CompressedOops tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
@@ -26,6 +26,7 @@
  * @bug 8024927
  * @summary Testing address of compressed class pointer space as best as possible.
  * @requires vm.bits == 64 & !vm.graal.enabled
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassSpaceSize.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassSpaceSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassSpaceSize.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassSpaceSize.java
@@ -26,6 +26,7 @@
  * @bug 8022865
  * @summary Tests for the -XX:CompressedClassSpaceSize command line option
  * @requires vm.bits == 64 & vm.opt.final.UseCompressedOops == true
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedKlassPointerAndOops.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedKlassPointerAndOops.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedKlassPointerAndOops.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedKlassPointerAndOops.java
@@ -29,6 +29,7 @@
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @requires vm.bits == 64
+ * @requires vm.flagless
  * @run driver CompressedKlassPointerAndOops
  */
 

--- a/test/hotspot/jtreg/runtime/CompressedOops/ObjectAlignment.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/ObjectAlignment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/CompressedOops/ObjectAlignment.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/ObjectAlignment.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8022865
  * @summary Tests for the -XX:ObjectAlignmentInBytes command line option
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/CompressedOops/UseCompressedOops.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/UseCompressedOops.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8022865
  * @summary Tests for different combination of UseCompressedOops options
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management


### PR DESCRIPTION
Hi all,

could you please review this patch that adds `@requires vm.flagless` to `runtime/CompressedOops/` tests as they ignore external VM flags in the JVMs which perform actual testing actions?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271824](https://bugs.openjdk.java.net/browse/JDK-8271824): mark hotspot runtime/CompressedOops tests which ignore external VM flags


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4980/head:pull/4980` \
`$ git checkout pull/4980`

Update a local copy of the PR: \
`$ git checkout pull/4980` \
`$ git pull https://git.openjdk.java.net/jdk pull/4980/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4980`

View PR using the GUI difftool: \
`$ git pr show -t 4980`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4980.diff">https://git.openjdk.java.net/jdk/pull/4980.diff</a>

</details>
