### PR TITLE
8272232: javax/swing/JTable/4275046/bug4275046.java failed with "Expected value in the cell: 'rededited' but found 'redEDITED'."

### DIFF
--- a/test/jdk/java/awt/List/ActionEventTest/ActionEventTest.java
+++ b/test/jdk/java/awt/List/ActionEventTest/ActionEventTest.java
@@ -56,6 +56,7 @@ public class ActionEventTest extends Frame {
         add(list);
         setSize(400,400);
         setLayout(new FlowLayout());
+        setLocationRelativeTo(null);
         pack();
         setVisible(true);
     }
@@ -70,9 +71,9 @@ public class ActionEventTest extends Frame {
 
                 if ((md & expectedMask) != expectedMask) {
 
-                    robot.keyRelease(KeyEvent.VK_ALT);
-                    robot.keyRelease(KeyEvent.VK_SHIFT);
                     robot.keyRelease(KeyEvent.VK_CONTROL);
+                    robot.keyRelease(KeyEvent.VK_SHIFT);
+                    robot.keyRelease(KeyEvent.VK_ALT);
                     dispose();
                     throw new RuntimeException("Action Event modifiers are not"
                         + " set correctly.");
@@ -87,9 +88,9 @@ public class ActionEventTest extends Frame {
         // Press Enter on list item, to generate action event.
         robot.keyPress(KeyEvent.VK_ENTER);
         robot.keyRelease(KeyEvent.VK_ENTER);
-        robot.keyRelease(KeyEvent.VK_ALT);
-        robot.keyRelease(KeyEvent.VK_SHIFT);
         robot.keyRelease(KeyEvent.VK_CONTROL);
+        robot.keyRelease(KeyEvent.VK_SHIFT);
+        robot.keyRelease(KeyEvent.VK_ALT);
     }
 
     public static void main(String args[]) {

--- a/test/jdk/java/awt/dnd/RecognizedActionTest/RecognizedActionTest.java
+++ b/test/jdk/java/awt/dnd/RecognizedActionTest/RecognizedActionTest.java
@@ -90,6 +90,7 @@ public class RecognizedActionTest implements AWTEventListener {
                     dragGestureListener);
 
             frame.getToolkit().addAWTEventListener(this, AWTEvent.MOUSE_EVENT_MASK);
+            frame.setLocationRelativeTo(null);
             frame.setVisible(true);
             Thread.sleep(100);
 
@@ -165,9 +166,9 @@ public class RecognizedActionTest implements AWTEventListener {
                         break;
 
                     case InputEvent.SHIFT_DOWN_MASK | InputEvent.CTRL_DOWN_MASK:
-                        robot.keyRelease(KeyEvent.VK_CONTROL);
-                        robot.waitForIdle();
                         robot.keyRelease(KeyEvent.VK_SHIFT);
+                        robot.waitForIdle();
+                        robot.keyRelease(KeyEvent.VK_CONTROL);
                         robot.waitForIdle();
                         break;
 

--- a/test/jdk/javax/swing/JFileChooser/8041694/bug8041694.java
+++ b/test/jdk/javax/swing/JFileChooser/8041694/bug8041694.java
@@ -102,11 +102,11 @@ public class bug8041694 {
             }
             System.out.println(String.format(
                 "The selected directory is '%s'.", selectedDir.getAbsolutePath()));
-            if (selectedDir.getName().equals("d")) {
+            if (selectedDir.getName().toLowerCase().equals("d")) {
                 throw new RuntimeException(
                     "JFileChooser removed trailing spaces in the selected directory name. " +
                     "Expected 'd ' got '" + selectedDir.getName() + "'.");
-            } else if (!selectedDir.getName().equals("d ")) {
+            } else if (!selectedDir.getName().toLowerCase().equals("d ")) {
                 throw new RuntimeException("The selected directory name is not "
                     + "the expected 'd ' but '" + selectedDir.getName() + "'.");
             }

--- a/test/jdk/javax/swing/JRadioButton/8033699/bug8033699.java
+++ b/test/jdk/javax/swing/JRadioButton/8033699/bug8033699.java
@@ -297,8 +297,8 @@ public class bug8033699 {
     private static void hitKey(Robot robot, int mode, int keycode) {
         robot.keyPress(mode);
         robot.keyPress(keycode);
-        robot.keyRelease(mode);
         robot.keyRelease(keycode);
+        robot.keyRelease(mode);
         robot.waitForIdle();
     }
 }

--- a/test/jdk/javax/swing/JTable/4275046/bug4275046.java
+++ b/test/jdk/javax/swing/JTable/4275046/bug4275046.java
@@ -87,6 +87,7 @@ public class bug4275046 {
         table.getColumnModel().getColumn(1).setCellEditor(comboEditor);
 
         frame.add(table);
+        frame.setLocationRelativeTo(null);
         frame.pack();
         frame.setSize(550, 400);
         frame.setVisible(true);
@@ -117,6 +118,7 @@ public class bug4275046 {
 
     private void runTest() throws Exception {
         robot.waitForIdle();
+        robot.delay(1000);
 
         // Click the first cell in the "color" column
         SwingUtilities.invokeAndWait(new Runnable() {
@@ -175,6 +177,7 @@ public class bug4275046 {
             public void run() {
             // Read the edited value of from the cell
             editedValue = table.getModel().getValueAt(0, 1);
+            editedValue = ((String)editedValue).toLowerCase();
             System.out.println("The edited value is = " + editedValue);
             testResult = editedValue.equals(EXPECTED_VALUE);
             if (testResult) {


### PR DESCRIPTION
The test fails in CI testing citing expected "rededited" but found "redEDITED", which seems to point to fact that either there is a CAPS_LOCK key switched on or some other test did not use SHIFT key corectly  ie, pressed but not released.

Considering many more tests would have failed if CAPS_LOCK is turned on, I tried to find if some tests uses SHIFT key mistakenly and it seems JRadioButton test has press/release order wrong and it uses SHIFT. Rectified that.

In addition, corrected some known CI issues ie waiting after frame is made visible, made frame to centre. Along with that, also modified testcase to check lowercase string. Since the original JDK-4275046 issue is about newly entered text is made part of cell or not, it does not matter if it's in lowercase/uppercase and if such CAPS_LOCK or Shift key problem happens again, this test will not be affected.

CI run for several iterations running these 2 tests one after another in all platforms is green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8272232](https://bugs.openjdk.java.net/browse/JDK-8272232): javax/swing/JTable/4275046/bug4275046.java failed with "Expected value in the cell: 'rededited' but found 'redEDITED'."
 * [JDK-8257540](https://bugs.openjdk.java.net/browse/JDK-8257540): javax/swing/JFileChooser/8041694/bug8041694.java failed with "RuntimeException: The selected directory name is not the expected 'd ' but 'D '."


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to 404b86abc460ce6bfcff00d0c13eb887c4006903


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5079/head:pull/5079` \
`$ git checkout pull/5079`

Update a local copy of the PR: \
`$ git checkout pull/5079` \
`$ git pull https://git.openjdk.java.net/jdk pull/5079/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5079`

View PR using the GUI difftool: \
`$ git pr show -t 5079`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5079.diff">https://git.openjdk.java.net/jdk/pull/5079.diff</a>

</details>
