### PR TITLE
8272291: mark hotspot runtime/logging tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/logging/ClassInitializationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassInitializationTest.java
@@ -25,6 +25,7 @@
 /*
  * @test ClassInitializationTest
  * @bug 8142976
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile BadMap50.jasm

--- a/test/hotspot/jtreg/runtime/logging/ClassInitializationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassInitializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
@@ -78,6 +78,7 @@ public class ClassLoadUnloadTest {
         Collections.addAll(argsList, args);
         Collections.addAll(argsList, "-Xmn8m");
         Collections.addAll(argsList, "-Dtest.class.path=" + System.getProperty("test.class.path", "."));
+        Collections.addAll(argsList, "-XX:+ClassUnloading");
         Collections.addAll(argsList, ClassUnloadTestMain.class.getName());
         return ProcessTools.createJavaProcessBuilder(argsList);
     }

--- a/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
@@ -25,7 +25,7 @@
 /*
  * @test ClassLoadUnloadTest
  * @bug 8142506
- * @requires vm.opt.final.ClassUnloading
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @library classes

--- a/test/hotspot/jtreg/runtime/logging/ClassResolutionTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassResolutionTest.java
@@ -25,6 +25,7 @@
 /*
  * @test ClassResolutionTest
  * @bug 8144874
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver ClassResolutionTest

--- a/test/hotspot/jtreg/runtime/logging/ClassResolutionTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassResolutionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/logging/CompressedOopsTest.java
+++ b/test/hotspot/jtreg/runtime/logging/CompressedOopsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/logging/CompressedOopsTest.java
+++ b/test/hotspot/jtreg/runtime/logging/CompressedOopsTest.java
@@ -24,7 +24,8 @@
 /*
  * @test
  * @bug 8149991
- * @requires vm.bits == 64 & vm.opt.final.UseCompressedOops == true
+ * @requires vm.bits == 64
+ * @requires vm.flagless
  * @summary -Xlog:gc+heap+coops=info should have output from the code
  * @library /test/lib
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/runtime/logging/CondyIndyTest.java
+++ b/test/hotspot/jtreg/runtime/logging/CondyIndyTest.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @summary Test -Xlog:methodhandles with a test that contains both a condy and indy.
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile CondyIndyMathOperation.jasm

--- a/test/hotspot/jtreg/runtime/logging/CondyIndyTest.java
+++ b/test/hotspot/jtreg/runtime/logging/CondyIndyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/logging/DefaultMethodsTest.java
+++ b/test/hotspot/jtreg/runtime/logging/DefaultMethodsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/logging/DefaultMethodsTest.java
+++ b/test/hotspot/jtreg/runtime/logging/DefaultMethodsTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8139564 8203960
  * @summary defaultmethods=debug should have logging from each of the statements in the code
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/logging/ExceptionsTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ExceptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/logging/ExceptionsTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ExceptionsTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8141211 8147477
  * @summary exceptions=info output should have an exception message for interpreter methods
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/logging/ItablesTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ItablesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/logging/ItablesTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ItablesTest.java
@@ -27,6 +27,7 @@
  * @summary itables=trace should have logging from each of the statements
  *          in the code
  * @requires vm.debug
+ * @requires vm.flagless
  * @library /test/lib
  * @compile ClassB.java
  *          ItablesVtableTest.java

--- a/test/hotspot/jtreg/runtime/logging/LoaderConstraintsTest.java
+++ b/test/hotspot/jtreg/runtime/logging/LoaderConstraintsTest.java
@@ -25,6 +25,7 @@
 /*
  * @test LoaderConstraintsTest
  * @bug 8149996
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib classes
  * @build test.Empty

--- a/test/hotspot/jtreg/runtime/logging/ModulesTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ModulesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/logging/ModulesTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ModulesTest.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @summary -Xlog:module should emit logging output
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/logging/MonitorInflationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/MonitorInflationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/logging/MonitorInflationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/MonitorInflationTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8133885
  * @summary monitorinflation=trace should have logging from each of the statements in the code
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/logging/MonitorMismatchTest.java
+++ b/test/hotspot/jtreg/runtime/logging/MonitorMismatchTest.java
@@ -25,6 +25,7 @@
 /*
  * @test MonitorMismatchTest
  * @bug 8150084
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile MonitorMismatchHelper.jasm

--- a/test/hotspot/jtreg/runtime/logging/MonitorMismatchTest.java
+++ b/test/hotspot/jtreg/runtime/logging/MonitorMismatchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/logging/OsCpuLoggingTest.java
+++ b/test/hotspot/jtreg/runtime/logging/OsCpuLoggingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/logging/OsCpuLoggingTest.java
+++ b/test/hotspot/jtreg/runtime/logging/OsCpuLoggingTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8151939
  * @summary os+cpu output should contain some os,cpu information
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/logging/ProtectionDomainVerificationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ProtectionDomainVerificationTest.java
@@ -24,6 +24,7 @@
 /*
  * @test ProtectionDomainVerificationTest
  * @bug 8149064
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver ProtectionDomainVerificationTest

--- a/test/hotspot/jtreg/runtime/logging/SafepointCleanupTest.java
+++ b/test/hotspot/jtreg/runtime/logging/SafepointCleanupTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8149991
  * @summary safepoint+cleanup=info should have output from the code
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/logging/SafepointCleanupTest.java
+++ b/test/hotspot/jtreg/runtime/logging/SafepointCleanupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/logging/SafepointTest.java
+++ b/test/hotspot/jtreg/runtime/logging/SafepointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/logging/SafepointTest.java
+++ b/test/hotspot/jtreg/runtime/logging/SafepointTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8140348
  * @summary safepoint=trace should have output from each log statement in the code
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/logging/StackWalkTest.java
+++ b/test/hotspot/jtreg/runtime/logging/StackWalkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/logging/StackWalkTest.java
+++ b/test/hotspot/jtreg/runtime/logging/StackWalkTest.java
@@ -26,6 +26,7 @@
  * @test StackWalkTest
  * @bug 8160064
  * @summary -Xlog:stackwalk should produce logging from the source code
+ * @requires vm.flagless
  * @library /test/lib
  * @run driver StackWalkTest
  */

