### PR TITLE
8271121: ZGC: stack overflow (segv) when -Xlog:gc+start=debug

### DIFF
--- a/src/hotspot/share/gc/z/zStat.cpp
+++ b/src/hotspot/share/gc/z/zStat.cpp
@@ -760,8 +760,10 @@ ZStatCriticalPhase::ZStatCriticalPhase(const char* name, bool verbose) :
     _verbose(verbose) {}
 
 void ZStatCriticalPhase::register_start(const Ticks& start) const {
-  LogTarget(Debug, gc, start) log;
-  log_start(log, true /* thread */);
+  // This is called from sensitive contexts, for example before an allocation stall
+  // has been resolved. This means we must not access any oops in here since that
+  // could lead to infinite recursion. Without access to the thread name we can't
+  // really log anything useful here.
 }
 
 void ZStatCriticalPhase::register_end(const Ticks& start, const Ticks& end) const {


### PR DESCRIPTION
When an allocation stall happens we're trying to access oops (the thread and thread name) while logging. We shouldn't do that since it can lead to a recursive allocation stall situation, which eventually will cause a stack overflow. I suggest we simply don't log anything in ZStatCriticalPhase::register_start(). The useful part of the logging happens in ZStatCriticalPhase::register_end() anyway, where it's safe to access oops.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271121](https://bugs.openjdk.java.net/browse/JDK-8271121): ZGC: stack overflow (segv) when -Xlog:gc+start=debug


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - Committer)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4990/head:pull/4990` \
`$ git checkout pull/4990`

Update a local copy of the PR: \
`$ git checkout pull/4990` \
`$ git pull https://git.openjdk.java.net/jdk pull/4990/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4990`

View PR using the GUI difftool: \
`$ git pr show -t 4990`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4990.diff">https://git.openjdk.java.net/jdk/pull/4990.diff</a>

</details>
