### PR TITLE
8271732: Regression in StringBuilder.charAt bounds checking

### DIFF
--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -349,10 +349,11 @@ abstract class AbstractStringBuilder implements Appendable, CharSequence {
      */
     @Override
     public char charAt(int index) {
+        checkIndex(index, count);
         if (isLatin1()) {
-            return StringLatin1.charAt(value, index);
+            return (char)(value[index] & 0xff);
         }
-        return StringUTF16.charAt(value, index);
+        return StringUTF16.getChar(value, index);
     }
 
     /**

--- a/test/jdk/java/lang/StringBuilder/CharAt.java
+++ b/test/jdk/java/lang/StringBuilder/CharAt.java
@@ -75,7 +75,7 @@ public class CharAt {
 
             try {
                 sbufUtf16.charAt(index);
-                fail("StringBuffer.charAt index: " + i + " does not throw IOOBE as expected (UTF-16)");
+                fail("StringBuffer.charAt index: " + index + " does not throw IOOBE as expected (UTF-16)");
             } catch (IndexOutOfBoundsException ex) {
                 // OK
             }

--- a/test/jdk/java/lang/StringBuilder/CharAt.java
+++ b/test/jdk/java/lang/StringBuilder/CharAt.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8271732
+ * @summary Basic test that charAt throws IIOBE as expected for out of bounds indexes.
+ * @run testng CharAt
+ */
+
+import java.util.List;
+
+import org.testng.annotations.Test;
+import org.testng.annotations.DataProvider;
+import static org.testng.Assert.*;
+
+public class CharAt {
+
+    /**
+     * StringBuilder/-Buffer.charAt throws:
+     * IndexOutOfBoundsException - if index is negative or greater than or equal to length().
+     * the test inputs, expected to throw IndexOutOfBoundsException.
+     */
+    @Test
+    public void charAtIIOBE() {
+        StringBuilder sb = new StringBuilder("test");
+        StringBuffer sbuf = new StringBuffer("test");
+        List<Integer> outOfBoundsIndices = List.of(Integer.MIN_VALUE, -2, -1, 4, 5, Integer.MAX_VALUE);
+
+        for (int i : outOfBoundsIndices) {
+            try {
+                sb.charAt(i);
+                fail("StringBuilder.charAt index: " + i + " does not throw IOOBE as expected");
+            } catch (IndexOutOfBoundsException ex) {
+                // OK
+            }
+
+            try {
+                sbuf.charAt(i);
+                fail("StringBuffer.charAt index: " + i + " does not throw IOOBE as expected");
+            } catch (IndexOutOfBoundsException ex) {
+                // OK
+            }
+        }
+    }
+}

--- a/test/jdk/java/lang/StringBuilder/CharAt.java
+++ b/test/jdk/java/lang/StringBuilder/CharAt.java
@@ -75,7 +75,7 @@ public class CharAt {
 
             try {
                 sbufUtf16.charAt(index);
-                fail("StringBuilder.charAt index: " + i + " does not throw IOOBE as expected (UTF-16)");
+                fail("StringBuffer.charAt index: " + i + " does not throw IOOBE as expected (UTF-16)");
             } catch (IndexOutOfBoundsException ex) {
                 // OK
             }

--- a/test/jdk/java/lang/StringBuilder/CharAt.java
+++ b/test/jdk/java/lang/StringBuilder/CharAt.java
@@ -45,19 +45,37 @@ public class CharAt {
     public void charAtIIOBE() {
         StringBuilder sb = new StringBuilder("test");
         StringBuffer sbuf = new StringBuffer("test");
+
+        StringBuilder sbUtf16 = new StringBuilder("\uFF34est"); // Fullwidth Latin Capital Letter T
+        StringBuffer sbufUtf16 = new StringBuffer("\uFF34est");
+
         List<Integer> outOfBoundsIndices = List.of(Integer.MIN_VALUE, -2, -1, 4, 5, Integer.MAX_VALUE);
 
-        for (int i : outOfBoundsIndices) {
+        for (int index : outOfBoundsIndices) {
             try {
-                sb.charAt(i);
-                fail("StringBuilder.charAt index: " + i + " does not throw IOOBE as expected");
+                sb.charAt(index);
+                fail("StringBuilder.charAt index: " + index + " does not throw IOOBE as expected");
             } catch (IndexOutOfBoundsException ex) {
                 // OK
             }
 
             try {
-                sbuf.charAt(i);
-                fail("StringBuffer.charAt index: " + i + " does not throw IOOBE as expected");
+                sbUtf16.charAt(index);
+                fail("StringBuilder.charAt index: " + index + " does not throw IOOBE as expected (UTF-16)");
+            } catch (IndexOutOfBoundsException ex) {
+                // OK
+            }
+
+            try {
+                sbuf.charAt(index);
+                fail("StringBuffer.charAt index: " + index + " does not throw IOOBE as expected");
+            } catch (IndexOutOfBoundsException ex) {
+                // OK
+            }
+
+            try {
+                sbufUtf16.charAt(index);
+                fail("StringBuilder.charAt index: " + i + " does not throw IOOBE as expected (UTF-16)");
             } catch (IndexOutOfBoundsException ex) {
                 // OK
             }

--- a/test/micro/org/openjdk/bench/java/lang/StringBuilders.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringBuilders.java
@@ -24,18 +24,25 @@ package org.openjdk.bench.java.lang;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(3)
 public class StringBuilders {
 
     private String[] strings;
@@ -328,6 +335,20 @@ public class StringBuilders {
 
         return new StringBuilder().append('L').append(str, beginIndex,
                 endIndex).append(';').toString();
+    }
+
+    public int charAt_index = 3;
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public char charAtLatin1() {
+        return sbLatin1.charAt(charAt_index);
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public char charAtUtf16() {
+        return sbUtf16.charAt(charAt_index);
     }
 
     @State(Scope.Thread)


### PR DESCRIPTION
In #4738 we removed the `checkIndex(value, count)` call in `ASB.charAt` to avoid potentially getting two bounds checks in the UTF-16 case. Problem is this optimization cause a regression since `StringUTF16.charAt(..)` checks `index` against the length of the `value` array and not `count`.

A correct fix that still maintain the possible performance advantage reported by #4738 is to reinstate the `checkIndex(value, count)` and call `StringUTF16.getChar` instead of `charAt`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271732](https://bugs.openjdk.java.net/browse/JDK-8271732): Regression in StringBuilder.charAt bounds checking


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5086/head:pull/5086` \
`$ git checkout pull/5086`

Update a local copy of the PR: \
`$ git checkout pull/5086` \
`$ git pull https://git.openjdk.java.net/jdk pull/5086/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5086`

View PR using the GUI difftool: \
`$ git pr show -t 5086`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5086.diff">https://git.openjdk.java.net/jdk/pull/5086.diff</a>

</details>
