### PR TITLE
8271951: Consolidate preserved marks overflow stack in SerialGC

### DIFF
--- a/src/hotspot/share/gc/serial/genMarkSweep.cpp
+++ b/src/hotspot/share/gc/serial/genMarkSweep.cpp
@@ -167,8 +167,7 @@ void GenMarkSweep::deallocate_stacks() {
   GenCollectedHeap* gch = GenCollectedHeap::heap();
   gch->release_scratch();
 
-  _preserved_mark_stack.clear(true);
-  _preserved_oop_stack.clear(true);
+  _preserved_overflow_stack.clear(true);
   _marking_stack.clear();
   _objarray_stack.clear(true);
 }

--- a/src/hotspot/share/gc/serial/markSweep.cpp
+++ b/src/hotspot/share/gc/serial/markSweep.cpp
@@ -160,7 +160,7 @@ void MarkSweep::preserve_mark(oop obj, markWord mark) {
   // sufficient space for the marks we need to preserve but if it isn't we fall
   // back to using Stacks to keep track of the overflow.
   if (_preserved_count < _preserved_count_max) {
-    _preserved_marks[_preserved_count++].init(obj, mark);
+    _preserved_marks[_preserved_count++] = PreservedMark(obj, mark);
   } else {
     _preserved_overflow_stack.push(PreservedMark(obj, mark));
   }

--- a/src/hotspot/share/gc/serial/markSweep.cpp
+++ b/src/hotspot/share/gc/serial/markSweep.cpp
@@ -49,8 +49,7 @@ uint                    MarkSweep::_total_invocations = 0;
 Stack<oop, mtGC>              MarkSweep::_marking_stack;
 Stack<ObjArrayTask, mtGC>     MarkSweep::_objarray_stack;
 
-Stack<oop, mtGC>              MarkSweep::_preserved_oop_stack;
-Stack<markWord, mtGC>         MarkSweep::_preserved_mark_stack;
+Stack<PreservedMark, mtGC>    MarkSweep::_preserved_overflow_stack;
 size_t                  MarkSweep::_preserved_count = 0;
 size_t                  MarkSweep::_preserved_count_max = 0;
 PreservedMark*          MarkSweep::_preserved_marks = NULL;
@@ -163,8 +162,7 @@ void MarkSweep::preserve_mark(oop obj, markWord mark) {
   if (_preserved_count < _preserved_count_max) {
     _preserved_marks[_preserved_count++].init(obj, mark);
   } else {
-    _preserved_mark_stack.push(mark);
-    _preserved_oop_stack.push(obj);
+    _preserved_overflow_stack.push(PreservedMark(obj, mark));
   }
 }
 
@@ -176,26 +174,21 @@ void MarkSweep::set_ref_processor(ReferenceProcessor* rp) {
 AdjustPointerClosure MarkSweep::adjust_pointer_closure;
 
 void MarkSweep::adjust_marks() {
-  assert( _preserved_oop_stack.size() == _preserved_mark_stack.size(),
-         "inconsistent preserved oop stacks");
-
   // adjust the oops we saved earlier
   for (size_t i = 0; i < _preserved_count; i++) {
     _preserved_marks[i].adjust_pointer();
   }
 
   // deal with the overflow stack
-  StackIterator<oop, mtGC> iter(_preserved_oop_stack);
+  StackIterator<PreservedMark, mtGC> iter(_preserved_overflow_stack);
   while (!iter.is_empty()) {
-    oop* p = iter.next_addr();
-    adjust_pointer(p);
+    PreservedMark* p = iter.next_addr();
+    p->adjust_pointer();
   }
 }
 
 void MarkSweep::restore_marks() {
-  assert(_preserved_oop_stack.size() == _preserved_mark_stack.size(),
-         "inconsistent preserved oop stacks");
-  log_trace(gc)("Restoring " SIZE_FORMAT " marks", _preserved_count + _preserved_oop_stack.size());
+  log_trace(gc)("Restoring " SIZE_FORMAT " marks", _preserved_count + _preserved_overflow_stack.size());
 
   // restore the marks we saved earlier
   for (size_t i = 0; i < _preserved_count; i++) {
@@ -203,10 +196,9 @@ void MarkSweep::restore_marks() {
   }
 
   // deal with the overflow
-  while (!_preserved_oop_stack.is_empty()) {
-    oop obj       = _preserved_oop_stack.pop();
-    markWord mark = _preserved_mark_stack.pop();
-    obj->set_mark(mark);
+  while (!_preserved_overflow_stack.is_empty()) {
+    PreservedMark p = _preserved_overflow_stack.pop();
+    p.restore();
   }
 }
 

--- a/src/hotspot/share/gc/serial/markSweep.hpp
+++ b/src/hotspot/share/gc/serial/markSweep.hpp
@@ -199,12 +199,6 @@ private:
 
 public:
   PreservedMark(oop obj, markWord mark) : _obj(obj), _mark(mark) {}
-
-  void init(oop obj, markWord mark) {
-    _obj = obj;
-    _mark = mark;
-  }
-
   void adjust_pointer();
   void restore();
 };

--- a/src/hotspot/share/gc/serial/markSweep.hpp
+++ b/src/hotspot/share/gc/serial/markSweep.hpp
@@ -100,8 +100,7 @@ class MarkSweep : AllStatic {
   static Stack<ObjArrayTask, mtGC>             _objarray_stack;
 
   // Space for storing/restoring mark word
-  static Stack<markWord, mtGC>                 _preserved_mark_stack;
-  static Stack<oop, mtGC>                      _preserved_oop_stack;
+  static Stack<PreservedMark, mtGC>      _preserved_overflow_stack;
   static size_t                          _preserved_count;
   static size_t                          _preserved_count_max;
   static PreservedMark*                  _preserved_marks;
@@ -199,6 +198,8 @@ private:
   markWord _mark;
 
 public:
+  PreservedMark(oop obj, markWord mark) : _obj(obj), _mark(mark) {}
+
   void init(oop obj, markWord mark) {
     _obj = obj;
     _mark = mark;


### PR DESCRIPTION
In SerialGC we put preserved marks in space that we may have in the young gen, and failing that, we push it to an overflow stack. The overflow stack is actually two stacks, and replicate behavior of the in-place preserved marks. These can be consolidated.

Testing:
 - [x] tier1
 - [x] tier2
 - [x] hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271951](https://bugs.openjdk.java.net/browse/JDK-8271951): Consolidate preserved marks overflow stack in SerialGC


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to fb48de4d24eb990d0b8169ad7996c265a68e93b0
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to fb48de4d24eb990d0b8169ad7996c265a68e93b0


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5022/head:pull/5022` \
`$ git checkout pull/5022`

Update a local copy of the PR: \
`$ git checkout pull/5022` \
`$ git pull https://git.openjdk.java.net/jdk pull/5022/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5022`

View PR using the GUI difftool: \
`$ git pr show -t 5022`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5022.diff">https://git.openjdk.java.net/jdk/pull/5022.diff</a>

</details>
