### PR TITLE
8271925: ZGC: Arraycopy stub passes invalid oop to load barrier

### DIFF
--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -306,7 +306,7 @@ void ZBarrierSetC2::clone_at_expansion(PhaseMacroExpand* phase, ArrayCopyNode* a
       if (offset != arrayOopDesc::base_offset_in_bytes(T_OBJECT)) {
         assert(!UseCompressedClassPointers, "should only happen without compressed class pointers");
         assert((arrayOopDesc::base_offset_in_bytes(T_OBJECT) - offset) == BytesPerLong, "unexpected offset");
-        length = phase->transform_later(new SubXNode(length, phase->longcon(1))); // Size is in longs
+        length = phase->transform_later(new SubLNode(length, phase->longcon(1))); // Size is in longs
         src_offset = phase->longcon(arrayOopDesc::base_offset_in_bytes(T_OBJECT));
         dest_offset = src_offset;
       }


### PR DESCRIPTION
The fix for [JDK-8270461](https://bugs.openjdk.java.net/browse/JDK-8270461), see [PR 252](https://git.openjdk.java.net/jdk17/pull/252), made sure that the arraycopy offset when cloning an oop array always points to the first element of the array. However, it missed to adjust the copy length as well, leading to reading/copying 8 bytes beyond the end of the array.

This only reproduces in Valhalla (probably because the mark word layout differs there) and only with  `-XX:-UseCompressedClassPointers`. I'll backport the fix to JDK 17u.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271925](https://bugs.openjdk.java.net/browse/JDK-8271925): ZGC: Arraycopy stub passes invalid oop to load barrier


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**) ⚠️ Review applies to 59bb2fdfe5ca20a5a958755645880f447ea631d9
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5014/head:pull/5014` \
`$ git checkout pull/5014`

Update a local copy of the PR: \
`$ git checkout pull/5014` \
`$ git pull https://git.openjdk.java.net/jdk pull/5014/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5014`

View PR using the GUI difftool: \
`$ git pr show -t 5014`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5014.diff">https://git.openjdk.java.net/jdk/pull/5014.diff</a>

</details>
