### PR TITLE
8271869: AArch64: build errors with GCC11 in frame::saved_oop_result

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -236,14 +236,20 @@ inline JavaCallWrapper** frame::entry_frame_call_wrapper_addr() const {
 // Compiled frames
 
 inline oop frame::saved_oop_result(RegisterMap* map) const {
+  PRAGMA_DIAG_PUSH
+  PRAGMA_NONNULL_IGNORED
   oop* result_adr = (oop *)map->location(r0->as_VMReg());
+  PRAGMA_DIAG_POP
   guarantee(result_adr != NULL, "bad register save location");
 
   return (*result_adr);
 }
 
 inline void frame::set_saved_oop_result(RegisterMap* map, oop obj) {
+  PRAGMA_DIAG_PUSH
+  PRAGMA_NONNULL_IGNORED
   oop* result_adr = (oop *)map->location(r0->as_VMReg());
+  PRAGMA_DIAG_POP
   guarantee(result_adr != NULL, "bad register save location");
 
   *result_adr = obj;


### PR DESCRIPTION
GCC11 warns that r0 is null. It does not complain if r1 is used instead.

AIUI, it is undefined behaviour in C++ to call member functions without
a valid this pointer. So, technically GCC is correct to warn.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271869](https://bugs.openjdk.java.net/browse/JDK-8271869): AArch64: build errors with GCC11 in frame::saved_oop_result


### Reviewers
 * [Nick Gasson](https://openjdk.java.net/census#ngasson) (@nick-arm - **Reviewer**)
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5020/head:pull/5020` \
`$ git checkout pull/5020`

Update a local copy of the PR: \
`$ git checkout pull/5020` \
`$ git pull https://git.openjdk.java.net/jdk pull/5020/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5020`

View PR using the GUI difftool: \
`$ git pr show -t 5020`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5020.diff">https://git.openjdk.java.net/jdk/pull/5020.diff</a>

</details>
