### PR TITLE
8271931: Make AbortVMOnVMOperationTimeout more resilient to OS scheduling

### DIFF
--- a/src/hotspot/share/runtime/vmThread.cpp
+++ b/src/hotspot/share/runtime/vmThread.cpp
@@ -86,7 +86,6 @@ void VMOperationTimeoutTask::disarm() {
   // Repeat the timeout-check logic on the VM thread, because
   // VMOperationTimeoutTask might miss the arm-disarm window depending on
   // the scheduling.
-  assert(Thread::current()->is_VM_thread(), "Check timeout on VM thread");
   if (vm_op_duration > AbortVMOnVMOperationTimeoutDelay) {
     fatal("%s VM operation took too long: completed in " JLONG_FORMAT " ms (timeout: " INTX_FORMAT " ms)",
           _vm_op_name, vm_op_duration, AbortVMOnVMOperationTimeoutDelay);

--- a/src/hotspot/share/runtime/vmThread.cpp
+++ b/src/hotspot/share/runtime/vmThread.cpp
@@ -91,6 +91,7 @@ void VMOperationTimeoutTask::disarm() {
     fatal("%s VM operation took too long: completed in " JLONG_FORMAT " ms (timeout: " INTX_FORMAT " ms)",
           _vm_op_name, vm_op_duration, AbortVMOnVMOperationTimeoutDelay);
   }
+  _vm_op_name = nullptr;
 }
 
 //------------------------------------------------------------------------------------------------------------------

--- a/src/hotspot/share/runtime/vmThread.hpp
+++ b/src/hotspot/share/runtime/vmThread.hpp
@@ -47,7 +47,7 @@ public:
   virtual void task();
 
   bool is_armed();
-  void arm();
+  jlong arm();
   void disarm();
 };
 

--- a/src/hotspot/share/runtime/vmThread.hpp
+++ b/src/hotspot/share/runtime/vmThread.hpp
@@ -39,7 +39,7 @@ class VMOperationTimeoutTask : public PeriodicTask {
 private:
   volatile int _armed;
   jlong _arm_time;
-
+  const char* _vm_op_name = nullptr;
 public:
   VMOperationTimeoutTask(size_t interval_time) :
           PeriodicTask(interval_time), _armed(0), _arm_time(0) {}
@@ -47,7 +47,7 @@ public:
   virtual void task();
 
   bool is_armed();
-  jlong arm();
+  void arm(const char* vm_op_name);
   void disarm();
 };
 

--- a/src/hotspot/share/runtime/vmThread.hpp
+++ b/src/hotspot/share/runtime/vmThread.hpp
@@ -39,10 +39,10 @@ class VMOperationTimeoutTask : public PeriodicTask {
 private:
   volatile int _armed;
   jlong _arm_time;
-  const char* _vm_op_name = nullptr;
+  const char* _vm_op_name;
 public:
   VMOperationTimeoutTask(size_t interval_time) :
-          PeriodicTask(interval_time), _armed(0), _arm_time(0) {}
+          PeriodicTask(interval_time), _armed(0), _arm_time(0), _vm_op_name(nullptr) {}
 
   virtual void task();
 


### PR DESCRIPTION
Perform VM-op timeout also on the VM thread. If a VM-op is stuck, the existing watcher-thread based machinery will kick in and detect it.

Test: tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271931](https://bugs.openjdk.java.net/browse/JDK-8271931): Make AbortVMOnVMOperationTimeout more resilient to OS scheduling


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to e9b2642604488597b4f508b0bcdb6406dab8df52
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5016/head:pull/5016` \
`$ git checkout pull/5016`

Update a local copy of the PR: \
`$ git checkout pull/5016` \
`$ git pull https://git.openjdk.java.net/jdk pull/5016/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5016`

View PR using the GUI difftool: \
`$ git pr show -t 5016`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5016.diff">https://git.openjdk.java.net/jdk/pull/5016.diff</a>

</details>
