### PR TITLE
8272216: G1: replace G1ParScanThreadState::_dest with a constant

### DIFF
--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -351,6 +351,8 @@ HeapWord* G1ParScanThreadState::allocate_in_next_plab(G1HeapRegionAttr* dest,
 }
 
 G1HeapRegionAttr G1ParScanThreadState::next_region_attr(G1HeapRegionAttr const region_attr, markWord const m, uint& age) {
+  assert(region_attr.is_young() || region_attr.is_old(), "must be either Young or Old");
+
   if (region_attr.is_young()) {
     age = !m.has_displaced_mark_helper() ? m.age()
                                          : m.displaced_mark_helper().age();
@@ -358,7 +360,6 @@ G1HeapRegionAttr G1ParScanThreadState::next_region_attr(G1HeapRegionAttr const r
       return region_attr;
     }
   }
-  assert(region_attr.is_young() || region_attr.is_old(), "must be either Young or Old");
   // young-to-old (promotion) or old-to-old; destination is old in both cases.
   return G1HeapRegionAttr::Old;
 }

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -94,11 +94,6 @@ G1ParScanThreadState::G1ParScanThreadState(G1CollectedHeap* g1h,
 
   _plab_allocator = new G1PLABAllocator(_g1h->allocator());
 
-  // The dest for Young is used when the objects are aged enough to
-  // need to be moved to the next space.
-  _dest[G1HeapRegionAttr::Young] = G1HeapRegionAttr::Old;
-  _dest[G1HeapRegionAttr::Old]   = G1HeapRegionAttr::Old;
-
   _closures = G1EvacuationRootClosures::create_root_closures(this, _g1h);
 
   _oops_into_optional_regions = new G1OopStarChunkedList[_num_optional_regions];
@@ -363,7 +358,9 @@ G1HeapRegionAttr G1ParScanThreadState::next_region_attr(G1HeapRegionAttr const r
       return region_attr;
     }
   }
-  return dest(region_attr);
+  assert(region_attr.is_young() || region_attr.is_old(), "must be either Young or Old");
+  // young-to-old (promotion) or old-to-old; destination is old in both cases.
+  return G1HeapRegionAttr::Old;
 }
 
 void G1ParScanThreadState::report_promotion_event(G1HeapRegionAttr const dest_attr,

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
@@ -55,7 +55,6 @@ class G1ParScanThreadState : public CHeapObj<mtGC> {
   G1PLABAllocator* _plab_allocator;
 
   AgeTable _age_table;
-  G1HeapRegionAttr _dest[G1HeapRegionAttr::Num];
   // Local tenuring threshold.
   uint _tenuring_threshold;
   G1ScanEvacuatedObjClosure  _scanner;
@@ -87,14 +86,6 @@ class G1ParScanThreadState : public CHeapObj<mtGC> {
   StringDedup::Requests _string_dedup_requests;
 
   G1CardTable* ct() { return _ct; }
-
-  G1HeapRegionAttr dest(G1HeapRegionAttr original) const {
-    assert(original.is_valid(),
-           "Original region attr invalid: %s", original.get_type_str());
-    assert(_dest[original.type()].is_valid_gen(),
-           "Dest region attr is invalid: %s", _dest[original.type()].get_type_str());
-    return _dest[original.type()];
-  }
 
   size_t _num_optional_regions;
   G1OopStarChunkedList* _oops_into_optional_regions;


### PR DESCRIPTION
Simple change of removing an array with statically-known identical elements.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272216](https://bugs.openjdk.java.net/browse/JDK-8272216): G1: replace G1ParScanThreadState::_dest with a constant


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to a134b43260579bf7c9735d10ca24e7821d5daa9d
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5065/head:pull/5065` \
`$ git checkout pull/5065`

Update a local copy of the PR: \
`$ git checkout pull/5065` \
`$ git pull https://git.openjdk.java.net/jdk pull/5065/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5065`

View PR using the GUI difftool: \
`$ git pr show -t 5065`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5065.diff">https://git.openjdk.java.net/jdk/pull/5065.diff</a>

</details>
