### PR TITLE
[PATCH] Avoid looking for standard encodings in jshell modules

### DIFF
--- a/src/jdk.internal.ed/share/classes/jdk/internal/editor/external/ExternalEditor.java
+++ b/src/jdk.internal.ed/share/classes/jdk/internal/editor/external/ExternalEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 package jdk.internal.editor.external;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.ClosedWatchServiceException;
 import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
@@ -120,7 +120,7 @@ public class ExternalEditor {
         this.watcher = FileSystems.getDefault().newWatchService();
         this.dir = Files.createTempDirectory("extedit");
         this.tmpfile = Files.createTempFile(dir, null, ".java");
-        Files.write(tmpfile, initialText.getBytes(Charset.forName("UTF-8")));
+        Files.write(tmpfile, initialText.getBytes(StandardCharsets.UTF_8));
         dir.register(watcher,
                 ENTRY_CREATE,
                 ENTRY_DELETE,

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/ConsoleIOContext.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/ConsoleIOContext.java
@@ -35,7 +35,7 @@ import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.URI;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1309,7 +1309,7 @@ class ConsoleIOContext extends IOContext {
 
         protected ProgrammaticInTerminal(InputStream input, OutputStream output,
                                          String terminal, Size size, Size bufferSize) throws Exception {
-            super("non-system-in", terminal, output, Charset.forName("UTF-8"));
+            super("non-system-in", terminal, output, StandardCharsets.UTF_8);
             this.inputReader = NonBlocking.nonBlocking(getName(), input, encoding());
             Attributes a = new Attributes(getAttributes());
             a.setLocalFlag(LocalFlag.ECHO, false);

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/DemultiplexInput.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/DemultiplexInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
@@ -64,7 +65,7 @@ class DemultiplexInput extends Thread {
                 int dataLen = delegate.read();
                 byte[] data = new byte[dataLen];
                 DemultiplexInput.this.delegate.readFully(data);
-                String chan = new String(name, "UTF-8");
+                String chan = new String(name, StandardCharsets.UTF_8);
                 OutputStream out = io.get(chan);
                 if (out == null) {
                     debug("Unexpected channel name: %s", chan);

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/MultiplexingOutputStream.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/MultiplexingOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@ package jdk.jshell.execution;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Packetize an OutputStream, dividing it into named channels.
@@ -40,12 +40,8 @@ class MultiplexingOutputStream extends OutputStream {
     private final OutputStream delegate;
 
     MultiplexingOutputStream(String name, OutputStream delegate) {
-        try {
-            this.name = name.getBytes("UTF-8");
-            this.delegate = delegate;
-        } catch (UnsupportedEncodingException ex) {
-            throw new IllegalStateException(ex); //should not happen
-        }
+        this.name = name.getBytes(StandardCharsets.UTF_8);
+        this.delegate = delegate;
     }
 
     @Override

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/Util.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -120,7 +121,7 @@ public class Util {
                             for (int i = 0; i < len; i++) {
                                 message[i] = (byte) super.read();
                             }
-                            throw new IOException(new String(message, "UTF-8"));
+                            throw new IOException(new String(message, StandardCharsets.UTF_8));
                         case -1:
                             return -1;
                         default:
@@ -183,7 +184,7 @@ public class Util {
                             debug(ex, "$" + e.getKey() + "-input-requested.write");
                         }
                     } catch (IOException exc) {
-                        byte[] message = exc.getMessage().getBytes("UTF-8");
+                        byte[] message = exc.getMessage().getBytes(StandardCharsets.UTF_8);
                         inTarget.write(TAG_EXCEPTION);
                         inTarget.write((message.length >>  0) & 0xFF);
                         inTarget.write((message.length >>  8) & 0xFF);


### PR DESCRIPTION
In many places standard charsets are looked up via their names, for example:
absolutePath.getBytes("UTF-8");

This could be done more efficiently with use of java.nio.charset.StandardCharsets:
absolutePath.getBytes(StandardCharsets.UTF_8);

The later variant also makes the code cleaner, as it is known not to throw UnsupportedEncodingException in contrary to the former variant.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5117/head:pull/5117` \
`$ git checkout pull/5117`

Update a local copy of the PR: \
`$ git checkout pull/5117` \
`$ git pull https://git.openjdk.java.net/jdk pull/5117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5117`

View PR using the GUI difftool: \
`$ git pr show -t 5117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5117.diff">https://git.openjdk.java.net/jdk/pull/5117.diff</a>

</details>
