### PR TITLE
Fix warnings when compiling without optimizations

### DIFF
--- a/src/java.base/share/native/libverify/check_code.c
+++ b/src/java.base/share/native/libverify/check_code.c
@@ -939,6 +939,7 @@ read_all_code(context_type* context, jclass cb, int num_methods,
     int i;
 
     lengths = malloc(sizeof(int) * num_methods);
+    memset(lengths, 0, sizeof(int) * num_methods);
     check_and_push(context, lengths, VM_MALLOC_BLK);
 
     code = malloc(sizeof(unsigned char*) * num_methods);

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_sign.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_sign.c
@@ -150,7 +150,10 @@ JNIEXPORT jbyteArray JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1Sign
     }
 
     free(ckpData);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfree-nonheap-object"
     if (bufP != BUF) { free(bufP); }
+#pragma GCC diagnostic pop
 
     TRACE0("FINISHED\n");
     return jSignature;


### PR DESCRIPTION
These warnings came up when trying to compile without -O3 flag and since jdk uses -Werror, i had to fix them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5123/head:pull/5123` \
`$ git checkout pull/5123`

Update a local copy of the PR: \
`$ git checkout pull/5123` \
`$ git pull https://git.openjdk.java.net/jdk pull/5123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5123`

View PR using the GUI difftool: \
`$ git pr show -t 5123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5123.diff">https://git.openjdk.java.net/jdk/pull/5123.diff</a>

</details>
