### PR TITLE
8272168: some hotspot runtime/logging tests don't check exit code

### DIFF
--- a/test/hotspot/jtreg/runtime/logging/ClassInitializationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassInitializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,7 @@ public class ClassInitializationTest {
                                                                   "-Xmx128m",
                                                                   "BadMap50");
         OutputAnalyzer out = new OutputAnalyzer(pb.start());
+        out.shouldNotHaveExitValue(0);
         out.shouldContain("Start class verification for:");
         out.shouldContain("End class verification for:");
         out.shouldContain("Initializing");
@@ -69,6 +70,7 @@ public class ClassInitializationTest {
                                                    "-Xmx128m",
                                                    "BadMap50");
         out = new OutputAnalyzer(pb.start());
+        out.shouldNotHaveExitValue(0);
         out.shouldNotContain("[class,init]");
         out.shouldNotContain("Fail over class verification to old verifier for: BadMap50");
 

--- a/test/hotspot/jtreg/runtime/logging/ClassResolutionTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassResolutionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,14 +62,17 @@ public class ClassResolutionTest {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xlog:class+resolve=debug",
                                                                   ClassResolutionTestMain.class.getName());
         OutputAnalyzer o = new OutputAnalyzer(pb.start());
+        o.shouldHaveExitValue(0);
         o.shouldContain("[class,resolve] ClassResolutionTest$ClassResolutionTestMain$Thing1Handler ClassResolutionTest$ClassResolutionTestMain$Thing1");
         o.shouldContain("[class,resolve] resolve JVM_CONSTANT_MethodHandle");
+
 
         // (2) class+resolve should turn off.
         pb = ProcessTools.createJavaProcessBuilder("-Xlog:class+resolve=debug",
                                                    "-Xlog:class+resolve=off",
                                                    ClassResolutionTestMain.class.getName());
         o = new OutputAnalyzer(pb.start());
+        o.shouldHaveExitValue(0);
         o.shouldNotContain("[class,resolve]");
     };
 

--- a/test/hotspot/jtreg/runtime/logging/ClassResolutionTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassResolutionTest.java
@@ -66,7 +66,6 @@ public class ClassResolutionTest {
         o.shouldContain("[class,resolve] ClassResolutionTest$ClassResolutionTestMain$Thing1Handler ClassResolutionTest$ClassResolutionTestMain$Thing1");
         o.shouldContain("[class,resolve] resolve JVM_CONSTANT_MethodHandle");
 
-
         // (2) class+resolve should turn off.
         pb = ProcessTools.createJavaProcessBuilder("-Xlog:class+resolve=debug",
                                                    "-Xlog:class+resolve=off",

--- a/test/hotspot/jtreg/runtime/logging/CondyIndyTest.java
+++ b/test/hotspot/jtreg/runtime/logging/CondyIndyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,7 @@ public class CondyIndyTest {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xlog:methodhandles",
                                                                   "CondyIndy");
         OutputAnalyzer o = new OutputAnalyzer(pb.start());
+        o.shouldHaveExitValue(0);
         o.shouldContain("[info][methodhandles");
         o.shouldNotContain("[debug][methodhandles,indy");
         o.shouldNotContain("[debug][methodhandles,condy");
@@ -50,6 +51,7 @@ public class CondyIndyTest {
         pb = ProcessTools.createJavaProcessBuilder("-Xlog:methodhandles+condy=debug",
                                                    "CondyIndy");
         o = new OutputAnalyzer(pb.start());
+        o.shouldHaveExitValue(0);
         o.shouldNotContain("[info ][methodhandles");
         o.shouldNotContain("[debug][methodhandles,indy");
         o.shouldContain("[debug][methodhandles,condy");
@@ -58,6 +60,7 @@ public class CondyIndyTest {
         pb = ProcessTools.createJavaProcessBuilder("-Xlog:methodhandles+indy=debug",
                                                    "CondyIndy");
         o = new OutputAnalyzer(pb.start());
+        o.shouldHaveExitValue(0);
         o.shouldNotContain("[info ][methodhandles");
         o.shouldContain("[debug][methodhandles,indy");
         o.shouldNotContain("[debug][methodhandles,condy");
@@ -68,6 +71,7 @@ public class CondyIndyTest {
                                                    "-Xlog:methodhandles+indy=debug",
                                                    "CondyIndy");
         o = new OutputAnalyzer(pb.start());
+        o.shouldHaveExitValue(0);
         o.shouldContain("[info ][methodhandles");
         o.shouldContain("[debug][methodhandles,indy");
         o.shouldContain("[debug][methodhandles,condy");

--- a/test/hotspot/jtreg/runtime/logging/LoaderConstraintsTest.java
+++ b/test/hotspot/jtreg/runtime/logging/LoaderConstraintsTest.java
@@ -69,11 +69,13 @@ public class LoaderConstraintsTest {
         // -Xlog:class+loader+constraints=info
         pb = exec("-Xlog:class+loader+constraints=info");
         out = new OutputAnalyzer(pb.start());
+        out.shouldHaveExitValue(0);
         out.shouldContain("[class,loader,constraints] adding new constraint for name: java/lang/Class, loader[0]: 'app', loader[1]: 'bootstrap'");
 
         // -Xlog:class+loader+constraints=off
         pb = exec("-Xlog:class+loader+constraints=off");
         out = new OutputAnalyzer(pb.start());
+        out.shouldHaveExitValue(0);
         out.shouldNotContain("[class,loader,constraints]");
 
     }

--- a/test/hotspot/jtreg/runtime/logging/MonitorMismatchTest.java
+++ b/test/hotspot/jtreg/runtime/logging/MonitorMismatchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,7 @@ public class MonitorMismatchTest {
                                                                   "-Xlog:monitormismatch=info",
                                                                   "MonitorMismatchHelper");
         OutputAnalyzer o = new OutputAnalyzer(pb.start());
+        o.shouldHaveExitValue(0);
         o.shouldContain("[monitormismatch] Monitor mismatch in method");
 
         // monitormismatch should turn off.
@@ -52,6 +53,7 @@ public class MonitorMismatchTest {
                                                    "-Xlog:monitormismatch=off",
                                                    "MonitorMismatchHelper");
         o = new OutputAnalyzer(pb.start());
+        o.shouldHaveExitValue(0);
         o.shouldNotContain("[monitormismatch]");
     };
 


### PR DESCRIPTION
Hi all,

could you please review the patch that adds a check of exit code in five runtime/logging tests?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272168](https://bugs.openjdk.java.net/browse/JDK-8272168): some hotspot runtime/logging tests don't check exit code


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5062/head:pull/5062` \
`$ git checkout pull/5062`

Update a local copy of the PR: \
`$ git checkout pull/5062` \
`$ git pull https://git.openjdk.java.net/jdk pull/5062/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5062`

View PR using the GUI difftool: \
`$ git pr show -t 5062`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5062.diff">https://git.openjdk.java.net/jdk/pull/5062.diff</a>

</details>
