### PR TITLE
8272231 G1: Refactor G1CardSet::get_card_set to return G1CardSetHashTableValue*

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.cpp
@@ -192,7 +192,7 @@ class G1CardSetHashTable : public CHeapObj<mtGCCardSet> {
   };
 
   class G1CardSetHashTableFound : public StackObj {
-    G1CardSetHashTableValue* _value;
+    G1CardSetHashTableValue* _value = nullptr;
   public:
     void operator()(G1CardSetHashTableValue* value) {
       _value = value;
@@ -247,14 +247,12 @@ public:
     return found.value();
   }
 
-  CardSetPtr get(uint region_idx) {
+  G1CardSetHashTableValue* get(uint region_idx) {
     G1CardSetHashTableLookUp lookup(region_idx);
     G1CardSetHashTableFound found;
 
-    if (_table.get(Thread::current(), lookup, found)) {
-      return found.value()->_card_set;
-    }
-    return nullptr;
+    _table.get(Thread::current(), lookup, found);
+    return found.value();
   }
 
   void iterate_safepoint(G1CardSet::G1CardSetPtrIterator* cl2) {
@@ -611,8 +609,7 @@ void G1CardSet::transfer_cards_in_howl(CardSetPtr parent_card_set,
     G1CardSetHowl* howling_array = card_set_ptr<G1CardSetHowl>(parent_card_set);
     Atomic::add(&howling_array->_num_entries, diff, memory_order_relaxed);
 
-    bool should_grow_table = false;
-    G1CardSetHashTableValue* table_entry = get_or_add_card_set(card_region, &should_grow_table);
+    G1CardSetHashTableValue* table_entry = get_card_set(card_region);
     Atomic::add(&table_entry->_num_occupied, diff, memory_order_relaxed);
 
     Atomic::add(&_num_occupied, diff, memory_order_relaxed);
@@ -656,7 +653,7 @@ G1CardSetHashTableValue* G1CardSet::get_or_add_card_set(uint card_region, bool* 
   return _table->get_or_add(card_region, should_grow_table);
 }
 
-G1CardSet::CardSetPtr G1CardSet::get_card_set(uint card_region) {
+G1CardSetHashTableValue* G1CardSet::get_card_set(uint card_region) {
   return _table->get(card_region);
 }
 
@@ -709,10 +706,13 @@ bool G1CardSet::contains_card(uint card_region, uint card_in_region) {
 
   // Protect the card set from reclamation.
   GlobalCounter::CriticalSection cs(Thread::current());
-  CardSetPtr card_set = get_card_set(card_region);
-  if (card_set == nullptr) {
+  G1CardSetHashTableValue* table_entry = get_card_set(card_region);
+  if (table_entry == nullptr) {
     return false;
-  } else if (card_set == FullCardSet) {
+  }
+
+  CardSetPtr card_set = table_entry->_card_set;
+  if (card_set == FullCardSet) {
     // contains_card() is not a performance critical method so we do not hide that
     // case in the switch below.
     return true;
@@ -736,11 +736,14 @@ bool G1CardSet::contains_card(uint card_region, uint card_in_region) {
 }
 
 void G1CardSet::print_info(outputStream* st, uint card_region, uint card_in_region) {
-  CardSetPtr card_set = get_card_set(card_region);
-  if (card_set == nullptr) {
+  G1CardSetHashTableValue* table_entry = get_card_set(card_region);
+  if (table_entry == nullptr) {
     st->print("NULL card set");
     return;
-  } else if (card_set == FullCardSet) {
+  }
+
+  CardSetPtr card_set = table_entry->_card_set;
+  if (card_set == FullCardSet) {
     st->print("FULL card set)");
     return;
   }

--- a/src/hotspot/share/gc/g1/g1CardSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.cpp
@@ -192,8 +192,10 @@ class G1CardSetHashTable : public CHeapObj<mtGCCardSet> {
   };
 
   class G1CardSetHashTableFound : public StackObj {
-    G1CardSetHashTableValue* _value = nullptr;
+    G1CardSetHashTableValue* _value;
   public:
+    G1CardSetHashTableFound() : _value(nullptr) { }
+
     void operator()(G1CardSetHashTableValue* value) {
       _value = value;
     }
@@ -610,6 +612,8 @@ void G1CardSet::transfer_cards_in_howl(CardSetPtr parent_card_set,
     Atomic::add(&howling_array->_num_entries, diff, memory_order_relaxed);
 
     G1CardSetHashTableValue* table_entry = get_card_set(card_region);
+    assert(table_entry != nullptr, "Table entry not found for transferred cards");
+
     Atomic::add(&table_entry->_num_occupied, diff, memory_order_relaxed);
 
     Atomic::add(&_num_occupied, diff, memory_order_relaxed);

--- a/src/hotspot/share/gc/g1/g1CardSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.hpp
@@ -254,7 +254,7 @@ private:
   G1AddCardResult add_to_howl(CardSetPtr parent_card_set, uint card_region, uint card_in_region, bool increment_total = true);
 
   G1CardSetHashTableValue* get_or_add_card_set(uint card_region, bool* should_grow_table);
-  CardSetPtr get_card_set(uint card_region);
+  G1CardSetHashTableValue* get_card_set(uint card_region);
 
   // Iterate over cards of a card set container during transfer of the cards from
   // one container to another. Executes


### PR DESCRIPTION
Hi all,

Please review this change to return G1CardSetHashTableValue* from G1CardSet::get_card_set. Consequently, we do not have to use G1CardSet::get_or_add_card_set in instances where we only need to get the table entry (such as in G1CardSet::transfer_cards_in_howl).

Testing: Tier 1-5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272231](https://bugs.openjdk.java.net/browse/JDK-8272231): G1: Refactor G1CardSet::get_card_set to return G1CardSetHashTableValue*


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 1a0ffeed745b729422a1f46b748f24b3576e2848
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5072/head:pull/5072` \
`$ git checkout pull/5072`

Update a local copy of the PR: \
`$ git checkout pull/5072` \
`$ git pull https://git.openjdk.java.net/jdk pull/5072/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5072`

View PR using the GUI difftool: \
`$ git pr show -t 5072`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5072.diff">https://git.openjdk.java.net/jdk/pull/5072.diff</a>

</details>
