### PR TITLE
8271825: mark hotspot runtime/LoadClass tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/LoadClass/LoadClassNegative.java
+++ b/test/hotspot/jtreg/runtime/LoadClass/LoadClassNegative.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/LoadClass/LoadClassNegative.java
+++ b/test/hotspot/jtreg/runtime/LoadClass/LoadClassNegative.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8020675
  * @summary make sure there is no fatal error if a class is loaded from an invalid jar file which is in the bootclasspath
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/LoadClass/LongBCP.java
+++ b/test/hotspot/jtreg/runtime/LoadClass/LongBCP.java
@@ -26,6 +26,7 @@
  * @summary JVM should be able to handle full path (directory path plus
  *          class name) or directory path longer than MAX_PATH specified
  *          in -Xbootclasspath/a on windows.
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/LoadClass/TestResize.java
+++ b/test/hotspot/jtreg/runtime/LoadClass/TestResize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/LoadClass/TestResize.java
+++ b/test/hotspot/jtreg/runtime/LoadClass/TestResize.java
@@ -26,6 +26,7 @@
  * @bug 8184765
  * @summary make sure the SystemDictionary gets resized when load factor is too high
  * @requires vm.debug
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management


### PR DESCRIPTION
Hi all,

could you please review this test-only patch that adds `@requires vm.flagless` to three `runtime/LoadClass` tests?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271825](https://bugs.openjdk.java.net/browse/JDK-8271825): mark hotspot runtime/LoadClass tests which ignore external VM flags


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4981/head:pull/4981` \
`$ git checkout pull/4981`

Update a local copy of the PR: \
`$ git checkout pull/4981` \
`$ git pull https://git.openjdk.java.net/jdk pull/4981/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4981`

View PR using the GUI difftool: \
`$ git pr show -t 4981`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4981.diff">https://git.openjdk.java.net/jdk/pull/4981.diff</a>

</details>
