### PR TITLE
8272107: Removal of Unsafe::defineAnonymousClass left a dangling C++ class

### DIFF
--- a/src/hotspot/share/memory/iterator.hpp
+++ b/src/hotspot/share/memory/iterator.hpp
@@ -341,11 +341,6 @@ public:
 class SymbolClosure : public StackObj {
  public:
   virtual void do_symbol(Symbol**) = 0;
-
-  static Symbol* load_symbol(Symbol** p) {
-    return *p;
-  }
-
 };
 
 template <typename E>

--- a/src/hotspot/share/memory/iterator.hpp
+++ b/src/hotspot/share/memory/iterator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -342,16 +342,10 @@ class SymbolClosure : public StackObj {
  public:
   virtual void do_symbol(Symbol**) = 0;
 
-  // Clear LSB in symbol address; it can be set by CPSlot.
   static Symbol* load_symbol(Symbol** p) {
-    return (Symbol*)(intptr_t(*p) & ~1);
+    return *p;
   }
 
-  // Store symbol, adjusting new pointer if the original pointer was adjusted
-  // (symbol references in constant pool slots have their LSB set to 1).
-  static void store_symbol(Symbol** p, Symbol* sym) {
-    *p = (Symbol*)(intptr_t(sym) | (intptr_t(*p) & 1));
-  }
 };
 
 template <typename E>

