### PR TITLE
8271560: sun/security/ssl/DHKeyExchange/LegacyDHEKeyExchange.java still fails due to "An established connection was aborted by the software in your host machine"

### DIFF
--- a/test/jdk/sun/security/ssl/DHKeyExchange/LegacyDHEKeyExchange.java
+++ b/test/jdk/sun/security/ssl/DHKeyExchange/LegacyDHEKeyExchange.java
@@ -32,8 +32,10 @@
  * @run main/othervm -Djdk.tls.ephemeralDHKeySize=legacy LegacyDHEKeyExchange
  */
 
+import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSocket;
+import java.net.SocketException;
 import java.util.concurrent.CountDownLatch;
 
 public class LegacyDHEKeyExchange extends SSLSocketTemplate{
@@ -53,6 +55,10 @@ public class LegacyDHEKeyExchange extends SSLSocketTemplate{
                 throw she;
             }
             System.out.println("Expected exception thrown in server");
+        } catch (SSLException | SocketException se) {
+            // The client side may have closed the socket.
+            System.out.println("Server exception:");
+            se.printStackTrace(System.out);
         } finally {
             connDoneLatch.countDown();
             connDoneLatch.await();
@@ -75,6 +81,10 @@ public class LegacyDHEKeyExchange extends SSLSocketTemplate{
                 throw she;
             }
             System.out.println("Expected exception thrown in client");
+        } catch (SSLException | SocketException se) {
+            // The server side may have closed the socket.
+            System.out.println("Client exception:");
+            se.printStackTrace(System.out);
         } finally {
             connDoneLatch.countDown();
             connDoneLatch.await();

--- a/test/jdk/sun/security/ssl/DHKeyExchange/LegacyDHEKeyExchange.java
+++ b/test/jdk/sun/security/ssl/DHKeyExchange/LegacyDHEKeyExchange.java
@@ -60,6 +60,7 @@ public class LegacyDHEKeyExchange extends SSLSocketTemplate{
             }
             System.out.println("Expected exception thrown in server");
         } catch (SSLException | SocketException se) {
+            // The client side may have closed the socket.
             if (isConnectionAborted(se)) {
                 System.out.println("Server exception:");
                 se.printStackTrace(System.out);
@@ -89,6 +90,7 @@ public class LegacyDHEKeyExchange extends SSLSocketTemplate{
             }
             System.out.println("Expected exception thrown in client");
         } catch (SSLException | SocketException se) {
+            // The server side may have closed the socket.
             if (isConnectionAborted(se)) {
                 System.out.println("Client exception:");
                 se.printStackTrace(System.out);

--- a/test/jdk/sun/security/ssl/DHKeyExchange/LegacyDHEKeyExchange.java
+++ b/test/jdk/sun/security/ssl/DHKeyExchange/LegacyDHEKeyExchange.java
@@ -35,7 +35,6 @@
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSocket;
-import java.io.IOException;
 import java.net.SocketException;
 import java.util.concurrent.CountDownLatch;
 
@@ -44,9 +43,6 @@ public class LegacyDHEKeyExchange extends SSLSocketTemplate{
     private final CountDownLatch connDoneLatch = new CountDownLatch(2);
 
     private static final int LINGER_TIMEOUT = 30; // in seconds
-
-    private static final String CONN_ABORTED_EX = "An established connection was" +
-            " aborted by the software in your host machine";
 
     @Override
     protected void runServerApplication(SSLSocket socket) throws Exception {
@@ -61,12 +57,8 @@ public class LegacyDHEKeyExchange extends SSLSocketTemplate{
             System.out.println("Expected exception thrown in server");
         } catch (SSLException | SocketException se) {
             // The client side may have closed the socket.
-            if (isConnectionAborted(se)) {
-                System.out.println("Server exception:");
-                se.printStackTrace(System.out);
-            } else {
-                throw se;
-            }
+            System.out.println("Server exception:");
+            se.printStackTrace(System.out);
         } finally {
             connDoneLatch.countDown();
             connDoneLatch.await();
@@ -91,20 +83,12 @@ public class LegacyDHEKeyExchange extends SSLSocketTemplate{
             System.out.println("Expected exception thrown in client");
         } catch (SSLException | SocketException se) {
             // The server side may have closed the socket.
-            if (isConnectionAborted(se)) {
-                System.out.println("Client exception:");
-                se.printStackTrace(System.out);
-            } else {
-                throw se;
-            }
+            System.out.println("Client exception:");
+            se.printStackTrace(System.out);
         } finally {
             connDoneLatch.countDown();
             connDoneLatch.await();
         }
-    }
-
-    private boolean isConnectionAborted(IOException ioe) {
-        return CONN_ABORTED_EX.equals(ioe.getMessage());
     }
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
The following test has been seen to fail intermittently on Windows platform:
sun/security/ssl/DHKeyExchange/LegacyDHEKeyExchange.java
with the exception:
 java.net.SocketException: An established connection was aborted by the software in your host machine

The test seems to be suffering from some race condition in occasions that should be handled to avoid instability

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271560](https://bugs.openjdk.java.net/browse/JDK-8271560): sun/security/ssl/DHKeyExchange/LegacyDHEKeyExchange.java still fails due to "An established connection was aborted by the software in your host machine"


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)
 * [Rajan Halade](https://openjdk.java.net/census#rhalade) (@rhalade - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4993/head:pull/4993` \
`$ git checkout pull/4993`

Update a local copy of the PR: \
`$ git checkout pull/4993` \
`$ git pull https://git.openjdk.java.net/jdk pull/4993/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4993`

View PR using the GUI difftool: \
`$ git pr show -t 4993`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4993.diff">https://git.openjdk.java.net/jdk/pull/4993.diff</a>

</details>
