### PR TITLE
8272137: Make Iterable classes streamable

### DIFF
--- a/src/java.base/share/classes/java/util/Collection.java
+++ b/src/java.base/share/classes/java/util/Collection.java
@@ -27,7 +27,9 @@ package java.util;
 
 import java.util.function.IntFunction;
 import java.util.function.Predicate;
+import java.util.stream.ParallelStreamable;
 import java.util.stream.Stream;
+import java.util.stream.Streamable;
 import java.util.stream.StreamSupport;
 
 /**
@@ -250,7 +252,7 @@ import java.util.stream.StreamSupport;
  * @since 1.2
  */
 
-public interface Collection<E> extends Iterable<E> {
+public interface Collection<E> extends Iterable<E>, Streamable<E>, ParallelStreamable<E> {
     // Query Operations
 
     /**
@@ -739,13 +741,14 @@ public interface Collection<E> extends Iterable<E> {
      * @return a sequential {@code Stream} over the elements in this collection
      * @since 1.8
      */
+    @Override
     default Stream<E> stream() {
         return StreamSupport.stream(spliterator(), false);
     }
 
     /**
      * Returns a possibly parallel {@code Stream} with this collection as its
-     * source.  It is allowable for this method to return a sequential stream.
+     * source. It is allowable for this method to return a sequential stream.
      *
      * <p>This method should be overridden when the {@link #spliterator()}
      * method cannot return a spliterator that is {@code IMMUTABLE},
@@ -760,6 +763,7 @@ public interface Collection<E> extends Iterable<E> {
      * collection
      * @since 1.8
      */
+    @Override
     default Stream<E> parallelStream() {
         return StreamSupport.stream(spliterator(), true);
     }

--- a/src/java.base/share/classes/java/util/Optional.java
+++ b/src/java.base/share/classes/java/util/Optional.java
@@ -29,6 +29,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+import java.util.stream.Streamable;
 
 /**
  * A container object which may or may not contain a non-{@code null} value.
@@ -59,7 +60,7 @@ import java.util.stream.Stream;
  * @since 1.8
  */
 @jdk.internal.ValueBased
-public final class Optional<T> {
+public final class Optional<T> implements Streamable<T> {
     /**
      * Common instance for {@code empty()}.
      */
@@ -330,6 +331,7 @@ public final class Optional<T> {
      * @return the optional value as a {@code Stream}
      * @since 9
      */
+    @Override
     public Stream<T> stream() {
         if (!isPresent()) {
             return Stream.empty();

--- a/src/java.base/share/classes/java/util/stream/ParallelStreamable.java
+++ b/src/java.base/share/classes/java/util/stream/ParallelStreamable.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package java.util.stream;
+
+/**
+ * Implementing this interface allows an object to be streamed, possibly in
+ * parallel, using the Stream API.
+ *
+ * @param <T> the type of element(s) returned by the stream
+ *
+ * @author  Rik Schaaf
+ * @see     Collection
+ * @since 18
+ */
+public interface ParallelStreamable<T> {
+
+    /**
+     * Returns a possibly parallel {@code Stream} with this object as its
+     * source. It is allowable for this method to return a sequential stream.
+     *
+     * @return a possibly parallel {@code Stream} over the element(s) in this
+     * object
+     * @since 18
+     */
+    Stream<T> parallelStream();
+}

--- a/src/java.base/share/classes/java/util/stream/Streamable.java
+++ b/src/java.base/share/classes/java/util/stream/Streamable.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package java.util.stream;
+
+/**
+ * Implementing this interface allows an object to be sequentially streamed
+ * using the Stream API.
+ *
+ * @param <T> the type of element(s) returned by the stream
+ *
+ * @author  Rik Schaaf
+ * @see     Collection
+ * @see     Optional
+ * @since 18
+ */
+public interface Streamable<T> {
+
+    /**
+     * Returns a sequential {@code Stream} with this object as its source.
+     *
+     * @return a sequential {@code Stream} over the element(s) in this object
+     * @since 18
+     */
+    Stream<T> stream();
+}


### PR DESCRIPTION
create Streamable and ParallelStreamable interface and use them in Collection and Optional

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8272137](https://bugs.openjdk.java.net/browse/JDK-8272137): Make Iterable classes streamable


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5049/head:pull/5049` \
`$ git checkout pull/5049`

Update a local copy of the PR: \
`$ git checkout pull/5049` \
`$ git pull https://git.openjdk.java.net/jdk pull/5049/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5049`

View PR using the GUI difftool: \
`$ git pr show -t 5049`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5049.diff">https://git.openjdk.java.net/jdk/pull/5049.diff</a>

</details>
