### PR TITLE
8272310: AArch64: Add missing changes for shared vector helper methods in m4 files

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64_neon_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_neon_ad.m4
@@ -872,7 +872,7 @@ instruct vcmpD(vecD dst, vecD src1, vecD src2, immI cond)
   format %{ "vcmpD  $dst, $src1, $src2\t# vector compare " %}
   ins_cost(INSN_COST);
   ins_encode %{
-    BasicType bt = vector_element_basic_type(this);
+    BasicType bt = Matcher::vector_element_basic_type(this);
     assert(type2aelembytes(bt) != 8, "not supported");
     __ neon_compare(as_FloatRegister($dst$$reg), bt, as_FloatRegister($src1$$reg),
                     as_FloatRegister($src2$$reg), (int)$cond$$constant, /*isQ*/ false);
@@ -887,7 +887,7 @@ instruct vcmpX(vecX dst, vecX src1, vecX src2, immI cond)
   format %{ "vcmpX  $dst, $src1, $src2\t# vector compare " %}
   ins_cost(INSN_COST);
   ins_encode %{
-    BasicType bt = vector_element_basic_type(this);
+    BasicType bt = Matcher::vector_element_basic_type(this);
     __ neon_compare(as_FloatRegister($dst$$reg), bt, as_FloatRegister($src1$$reg),
                     as_FloatRegister($src2$$reg), (int)$cond$$constant, /*isQ*/ true);
   %}
@@ -2292,7 +2292,7 @@ ifelse($1, `_LT8B', `
     __ clz($dst$$Register, $dst$$Register);
     __ lsrw($dst$$Register, $dst$$Register, 3);dnl
 ifelse(`$1', `_LT8B', `
-    __ movw(rscratch1, vector_length(this, $src));
+    __ movw(rscratch1, Matcher::vector_length(this, $src));
     __ cmpw($dst$$Register, rscratch1);
     __ cselw($dst$$Register, rscratch1, $dst$$Register, Assembler::GE);')
   %}

--- a/src/hotspot/cpu/aarch64/aarch64_sve_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_sve_ad.m4
@@ -214,7 +214,7 @@ instruct loadV(vReg dst, vmemA mem) %{
   ins_encode %{
     FloatRegister dst_reg = as_FloatRegister($dst$$reg);
     loadStoreA_predicate(C2_MacroAssembler(&cbuf), false, dst_reg, ptrue,
-                         vector_element_basic_type(this), $mem->opcode(),
+                         Matcher::vector_element_basic_type(this), $mem->opcode(),
                          as_Register($mem$$base), $mem$$index, $mem$$scale, $mem$$disp);
   %}
   ins_pipe(pipe_slow);
@@ -228,7 +228,7 @@ instruct storeV(vReg src, vmemA mem) %{
   ins_encode %{
     FloatRegister src_reg = as_FloatRegister($src$$reg);
     loadStoreA_predicate(C2_MacroAssembler(&cbuf), true, src_reg, ptrue,
-                         vector_element_basic_type(this, $src), $mem->opcode(),
+                         Matcher::vector_element_basic_type(this, $src), $mem->opcode(),
                          as_Register($mem$$base), $mem$$index, $mem$$scale, $mem$$disp);
   %}
   ins_pipe(pipe_slow);
@@ -386,7 +386,7 @@ instruct vmin(vReg dst_src1, vReg src2) %{
   ins_cost(SVE_COST);
   format %{ "sve_min $dst_src1, $dst_src1, $src2\t # vector (sve)" %}
   ins_encode %{
-    BasicType bt = vector_element_basic_type(this);
+    BasicType bt = Matcher::vector_element_basic_type(this);
     Assembler::SIMD_RegVariant size = elemType_to_regVariant(bt);
     if (is_floating_point_type(bt)) {
       __ sve_fmin(as_FloatRegister($dst_src1$$reg), size,
@@ -406,7 +406,7 @@ instruct vmax(vReg dst_src1, vReg src2) %{
   ins_cost(SVE_COST);
   format %{ "sve_max $dst_src1, $dst_src1, $src2\t # vector (sve)" %}
   ins_encode %{
-    BasicType bt = vector_element_basic_type(this);
+    BasicType bt = Matcher::vector_element_basic_type(this);
     Assembler::SIMD_RegVariant size = elemType_to_regVariant(bt);
     if (is_floating_point_type(bt)) {
       __ sve_fmax(as_FloatRegister($dst_src1$$reg), size,


### PR DESCRIPTION
This is a followed-up fixing to [1] which moved several vector helper methods to a shared header. However, the changes in the
aarch64 ad files (`aarch64_neon.ad, aarch64_sve.ad`) are forgotten to be added into the relative m4 files.

This patch adds the missing changes in the m4 files to make everything right.

[1] https://bugs.openjdk.java.net/browse/JDK-8270519

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272310](https://bugs.openjdk.java.net/browse/JDK-8272310): AArch64: Add missing changes for shared vector helper methods in m4 files


### Reviewers
 * @martin-g (no known github.com user name / role)
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5081/head:pull/5081` \
`$ git checkout pull/5081`

Update a local copy of the PR: \
`$ git checkout pull/5081` \
`$ git pull https://git.openjdk.java.net/jdk pull/5081/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5081`

View PR using the GUI difftool: \
`$ git pr show -t 5081`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5081.diff">https://git.openjdk.java.net/jdk/pull/5081.diff</a>

</details>
