### PR TITLE
8271890

### DIFF
--- a/test/hotspot/jtreg/runtime/Dictionary/CleanProtectionDomain.java
+++ b/test/hotspot/jtreg/runtime/Dictionary/CleanProtectionDomain.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @summary Verifies the creation and cleaup of entries in the Protection Domain Table
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @build sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/runtime/Dictionary/ProtectionDomainCacheTest.java
+++ b/test/hotspot/jtreg/runtime/Dictionary/ProtectionDomainCacheTest.java
@@ -26,6 +26,7 @@
  * @bug 8151486 8218266
  * @summary Call Class.forName() on the system classloader from a class loaded
  *          from a custom classloader, using the current class's protection domain.
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @build jdk.test.lib.Utils


### PR DESCRIPTION
Hi all,

could you please review the patch that adds `@requires vm.flagless` to both `runtime/Dictionary` as they ignore external VM flags?

Thanks,
-- Igor