--- a/test/hotspot/jtreg/runtime/logging/StartupTimeTest.java
+++ b/test/hotspot/jtreg/runtime/logging/StartupTimeTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8148630
  * @summary -Xlog:startuptime should produce logging from the source code
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/logging/StartupTimeTest.java
+++ b/test/hotspot/jtreg/runtime/logging/StartupTimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/logging/ThreadLoggingTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ThreadLoggingTest.java
@@ -26,6 +26,7 @@
  * @test
  * @bug 8149036 8150619
  * @summary os+thread output should contain logging calls for thread start stop attaches detaches
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/logging/VMOperationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/VMOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/logging/VMOperationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/VMOperationTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8143157
  * @summary vmoperation=debug should have logging output
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/logging/VerificationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/VerificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/logging/VerificationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/VerificationTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8150083 8234656
  * @summary test enabling and disabling verification logging and verification log levels
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/logging/VtablesTest.java
+++ b/test/hotspot/jtreg/runtime/logging/VtablesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/logging/VtablesTest.java
+++ b/test/hotspot/jtreg/runtime/logging/VtablesTest.java
@@ -27,6 +27,7 @@
  * @summary vtables=trace should have logging from each of the statements in the code
  * @library /test/lib
  * @requires vm.debug
+ * @requires vm.flagless
  * @compile ClassB.java
  *          p1/A.java
  *          p2/B.jcod

--- a/test/hotspot/jtreg/runtime/logging/loadLibraryTest/LoadLibraryTest.java
+++ b/test/hotspot/jtreg/runtime/logging/loadLibraryTest/LoadLibraryTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8187305
  * @summary Tests logging of shared library loads and unloads.
+ * @requires vm.flagless
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox


### PR DESCRIPTION
Hi all,

could you please review the patch that adds `@requires vm.flagless` to 23 hotspot runtime/logging tests that ignore external VM flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272291](https://bugs.openjdk.java.net/browse/JDK-8272291): mark hotspot runtime/logging tests which ignore external VM flags


### Reviewers
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer) ⚠️ Review applies to 5a5357ce50827b9cdcbec82d30a4087b21d8c9ce
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5075/head:pull/5075` \
`$ git checkout pull/5075`

Update a local copy of the PR: \
`$ git checkout pull/5075` \
`$ git pull https://git.openjdk.java.net/jdk pull/5075/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5075`

View PR using the GUI difftool: \
`$ git pr show -t 5075`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5075.diff">https://git.openjdk.java.net/jdk/pull/5075.diff</a>

</details>
