### PR TITLE
8271862: C2 intrinsic for Reference.refersTo() is often not used

### DIFF
--- a/src/java.base/share/classes/java/lang/ref/PhantomReference.java
+++ b/src/java.base/share/classes/java/lang/ref/PhantomReference.java
@@ -69,8 +69,12 @@ public class PhantomReference<T> extends Reference<T> {
      * do reference processing concurrently.
      */
     @Override
+    boolean refersToImpl(T obj) {
+        return refersTo0(obj);
+    }
+
     @IntrinsicCandidate
-    native final boolean refersTo0(Object o);
+    private native final boolean refersTo0(Object o);
 
     /**
      * Creates a new phantom reference that refers to the given object and

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -363,13 +363,20 @@ public abstract class Reference<T> {
      * @since 16
      */
     public final boolean refersTo(T obj) {
-        return refersTo0(obj);
+        return refersToImpl(obj);
     }
 
     /* Implementation of refersTo(), overridden for phantom references.
+     * This method exists only to avoid making refersTo0() virtual. Making
+     * refersTo0() virtual has the undesirable effect of C2 often preferring
+     * to call the native implementation over the intrinsic.
      */
+    boolean refersToImpl(T obj) {
+        return refersTo0(obj);
+    }
+
     @IntrinsicCandidate
-    native boolean refersTo0(Object o);
+    private native final boolean refersTo0(Object o);
 
     /**
      * Clears this reference object.  Invoking this method will not cause this


### PR DESCRIPTION
While fixing JDK-8270626 it was discovered that the C2 intrinsic for `Reference.refersTo()` is not used as often as one would think. Instead C2 often prefers using the native implementation, which is much slower which defeats the purpose of having an intrinsic in the first place.

The problem arise from having `refersTo0()` be virtual, native and @IntrinsicCandidate. This can be worked around by introducing an virtual method layer and so that `refersTo0()` can be made `final`. That's what this patch does, by adding a virtual `refersToImpl()` which in turn calls the now final `refersTo0()`.

It should be noted that `Object.clone()` and `Object.hashCode()` are also virtual, native and @IntrinsicCandidate and these methods get special treatment by C2 to get the intrinsic generated more optimally. We might want to do a similar optimization for `Reference.refersTo0()`. In that case, it is suggested that such an improvement could come later and be handled as a separate enhancement, and @kimbarrett has already filed JDK-8272140 to track that.