### PR TITLE
8272050: typo in MachSpillCopyNode::implementation after JDK-8131362

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -2161,7 +2161,7 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
                      as_FloatRegister(Matcher::_regEncode[src_lo]));
         }
       } else if (dst_lo_rc == rc_float) { // fpr --> fpr copy
-          if (cbuf) {
+        if (is64) {
             __ fmovd(as_FloatRegister(Matcher::_regEncode[dst_lo]),
                      as_FloatRegister(Matcher::_regEncode[src_lo]));
         } else {


### PR DESCRIPTION
After refactoring done by JDK-8131362, the fpr --> fpr case now checks "cbuf" instead of "is64" when it decides between fmovd and fmovs. But since this is register to register, it appears to be harmless.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272050](https://bugs.openjdk.java.net/browse/JDK-8272050): typo in MachSpillCopyNode::implementation after JDK-8131362


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5060/head:pull/5060` \
`$ git checkout pull/5060`

Update a local copy of the PR: \
`$ git checkout pull/5060` \
`$ git pull https://git.openjdk.java.net/jdk pull/5060/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5060`

View PR using the GUI difftool: \
`$ git pr show -t 5060`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5060.diff">https://git.openjdk.java.net/jdk/pull/5060.diff</a>

</details>
