### PR TITLE
8272120: Avoid looking for standard encodings in "java." modules

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
@@ -55,6 +55,8 @@ import sun.security.x509.PKIXExtensions;
 import sun.security.x509.URIName;
 import sun.security.x509.X509CertImpl;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * This is a class that checks the revocation status of a certificate(s) using
  * OCSP. It is not a PKIXCertPathChecker and therefore can be used outside of
@@ -176,7 +178,7 @@ public final class OCSP {
         try {
             String encodedGetReq = responderURI.toString() + "/" +
                     URLEncoder.encode(Base64.getEncoder().encodeToString(bytes),
-                            "UTF-8");
+                                      UTF_8);
 
             if (encodedGetReq.length() <= 255) {
                 url = new URL(encodedGetReq);

--- a/src/java.management/share/classes/com/sun/jmx/remote/security/HashedPasswordManager.java
+++ b/src/java.management/share/classes/com/sun/jmx/remote/security/HashedPasswordManager.java
@@ -30,8 +30,6 @@ import java.io.*;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.channels.FileLock;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -40,6 +38,8 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * HashedPasswordManager loads passwords from the password file and optionally
@@ -139,7 +139,7 @@ final public class HashedPasswordManager {
             MessageDigest digest = MessageDigest.getInstance(algorithm);
             digest.reset();
             digest.update(salt);
-            byte[] hash = digest.digest(password.getBytes(StandardCharsets.UTF_8));
+            byte[] hash = digest.digest(password.getBytes(UTF_8));
             String saltStr = Base64.getEncoder().encodeToString(salt);
             String hashStr = Base64.getEncoder().encodeToString(hash);
 
@@ -167,7 +167,7 @@ final public class HashedPasswordManager {
                 }
                 lock.release();
             }
-            String str = new String(data, StandardCharsets.UTF_8);
+            String str = new String(data, UTF_8);
             return str.split("\\r?\\n");
         }
     }
