### PR TITLE
8272135: jshell: Method cannot use its overloaded version

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/Eval.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/Eval.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,14 +34,17 @@ import javax.lang.model.element.Name;
 import com.sun.source.tree.ArrayTypeTree;
 import com.sun.source.tree.AssignmentTree;
 import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ExpressionStatementTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.ModifiersTree;
 import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
+import com.sun.source.util.TreePathScanner;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.Pretty;
 import java.io.IOException;
@@ -829,7 +832,7 @@ class Eval {
      * @param userSource the incoming bad user source
      * @return a rejected snippet
      */
-    private List<Snippet> compileFailResult(BaseTask xt, String userSource, Kind probableKind) {
+    private List<Snippet> compileFailResult(BaseTask<?> xt, String userSource, Kind probableKind) {
         return compileFailResult(xt.getDiagnostics(), userSource, probableKind);
     }
 
@@ -1007,6 +1010,53 @@ class Eval {
 
             ins.stream().forEach(Unit::initialize);
             ins.stream().forEach(u -> u.setWrap(ins, ins));
+
+            if (ins.stream().anyMatch(u -> u.snippet().kind() == Kind.METHOD)) {
+                //if there is any method declaration, check the body of the method for
+                //invocations of a method of the same name. It may be an invocation of
+                //an overloaded method, in which case we need to add all the overloads to
+                //ins, so that they are processed together and can refer to each other:
+                Set<Unit> overloads = new LinkedHashSet<>();
+                Map<OuterWrap, Unit> outter2Unit = new LinkedHashMap<>();
+                ins.forEach(u -> outter2Unit.put(u.snippet().outerWrap(), u));
+
+                state.taskFactory.analyze(outter2Unit.keySet(), at -> {
+                    Set<Unit> suspiciousMethodInvocation = new LinkedHashSet<>();
+                    for (CompilationUnitTree cut : at.cuTrees()) {
+                        Unit unit = outter2Unit.get(at.sourceForFile(cut.getSourceFile()));
+                        String name = unit.snippet().name();
+
+                        new TreePathScanner<Void, Void>() {
+                            @Override
+                            public Void visitMethodInvocation(MethodInvocationTree node, Void p) {
+                                if (node.getMethodSelect().getKind() == Tree.Kind.IDENTIFIER &&
+                                    ((IdentifierTree) node.getMethodSelect()).getName().contentEquals(name)) {
+                                    suspiciousMethodInvocation.add(unit);
+                                }
+                                return super.visitMethodInvocation(node, p);
+                            }
+
+                        }.scan(cut, null);
+                    }
+                    for (Unit source : suspiciousMethodInvocation) {
+                        for (Snippet dep : state.maps.snippetList()) {
+                            if (dep != source.snippet() && dep.status().isActive() &&
+                                dep.kind() == Kind.METHOD &&
+                                source.snippet().kind() == Kind.METHOD &&
+                                dep.name().equals(source.snippet().name())) {
+                                overloads.add(new Unit(state, dep, source.snippet(), new DiagList()));
+                            }
+                        }
+                    }
+                    return null;
+                });
+
+                if (ins.addAll(overloads)) {
+                    ins.stream().forEach(Unit::initialize);
+                    ins.stream().forEach(u -> u.setWrap(ins, ins));
+                }
+            }
+
             state.taskFactory.analyze(outerWrapSet(ins), at -> {
                 ins.stream().forEach(u -> u.setDiagnostics(at));
 

--- a/src/jdk.jshell/share/classes/jdk/jshell/TreeDissector.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/TreeDissector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,18 +58,18 @@ import jdk.jshell.Util.Pair;
 
 class TreeDissector {
 
-    private final TaskFactory.BaseTask bt;
+    private final TaskFactory.BaseTask<?> bt;
     private final ClassTree targetClass;
     private final CompilationUnitTree targetCompilationUnit;
     private SourcePositions theSourcePositions = null;
 
-    private TreeDissector(TaskFactory.BaseTask bt, CompilationUnitTree targetCompilationUnit, ClassTree targetClass) {
+    private TreeDissector(TaskFactory.BaseTask<?> bt, CompilationUnitTree targetCompilationUnit, ClassTree targetClass) {
         this.bt = bt;
         this.targetCompilationUnit = targetCompilationUnit;
         this.targetClass = targetClass;
     }
 
-    static TreeDissector createByFirstClass(TaskFactory.BaseTask bt) {
+    static TreeDissector createByFirstClass(TaskFactory.BaseTask<?> bt) {
         Pair<CompilationUnitTree, ClassTree> pair = classes(bt.firstCuTree())
                 .findFirst().orElseGet(() -> new Pair<>(bt.firstCuTree(), null));
 
@@ -92,7 +92,7 @@ class TreeDissector {
                 .flatMap(TreeDissector::classes);
     }
 
-    static TreeDissector createBySnippet(TaskFactory.BaseTask bt, Snippet si) {
+    static TreeDissector createBySnippet(TaskFactory.BaseTask<?> bt, Snippet si) {
         String name = si.className();
 
         Pair<CompilationUnitTree, ClassTree> pair = classes(bt.cuTrees())

--- a/test/langtools/jdk/jshell/MethodsTest.java
+++ b/test/langtools/jdk/jshell/MethodsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8080357 8167643 8187359 8199762 8080353 8246353 8247456 8267221
+ * @bug 8080357 8167643 8187359 8199762 8080353 8246353 8247456 8267221 8272135
  * @summary Tests for EvaluationState.methods
  * @build KullaTesting TestingInputStream ExpectedDiagnostic
  * @run testng MethodsTest
@@ -383,5 +383,18 @@ public class MethodsTest extends KullaTesting {
         assertEquals(m2.parameterTypes(), "int[]...");
         MethodSnippet m3 = methodKey(assertEval("void m3(int[][] p) { }", added(VALID)));
         assertEquals(m3.parameterTypes(), "int[][]");
+    }
+
+    public void testOverloadCalls() {
+        MethodSnippet orig = methodKey(assertEval("int m(String s) { return 0; }"));
+        MethodSnippet overload = methodKey(assertEval("int m(int i) { return 1; }"));
+        assertEval("m(\"\")", "0");
+        assertEval("m(0)", "1");
+        assertEval("int m(String s) { return m(0); }",
+                   ste(MAIN_SNIPPET, VALID, VALID, true, null),
+                   ste(overload, VALID, VALID, true, MAIN_SNIPPET),
+                   ste(orig, VALID, OVERWRITTEN, false, MAIN_SNIPPET));
+        assertEval("m(\"\")", "1");
+        assertEval("m(0)", "1");
     }
 }


### PR DESCRIPTION
Consider separate snippets like:
```
int m(int i) { return 1; }
```
and:
```
int m(String s) { return m(0); }
```

If these are independent snippets, JShell will currently compile first the first snippet (say into class called `A`), and then the second snippet. The actual code for the second snippet will be in this direction:
```
import static A.m;
public class B {
    int m(String s) { return m(0); }
}
```

Note that here the method resolution, when seeing method name `m`, will not see the `m(int)` method at all, as the lookup will stop on the current class' method called `m` and will never proceed to look at the `m` method from the first snippet/class `A`.

JShell generally tries to coalescence processing of overloading methods (in the `Unit.setWrap` method), but the overloaded methods must be together part of the input, which is not the case in the above example.

The proposed solution is to detect the possibility of the above situation (call of a method that has the same name as the current snippet's method), and add all same-named overloads to the processing set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272135](https://bugs.openjdk.java.net/browse/JDK-8272135): jshell: Method cannot use its overloaded version


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5111/head:pull/5111` \
`$ git checkout pull/5111`

Update a local copy of the PR: \
`$ git checkout pull/5111` \
`$ git pull https://git.openjdk.java.net/jdk pull/5111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5111`

View PR using the GUI difftool: \
`$ git pr show -t 5111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5111.diff">https://git.openjdk.java.net/jdk/pull/5111.diff</a>

</details>
