### PR TITLE
8271930: Simplify end_card calculation in G1BlockOffsetTablePart::verify

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
@@ -338,8 +338,8 @@ void G1BlockOffsetTablePart::verify() const {
   assert(_hr->bottom() < _hr->top(), "Only non-empty regions should be verified.");
   size_t start_card = _bot->index_for(_hr->bottom());
   // Do not verify beyond the BOT allocation threshold.
-  size_t next_offset_index = _bot->index_for_raw(_next_offset_threshold);
-  size_t end_card = MIN2(_bot->index_for(_hr->top() - 1), next_offset_index - 1);
+  assert(_hr->top() <= _next_offset_threshold, "invariant");
+  size_t end_card = _bot->index_for(_hr->top() - 1);
 
   for (size_t current_card = start_card; current_card < end_card; current_card++) {
     u_char entry = _bot->offset_array(current_card);
@@ -399,13 +399,6 @@ void G1BlockOffsetTablePart::print_on(outputStream* out) {
 }
 #endif // !PRODUCT
 
-HeapWord* G1BlockOffsetTablePart::initialize_threshold_raw() {
-  size_t next_offset_index = _bot->index_for_raw(_hr->bottom()) + 1;
-  _next_offset_threshold =
-    _bot->address_for_index_raw(next_offset_index);
-  return _next_offset_threshold;
-}
-
 void G1BlockOffsetTablePart::zero_bottom_entry_raw() {
   size_t bottom_index = _bot->index_for_raw(_hr->bottom());
   assert(_bot->address_for_index_raw(bottom_index) == _hr->bottom(),
@@ -414,9 +407,7 @@ void G1BlockOffsetTablePart::zero_bottom_entry_raw() {
 }
 
 HeapWord* G1BlockOffsetTablePart::initialize_threshold() {
-  size_t next_offset_index = _bot->index_for(_hr->bottom()) + 1 ;
-  _next_offset_threshold =
-    _bot->address_for_index(next_offset_index);
+  _next_offset_threshold = _hr->bottom() + BOTConstants::N_words;
   return _next_offset_threshold;
 }
 

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -134,9 +134,6 @@ private:
   // Zero out the entry for _bottom (offset will be zero). Does not check for availability of the
   // memory first.
   void zero_bottom_entry_raw();
-  // Variant of initialize_threshold that does not check for availability of the
-  // memory first.
-  HeapWord* initialize_threshold_raw();
 
   inline size_t block_size(const HeapWord* p) const;
 
@@ -200,7 +197,7 @@ public:
 
   void reset_bot() {
     zero_bottom_entry_raw();
-    initialize_threshold_raw();
+    initialize_threshold();
   }
 
   // Return the next threshold, the point at which the table should be

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -714,7 +714,7 @@ void HeapRegion::verify(VerifyOption vo,
     p += obj_size;
   }
 
-  // only regions in old generation contain valid BOT
+  // Only regions in old generation contain valid BOT.
   if (!is_empty() && !is_young()) {
     _bot_part.verify();
   }

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -714,7 +714,8 @@ void HeapRegion::verify(VerifyOption vo,
     p += obj_size;
   }
 
-  if (!is_empty()) {
+  // only regions in old generation contain valid BOT
+  if (!is_empty() && !is_young()) {
     _bot_part.verify();
   }
 


### PR DESCRIPTION
Simplify `end_card` calculation and some general cleanup.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271930](https://bugs.openjdk.java.net/browse/JDK-8271930): Simplify end_card calculation in G1BlockOffsetTablePart::verify


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 82b0533c148a369ac179b948c672f78f03f6102c
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5015/head:pull/5015` \
`$ git checkout pull/5015`

Update a local copy of the PR: \
`$ git checkout pull/5015` \
`$ git pull https://git.openjdk.java.net/jdk pull/5015/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5015`

View PR using the GUI difftool: \
`$ git pr show -t 5015`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5015.diff">https://git.openjdk.java.net/jdk/pull/5015.diff</a>

</details>
