### PR TITLE
8272148: JDesktopPane:getComponentCount() returns one extra than expected with GTKLookAndFeel

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -181,11 +181,15 @@ import static javax.swing.ClientPropertyKey.JComponent_TRANSFER_HANDLER;
  * need a specific value for a particular property you should
  * explicitly set it.
  * <p>
- * Containers inherited from <code>JComponent</code> can contain any
- * number of default components as children. This behaviour can also
- * change according to look and feel, as some look and feels may add a
- * default component to a container, where as other look and feels may
- * choose not to do so.
+ * A <code>JComponent</code> may contain any number of default or initial
+ * components as children. This behaviour may change according to look and
+ * feel, therefore a <code>JComponent</code> may contain some default or
+ * initial components as children for a particular Look and Feel, whereas it
+ * may not do so for some other Look and Feel. Within a particular Look and
+ * Feel also, this behaviour may change depending upon the configuration
+ * properties of the <code>JComponent</code>. In summary, it is not valid
+ * to assume a JComponent has no children just because the application
+ * did not directly add them.
  * <p>
  * In release 1.4, the focus subsystem was rearchitected.
  * For more information, see

--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -181,6 +181,12 @@ import static javax.swing.ClientPropertyKey.JComponent_TRANSFER_HANDLER;
  * need a specific value for a particular property you should
  * explicitly set it.
  * <p>
+ * Containers inherited from <code>JComponent</code> can contain any
+ * number of default components as children. This behaviour can also
+ * change according to look and feel, as some look and feels may add a
+ * default component to a container, where as other look and feels may
+ * choose not to do so.
+ * <p>
  * In release 1.4, the focus subsystem was rearchitected.
  * For more information, see
  * <a href="https://docs.oracle.com/javase/tutorial/uiswing/misc/focus.html">


### PR DESCRIPTION
A container may include few default components as children, which are added to it during creation. Due to this, calling function getChildrenCount on a new created instance may return non zero value. This behaviour may vary according to L&F also, as some L&F may add some default components to a container, but other L&F may choose not to do so.

The current bugs reports that this behaviour looks suspicious as it is expected that a newly created container will have zero  children.

Current specification is not clear on this whether it is allowed for a container to contain default components or not. The fix make changes to the specification to clarify the same.

Note: I think this will need a CSR, I will file one after the review is completed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272148](https://bugs.openjdk.java.net/browse/JDK-8272148): JDesktopPane:getComponentCount() returns one extra than expected with GTKLookAndFeel


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5121/head:pull/5121` \
`$ git checkout pull/5121`

Update a local copy of the PR: \
`$ git checkout pull/5121` \
`$ git pull https://git.openjdk.java.net/jdk pull/5121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5121`

View PR using the GUI difftool: \
`$ git pr show -t 5121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5121.diff">https://git.openjdk.java.net/jdk/pull/5121.diff</a>

</details>
