### PR TITLE
8272417: ZGC: fastdebug build crashes when printing ClassLoaderData

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -964,11 +964,13 @@ void ClassLoaderData::print_on(outputStream* out) const {
   out->print_cr(" - keep alive          %d", _keep_alive);
   out->print   (" - claim               ");
   switch(_claim) {
-    case _claim_none:       out->print_cr("none"); break;
-    case _claim_finalizable:out->print_cr("finalizable"); break;
-    case _claim_strong:     out->print_cr("strong"); break;
-    case _claim_other:      out->print_cr("other"); break;
-    default:                ShouldNotReachHere();
+    case _claim_none:                       out->print_cr("none"); break;
+    case _claim_finalizable:                out->print_cr("finalizable"); break;
+    case _claim_strong:                     out->print_cr("strong"); break;
+    case _claim_other:                      out->print_cr("other"); break;
+    case _claim_other | _claim_finalizable: out->print_cr("other and finalizable"); break;
+    case _claim_other | _claim_strong:      out->print_cr("other and strong"); break;
+    default:                                ShouldNotReachHere();
   }
   out->print_cr(" - handles             %d", _handles.count());
   out->print_cr(" - dependency count    %d", _dependency_count);

--- a/src/hotspot/share/gc/z/zVerify.cpp
+++ b/src/hotspot/share/gc/z/zVerify.cpp
@@ -23,7 +23,6 @@
 
 #include "precompiled.hpp"
 #include "classfile/classLoaderData.hpp"
-#include "classfile/classLoaderDataGraph.hpp"
 #include "gc/shared/gc_globals.hpp"
 #include "gc/z/zAddress.inline.hpp"
 #include "gc/z/zHeap.inline.hpp"
@@ -186,10 +185,6 @@ public:
   ZVerifyOopClosure(bool verify_weaks) :
       ClaimMetadataVisitingOopIterateClosure(ClassLoaderData::_claim_other),
       _verify_weaks(verify_weaks) {}
-
-  ~ZVerifyOopClosure() {
-    ClassLoaderDataGraph::clear_claimed_marks(ClassLoaderData::_claim_other);
-  }
 
   virtual void do_oop(oop* p) {
     if (_verify_weaks) {

--- a/src/hotspot/share/gc/z/zVerify.cpp
+++ b/src/hotspot/share/gc/z/zVerify.cpp
@@ -23,6 +23,7 @@
 
 #include "precompiled.hpp"
 #include "classfile/classLoaderData.hpp"
+#include "classfile/classLoaderDataGraph.hpp"
 #include "gc/shared/gc_globals.hpp"
 #include "gc/z/zAddress.inline.hpp"
 #include "gc/z/zHeap.inline.hpp"
@@ -185,6 +186,10 @@ public:
   ZVerifyOopClosure(bool verify_weaks) :
       ClaimMetadataVisitingOopIterateClosure(ClassLoaderData::_claim_other),
       _verify_weaks(verify_weaks) {}
+
+  ~ZVerifyOopClosure() {
+    ClassLoaderDataGraph::clear_claimed_marks(ClassLoaderData::_claim_other);
+  }
 
   virtual void do_oop(oop* p) {
     if (_verify_weaks) {


### PR DESCRIPTION
Following test fails on fastdebug build with the options: "-XX:+UseZGC -XX:+VerifyAfterGC -Xlog:gc*=trace". It crashes on the unknown claim value of the ClassLoaderData

public class A {
    public static void main(String... args) {
        System.gc();
    }
}

The unknown claim value  of the ClassLoaderData is "ClassLoaderData::_claim_other | ClassLoaderData::_claim_strong" which is introduced by the ZVerifyOopClosure. This patch clears the CLD's claimed marks after the ZGC verification

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272417](https://bugs.openjdk.java.net/browse/JDK-8272417): ZGC: fastdebug build crashes when printing ClassLoaderData


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5107/head:pull/5107` \
`$ git checkout pull/5107`

Update a local copy of the PR: \
`$ git checkout pull/5107` \
`$ git pull https://git.openjdk.java.net/jdk pull/5107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5107`

View PR using the GUI difftool: \
`$ git pr show -t 5107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5107.diff">https://git.openjdk.java.net/jdk/pull/5107.diff</a>

</details>
