### PR TITLE
8261455: Automatically generate the CDS archive if necessary

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -1382,14 +1382,6 @@ const char* os::dll_file_extension() { return ".so"; }
 // directory not the java application's temp directory, ala java.io.tmpdir.
 const char* os::get_temp_directory() { return "/tmp"; }
 
-static bool file_exists(const char* filename) {
-  struct stat statbuf;
-  if (filename == NULL || strlen(filename) == 0) {
-    return false;
-  }
-  return os::stat(filename, &statbuf) == 0;
-}
-
 // check if addr is inside libjvm.so
 bool os::address_is_in_vm(address addr) {
   static address libjvm_base_addr;
@@ -2424,7 +2416,7 @@ static void print_sys_devices_cpu_info(outputStream* st, char* buf, size_t bufle
       snprintf(hbuf_type, 60, "/sys/devices/system/cpu/cpu0/cache/index%u/type", i);
       snprintf(hbuf_size, 60, "/sys/devices/system/cpu/cpu0/cache/index%u/size", i);
       snprintf(hbuf_coherency_line_size, 80, "/sys/devices/system/cpu/cpu0/cache/index%u/coherency_line_size", i);
-      if (file_exists(hbuf_level)) {
+      if (os::file_exists(hbuf_level)) {
         _print_ascii_file_h("cache level", hbuf_level, st);
         _print_ascii_file_h("cache type", hbuf_type, st);
         _print_ascii_file_h("cache size", hbuf_size, st);

--- a/src/hotspot/share/cds/dynamicArchive.cpp
+++ b/src/hotspot/share/cds/dynamicArchive.cpp
@@ -367,11 +367,14 @@ void DynamicArchive::prepare_for_dynamic_dumping() {
 }
 
 void DynamicArchive::dump(const char* archive_name, TRAPS) {
-  assert(UseSharedSpaces && RecordDynamicDumpInfo, "already checked in arguments.cpp?");
+  assert((UseSharedSpaces && RecordDynamicDumpInfo) || AutoCreateSharedArchive, "already checked in arguments.cpp?");
   assert(ArchiveClassesAtExit == nullptr, "already checked in arguments.cpp?");
   ArchiveClassesAtExit = archive_name;
   if (Arguments::init_shared_archive_paths()) {
-    prepare_for_dynamic_dumping();
+    if (!AutoCreateSharedArchive) {
+      // When dump at exit, prepare_for_dynamic_dumping already called.
+      prepare_for_dynamic_dumping();
+    }
     if (DynamicDumpSharedSpaces) {
       dump(CHECK);
     }

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -450,6 +450,7 @@ public:
   static void assert_mark(bool check);
 
   // File manipulation.
+  bool  validate_archive() NOT_CDS_RETURN_(false);
   bool  initialize() NOT_CDS_RETURN_(false);
   bool  open_for_read();
   void  open_for_write(const char* path = NULL);

--- a/src/hotspot/share/logging/logFileOutput.cpp
+++ b/src/hotspot/share/logging/logFileOutput.cpp
@@ -92,11 +92,6 @@ static size_t parse_value(const char* value_str) {
   return value;
 }
 
-static bool file_exists(const char* filename) {
-  struct stat dummy_stat;
-  return os::stat(filename, &dummy_stat) == 0;
-}
-
 static uint number_of_digits(uint number) {
   return number < 10 ? 1 : (number < 100 ? 2 : 3);
 }
@@ -139,7 +134,7 @@ static uint next_file_number(const char* filename,
     assert(ret > 0 && static_cast<size_t>(ret) == len - 1,
            "incorrect buffer length calculation");
 
-    if (file_exists(archive_name) && !is_regular_file(archive_name)) {
+    if (os::file_exists(archive_name) && !is_regular_file(archive_name)) {
       // We've encountered something that's not a regular file among the
       // possible file rotation targets. Fail immediately to prevent
       // problems later.
@@ -150,7 +145,7 @@ static uint next_file_number(const char* filename,
     }
 
     // Stop looking if we find an unused file name
-    if (!file_exists(archive_name)) {
+    if (!os::file_exists(archive_name)) {
       next_num = i;
       found = true;
       break;
@@ -233,7 +228,7 @@ bool LogFileOutput::initialize(const char* options, outputStream* errstream) {
     return false;
   }
 
-  bool file_exist = file_exists(_file_name);
+  bool file_exist = os::file_exists(_file_name);
   if (file_exist && _is_default_file_count && is_fifo_file(_file_name)) {
     _file_count = 0; // Prevent file rotation for fifo's such as named pipes.
   }

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1827,6 +1827,9 @@ const intx ObjectAlignmentInBytes = 8;
   product(bool, RecordDynamicDumpInfo, false,                               \
           "Record class info for jcmd VM.cds dynamic_dump")                 \
                                                                             \
+  product(bool, AutoCreateSharedArchive, false,                             \
+          "Create shared archive at exit if cds mapping failed")            \
+                                                                            \
   product(bool, PrintSharedArchiveAndExit, false,                           \
           "Print shared archive file contents")                             \
                                                                             \

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -57,6 +57,7 @@
 #include "oops/oop.inline.hpp"
 #include "oops/symbol.hpp"
 #include "prims/jvmtiExport.hpp"
+#include "runtime/arguments.hpp"
 #include "runtime/deoptimization.hpp"
 #include "runtime/flags/flagSetting.hpp"
 #include "runtime/handles.inline.hpp"
@@ -502,7 +503,16 @@ void before_exit(JavaThread* thread) {
 #if INCLUDE_CDS
   if (DynamicDumpSharedSpaces) {
     ExceptionMark em(thread);
-    DynamicArchive::dump(thread);
+    if (AutoCreateSharedArchive) {
+      // for case base:top, or top only
+      const char* archive = Arguments::GetSharedDynamicArchivePath();
+      if (archive == nullptr) {
+        archive = Arguments::GetSharedArchivePath();
+      }
+      DynamicArchive::dump(archive, thread);
+    } else {
+      DynamicArchive::dump(thread);
+    }
     if (thread->has_pending_exception()) {
       ResourceMark rm(thread);
       oop pending_exception = thread->pending_exception();

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1334,6 +1334,14 @@ char* os::format_boot_path(const char* format_string,
     return formatted_path;
 }
 
+bool os::file_exists(const char* filename) {
+  struct stat statbuf;
+  if (filename == NULL || strlen(filename) == 0) {
+    return false;
+  }
+  return os::stat(filename, &statbuf) == 0;
+}
+
 // This function is a proxy to fopen, it tries to add a non standard flag ('e' or 'N')
 // that ensures automatic closing of the file on exec. If it can not find support in
 // the underlying c library, it will make an extra system call (fcntl) to ensure automatic

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -542,6 +542,7 @@ class os: AllStatic {
   static void die();
 
   // File i/o operations
+  static bool file_exists(const char* file);
   static int open(const char *path, int oflag, int mode);
   static FILE* open(int fd, const char* mode);
   static FILE* fopen(const char* path, const char* mode);

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @summary test -XX:+AutoCreateSharedArchive feature
+ * @requires vm.cds
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
+ * @build Hello
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar hello.jar Hello
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:./WhiteBox.jar TestAutoCreateSharedArchive
+ */
+
+import java.io.IOException;
+import java.io.File;
+
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.cds.CDSArchiveUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.helpers.ClassFileInstaller;
+
+public class TestAutoCreateSharedArchive extends DynamicArchiveTestBase {
+    private static final String ARCHIVE_NAME = CDSTestUtils.getOutputFileName("top.jsa");
+    private static final String HELLO_SOURCE = "Hello source: shared objects file (top)";
+
+    public static void main(String[] args) throws Exception {
+        runTest(TestAutoCreateSharedArchive::testAutoCreateSharedArchive);
+    }
+
+    public static void checkFileExists(String fileName) throws Exception {
+        File file = new File(fileName);
+        if (!file.exists()) {
+             throw new IOException("Archive " + file.getName() + " is not autamatically created!");
+        }
+    }
+
+    public static String startNewArchive(String testName) {
+        String newArchiveName = TestCommon.getNewArchiveName(testName);
+        TestCommon.setCurrentArchiveName(newArchiveName);
+        return newArchiveName;
+    }
+
+    private static void testAutoCreateSharedArchive() throws Exception {
+        String appJar = ClassFileInstaller.getJarPath("hello.jar");
+        String mainAppClass = "Hello";
+
+        File archiveFile = new File(ARCHIVE_NAME);
+        if (archiveFile.exists()) {
+          archiveFile.delete();
+        }
+
+        // 1. run with non-existing archive should automatically create dynamic archive
+        System.out.println("1. run with non-existing archive should automatically create dynamic archive");
+        run(ARCHIVE_NAME,
+            "-Xshare:auto",
+            "-XX:+AutoCreateSharedArchive",
+            "-Xlog:cds",
+            "-cp", appJar,
+            mainAppClass)
+            .assertNormalExit(output -> {
+                output.shouldHaveExitValue(0);
+                });
+        checkFileExists(ARCHIVE_NAME); 
+
+        // 2. run with the created dynamic archive should pass
+        System.out.println("2. run with the created dynamic archive should pass");
+        run(ARCHIVE_NAME,
+            "-Xlog:cds",
+            "-Xlog:class+load",
+            "-cp", appJar,
+            mainAppClass)
+            .assertNormalExit(output -> {
+                output.shouldHaveExitValue(0)
+                      .shouldContain(HELLO_SOURCE);
+                });
+
+        // 3. run with the created dynamic archive with -XX:+AutoCreateSharedArchive should pass
+        System.out.println("3. run with the created dynamic archive with -XX:+AutoCreateSharedArchive should pass");
+        run(ARCHIVE_NAME,
+            "-Xlog:cds",
+            "-Xlog:class+load",
+            "-Xlog:cds+dynamic=info",
+            "-XX:+AutoCreateSharedArchive",
+            "-cp", appJar,
+            mainAppClass)
+            .assertNormalExit(output -> {
+                output.shouldHaveExitValue(0)
+                      .shouldContain(HELLO_SOURCE);
+                });
+
+        // 4. run with a bad versioned archive should create dynamic archive
+        System.out.println("4. run with a bad versioned archive should create dynamic archive");
+        archiveFile = new File(ARCHIVE_NAME);
+        String modVersion = startNewArchive("modify-version");
+        File copiedJsa = CDSArchiveUtils.copyArchiveFile(archiveFile, modVersion);
+        CDSArchiveUtils.modifyHeaderIntField(copiedJsa, CDSArchiveUtils.offsetVersion, 0x00000000);
+
+        run(modVersion,
+            "-Xshare:auto",
+            "-XX:+AutoCreateSharedArchive",
+            "-Xlog:cds",
+            "-Xlog:cds+dynamic=info",
+            "-cp", appJar,
+            mainAppClass)
+            .assertNormalExit(output -> {
+                output.shouldHaveExitValue(0);
+                });
+        checkFileExists(modVersion);
+
+        // 5. run with the new created archive should pass
+        System.out.println("5. run with the new created archive should pass");
+         run(modVersion,
+            "-Xlog:cds",
+            "-Xlog:class+load",
+            "-cp", appJar,
+            mainAppClass)
+            .assertNormalExit(output -> {
+                output.shouldHaveExitValue(0)
+                      .shouldContain(HELLO_SOURCE);
+                });
+    }
+}


### PR DESCRIPTION
When shared archive (dynamic archive) failed to map due to damage of the archive file, dump/run jdk version mismatch or non-existence file etc, the new patch will automatically create a new shared archive if -XX:+AutoCreateSharedArchive specified with the name based on SharedArchiveFile.

Tests: tier1,tier2,tier3,tier4

Thanks
Yumin
