### PR TITLE
8271949: dumppath in -XX:FlightRecorderOptions does not affect

### DIFF
--- a/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@
 #include "jfr/recorder/repository/jfrRepository.hpp"
 #include "jfr/recorder/repository/jfrChunkRotation.hpp"
 #include "jfr/recorder/repository/jfrChunkWriter.hpp"
+#include "jfr/recorder/repository/jfrEmergencyDump.hpp"
 #include "jfr/recorder/service/jfrEventThrottler.hpp"
 #include "jfr/recorder/service/jfrOptionSet.hpp"
 #include "jfr/recorder/stacktrace/jfrStackTraceRepository.hpp"
@@ -314,6 +315,16 @@ JVM_END
 JVM_ENTRY_NO_ENV(void, jfr_set_repository_location(JNIEnv* env, jobject repo, jstring location))
   return JfrRepository::set_path(location, thread);
 JVM_END
+
+NO_TRANSITION(void, jfr_set_dump_path(JNIEnv* env, jobject jvm, jstring dumppath))
+  const char* dump_path = env->GetStringUTFChars(dumppath, NULL);
+  JfrEmergencyDump::set_dump_path(dump_path);
+  env->ReleaseStringUTFChars(dumppath, dump_path);
+NO_TRANSITION_END
+
+NO_TRANSITION(jstring, jfr_get_dump_path(JNIEnv* env, jobject jvm))
+  return env->NewStringUTF(JfrEmergencyDump::get_dump_path());
+NO_TRANSITION_END
 
 JVM_ENTRY_NO_ENV(void, jfr_uncaught_exception(JNIEnv* env, jobject jvm, jobject t, jthrowable throwable))
   JfrJavaSupport::uncaught_exception(throwable, thread);

--- a/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,6 +112,10 @@ jdouble JNICALL jfr_time_conv_factor(JNIEnv* env, jobject jvm);
 jlong JNICALL jfr_type_id(JNIEnv* env, jobject jvm, jclass jc);
 
 void JNICALL jfr_set_repository_location(JNIEnv* env, jobject repo, jstring location);
+
+void JNICALL jfr_set_dump_path(JNIEnv* env, jobject jvm, jstring dumppath);
+
+jstring JNICALL jfr_get_dump_path(JNIEnv* env, jobject jvm);
 
 jobject JNICALL jfr_get_event_writer(JNIEnv* env, jclass cls);
 

