### PR TITLE
8272396: mismatching debug output streams

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/RSAKeyExchange.java
+++ b/src/java.base/share/classes/sun/security/ssl/RSAKeyExchange.java
@@ -236,8 +236,7 @@ final class RSAKeyExchange {
                     NoSuchAlgorithmException iae) {
                 // unlikely to happen, otherwise, must be a provider exception
                 if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
-                    SSLLogger.fine("RSA premaster secret generation error:");
-                    iae.printStackTrace(System.out);
+                    SSLLogger.fine("RSA premaster secret generation error", iae);
                 }
 
                 throw new GeneralSecurityException(


### PR DESCRIPTION
Please review this simple code clean up.  In RSAKeyExchange, a same debug log message is broken apart into System.out and System.err.  The SSLLogger should be used for SSL debug log dumpling in JDK.

Simple update and code clean up only, no new regression test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272396](https://bugs.openjdk.java.net/browse/JDK-8272396): mismatching debug output streams


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5105/head:pull/5105` \
`$ git checkout pull/5105`

Update a local copy of the PR: \
`$ git checkout pull/5105` \
`$ git pull https://git.openjdk.java.net/jdk pull/5105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5105`

View PR using the GUI difftool: \
`$ git pr show -t 5105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5105.diff">https://git.openjdk.java.net/jdk/pull/5105.diff</a>

</details>
