### PR TITLE
8272138: ZGC: Adopt relaxed ordering for self-healing

### DIFF
--- a/src/hotspot/share/gc/z/zBarrier.inline.hpp
+++ b/src/hotspot/share/gc/z/zBarrier.inline.hpp
@@ -117,7 +117,7 @@ inline void ZBarrier::self_heal(volatile oop* p, uintptr_t addr, uintptr_t heal_
 
   for (;;) {
     // Heal
-    const uintptr_t prev_addr = Atomic::cmpxchg((volatile uintptr_t*)p, addr, heal_addr);
+    const uintptr_t prev_addr = Atomic::cmpxchg((volatile uintptr_t*)p, addr, heal_addr, memory_order_relaxed);
     if (prev_addr == addr) {
       // Success
       return;

--- a/src/hotspot/share/gc/z/zForwarding.inline.hpp
+++ b/src/hotspot/share/gc/z/zForwarding.inline.hpp
@@ -136,6 +136,10 @@ inline uintptr_t ZForwarding::insert(uintptr_t from_index, uintptr_t to_offset, 
   const ZForwardingEntry new_entry(from_index, to_offset);
   const ZForwardingEntry old_entry; // Empty
 
+  // Make sure that object copy is finished
+  // before forwarding table installation
+  OrderAccess::release();
+
   for (;;) {
     const ZForwardingEntry prev_entry = Atomic::cmpxchg(entries() + *cursor, old_entry, new_entry, memory_order_relaxed);
     if (!prev_entry.populated()) {

--- a/src/hotspot/share/gc/z/zForwarding.inline.hpp
+++ b/src/hotspot/share/gc/z/zForwarding.inline.hpp
@@ -137,7 +137,7 @@ inline uintptr_t ZForwarding::insert(uintptr_t from_index, uintptr_t to_offset, 
   const ZForwardingEntry old_entry; // Empty
 
   for (;;) {
-    const ZForwardingEntry prev_entry = Atomic::cmpxchg(entries() + *cursor, old_entry, new_entry, memory_order_release);
+    const ZForwardingEntry prev_entry = Atomic::cmpxchg(entries() + *cursor, old_entry, new_entry, memory_order_relaxed);
     if (!prev_entry.populated()) {
       // Success
       return to_offset;

--- a/src/hotspot/share/gc/z/zRelocate.cpp
+++ b/src/hotspot/share/gc/z/zRelocate.cpp
@@ -74,10 +74,6 @@ static uintptr_t relocate_object_inner(ZForwarding* forwarding, uintptr_t from_a
   // Copy object
   ZUtils::object_copy_disjoint(from_addr, to_addr, size);
 
-  // Make sure object copy is finished
-  // before forwarding table installation
-  OrderAccess::release();
-
   // Insert forwarding
   const uintptr_t to_addr_final = forwarding_insert(forwarding, from_addr, to_addr, cursor);
   if (to_addr_final != to_addr) {
@@ -306,10 +302,6 @@ private:
     } else {
       ZUtils::object_copy_disjoint(from_addr, to_addr, size);
     }
-    
-    // Make sure object copy is finished
-    // before forwarding table installation
-    OrderAccess::release();
 
     // Insert forwarding
     if (forwarding_insert(_forwarding, from_addr, to_addr, &cursor) != to_addr) {

--- a/src/hotspot/share/gc/z/zRelocate.cpp
+++ b/src/hotspot/share/gc/z/zRelocate.cpp
@@ -74,7 +74,10 @@ static uintptr_t relocate_object_inner(ZForwarding* forwarding, uintptr_t from_a
   // Copy object
   ZUtils::object_copy_disjoint(from_addr, to_addr, size);
 
+  // Make sure object copy is finished
+  // before forwarding table installation
   OrderAccess::release();
+
   // Insert forwarding
   const uintptr_t to_addr_final = forwarding_insert(forwarding, from_addr, to_addr, cursor);
   if (to_addr_final != to_addr) {
@@ -303,8 +306,11 @@ private:
     } else {
       ZUtils::object_copy_disjoint(from_addr, to_addr, size);
     }
-
+    
+    // Make sure object copy is finished
+    // before forwarding table installation
     OrderAccess::release();
+
     // Insert forwarding
     if (forwarding_insert(_forwarding, from_addr, to_addr, &cursor) != to_addr) {
       // Already relocated, undo allocation

--- a/src/hotspot/share/gc/z/zRelocate.cpp
+++ b/src/hotspot/share/gc/z/zRelocate.cpp
@@ -74,6 +74,7 @@ static uintptr_t relocate_object_inner(ZForwarding* forwarding, uintptr_t from_a
   // Copy object
   ZUtils::object_copy_disjoint(from_addr, to_addr, size);
 
+  OrderAccess::release();
   // Insert forwarding
   const uintptr_t to_addr_final = forwarding_insert(forwarding, from_addr, to_addr, cursor);
   if (to_addr_final != to_addr) {
@@ -303,6 +304,7 @@ private:
       ZUtils::object_copy_disjoint(from_addr, to_addr, size);
     }
 
+    OrderAccess::release();
     // Insert forwarding
     if (forwarding_insert(_forwarding, from_addr, to_addr, &cursor) != to_addr) {
       // Already relocated, undo allocation


### PR DESCRIPTION
ZGC utilizes self-healing in load barrier to fix references to old objects. Currently, this fixing (ZBarrier::self_heal) adopts memory_order_conservative to guarantee that (1) the slow path (relocate, mark, etc. where we get healed address) always happens before self healing, and (2) the other thread that accesses the same reference is able to access the content at the healed address.
Let us consider changing the bounded releasing CAS in forwarding table installation to unbounded. In this way, the release (OrderAccess::release()) serves as a membar to block any subsequent store operations (forwarding table installation and self healing). More specifically, we can use release(), relaxed_cas() in the forwarding table and relaxed_cas() in the self healing. In the scenario when a thread reads healed address from forwarding table, relaxed_cas() is also fine due to the load-acquire in forwarding table.
Since release is done only in forwarding table, the majority of self heals, which only remap the pointer, is no longer restricted by the memory order. Performance is visibly improved, demonstrated by benchmark corretto/heapothesys on AArch64. The optimized version decreases both average concurrent mark/relocation time by 15%-20% and 10%-15%, respectively。
```
baseline
[1000.412s][info   ][gc,stats    ]       Phase: Concurrent Relocate                           0.000 / 0.000       161.031 / 232.546     147.641 / 289.855     147.641 / 289.855     ms
[1100.412s][info   ][gc,stats    ]       Phase: Concurrent Relocate                         220.739 / 220.739     162.373 / 232.546     149.909 / 289.855     149.909 / 289.855     ms
[1200.411s][info   ][gc,stats    ]       Phase: Concurrent Relocate                           0.000 / 0.000       157.900 / 232.546     148.912 / 289.855     148.912 / 289.855     ms
[1000.412s][info   ][gc,stats    ]       Phase: Concurrent Mark                               0.000 / 0.000       816.505 / 1508.676    759.533 / 1567.506    759.533 / 1567.506    ms
[1100.412s][info   ][gc,stats    ]       Phase: Concurrent Mark                            1262.680 / 1262.680    838.750 / 1508.676    772.495 / 1567.506    772.495 / 1567.506    ms
[1200.411s][info   ][gc,stats    ]       Phase: Concurrent Mark                               0.000 / 0.000       813.220 / 1422.825    769.346 / 1567.506    769.346 / 1567.506    ms
optimized
[1000.447s][info   ][gc,stats    ]       Phase: Concurrent Relocate                         248.035 / 248.035     162.719 / 253.498     124.061 / 273.227     124.061 / 273.227     ms
[1100.447s][info   ][gc,stats    ]       Phase: Concurrent Relocate                         217.434 / 217.434     161.209 / 253.498     126.767 / 273.227     126.767 / 273.227     ms
[1200.447s][info   ][gc,stats    ]       Phase: Concurrent Relocate                           0.000 / 0.000       164.023 / 253.498     129.314 / 273.227     129.314 / 273.227     ms
[1000.447s][info   ][gc,stats    ]       Phase: Concurrent Mark                            1224.059 / 1224.059    809.838 / 1518.214    582.867 / 1518.214    582.867 / 1518.214    ms
[1100.447s][info   ][gc,stats    ]       Phase: Concurrent Mark                            1302.235 / 1302.235    793.589 / 1518.214    600.215 / 1518.214    600.215 / 1518.214    ms
[1200.447s][info   ][gc,stats    ]       Phase: Concurrent Mark                               0.000 / 0.000       821.320 / 1518.214    615.187 / 1518.214    615.187 / 1518.214    ms
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272138](https://bugs.openjdk.java.net/browse/JDK-8272138): ZGC: Adopt relaxed ordering for self-healing


### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)


### Contributors
 * Hao Tang `<albert.th@alibaba-inc.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5046/head:pull/5046` \
`$ git checkout pull/5046`

Update a local copy of the PR: \
`$ git checkout pull/5046` \
`$ git pull https://git.openjdk.java.net/jdk pull/5046/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5046`

View PR using the GUI difftool: \
`$ git pr show -t 5046`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5046.diff">https://git.openjdk.java.net/jdk/pull/5046.diff</a>

</details>
