### PR TITLE
8271928: ErroneousTree with start position -1

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
@@ -548,8 +548,13 @@ public class TreeInfo {
             }
             case ERRONEOUS: {
                 JCErroneous node = (JCErroneous)tree;
-                if (node.errs != null && node.errs.nonEmpty())
-                    return getStartPos(node.errs.head);
+                if (node.errs != null && node.errs.nonEmpty()) {
+                    int pos = getStartPos(node.errs.head);
+                    if (pos != Position.NOPOS) {
+                        return pos;
+                    }
+                }
+                break;
             }
         }
         return tree.pos;


### PR DESCRIPTION
For some (very) erroneous code, the javac's parser may create an `ErroneousTree`, which contains an empty `ModifiersTree`. The empty `ModifiersTree` will not have the position, set but the `ModifiersTree`'s position will be used as the start position of the `ErroneousTree`, leading to start position `-1`. The proposal is to fall back on the the `ErroneousTree`'s `pos` when the nested tree does not have any position set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271928](https://bugs.openjdk.java.net/browse/JDK-8271928): ErroneousTree with start position -1


### Reviewers
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**)
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5018/head:pull/5018` \
`$ git checkout pull/5018`

Update a local copy of the PR: \
`$ git checkout pull/5018` \
`$ git pull https://git.openjdk.java.net/jdk pull/5018/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5018`

View PR using the GUI difftool: \
`$ git pr show -t 5018`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5018.diff">https://git.openjdk.java.net/jdk/pull/5018.diff</a>

</details>