@@ -175,7 +175,7 @@ final public class HashedPasswordManager {
     private void writePasswordFile(String input) throws IOException {
         synchronized (HashedPasswordManager.class) {
             try (FileOutputStream fout = new FileOutputStream(passwordFile);
-                    OutputStreamWriter out = new OutputStreamWriter(fout, StandardCharsets.UTF_8);
+                    OutputStreamWriter out = new OutputStreamWriter(fout, UTF_8);
                     FileLock lock = fout.getChannel().lock()) {
                 out.write(input);
                 lock.release();
@@ -199,7 +199,7 @@ final public class HashedPasswordManager {
                 MessageDigest digest = MessageDigest.getInstance(us.hashAlgorithm);
                 digest.reset();
                 digest.update(salt);
-                ByteBuffer byteBuffer = Charset.forName("UTF-8").encode(CharBuffer.wrap(inputPassword));
+                ByteBuffer byteBuffer = UTF_8.encode(CharBuffer.wrap(inputPassword));
                 byte[] passwordBytes = new byte[byteBuffer.limit()];
                 byteBuffer.get(passwordBytes);
                 byte[] hash = digest.digest(passwordBytes);

--- a/src/java.management/share/classes/javax/management/loading/MLetParser.java
+++ b/src/java.management/share/classes/javax/management/loading/MLetParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package javax.management.loading;
 
 import static com.sun.jmx.defaults.JmxProperties.MLET_LOGGER;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -164,7 +165,7 @@ class MLetParser {
 
         conn = url.openConnection();
         Reader in = new BufferedReader(new InputStreamReader(conn.getInputStream(),
-                                                             "UTF-8"));
+                                                             UTF_8));
 
         // The original URL may have been redirected - this
         // sets it to whatever URL/codebase we ended up getting

--- a/src/java.management/share/classes/sun/management/counter/perf/PerfDataEntry.java
+++ b/src/java.management/share/classes/sun/management/counter/perf/PerfDataEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,8 @@ package sun.management.counter.perf;
 
 import sun.management.counter.*;
 import java.nio.*;
-import java.io.UnsupportedEncodingException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 class PerfDataEntry {
     private class EntryFieldOffset {
@@ -127,14 +128,7 @@ class PerfDataEntry {
         }
 
         // convert name into a String
-        try {
-            name = new String(symbolBytes, "UTF-8");
-        }
-        catch (UnsupportedEncodingException e) {
-            // should not reach here
-            // "UTF-8" is always a known encoding
-            throw new InternalError(e.getMessage(), e);
-        }
+        name = new String(symbolBytes, UTF_8);
 
         if (variability == Variability.INVALID) {
             throw new InstrumentationException("Invalid variability attribute:" +

--- a/src/java.management/share/classes/sun/management/counter/perf/PerfDataType.java
+++ b/src/java.management/share/classes/sun/management/counter/perf/PerfDataType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 
 package sun.management.counter.perf;
 
-import java.io.UnsupportedEncodingException;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * A typesafe enumeration for the data types supported for
@@ -88,12 +88,7 @@ class PerfDataType {
     private PerfDataType(String name, String c, int size) {
         this.name = name;
         this.size = size;
-        try {
-            byte[] b = c.getBytes("UTF-8");
-            this.value = b[0];
-        } catch (UnsupportedEncodingException e) {
-            // ignore, "UTF-8" is always a known encoding
-            throw new InternalError("Unknown encoding", e);
-        }
+        byte[] b = c.getBytes(UTF_8);
+        this.value = b[0];
     }
 }

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/Ber.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/Ber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@ import java.io.ByteArrayInputStream;
 
 import sun.security.util.HexDumpEncoder;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
   * Base class that defines common fields, constants, and debug method.
   *
@@ -50,7 +52,7 @@ public abstract class Ber {
 
         try {
             outStream.write('\n');
-            outStream.write(tag.getBytes("UTF8"));
+            outStream.write(tag.getBytes(UTF_8));
 
             new HexDumpEncoder().encodeBuffer(
                 new ByteArrayInputStream(bytes, from, to),
@@ -60,7 +62,7 @@ public abstract class Ber {
         } catch (IOException e) {
             try {
                 outStream.write(
-                    "Ber.dumpBER(): error encountered\n".getBytes("UTF8"));
+                    "Ber.dumpBER(): error encountered\n".getBytes(UTF_8));
             } catch (IOException e2) {
                 // ignore
             }

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/BerDecoder.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/BerDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,8 @@
 
 package com.sun.jndi.ldap;
 
-import java.io.UnsupportedEncodingException;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
   * A BER decoder. Contains methods to parse a BER buffer.
@@ -266,17 +267,9 @@ public final class BerDecoder extends Ber {
 
             System.arraycopy(buf, offset, buf2, 0, len);
             if (decodeUTF8) {
-                try {
-                    retstr = new String(buf2, "UTF8");
-                } catch (UnsupportedEncodingException e) {
-                    throw new DecodeException("UTF8 not available on platform");
-                }
+                retstr = new String(buf2, UTF_8);
             } else {
-                try {
-                    retstr = new String(buf2, "8859_1");
-                } catch (UnsupportedEncodingException e) {
-                    throw new DecodeException("8859_1 not available on platform");
-                }
+                retstr = new String(buf2, ISO_8859_1);
             }
             offset += len;
         }

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/BerEncoder.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/BerEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,8 @@
 
 package com.sun.jndi.ldap;
 
-import java.io.UnsupportedEncodingException;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
   * A BER encoder.
@@ -316,19 +317,11 @@ public final class BerEncoder extends Ber {
         if (str == null) {
             count = 0;
         } else if (encodeUTF8) {
-            try {
-                bytes = str.getBytes("UTF8");
-                count = bytes.length;
-            } catch (UnsupportedEncodingException e) {
-                throw new EncodeException("UTF8 not available on platform");
-            }
+            bytes = str.getBytes(UTF_8);
+            count = bytes.length;
         } else {
-            try {
-                bytes = str.getBytes("8859_1");
-                count = bytes.length;
-            } catch (UnsupportedEncodingException e) {
-                throw new EncodeException("8859_1 not available on platform");
-            }
+            bytes = str.getBytes(ISO_8859_1);
+            count = bytes.length;
         }
 
         encodeLength(count);

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/Filter.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/Filter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,9 @@ import javax.naming.directory.InvalidSearchFilterException;
 
 import java.io.IOException;
 
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * LDAP (RFC-1960) and LDAPv3 (RFC-2254) search filters.
  *
@@ -59,9 +62,9 @@ final class Filter {
         byte[] filter;
         int filterLen;
         if (isLdapv3) {
-            filter = filterStr.getBytes("UTF8");
+            filter = filterStr.getBytes(UTF_8);
         } else {
-            filter = filterStr.getBytes("8859_1");
+            filter = filterStr.getBytes(ISO_8859_1);
         }
         filterLen = filter.length;
         if (dbg) {

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapClient.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,9 @@ import com.sun.jndi.ldap.pool.PooledConnection;
 import com.sun.jndi.ldap.pool.PoolCallback;
 import com.sun.jndi.ldap.sasl.LdapSasl;
 import com.sun.jndi.ldap.sasl.SaslInputStream;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * LDAP (RFC-1777) and LDAPv3 (RFC-2251) compliant client
@@ -421,9 +424,9 @@ public final class LdapClient implements PooledConnection {
 
         if (pw instanceof String) {
             if (v3) {
-                return ((String)pw).getBytes("UTF8");
+                return ((String)pw).getBytes(UTF_8);
             } else {
-                return ((String)pw).getBytes("8859_1");
+                return ((String)pw).getBytes(ISO_8859_1);
             }
         } else {
             return (byte[])pw;
@@ -1153,7 +1156,7 @@ public final class LdapClient implements PooledConnection {
 
                         // replace any escaped characters in the value
                         byte[] val = isLdapv3 ?
-                            value.getBytes("UTF8") : value.getBytes("8859_1");
+                            value.getBytes(UTF_8) : value.getBytes(ISO_8859_1);
                         ber.encodeOctetString(
                             Filter.unescapeFilterValue(val, 0, val.length),
                             Ber.ASN_OCTET_STR);

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapName.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import javax.naming.directory.Attributes;
 import javax.naming.directory.Attribute;
 import javax.naming.directory.BasicAttributes;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * <code>LdapName</code> implements compound names for LDAP v3 as
@@ -900,11 +901,7 @@ public final class LdapName implements Name {
                         // Convert hex-encoded UTF-8 to 16-bit chars.
                         byte[] utf8 = getUtf8Octets(chars, i, end);
                         if (utf8.length > 0) {
-                            try {
-                                buf.append(new String(utf8, "UTF8"));
-                            } catch (java.io.UnsupportedEncodingException e) {
-                                // shouldn't happen
-                            }
+                            buf.append(new String(utf8, UTF_8));
                             i += utf8.length * 3 - 1;
                         } else {
                             throw new IllegalArgumentException(

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/sasl/DefaultCallbackHandler.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/sasl/DefaultCallbackHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@ import javax.security.auth.callback.*;
 import javax.security.sasl.RealmCallback;
 import javax.security.sasl.RealmChoiceCallback;
 import java.io.IOException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * DefaultCallbackHandler for satisfying NameCallback and
@@ -60,7 +62,7 @@ final class DefaultCallbackHandler implements CallbackHandler {
             passwd = ((char[])cred).clone();
         } else if (cred != null) {
             // assume UTF-8 encoding
-            String orig = new String((byte[])cred, "UTF8");
+            String orig = new String((byte[])cred, UTF_8);
             passwd = orig.toCharArray();
         }
     }

--- a/src/java.naming/share/classes/javax/naming/ldap/Rdn.java
+++ b/src/java.naming/share/classes/javax/naming/ldap/Rdn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,8 @@ import java.io.Serializable;
 import java.io.ObjectOutputStream;
 import java.io.ObjectInputStream;
 import java.io.IOException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * This class represents a relative distinguished name, or RDN, which is a
@@ -643,11 +645,7 @@ public class Rdn implements Serializable, Comparable<Object> {
                         // Convert hex-encoded UTF-8 to 16-bit chars.
                         byte[] utf8 = getUtf8Octets(chars, i, end);
                         if (utf8.length > 0) {
-                            try {
-                                builder.append(new String(utf8, "UTF8"));
-                            } catch (java.io.UnsupportedEncodingException e) {
-                                // shouldn't happen
-                            }
+                            builder.append(new String(utf8, UTF_8));
                             i += utf8.length * 3 - 1;
                         } else { // no utf8 bytes available, invalid DN
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/ResponseContent.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ResponseContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import java.net.http.HttpResponse;
 import jdk.internal.net.http.common.Logger;
 import jdk.internal.net.http.common.Utils;
 import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Implements chunked/fixed transfer encodings of HTTP/1.1 responses.
@@ -159,7 +160,7 @@ class ResponseContent {
             printable.get(bytes, 0, bytes.length);
             String msg = "============== accepted ==================\n";
             try {
-                var str = new String(bytes, "UTF-8");
+                var str = new String(bytes, UTF_8);
                 msg += str;
             } catch (Exception x) {
                 msg += x;

--- a/src/java.xml/share/classes/javax/xml/catalog/Normalizer.java
+++ b/src/java.xml/share/classes/javax/xml/catalog/Normalizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,10 @@
  */
 package javax.xml.catalog;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * The Normalizer is responsible for normalizing Public and System Identifiers
@@ -93,13 +94,9 @@ class Normalizer {
     static String encodeURN(String publicId) {
         String urn = normalizePublicId(publicId);
 
-        try {
-            urn = URLEncoder.encode(urn, "UTF-8");
-            urn = urn.replace("::", ";");
-            urn = urn.replace("//", ":");
-        } catch (UnsupportedEncodingException ex) {
-            CatalogMessages.reportRunTimeError(CatalogMessages.ERR_OTHER, ex);
-        }
+        urn = URLEncoder.encode(urn, UTF_8);
+        urn = urn.replace("::", ";");
+        urn = urn.replace("//", ":");
         return Util.URN + urn;
     }
 
@@ -119,13 +116,9 @@ class Normalizer {
         } else {
             return urn;
         }
-        try {
-            publicId = publicId.replace(":", "//");
-            publicId = publicId.replace(";", "::");
-            publicId = URLDecoder.decode(publicId, "UTF-8");
-        } catch (UnsupportedEncodingException ex) {
-            CatalogMessages.reportRunTimeError(CatalogMessages.ERR_OTHER, ex);
-        }
+        publicId = publicId.replace(":", "//");
+        publicId = publicId.replace(";", "::");
+        publicId = URLDecoder.decode(publicId, UTF_8);
 
         return publicId;
     }
@@ -141,14 +134,8 @@ class Normalizer {
             return null;
         }
 
-        byte[] bytes;
         uriref = uriref.trim();
-        try {
-            bytes = uriref.getBytes("UTF-8");
-        } catch (UnsupportedEncodingException uee) {
-            // this can't happen
-            return uriref;
-        }
+        byte[] bytes = uriref.getBytes(UTF_8);
 
         StringBuilder newRef = new StringBuilder(bytes.length);
         for (int count = 0; count < bytes.length; count++) {


### PR DESCRIPTION
This is the continuation of JDK-8233884 and JDK-8271456. This change affects fewer cases so I fix all "java." modules at once.

In many places standard charsets are looked up via their names, for example:
absolutePath.getBytes("UTF-8");

This could be done more efficiently(up to x20 time faster) with use of java.nio.charset.StandardCharsets:
absolutePath.getBytes(StandardCharsets.UTF_8);

The later variant also makes the code cleaner, as it is known not to throw UnsupportedEncodingException in contrary to the former variant.

tested by the tier1/tier2/tier3 tests on Linux/Windows/macOS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272120](https://bugs.openjdk.java.net/browse/JDK-8272120): Avoid looking for standard encodings in "java." modules


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5063/head:pull/5063` \
`$ git checkout pull/5063`

Update a local copy of the PR: \
`$ git checkout pull/5063` \
`$ git pull https://git.openjdk.java.net/jdk pull/5063/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5063`

View PR using the GUI difftool: \
`$ git pr show -t 5063`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5063.diff">https://git.openjdk.java.net/jdk/pull/5063.diff</a>

</details>
