### PR TITLE
8271956: AArch64: C1 build failed after JDK-8270947

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -37,6 +37,7 @@
 #include "gc/shared/tlab_globals.hpp"
 #include "interpreter/bytecodeHistogram.hpp"
 #include "interpreter/interpreter.hpp"
+#include "compiler/compileTask.hpp"
 #include "compiler/disassembler.hpp"
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"


### PR DESCRIPTION
C1 build failed on AArch64 with the following error message:
```
  src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp:4642:30: error:
  invalid use of incomplete type 'class CompileTask'
```

Including the header would fix this error. Note that this header is
included already under COMPILER2 by "opto/compile.hpp".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271956](https://bugs.openjdk.java.net/browse/JDK-8271956): AArch64: C1 build failed after JDK-8270947


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Nick Gasson](https://openjdk.java.net/census#ngasson) (@nick-arm - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5045/head:pull/5045` \
`$ git checkout pull/5045`

Update a local copy of the PR: \
`$ git checkout pull/5045` \
`$ git pull https://git.openjdk.java.net/jdk pull/5045/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5045`

View PR using the GUI difftool: \
`$ git pr show -t 5045`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5045.diff">https://git.openjdk.java.net/jdk/pull/5045.diff</a>

</details>
