### PR TITLE
8272169: runtime/logging/LoaderConstraintsTest.java doesn't build test.Empty

### DIFF
--- a/test/hotspot/jtreg/runtime/logging/LoaderConstraintsTest.java
+++ b/test/hotspot/jtreg/runtime/logging/LoaderConstraintsTest.java
@@ -27,6 +27,7 @@
  * @bug 8149996
  * @modules java.base/jdk.internal.misc
  * @library /test/lib classes
+ * @build test.Empty
  * @run driver LoaderConstraintsTest
  */
 


### PR DESCRIPTION
Hi all,

could you please review this one-liner fix for `LoaderConstraintsTest` test?
from JBS:
> `runtime/logging/LoaderConstraintsTest.java` test doesn't build `test.Empty` and hence its child JVM fails w/ `CNFE`.

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272169](https://bugs.openjdk.java.net/browse/JDK-8272169): runtime/logging/LoaderConstraintsTest.java doesn't build test.Empty


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5059/head:pull/5059` \
`$ git checkout pull/5059`

Update a local copy of the PR: \
`$ git checkout pull/5059` \
`$ git pull https://git.openjdk.java.net/jdk pull/5059/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5059`

View PR using the GUI difftool: \
`$ git pr show -t 5059`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5059.diff">https://git.openjdk.java.net/jdk/pull/5059.diff</a>

</details>
