### PR TITLE
JDK-8272318: Improve performance of HeapDumpAllTest

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpAllTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpAllTest.java
@@ -21,6 +21,10 @@
  * questions.
  */
 
+import java.io.IOException;
+
+import jdk.test.lib.dcmd.CommandExecutor;
+
 /*
  * @test
  * @summary Test of diagnostic command GC.heap_dump -all=true
@@ -35,6 +39,14 @@ public class HeapDumpAllTest extends HeapDumpTest {
     public HeapDumpAllTest() {
         super();
         heapDumpArgs = "-all=true";
+    }
+
+    @Override
+    public void run(CommandExecutor executor, boolean overwrite) throws IOException {
+        // Trigger gc by hand, so the created heap dump isnt't too large and
+        // takes too long to parse.
+        System.gc();
+        super.run(executor, overwrite);
     }
 
     /* See HeapDumpTest for test cases */


### PR DESCRIPTION
This change triggers a GC by System.gc() in the test case, so the created heap dump is significantly smaller and the test runs much faster.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272318](https://bugs.openjdk.java.net/browse/JDK-8272318): Improve performance of HeapDumpAllTest


### Reviewers
 * [Lutz Schmidt](https://openjdk.java.net/census#lucy) (@RealLucy - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5084/head:pull/5084` \
`$ git checkout pull/5084`

Update a local copy of the PR: \
`$ git checkout pull/5084` \
`$ git pull https://git.openjdk.java.net/jdk pull/5084/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5084`

View PR using the GUI difftool: \
`$ git pr show -t 5084`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5084.diff">https://git.openjdk.java.net/jdk/pull/5084.diff</a>

</details>
