### PR TITLE
8272439: G1: add documentation to G1CardSetInlinePtr

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.cpp
@@ -45,7 +45,7 @@
 G1CardSet::CardSetPtr G1CardSet::FullCardSet = (G1CardSet::CardSetPtr)-1;
 
 G1CardSetConfiguration::G1CardSetConfiguration() :
-  _inline_ptr_bits_per_card(HeapRegion::LogOfHRGrainBytes - CardTable::card_shift) {
+  _inline_ptr_bits_per_card(HeapRegion::LogCardsPerRegion) {
 
   // Array of Cards card set container size calculation
   _num_cards_in_array = G1RemSetArrayOfCardsEntries;

--- a/src/hotspot/share/gc/g1/g1CardSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.hpp
@@ -47,8 +47,10 @@ enum G1AddCardResult {
 };
 
 class G1CardSetConfiguration {
-  // #bits required to hold the max card index; log(#cards_per_region)
+  // Holds the number of bits required to cover the maximum card index for the
+  // regions covered by this card set.
   uint _inline_ptr_bits_per_card;
+
   uint _num_cards_in_array;
   uint _num_cards_in_howl_bitmap;
   uint _num_buckets_in_howl;

--- a/src/hotspot/share/gc/g1/g1CardSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.hpp
@@ -47,6 +47,7 @@ enum G1AddCardResult {
 };
 
 class G1CardSetConfiguration {
+  // #bits required to hold the max card index; log(#cards_per_region)
   uint _inline_ptr_bits_per_card;
   uint _num_cards_in_array;
   uint _num_cards_in_howl_bitmap;

--- a/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
@@ -36,6 +36,38 @@
 
 #include "runtime/thread.inline.hpp"
 
+// A helper class to encode a few card indexes within a CardSetPtr.
+//
+// The pointer value (either 32 or 64 bits) is split into two areas:
+//
+// - Header containing identifying tag and number of encoded cards.
+// - Data area containing the card indexes themselves
+//
+// The header starts (from LSB) with the identifying tag (two bits,
+// always 00), and three bits size. The size stores the number of
+// valid card indexes after the header.
+//
+// The data area makes up the remainder of the word, with card indexes
+// put one after another at increasing bit positions. The separate
+// card indexes use just enough space (bits) to represent the whole
+// range of cards needed for covering the whole range of values
+// (typically in a region). There may be unused space at the top of
+// the word.
+//
+// Example:
+//
+//   64 bit pointer size, with 8M-size regions (8M == 2^23)
+// -> 2^14 (2^23 / 2^9) cards; each card represents 512 bytes in a region
+// -> 14 bits per card; must have enough bits to hold the max card index
+// -> may encode up to 4 cards into it, using 61 bits (5 bits header + 4 * 14)
+//
+// M                                                     L
+// S                                                     S
+// B                                                     B
+// +------+         +---------------+--------------+-----+
+// |unused|   ...   |  card_index1  | card_index0  |SSS00|
+// +------+         +---------------+--------------+-----+
+
 class G1CardSetInlinePtr : public StackObj {
   friend class G1CardSetContainersTest;
 

--- a/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
@@ -67,7 +67,6 @@
 // +------+         +---------------+--------------+-----+
 // |unused|   ...   |  card_index1  | card_index0  |SSS00|
 // +------+         +---------------+--------------+-----+
-
 class G1CardSetInlinePtr : public StackObj {
   friend class G1CardSetContainersTest;
 


### PR DESCRIPTION
Add some documentation to `class G1CardSetInlinePtr`, and simplify a field initialization in `G1CardSetConfiguration`.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272439](https://bugs.openjdk.java.net/browse/JDK-8272439): G1: add documentation to G1CardSetInlinePtr


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to e282d72d1386ef01ef5602d58abb8f1361b2c289
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Contributors
 * Thomas Schatzl `<tschatzl@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5108/head:pull/5108` \
`$ git checkout pull/5108`

Update a local copy of the PR: \
`$ git checkout pull/5108` \
`$ git pull https://git.openjdk.java.net/jdk pull/5108/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5108`

View PR using the GUI difftool: \
`$ git pr show -t 5108`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5108.diff">https://git.openjdk.java.net/jdk/pull/5108.diff</a>

</details>
