### PR TITLE
8271878: UnProblemList jdk/jfr/event/gc/detailed/TestEvacuationFailedEvent.java in JDK18

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -826,7 +826,7 @@ jdk/jfr/event/compiler/TestCodeSweeper.java                     8225209    gener
 jdk/jfr/event/os/TestThreadContextSwitches.java                 8247776 windows-all
 jdk/jfr/startupargs/TestStartName.java                          8214685 windows-x64
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
-jdk/jfr/event/gc/detailed/TestEvacuationFailedEvent.java        8263461 linux-all,windows-x64
+jdk/jfr/event/gc/detailed/TestEvacuationFailedEvent.java        8263461 linux-x64
 jdk/jfr/api/consumer/streaming/TestLatestEvent.java             8268297 windows-x64
 jdk/jfr/event/oldobject/TestObjectSize.java                     8269418 macosx-x64
 


### PR DESCRIPTION
This reverts commit 5f547e8c119e9c0f6a000d2fdc2a693a4e601ba0

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271878](https://bugs.openjdk.java.net/browse/JDK-8271878): UnProblemList jdk/jfr/event/gc/detailed/TestEvacuationFailedEvent.java in JDK18


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5011/head:pull/5011` \
`$ git checkout pull/5011`

Update a local copy of the PR: \
`$ git checkout pull/5011` \
`$ git pull https://git.openjdk.java.net/jdk pull/5011/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5011`

View PR using the GUI difftool: \
`$ git pr show -t 5011`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5011.diff">https://git.openjdk.java.net/jdk/pull/5011.diff</a>

</details>