--- a/src/hotspot/share/jfr/jni/jfrJniMethodRegistration.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethodRegistration.cpp
@@ -75,6 +75,8 @@ JfrJniMethodRegistration::JfrJniMethodRegistration(JNIEnv* env) {
       (char*)"flush", (char*)"(Ljdk/jfr/internal/EventWriter;II)Z", (void*)jfr_event_writer_flush,
       (char*)"flush", (char*)"()V", (void*)jfr_flush,
       (char*)"setRepositoryLocation", (char*)"(Ljava/lang/String;)V", (void*)jfr_set_repository_location,
+      (char*)"setDumpPath", (char*)"(Ljava/lang/String;)V", (void*)jfr_set_dump_path,
+      (char*)"getDumpPath", (char*)"()Ljava/lang/String;", (void*)jfr_get_dump_path,
       (char*)"abort", (char*)"(Ljava/lang/String;)V", (void*)jfr_abort,
       (char*)"addStringConstant", (char*)"(JLjava/lang/String;)Z", (void*)jfr_add_string_constant,
       (char*)"uncaughtException", (char*)"(Ljava/lang/Thread;Ljava/lang/Throwable;)V", (void*)jfr_uncaught_exception,

--- a/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp
@@ -41,6 +41,8 @@
 #include "utilities/growableArray.hpp"
 #include "utilities/ostream.hpp"
 
+char JfrEmergencyDump::_dump_path[JVM_MAXPATHLEN] = { 0 };
+
 static const char vm_error_filename_fmt[] = "hs_err_pid%p.jfr";
 static const char vm_oom_filename_fmt[] = "hs_oom_pid%p.jfr";
 static const char vm_soe_filename_fmt[] = "hs_soe_pid%p.jfr";
@@ -66,12 +68,17 @@ static bool is_path_empty() {
 }
 
 // returns with an appended file separator (if successful)
-static size_t get_current_directory() {
-  if (os::get_current_directory(_path_buffer, sizeof(_path_buffer)) == NULL) {
-    return 0;
+static size_t get_dump_directory() {
+  const char* dump_path = JfrEmergencyDump::get_dump_path();
+  if (*dump_path == '\0') {
+    if (os::get_current_directory(_path_buffer, sizeof(_path_buffer)) == NULL) {
+      return 0;
+    }
+  } else {
+    strcpy(_path_buffer, dump_path);
   }
-  const size_t cwd_len = strlen(_path_buffer);
-  const int result = jio_snprintf(_path_buffer + cwd_len,
+  const size_t path_len = strlen(_path_buffer);
+  const int result = jio_snprintf(_path_buffer + path_len,
                                   sizeof(_path_buffer),
                                   "%s",
                                   os::file_separator());
@@ -105,7 +112,7 @@ static void close_emergency_dump_file() {
 static const char* create_emergency_dump_path() {
   assert(is_path_empty(), "invariant");
 
-  const size_t path_len = get_current_directory();
+  const size_t path_len = get_dump_directory();
   if (path_len == 0) {
     return NULL;
   }
@@ -148,6 +155,19 @@ static void report(outputStream* st, bool emergency_file_opened, const char* rep
     st->print_raw_cr(_path_buffer);
     st->print_raw_cr("#");
   }
+}
+
+void JfrEmergencyDump::set_dump_path(const char* dump_path) {
+  if (dump_path != NULL) {
+    if (strlen(dump_path) < JVM_MAXPATHLEN) {
+      strncpy(_dump_path, dump_path, JVM_MAXPATHLEN);
+      _dump_path[JVM_MAXPATHLEN - 1] = '\0';
+    }
+  }
+}
+
+const char* JfrEmergencyDump::get_dump_path() {
+  return _dump_path;
 }
 
 void JfrEmergencyDump::on_vm_error_report(outputStream* st, const char* repository_path) {

--- a/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.hpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,12 @@
 // Responsible for creating an hs_err<pid>.jfr file in exceptional shutdown situations (crash, OOM)
 //
 class JfrEmergencyDump : AllStatic {
+ private:
+  static char _dump_path[JVM_MAXPATHLEN];
+
  public:
+  static void set_dump_path(const char* dump_path);
+  static const char* get_dump_path();
   static const char* chunk_path(const char* repository_path);
   static void on_vm_error(const char* repository_path);
   static void on_vm_error_report(outputStream* st, const char* repository_path);

--- a/src/hotspot/share/jfr/recorder/service/jfrOptionSet.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrOptionSet.cpp
@@ -163,6 +163,7 @@ bool JfrOptionSet::allow_event_retransforms() {
 
 // default options for the dcmd parser
 const char* const default_repository = NULL;
+const char* const default_dumppath = NULL;
 const char* const default_global_buffer_size = "512k";
 const char* const default_num_global_buffers = "20";
 const char* const default_memory_size = "10m";
@@ -181,6 +182,13 @@ static DCmdArgument<char*> _dcmd_repository(
   "STRING",
   false,
   default_repository);
+
+static DCmdArgument<char*> _dcmd_dumppath(
+  "dumppath",
+  "Path to emergency dump",
+  "STRING",
+  false,
+  default_dumppath);
 
 static DCmdArgument<MemorySizeArgument> _dcmd_threadbuffersize(
   "threadbuffersize",
@@ -258,6 +266,7 @@ static DCmdParser _parser;
 
 static void register_parser_options() {
   _parser.add_dcmd_option(&_dcmd_repository);
+  _parser.add_dcmd_option(&_dcmd_dumppath);
   _parser.add_dcmd_option(&_dcmd_threadbuffersize);
   _parser.add_dcmd_option(&_dcmd_memorysize);
   _parser.add_dcmd_option(&_dcmd_globalbuffersize);
@@ -344,6 +353,18 @@ bool JfrOptionSet::configure(TRAPS) {
     }
     strncpy(repo_copy, repo, len + 1);
     configure._repository_path.set_value(repo_copy);
+  }
+
+  configure._dump_path.set_is_set(_dcmd_dumppath.is_set());
+  char* dumppath = _dcmd_dumppath.value();
+  if (dumppath != NULL) {
+    const size_t len = strlen(dumppath);
+    char* dumppath_copy = JfrCHeapObj::new_array<char>(len + 1);
+    if (NULL == dumppath_copy) {
+      return false;
+    }
+    strncpy(dumppath_copy, dumppath, len + 1);
+    configure._dump_path.set_value(dumppath_copy);
   }
 
   configure._stack_depth.set_is_set(_dcmd_stackdepth.is_set());

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
@@ -473,12 +473,25 @@ public final class JVM {
     public native void flush();
 
     /**
-     * Sets the location of the disk repository, to be used at an emergency
-     * dump.
+     * Sets the location of the disk repository.
      *
      * @param dirText
      */
     public native void setRepositoryLocation(String dirText);
+
+    /**
+     * Sets the path to emergency dump.
+     *
+     * @param dumpPathText
+     */
+    public native void setDumpPath(String dumpPathText);
+
+    /**
+     * Gets the path to emergency dump.
+     *
+     * @return The path to emergency dump.
+     */
+    public native String getDumpPath();
 
    /**
     * Access to VM termination support.

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Options.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Options.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public final class Options {
     private static final int DEFAULT_STACK_DEPTH = 64;
     private static final boolean DEFAULT_SAMPLE_THREADS = true;
     private static final long DEFAULT_MAX_CHUNK_SIZE = 12 * 1024 * 1024;
-    private static final SafePath DEFAULT_DUMP_PATH = SecuritySupport.USER_HOME;
+    private static final SafePath DEFAULT_DUMP_PATH = new SafePath(".");
 
     private static long memorySize;
     private static long globalBufferSize;
@@ -57,7 +57,6 @@ public final class Options {
     private static int stackDepth;
     private static boolean sampleThreads;
     private static long maxChunkSize;
-    private static SafePath dumpPath;
 
     static {
         final long pageSize = Unsafe.getUnsafe().pageSize();
@@ -114,11 +113,11 @@ public final class Options {
     }
 
     public static synchronized void setDumpPath(SafePath path) {
-        dumpPath = path;
+        jvm.setDumpPath(path.toString());
     }
 
     public static synchronized SafePath getDumpPath() {
-        return dumpPath;
+        return new SafePath(jvm.getDumpPath());
     }
 
     public static synchronized void setStackDepth(Integer stackTraceDepth) {


### PR DESCRIPTION
We set `dumppath` in `-XX:FlightRecorderOptions` or `JFR.configure dumppath` jcmd when we want to set emergency dump path. However they do not afffect.

### -XX:FlightRecorderOptions

```
$ java -XX:FlightRecorderOptions=dumppath=`pwd` -XX:StartFlightRecording -Xlog:exceptions=info --version
[0.032s][info][exceptions] Exception <a 'java/lang/IllegalArgumentException'{0x00000007470163b8}: Unknown argument 'dumppath' in diagnostic command.> (0x00000007470163b8)
thrown [open/src/hotspot/share/services/diagnosticFramework.cpp, line 215]
for thread 0x00007f4f700236a0
[0.033s][error][arguments ] Unknown argument 'dumppath' in diagnostic command.
Error occurred during initialization of VM
Failure when starting JFR on_create_vm_2
```

### jcmd

`jcmd` shows the configuration change was succeeded, but it would not affect.

```
$ jcmd 1046 JFR.configure dumppath=/tmp
1046:
Dump path: /tmp
```