### PR TITLE
8271891: mark hotspot runtime/Safepoint tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/Safepoint/TestAbortOnVMOperationTimeout.java
+++ b/test/hotspot/jtreg/runtime/Safepoint/TestAbortOnVMOperationTimeout.java
@@ -28,6 +28,7 @@ import jdk.test.lib.process.*;
  * @test TestAbortOnVMOperationTimeout
  * @bug 8181143 8269523
  * @summary Check abort on VM timeout is working
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/Safepoint/TestAbortVMOnSafepointTimeout.java
+++ b/test/hotspot/jtreg/runtime/Safepoint/TestAbortVMOnSafepointTimeout.java
@@ -30,6 +30,7 @@ import sun.hotspot.WhiteBox;
  * @test TestAbortVMOnSafepointTimeout
  * @summary Check if VM can kill thread which doesn't reach safepoint.
  * @bug 8219584 8227528
+ * @requires vm.flagless
  * @library /testlibrary /test/lib
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox


### PR DESCRIPTION
Hi all,

please review this small patch that `@requires vm.flagless` to `runtime/Safepoint` tests.

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271891](https://bugs.openjdk.java.net/browse/JDK-8271891): mark hotspot runtime/Safepoint tests which ignore external VM flags


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5000/head:pull/5000` \
`$ git checkout pull/5000`

Update a local copy of the PR: \
`$ git checkout pull/5000` \
`$ git pull https://git.openjdk.java.net/jdk pull/5000/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5000`

View PR using the GUI difftool: \
`$ git pr show -t 5000`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5000.diff">https://git.openjdk.java.net/jdk/pull/5000.diff</a>

</details>
