### PR TITLE
8272305: several hotspot runtime/modules don't check exit codes

### DIFF
--- a/test/hotspot/jtreg/runtime/modules/ClassLoaderNoUnnamedModuleTest.java
+++ b/test/hotspot/jtreg/runtime/modules/ClassLoaderNoUnnamedModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/modules/ClassLoaderNoUnnamedModuleTest.java
+++ b/test/hotspot/jtreg/runtime/modules/ClassLoaderNoUnnamedModuleTest.java
@@ -42,6 +42,7 @@ public class ClassLoaderNoUnnamedModuleTest {
                                "-XX:-CreateCoredumpOnCrash",
                                "ClassLoaderNoUnnamedModule");
         OutputAnalyzer oa = new OutputAnalyzer(pb.start());
+        oa.shouldNotHaveExitValue(0);
         oa.shouldContain("Internal Error");
         oa.shouldContain("unnamed module");
         oa.shouldContain("null or not an instance of java.lang.Module");

--- a/test/hotspot/jtreg/runtime/modules/IgnoreModulePropertiesTest.java
+++ b/test/hotspot/jtreg/runtime/modules/IgnoreModulePropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/modules/IgnoreModulePropertiesTest.java
+++ b/test/hotspot/jtreg/runtime/modules/IgnoreModulePropertiesTest.java
@@ -58,27 +58,28 @@ public class IgnoreModulePropertiesTest {
     // For options of the form "option=value", check that an exception gets thrown for
     // the illegal value and then check that its corresponding property is handled
     // correctly.
-    public static void testOption(boolean positive,
+    public static void testOption(boolean shouldVMFail,
                                   String option, String value,
                                   String prop, String result) throws Exception {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
             option + "=" + value, "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        if (positive) {
-            output.shouldHaveExitValue(0);
-        } else {
+        if (shouldVMFail) {
             output.shouldNotHaveExitValue(0);
+        } else {
+            output.shouldHaveExitValue(0);
         }
         output.shouldContain(result);
         testProperty(prop, value);
     }
 
     public static void main(String[] args) throws Exception {
-        testOption(false, "--add-modules", "java.sqlx", "jdk.module.addmods.0", "java.lang.module.FindException");
-        testOption(false, "--limit-modules", "java.sqlx", "jdk.module.limitmods", "java.lang.module.FindException");
-        testOption(true,  "--add-reads", "xyzz=yyzd", "jdk.module.addreads.0", "WARNING: Unknown module: xyzz");
-        testOption(true,  "--add-exports", "java.base/xyzz=yyzd", "jdk.module.addexports.0",
+        testOption(/*shouldVMFail=*/true, "--add-modules", "java.sqlx", "jdk.module.addmods.0", "java.lang.module.FindException");
+        testOption(/*shouldVMFail=*/true, "--limit-modules", "java.sqlx", "jdk.module.limitmods", "java.lang.module.FindException");
+        testOption(/*shouldVMFail=*/true, "--patch-module", "=d", "jdk.module.patch.0", "Unable to parse --patch-module");
+
+        testOption(/*shouldVMFail=*/false,  "--add-reads", "xyzz=yyzd", "jdk.module.addreads.0", "WARNING: Unknown module: xyzz");
+        testOption(/*shouldVMFail=*/false,  "--add-exports", "java.base/xyzz=yyzd", "jdk.module.addexports.0",
                    "WARNING: package xyzz not in java.base");
-        testOption(false, "--patch-module", "=d", "jdk.module.patch.0", "Unable to parse --patch-module");
     }
 }

--- a/test/hotspot/jtreg/runtime/modules/IgnoreModulePropertiesTest.java
+++ b/test/hotspot/jtreg/runtime/modules/IgnoreModulePropertiesTest.java
@@ -58,21 +58,27 @@ public class IgnoreModulePropertiesTest {
     // For options of the form "option=value", check that an exception gets thrown for
     // the illegal value and then check that its corresponding property is handled
     // correctly.
-    public static void testOption(String option, String value,
+    public static void testOption(boolean positive,
+                                  String option, String value,
                                   String prop, String result) throws Exception {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
             option + "=" + value, "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        if (positive) {
+            output.shouldHaveExitValue(0);
+        } else {
+            output.shouldNotHaveExitValue(0);
+        }
         output.shouldContain(result);
         testProperty(prop, value);
     }
 
     public static void main(String[] args) throws Exception {
-        testOption("--add-modules", "java.sqlx", "jdk.module.addmods.0", "java.lang.module.FindException");
-        testOption("--limit-modules", "java.sqlx", "jdk.module.limitmods", "java.lang.module.FindException");
-        testOption("--add-reads", "xyzz=yyzd", "jdk.module.addreads.0", "WARNING: Unknown module: xyzz");
-        testOption("--add-exports", "java.base/xyzz=yyzd", "jdk.module.addexports.0",
+        testOption(false, "--add-modules", "java.sqlx", "jdk.module.addmods.0", "java.lang.module.FindException");
+        testOption(false, "--limit-modules", "java.sqlx", "jdk.module.limitmods", "java.lang.module.FindException");
+        testOption(true,  "--add-reads", "xyzz=yyzd", "jdk.module.addreads.0", "WARNING: Unknown module: xyzz");
+        testOption(true,  "--add-exports", "java.base/xyzz=yyzd", "jdk.module.addexports.0",
                    "WARNING: package xyzz not in java.base");
-        testOption("--patch-module", "=d", "jdk.module.patch.0", "Unable to parse --patch-module");
+        testOption(false, "--patch-module", "=d", "jdk.module.patch.0", "Unable to parse --patch-module");
     }
 }

--- a/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleCDS.java
+++ b/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleCDS.java
@@ -52,6 +52,7 @@ public class PatchModuleCDS {
             "-version");
         new OutputAnalyzer(pb.start())
             // --patch-module is not supported during CDS dumping
+            .shouldNotHaveExitValue(0)
             .shouldContain("Cannot use the following option when dumping the shared archive: --patch-module");
 
         // Case 2: Test that directory in --patch-module is supported for CDS dumping
@@ -76,6 +77,7 @@ public class PatchModuleCDS {
             "-version");
         new OutputAnalyzer(pb.start())
             // --patch-module is not supported during CDS dumping
+            .shouldNotHaveExitValue(0)
             .shouldContain("Cannot use the following option when dumping the shared archive: --patch-module");
 
         // Case 3a: Test CDS dumping with jar file in --patch-module
@@ -91,6 +93,7 @@ public class PatchModuleCDS {
             "PatchModuleMain", "javax.naming.spi.NamingManager");
         new OutputAnalyzer(pb.start())
             // --patch-module is not supported during CDS dumping
+            .shouldNotHaveExitValue(0)
             .shouldContain("Cannot use the following option when dumping the shared archive: --patch-module");
 
         // Case 3b: Test CDS run with jar file in --patch-module

--- a/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleTraceCL.java
+++ b/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleTraceCL.java
@@ -56,6 +56,7 @@ public class PatchModuleTraceCL {
              "-Xlog:class+load=info", "PatchModuleMain", "javax.naming.spi.NamingManager");
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldHaveExitValue(0);
         // "modules" jimage case.
         output.shouldContain("[class,load] java.lang.Thread source: jrt:/java.base");
         // --patch-module case.

--- a/test/hotspot/jtreg/runtime/modules/Visibility/XbootcpNoVisibility.java
+++ b/test/hotspot/jtreg/runtime/modules/Visibility/XbootcpNoVisibility.java
@@ -75,6 +75,8 @@ public class XbootcpNoVisibility {
         new OutputAnalyzer(ProcessTools.createJavaProcessBuilder(
                 "-Xbootclasspath/a:.",
                 "Vis3_A")
-            .start()).shouldContain("XbootcpNoVisibility PASSED");
+            .start())
+            .shouldHaveExitValue(0)
+            .shouldContain("XbootcpNoVisibility PASSED");
     }
 }


### PR DESCRIPTION
Hi all,

could you please review this patch that adds exit code checks to five `runtime/modules` tests?

testing: `runtime/modules` on `{linux,windows,macos}-x64`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272305](https://bugs.openjdk.java.net/browse/JDK-8272305): several hotspot runtime/modules don't check exit codes


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer) ⚠️ Review applies to 96e2af1b19131302403a82ef432b603ba5f8064d


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5078/head:pull/5078` \
`$ git checkout pull/5078`

Update a local copy of the PR: \
`$ git checkout pull/5078` \
`$ git pull https://git.openjdk.java.net/jdk pull/5078/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5078`

View PR using the GUI difftool: \
`$ git pr show -t 5078`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5078.diff">https://git.openjdk.java.net/jdk/pull/5078.diff</a>

</details>
