### PR TITLE
8271886: mark hotspot runtime/InvocationTests tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/InvocationTests/invocationC1Tests.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/invocationC1Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/InvocationTests/invocationC1Tests.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/invocationC1Tests.java
@@ -26,6 +26,7 @@
  * @test
  * @bug 8226956
  * @summary Run invocation tests against C1 compiler
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.org.objectweb.asm
  *          java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/runtime/InvocationTests/invocationOldCHATests.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/invocationOldCHATests.java
@@ -25,6 +25,7 @@
 /*
  * @test
  * @summary Run invocation tests with old CHA (-XX:-UseVtableBasedCHA)
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.org.objectweb.asm
  *          java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/runtime/InvocationTests/invokeinterfaceTests.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/invokeinterfaceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/InvocationTests/invokeinterfaceTests.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/invokeinterfaceTests.java
@@ -26,6 +26,7 @@
  * @test
  * @bug 8224137
  * @summary Run invokeinterface invocation tests
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.org.objectweb.asm
  *          java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/runtime/InvocationTests/invokespecialTests.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/invokespecialTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/InvocationTests/invokespecialTests.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/invokespecialTests.java
@@ -26,6 +26,7 @@
  * @test
  * @bug 8224137
  * @summary Run invokespecial invocation tests
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.org.objectweb.asm
  *          java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/runtime/InvocationTests/invokevirtualTests.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/invokevirtualTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/InvocationTests/invokevirtualTests.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/invokevirtualTests.java
@@ -26,6 +26,7 @@
  * @test
  * @bug 8224137
  * @summary Run invokevirtual invocation tests
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.org.objectweb.asm
  *          java.base/jdk.internal.misc


### PR DESCRIPTION
Hi all,

could you please review this patch that adds `@requires vm.flagless` to all the `runtime/InvocationTests` tests as they ignore external VM flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271886](https://bugs.openjdk.java.net/browse/JDK-8271886): mark hotspot runtime/InvocationTests tests which ignore external VM flags


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/4997/head:pull/4997` \
`$ git checkout pull/4997`

Update a local copy of the PR: \
`$ git checkout pull/4997` \
`$ git pull https://git.openjdk.java.net/jdk pull/4997/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4997`

View PR using the GUI difftool: \
`$ git pr show -t 4997`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/4997.diff">https://git.openjdk.java.net/jdk/pull/4997.diff</a>

</details>
