### PR TITLE
8271836: runtime/ErrorHandling/ClassPathEnvVar.java fails with release VMs

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/ClassPathEnvVar.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ClassPathEnvVar.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8271003
  * @summary CLASSPATH env variable setting should not be truncated in a hs err log.
+ * @requires vm.debug
  * @library /test/lib
  * @run driver ClassPathEnvVar
  */


### PR DESCRIPTION
Hi all,

runtime/ErrorHandling/ClassPathEnvVar.java fails with release VMs.
The fix is only run the test with debug VMs.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271836](https://bugs.openjdk.java.net/browse/JDK-8271836): runtime/ErrorHandling/ClassPathEnvVar.java fails with release VMs


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4987/head:pull/4987` \
`$ git checkout pull/4987`

Update a local copy of the PR: \
`$ git checkout pull/4987` \
`$ git pull https://git.openjdk.java.net/jdk pull/4987/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4987`

View PR using the GUI difftool: \
`$ git pr show -t 4987`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4987.diff">https://git.openjdk.java.net/jdk/pull/4987.diff</a>

</details>
