### PR TITLE
8272348: Update CDS tests in anticipation of JDK-8270489

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1936,12 +1936,20 @@ WB_ENTRY(jboolean, WB_IsShared(JNIEnv* env, jobject wb, jobject obj))
   return Universe::heap()->is_archived_object(obj_oop);
 WB_END
 
+WB_ENTRY(jboolean, WB_IsSharedInternedString(JNIEnv* env, jobject wb, jobject str))
+  ResourceMark rm(THREAD);
+  oop str_oop = JNIHandles::resolve(str);
+  int length;
+  jchar* chars = java_lang_String::as_unicode_string(str_oop, length, CHECK_(false));
+  return StringTable::lookup_shared(chars, length) == str_oop;
+WB_END
+
 WB_ENTRY(jboolean, WB_IsSharedClass(JNIEnv* env, jobject wb, jclass clazz))
   return (jboolean)MetaspaceShared::is_in_shared_metaspace(java_lang_Class::as_Klass(JNIHandles::resolve_non_null(clazz)));
 WB_END
 
-WB_ENTRY(jboolean, WB_AreSharedStringsIgnored(JNIEnv* env))
-  return !HeapShared::closed_regions_mapped();
+WB_ENTRY(jboolean, WB_AreSharedStringsMapped(JNIEnv* env))
+  return HeapShared::closed_regions_mapped();
 WB_END
 
 WB_ENTRY(jobject, WB_GetResolvedReferences(JNIEnv* env, jobject wb, jclass clazz))
@@ -2625,8 +2633,9 @@ static JNINativeMethod methods[] = {
                                                       (void*)&WB_GetDefaultArchivePath},
   {CC"isSharingEnabled",   CC"()Z",                   (void*)&WB_IsSharingEnabled},
   {CC"isShared",           CC"(Ljava/lang/Object;)Z", (void*)&WB_IsShared },
+  {CC"isSharedInternedString", CC"(Ljava/lang/String;)Z", (void*)&WB_IsSharedInternedString },
   {CC"isSharedClass",      CC"(Ljava/lang/Class;)Z",  (void*)&WB_IsSharedClass },
-  {CC"areSharedStringsIgnored",           CC"()Z",    (void*)&WB_AreSharedStringsIgnored },
+  {CC"areSharedStringsMapped",            CC"()Z",    (void*)&WB_AreSharedStringsMapped },
   {CC"getResolvedReferences", CC"(Ljava/lang/Class;)Ljava/lang/Object;", (void*)&WB_GetResolvedReferences},
   {CC"linkClass",          CC"(Ljava/lang/Class;)V",  (void*)&WB_LinkClass},
   {CC"areOpenArchiveHeapObjectsMapped",   CC"()Z",    (void*)&WB_AreOpenArchiveHeapObjectsMapped},

