### PR TITLE
8271840: Add simple Integer.toString microbenchmarks

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/Integers.java
+++ b/test/micro/org/openjdk/bench/java/lang/Integers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,36 +24,48 @@ package org.openjdk.bench.java.lang;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Tests java.lang.Integer
+ * Test various java.lang.Integer operations
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(3)
 public class Integers {
 
     @Param("500")
     private int size;
 
     private String[] strings;
+    private int[] intsSmall;
+    private int[] intsBig;
 
     @Setup
     public void setup() {
         Random r = new Random(0);
         strings = new String[size];
+        intsSmall = new int[size];
+        intsBig = new int[size];
         for (int i = 0; i < size; i++) {
-            strings[i] = "" + (r.nextInt(10000) - 5000);
+            strings[i] = "" + (r.nextInt(10000) - (5000));
+            intsSmall[i] = 100 * i + i + 103;
+            intsBig[i] = ((100 * i + i) << 24) + 4543 + i * 4;
         }
     }
 
@@ -61,6 +73,22 @@ public class Integers {
     public void parseInt(Blackhole bh) {
         for (String s : strings) {
             bh.consume(Integer.parseInt(s));
+        }
+    }
+
+    /** Performs toString on small values, just a couple of digits. */
+    @Benchmark
+    public void toStringSmall(Blackhole bh) {
+        for (int i : intsSmall) {
+            bh.consume(Integer.toString(i));
+        }
+    }
+
+    /** Performs toString on large values, roughly 10 digits. */
+    @Benchmark
+    public void toStringBig(Blackhole bh) {
+        for (int i : intsBig) {
+            bh.consume(Integer.toString(i));
         }
     }
 }

--- a/test/micro/org/openjdk/bench/java/lang/Longs.java
+++ b/test/micro/org/openjdk/bench/java/lang/Longs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,13 +24,15 @@ package org.openjdk.bench.java.lang;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 import java.util.concurrent.TimeUnit;
@@ -38,6 +40,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(3)
 public class Longs {
 
     @Param("500")
@@ -56,18 +61,16 @@ public class Longs {
         }
     }
 
-    /** Performs toString on a bunch of java.lang.Long:s, all with small values, just a couple of digits. */
+    /** Performs toString on small values, just a couple of digits. */
     @Benchmark
-    @Threads(Threads.MAX)
     public void toStringSmall(Blackhole bh) {
         for (long value : longArraySmall) {
             bh.consume(Long.toString(value));
         }
     }
 
-    /** Performs toString on a bunch of java.lang.Long:s, all with large values, around 10 digits. */
+    /** Performs toString on large values, around 10 digits. */
     @Benchmark
-    @Threads(Threads.MAX)
     public void toStringBig(Blackhole bh) {
         for (long value : longArrayBig) {
             bh.consume(Long.toString(value));
@@ -80,7 +83,6 @@ public class Longs {
     public int innerLoops = 1500;
 
     @Benchmark
-    @Threads(Threads.MAX)
     public long repetitiveSubtraction() {
         long x = 127, dx = 0;
 


### PR DESCRIPTION
This adds Integer.toString microbenchmarks, roughly similar to the Long.toString microbenchmarks (toStringSmall should use an equivalent data set). This is useful for comparison purposes and completeness.

Also tuned existing benchmarks to harmonize setup, reduce runtime without significantly harming reliability of results, and remove the explicit Threads.MAX from Longs

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271840](https://bugs.openjdk.java.net/browse/JDK-8271840): Add simple Integer.toString microbenchmarks


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4988/head:pull/4988` \
`$ git checkout pull/4988`

Update a local copy of the PR: \
`$ git checkout pull/4988` \
`$ git pull https://git.openjdk.java.net/jdk pull/4988/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4988`

View PR using the GUI difftool: \
`$ git pr show -t 4988`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4988.diff">https://git.openjdk.java.net/jdk/pull/4988.diff</a>

</details>
