### PR TITLE
8272327: Shenandoah: Avoid enqueuing duplicate string candidates

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
@@ -261,7 +261,9 @@ inline void ShenandoahMark::mark_through_ref(T* p, ShenandoahObjToScanQueue* q, 
       if ((STRING_DEDUP == ENQUEUE_DEDUP) && ShenandoahStringDedup::is_candidate(obj)) {
         assert(ShenandoahStringDedup::is_enabled(), "Must be enabled");
         req->add(obj);
-      } else if ((STRING_DEDUP == ALWAYS_DEDUP) && ShenandoahStringDedup::is_string_candidate(obj)) {
+      } else if ((STRING_DEDUP == ALWAYS_DEDUP) &&
+                 ShenandoahStringDedup::is_string_candidate(obj) &&
+                 !ShenandoahStringDedup::dedup_requested(obj)) {
         assert(ShenandoahStringDedup::is_enabled(), "Must be enabled");
         req->add(obj);
       }

--- a/src/hotspot/share/gc/shenandoah/shenandoahStringDedup.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahStringDedup.hpp
@@ -31,6 +31,7 @@ class ShenandoahStringDedup : public StringDedup {
 public:
   static inline bool is_string_candidate(oop obj);
   static inline bool is_candidate(oop obj);
+  static inline bool dedup_requested(oop obj);
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHSTRINGDEDUP_HPP


### PR DESCRIPTION
Now, there is a new API java_lang_String::test_and_set_deduplication_requested() that can help to identify if a string candidate has been enqueued, so that we can avoid enqueuing duplicate entries.

Test:
- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272327](https://bugs.openjdk.java.net/browse/JDK-8272327): Shenandoah: Avoid enqueuing duplicate string candidates


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5096/head:pull/5096` \
`$ git checkout pull/5096`

Update a local copy of the PR: \
`$ git checkout pull/5096` \
`$ git pull https://git.openjdk.java.net/jdk pull/5096/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5096`

View PR using the GUI difftool: \
`$ git pr show -t 5096`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5096.diff">https://git.openjdk.java.net/jdk/pull/5096.diff</a>

</details>