--- a/src/hotspot/share/memory/metaspaceClosure.hpp
+++ b/src/hotspot/share/memory/metaspaceClosure.hpp
@@ -128,8 +128,8 @@ public:
     virtual ~Ref() {}
 
     address obj() const {
-      // In some rare cases (see CPSlot in constantPool.hpp) we store some flags in the lowest
-      // 2 bits of a MetaspaceObj pointer. Unmask these when manipulating the pointer.
+      // In some rare cases we store some flags in the lowest 2 bits of a
+      // MetaspaceObj pointer. Unmask these when manipulating the pointer.
       uintx p = (uintx)*mpp();
       return (address)(p & (~FLAG_MASK));
     }

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -2390,8 +2390,11 @@ void ConstantPool::verify_on(outputStream* st) {
     constantTag tag = tag_at(i);
     if (tag.is_klass() || tag.is_unresolved_klass()) {
       guarantee(klass_name_at(i)->refcount() != 0, "should have nonzero reference count");
-    } else if (tag.is_symbol() || tag.is_string()) {
-      Symbol* entry = slot_at(i);
+    } else if (tag.is_symbol()) {
+      Symbol* entry = symbol_at(i);
+      guarantee(entry->refcount() != 0, "should have nonzero reference count");
+    } else if (tag.is_string()) {
+      Symbol* entry = unresolved_string_at(i);
       guarantee(entry->refcount() != 0, "should have nonzero reference count");
     }
   }

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -2390,12 +2390,9 @@ void ConstantPool::verify_on(outputStream* st) {
     constantTag tag = tag_at(i);
     if (tag.is_klass() || tag.is_unresolved_klass()) {
       guarantee(klass_name_at(i)->refcount() != 0, "should have nonzero reference count");
-    } else if (tag.is_symbol()) {
-      CPSlot entry = slot_at(i);
-      guarantee(entry.get_symbol()->refcount() != 0, "should have nonzero reference count");
-    } else if (tag.is_string()) {
-      CPSlot entry = slot_at(i);
-      guarantee(entry.get_symbol()->refcount() != 0, "should have nonzero reference count");
+    } else if (tag.is_symbol() || tag.is_string()) {
+      Symbol* entry = slot_at(i);
+      guarantee(entry->refcount() != 0, "should have nonzero reference count");
     }
   }
   if (pool_holder() != NULL) {

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -319,10 +319,11 @@ class ConstantPool : public Metadata {
     *int_at_addr(which) = ((jint) name_and_type_index<<16) | bsms_attribute_index;
   }
 
-  // Note that release_tag_at_put is not needed here because this is called only when
-  // constructing a ConstantPool in a single thread, with no possibility of concurrent access.
   void unresolved_string_at_put(int which, Symbol* s) {
     assert(s->refcount() != 0, "should have nonzero refcount");
+    // Note that release_tag_at_put is not needed here because this is called only
+    // when constructing a ConstantPool in a single thread, with no possibility
+    // of concurrent access.
     tag_at_put(which, JVM_CONSTANT_String);
     *symbol_at_addr(which) = s;
   }

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -49,22 +49,6 @@
 
 class SymbolHashMap;
 
-class CPSlot {
- friend class ConstantPool;
-  intptr_t _ptr;
-  enum TagBits  {_pseudo_bit = 1};
- public:
-
-  CPSlot(intptr_t ptr): _ptr(ptr) {}
-  CPSlot(Symbol* ptr, int tag_bits = 0): _ptr((intptr_t)ptr | tag_bits) {}
-
-  intptr_t value()   { return _ptr; }
-
-  Symbol* get_symbol() {
-    return (Symbol*)(_ptr & ~_pseudo_bit);
-  }
-};
-
 // This represents a JVM_CONSTANT_Class, JVM_CONSTANT_UnresolvedClass, or
 // JVM_CONSTANT_UnresolvedClassInError slot in the constant pool.
 class CPKlassSlot {
@@ -152,12 +136,12 @@ class ConstantPool : public Metadata {
  private:
   intptr_t* base() const { return (intptr_t*) (((char*) this) + sizeof(ConstantPool)); }
 
-  CPSlot slot_at(int which) const;
+  Symbol* slot_at(int which) const;
 
-  void slot_at_put(int which, CPSlot s) const {
+  void slot_at_put(int which, Symbol* s) const {
     assert(is_within_bounds(which), "index out of bounds");
-    assert(s.value() != 0, "Caught something");
-    *(intptr_t*)&base()[which] = s.value();
+    assert(s != 0, "Caught something");
+    *(intptr_t*)&base()[which] = (intptr_t)s;
   }
   intptr_t* obj_at_addr(int which) const {
     assert(is_within_bounds(which), "index out of bounds");
@@ -344,7 +328,7 @@ class ConstantPool : public Metadata {
 
   void unresolved_string_at_put(int which, Symbol* s) {
     release_tag_at_put(which, JVM_CONSTANT_String);
-    slot_at_put(which, CPSlot(s));
+    slot_at_put(which, s);
   }
 
   void int_at_put(int which, jint i) {
@@ -497,7 +481,7 @@ class ConstantPool : public Metadata {
 
   Symbol* unresolved_string_at(int which) {
     assert(tag_at(which).is_string(), "Corrupted constant pool");
-    Symbol* sym = slot_at(which).get_symbol();
+    Symbol* sym = slot_at(which);
     return sym;
   }
 

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -319,6 +319,8 @@ class ConstantPool : public Metadata {
     *int_at_addr(which) = ((jint) name_and_type_index<<16) | bsms_attribute_index;
   }
 
+  // Note that release_tag_at_put is not needed here because this is called only when
+  // constructing a ConstantPool in a single thread, with no possibility of concurrent access.
   void unresolved_string_at_put(int which, Symbol* s) {
     assert(s->refcount() != 0, "should have nonzero refcount");
     tag_at_put(which, JVM_CONSTANT_String);

--- a/src/hotspot/share/oops/constantPool.inline.hpp
+++ b/src/hotspot/share/oops/constantPool.inline.hpp
@@ -30,15 +30,6 @@
 #include "oops/cpCache.inline.hpp"
 #include "runtime/atomic.hpp"
 
-inline Symbol* ConstantPool::slot_at(int which) const {
-  assert(is_within_bounds(which), "index out of bounds");
-  assert(!tag_at(which).is_unresolved_klass() && !tag_at(which).is_unresolved_klass_in_error(), "Corrupted constant pool");
-  // Uses volatile because the klass slot changes without a lock.
-  intptr_t adr = Atomic::load_acquire(obj_at_addr(which));
-  assert(adr != 0 || which == 0, "cp entry for klass should not be zero");
-  return (Symbol*)adr;
-}
-
 inline Klass* ConstantPool::resolved_klass_at(int which) const {  // Used by Compiler
   guarantee(tag_at(which).is_klass(), "Corrupted constant pool");
   // Must do an acquire here in case another thread resolved the klass

--- a/src/hotspot/share/oops/constantPool.inline.hpp
+++ b/src/hotspot/share/oops/constantPool.inline.hpp
@@ -30,13 +30,13 @@
 #include "oops/cpCache.inline.hpp"
 #include "runtime/atomic.hpp"
 
-inline CPSlot ConstantPool::slot_at(int which) const {
+inline Symbol* ConstantPool::slot_at(int which) const {
   assert(is_within_bounds(which), "index out of bounds");
   assert(!tag_at(which).is_unresolved_klass() && !tag_at(which).is_unresolved_klass_in_error(), "Corrupted constant pool");
   // Uses volatile because the klass slot changes without a lock.
   intptr_t adr = Atomic::load_acquire(obj_at_addr(which));
   assert(adr != 0 || which == 0, "cp entry for klass should not be zero");
-  return CPSlot(adr);
+  return (Symbol*)adr;
 }
 
 inline Klass* ConstantPool::resolved_klass_at(int which) const {  // Used by Compiler

--- a/src/hotspot/share/oops/symbol.hpp
+++ b/src/hotspot/share/oops/symbol.hpp
@@ -46,7 +46,7 @@
 // in the SymbolTable bucket (the _literal field in HashtableEntry)
 // that points to the Symbol.  All other stores of a Symbol*
 // to a field of a persistent variable (e.g., the _name filed in
-// fieldDescriptor or _ptr in a CPSlot) is reference counted.
+// fieldDescriptor or symbol in a constant pool) is reference counted.
 //
 // 1) The lookup of a "name" in the SymbolTable either creates a Symbol F for
 // "name" and returns a pointer to F or finds a pre-existing Symbol F for

--- a/src/hotspot/share/oops/symbol.hpp
+++ b/src/hotspot/share/oops/symbol.hpp
@@ -45,7 +45,7 @@
 // saved in persistent storage.  This does not include the pointer
 // in the SymbolTable bucket (the _literal field in HashtableEntry)
 // that points to the Symbol.  All other stores of a Symbol*
-// to a field of a persistent variable (e.g., the _name filed in
+// to a field of a persistent variable (e.g., the _name field in
 // fieldDescriptor or symbol in a constant pool) is reference counted.
 //
 // 1) The lookup of a "name" in the SymbolTable either creates a Symbol F for

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -1305,7 +1305,7 @@ class SymbolTableDumper : public SymbolClosure {
 
 void SymbolTableDumper::do_symbol(Symbol** p) {
   ResourceMark rm;
-  Symbol* sym = load_symbol(p);
+  Symbol* sym = *p;
   int len = sym->utf8_length();
   if (len > 0) {
     char* s = sym->as_utf8();


### PR DESCRIPTION
Please review this change to remove the now unused CPSlot class.  Uses of CPSlot have been replaced with Symbol*.  The change was tested by running JCK lang and VM tests, Mach5 tiers 1-2 on Linux, Mac OS, and WIndows and Macn5 tiers 3-5 on Linux x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272107](https://bugs.openjdk.java.net/browse/JDK-8272107): Removal of Unsafe::defineAnonymousClass left a dangling C++ class


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to 324677d2ffe4f4b04fd26c906a43db0f73f1fbd5
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to 42afa81102dafd6fcc6dbcf8fd2486d49920208f
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 42afa81102dafd6fcc6dbcf8fd2486d49920208f


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5070/head:pull/5070` \
`$ git checkout pull/5070`

Update a local copy of the PR: \
`$ git checkout pull/5070` \
`$ git pull https://git.openjdk.java.net/jdk pull/5070/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5070`

View PR using the GUI difftool: \
`$ git pr show -t 5070`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5070.diff">https://git.openjdk.java.net/jdk/pull/5070.diff</a>

</details>
