### PR TITLE
8263940: NPE when creating default file system when default file system provider is packaged as JAR file on class path

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -33,7 +33,6 @@ import java.io.File;
 import java.io.RandomAccessFile;
 import java.io.UncheckedIOException;
 import java.lang.ref.Cleaner.Cleanable;
-import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.file.InvalidPathException;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -69,6 +68,7 @@ import jdk.internal.perf.PerfCounter;
 import jdk.internal.ref.CleanerFactory;
 import jdk.internal.vm.annotation.Stable;
 import sun.nio.cs.UTF_8;
+import sun.nio.fs.DefaultFileSystemProvider;
 import sun.security.util.SignatureFileVerifier;
 
 import static java.util.zip.ZipConstants64.*;
@@ -1255,14 +1255,19 @@ public class ZipFile implements ZipConstants, Closeable {
             }
         }
         private static final HashMap<Key, Source> files = new HashMap<>();
-
+        /**
+         * Use the platform's default file system to avoid
+         * issues when the VM is configured to use a custom file system provider.
+         */
+        private static final java.nio.file.FileSystem builtInFS =
+                DefaultFileSystemProvider.theFileSystem();
 
         static Source get(File file, boolean toDelete, ZipCoder zc) throws IOException {
             final Key key;
             try {
                 key = new Key(file,
-                        Files.readAttributes(file.toPath(), BasicFileAttributes.class),
-                        zc);
+                        Files.readAttributes(builtInFS.getPath(file.getPath()),
+                                BasicFileAttributes.class), zc);
             } catch (InvalidPathException ipe) {
                 throw new IOException(ipe);
             }

--- a/test/jdk/java/nio/file/spi/SetDefaultProvider.java
+++ b/test/jdk/java/nio/file/spi/SetDefaultProvider.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8266345
+ * @bug 4313887 7006126 8142968 8178380 8183320 8210112 8266345 8263940
  * @modules jdk.jartool
  * @library /test/lib
  * @build SetDefaultProvider TestProvider m/* jdk.test.lib.process.ProcessTools
@@ -37,11 +37,14 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.spi.ToolProvider;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import jdk.test.lib.process.ProcessTools;
 
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
@@ -71,6 +74,45 @@ public class SetDefaultProvider {
         String classpath = moduleClasses + File.pathSeparator + testClasses;
         int exitValue = exec(SET_DEFAULT_FSP, "-cp", classpath, "p.Main");
         assertTrue(exitValue == 0);
+    }
+
+    /**
+     * Test override of default FileSystemProvider with a
+     * FileSystemProvider jar and the main application on the class path.
+     */
+    public void testClassPathWithFileSystemProviderJar() throws Exception {
+        String testClasses = System.getProperty("test.classes");
+        Path jar = Path.of("testFileSystemProvider.jar");
+        Files.deleteIfExists(jar);
+        createFileSystemProviderJar(jar, Path.of(testClasses));
+        String classpath = jar + File.pathSeparator + testClasses
+                + File.separator + "modules" + File.separator + "m";
+        int exitValue = exec(SET_DEFAULT_FSP, "-cp", classpath, "p.Main");
+        assertTrue(exitValue == 0);
+    }
+
+    /**
+     * Creates a JAR containing the FileSystemProvider used to override the
+     * default FileSystemProvider
+     */
+    private void createFileSystemProviderJar(Path jar, Path dir) throws IOException {
+
+        List<String>  args = new ArrayList<>();
+        args.add("--create");
+        args.add("--file=" + jar);
+        try (Stream<Path> stream = Files.list(dir)) {
+            List<String> paths = stream
+                    .map(path -> path.getFileName().toString())
+                    .filter(f -> f.startsWith("TestProvider"))
+                    .collect(Collectors.toList());
+            for(var p : paths) {
+                args.add("-C");
+                args.add(dir.toString());
+                args.add(p);
+            }
+        }
+        int ret = JAR_TOOL.run(System.out, System.out, args.toArray(new String[0]));
+        assertTrue(ret == 0);
     }
 
     /**

--- a/test/jdk/java/nio/file/spi/SetDefaultProvider.java
+++ b/test/jdk/java/nio/file/spi/SetDefaultProvider.java
@@ -104,7 +104,7 @@ public class SetDefaultProvider {
             List<String> paths = stream
                     .map(path -> path.getFileName().toString())
                     .filter(f -> f.startsWith("TestProvider"))
-                    .collect(Collectors.toList());
+                    .toList();
             for(var p : paths) {
                 args.add("-C");
                 args.add(dir.toString());


### PR DESCRIPTION
Hi all,

Please review the fix for JDK-8263940 to address an issues when the default file system provider is packaged as JAR file on class path.

The patch also addresses the `@bug` line for JDK-8271194

Mach5 Tier1 - Tier3 have run without issues

Best,
Lance

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263940](https://bugs.openjdk.java.net/browse/JDK-8263940): NPE when creating default file system when default file system provider is packaged as JAR file on class path


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to c09d7c32ac0f8a4ebdd9d9103d8d47066358c458
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5103/head:pull/5103` \
`$ git checkout pull/5103`

Update a local copy of the PR: \
`$ git checkout pull/5103` \
`$ git pull https://git.openjdk.java.net/jdk pull/5103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5103`

View PR using the GUI difftool: \
`$ git pr show -t 5103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5103.diff">https://git.openjdk.java.net/jdk/pull/5103.diff</a>

</details>
