### PR TITLE
8272196: Remove unused class ParStrongRootsScope

### DIFF
--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -784,14 +784,6 @@ void ParallelScavengeHeap::resize_old_gen(size_t desired_free_space) {
   _old_gen->resize(desired_free_space);
 }
 
-ParallelScavengeHeap::ParStrongRootsScope::ParStrongRootsScope() {
-  // nothing particular
-}
-
-ParallelScavengeHeap::ParStrongRootsScope::~ParStrongRootsScope() {
-  // nothing particular
-}
-
 #ifndef PRODUCT
 void ParallelScavengeHeap::record_gen_tops_before_GC() {
   if (ZapUnusedHeapArea) {

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
@@ -247,13 +247,6 @@ class ParallelScavengeHeap : public CollectedHeap {
   // Mangle the unused parts of all spaces in the heap
   void gen_mangle_unused_area() PRODUCT_RETURN;
 
-  // Call these in sequential code around the processing of strong roots.
-  class ParStrongRootsScope : public MarkScope {
-   public:
-    ParStrongRootsScope();
-    ~ParStrongRootsScope();
-  };
-
   GCMemoryManager* old_gc_manager() const { return _old_manager; }
   GCMemoryManager* young_gc_manager() const { return _young_manager; }
 


### PR DESCRIPTION
Trivial change of removing an unused class definition.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272196](https://bugs.openjdk.java.net/browse/JDK-8272196): Remove unused class ParStrongRootsScope


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5064/head:pull/5064` \
`$ git checkout pull/5064`

Update a local copy of the PR: \
`$ git checkout pull/5064` \
`$ git pull https://git.openjdk.java.net/jdk pull/5064/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5064`

View PR using the GUI difftool: \
`$ git pr show -t 5064`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5064.diff">https://git.openjdk.java.net/jdk/pull/5064.diff</a>

</details>
