### PR TITLE
8272146: Disable Fibonacci test on memory constrained systems

### DIFF
--- a/test/hotspot/jtreg/runtime/Thread/Fibonacci.java
+++ b/test/hotspot/jtreg/runtime/Thread/Fibonacci.java
@@ -28,6 +28,7 @@
  *     This test is skipped on 32-bit Windows: limited virtual space on Win-32
  *     make this test inherently unstable on Windows with 32-bit VM data model.
  * @requires !(os.family == "windows" & sun.arch.data.model == "32")
+ * @requires !(os.family == "linux" & os.maxMemory < 512M)
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run main/othervm Fibonacci 15


### PR DESCRIPTION
Hi,

please review this small change to the Fibonacci test case. I added an additional memory requirement for Linux, as I am seeing the test fail on some embedded and emulated devices which do not have enough memory to execute the test case.
The test succeeds on a device with 512MB of physical memory, so I guess this upper bound should be fine. The problem seems to be the kernel memory, as the devices have enough swap space to handle the other test cases.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272146](https://bugs.openjdk.java.net/browse/JDK-8272146): Disable Fibonacci test on memory constrained systems


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5051/head:pull/5051` \
`$ git checkout pull/5051`

Update a local copy of the PR: \
`$ git checkout pull/5051` \
`$ git pull https://git.openjdk.java.net/jdk pull/5051/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5051`

View PR using the GUI difftool: \
`$ git pr show -t 5051`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5051.diff">https://git.openjdk.java.net/jdk/pull/5051.diff</a>

</details>
