### PR TITLE
8270137: Kerberos Credential Retrieval from Cache not Working in Cross-Realm Setup

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/CredentialsUtil.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/CredentialsUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,8 +87,8 @@ public class CredentialsUtil {
         }
         Credentials creds = serviceCreds(
                 KDCOptions.with(KDCOptions.FORWARDABLE),
-                ccreds, ccreds.getClient(), sname, null,
-                new PAData[] {
+                ccreds, ccreds.getClient(), sname, client,
+                null, new PAData[] {
                         new PAData(Krb5.PA_FOR_USER,
                                 new PAForUserEnc(client,
                                         ccreds.getSessionKey()).asn1Encode()),
@@ -136,7 +136,7 @@ public class CredentialsUtil {
         }
         Credentials creds = serviceCreds(KDCOptions.with(
                 KDCOptions.CNAME_IN_ADDL_TKT, KDCOptions.FORWARDABLE),
-                ccreds, ccreds.getClient(), backendPrincipal,
+                ccreds, ccreds.getClient(), backendPrincipal, null,
                 new Ticket[] {second}, new PAData[] {
                         new PAData(Krb5.PA_PAC_OPTIONS,
                                 new PaPacOptions()
@@ -313,7 +313,7 @@ public class CredentialsUtil {
             throws KrbException, IOException {
         return serviceCreds(new KDCOptions(), ccreds,
                 ccreds.getClient(), service, null, null,
-                S4U2Type.NONE);
+                null, S4U2Type.NONE);
     }
 
     /*
@@ -325,13 +325,13 @@ public class CredentialsUtil {
     private static Credentials serviceCreds(
             KDCOptions options, Credentials asCreds,
             PrincipalName cname, PrincipalName sname,
-            Ticket[] additionalTickets, PAData[] extraPAs,
-            S4U2Type s4u2Type)
+            PrincipalName user, Ticket[] additionalTickets,
+            PAData[] extraPAs, S4U2Type s4u2Type)
             throws KrbException, IOException {
         if (!Config.DISABLE_REFERRALS) {
             try {
                 return serviceCredsReferrals(options, asCreds, cname, sname,
-                        s4u2Type, additionalTickets, extraPAs);
+                        s4u2Type, user, additionalTickets, extraPAs);
             } catch (KrbException e) {
                 // Server may raise an error if CANONICALIZE is true.
                 // Try CANONICALIZE false.
@@ -339,7 +339,7 @@ public class CredentialsUtil {
         }
         return serviceCredsSingle(options, asCreds, cname,
                 asCreds.getClientAlias(), sname, sname, s4u2Type,
-                additionalTickets, extraPAs);
+                user, additionalTickets, extraPAs);
     }
 
     /*
@@ -349,8 +349,8 @@ public class CredentialsUtil {
     private static Credentials serviceCredsReferrals(
             KDCOptions options, Credentials asCreds,
             PrincipalName cname, PrincipalName sname,
-            S4U2Type s4u2Type, Ticket[] additionalTickets,
-            PAData[] extraPAs)
+            S4U2Type s4u2Type, PrincipalName user,
+            Ticket[] additionalTickets, PAData[] extraPAs)
                     throws KrbException, IOException {
         options = new KDCOptions(options.toBooleanArray());
         options.set(KDCOptions.CANONICALIZE, true);
@@ -362,12 +362,13 @@ public class CredentialsUtil {
         PrincipalName clientAlias = asCreds.getClientAlias();
         while (referrals.size() <= Config.MAX_REFERRALS) {
             ReferralsCache.ReferralCacheEntry ref =
-                    ReferralsCache.get(cname, sname, refSname.getRealmString());
+                    ReferralsCache.get(cname, sname, user,
+                            additionalTickets, refSname.getRealmString());
             String toRealm = null;
             if (ref == null) {
                 creds = serviceCredsSingle(options, asCreds, cname,
                         clientAlias, refSname, cSname, s4u2Type,
-                        additionalTickets, extraPAs);
+                        user, additionalTickets, extraPAs);
                 PrincipalName server = creds.getServer();
                 if (!refSname.equals(server)) {
                     String[] serverNameStrings = server.getNameStrings();
@@ -378,15 +379,9 @@ public class CredentialsUtil {
                                 serverNameStrings[1])) {
                         // Server Name (sname) has the following format:
                         //      krbtgt/TO-REALM.COM@FROM-REALM.COM
-                        if (s4u2Type == S4U2Type.NONE) {
-                            // Do not store S4U2Self or S4U2Proxy referral
-                            // TGTs in the cache. Caching such tickets is not
-                            // defined in MS-SFU and may cause unexpected
-                            // results when using them in a different context.
-                            ReferralsCache.put(cname, sname,
-                                    server.getRealmString(),
-                                    serverNameStrings[1], creds);
-                        }
+                        ReferralsCache.put(cname, sname, user,
+                                additionalTickets, server.getRealmString(),
+                                serverNameStrings[1], creds);
                         toRealm = serverNameStrings[1];
                         isReferral = true;
                     }
@@ -411,7 +406,7 @@ public class CredentialsUtil {
                     }
                     additionalTickets[0] = credsInOut[1].getTicket();
                 } else if (s4u2Type == S4U2Type.SELF) {
-                    handleS4U2SelfReferral(extraPAs, asCreds, creds);
+                    handleS4U2SelfReferral(extraPAs, user, asCreds, creds);
                 }
                 if (referrals.contains(toRealm)) {
                     // Referrals loop detected
@@ -440,8 +435,8 @@ public class CredentialsUtil {
             KDCOptions options, Credentials asCreds,
             PrincipalName cname, PrincipalName clientAlias,
             PrincipalName refSname, PrincipalName sname,
-            S4U2Type s4u2Type, Ticket[] additionalTickets,
-            PAData[] extraPAs)
+            S4U2Type s4u2Type, PrincipalName user,
+            Ticket[] additionalTickets, PAData[] extraPAs)
                     throws KrbException, IOException {
         Credentials theCreds = null;
         boolean[] okAsDelegate = new boolean[]{true};
@@ -469,7 +464,7 @@ public class CredentialsUtil {
                 Credentials.printDebug(newTgt);
             }
             if (s4u2Type == S4U2Type.SELF) {
-                handleS4U2SelfReferral(extraPAs, asCreds, newTgt);
+                handleS4U2SelfReferral(extraPAs, user, asCreds, newTgt);
             }
             asCreds = newTgt;
             cname = asCreds.getClient();
@@ -498,7 +493,7 @@ public class CredentialsUtil {
      * different realm or when using a referral TGT.
      */
     private static void handleS4U2SelfReferral(PAData[] pas,
-            Credentials oldCeds, Credentials newCreds)
+            PrincipalName user, Credentials oldCeds, Credentials newCreds)
                     throws Asn1Exception, KrbException, IOException {
         if (DEBUG) {
             System.out.println(">>> Handling S4U2Self referral");
@@ -506,11 +501,8 @@ public class CredentialsUtil {
         for (int i = 0; i < pas.length; i++) {
             PAData pa = pas[i];
             if (pa.getType() == Krb5.PA_FOR_USER) {
-                PAForUserEnc paForUser = new PAForUserEnc(
-                        new DerValue(pa.getValue()),
-                        oldCeds.getSessionKey());
                 pas[i] = new PAData(Krb5.PA_FOR_USER,
-                        new PAForUserEnc(paForUser.getName(),
+                        new PAForUserEnc(user,
                                 newCreds.getSessionKey()).asn1Encode());
                 break;
             }

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/ReferralsCache.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/ReferralsCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Red Hat, Inc.
+ * Copyright (c) 2019, 2021, Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,12 +25,14 @@
 
 package sun.security.krb5.internal;
 
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 import sun.security.krb5.Credentials;
 import sun.security.krb5.PrincipalName;
@@ -51,19 +53,33 @@ final class ReferralsCache {
     private static final class ReferralCacheKey {
         private PrincipalName cname;
         private PrincipalName sname;
-        ReferralCacheKey (PrincipalName cname, PrincipalName sname) {
+        private PrincipalName user; // S4U2Self only
+        private byte[] clientSvcTicketEnc; // S4U2Proxy only
+        ReferralCacheKey (PrincipalName cname, PrincipalName sname,
+                PrincipalName user, Ticket clientSvcTicket) {
             this.cname = cname;
             this.sname = sname;
+            this.user = user;
+            if (clientSvcTicket != null && clientSvcTicket.encPart != null) {
+                byte[] clientSvcTicketEnc = clientSvcTicket.encPart.getBytes();
+                if (clientSvcTicketEnc.length > 0) {
+                    this.clientSvcTicketEnc = clientSvcTicketEnc;
+                }
+            }
         }
         public boolean equals(Object other) {
             if (!(other instanceof ReferralCacheKey))
                 return false;
             ReferralCacheKey that = (ReferralCacheKey)other;
             return cname.equals(that.cname) &&
-                    sname.equals(that.sname);
+                    sname.equals(that.sname) &&
+                    Objects.equals(user, that.user) &&
+                    Arrays.equals(clientSvcTicketEnc, that.clientSvcTicketEnc);
         }
         public int hashCode() {
-            return cname.hashCode() + sname.hashCode();
+            return cname.hashCode() + sname.hashCode() +
+                    Objects.hashCode(user) +
+                    Arrays.hashCode(clientSvcTicketEnc);
         }
     }
 
@@ -84,7 +100,8 @@ final class ReferralsCache {
 
     /*
      * Add a new referral entry to the cache, including: client principal,
-     * service principal, source KDC realm, destination KDC realm and
+     * service principal, user principal (S4U2Self only), client service
+     * ticket (S4U2Proxy only), source KDC realm, destination KDC realm and
      * referral TGT.
      *
      * If a loop is generated when adding the new referral, the first hop is
@@ -94,8 +111,12 @@ final class ReferralsCache {
      * REALM-1.COM -> REALM-2.COM referral entry is removed from the cache.
      */
     static synchronized void put(PrincipalName cname, PrincipalName service,
-            String fromRealm, String toRealm, Credentials creds) {
-        ReferralCacheKey k = new ReferralCacheKey(cname, service);
+            PrincipalName user, Ticket[] clientSvcTickets, String fromRealm,
+            String toRealm, Credentials creds) {
+        Ticket clientSvcTicket = (clientSvcTickets != null ?
+                clientSvcTickets[0] : null);
+        ReferralCacheKey k = new ReferralCacheKey(cname, service,
+                user, clientSvcTicket);
         pruneExpired(k);
         if (creds.getEndTime().before(new Date())) {
             return;
@@ -125,11 +146,16 @@ final class ReferralsCache {
 
     /*
      * Obtain a referral entry from the cache given a client principal,
-     * service principal and a source KDC realm.
+     * a service principal, a user principal (S4U2Self only), a client
+     * service ticket (S4U2Proxy only) and a source KDC realm.
      */
     static synchronized ReferralCacheEntry get(PrincipalName cname,
-            PrincipalName service, String fromRealm) {
-        ReferralCacheKey k = new ReferralCacheKey(cname, service);
+            PrincipalName service, PrincipalName user,
+            Ticket[] clientSvcTickets, String fromRealm) {
+        Ticket clientSvcTicket = (clientSvcTickets != null ?
+                clientSvcTickets[0] : null);
+        ReferralCacheKey k = new ReferralCacheKey(cname, service,
+                user, clientSvcTicket);
         pruneExpired(k);
         Map<String, ReferralCacheEntry> entries = referralsMap.get(k);
         if (entries != null) {

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/ReferralsCache.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/ReferralsCache.java
@@ -54,16 +54,16 @@ final class ReferralsCache {
         private PrincipalName cname;
         private PrincipalName sname;
         private PrincipalName user; // S4U2Self only
-        private byte[] clientSvcTicketEnc; // S4U2Proxy only
+        private byte[] userSvcTicketEnc; // S4U2Proxy only
         ReferralCacheKey (PrincipalName cname, PrincipalName sname,
-                PrincipalName user, Ticket clientSvcTicket) {
+                PrincipalName user, Ticket userSvcTicket) {
             this.cname = cname;
             this.sname = sname;
             this.user = user;
-            if (clientSvcTicket != null && clientSvcTicket.encPart != null) {
-                byte[] clientSvcTicketEnc = clientSvcTicket.encPart.getBytes();
-                if (clientSvcTicketEnc.length > 0) {
-                    this.clientSvcTicketEnc = clientSvcTicketEnc;
+            if (userSvcTicket != null && userSvcTicket.encPart != null) {
+                byte[] userSvcTicketEnc = userSvcTicket.encPart.getBytes();
+                if (userSvcTicketEnc.length > 0) {
+                    this.userSvcTicketEnc = userSvcTicketEnc;
                 }
             }
         }
@@ -74,12 +74,12 @@ final class ReferralsCache {
             return cname.equals(that.cname) &&
                     sname.equals(that.sname) &&
                     Objects.equals(user, that.user) &&
-                    Arrays.equals(clientSvcTicketEnc, that.clientSvcTicketEnc);
+                    Arrays.equals(userSvcTicketEnc, that.userSvcTicketEnc);
         }
         public int hashCode() {
             return cname.hashCode() + sname.hashCode() +
                     Objects.hashCode(user) +
-                    Arrays.hashCode(clientSvcTicketEnc);
+                    Arrays.hashCode(userSvcTicketEnc);
         }
     }
 
@@ -111,12 +111,12 @@ final class ReferralsCache {
      * REALM-1.COM -> REALM-2.COM referral entry is removed from the cache.
      */
     static synchronized void put(PrincipalName cname, PrincipalName service,
-            PrincipalName user, Ticket[] clientSvcTickets, String fromRealm,
+            PrincipalName user, Ticket[] userSvcTickets, String fromRealm,
             String toRealm, Credentials creds) {
-        Ticket clientSvcTicket = (clientSvcTickets != null ?
-                clientSvcTickets[0] : null);
+        Ticket userSvcTicket = (userSvcTickets != null ?
+                userSvcTickets[0] : null);
         ReferralCacheKey k = new ReferralCacheKey(cname, service,
-                user, clientSvcTicket);
+                user, userSvcTicket);
         pruneExpired(k);
         if (creds.getEndTime().before(new Date())) {
             return;
@@ -151,11 +151,11 @@ final class ReferralsCache {
      */
     static synchronized ReferralCacheEntry get(PrincipalName cname,
             PrincipalName service, PrincipalName user,
-            Ticket[] clientSvcTickets, String fromRealm) {
-        Ticket clientSvcTicket = (clientSvcTickets != null ?
-                clientSvcTickets[0] : null);
+            Ticket[] userSvcTickets, String fromRealm) {
+        Ticket userSvcTicket = (userSvcTickets != null ?
+                userSvcTickets[0] : null);
         ReferralCacheKey k = new ReferralCacheKey(cname, service,
-                user, clientSvcTicket);
+                user, userSvcTicket);
         pruneExpired(k);
         Map<String, ReferralCacheEntry> entries = referralsMap.get(k);
         if (entries != null) {

--- a/test/jdk/sun/security/krb5/auto/ReferralsTest.java
+++ b/test/jdk/sun/security/krb5/auto/ReferralsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Red Hat, Inc.
+ * Copyright (c) 2019, 2021, Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -287,6 +287,16 @@ public class ReferralsTest {
      * on different realms.
      */
     private static void testImpersonation() throws Exception {
+        testImpersonationSingle();
+
+        // Try a second time to force the use of the Referrals Cache.
+        // During this execution, the referral ticket from RABBIT.HOLE
+        // to DEV.RABBIT.HOLE (upon the initial S4U2Self message) will
+        // be obtained from the Cache.
+        testImpersonationSingle();
+    }
+
+    private static void testImpersonationSingle() throws Exception {
         Context s = Context.fromUserPass(serviceKDC2Name, password, true);
         s.startAsServer(GSSUtil.GSS_KRB5_MECH_OID);
         GSSName impName = s.impersonate(userKDC1Name).cred().getName();
@@ -306,6 +316,16 @@ public class ReferralsTest {
      * because the server and the backend are on different realms.
      */
     private static void testDelegationWithReferrals() throws Exception {
+        testDelegationWithReferralsSingle();
+
+        // Try a second time to force the use of the Referrals Cache.
+        // During this execution, the referral ticket from RABBIT.HOLE
+        // to DEV.RABBIT.HOLE (upon the initial S4U2Proxy message) will
+        // be obtained from the Cache.
+        testDelegationWithReferralsSingle();
+    }
+
+    private static void testDelegationWithReferralsSingle() throws Exception {
         Context c = Context.fromUserPass(userKDC1Name, password, false);
         c.startAsClient(serviceName, GSSUtil.GSS_KRB5_MECH_OID);
         Context s = Context.fromUserPass(serviceKDC2Name, password, true);


### PR DESCRIPTION
I'd like to propose a fix for JDK-8270137 [1].

This bug is triggered when using a previously stored referral ticket (in the Referrals Cache) at the moment of following a S4U2Proxy cross-realm referral. The mistakenly-used referral ticket matched the client and service names but it was obtained as a result of a non-S4U2Proxy request. In fact, it was the middle service that got it while trying to determine the backend service realm in a previous S4U2Proxy communication. The mistakenly-used referral ticket was not bind to the impersonated user (in other words, it was not obtained attaching the user's TGS as part of a S4U2Proxy request) and, thus, must not be used.

Even when one possible approach to fix this issue could be to be more selective at the moment of getting referral tickets from the Cache (that is: do not get anything from the Cache if it's for a S4U2Proxy request), I decided to go one step further and enhance the Referrals Cache. With this enhancement, we add more information to the stored referral tickets such as a footprint of the TGS (in the case of S4U2Proxy requests) or the user principal (in the case of S4U2Self requests). We now allow to store S4U2Proxy and S4U2Self referrals tickets but those will be re-used only if there is a perfect match of the TGS or user principal. As an example, if a middle service tries to replicate the exact S4U2Self communication for exactly the same user, cached referral tickets should be okay. With this enhancement, we increase the use of the Cache and the performance (time, network resources, etc.).

The ReferralsTest is enhanced to reflect these new scenarios and now uses cached S4U2Proxy/S4U2Self referral tickets.

No regressions observed in jdk/sun/security/krb5.

--
[1] - https://bugs.openjdk.java.net/browse/JDK-8270137

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270137](https://bugs.openjdk.java.net/browse/JDK-8270137): Kerberos Credential Retrieval from Cache not Working in Cross-Realm Setup


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**) ⚠️ Review applies to 4260067e694762b7714fccb050a8822efcca3375


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5036/head:pull/5036` \
`$ git checkout pull/5036`

Update a local copy of the PR: \
`$ git checkout pull/5036` \
`$ git pull https://git.openjdk.java.net/jdk pull/5036/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5036`

View PR using the GUI difftool: \
`$ git pr show -t 5036`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5036.diff">https://git.openjdk.java.net/jdk/pull/5036.diff</a>

</details>
