### PR TITLE
8271888: build error after JDK-8271599

### DIFF
--- a/src/java.base/share/classes/java/lang/Math.java
+++ b/src/java.base/share/classes/java/lang/Math.java
@@ -1383,7 +1383,6 @@ public final class Math {
      *       </ul>
      *   </li>
      * </ul>
-     * <p>
      *
      * @param x the dividend
      * @param y the divisor


### PR DESCRIPTION
Remove extraneous <p> tag to fix build breakage.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271888](https://bugs.openjdk.java.net/browse/JDK-8271888): build error after JDK-8271599


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5002/head:pull/5002` \
`$ git checkout pull/5002`

Update a local copy of the PR: \
`$ git checkout pull/5002` \
`$ git pull https://git.openjdk.java.net/jdk pull/5002/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5002`

View PR using the GUI difftool: \
`$ git pr show -t 5002`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5002.diff">https://git.openjdk.java.net/jdk/pull/5002.diff</a>

</details>
