### PR TITLE
8270344: Session resumption errors

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/ClientHello.java
+++ b/src/java.base/share/classes/sun/security/ssl/ClientHello.java
@@ -538,14 +538,6 @@ final class ClientHello {
                 if (!session.getProtocolVersion().useTLS13PlusSpec()) {
                     sessionId = session.getSessionId();
                 }
-                if (!maxProtocolVersion.equals(sessionVersion)) {
-                    maxProtocolVersion = sessionVersion;
-
-                    // Update protocol version number in underlying socket and
-                    // handshake output stream, so that the output records
-                    // (at the record layer) have the correct version
-                    chc.setVersion(sessionVersion);
-                }
 
                 // If no new session is allowed, force use of the previous
                 // session ciphersuite, and add the renegotiation SCSV if
@@ -650,10 +642,6 @@ final class ClientHello {
 
             if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
                 SSLLogger.fine("Produced ClientHello handshake message", chm);
-            }
-
-            if (session != null) {
-                chc.handshakeSession = session;
             }
 
             // Output the handshake message.

--- a/src/java.base/share/classes/sun/security/ssl/ClientHello.java
+++ b/src/java.base/share/classes/sun/security/ssl/ClientHello.java
@@ -652,6 +652,10 @@ final class ClientHello {
                 SSLLogger.fine("Produced ClientHello handshake message", chm);
             }
 
+            if (session != null) {
+                chc.handshakeSession = session;
+            }
+
             // Output the handshake message.
             chm.write(chc.handshakeOutput);
             chc.handshakeOutput.flush();

--- a/src/java.base/share/classes/sun/security/ssl/ClientHello.java
+++ b/src/java.base/share/classes/sun/security/ssl/ClientHello.java
@@ -402,9 +402,6 @@ final class ClientHello {
             // clean up this producer
             chc.handshakeProducers.remove(SSLHandshake.CLIENT_HELLO.id);
 
-            // the max protocol version this client is supporting.
-            ProtocolVersion maxProtocolVersion = chc.maximumActiveProtocol;
-
             // session ID of the ClientHello message
             SessionId sessionId = new SessionId(new byte[0]);
 
@@ -572,7 +569,7 @@ final class ClientHello {
                             "no existing session can be resumed");
                 }
 
-                if (maxProtocolVersion.useTLS13PlusSpec() &&
+                if (chc.maximumActiveProtocol.useTLS13PlusSpec() &&
                         SSLConfiguration.useCompatibilityMode) {
                     // In compatibility mode, the TLS 1.3 legacy_session_id
                     // field MUST be non-empty, so a client not offering a
@@ -615,7 +612,7 @@ final class ClientHello {
             }
 
             // Create the handshake message.
-            ProtocolVersion clientHelloVersion = maxProtocolVersion;
+            ProtocolVersion clientHelloVersion = chc.maximumActiveProtocol;
             if (clientHelloVersion.useTLS13PlusSpec()) {
                 // In (D)TLS 1.3, the client indicates its version preferences
                 // in the "supported_versions" extension and the client_version

--- a/src/java.base/share/classes/sun/security/ssl/HandshakeContext.java
+++ b/src/java.base/share/classes/sun/security/ssl/HandshakeContext.java
@@ -534,15 +534,6 @@ abstract class HandshakeContext implements ConnectionContext {
         return activeProtocols.contains(protocolVersion);
     }
 
-    /**
-     * Set the active protocol version and propagate it to the SSLSocket
-     * and our handshake streams. Called from ClientHandshaker
-     * and ServerHandshaker with the negotiated protocol version.
-     */
-    void setVersion(ProtocolVersion protocolVersion) {
-        this.conContext.protocolVersion = protocolVersion;
-    }
-
     private static boolean isActivatable(CipherSuite suite,
             AlgorithmConstraints algorithmConstraints,
             Map<NamedGroupSpec, Boolean> cachedStatus) {

--- a/src/java.base/share/classes/sun/security/ssl/TransportContext.java
+++ b/src/java.base/share/classes/sun/security/ssl/TransportContext.java
@@ -81,7 +81,6 @@ final class TransportContext implements ConnectionContext {
     boolean                         needHandshakeFinishedStatus = false;
     boolean                         hasDelegatedFinished = false;
 
-
     // negotiated security parameters
     SSLSessionImpl                  conSession;
     ProtocolVersion                 protocolVersion;

--- a/test/jdk/sun/security/ssl/SSLSessionImpl/InvalidateSession.java
+++ b/test/jdk/sun/security/ssl/SSLSessionImpl/InvalidateSession.java
@@ -107,7 +107,7 @@ public class InvalidateSession {
         if (testIterationCount == 3 && !Objects.equals(cacheSession, sslSocket.getSession())) {
             throw new RuntimeException("Same session should have resumed");
         }
-        
+
         cacheSession = sslSocket.getSession();
 
         System.out.println("Got session: " + sslSocket.getSession());

--- a/test/jdk/sun/security/ssl/SSLSessionImpl/InvalidateSession.java
+++ b/test/jdk/sun/security/ssl/SSLSessionImpl/InvalidateSession.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8270344
+ * @library /test/lib
+ * @summary Session resumption errors
+ * @run main/othervm InvalidateSession
+ */
+
+import javax.net.*;
+import javax.net.ssl.*;
+import java.io.*;
+import java.net.*;
+import java.util.*;
+
+import jdk.test.lib.security.SecurityUtils;
+
+public class InvalidateSession {
+    static String pathToStores = "../../../../javax/net/ssl/etc";
+    static String keyStoreFile = "keystore";
+    static String trustStoreFile = "truststore";
+    static String passwd = "passphrase";
+    static Server server;
+    static SSLSession cacheSession;
+    static final String[] CLIENT_VERSIONS = {"TLSv1", "TLSv1.1", "TLSv1.2"};
+
+    public static void main(String args[]) throws Exception {
+        String keyFilename =
+                System.getProperty("test.src", "./") + "/" + pathToStores +
+                        "/" + keyStoreFile;
+        String trustFilename =
+                System.getProperty("test.src", "./") + "/" + pathToStores +
+                        "/" + trustStoreFile;
+
+        System.setProperty("javax.net.ssl.keyStore", keyFilename);
+        System.setProperty("javax.net.ssl.keyStorePassword", passwd);
+        System.setProperty("javax.net.ssl.trustStore", trustFilename);
+        System.setProperty("javax.net.ssl.trustStorePassword", passwd);
+
+        // drop the supported_versions extension to force test to use the legacy
+        // TLS protocol version field during handshakes
+        System.setProperty("jdk.tls.client.disableExtensions", "supported_versions");
+
+        SecurityUtils.removeFromDisabledTlsAlgs("TLSv1", "TLSv1.1");
+        server = startServer();
+        while (!server.started) {
+            Thread.yield();
+        }
+
+        InvalidateSession test = new InvalidateSession();
+        test.clientTest();
+        server.go = false;
+    }
+
+    /**
+     * 4 test iterations
+     * 1) Server configured with TLSv1, client with TLSv1, v1.1, v1.2
+     * - Handshake should succeed
+     * - Session "A" established
+     * 2) 2nd iteration, server configured with TLSv1.2 only
+     * - Session resumption should fail (Attempted to resume with TLSv1)
+     * - Session "A" should be invalidated
+     * 3) 3rd iteration, same server/client config
+     * - Session "A" should now be invalidated and no longer attempted
+     * - Handshake should succeed
+     * = Session "B" established
+     * 4) 4th iteration, same server/client config
+     * - Session "B" should resume without issue
+     */
+    private void clientTest() throws Exception {
+        for (int i = 1; i <= 4; i++) {
+            clientConnect(i);
+            Thread.sleep(1000);
+        }
+    }
+
+    public void clientConnect(int testIterationCount) throws Exception {
+        System.out.printf("Connecting to: localhost: %s, iteration count %d%n",
+                "localhost:" + server.port, testIterationCount);
+        SSLSocketFactory ssf = (SSLSocketFactory) SSLSocketFactory.getDefault();
+        SSLSocket sslSocket = (SSLSocket) ssf.createSocket("localhost", server.port);
+        sslSocket.setEnabledProtocols(CLIENT_VERSIONS);
+
+        try {
+            sslSocket.startHandshake();
+        } catch (Exception e) {
+
+            if (testIterationCount != 2) {
+                // only the 2nd handshake should fail (in which case we continue)
+                throw new RuntimeException("Unexpected exception", e);
+            }
+            return;
+        }
+        if (testIterationCount == 1) {
+            // capture the session ID
+            cacheSession = sslSocket.getSession();
+        } else {
+            // should be on 3rd or 4th iteration
+            // new session ID should be in use (check in 4th iteration)
+            if (Objects.equals(cacheSession, sslSocket.getSession()) && testIterationCount != 4) {
+                throw new RuntimeException("Same session should not be resumed");
+            }
+            cacheSession = sslSocket.getSession();
+        }
+
+        System.out.println("Got session: " + sslSocket.getSession());
+        try (
+        ObjectOutputStream oos = new ObjectOutputStream(sslSocket.getOutputStream());
+        ObjectInputStream ois = new ObjectInputStream(sslSocket.getInputStream())) {
+            oos.writeObject("Hello");
+            String serverMsg = (String) ois.readObject();
+            System.out.println("Server message : " + serverMsg);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        } finally {
+            sslSocket.close();
+        }
+    }
+
+    private static Server startServer() {
+        Server server = new Server();
+        new Thread(server).start();
+        return server;
+    }
+
+    private static class Server implements Runnable {
+        public volatile boolean go = true;
+        public volatile int port = 0;
+        public volatile boolean started = false;
+
+        @Override
+        public void run() {
+            try {
+                SSLContext sc = SSLContext.getDefault();
+                ServerSocketFactory fac = sc.getServerSocketFactory();
+                SSLServerSocket ssock = (SSLServerSocket)
+                        fac.createServerSocket(0);
+                this.port = ssock.getLocalPort();
+                ssock.setEnabledProtocols(new String[]{"TLSv1"});
+                started = true;
+                while (go) {
+                    try {
+                        System.out.println("Waiting for connection");
+                        Socket sock = ssock.accept();
+                        // now flip server to TLSv1.2 mode for successive connections
+                        ssock.setEnabledProtocols(new String[]{"TLSv1.2"});
+                        try (
+                        ObjectInputStream ois = new ObjectInputStream(sock.getInputStream());
+                        ObjectOutputStream oos = new ObjectOutputStream(sock.getOutputStream())) {
+                            String recv = (String) ois.readObject();
+                            oos.writeObject("Received: " + recv);
+                        } catch (SSLHandshakeException she) {
+                            System.out.println("Server caught :" + she);
+                        } finally {
+                            sock.close();
+                        }
+                    } catch (Exception ex) {
+                        throw new RuntimeException(ex);
+                    }
+                }
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Corner case where a session resumption can fail if the TLS server changes supported protocol versions in relation to a cached SSLSession. This is primarily an issue where the legacy TLS version is used in place of the newer "supported_versions" TLS extension.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270344](https://bugs.openjdk.java.net/browse/JDK-8270344): Session resumption errors


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5110/head:pull/5110` \
`$ git checkout pull/5110`

Update a local copy of the PR: \
`$ git checkout pull/5110` \
`$ git pull https://git.openjdk.java.net/jdk pull/5110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5110`

View PR using the GUI difftool: \
`$ git pr show -t 5110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5110.diff">https://git.openjdk.java.net/jdk/pull/5110.diff</a>

</details>
