### PR TITLE
JDK-8272326 java/util/Random/RandomTestMoments.java had two Gaussian fails

### DIFF
--- a/test/jdk/java/util/Random/RandomTestChiSquared.java
+++ b/test/jdk/java/util/Random/RandomTestChiSquared.java
@@ -224,7 +224,9 @@ public class RandomTestChiSquared {
     }
 
     public static void main(String[] args) {
-        RandomGeneratorFactory.all().forEach(factory -> {
+        RandomGeneratorFactory.all()
+                              .filter(f -> !f.name().equals("SecureRandom"))
+                              .forEach(factory -> {
             setRNG(factory.name());
 
             if (factory.name().equals("Random")) {

--- a/test/jdk/java/util/Random/RandomTestMoments.java
+++ b/test/jdk/java/util/Random/RandomTestMoments.java
@@ -194,7 +194,8 @@ public class RandomTestMoments {
 
     public static void main(String[] args) {
         RandomGeneratorFactory.all()
-             .forEach(factory -> {
+                              .filter(f -> !f.name().equals("SecureRandom"))
+                              .forEach(factory -> {
                 setRNG(factory.name());
                 testOneRng(factory.create(325) );
             });


### PR DESCRIPTION
RandomTestMoments.java and RandomTestChiSquared.java expect successive calls to nextLong to reproduce the same sequence of values. SecureRandom, by its nature, does not follow this requirement. The patch filters out SecureRandom from these tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272326](https://bugs.openjdk.java.net/browse/JDK-8272326): java/util/Random/RandomTestMoments.java had two Gaussian fails


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5124/head:pull/5124` \
`$ git checkout pull/5124`

Update a local copy of the PR: \
`$ git checkout pull/5124` \
`$ git pull https://git.openjdk.java.net/jdk pull/5124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5124`

View PR using the GUI difftool: \
`$ git pr show -t 5124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5124.diff">https://git.openjdk.java.net/jdk/pull/5124.diff</a>

</details>
