### PR TITLE
8272131: PhaseMacroExpand::generate_slow_arraycopy crash when clone null CallProjections.fallthrough_ioproj

### DIFF
--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -1098,7 +1098,7 @@ MergeMemNode* PhaseMacroExpand::generate_slow_arraycopy(ArrayCopyNode *ac,
   transform_later(out_mem);
 
   // When src is negative and arraycopy is before an infinite loop,_callprojs.fallthrough_ioproj
-  // could be NULL. Not clone and update NULL fallthrough_ioproj.
+  // could be NULL. Skip clone and update NULL fallthrough_ioproj.
   if (_callprojs.fallthrough_ioproj != NULL) {
     *io = _callprojs.fallthrough_ioproj->clone();
     transform_later(*io);

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -831,7 +831,9 @@ Node* PhaseMacroExpand::generate_arraycopy(ArrayCopyNode *ac, AllocateArrayNode*
   }
 
   _igvn.replace_node(_callprojs.fallthrough_memproj, out_mem);
-  _igvn.replace_node(_callprojs.fallthrough_ioproj, *io);
+  if (_callprojs.fallthrough_ioproj != NULL) {
+    _igvn.replace_node(_callprojs.fallthrough_ioproj, *io);
+  }
   _igvn.replace_node(_callprojs.fallthrough_catchproj, *ctrl);
 
 #ifdef ASSERT
@@ -1095,8 +1097,14 @@ MergeMemNode* PhaseMacroExpand::generate_slow_arraycopy(ArrayCopyNode *ac,
   }
   transform_later(out_mem);
 
-  *io = _callprojs.fallthrough_ioproj->clone();
-  transform_later(*io);
+  // When src is negative and arraycopy is before an infinite loop,_callprojs.fallthrough_ioproj
+  // could be NULL. Not clone and update NULL fallthrough_ioproj.
+  if (_callprojs.fallthrough_ioproj != NULL) {
+    *io = _callprojs.fallthrough_ioproj->clone();
+    transform_later(*io);
+  } else {
+    *io = NULL;
+  }
 
   return out_mem;
 }
@@ -1333,7 +1341,9 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
     }
 
     _igvn.replace_node(_callprojs.fallthrough_memproj, merge_mem);
-    _igvn.replace_node(_callprojs.fallthrough_ioproj, io);
+    if (_callprojs.fallthrough_ioproj != NULL) {
+      _igvn.replace_node(_callprojs.fallthrough_ioproj, io);
+    }
     _igvn.replace_node(_callprojs.fallthrough_catchproj, ctrl);
     return;
   }

--- a/test/hotspot/jtreg/compiler/arraycopy/TestIllegalArrayCopyBeforeInfiniteLoop.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestIllegalArrayCopyBeforeInfiniteLoop.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8272131
  * @requires vm.compiler2.enabled
- * @summary ArrayCopy with negative index before infinit loop
+ * @summary ArrayCopy with negative index before infinite loop
  * @run main/othervm -Xbatch -XX:-TieredCompilation
  *                   -XX:CompileCommand=compileonly,"*TestIllegalArrayCopyBeforeInfiniteLoop::foo"
  *                   compiler.arraycopy.TestIllegalArrayCopyBeforeInfiniteLoop

--- a/test/hotspot/jtreg/compiler/arraycopy/TestIllegalArrayCopyBeforeInfiniteLoop.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestIllegalArrayCopyBeforeInfiniteLoop.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8272131
+ * @requires vm.compiler2.enabled
+ * @summary ArrayCopy with negative index before infinit loop
+ * @run main/othervm -Xbatch -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,"*TestIllegalArrayCopyBeforeInfiniteLoop::foo"
+ *                   compiler.arraycopy.TestIllegalArrayCopyBeforeInfiniteLoop
+ */
+
+package compiler.arraycopy;
+
+import java.util.Arrays;
+
+public class TestIllegalArrayCopyBeforeInfiniteLoop {
+    private static char src[] = new char[10];
+    private static int count = 0;
+    private static final int iter = 10_000;
+
+    public static void main(String[] args) throws Exception {
+        for (int i = 0; i < iter; ++i) {
+            foo();
+        }
+        if (count != iter) {
+            throw new RuntimeException("test failed");
+        }
+    }
+
+    static void foo() {
+        try {
+            Arrays.copyOfRange(src, -1, 128);
+            do {
+            } while (true);
+        } catch (ArrayIndexOutOfBoundsException ex) {
+            count++;
+        }
+    }
+}


### PR DESCRIPTION
This fix a crash in PhaseMacroExpand::generate_slow_arraycopy in following case, because arraycopy node's fallthrough_ioproj is NULL.
- arraycopy has ArrayIndexOutOfBoundsException exception
- arraycopy is before an infinite loop

Fix is not cloning and replacing fallthrough_ioproj when it is NULL.

```
    static void foo() {
        try {
            Arrays.copyOfRange(src, -1, 128);
            do {
            } while (true);
        } catch (ArrayIndexOutOfBoundsException ex) {
            count++;
        }
    }
```

New test is added.
Test: Linux X64 tier1/tier2/tier3 release/fastdebug passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272131](https://bugs.openjdk.java.net/browse/JDK-8272131): PhaseMacroExpand::generate_slow_arraycopy crash when clone null CallProjections.fallthrough_ioproj


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**) ⚠️ Review applies to 1c9ce9651850bf24408fcd1c9e7c0a2bb9927fd0
 * [Xin Liu](https://openjdk.java.net/census#xliu) (@navyxliu - Committer) ⚠️ Review applies to 1c9ce9651850bf24408fcd1c9e7c0a2bb9927fd0
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5054/head:pull/5054` \
`$ git checkout pull/5054`

Update a local copy of the PR: \
`$ git checkout pull/5054` \
`$ git pull https://git.openjdk.java.net/jdk pull/5054/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5054`

View PR using the GUI difftool: \
`$ git pr show -t 5054`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5054.diff">https://git.openjdk.java.net/jdk/pull/5054.diff</a>

</details>
