### PR TITLE
8271828: mark hotspot runtime/classFileParserBug tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/classFileParserBug/ClassFileParserBug.java
+++ b/test/hotspot/jtreg/runtime/classFileParserBug/ClassFileParserBug.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/classFileParserBug/ClassFileParserBug.java
+++ b/test/hotspot/jtreg/runtime/classFileParserBug/ClassFileParserBug.java
@@ -26,6 +26,7 @@
  * @bug 8040018
  * @library /test/lib
  * @summary Check for exception instead of assert.
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @compile LambdaMath.jcod

--- a/test/hotspot/jtreg/runtime/classFileParserBug/TestBadPackageWithInterface.java
+++ b/test/hotspot/jtreg/runtime/classFileParserBug/TestBadPackageWithInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/classFileParserBug/TestBadPackageWithInterface.java
+++ b/test/hotspot/jtreg/runtime/classFileParserBug/TestBadPackageWithInterface.java
@@ -26,6 +26,7 @@
  * @bug 8245487
  * @summary Check that if the VM rejects classes from packages starting with "java/", it will exit
  *          cleanly after InstanceKlass::verify_on(), and not leave freed memory in _local_interfaces.
+ * @requires vm.flagless
  * @library /test/lib
  * @compile BadClassPackage.jasm
  * @run driver TestBadPackageWithInterface

--- a/test/hotspot/jtreg/runtime/classFileParserBug/TestEmptyBootstrapMethodsAttr.java
+++ b/test/hotspot/jtreg/runtime/classFileParserBug/TestEmptyBootstrapMethodsAttr.java
@@ -26,6 +26,7 @@
  * @bug 8041918
  * @library /test/lib
  * @summary Test empty bootstrap_methods table within BootstrapMethods attribute
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @compile emptynumbootstrapmethods1.jcod emptynumbootstrapmethods2.jcod

--- a/test/hotspot/jtreg/runtime/classFileParserBug/TestEmptyBootstrapMethodsAttr.java
+++ b/test/hotspot/jtreg/runtime/classFileParserBug/TestEmptyBootstrapMethodsAttr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Hi all,

could you please review the patch that adds `@requires vm.flagless` to three `runtime/classFileParserBug` tests that ignore external VM flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271828](https://bugs.openjdk.java.net/browse/JDK-8271828): mark hotspot runtime/classFileParserBug tests which ignore external VM flags


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4984/head:pull/4984` \
`$ git checkout pull/4984`

Update a local copy of the PR: \
`$ git checkout pull/4984` \
`$ git pull https://git.openjdk.java.net/jdk pull/4984/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4984`

View PR using the GUI difftool: \
`$ git pr show -t 4984`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4984.diff">https://git.openjdk.java.net/jdk/pull/4984.diff</a>

</details>
