### PR TITLE
8272342: [TEST_BUG] java/awt/print/PrinterJob/PageDialogMarginTest.java catches all exceptions

### DIFF
--- a/test/jdk/java/awt/print/PrinterJob/PageDialogMarginTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PageDialogMarginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021,  Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,29 +33,33 @@ import java.awt.print.PageFormat;
 import java.awt.print.PrinterJob;
 import javax.print.attribute.HashPrintRequestAttributeSet;
 import javax.print.attribute.PrintRequestAttributeSet;
+import javax.print.attribute.standard.DialogTypeSelection;
 import javax.print.attribute.standard.MediaPrintableArea;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
+import java.text.MessageFormat;
+import java.util.Locale;
 
 public class PageDialogMarginTest {
 
-    public static void main(String args[]) throws Exception {
+    public static void main(String[] args) throws Exception {
+
+        Locale.setDefault(Locale.US);
         String[] instructions
                 = {
                     "Page Dialog will be shown.",
                     "Change top(in) margin value from 1.0 to 2.0",
                     "Then select OK."
                 };
-        SwingUtilities.invokeAndWait(() -> {
-            JOptionPane.showMessageDialog((Component) null,
-                    instructions, "Instructions",
-                    JOptionPane.INFORMATION_MESSAGE);
-        });
+        SwingUtilities.invokeAndWait(() -> JOptionPane.showMessageDialog(null,
+                instructions, "Instructions",
+                JOptionPane.INFORMATION_MESSAGE));
         PrinterJob pj = PrinterJob.getPrinterJob();
 
         HashPrintRequestAttributeSet aset = new HashPrintRequestAttributeSet();
-        PageFormat pf;
-        pf = pj.pageDialog(aset);
+
+        PageFormat pf = pj.pageDialog(aset);
+
         double left = pf.getImageableX();
         double top = pf.getImageableY();
         System.out.println("pageDialog - left/top from pageFormat: " + left / 72

--- a/test/jdk/java/awt/print/PrinterJob/PageDialogMarginTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PageDialogMarginTest.java
@@ -28,22 +28,19 @@
  *           entry is working
  * @run      main/manual PageDialogMarginTest
  */
-import java.awt.Component;
+
 import java.awt.print.PageFormat;
 import java.awt.print.PrinterJob;
+import java.util.Locale;
 import javax.print.attribute.HashPrintRequestAttributeSet;
 import javax.print.attribute.PrintRequestAttributeSet;
-import javax.print.attribute.standard.DialogTypeSelection;
 import javax.print.attribute.standard.MediaPrintableArea;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
-import java.text.MessageFormat;
-import java.util.Locale;
 
 public class PageDialogMarginTest {
 
     public static void main(String[] args) throws Exception {
-
         Locale.setDefault(Locale.US);
         String[] instructions
                 = {
@@ -57,11 +54,10 @@ public class PageDialogMarginTest {
         PrinterJob pj = PrinterJob.getPrinterJob();
 
         HashPrintRequestAttributeSet aset = new HashPrintRequestAttributeSet();
-
         PageFormat pf = pj.pageDialog(aset);
-
         double left = pf.getImageableX();
         double top = pf.getImageableY();
+
         System.out.println("pageDialog - left/top from pageFormat: " + left / 72
                                    + " " + top / 72);
         System.out.println("pageDialog - left/top from attribute set: "

--- a/test/jdk/java/awt/print/PrinterJob/PageDialogMarginTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PageDialogMarginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021,  Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/print/PrinterJob/PageDialogMarginTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PageDialogMarginTest.java
@@ -52,22 +52,19 @@ public class PageDialogMarginTest {
                     JOptionPane.INFORMATION_MESSAGE);
         });
         PrinterJob pj = PrinterJob.getPrinterJob();
-        try {
-            HashPrintRequestAttributeSet aset = new HashPrintRequestAttributeSet();
-            PageFormat pf;
-            pf = pj.pageDialog(aset);
-            double left = pf.getImageableX();
-            double top = pf.getImageableY();
-            System.out.println("pageDialog - left/top from pageFormat: " + left / 72
-                    + " " + top / 72);
-            System.out.println("pageDialog - left/top from attribute set: "
-                    + getPrintableXFromASet(aset) + " "
-                    + getPrintableYFromASet(aset));
-            if (top / 72 != 2.0f || getPrintableYFromASet(aset) != 2.0f) {
-                throw new RuntimeException("Top margin value not updated");
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
+
+        HashPrintRequestAttributeSet aset = new HashPrintRequestAttributeSet();
+        PageFormat pf;
+        pf = pj.pageDialog(aset);
+        double left = pf.getImageableX();
+        double top = pf.getImageableY();
+        System.out.println("pageDialog - left/top from pageFormat: " + left / 72
+                                   + " " + top / 72);
+        System.out.println("pageDialog - left/top from attribute set: "
+                                   + getPrintableXFromASet(aset) + " "
+                                   + getPrintableYFromASet(aset));
+        if (top / 72 != 2.0f || getPrintableYFromASet(aset) != 2.0f) {
+            throw new RuntimeException("Top margin value not updated");
         }
     }
 


### PR DESCRIPTION
Removed try catch block so the test can function as expected and fail
when it ought to, rather than passing all the time because of catch
block catching all exceptions and Passing test even there is a failure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272342](https://bugs.openjdk.java.net/browse/JDK-8272342): [TEST_BUG] java/awt/print/PrinterJob/PageDialogMarginTest.java catches all exceptions


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**) ⚠️ Review applies to 2c181a8aef975369f982e78aac0da89540a304c5


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5115/head:pull/5115` \
`$ git checkout pull/5115`

Update a local copy of the PR: \
`$ git checkout pull/5115` \
`$ git pull https://git.openjdk.java.net/jdk pull/5115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5115`

View PR using the GUI difftool: \
`$ git pr show -t 5115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5115.diff">https://git.openjdk.java.net/jdk/pull/5115.diff</a>

</details>
