### PR TITLE
JDK-8272158: SoftReference related bugs under memory pressure

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/MemberSummaryBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/MemberSummaryBuilder.java
@@ -270,9 +270,6 @@ public abstract class MemberSummaryBuilder extends AbstractMemberBuilder {
                                     new DocFinder.Input(utils, member));
                     if (inheritedDoc.holder != null
                             && !utils.getFirstSentenceTrees(inheritedDoc.holder).isEmpty()) {
-                        // let the comment helper know of the overridden element
-                        CommentHelper ch = utils.getCommentHelper(member);
-                        ch.setOverrideElement(inheritedDoc.holder);
                         firstSentenceTags = utils.getFirstSentenceTrees(inheritedDoc.holder);
                     }
                 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/VisibleMemberTable.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/VisibleMemberTable.java
@@ -947,13 +947,14 @@ public class VisibleMemberTable {
     Map<ExecutableElement, SoftReference<ImplementedMethods>> implementMethodsFinders = new HashMap<>();
 
     private ImplementedMethods getImplementedMethodsFinder(ExecutableElement method) {
-        SoftReference<ImplementedMethods> imf = implementMethodsFinders.get(method);
-        // IMF does not exist or referent was gc'ed away ?
-        if (imf == null || imf.get() == null) {
-            imf = new SoftReference<>(new ImplementedMethods(method));
-            implementMethodsFinders.put(method, imf);
+        SoftReference<ImplementedMethods> ref = implementMethodsFinders.get(method);
+        ImplementedMethods imf = ref == null ? null : ref.get();
+        // imf does not exist or was gc'ed away?
+        if (imf == null) {
+            imf = new ImplementedMethods(method);
+            implementMethodsFinders.put(method, new SoftReference<>(imf));
         }
-        return imf.get();
+        return imf;
     }
 
     public List<ExecutableElement> getImplementedMethods(ExecutableElement method) {


### PR DESCRIPTION
This change fixes two problems related to usage of soft references in javadoc. 

The one in `VisibleMemberTable` is rather trivial, it just avoids getting the softly referenced value twice, which allowed GC to clear the reference between the two calls. 

For the one in `CommentHelper`, I considered a few different solutions: Store CommentHelper instances with hard references, compute the overridden element information on demand instead of storing it in the object, or ignore missing overridden object info based on the rationale that any issues should already have been reported on the overridden element itself. I decided to go with the on-demand lookup of overridden elements as the additional overhead was minimal (a total of 3 milliseconds for the JDK docs) and the reduction in state/complexity seemed like an additional benefit.

I labeled the issue as "noreg-hard". To test the fix I ran the JDK `docs` target with reduced heap space (appending `-Xmx664m` to `$1_JAVA_ARGS` in make/Docs.gmk). With max heap values in that range, the task either succeeds or fails with `OutOfMemoryError`. Previously, it sometimes failed with `NullPointerException` due to one of the two issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272158](https://bugs.openjdk.java.net/browse/JDK-8272158): SoftReference related bugs under memory pressure


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5080/head:pull/5080` \
`$ git checkout pull/5080`

Update a local copy of the PR: \
`$ git checkout pull/5080` \
`$ git pull https://git.openjdk.java.net/jdk pull/5080/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5080`

View PR using the GUI difftool: \
`$ git pr show -t 5080`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5080.diff">https://git.openjdk.java.net/jdk/pull/5080.diff</a>

</details>
