### PR TITLE
8272161: Make evacuation failure data structures local to collection

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2999,7 +2999,8 @@ public:
 
 class G1PreservedMarksSet : public PreservedMarksSet {
 public:
-  G1PreservedMarksSet(uint num_workers) : PreservedMarksSet(false /* in_c_heap */) {
+
+  G1PreservedMarksSet(uint num_workers) : PreservedMarksSet(true /* in_c_heap */) {
     init(num_workers);
   }
 

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -24,7 +24,6 @@
 
 #include "precompiled.hpp"
 #include "gc/g1/g1Allocator.inline.hpp"
-#include "gc/g1/g1BarrierSet.inline.hpp"
 #include "gc/g1/g1CollectedHeap.inline.hpp"
 #include "gc/g1/g1CollectionSet.hpp"
 #include "gc/g1/g1OopClosures.inline.hpp"

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "gc/g1/g1Allocator.inline.hpp"
+#include "gc/g1/g1BarrierSet.inline.hpp"
 #include "gc/g1/g1CollectedHeap.inline.hpp"
 #include "gc/g1/g1CollectionSet.hpp"
 #include "gc/g1/g1OopClosures.inline.hpp"
@@ -32,6 +33,7 @@
 #include "gc/g1/g1StringDedup.hpp"
 #include "gc/g1/g1Trace.hpp"
 #include "gc/shared/partialArrayTaskStepper.inline.hpp"
+#include "gc/shared/preservedMarks.inline.hpp"
 #include "gc/shared/stringdedup/stringDedup.hpp"
 #include "gc/shared/taskqueue.inline.hpp"
 #include "memory/allocation.inline.hpp"
@@ -52,6 +54,7 @@
 
 G1ParScanThreadState::G1ParScanThreadState(G1CollectedHeap* g1h,
                                            G1RedirtyCardsQueueSet* rdcqs,
+                                           PreservedMarks* preserved_marks,
                                            uint worker_id,
                                            uint n_workers,
                                            size_t young_cset_length,
@@ -79,7 +82,9 @@ G1ParScanThreadState::G1ParScanThreadState(G1CollectedHeap* g1h,
     _string_dedup_requests(),
     _num_optional_regions(optional_cset_length),
     _numa(g1h->numa()),
-    _obj_alloc_stat(NULL)
+    _obj_alloc_stat(NULL),
+    _preserved_marks(preserved_marks),
+    _evacuation_failed_info()
 {
   // We allocate number of young gen regions in the collection set plus one
   // entries, since entry 0 keeps track of surviving bytes for non-young regions.
@@ -112,6 +117,10 @@ size_t G1ParScanThreadState::flush(size_t* surviving_young_words) {
   // Update allocation statistics.
   _plab_allocator->flush_and_retire_stats();
   _g1h->policy()->record_age_table(&_age_table);
+
+  if (_evacuation_failed_info.has_failed()) {
+     _g1h->gc_tracer_stw()->report_evacuation_failed(_evacuation_failed_info);
+  }
 
   size_t sum = 0;
   for (uint i = 0; i < _surviving_words_length; i++) {
@@ -371,12 +380,12 @@ void G1ParScanThreadState::report_promotion_event(G1HeapRegionAttr const dest_at
                                                   HeapWord * const obj_ptr, uint node_index) const {
   PLAB* alloc_buf = _plab_allocator->alloc_buffer(dest_attr, node_index);
   if (alloc_buf->contains(obj_ptr)) {
-    _g1h->_gc_tracer_stw->report_promotion_in_new_plab_event(old->klass(), word_sz * HeapWordSize, age,
-                                                             dest_attr.type() == G1HeapRegionAttr::Old,
-                                                             alloc_buf->word_sz() * HeapWordSize);
+    _g1h->gc_tracer_stw()->report_promotion_in_new_plab_event(old->klass(), word_sz * HeapWordSize, age,
+                                                              dest_attr.type() == G1HeapRegionAttr::Old,
+                                                              alloc_buf->word_sz() * HeapWordSize);
   } else {
-    _g1h->_gc_tracer_stw->report_promotion_outside_plab_event(old->klass(), word_sz * HeapWordSize, age,
-                                                              dest_attr.type() == G1HeapRegionAttr::Old);
+    _g1h->gc_tracer_stw()->report_promotion_outside_plab_event(old->klass(), word_sz * HeapWordSize, age,
+                                                               dest_attr.type() == G1HeapRegionAttr::Old);
   }
 }
 
@@ -403,7 +412,7 @@ HeapWord* G1ParScanThreadState::allocate_copy_slow(G1HeapRegionAttr* dest_attr,
   }
   if (obj_ptr != NULL) {
     update_numa_stats(node_index);
-    if (_g1h->_gc_tracer_stw->should_report_promotion_events()) {
+    if (_g1h->gc_tracer_stw()->should_report_promotion_events()) {
       // The events are checked individually as part of the actual commit
       report_promotion_event(*dest_attr, old, word_sz, age, obj_ptr, node_index);
     }
@@ -447,7 +456,7 @@ oop G1ParScanThreadState::do_copy_to_survivor_space(G1HeapRegionAttr const regio
     if (obj_ptr == NULL) {
       // This will either forward-to-self, or detect that someone else has
       // installed a forwarding pointer.
-      return handle_evacuation_failure_par(old, old_mark);
+      return handle_evacuation_failure_par(old, old_mark, word_sz);
     }
   }
 
@@ -460,7 +469,7 @@ oop G1ParScanThreadState::do_copy_to_survivor_space(G1HeapRegionAttr const regio
     // Doing this after all the allocation attempts also tests the
     // undo_allocation() method too.
     undo_allocation(dest_attr, obj_ptr, word_sz, node_index);
-    return handle_evacuation_failure_par(old, old_mark);
+    return handle_evacuation_failure_par(old, old_mark, word_sz);
   }
 #endif // !PRODUCT
 
@@ -543,7 +552,8 @@ G1ParScanThreadState* G1ParScanThreadStateSet::state_for_worker(uint worker_id) 
   assert(worker_id < _n_workers, "out of bounds access");
   if (_states[worker_id] == NULL) {
     _states[worker_id] =
-      new G1ParScanThreadState(_g1h, _rdcqs,
+      new G1ParScanThreadState(_g1h, rdcqs(),
+                               _preserved_marks_set->get(worker_id),
                                worker_id, _n_workers,
                                _young_cset_length, _optional_cset_length);
   }
@@ -597,7 +607,7 @@ void G1ParScanThreadStateSet::record_unused_optional_region(HeapRegion* hr) {
 }
 
 NOINLINE
-oop G1ParScanThreadState::handle_evacuation_failure_par(oop old, markWord m) {
+oop G1ParScanThreadState::handle_evacuation_failure_par(oop old, markWord m, size_t word_sz) {
   assert(_g1h->is_in_cset(old), "Object " PTR_FORMAT " should be in the CSet", p2i(old));
 
   oop forward_ptr = old->forward_to_atomic(old, m, memory_order_relaxed);
@@ -609,7 +619,8 @@ oop G1ParScanThreadState::handle_evacuation_failure_par(oop old, markWord m) {
       _g1h->hr_printer()->evac_failure(r);
     }
 
-    _g1h->preserve_mark_during_evac_failure(_worker_id, old, m);
+    _preserved_marks->push_if_necessary(old, m);
+    _evacuation_failed_info.register_copy_failure(word_sz);
 
     G1ScanInYoungSetter x(&_scanner, r->is_young());
     old->oop_iterate_backwards(&_scanner);
@@ -655,11 +666,13 @@ void G1ParScanThreadState::update_numa_stats(uint node_index) {
 
 G1ParScanThreadStateSet::G1ParScanThreadStateSet(G1CollectedHeap* g1h,
                                                  G1RedirtyCardsQueueSet* rdcqs,
+                                                 PreservedMarksSet* preserved_marks_set,
                                                  uint n_workers,
                                                  size_t young_cset_length,
                                                  size_t optional_cset_length) :
     _g1h(g1h),
     _rdcqs(rdcqs),
+    _preserved_marks_set(preserved_marks_set),
     _states(NEW_C_HEAP_ARRAY(G1ParScanThreadState*, n_workers, mtGC)),
     _surviving_young_words_total(NEW_C_HEAP_ARRAY(size_t, young_cset_length + 1, mtGC)),
     _young_cset_length(young_cset_length),

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
@@ -32,6 +32,7 @@
 #include "gc/g1/g1RemSet.hpp"
 #include "gc/g1/heapRegionRemSet.inline.hpp"
 #include "gc/shared/ageTable.hpp"
+#include "gc/shared/copyFailedInfo.hpp"
 #include "gc/shared/partialArrayTaskStepper.hpp"
 #include "gc/shared/stringdedup/stringDedup.hpp"
 #include "gc/shared/taskqueue.hpp"
@@ -43,6 +44,8 @@ class G1OopStarChunkedList;
 class G1PLABAllocator;
 class G1EvacuationRootClosures;
 class HeapRegion;
+class PreservedMarks;
+class PreservedMarksSet;
 class outputStream;
 
 class G1ParScanThreadState : public CHeapObj<mtGC> {
@@ -100,15 +103,21 @@ class G1ParScanThreadState : public CHeapObj<mtGC> {
   G1OopStarChunkedList* _oops_into_optional_regions;
 
   G1NUMA* _numa;
-
   // Records how many object allocations happened at each node during copy to survivor.
   // Only starts recording when log of gc+heap+numa is enabled and its data is
   // transferred when flushed.
   size_t* _obj_alloc_stat;
 
+  // Per-thread evacuation failure data structures.
+  PreservedMarks* _preserved_marks;
+  EvacuationFailedInfo _evacuation_failed_info;
+
+  void handle_evacuation_failure_notifications(oop obj, markWord m, size_t word_sz);
+
 public:
   G1ParScanThreadState(G1CollectedHeap* g1h,
                        G1RedirtyCardsQueueSet* rdcqs,
+                       PreservedMarks* preserved_marks,
                        uint worker_id,
                        uint n_workers,
                        size_t young_cset_length,
@@ -222,7 +231,7 @@ public:
   void reset_trim_ticks();
 
   // An attempt to evacuate "obj" has failed; take necessary steps.
-  oop handle_evacuation_failure_par(oop obj, markWord m);
+  oop handle_evacuation_failure_par(oop obj, markWord m, size_t word_sz);
 
   template <typename T>
   inline void remember_root_into_optional_region(T* p);
@@ -235,6 +244,7 @@ public:
 class G1ParScanThreadStateSet : public StackObj {
   G1CollectedHeap* _g1h;
   G1RedirtyCardsQueueSet* _rdcqs;
+  PreservedMarksSet* _preserved_marks_set;
   G1ParScanThreadState** _states;
   size_t* _surviving_young_words_total;
   size_t _young_cset_length;
@@ -245,10 +255,14 @@ class G1ParScanThreadStateSet : public StackObj {
  public:
   G1ParScanThreadStateSet(G1CollectedHeap* g1h,
                           G1RedirtyCardsQueueSet* rdcqs,
+                          PreservedMarksSet* preserved_marks_set,
                           uint n_workers,
                           size_t young_cset_length,
                           size_t optional_cset_length);
   ~G1ParScanThreadStateSet();
+
+  G1RedirtyCardsQueueSet* rdcqs() { return _rdcqs; }
+  PreservedMarksSet* preserved_marks_set() { return _preserved_marks_set; }
 
   void flush();
   void record_unused_optional_region(HeapRegion* hr);

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.hpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.hpp
@@ -48,8 +48,7 @@ class G1PostEvacuateCollectionSetCleanupTask1 : public G1BatchedGangTask {
   class RemoveSelfForwardPtrsTask;
 
 public:
-  G1PostEvacuateCollectionSetCleanupTask1(G1ParScanThreadStateSet* per_thread_states,
-                                          G1RedirtyCardsQueueSet* rdcqs);
+  G1PostEvacuateCollectionSetCleanupTask1(G1ParScanThreadStateSet* per_thread_states);
 };
 
 class G1PostEvacuateCollectionSetCleanupTask1::MergePssTask : public G1AbstractSubTask {
@@ -114,10 +113,8 @@ class G1PostEvacuateCollectionSetCleanupTask2 : public G1BatchedGangTask {
   class FreeCollectionSetTask;
 
 public:
-  G1PostEvacuateCollectionSetCleanupTask2(PreservedMarksSet* preserved_marks_set,
-                                          G1RedirtyCardsQueueSet* rdcqs,
-                                          G1EvacuationInfo* evacuation_info,
-                                          const size_t* surviving_young_words);
+  G1PostEvacuateCollectionSetCleanupTask2(G1ParScanThreadStateSet* per_thread_states,
+                                          G1EvacuationInfo* evacuation_info);
 };
 
 class G1PostEvacuateCollectionSetCleanupTask2::ResetHotCardCacheTask : public G1AbstractSubTask {


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that moves some evacuation (failure) related data structures into the per-thread evacuation context (`G1ParThreadScanState`) which removes some young collection related code from G1CollectedHeap?

Testing: tier1-5

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272161](https://bugs.openjdk.java.net/browse/JDK-8272161): Make evacuation failure data structures local to collection


### Reviewers
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5066/head:pull/5066` \
`$ git checkout pull/5066`

Update a local copy of the PR: \
`$ git checkout pull/5066` \
`$ git pull https://git.openjdk.java.net/jdk pull/5066/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5066`

View PR using the GUI difftool: \
`$ git pr show -t 5066`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5066.diff">https://git.openjdk.java.net/jdk/pull/5066.diff</a>

</details>
