### PR TITLE
8272235: G1: update outdated code root fixup

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3720,7 +3720,7 @@ void G1CollectedHeap::evacuate_initial_collection_set(G1ParScanThreadStateSet* p
     task_time = run_task_timed(&g1_par_task);
     // Closing the inner scope will execute the destructor for the
     // G1RootProcessor object. By subtracting the WorkGang task from the total
-    // time of this scope, we get the "NMethod List Cleanup" time. Such list is
+    // time of this scope, we get the "NMethod List Cleanup" time. This list is
     // constructed during "STW two-phase nmethod root processing", see more in
     // nmethod.hpp
   }

--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
@@ -154,7 +154,7 @@ G1GCPhaseTimes::G1GCPhaseTimes(STWGCTimer* gc_timer, uint max_gc_threads) :
 void G1GCPhaseTimes::reset() {
   _cur_collection_initial_evac_time_ms = 0.0;
   _cur_optional_evac_time_ms = 0.0;
-  _cur_collection_code_root_fixup_time_ms = 0.0;
+  _cur_collection_nmethod_list_cleanup_time_ms = 0.0;
   _cur_merge_heap_roots_time_ms = 0.0;
   _cur_optional_merge_heap_roots_time_ms = 0.0;
   _cur_prepare_merge_heap_roots_time_ms = 0.0;
@@ -448,7 +448,7 @@ double G1GCPhaseTimes::print_evacuate_initial_collection_set() const {
 }
 
 double G1GCPhaseTimes::print_post_evacuate_collection_set() const {
-  const double sum_ms = _cur_collection_code_root_fixup_time_ms +
+  const double sum_ms = _cur_collection_nmethod_list_cleanup_time_ms +
                         _recorded_preserve_cm_referents_time_ms +
                         _cur_ref_proc_time_ms +
                         (_weak_phase_times.total_time_sec() * MILLIUNITS) +
@@ -461,7 +461,7 @@ double G1GCPhaseTimes::print_post_evacuate_collection_set() const {
 
   info_time("Post Evacuate Collection Set", sum_ms);
 
-  debug_time("Code Roots Fixup", _cur_collection_code_root_fixup_time_ms);
+  debug_time("NMethod List Cleanup", _cur_collection_nmethod_list_cleanup_time_ms);
 
   debug_time_for_reference("Reference Processing", _cur_ref_proc_time_ms);
   _ref_phase_times.print_all_references(2, false);

--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.hpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.hpp
@@ -154,7 +154,7 @@ class G1GCPhaseTimes : public CHeapObj<mtGC> {
 
   double _cur_collection_initial_evac_time_ms;
   double _cur_optional_evac_time_ms;
-  double _cur_collection_code_root_fixup_time_ms;
+  double _cur_collection_nmethod_list_cleanup_time_ms;
 
   double _cur_merge_heap_roots_time_ms;
   double _cur_optional_merge_heap_roots_time_ms;
@@ -283,8 +283,8 @@ class G1GCPhaseTimes : public CHeapObj<mtGC> {
     _cur_optional_evac_time_ms += ms;
   }
 
-  void record_or_add_code_root_fixup_time(double ms) {
-    _cur_collection_code_root_fixup_time_ms += ms;
+  void record_or_add_nmethod_list_cleanup_time(double ms) {
+    _cur_collection_nmethod_list_cleanup_time_ms += ms;
   }
 
   void record_merge_heap_roots_time(double ms) {

--- a/test/hotspot/jtreg/gc/g1/TestGCLogMessages.java
+++ b/test/hotspot/jtreg/gc/g1/TestGCLogMessages.java
@@ -156,6 +156,10 @@ public class TestGCLogMessages {
         // TLAB handling
         new LogMessageWithLevel("Prepare TLABs", Level.DEBUG),
         new LogMessageWithLevel("Resize TLABs", Level.DEBUG),
+
+        // NMethod List Cleanup
+        new LogMessageWithLevel("NMethod List Cleanup", Level.DEBUG),
+
         // Reference Processing
         new LogMessageWithLevel("Reference Processing", Level.DEBUG),
         // VM internal reference processing


### PR DESCRIPTION
Simple change of updating outdated comments and certain renaming.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272235](https://bugs.openjdk.java.net/browse/JDK-8272235): G1: update outdated code root fixup


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to bcd8b8e338708979c1515d10b90531a3a57c443f
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5073/head:pull/5073` \
`$ git checkout pull/5073`

Update a local copy of the PR: \
`$ git checkout pull/5073` \
`$ git pull https://git.openjdk.java.net/jdk pull/5073/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5073`

View PR using the GUI difftool: \
`$ git pr show -t 5073`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5073.diff">https://git.openjdk.java.net/jdk/pull/5073.diff</a>

</details>
