### PR TITLE
8272461: G1: remove empty declaration of cleanup_after_scan_heap_roots

### DIFF
--- a/src/hotspot/share/gc/g1/g1RemSet.hpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.hpp
@@ -107,8 +107,7 @@ public:
   // Prepare for and cleanup after scanning the heap roots. Must be called
   // once before and after in sequential code.
   void prepare_for_scan_heap_roots();
-  // Cleans the card table from temporary duplicate detection information.
-  void cleanup_after_scan_heap_roots();
+
   // Print coarsening stats.
   void print_coarsen_stats();
   // Creates a gang task for cleaining up temporary data structures and the


### PR DESCRIPTION
Trivial change of removing an empty declaration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272461](https://bugs.openjdk.java.net/browse/JDK-8272461): G1: remove empty declaration of cleanup_after_scan_heap_roots


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5114/head:pull/5114` \
`$ git checkout pull/5114`

Update a local copy of the PR: \
`$ git checkout pull/5114` \
`$ git pull https://git.openjdk.java.net/jdk pull/5114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5114`

View PR using the GUI difftool: \
`$ git pr show -t 5114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5114.diff">https://git.openjdk.java.net/jdk/pull/5114.diff</a>

</details>
