### PR TITLE
8271863: ProblemList serviceability/sa/TestJmapCore.java on linux-x64 with ZGC

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -38,7 +38,7 @@ serviceability/sa/ClhsdbFindPC.java#id1                       8268722   macosx-x
 serviceability/sa/ClhsdbFindPC.java#id3                       8268722   macosx-x64
 serviceability/sa/ClhsdbPmap.java#id1                         8268722   macosx-x64
 serviceability/sa/ClhsdbPstack.java#id1                       8268722   macosx-x64
-serviceability/sa/TestJmapCore.java                           8268722,8268283   macosx-x64,linux-aarch64
+serviceability/sa/TestJmapCore.java                           8268722,8268283,8270202   macosx-x64,linux-aarch64,linux-x64
 serviceability/sa/TestJmapCoreMetaspace.java                  8268722,8268636   generic-all
 
 serviceability/sa/TestJhsdbJstackMixed.java                   8248912   generic-all


### PR DESCRIPTION
We saw some failures of TestJmapCore.java, and we need more time to fix it. So we should add it to ProblemList-zgc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271863](https://bugs.openjdk.java.net/browse/JDK-8271863): ProblemList serviceability/sa/TestJmapCore.java on linux-x64 with ZGC


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4994/head:pull/4994` \
`$ git checkout pull/4994`

Update a local copy of the PR: \
`$ git checkout pull/4994` \
`$ git pull https://git.openjdk.java.net/jdk pull/4994/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4994`

View PR using the GUI difftool: \
`$ git pr show -t 4994`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4994.diff">https://git.openjdk.java.net/jdk/pull/4994.diff</a>

</details>
