### PR TITLE
8231356: Fix broken ResourceObj::operator new[] in debug builds

### DIFF
--- a/src/hotspot/share/memory/allocation.cpp
+++ b/src/hotspot/share/memory/allocation.cpp
@@ -133,10 +133,6 @@ void* ResourceObj::operator new(size_t size, allocation_type type, MEMFLAGS flag
   return res;
 }
 
-void* ResourceObj::operator new [](size_t size, allocation_type type, MEMFLAGS flags) throw() {
-  return (address) operator new(size, type, flags);
-}
-
 void* ResourceObj::operator new(size_t size, const std::nothrow_t&  nothrow_constant,
     allocation_type type, MEMFLAGS flags) throw() {
   // should only call this with std::nothrow, use other operator new() otherwise
@@ -154,11 +150,6 @@ void* ResourceObj::operator new(size_t size, const std::nothrow_t&  nothrow_cons
     ShouldNotReachHere();
   }
   return res;
-}
-
-void* ResourceObj::operator new [](size_t size, const std::nothrow_t&  nothrow_constant,
-    allocation_type type, MEMFLAGS flags) throw() {
-  return (address)operator new(size, nothrow_constant, type, flags);
 }
 
 void ResourceObj::operator delete(void* p) {

--- a/src/hotspot/share/memory/allocation.cpp
+++ b/src/hotspot/share/memory/allocation.cpp
@@ -110,12 +110,6 @@ void* ResourceObj::operator new(size_t size, Arena *arena) throw() {
   return res;
 }
 
-void* ResourceObj::operator new [](size_t size, Arena *arena) throw() {
-  address res = (address)arena->Amalloc(size);
-  DEBUG_ONLY(set_allocation_type(res, ARENA);)
-  return res;
-}
-
 void* ResourceObj::operator new(size_t size, allocation_type type, MEMFLAGS flags) throw() {
   address res = NULL;
   switch (type) {
@@ -157,10 +151,6 @@ void ResourceObj::operator delete(void* p) {
          "delete only allowed for C_HEAP objects");
   DEBUG_ONLY(((ResourceObj *)p)->_allocation_t[0] = (uintptr_t)badHeapOopVal;)
   FreeHeap(p);
-}
-
-void ResourceObj::operator delete [](void* p) {
-  operator delete(p);
 }
 
 #ifdef ASSERT

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -426,10 +426,8 @@ protected:
       allocation_type type, MEMFLAGS flags) throw();
   void* operator new [](size_t size, const std::nothrow_t&  nothrow_constant,
       allocation_type type, MEMFLAGS flags) throw() = delete;
-
   void* operator new(size_t size, Arena *arena) throw();
-
-  void* operator new [](size_t size, Arena *arena) throw();
+  void* operator new [](size_t size, Arena *arena) throw() = delete;
 
   void* operator new(size_t size) throw() {
       address res = (address)resource_allocate_bytes(size);
@@ -443,20 +441,10 @@ protected:
       return res;
   }
 
-  void* operator new [](size_t size) throw() {
-      address res = (address)resource_allocate_bytes(size);
-      DEBUG_ONLY(set_allocation_type(res, RESOURCE_AREA);)
-      return res;
-  }
-
-  void* operator new [](size_t size, const std::nothrow_t& nothrow_constant) throw() {
-      address res = (address)resource_allocate_bytes(size, AllocFailStrategy::RETURN_NULL);
-      DEBUG_ONLY(if (res != NULL) set_allocation_type(res, RESOURCE_AREA);)
-      return res;
-  }
-
+  void* operator new [](size_t size) throw() = delete;
+  void* operator new [](size_t size, const std::nothrow_t& nothrow_constant) throw() = delete;
   void  operator delete(void* p);
-  void  operator delete [](void* p);
+  void  operator delete [](void* p) = delete;
 };
 
 // One of the following macros must be used when allocating an array

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -421,11 +421,11 @@ protected:
 
  public:
   void* operator new(size_t size, allocation_type type, MEMFLAGS flags) throw();
-  void* operator new [](size_t size, allocation_type type, MEMFLAGS flags) throw();
+  void* operator new [](size_t size, allocation_type type, MEMFLAGS flags) throw() = delete;
   void* operator new(size_t size, const std::nothrow_t&  nothrow_constant,
       allocation_type type, MEMFLAGS flags) throw();
   void* operator new [](size_t size, const std::nothrow_t&  nothrow_constant,
-      allocation_type type, MEMFLAGS flags) throw();
+      allocation_type type, MEMFLAGS flags) throw() = delete;
 
   void* operator new(size_t size, Arena *arena) throw();
 


### PR DESCRIPTION
ResourceObj::operator new[] calls ResourceObj::operator new (non array version). In debug builds, each resource object (on C_HEAP) will be initialized with set_allocation_type() (which is correct). What is not correct is that the constructor (and thus) set_allocation_type() is called on the array itself (which is not a ResourceObj). This initialization will be partially overwritten by the header that keeps track of the array size. When the array destructor later is called, it will also chain call the non-array destructor. In debug builds the verification of _allocation_t[0] will fail as it has been overwritten by the code that keeps track of the array size.

The following assert will fail:
assert(~(_allocation_t[0] | allocation_mask) == (uintptr_t)this, "lost resource object");

The reason that it has not been detected is that no one uses ResourceObj::operator new[] on resource objects with C_HEAP storage.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8231356](https://bugs.openjdk.java.net/browse/JDK-8231356): Fix broken ResourceObj::operator new[] in debug builds


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5055/head:pull/5055` \
`$ git checkout pull/5055`

Update a local copy of the PR: \
`$ git checkout pull/5055` \
`$ git pull https://git.openjdk.java.net/jdk pull/5055/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5055`

View PR using the GUI difftool: \
`$ git pr show -t 5055`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5055.diff">https://git.openjdk.java.net/jdk/pull/5055.diff</a>

</details>
