### PR TITLE
8271953: fix mis-merge in JDK-8271878

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -824,7 +824,6 @@ jdk/jfr/event/compiler/TestCodeSweeper.java                     8225209    gener
 jdk/jfr/event/os/TestThreadContextSwitches.java                 8247776 windows-all
 jdk/jfr/startupargs/TestStartName.java                          8214685 windows-x64
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
-jdk/jfr/event/gc/detailed/TestEvacuationFailedEvent.java        8263461 linux-x64
 jdk/jfr/api/consumer/streaming/TestLatestEvent.java             8268297 windows-x64
 jdk/jfr/event/oldobject/TestObjectSize.java                     8269418 macosx-x64
 


### PR DESCRIPTION
A trivial change to fix a mis-merge in JDK-8271878.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271953](https://bugs.openjdk.java.net/browse/JDK-8271953): fix mis-merge in JDK-8271878


### Reviewers
 * [Jesper Wilhelmsson](https://openjdk.java.net/census#jwilhelm) (@JesperIRL - **Reviewer**)
 * [Christian Tornqvist](https://openjdk.java.net/census#ctornqvi) (@ctornqvi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5023/head:pull/5023` \
`$ git checkout pull/5023`

Update a local copy of the PR: \
`$ git checkout pull/5023` \
`$ git pull https://git.openjdk.java.net/jdk pull/5023/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5023`

View PR using the GUI difftool: \
`$ git pr show -t 5023`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5023.diff">https://git.openjdk.java.net/jdk/pull/5023.diff</a>

</details>
