### PR TITLE
JDK-8264274: Block tags in overview.html are ignored

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractOverviewIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractOverviewIndexWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,9 +66,8 @@ public abstract class AbstractOverviewIndexWriter extends HtmlDocletWriter {
      */
     protected void addOverviewHeader(Content main) {
         addConfigurationTitle(main);
-        if (!utils.getFullBody(configuration.overviewElement).isEmpty()) {
-            addOverviewComment(main);
-        }
+        addOverviewComment(main);
+        addOverviewTags(main);
     }
 
     /**
@@ -81,6 +80,17 @@ public abstract class AbstractOverviewIndexWriter extends HtmlDocletWriter {
     protected void addOverviewComment(Content htmltree) {
         if (!utils.getFullBody(configuration.overviewElement).isEmpty()) {
             addInlineComment(configuration.overviewElement, htmltree);
+        }
+    }
+
+    /**
+     * Adds the block tags provided in the file specified by the "-overview" option.
+     *
+     * @param htmlTree the content tree to which the tags will be added
+     */
+    protected void addOverviewTags(Content htmlTree) {
+        if (!utils.getFullBody(configuration.overviewElement).isEmpty()) {
+            addTagsInfo(configuration.overviewElement, htmlTree);
         }
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testOverview/TestOverview.java
+++ b/test/langtools/jdk/javadoc/doclet/testOverview/TestOverview.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8173302 8182765 8196202 8210047
+ * @bug 8173302 8182765 8196202 8210047 8264274
  * @summary make sure the overview-summary and module-summary pages don't
  *          don't have the See link, and the overview is copied correctly.
  * @library ../../lib
@@ -50,7 +50,7 @@ public class TestOverview extends JavadocTester {
                     "-sourcepath", testSrc("src"),
                     "p1", "p2");
         checkExit(Exit.OK);
-        checkOverview();
+        checkOverview("");
     }
 
     @Test
@@ -62,10 +62,10 @@ public class TestOverview extends JavadocTester {
                     "-sourcepath", testSrc("msrc"),
                     "p1", "p2");
         checkExit(Exit.OK);
-        checkOverview();
+        checkOverview("acme/");
     }
 
-    void checkOverview() {
+    void checkOverview(String modulePrefix) {
         checkOutput("index.html", true,
                 """
                     <main role="main">
@@ -73,6 +73,14 @@ public class TestOverview extends JavadocTester {
                     <h1 class="title">Document Title</h1>
                     </div>
                     <div class="block">This is line1. This is line 2.</div>
-                    """);
+                    <dl class="notes">
+                    <dt>See Also:</dt>
+                    <dd>
+                    <ul class="see-list">
+                    <li><a href="%1$sp1/C.html" title="class in p1"><code>C</code></a></li>
+                    </ul>
+                    </dd>
+                    </dl>
+                    """.formatted(modulePrefix));
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testOverview/TestOverview.java
+++ b/test/langtools/jdk/javadoc/doclet/testOverview/TestOverview.java
@@ -77,10 +77,10 @@ public class TestOverview extends JavadocTester {
                     <dt>See Also:</dt>
                     <dd>
                     <ul class="see-list">
-                    <li><a href="%1$sp1/C.html" title="class in p1"><code>C</code></a></li>
+                    <li><a href="%sp1/C.html" title="class in p1"><code>C</code></a></li>
                     </ul>
                     </dd>
                     </dl>
-                    """.formatted(modulePrefix));
+                    """.formatted(modulePrefix)); // adapt expected reference URL to module context
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testOverview/overview.html
+++ b/test/langtools/jdk/javadoc/doclet/testOverview/overview.html
@@ -2,5 +2,6 @@
 <html>
 <body bgcolor="white">
     This is line1. This is line 2.
+    @see p1.C
 </body>
 </html>


### PR DESCRIPTION
This is a simple fix to generate block tags in overview files specified by the `-overview` option. 

I added a protected `addOverviewTags` method in `AbstractOverviewIndexWriter` which is probably overkill but keeps things flexible and separated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264274](https://bugs.openjdk.java.net/browse/JDK-8264274): Block tags in overview.html are ignored


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5099/head:pull/5099` \
`$ git checkout pull/5099`

Update a local copy of the PR: \
`$ git checkout pull/5099` \
`$ git pull https://git.openjdk.java.net/jdk pull/5099/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5099`

View PR using the GUI difftool: \
`$ git pr show -t 5099`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5099.diff">https://git.openjdk.java.net/jdk/pull/5099.diff</a>

</details>
