### PR TITLE
8272391: Undeleted debug information

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/DSAParameterGenerator.java
+++ b/src/java.base/share/classes/sun/security/provider/DSAParameterGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -187,7 +187,6 @@ public class DSAParameterGenerator extends AlgorithmParameterGeneratorSpi {
             hashObj = MessageDigest.getInstance(hashAlg);
         } catch (NoSuchAlgorithmException nsae) {
             // should never happen
-            nsae.printStackTrace();
         }
 
         /* Step 3, 4: Useful variables */


### PR DESCRIPTION
There is debug code in the DSAParameterGenerator that dump debug information to standard-err.  It should be deleted. 

Simple code clean up, no new regression test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272391](https://bugs.openjdk.java.net/browse/JDK-8272391): Undeleted debug information


### Reviewers
 * [Bradford Wetmore](https://openjdk.java.net/census#wetmore) (@bradfordwetmore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5104/head:pull/5104` \
`$ git checkout pull/5104`

Update a local copy of the PR: \
`$ git checkout pull/5104` \
`$ git pull https://git.openjdk.java.net/jdk pull/5104/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5104`

View PR using the GUI difftool: \
`$ git pr show -t 5104`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5104.diff">https://git.openjdk.java.net/jdk/pull/5104.diff</a>

</details>
