### PR TITLE
8273934: Remove unused perfcounters

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.hpp
+++ b/src/hotspot/share/compiler/compileBroker.hpp
@@ -181,14 +181,12 @@ class CompileBroker: AllStatic {
 
   // performance counters
   static PerfCounter* _perf_total_compilation;
-  static PerfCounter* _perf_native_compilation;
   static PerfCounter* _perf_osr_compilation;
   static PerfCounter* _perf_standard_compilation;
 
   static PerfCounter* _perf_total_bailout_count;
   static PerfCounter* _perf_total_invalidated_count;
-  static PerfCounter* _perf_total_compile_count;
-  static PerfCounter* _perf_total_native_compile_count;
+  static PerfCounter* _perf_total_compile_count;  
   static PerfCounter* _perf_total_osr_compile_count;
   static PerfCounter* _perf_total_standard_compile_count;
 

--- a/src/hotspot/share/compiler/compileBroker.hpp
+++ b/src/hotspot/share/compiler/compileBroker.hpp
@@ -186,7 +186,7 @@ class CompileBroker: AllStatic {
 
   static PerfCounter* _perf_total_bailout_count;
   static PerfCounter* _perf_total_invalidated_count;
-  static PerfCounter* _perf_total_compile_count;  
+  static PerfCounter* _perf_total_compile_count;
   static PerfCounter* _perf_total_osr_compile_count;
   static PerfCounter* _perf_total_standard_compile_count;
 


### PR DESCRIPTION
This patch removes two unused PerfCounters.

Please review,
Regards,
Nils Eliasson

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273934](https://bugs.openjdk.java.net/browse/JDK-8273934): Remove unused perfcounters


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5093/head:pull/5093` \
`$ git checkout pull/5093`

Update a local copy of the PR: \
`$ git checkout pull/5093` \
`$ git pull https://git.openjdk.java.net/jdk pull/5093/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5093`

View PR using the GUI difftool: \
`$ git pr show -t 5093`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5093.diff">https://git.openjdk.java.net/jdk/pull/5093.diff</a>

</details>
