### PR TITLE
8272335: runtime/cds/appcds/MoveJDKTest.java doesn't check exit codes

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/MoveJDKTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/MoveJDKTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/cds/appcds/MoveJDKTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/MoveJDKTest.java
@@ -54,7 +54,8 @@ public class MoveJDKTest {
         String jsaOpt = "-XX:SharedArchiveFile=" + jsaFile;
         {
             ProcessBuilder pb = makeBuilder(java_home_src + "/bin/java", "-Xshare:dump", jsaOpt);
-            TestCommon.executeAndLog(pb, "dump");
+            TestCommon.executeAndLog(pb, "dump")
+                      .shouldHaveExitValue(0);
         }
         {
             ProcessBuilder pb = makeBuilder(java_home_src + "/bin/java",
@@ -63,6 +64,7 @@ public class MoveJDKTest {
                                             "-Xlog:class+path=info",
                                             "-version");
             OutputAnalyzer out = TestCommon.executeAndLog(pb, "exec-src");
+            out.shouldHaveExitValue(0);
             out.shouldNotContain("shared class paths mismatch");
             out.shouldNotContain("BOOT classpath mismatch");
         }
@@ -78,6 +80,7 @@ public class MoveJDKTest {
                                             "-Xlog:class+path=info",
                                             "-version");
             OutputAnalyzer out = TestCommon.executeAndLog(pb, "exec-dst");
+            out.shouldHaveExitValue(0);
             out.shouldNotContain("shared class paths mismatch");
             out.shouldNotContain("BOOT classpath mismatch");
         }
@@ -91,7 +94,8 @@ public class MoveJDKTest {
                                             "-Xshare:dump",
                                             dumptimeBootAppendOpt,
                                             jsaOpt);
-            TestCommon.executeAndLog(pb, "dump");
+            TestCommon.executeAndLog(pb, "dump")
+                      .shouldHaveExitValue(0);
         }
         {
             String runtimeBootAppendOpt = dumptimeBootAppendOpt + System.getProperty("path.separator") + helloJar;
@@ -102,6 +106,7 @@ public class MoveJDKTest {
                                             "-Xlog:class+path=info",
                                             "-version");
             OutputAnalyzer out = TestCommon.executeAndLog(pb, "exec-dst");
+            out.shouldHaveExitValue(0);
             out.shouldNotContain("shared class paths mismatch");
             out.shouldNotContain("BOOT classpath mismatch");
         }


### PR DESCRIPTION
Hi all,

could you please review this small patch that adds exit code checks to `runtime/cds/appcds/MoveJDKTest.java` test?

testing: `runtime/cds/appcds/MoveJDKTest.java` on `linux-x64-{product,fastdebug}`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272335](https://bugs.openjdk.java.net/browse/JDK-8272335): runtime/cds/appcds/MoveJDKTest.java doesn't check exit codes


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5089/head:pull/5089` \
`$ git checkout pull/5089`

Update a local copy of the PR: \
`$ git checkout pull/5089` \
`$ git pull https://git.openjdk.java.net/jdk pull/5089/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5089`

View PR using the GUI difftool: \
`$ git pr show -t 5089`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5089.diff">https://git.openjdk.java.net/jdk/pull/5089.diff</a>

</details>
