### PR TITLE
JDK-8271858: Handle to jimage file inherited into child processes (posix)

### DIFF
--- a/src/java.base/unix/native/libjimage/osSupport_unix.cpp
+++ b/src/java.base/unix/native/libjimage/osSupport_unix.cpp
@@ -38,7 +38,7 @@
  * Return the file descriptor.
  */
 jint osSupport::openReadOnly(const char *path) {
-    return ::open(path, 0);
+    return ::open(path, O_CLOEXEC);
 }
 
 /**


### PR DESCRIPTION
We should not leak the handle to the jimage file (lib/modules) to childs.

JDK-8194734 did solve this for windows. We should use FD_CLOEXEC on Posix as well.

Note that this only poses a problem when a child process is spawned off not via `Runtime.exec` but via another route since the spawnhelper closes all file descriptors.

---
test:

manually verified that lib/modules now has the FD_CLOEXEC flag set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8271858](https://bugs.openjdk.java.net/browse/JDK-8271858): Handle to jimage file inherited into child processes (posix)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4991/head:pull/4991` \
`$ git checkout pull/4991`

Update a local copy of the PR: \
`$ git checkout pull/4991` \
`$ git pull https://git.openjdk.java.net/jdk pull/4991/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4991`

View PR using the GUI difftool: \
`$ git pr show -t 4991`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4991.diff">https://git.openjdk.java.net/jdk/pull/4991.diff</a>

</details>
