### PR TITLE
8271855: [TESTBUG] Wrong weakCompareAndSet assumption in UnsafeIntrinsicsTest

### DIFF
--- a/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
@@ -24,7 +24,7 @@
 /*
  * @test id=Z
  * @key randomness
- * @bug 8059022
+ * @bug 8059022 8271855
  * @modules java.base/jdk.internal.misc:+open
  * @summary Validate barriers after Unsafe getReference, CAS and swap (GetAndSet)
  * @requires vm.gc.Z

--- a/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
@@ -321,7 +321,7 @@ class Runner implements Runnable {
         // Weak CAS - should almost always be true within a single thread - no other thread can have overwritten
         // Spurious failures are allowed. So, we retry a couple of times on failure.
         boolean ok = false;
-        for (int i = 0; i < 4; ++i) {
+        for (int i = 0; i < 3; ++i) {
             ok = UNSAFE.weakCompareAndSetReference(startNode, offset, expectedNext, head);
             if (ok) break;
         }

--- a/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
@@ -319,9 +319,9 @@ class Runner implements Runnable {
 
     private Node mergeImplWeakCAS(Node startNode, Node expectedNext, Node head) {
         // Weak CAS - should almost always be true within a single thread - no other thread can have overwritten
-        // Spurious failures are allowed. We expect the 2nd attempt to work.
+        // Spurious failures are allowed. So, we retry a couple of times on failure.
         boolean ok = false;
-        for (int i = 0; i < 2; ++i) {
+        for (int i = 0; i < 4; ++i) {
             ok = UNSAFE.weakCompareAndSetReference(startNode, offset, expectedNext, head);
             if (ok) break;
         }

--- a/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
@@ -301,7 +301,7 @@ class Runner implements Runnable {
     private Node mergeImplCAS(Node startNode, Node expectedNext, Node head) {
         // CAS - should always be true within a single thread - no other thread can have overwritten
         if (!UNSAFE.compareAndSetReference(startNode, offset, expectedNext, head)) {
-            throw new Error("CAS should always succeed on thread local objects, check you barrier implementation");
+            throw new Error("CAS should always succeed on thread local objects, check your barrier implementation");
         }
         return expectedNext; // continue on old circle
     }
@@ -309,7 +309,7 @@ class Runner implements Runnable {
     private Node mergeImplCASFail(Node startNode, Node expectedNext, Node head) {
         // Force a fail
         if (UNSAFE.compareAndSetReference(startNode, offset, "fail", head)) {
-            throw new Error("This CAS should always fail, check you barrier implementation");
+            throw new Error("This CAS should always fail, check your barrier implementation");
         }
         if (startNode.next() != expectedNext) {
             throw new Error("Shouldn't have changed");
@@ -326,7 +326,7 @@ class Runner implements Runnable {
             if (ok) break;
         }
         if (!ok) {
-            throw new Error("Weak CAS should always succeed on thread local objects, check you barrier implementation");
+            throw new Error("Weak CAS should almost always succeed on thread local objects, check your barrier implementation");
         }
         return expectedNext; // continue on old circle
     }
@@ -334,7 +334,7 @@ class Runner implements Runnable {
     private Node mergeImplWeakCASFail(Node startNode, Node expectedNext, Node head) {
         // Force a fail
         if (UNSAFE.weakCompareAndSetReference(startNode, offset, "fail", head)) {
-            throw new Error("This weak CAS should always fail, check you barrier implementation");
+            throw new Error("This weak CAS should always fail, check your barrier implementation");
         }
         if (startNode.next() != expectedNext) {
             throw new Error("Shouldn't have changed");
@@ -346,7 +346,7 @@ class Runner implements Runnable {
         // CmpX - should always be true within a single thread - no other thread can have overwritten
         Object res = UNSAFE.compareAndExchangeReference(startNode, offset, expectedNext, head);
         if (!res.equals(expectedNext)) {
-            throw new Error("Fail CmpX should always succeed on thread local objects, check you barrier implementation");
+            throw new Error("Fail CmpX should always succeed on thread local objects, check your barrier implementation");
         }
         return expectedNext; // continue on old circle
     }


### PR DESCRIPTION
We need a fix for test failures due to wrong assumption. (See JBS issue for details.) I suggest to give weakCompareAndSet several chances.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271855](https://bugs.openjdk.java.net/browse/JDK-8271855): [TESTBUG] Wrong weakCompareAndSet assumption in UnsafeIntrinsicsTest


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4992/head:pull/4992` \
`$ git checkout pull/4992`

Update a local copy of the PR: \
`$ git checkout pull/4992` \
`$ git pull https://git.openjdk.java.net/jdk pull/4992/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4992`

View PR using the GUI difftool: \
`$ git pr show -t 4992`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4992.diff">https://git.openjdk.java.net/jdk/pull/4992.diff</a>

</details>
