### PR TITLE
8267833: Improve G1CardSetInlinePtr::add()

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
@@ -63,6 +63,9 @@ class G1CardSetInlinePtr : public StackObj {
     uint result = ((uintptr_t)value >> card_pos) & (((uintptr_t)1 << bits_per_card) - 1);
     return result;
   }
+
+  uint find(uint const card_idx, uint const bits_per_card, uint start_at, uint end_at);
+
 public:
   G1CardSetInlinePtr() : _value_addr(nullptr), _value((CardSetPtr)G1CardSet::CardSetInlinePtr) { }
 

--- a/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
@@ -64,7 +64,7 @@ class G1CardSetInlinePtr : public StackObj {
     return result;
   }
 
-  uint find(uint const card_idx, uint const bits_per_card, uint start_at, uint end_at);
+  uint find(uint const card_idx, uint const bits_per_card, uint start_at, uint num_elems);
 
 public:
   G1CardSetInlinePtr() : _value_addr(nullptr), _value((CardSetPtr)G1CardSet::CardSetInlinePtr) { }

--- a/src/hotspot/share/gc/g1/g1CardSetContainers.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.inline.hpp
@@ -77,10 +77,11 @@ inline G1AddCardResult G1CardSetInlinePtr::add(uint card_idx, uint bits_per_card
 }
 
 inline uint G1CardSetInlinePtr::find(uint card_idx, uint bits_per_card, uint start_at, uint end_at) {
-  uintptr_t const card_mask = (1 << bits_per_card) - 1;
-
-  uintptr_t value = ((uintptr_t)_value) >> card_pos_for(start_at, bits_per_card);
   assert(start_at < end_at, "Precondition! %d < %d", start_at, end_at);
+
+  uintptr_t const card_mask = (1 << bits_per_card) - 1;
+  uintptr_t value = ((uintptr_t)_value) >> card_pos_for(start_at, bits_per_card);
+
   // Check if the card is already stored in the pointer.
   for (uint cur_idx = start_at; cur_idx < end_at; cur_idx++) {
     if ((value & card_mask) == card_idx) {

--- a/src/hotspot/share/gc/g1/g1CardSetContainers.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.inline.hpp
@@ -76,25 +76,25 @@ inline G1AddCardResult G1CardSetInlinePtr::add(uint card_idx, uint bits_per_card
   }
 }
 
-inline uint G1CardSetInlinePtr::find(uint card_idx, uint bits_per_card, uint start_at, uint end_at) {
-  assert(start_at < end_at, "Precondition!");
+inline uint G1CardSetInlinePtr::find(uint card_idx, uint bits_per_card, uint start_at, uint num_elems) {
+  assert(start_at < num_elems, "Precondition!");
 
   uintptr_t const card_mask = (1 << bits_per_card) - 1;
   uintptr_t value = ((uintptr_t)_value) >> card_pos_for(start_at, bits_per_card);
 
   // Check if the card is already stored in the pointer.
-  for (uint cur_idx = start_at; cur_idx < end_at; cur_idx++) {
+  for (uint cur_idx = start_at; cur_idx < num_elems; cur_idx++) {
     if ((value & card_mask) == card_idx) {
       return cur_idx;
     }
     value >>= bits_per_card;
   }
-  return end_at;
+  return num_elems;
 }
 
 inline bool G1CardSetInlinePtr::contains(uint card_idx, uint bits_per_card) {
   uint num_elems = num_cards_in(_value);
-  if(num_elems == 0) {
+  if (num_elems == 0) {
     return false;
   }
   uint cur_idx = find(card_idx, bits_per_card, 0, num_elems);

--- a/src/hotspot/share/gc/g1/g1CardSetContainers.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.inline.hpp
@@ -77,7 +77,7 @@ inline G1AddCardResult G1CardSetInlinePtr::add(uint card_idx, uint bits_per_card
 }
 
 inline uint G1CardSetInlinePtr::find(uint card_idx, uint bits_per_card, uint start_at, uint end_at) {
-  assert(start_at < end_at, "Precondition! %d < %d", start_at, end_at);
+  assert(start_at < end_at, "Precondition!");
 
   uintptr_t const card_mask = (1 << bits_per_card) - 1;
   uintptr_t value = ((uintptr_t)_value) >> card_pos_for(start_at, bits_per_card);

--- a/src/hotspot/share/gc/g1/g1CardSetContainers.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.inline.hpp
@@ -47,10 +47,14 @@ inline G1CardSetInlinePtr::CardSetPtr G1CardSetInlinePtr::merge(CardSetPtr orig_
 inline G1AddCardResult G1CardSetInlinePtr::add(uint card_idx, uint bits_per_card, uint max_cards_in_inline_ptr) {
   assert(_value_addr != nullptr, "No value address available, cannot add to set.");
 
+  uint cur_idx = 0;
   while (true) {
     uint num_elems = num_cards_in(_value);
+    if (num_elems > 0) {
+      cur_idx = find(card_idx, bits_per_card, cur_idx, num_elems);
+    }
     // Check if the card is already stored in the pointer.
-    if (contains(card_idx, bits_per_card)) {
+    if (cur_idx < num_elems) {
       return Found;
     }
     // Check if there is actually enough space.
@@ -72,19 +76,26 @@ inline G1AddCardResult G1CardSetInlinePtr::add(uint card_idx, uint bits_per_card
   }
 }
 
-inline bool G1CardSetInlinePtr::contains(uint card_idx, uint bits_per_card) {
-  uint num_elems = num_cards_in(_value);
+inline uint G1CardSetInlinePtr::find(uint card_idx, uint bits_per_card, uint start_at, uint end_at) {
   uintptr_t const card_mask = (1 << bits_per_card) - 1;
 
-  uintptr_t value = ((uintptr_t)_value) >> card_pos_for(0, bits_per_card);
+  uintptr_t value = ((uintptr_t)_value) >> card_pos_for(start_at, bits_per_card);
+  assert(start_at < end_at, "Precondition! %d < %d", start_at, end_at);
   // Check if the card is already stored in the pointer.
-  for (uint cur_idx = 0; cur_idx < num_elems; cur_idx++) {
+  for (uint cur_idx = start_at; cur_idx < end_at; cur_idx++) {
     if ((value & card_mask) == card_idx) {
-      return true;
+      return cur_idx;
     }
     value >>= bits_per_card;
   }
-  return false;
+  return end_at;
+}
+
+inline bool G1CardSetInlinePtr::contains(uint card_idx, uint bits_per_card) {
+  uint num_elems = num_cards_in(_value);
+  assert(num_elems > 0, "Precondition!");
+  uint cur_idx = find(card_idx, bits_per_card, 0, num_elems);
+  return cur_idx < num_elems;
 }
 
 template <class CardVisitor>

--- a/src/hotspot/share/gc/g1/g1CardSetContainers.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.inline.hpp
@@ -93,7 +93,9 @@ inline uint G1CardSetInlinePtr::find(uint card_idx, uint bits_per_card, uint sta
 
 inline bool G1CardSetInlinePtr::contains(uint card_idx, uint bits_per_card) {
   uint num_elems = num_cards_in(_value);
-  assert(num_elems > 0, "Precondition!");
+  if(num_elems == 0) {
+    return false;
+  }
   uint cur_idx = find(card_idx, bits_per_card, 0, num_elems);
   return cur_idx < num_elems;
 }


### PR DESCRIPTION
Hi all,

Please review this cleanup change to reduce the number of comparisons made when adding entries to an inline pointer cardset container. We allow the find to restart from a previously known index.

Testing: Tier 1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267833](https://bugs.openjdk.java.net/browse/JDK-8267833): Improve G1CardSetInlinePtr::add()


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to e271088aa218475ebd93b52846fcee30d403f792
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5067/head:pull/5067` \
`$ git checkout pull/5067`

Update a local copy of the PR: \
`$ git checkout pull/5067` \
`$ git pull https://git.openjdk.java.net/jdk pull/5067/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5067`

View PR using the GUI difftool: \
`$ git pr show -t 5067`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5067.diff">https://git.openjdk.java.net/jdk/pull/5067.diff</a>

</details>
