### PR TITLE
8140241: (fc) Data transfer from FileChannel to itself causes hang in case of overlap

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -586,11 +586,13 @@ public class FileChannelImpl
             return IOStatus.UNSUPPORTED;
 
         if (target == this) {
-            long posTarget = ((FileChannel)target).position();
-            if (position() - count + 1 <= posTarget &&
-                posTarget - count + 1 <= position() &&
-                !nd.canTransferToFromOverlappedMap()) {
-                return IOStatus.UNSUPPORTED_CASE;
+            synchronized (positionLock) {
+                long posThis = position();
+                if (posThis - count + 1 <= position &&
+                    position - count + 1 <= posThis &&
+                    !nd.canTransferToFromOverlappedMap()) {
+                    return IOStatus.UNSUPPORTED_CASE;
+                }
             }
         }
 
@@ -686,7 +688,7 @@ public class FileChannelImpl
             return 0;
 
         if ((sz - position) < count)
-            count = (int)(sz - position);
+            count = sz - position;
 
         // Attempt a direct transfer, if the kernel supports it, limiting
         // the number of bytes according to which platform

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -587,8 +587,8 @@ public class FileChannelImpl
 
         if (target == this) {
             long posTarget = ((FileChannel)target).position();
-            if (posTarget + count - 1 >= position() &&
-                position() + count - 1 >= posTarget &&
+            if (position() - count + 1 <= posTarget &&
+                posTarget - count + 1 <= position() &&
                 !nd.canTransferToFromOverlappedMap()) {
                 return IOStatus.UNSUPPORTED_CASE;
             }
@@ -714,8 +714,8 @@ public class FileChannelImpl
             long max = Math.min(count, src.size() - pos);
 
             if (src == this) {
-                if (pos + max - 1 >= position() &&
-                    position() + max - 1 >= pos &&
+                if (position() - max + 1 <= pos &&
+                    pos - max + 1 <= position() &&
                     !nd.canTransferToFromOverlappedMap()) {
                     return IOStatus.UNSUPPORTED_CASE;
                 }
@@ -796,9 +796,10 @@ public class FileChannelImpl
             throw new IllegalArgumentException();
         if (position > size())
             return 0;
+
         if (src instanceof FileChannelImpl) {
             long n = transferFromFileChannel((FileChannelImpl)src, position, count);
-            if (n > 0)
+            if (n >= 0)
                 return n;
         }
 

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -586,13 +586,11 @@ public class FileChannelImpl
             return IOStatus.UNSUPPORTED;
 
         if (target == this) {
-            synchronized (positionLock) {
-                long posThis = position();
-                if (posThis - count + 1 <= position &&
-                    position - count + 1 <= posThis &&
-                    !nd.canTransferToFromOverlappedMap()) {
-                    return IOStatus.UNSUPPORTED_CASE;
-                }
+            long posThis = position();
+            if (posThis - count + 1 <= position &&
+                position - count + 1 <= posThis &&
+                !nd.canTransferToFromOverlappedMap()) {
+                return IOStatus.UNSUPPORTED_CASE;
             }
         }
 
@@ -799,8 +797,8 @@ public class FileChannelImpl
         if (position > size())
             return 0;
 
-        if (src instanceof FileChannelImpl) {
-            long n = transferFromFileChannel((FileChannelImpl)src, position, count);
+        if (src instanceof FileChannelImpl fci) {
+            long n = transferFromFileChannel(fci, position, count);
             if (n >= 0)
                 return n;
         }

--- a/src/java.base/share/classes/sun/nio/ch/FileDispatcher.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,6 +66,8 @@ abstract class FileDispatcher extends NativeDispatcher {
     abstract boolean canTransferToDirectly(SelectableChannel sc);
 
     abstract boolean transferToDirectlyNeedsPositionLock();
+
+    abstract boolean canTransferToFromOverlappedMap();
 
     abstract int setDirectIO(FileDescriptor fd, String path);
 }

--- a/src/java.base/unix/classes/sun/nio/ch/FileDispatcherImpl.java
+++ b/src/java.base/unix/classes/sun/nio/ch/FileDispatcherImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,6 +126,10 @@ class FileDispatcherImpl extends FileDispatcher {
         return false;
     }
 
+    boolean canTransferToFromOverlappedMap() {
+        return canTransferToFromOverlappedMap0();
+    }
+
     int setDirectIO(FileDescriptor fd, String path) {
         int result = -1;
         try {
@@ -183,6 +187,8 @@ class FileDispatcherImpl extends FileDispatcher {
     static native void dup0(FileDescriptor fd1, FileDescriptor fd2) throws IOException;
 
     static native void closeIntFD(int fd) throws IOException;
+
+    static native boolean canTransferToFromOverlappedMap0();
 
     static native int setDirect0(FileDescriptor fd) throws IOException;
 

--- a/src/java.base/unix/native/libnio/ch/FileDispatcherImpl.c
+++ b/src/java.base/unix/native/libnio/ch/FileDispatcherImpl.c
@@ -338,6 +338,16 @@ Java_sun_nio_ch_FileDispatcherImpl_closeIntFD(JNIEnv *env, jclass clazz, jint fd
     closeFileDescriptor(env, fd);
 }
 
+JNIEXPORT jboolean JNICALL
+Java_sun_nio_ch_FileDispatcherImpl_canTransferToFromOverlappedMap0(JNIEnv *env, jclass clazz)
+{
+#ifdef MACOSX
+    return JNI_FALSE;
+#else
+    return JNI_TRUE;
+#endif
+}
+
 JNIEXPORT jint JNICALL
 Java_sun_nio_ch_FileDispatcherImpl_setDirect0(JNIEnv *env, jclass clazz,
                                            jobject fdo)

--- a/src/java.base/windows/classes/sun/nio/ch/FileDispatcherImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/FileDispatcherImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,6 +122,10 @@ class FileDispatcherImpl extends FileDispatcher {
     }
 
     boolean transferToDirectlyNeedsPositionLock() {
+        return true;
+    }
+
+    boolean canTransferToFromOverlappedMap() {
         return true;
     }
 

--- a/test/jdk/java/nio/channels/FileChannel/TransferOverlappedFileChannel.java
+++ b/test/jdk/java/nio/channels/FileChannel/TransferOverlappedFileChannel.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8140241
+ * @summary Test transferring to and from same file channel
+ */
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.io.RandomAccessFile;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.util.Random;
+
+public class TransferOverlappedFileChannel {
+
+    private static File file;
+    private static FileChannel channel;
+
+    public static void main(String[] args) throws Exception {
+        file = File.createTempFile("readingin", null);
+        file.deleteOnExit();
+        generateBigFile(file);
+        RandomAccessFile raf = new RandomAccessFile(file, "rw");
+        channel = raf.getChannel();
+        transferToNoOverlap();
+        transferToOverlap();
+        transferFromNoOverlap();
+        transferFromOverlap();
+        channel.close();
+        file.delete();
+    }
+
+    private static void transferToNoOverlap() throws IOException {
+        final long length = file.length();
+
+        // position at three quarters
+        channel.position(length*3/4);
+        // copy last quarter to third quarter
+        // (copied and overwritten regions do NOT overlap)
+        // So: 1 2 3 4 -> 1 2 4 4
+        channel.transferTo(length / 2, length / 4, channel);
+        System.out.println("transferToNoOverlap: OK");
+    }
+
+    private static void transferToOverlap() throws IOException {
+        final long length = file.length();
+
+        // position at half
+        channel.position(length/2);
+        // copy last half to second quarter
+        // (copied and overwritten regions DO overlap)
+        // So: 1 2 3 4 -> 1 3 4 4
+        channel.transferTo(length / 4, length / 2, channel);
+        System.out.println("transferToOverlap: OK");
+    }
+
+    private static void transferFromNoOverlap() throws IOException {
+        final long length = file.length();
+
+        // position at three quarters
+        channel.position(length*3/4);
+        // copy last quarter to third quarter
+        // (copied and overwritten regions do NOT overlap)
+        // So: 1 2 3 4 -> 1 2 4 4
+        channel.transferFrom(channel, length / 2, length / 4);
+        System.out.println("transferFromNoOverlap: OK");
+    }
+
+    private static void transferFromOverlap() throws IOException {
+        final long length = file.length();
+
+        // position at half
+        channel.position(length/2);
+        // copy last half to second quarter
+        // (copied and overwritten regions DO overlap)
+        // So: 1 2 3 4 -> 1 3 4 4
+        channel.transferFrom(channel, length / 4, length / 2);
+        System.out.println("transferFromOverlap: OK");
+    }
+
+    static void generateBigFile(File file) throws Exception {
+        OutputStream out = new BufferedOutputStream(
+                new FileOutputStream(file));
+        byte[] randomBytes = new byte[1024];
+        Random rand = new Random(0);
+        rand.nextBytes(randomBytes);
+        for (int i = 0; i < 1024; i++) {
+            out.write(randomBytes);
+        }
+        out.flush();
+        out.close();
+    }
+}


### PR DESCRIPTION
This request proposes to fix a failure on macOS which occurs when transferring to or from a file channel from or to the same file channel when the source and destination intervals overlap.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8140241](https://bugs.openjdk.java.net/browse/JDK-8140241): (fc) Data transfer from FileChannel to itself causes hang in case of overlap


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5061/head:pull/5061` \
`$ git checkout pull/5061`

Update a local copy of the PR: \
`$ git checkout pull/5061` \
`$ git pull https://git.openjdk.java.net/jdk pull/5061/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5061`

View PR using the GUI difftool: \
`$ git pr show -t 5061`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5061.diff">https://git.openjdk.java.net/jdk/pull/5061.diff</a>

</details>
