### PR TITLE
8272459: ProblemList compiler/codecache/TestStressCodeBuffers.java on aarch64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -69,6 +69,7 @@ compiler/whitebox/EnqueueMethodForCompilationTest.java 8265360 macosx-aarch64
 compiler/whitebox/MakeMethodNotCompilableTest.java 8265360 macosx-aarch64
 
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-x64
+compiler/codecache/TestStressCodeBuffers.java 8272094 generic-aarch64
 
 
 #############################################################################


### PR DESCRIPTION
A trivial fix to ProblemList compiler/codecache/TestStressCodeBuffers.java on aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272459](https://bugs.openjdk.java.net/browse/JDK-8272459): ProblemList compiler/codecache/TestStressCodeBuffers.java on aarch64


### Reviewers
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5113/head:pull/5113` \
`$ git checkout pull/5113`

Update a local copy of the PR: \
`$ git checkout pull/5113` \
`$ git pull https://git.openjdk.java.net/jdk pull/5113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5113`

View PR using the GUI difftool: \
`$ git pr show -t 5113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5113.diff">https://git.openjdk.java.net/jdk/pull/5113.diff</a>

</details>
