### PR TITLE
8272297: FileInputStream should override transferTo() for better performance

### DIFF
--- a/src/java.base/share/classes/java/io/FileInputStream.java
+++ b/src/java.base/share/classes/java/io/FileInputStream.java
@@ -367,7 +367,9 @@ public class FileInputStream extends InputStream
 
                 // Return if transferTo() copies enough bytes, but if it does
                 // not, then use the superclass method to copy those remaining
-                if (fci.transferTo(pos, count, fco) == count) {
+                long transferred = fci.transferTo(pos, count, fco);
+                fci.position(pos + transferred);
+                if (transferred == count) {
                     return count;
                 }
             }

--- a/src/java.base/share/classes/java/io/FileInputStream.java
+++ b/src/java.base/share/classes/java/io/FileInputStream.java
@@ -358,23 +358,21 @@ public class FileInputStream extends InputStream
      * {@inheritDoc}
      */
     public long transferTo(OutputStream out) throws IOException {
+        long transferred = 0L;
         if (out instanceof FileOutputStream fos) {
-            FileChannel fci = getChannel();
-            long pos = fci.position();
-            long count = fci.size() - pos;
+            FileChannel fc = getChannel();
+            long pos = fc.position();
+            long count = fc.size() - pos;
             if (pos >= 0 && count >= 0) {
-                FileChannel fco = fos.getChannel();
-
-                // Return if transferTo() copies enough bytes, but if it does
-                // not, then use the superclass method to copy those remaining
-                long transferred = fci.transferTo(pos, count, fco);
-                fci.position(pos + transferred);
-                if (transferred == count) {
-                    return count;
+                transferred = fc.transferTo(pos, Long.MAX_VALUE, fos.getChannel());
+                long newPos = pos + transferred;
+                fc.position(newPos);
+                if (newPos >= fc.size()) {
+                    return transferred;
                 }
             }
         }
-        return super.transferTo(out);
+        return transferred + super.transferTo(out);
     }
 
     private long length() throws IOException {

--- a/src/java.base/share/classes/java/io/FileInputStream.java
+++ b/src/java.base/share/classes/java/io/FileInputStream.java
@@ -354,6 +354,27 @@ public class FileInputStream extends InputStream
         return (capacity == nread) ? buf : Arrays.copyOf(buf, nread);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    public long transferTo(OutputStream out) throws IOException {
+        if (out instanceof FileOutputStream fos) {
+            FileChannel fci = getChannel();
+            long pos = fci.position();
+            long count = fci.size() - pos;
+            if (pos >= 0 && count >= 0) {
+                FileChannel fco = fos.getChannel();
+
+                // Return if transferTo() copies enough bytes, but if it does
+                // not, then use the superclass method to copy those remaining
+                if (fci.transferTo(pos, count, fco) == count) {
+                    return count;
+                }
+            }
+        }
+        return super.transferTo(out);
+    }
+
     private long length() throws IOException {
         return length0();
     }

--- a/src/java.base/share/classes/java/io/FileInputStream.java
+++ b/src/java.base/share/classes/java/io/FileInputStream.java
@@ -362,14 +362,11 @@ public class FileInputStream extends InputStream
         if (out instanceof FileOutputStream fos) {
             FileChannel fc = getChannel();
             long pos = fc.position();
-            long count = fc.size() - pos;
-            if (pos >= 0 && count >= 0) {
-                transferred = fc.transferTo(pos, Long.MAX_VALUE, fos.getChannel());
-                long newPos = pos + transferred;
-                fc.position(newPos);
-                if (newPos >= fc.size()) {
-                    return transferred;
-                }
+            transferred = fc.transferTo(pos, Long.MAX_VALUE, fos.getChannel());
+            long newPos = pos + transferred;
+            fc.position(newPos);
+            if (newPos >= fc.size()) {
+                return transferred;
             }
         }
         return transferred + super.transferTo(out);

--- a/test/jdk/java/io/FileInputStream/TransferTo.java
+++ b/test/jdk/java/io/FileInputStream/TransferTo.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @library /test/lib
+ * @build jdk.test.lib.RandomFactory
+ * @run main TransferTo
+ * @bug 8272297
+ * @summary Test FileInputStream.transferTo(FileOutputStream)
+ * @key randomness
+ */
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Random;
+import jdk.test.lib.RandomFactory;
+
+public class TransferTo {
+    private static int MIN_SIZE      = 10_000;
+    private static int MAX_SIZE_INCR = 100_000_000 - MIN_SIZE;
+
+    private static int ITERATIONS = 10;
+
+    private static final Random RND = RandomFactory.getRandom();
+
+    public static void main(String[] args) throws IOException {
+        File dir = new File(".");
+        File in = File.createTempFile("src", ".dat", dir);
+        in.deleteOnExit();
+
+        int length = MIN_SIZE + RND.nextInt(MAX_SIZE_INCR);
+        byte[] bytes = new byte[length];
+
+        try (RandomAccessFile rafi = new RandomAccessFile(in, "rw")) {
+            rafi.write(bytes);
+        }
+
+        File out = File.createTempFile("dst", ".dat", dir);
+        out.deleteOnExit();
+
+        for (int i = 0; i < ITERATIONS; i++) {
+            int posIn = RND.nextInt(length);
+            int posOut = RND.nextInt(MIN_SIZE);
+
+            try (RandomAccessFile rafo = new RandomAccessFile(out, "rw")) {
+                rafo.setLength(posOut);
+            }
+
+            test(in, posIn, out, posOut);
+
+            out.delete();
+            out = File.createTempFile("dst", ".dat", dir);
+            out.deleteOnExit();
+        }
+    }
+
+    private static void test(File in, int posIn, File out, int posOut)
+        throws IOException {
+        try (FileInputStream fis = new FileInputStream(in)) {
+            try (FileChannel fci = fis.getChannel()) {
+                fci.position(posIn);
+                long size = fci.size();
+                long length = size - posIn;
+                int count = Math.toIntExact(length);
+
+                try (FileOutputStream fos = new FileOutputStream(out)) {
+                    try (FileChannel fco = fos.getChannel()) {
+                        fco.position(posOut);
+
+                        long transferred = fis.transferTo(fos);
+                        if (transferred != count)
+                            fail(posIn, size, posOut,
+                                "Transferred " + transferred +
+                                ", expected " + count);
+
+                        if (fci.position() != posIn + count)
+                            fail(posIn, size, posOut,
+                                "Input position " + fci.position() +
+                                ", expected " + posIn + count);
+
+                        if (fco.position() != posOut + count)
+                            fail(posIn, size, posOut,
+                                "Output position " + fco.position() +
+                                ", expected " + posOut + count);
+
+                        byte[] bytesIn = Files.readAllBytes(in.toPath());
+                        byte[] bytesOut = Files.readAllBytes(out.toPath());
+                        if (!Arrays.equals(bytesIn, posIn, posIn + count,
+                                           bytesOut, posOut, posOut + count))
+                            fail(posIn, size, posOut, "Contents unequal");
+                    }
+                }
+            }
+        }
+    }
+
+    private static void fail(int posIn, long size, int posOut,
+                             String msg) {
+        System.out.printf("Failure for posIn %s, size %d, posOut %d%n",
+                          posIn, size, posOut);
+        throw new RuntimeException(msg);
+    }
+}


### PR DESCRIPTION
Please consider this request to add an override `java.io.FileInputStream.transferTo(OutputStream)` with improved performance if the parameter is a `FileOutputStream`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272297](https://bugs.openjdk.java.net/browse/JDK-8272297): FileInputStream should override transferTo() for better performance


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5097/head:pull/5097` \
`$ git checkout pull/5097`

Update a local copy of the PR: \
`$ git checkout pull/5097` \
`$ git pull https://git.openjdk.java.net/jdk pull/5097/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5097`

View PR using the GUI difftool: \
`$ git pr show -t 5097`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5097.diff">https://git.openjdk.java.net/jdk/pull/5097.diff</a>

</details>
