### PR TITLE
8271826: mark hotspot runtime/condy tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/condy/BadBSMUseTest.java
+++ b/test/hotspot/jtreg/runtime/condy/BadBSMUseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/condy/BadBSMUseTest.java
+++ b/test/hotspot/jtreg/runtime/condy/BadBSMUseTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8186211
  * @summary CONSTANT_Dynamic_info structure's tries to use a BSM index whose signature is for an invokedynamic and vice versa.
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile CondyUsesIndyBSM.jcod

--- a/test/hotspot/jtreg/runtime/condy/CondyLDCTest.java
+++ b/test/hotspot/jtreg/runtime/condy/CondyLDCTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/condy/CondyLDCTest.java
+++ b/test/hotspot/jtreg/runtime/condy/CondyLDCTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8186211
  * @summary Tests various ldc, ldc_w, ldc2_w instructions of CONSTANT_Dynamic.
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile CondyUseLDC_W.jasm

--- a/test/hotspot/jtreg/runtime/condy/CondyNewInvokeSpecialTest.java
+++ b/test/hotspot/jtreg/runtime/condy/CondyNewInvokeSpecialTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/condy/CondyNewInvokeSpecialTest.java
+++ b/test/hotspot/jtreg/runtime/condy/CondyNewInvokeSpecialTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8186211
  * @summary Test CONSTANT_Dynamic where the BSM is invoked via a REF_newInvokeSpecial.
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile CondyNewInvokeSpecial.jasm

--- a/test/hotspot/jtreg/runtime/condy/escapeAnalysis/TestEscapeCondy.java
+++ b/test/hotspot/jtreg/runtime/condy/escapeAnalysis/TestEscapeCondy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/condy/escapeAnalysis/TestEscapeCondy.java
+++ b/test/hotspot/jtreg/runtime/condy/escapeAnalysis/TestEscapeCondy.java
@@ -26,6 +26,7 @@
  * @bug 8216970
  * @summary Ensure escape analysis can handle an ldc of a dynamic
  *          constant whose return type is an array of boolean.
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile TestEscapeThroughInvokeWithCondy$A.jasm

--- a/test/hotspot/jtreg/runtime/condy/staticInit/TestInitException.java
+++ b/test/hotspot/jtreg/runtime/condy/staticInit/TestInitException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/condy/staticInit/TestInitException.java
+++ b/test/hotspot/jtreg/runtime/condy/staticInit/TestInitException.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8228485
  * @summary Correctly handle initialization error for Condy BSM.
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile Example.jasm


### PR DESCRIPTION
Hi all,

could you please review this patch that adds `@requires vm.flagless` to five `runtime/condy/` tests which ignore external VM flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271826](https://bugs.openjdk.java.net/browse/JDK-8271826): mark hotspot runtime/condy tests which ignore external VM flags


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4982/head:pull/4982` \
`$ git checkout pull/4982`

Update a local copy of the PR: \
`$ git checkout pull/4982` \
`$ git pull https://git.openjdk.java.net/jdk pull/4982/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4982`

View PR using the GUI difftool: \
`$ git pr show -t 4982`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4982.diff">https://git.openjdk.java.net/jdk/pull/4982.diff</a>

</details>
