### PR TITLE
8271490: [ppc] [s390]: Crash in JavaThread::pd_get_top_frame_for_profiling

### DIFF
--- a/src/hotspot/cpu/ppc/frame_ppc.cpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.cpp
@@ -52,7 +52,6 @@ void RegisterMap::check_location_valid() {
 #endif // ASSERT
 
 bool frame::safe_for_sender(JavaThread *thread) {
-  bool safe = false;
   address sp = (address)_sp;
   address fp = (address)_fp;
   address unextended_sp = (address)_unextended_sp;
@@ -70,28 +69,23 @@ bool frame::safe_for_sender(JavaThread *thread) {
 
   // An fp must be within the stack and above (but not equal) sp.
   bool fp_safe = thread->is_in_stack_range_excl(fp, sp);
-  // An interpreter fp must be within the stack and above (but not equal) sp.
-  // Moreover, it must be at least the size of the ijava_state structure.
+  // An interpreter fp must be fp_safe.
+  // Moreover, it must be at a distance at least the size of the ijava_state structure.
   bool fp_interp_safe = fp_safe && ((fp - sp) >= ijava_state_size);
 
   // We know sp/unextended_sp are safe, only fp is questionable here
 
   // If the current frame is known to the code cache then we can attempt to
-  // to construct the sender and do some validation of it. This goes a long way
+  // construct the sender and do some validation of it. This goes a long way
   // toward eliminating issues when we get in frame construction code
 
   if (_cb != NULL ){
-    // Entry frame checks
-    if (is_entry_frame()) {
-      // An entry frame must have a valid fp.
-      return fp_safe && is_entry_frame_valid(thread);
-    }
 
-    // Now check if the frame is complete and the test is
-    // reliable. Unfortunately we can only check frame completeness for
-    // runtime stubs and nmethods. Other generic buffer blobs are more
-    // problematic so we just assume they are OK. Adapter blobs never have a
-    // complete frame and are never OK
+    // First check if the frame is complete and the test is reliable.
+    // Unfortunately we can only check frame completeness for runtime stubs
+    // and nmethods. Other generic buffer blobs are more problematic
+    // so we just assume they are OK.
+    // Adapter blobs never have a complete frame and are never OK
     if (!_cb->is_frame_complete_at(_pc)) {
       if (_cb->is_compiled() || _cb->is_adapter_blob() || _cb->is_runtime_stub()) {
         return false;
@@ -103,7 +97,20 @@ bool frame::safe_for_sender(JavaThread *thread) {
       return false;
     }
 
+    // Entry frame checks
+    if (is_entry_frame()) {
+      // An entry frame must have a valid fp.
+      return fp_safe && is_entry_frame_valid(thread);
+    }
+
     if (is_interpreted_frame() && !fp_interp_safe) {
+      return false;
+    }
+
+    // At this point, there still is a chance that fp_safe is false.
+    // In particular, (fp == NULL) might be true. So let's check and
+    // bail out before we actually dereference from fp.
+    if (!fp_safe) {
       return false;
     }
 

--- a/src/hotspot/cpu/s390/frame_s390.cpp
+++ b/src/hotspot/cpu/s390/frame_s390.cpp
@@ -55,7 +55,6 @@ void RegisterMap::check_location_valid() {
 // Profiling/safepoint support
 
 bool frame::safe_for_sender(JavaThread *thread) {
-  bool safe = false;
   address sp = (address)_sp;
   address fp = (address)_fp;
   address unextended_sp = (address)_unextended_sp;
@@ -73,28 +72,23 @@ bool frame::safe_for_sender(JavaThread *thread) {
 
   // An fp must be within the stack and above (but not equal) sp.
   bool fp_safe = thread->is_in_stack_range_excl(fp, sp);
-  // An interpreter fp must be within the stack and above (but not equal) sp.
-  // Moreover, it must be at least the size of the z_ijava_state structure.
+  // An interpreter fp must be fp_safe.
+  // Moreover, it must be at a distance at least the size of the z_ijava_state structure.
   bool fp_interp_safe = fp_safe && ((fp - sp) >= z_ijava_state_size);
 
   // We know sp/unextended_sp are safe, only fp is questionable here
 
   // If the current frame is known to the code cache then we can attempt to
-  // to construct the sender and do some validation of it. This goes a long way
+  // construct the sender and do some validation of it. This goes a long way
   // toward eliminating issues when we get in frame construction code
 
   if (_cb != NULL ) {
-    // Entry frame checks
-    if (is_entry_frame()) {
-      // An entry frame must have a valid fp.
-      return fp_safe && is_entry_frame_valid(thread);
-    }
 
-    // Now check if the frame is complete and the test is
-    // reliable. Unfortunately we can only check frame completeness for
-    // runtime stubs. Other generic buffer blobs are more
-    // problematic so we just assume they are OK. Adapter blobs never have a
-    // complete frame and are never OK. nmethods should be OK on s390.
+    // First check if the frame is complete and the test is reliable.
+    // Unfortunately we can only check frame completeness for runtime stubs.
+    // Other generic buffer blobs are more problematic so we just assume they are OK.
+    // Adapter blobs never have a complete frame and are never OK.
+    // nmethods should be OK on s390.
     if (!_cb->is_frame_complete_at(_pc)) {
       if (_cb->is_adapter_blob() || _cb->is_runtime_stub()) {
         return false;
@@ -106,13 +100,26 @@ bool frame::safe_for_sender(JavaThread *thread) {
       return false;
     }
 
+    // Entry frame checks
+    if (is_entry_frame()) {
+      // An entry frame must have a valid fp.
+      return fp_safe && is_entry_frame_valid(thread);
+    }
+
     if (is_interpreted_frame() && !fp_interp_safe) {
+      return false;
+    }
+
+    // At this point, there still is a chance that fp_safe is false.
+    // In particular, (fp == NULL) might be true. So let's check and
+    // bail out before we actually dereference from fp.
+    if (!fp_safe) {
       return false;
     }
 
     z_abi_160* sender_abi = (z_abi_160*) fp;
     intptr_t* sender_sp = (intptr_t*) sender_abi->callers_sp;
-    address   sender_pc = (address) sender_abi->return_pc;
+    address   sender_pc = (address)   sender_abi->return_pc;
 
     // We must always be able to find a recognizable pc.
     CodeBlob* sender_blob = CodeCache::find_blob_unsafe(sender_pc);


### PR DESCRIPTION
Please review this pull request. It hardens the code on ppc and s390 against crashes while collecting stack traces for JFR. Stack frame collection in prims/forte.cpp will benefit from this fix as well as it uses the same platform-specific code.

Testing:
SAP-internal functional and stress testing. Verifying a positive effect is hard because the targeted crashes occur only very rarely. No negative side effects of the fix have been observed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271490](https://bugs.openjdk.java.net/browse/JDK-8271490): [ppc] [s390]: Crash in JavaThread::pd_get_top_frame_for_profiling


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Matthias Baesken](https://openjdk.java.net/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5071/head:pull/5071` \
`$ git checkout pull/5071`

Update a local copy of the PR: \
`$ git checkout pull/5071` \
`$ git pull https://git.openjdk.java.net/jdk pull/5071/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5071`

View PR using the GUI difftool: \
`$ git pr show -t 5071`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5071.diff">https://git.openjdk.java.net/jdk/pull/5071.diff</a>

</details>
