### PR TITLE
8272113: Build compare script fails with differences in classlist

### DIFF
--- a/make/scripts/compare.sh
+++ b/make/scripts/compare.sh
@@ -362,8 +362,14 @@ compare_general_files() {
                 THIS_FILE=$WORK_DIR/$f.this
                 $MKDIR -p $(dirname $OTHER_FILE) $(dirname $THIS_FILE)
                 $RM $OTHER_FILE $THIS_FILE
-                $CAT $OTHER_DIR/$f | $SORT > $OTHER_FILE
-                $CAT $THIS_DIR/$f  | $SORT > $THIS_FILE
+                # Also filter out the "id: NNNN" in the classlists
+                if [[ "$f" = *"/lib/classlist" ]]; then
+                    $CAT $OTHER_DIR/$f | $SORT | $SED "s| id: .*||g" > $OTHER_FILE
+                    $CAT $THIS_DIR/$f  | $SORT | $SED "s| id: .*||g" > $THIS_FILE
+                else
+                    $CAT $OTHER_DIR/$f | $SORT > $OTHER_FILE
+                    $CAT $THIS_DIR/$f  | $SORT > $THIS_FILE
+                fi
             else
                 OTHER_FILE=$OTHER_DIR/$f
                 THIS_FILE=$THIS_DIR/$f


### PR DESCRIPTION
The CDS classlist is generated with the `-XX:DumpLoadedClassList` option, which writes the name of the classes as they are being loaded. Since class loading order is affected by thread switching, the classes may appear in a non-deterministic order.

Previously, the build compare script would sort the classlist before comparing. Since https://bugs.openjdk.java.net/browse/JDK-8272113, each class in the classlist has a new ID, so even after sorting, the contents would differ:

```
$ diff classlist.1 classlist.2
207,208c207,208
< jdk/internal/misc/VM id: 201
< jdk/internal/util/SystemProps id: 202
---
> jdk/internal/misc/VM id: 202
> jdk/internal/util/SystemProps id: 201
```

The fix is to strip the id before doing the file comparison.

Tested with:

`mach5 remote-build -b linux-aarch64-cmp-baseline,macosx-x64-cmp-baseline,linux-x64-cmp-baseline,linux-arm32-open-cmp-baseline,windows-x64-cmp-baseline`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272113](https://bugs.openjdk.java.net/browse/JDK-8272113): Build compare script fails with differences in classlist


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5041/head:pull/5041` \
`$ git checkout pull/5041`

Update a local copy of the PR: \
`$ git checkout pull/5041` \
`$ git pull https://git.openjdk.java.net/jdk pull/5041/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5041`

View PR using the GUI difftool: \
`$ git pr show -t 5041`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5041.diff">https://git.openjdk.java.net/jdk/pull/5041.diff</a>

</details>
