### PR TITLE
8272334: com.sun.net.httpserver.HttpExchange: Improve API doc of getRequestHeaders

### DIFF
--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
@@ -81,13 +81,13 @@ public abstract class HttpExchange implements AutoCloseable {
      * Returns an immutable {@link Headers} containing the HTTP headers that
      * were included with this request.
      *
-     * <p> The keys in this {@code Headers} will be the header names, while the
-     * values will be a {@link java.util.List} of
+     * <p> The keys in this {@code Headers} are the header names, while the
+     * values are a {@link java.util.List} of
      * {@linkplain java.lang.String Strings} containing each value that was
      * included in the request, in the order they were included. Header fields
      * appearing multiple times are represented as multiple string values.
      *
-     * <p>The keys in {@code Headers} are case-insensitive.
+     * <p> The keys in {@code Headers} are case-insensitive.
      *
      * @return a read-only {@code Headers} which can be used to access request
      *         headers.
@@ -98,7 +98,7 @@ public abstract class HttpExchange implements AutoCloseable {
      * Returns a mutable {@link Headers} into which the HTTP response headers
      * can be stored and which will be transmitted as part of this response.
      *
-     * <p> The keys in the {@code Headers} will be the header names, while the
+     * <p> The keys in the {@code Headers} are the header names, while the
      * values must be a {@link java.util.List} of {@linkplain java.lang.String Strings}
      * containing each value that should be included multiple times (in the
      * order that they should be included).

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,32 +79,34 @@ public abstract class HttpExchange implements AutoCloseable {
     }
 
     /**
-     * Returns an immutable {@link Map} containing the HTTP headers that were
-     * included with this request. The keys in this {@code Map} will be the header
-     * names, while the values will be a {@link java.util.List} of
+     * Returns an immutable {@link Headers} containing the HTTP headers that
+     * were included with this request.
+     *
+     * <p>The keys in this {@code Headers} will be the header names, while the
+     * values will be a {@link java.util.List} of
      * {@linkplain java.lang.String Strings} containing each value that was
-     * included (either for a header that was listed several times, or one that
-     * accepts a comma-delimited list of values on a single line). In either of
-     * these cases, the values for the header name will be presented in the
-     * order that they were included in the request.
+     * included in the request, in the order they were included.
      *
-     * <p> The keys in {@code Map} are case-insensitive.
+     * <p>The keys in {@code Headers} are case-insensitive.
      *
-     * @return a read-only {@code Map} which can be used to access request headers
+     * @return a read-only {@code Headers} which can be used to access request
+     *         headers.
      */
     public abstract Headers getRequestHeaders();
 
     /**
-     * Returns a mutable {@link Map} into which the HTTP response headers can be
-     * stored and which will be transmitted as part of this response. The keys in
-     * the {@code Map} will be the header names, while the values must be a
-     * {@link java.util.List} of {@linkplain java.lang.String Strings} containing
-     * each value that should be included multiple times (in the order that they
-     * should be included).
+     * Returns a mutable {@link Headers} into which the HTTP response headers
+     * can be stored and which will be transmitted as part of this response.
      *
-     * <p> The keys in {@code Map} are case-insensitive.
+     * <p>The keys in the {@code Headers} will be the header names, while the
+     * values must be a {@link java.util.List} of {@linkplain java.lang.String Strings}
+     * containing each value that should be included multiple times (in the
+     * order that they should be included).
      *
-     * @return a writable {@code Map} which can be used to set response headers.
+     * <p>The keys in {@code Headers} are case-insensitive.
+     *
+     * @return a writable {@code Headers} which can be used to set response
+     *         headers.
      */
     public abstract Headers getResponseHeaders();
 

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
@@ -30,7 +30,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.URI;
-import java.util.Map;
 
 /**
  * This class encapsulates a HTTP request received and a
@@ -86,7 +85,7 @@ public abstract class HttpExchange implements AutoCloseable {
      * values will be a {@link java.util.List} of
      * {@linkplain java.lang.String Strings} containing each value that was
      * included in the request, in the order they were included. Header fields
-     * appearing on multiple lines are represented as multiple string values.
+     * appearing multiple times are represented as multiple string values.
      *
      * <p>The keys in {@code Headers} are case-insensitive.
      *
@@ -112,21 +111,21 @@ public abstract class HttpExchange implements AutoCloseable {
     public abstract Headers getResponseHeaders();
 
     /**
-     * Get the request {@link URI}.
+     * Returns the request {@link URI}.
      *
      * @return the request {@code URI}
      */
     public abstract URI getRequestURI();
 
     /**
-     * Get the request method.
+     * Returns the request method.
      *
      * @return the request method
      */
     public abstract String getRequestMethod();
 
     /**
-     * Get the {@link HttpContext} for this exchange.
+     * Returns the {@link HttpContext} for this exchange.
      *
      * @return the {@code HttpContext}
      */

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
@@ -82,10 +82,11 @@ public abstract class HttpExchange implements AutoCloseable {
      * Returns an immutable {@link Headers} containing the HTTP headers that
      * were included with this request.
      *
-     * <p>The keys in this {@code Headers} will be the header names, while the
+     * <p> The keys in this {@code Headers} will be the header names, while the
      * values will be a {@link java.util.List} of
      * {@linkplain java.lang.String Strings} containing each value that was
-     * included in the request, in the order they were included.
+     * included in the request, in the order they were included. Header fields
+     * appearing on multiple lines are represented as multiple string values.
      *
      * <p>The keys in {@code Headers} are case-insensitive.
      *
@@ -98,12 +99,12 @@ public abstract class HttpExchange implements AutoCloseable {
      * Returns a mutable {@link Headers} into which the HTTP response headers
      * can be stored and which will be transmitted as part of this response.
      *
-     * <p>The keys in the {@code Headers} will be the header names, while the
+     * <p> The keys in the {@code Headers} will be the header names, while the
      * values must be a {@link java.util.List} of {@linkplain java.lang.String Strings}
      * containing each value that should be included multiple times (in the
      * order that they should be included).
      *
-     * <p>The keys in {@code Headers} are case-insensitive.
+     * <p> The keys in {@code Headers} are case-insensitive.
      *
      * @return a writable {@code Headers} which can be used to set response
      *         headers.


### PR DESCRIPTION
This is a doc-only fix that improves the wording of the API doc of `getRequestHeaders()`. The other changes are trivial cleanup.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272334](https://bugs.openjdk.java.net/browse/JDK-8272334): com.sun.net.httpserver.HttpExchange: Improve API doc of getRequestHeaders


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Michael McMahon](https://openjdk.java.net/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**) ⚠️ Review applies to 5fdccc3213e8b6f9c8f733c721d3b922381426cb
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5100/head:pull/5100` \
`$ git checkout pull/5100`

Update a local copy of the PR: \
`$ git checkout pull/5100` \
`$ git pull https://git.openjdk.java.net/jdk pull/5100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5100`

View PR using the GUI difftool: \
`$ git pr show -t 5100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5100.diff">https://git.openjdk.java.net/jdk/pull/5100.diff</a>

</details>
