### PR TITLE
8272345: macos doesn't check `os::set_boot_path()` result

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -452,7 +452,9 @@ void os::init_system_properties_values() {
       }
     }
     Arguments::set_java_home(buf);
-    set_boot_path('/', ':');
+    if (!set_boot_path('/', ':')) {
+        vm_exit_during_initialization("Failed setting boot class path.", NULL);
+    }
   }
 
   // Where to look for native libraries.

--- a/test/hotspot/jtreg/runtime/cds/appcds/MoveJDKTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/MoveJDKTest.java
@@ -25,16 +25,16 @@
 /*
  * @test
  * @summary Test that CDS still works when the JDK is moved to a new directory
+ * @bug 8272345
  * @requires vm.cds
- * @requires os.family == "linux"
+ * @requires os.family == "linux" | os.family == "mac"
  * @library /test/lib
  * @compile test-classes/Hello.java
  * @run driver MoveJDKTest
  */
 
-// This test works only on Linux because it depends on symlinks and the name of the hotspot DLL (libjvm.so).
+// This test works only on Linux and MacOS because it depends on symlinks
 // It probably doesn't work on Windows.
-// TODO: change libjvm.so to libjvm.dylib on MacOS, before adding "@requires os.family == mac"
 
 import java.io.File;
 import java.nio.file.Files;
@@ -134,6 +134,7 @@ public class MoveJDKTest {
                 throw new RuntimeException("Cannot create directory: " + dst);
             }
         }
+        final String jvmLib = System.mapLibraryName("jvm");
         for (String child : src.list()) {
             if (child.equals(".") || child.equals("..")) {
                 continue;
@@ -145,7 +146,7 @@ public class MoveJDKTest {
                 throw new RuntimeException("Already exists: " + child_dst);
             }
             if (child_src.isFile()) {
-                if (child.equals("libjvm.so") || child.equals("java")) {
+                if (child.equals(jvmLib) || child.equals("java")) {
                     Files.copy(child_src.toPath(), /* copy data to -> */ child_dst.toPath());
                 } else {
                     Files.createSymbolicLink(child_dst.toPath(),  /* link to -> */ child_src.toPath());

--- a/test/hotspot/jtreg/runtime/cds/appcds/MoveJDKTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/MoveJDKTest.java
@@ -27,14 +27,12 @@
  * @summary Test that CDS still works when the JDK is moved to a new directory
  * @bug 8272345
  * @requires vm.cds
- * @requires os.family == "linux" | os.family == "mac"
+ * @comment This test doesn't work on Windows because it depends on symlinks
+ * @requires os.family != "windows"
  * @library /test/lib
  * @compile test-classes/Hello.java
  * @run driver MoveJDKTest
  */
-
-// This test works only on Linux and MacOS because it depends on symlinks
-// It probably doesn't work on Windows.
 
 import java.io.File;
 import java.nio.file.Files;


### PR DESCRIPTION
Hi all,

could you please review this small fix?

from JBS:
> we don't check `os::set_boot_path()` return value on macos, which leads to a crash/assert down the road in case we weren't able to set BCP. on all other OSes, we terminate JVM w/ "Failed setting boot class path." error message.

testing:
- [x] tier1
- [x] `runtime/cds/appcds/MoveJDKTest.java`


Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272345](https://bugs.openjdk.java.net/browse/JDK-8272345): macos doesn't check `os::set_boot_path()` result


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 1d8d2947ed21f0b631c53a70d6257142251fd36e


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5094/head:pull/5094` \
`$ git checkout pull/5094`

Update a local copy of the PR: \
`$ git checkout pull/5094` \
`$ git pull https://git.openjdk.java.net/jdk pull/5094/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5094`

View PR using the GUI difftool: \
`$ git pr show -t 5094`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5094.diff">https://git.openjdk.java.net/jdk/pull/5094.diff</a>

</details>