--- a/test/hotspot/jtreg/runtime/cds/ServiceLoaderTest.java
+++ b/test/hotspot/jtreg/runtime/cds/ServiceLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/cds/ServiceLoaderTest.java
+++ b/test/hotspot/jtreg/runtime/cds/ServiceLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,9 +49,9 @@ public class ServiceLoaderTest {
         CDSTestUtils.createArchiveAndCheck(opts);
 
         // Some mach5 tiers run with -vmoptions:-Xlog:cds=debug. This would cause the outputs to mismatch.
-        // Force -Xlog:cds=warning to supress the CDS logs.
+        // Force the log level to warning for all tags to supressed the CDS logs. Also disable the timestamp.
         opts.setUseVersion(false);
-        opts.addSuffix("-showversion", "-Xlog:cds=warning", "ServiceLoaderApp");
+        opts.addSuffix("-showversion", "-Xlog:all=warning::level,tags", "ServiceLoaderApp");
         OutputAnalyzer out1 = CDSTestUtils.runWithArchive(opts);
 
         opts.setXShareMode("off");

--- a/test/hotspot/jtreg/runtime/cds/SharedStringsWb.java
+++ b/test/hotspot/jtreg/runtime/cds/SharedStringsWb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,8 +29,8 @@ public class SharedStringsWb {
     public static void main(String[] args) throws Exception {
         WhiteBox wb = WhiteBox.getWhiteBox();
 
-        if (wb.areSharedStringsIgnored()) {
-            System.out.println("Shared strings are ignored, assuming PASS");
+        if (!wb.areSharedStringsMapped()) {
+            System.out.println("Shared strings are not mapped, assuming PASS");
             return;
         }
 
@@ -43,7 +43,7 @@ public class SharedStringsWb {
             throw new RuntimeException("Shared string is not a valid String: FAIL");
         }
 
-        if (wb.isShared(internedS)) {
+        if (wb.isSharedInternedString(internedS)) {
             System.out.println("Found shared string, result: PASS");
         } else {
             throw new RuntimeException("String is not shared, result: FAIL");

--- a/test/hotspot/jtreg/runtime/cds/appcds/DumpClassList.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/DumpClassList.java
@@ -97,8 +97,8 @@ public class DumpClassList {
             .shouldNotContain("Preload Warning: Cannot find java/lang/invoke/LambdaForm")
             .shouldNotContain("Preload Warning: Cannot find boot/append/Foo")
             .shouldNotContain("Preload Warning: Cannot find jdk/jfr/NewClass")
-            .shouldMatch(".info..class,load *. boot.append.Foo")      // from -Xlog:class+load
-            .shouldMatch("cds,class.*boot  boot.append.Foo")          // from -Xlog:cds+class
-            .shouldNotMatch(".info..class,load *. jdk.jfr.NewClass"); // from -Xlog:class+load
+            .shouldMatch("class,load *. boot.append.Foo")      // from -Xlog:class+load
+            .shouldMatch("cds,class.*boot  boot.append.Foo")   // from -Xlog:cds+class
+            .shouldNotMatch("class,load *. jdk.jfr.NewClass"); // from -Xlog:class+load
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/GCStressApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/GCStressApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,8 +62,8 @@ public class GCStressApp {
            return;
         }
 
-        if (wb.areSharedStringsIgnored()) {
-          System.out.println("Shared strings are ignored.");
+        if (!wb.areSharedStringsMapped()) {
+          System.out.println("Shared strings are not mapped.");
           return;
         }
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/RedefineClassApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/RedefineClassApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ public class RedefineClassApp {
     static Instrumentation instrumentation;
 
     public static void main(String args[]) throws Throwable {
-        if (wb.areSharedStringsIgnored()) {
+        if (!wb.areSharedStringsMapped()) {
           System.out.println("Shared strings are ignored.");
           return;
         }

--- a/test/hotspot/jtreg/runtime/cds/appcds/javaldr/GCSharedStringsDuringDumpWb.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/javaldr/GCSharedStringsDuringDumpWb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ public class GCSharedStringsDuringDumpWb {
     }
 
     public static void CheckString(WhiteBox wb, String s) {
-        if (!wb.areSharedStringsIgnored() && !wb.isShared(s)) {
+        if (wb.areSharedStringsMapped() && !wb.isSharedInternedString(s)) {
             throw new RuntimeException("String is not shared.");
         }
     }

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/ExerciseGC.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/ExerciseGC.java
@@ -26,6 +26,7 @@
  * @test
  * @summary Exercise GC with shared strings
  * @requires vm.cds.archived.java.heap
+ * @requires vm.gc == null
  * @library /test/hotspot/jtreg/runtime/cds/appcds /test/lib
  * @build HelloStringGC sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/FlagCombo.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/FlagCombo.java
@@ -26,6 +26,7 @@
  * @test
  * @summary Test relevant combinations of command line flags with shared strings
  * @requires vm.cds.archived.java.heap & vm.hasJFR
+ * @requires vm.gc == null
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build HelloString
  * @run driver FlagCombo
@@ -36,6 +37,7 @@
  * @summary Test relevant combinations of command line flags with shared strings
  * @comment A special test excluding the case that requires JFR
  * @requires vm.cds.archived.java.heap & !vm.hasJFR
+ * @requires vm.gc == null
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build HelloString
  * @run driver FlagCombo noJfr

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/HelloStringGC.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/HelloStringGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ public class HelloStringGC {
         String testString2 = "test123";
 
         WhiteBox wb = WhiteBox.getWhiteBox();
-        if (!wb.isShared(testString1) && !wb.areSharedStringsIgnored()) {
+        if (wb.areSharedStringsMapped() && !wb.isSharedInternedString(testString1)) {
             throw new RuntimeException("testString1 is not shared");
         }
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/HelloStringPlus.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/HelloStringPlus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ public class HelloStringPlus {
         System.out.println("Hello String: " + testString1);
 
         WhiteBox wb = WhiteBox.getWhiteBox();
-        if (!wb.isShared(testString1) && !wb.areSharedStringsIgnored()) {
+        if (wb.areSharedStringsMapped() && !wb.isSharedInternedString(testString1)) {
             throw new RuntimeException("testString1 is not shared");
         }
 
@@ -66,7 +66,7 @@ public class HelloStringPlus {
         // Check intern() method for "" string
         String empty = "";
         String empty_interned = empty.intern();
-        if (!wb.isShared(empty)) {
+        if (wb.areSharedStringsMapped() && !wb.isSharedInternedString(empty)) {
            throw new RuntimeException("Empty string should be shared");
         }
         if (empty_interned != empty) {

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/InternSharedString.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/InternSharedString.java
@@ -26,6 +26,7 @@
  * @test
  * @summary Test shared strings together with string intern operation
  * @requires vm.cds.archived.java.heap
+ * @requires vm.gc == null
  * @library /test/hotspot/jtreg/runtime/cds/appcds /test/lib
  * @compile InternStringTest.java
  * @build sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/InternStringTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/InternStringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,10 +38,12 @@ public class InternStringTest {
         // All string literals are shared.
         String shared1 = "LiveOak";
         String interned1 = shared1.intern();
-        if (wb.areSharedStringsIgnored() || wb.isShared(interned1)) {
-            System.out.println(passed_output1);
-        } else {
-            throw new RuntimeException("Failed: String is not shared.");
+        if (wb.areSharedStringsMapped()) {
+            if (wb.isSharedInternedString(interned1)) {
+                System.out.println(passed_output1);
+            } else {
+                throw new RuntimeException("Failed: String is not shared.");
+            }
         }
 
         // Test 2: shared_string1.intern() == shared_string2.intern()
@@ -58,10 +60,12 @@ public class InternStringTest {
             String a = "X" + latin1Sup.substring(1);
             String b = a.intern();
 
-            if (wb.areSharedStringsIgnored() || wb.isShared(b)) {
-                System.out.println(passed_output3);
-            } else {
-                throw new RuntimeException("Failed: expected shared string with latin1-supplement chars.");
+            if (wb.areSharedStringsMapped()) {
+                if (wb.isSharedInternedString(b)) {
+                    System.out.println(passed_output3);
+                } else {
+                    throw new RuntimeException("Failed: expected shared string with latin1-supplement chars.");
+                }
             }
         }
 
@@ -69,10 +73,12 @@ public class InternStringTest {
         {
             String a = "X" + nonWestern.substring(1);
             String b = a.intern();
-            if (wb.areSharedStringsIgnored() || wb.isShared(b)) {
-                System.out.println(passed_output4);
-            } else {
-                throw new RuntimeException("Failed: expected shared string with non-western chars.");
+            if (wb.areSharedStringsMapped()) {
+                if (wb.isSharedInternedString(b)) {
+                    System.out.println(passed_output4);
+                } else {
+                    throw new RuntimeException("Failed: expected shared string with non-western chars.");
+                }
             }
         }
     }

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/LargePages.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/LargePages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @test
  * @summary Basic shared string test with large pages
  * @requires vm.cds.archived.java.heap
+ * @requires vm.gc == null
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build HelloString
  * @run driver LargePages

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/LockSharedStrings.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/LockSharedStrings.java
@@ -26,6 +26,7 @@
  * @test
  * @summary Test locking on shared strings
  * @requires vm.cds.archived.java.heap
+ * @requires vm.gc == null
  * @library /test/hotspot/jtreg/runtime/cds/appcds /test/lib
  * @compile LockStringTest.java LockStringValueTest.java
  * @build sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/LockStringTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/LockStringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,13 +31,13 @@ public class LockStringTest extends Thread {
 
     public static void main(String[] args) throws Exception {
 
-        if (wb.areSharedStringsIgnored()) {
-            System.out.println("The shared strings are ignored");
+        if (!wb.areSharedStringsMapped()) {
+            System.out.println("The shared strings are not mapped");
             System.out.println("LockStringTest: PASS");
             return;
         }
 
-        if (!wb.isShared(LockStringTest.class)) {
+        if (!wb.isSharedClass(LockStringTest.class)) {
             throw new RuntimeException("Failed: LockStringTest class is not shared.");
         }
 
@@ -57,7 +57,7 @@ public class LockStringTest extends Thread {
         lock = s;
         done = false;
 
-        if (!wb.isShared(lock)) {
+        if (!wb.isSharedInternedString(lock)) {
             throw new RuntimeException("Failed: String \"" + lock + "\" is not shared.");
         }
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/LockStringValueTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/LockStringValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,13 +33,13 @@ public class LockStringValueTest {
         String s = "LiveOak";
         WhiteBox wb = WhiteBox.getWhiteBox();
 
-        if (wb.areSharedStringsIgnored()) {
-            System.out.println("The shared strings are ignored");
+        if (!wb.areSharedStringsMapped()) {
+            System.out.println("The shared strings are not mapped");
             System.out.println("LockStringValueTest: PASS");
             return;
         }
 
-        if (!wb.isShared(s)) {
+        if (!wb.isSharedInternedString(s)) {
             throw new RuntimeException("LockStringValueTest Failed: String is not shared.");
         }
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsBasicPlus.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsBasicPlus.java
@@ -26,6 +26,7 @@
  * @test
  * @summary Basic plus test for shared strings
  * @requires vm.cds.archived.java.heap
+ * @requires vm.gc == null
  * @library /test/hotspot/jtreg/runtime/cds/appcds /test/lib
  * @build HelloStringPlus sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsWb.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsWb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,10 +29,12 @@ public class SharedStringsWb {
         WhiteBox wb = WhiteBox.getWhiteBox();
         String s = "shared_test_string_unique_14325";
         s = s.intern();
-        if (wb.areSharedStringsIgnored() || wb.isShared(s)) {
-            System.out.println("Found shared string.");
-        } else {
-            throw new RuntimeException("String is not shared.");
+        if (wb.areSharedStringsMapped()) {
+            if (wb.isSharedInternedString(s)) {
+                System.out.println("Found shared string.");
+            } else {
+                throw new RuntimeException("String is not shared.");
+            }
         }
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsWbTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsWbTest.java
@@ -26,6 +26,7 @@
  * @test
  * @summary White box test for shared strings
  * @requires vm.cds.archived.java.heap
+ * @requires vm.gc == null
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build sun.hotspot.WhiteBox SharedStringsWb
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SysDictCrash.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SysDictCrash.java
@@ -27,6 +27,7 @@
  * @summary Regression test for JDK-8098821
  * @bug 8098821
  * @requires vm.cds.archived.java.heap
+ * @requires vm.gc == null
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @run driver SysDictCrash
  */

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -310,7 +310,7 @@ public class WhiteBox {
     makeMethodNotCompilable0(method, compLevel, isOsr);
   }
   public        int     getMethodCompilationLevel(Executable method) {
-    return getMethodCompilationLevel(method, false /*not ost*/);
+    return getMethodCompilationLevel(method, false /*not osr*/);
   }
   private native int     getMethodCompilationLevel0(Executable method, boolean isOsr);
   public         int     getMethodCompilationLevel(Executable method, boolean isOsr) {
@@ -591,7 +591,8 @@ public class WhiteBox {
   public native boolean isSharingEnabled();
   public native boolean isShared(Object o);
   public native boolean isSharedClass(Class<?> c);
-  public native boolean areSharedStringsIgnored();
+  public native boolean areSharedStringsMapped();
+  public native boolean isSharedInternedString(String s);
   public native boolean isCDSIncluded();
   public native boolean isJFRIncluded();
   public native boolean isJavaHeapArchiveSupported();
@@ -605,6 +606,7 @@ public class WhiteBox {
 
   // Handshakes
   public native int handshakeWalkStack(Thread t, boolean all_threads);
+  public native boolean handshakeReadMonitors(Thread t);
   public native void asyncHandshakeWalkStack(Thread t);
 
   public native void lockAndBlock(boolean suspender);

--- a/test/lib/sun/hotspot/WhiteBox.java
+++ b/test/lib/sun/hotspot/WhiteBox.java
@@ -592,7 +592,8 @@ public class WhiteBox {
   public native boolean isSharingEnabled();
   public native boolean isShared(Object o);
   public native boolean isSharedClass(Class<?> c);
-  public native boolean areSharedStringsIgnored();
+  public native boolean areSharedStringsMapped();
+  public native boolean isSharedInternedString(String s);
   public native boolean isCDSIncluded();
   public native boolean isJFRIncluded();
   public native boolean isJavaHeapArchiveSupported();


### PR DESCRIPTION
For testing https://github.com/openjdk/jdk/pull/5074 (Support archived heap objects in EpsilonGC), some CDS tests should be updated:

(1) Add `@require vm.gc == null` to mark test cases that will fail if a collector is explicitly specified using `-XX:+UseXXXGC`

(2) Rename this WhiteBox API to reflect what it checks:

```
!WB.areSharedStringsIgnored() -> WB.areSharedStringsMapped()
```
With EpsilonGC, the shared strings are not "ignored", but they are also not "mapped" either (they are copied into the Java heap). The existing tests are for mapped strings only, so they should check for `WB.areSharedStringsMapped()`.

(3) For test cases that check if a heap object is a shared interned string, instead of the generic `WB.isShared(Object o)` API, use a new specific API `WB.isSharedInternedString(String s)`. This API currently works only for "mapped shared strings", but in the future we may enhance it to check for "loaded shared strings" by EpsilonGC.

(4) Also fix the two test cases that were sensitive to irregular -Xlog output:

- ServiceLoaderTest.java: remove timestamp decorations from the logs
- DumpClassList.java: handle extra space characters that may appear in the tag decoration between square brackets.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272348](https://bugs.openjdk.java.net/browse/JDK-8272348): Update CDS tests in anticipation of JDK-8270489


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5095/head:pull/5095` \
`$ git checkout pull/5095`

Update a local copy of the PR: \
`$ git checkout pull/5095` \
`$ git pull https://git.openjdk.java.net/jdk pull/5095/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5095`

View PR using the GUI difftool: \
`$ git pr show -t 5095`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5095.diff">https://git.openjdk.java.net/jdk/pull/5095.diff</a>

</details>
