### PR TITLE
8271898: disable os.release_multi_mappings_vm on macOS-X64

### DIFF
--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -413,7 +413,11 @@ struct NUMASwitcher {
 #endif
 
 #ifndef _AIX // JDK-8257041
-TEST_VM(os, release_multi_mappings) {
+#if defined(__APPLE__) && !defined(AARCH64)  // See JDK-8267341.
+  TEST_VM(os, DISABLED_release_multi_mappings) {
+#else
+  TEST_VM(os, release_multi_mappings) {
+#endif
 
   // With NMT enabled, this will trigger JDK-8263464. For now disable the test if NMT=on.
   if (MemTracker::tracking_level() > NMT_off) {


### PR DESCRIPTION
A trivial fix to disable os.release_multi_mappings_vm on macOS-X64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271898](https://bugs.openjdk.java.net/browse/JDK-8271898): disable os.release_multi_mappings_vm on macOS-X64


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5006/head:pull/5006` \
`$ git checkout pull/5006`

Update a local copy of the PR: \
`$ git checkout pull/5006` \
`$ git pull https://git.openjdk.java.net/jdk pull/5006/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5006`

View PR using the GUI difftool: \
`$ git pr show -t 5006`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5006.diff">https://git.openjdk.java.net/jdk/pull/5006.diff</a>

</details>
