### PR TITLE
8272520: Inline GenericTaskQueue::initialize() to the constructor

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1511,7 +1511,6 @@ G1CollectedHeap::G1CollectedHeap() :
 
   for (uint i = 0; i < n_queues; i++) {
     G1ScannerTasksQueue* q = new G1ScannerTasksQueue();
-    q->initialize();
     _task_queues->register_queue(i, q);
     ::new (&_evacuation_failed_info_array[i]) EvacuationFailedInfo();
   }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -445,7 +445,6 @@ G1ConcurrentMark::G1ConcurrentMark(G1CollectedHeap* g1h,
 
   for (uint i = 0; i < _max_num_tasks; ++i) {
     G1CMTaskQueue* task_queue = new G1CMTaskQueue();
-    task_queue->initialize();
     _task_queues->register_queue(i, task_queue);
 
     _tasks[i] = new G1CMTask(i, this, task_queue, _region_mark_stats);

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
@@ -46,8 +46,6 @@ G1FullGCMarker::G1FullGCMarker(G1FullCollector* collector,
     _cld_closure(mark_closure(), ClassLoaderData::_claim_strong),
     _mark_stats_cache(mark_stats, G1RegionMarkStatsCache::RegionMarkStatsCacheSize) {
   _mark_stats_cache.reset();
-  _oop_stack.initialize();
-  _objarray_stack.initialize();
 }
 
 G1FullGCMarker::~G1FullGCMarker() {

--- a/src/hotspot/share/gc/parallel/psCompactionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.cpp
@@ -58,10 +58,6 @@ ParCompactionManager::ParCompactionManager() {
   _old_gen = heap->old_gen();
   _start_array = old_gen()->start_array();
 
-  marking_stack()->initialize();
-  _objarray_stack.initialize();
-  _region_stack.initialize();
-
   reset_bitmap_query_cache();
 }
 

--- a/src/hotspot/share/gc/parallel/psPromotionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.cpp
@@ -190,7 +190,6 @@ PSPromotionManager::PSPromotionManager() {
   _old_lab.set_start_array(old_gen()->start_array());
 
   uint queue_size;
-  claimed_stack_depth()->initialize();
   queue_size = claimed_stack_depth()->max_elems();
 
   _totally_drain = (ParallelGCThreads == 1) || (GCDrainStackTargetSize == 0);

--- a/src/hotspot/share/gc/shared/taskqueue.hpp
+++ b/src/hotspot/share/gc/shared/taskqueue.hpp
@@ -345,8 +345,6 @@ public:
   // Initializes the queue to empty.
   GenericTaskQueue();
 
-  void initialize();
-
   // Push the task "t" on the queue.  Returns "false" iff the queue is full.
   inline bool push(E t);
 
@@ -391,11 +389,6 @@ public:
   bool is_last_stolen_queue_id_valid() const { return _last_stolen_queue_id != InvalidQueueId; }
   void invalidate_last_stolen_queue_id()     { _last_stolen_queue_id = InvalidQueueId; }
 };
-
-template<class E, MEMFLAGS F, unsigned int N>
-GenericTaskQueue<E, F, N>::GenericTaskQueue() : _last_stolen_queue_id(InvalidQueueId), _seed(17 /* random number */) {
-  assert(sizeof(Age) == sizeof(size_t), "Depends on this.");
-}
 
 // OverflowTaskQueue is a TaskQueue that also includes an overflow stack for
 // elements that do not fit in the TaskQueue.

--- a/src/hotspot/share/gc/shared/taskqueue.inline.hpp
+++ b/src/hotspot/share/gc/shared/taskqueue.inline.hpp
@@ -49,10 +49,10 @@ inline GenericTaskQueueSet<T, F>::~GenericTaskQueueSet() {
 }
 
 template<class E, MEMFLAGS F, unsigned int N>
-inline GenericTaskQueue<E, F, N>::GenericTaskQueue() : _last_stolen_queue_id(InvalidQueueId), _seed(17 /* random number */) {
-  assert(sizeof(Age) == sizeof(size_t), "Depends on this.");
-  _elems = ArrayAllocator<E>::allocate(N, F);
-}
+inline GenericTaskQueue<E, F, N>::GenericTaskQueue() :
+  _elems(ArrayAllocator<E>::allocate(N, F)),
+  _last_stolen_queue_id(InvalidQueueId),
+  _seed(17 /* random number */) {}
 
 template<class E, MEMFLAGS F, unsigned int N>
 inline GenericTaskQueue<E, F, N>::~GenericTaskQueue() {

--- a/src/hotspot/share/gc/shared/taskqueue.inline.hpp
+++ b/src/hotspot/share/gc/shared/taskqueue.inline.hpp
@@ -49,7 +49,8 @@ inline GenericTaskQueueSet<T, F>::~GenericTaskQueueSet() {
 }
 
 template<class E, MEMFLAGS F, unsigned int N>
-inline void GenericTaskQueue<E, F, N>::initialize() {
+inline GenericTaskQueue<E, F, N>::GenericTaskQueue() : _last_stolen_queue_id(InvalidQueueId), _seed(17 /* random number */) {
+  assert(sizeof(Age) == sizeof(size_t), "Depends on this.");
   _elems = ArrayAllocator<E>::allocate(N, F);
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1425,7 +1425,6 @@ private:
     // Initialize queues for every workers
     for (uint i = 0; i < _num_workers; ++i) {
       ShenandoahObjToScanQueue* task_queue = new ShenandoahObjToScanQueue();
-      task_queue->initialize();
       _task_queues->register_queue(i, task_queue);
     }
     // Divide roots among the workers. Assume that object referencing distribution

--- a/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.cpp
@@ -40,7 +40,6 @@ ShenandoahMarkingContext::ShenandoahMarkingContext(MemRegion heap_region, MemReg
   assert(max_queues > 0, "At least one queue");
   for (uint i = 0; i < max_queues; ++i) {
     ShenandoahObjToScanQueue* task_queue = new ShenandoahObjToScanQueue();
-    task_queue->initialize();
     _task_queues->register_queue(i, task_queue);
   }
 }

--- a/src/hotspot/share/gc/z/zHeapIterator.cpp
+++ b/src/hotspot/share/gc/z/zHeapIterator.cpp
@@ -206,14 +206,12 @@ ZHeapIterator::ZHeapIterator(uint nworkers, bool visit_weaks) :
   // Create queues
   for (uint i = 0; i < _queues.size(); i++) {
     ZHeapIteratorQueue* const queue = new ZHeapIteratorQueue();
-    queue->initialize();
     _queues.register_queue(i, queue);
   }
 
   // Create array queues
   for (uint i = 0; i < _array_queues.size(); i++) {
     ZHeapIteratorArrayQueue* const array_queue = new ZHeapIteratorArrayQueue();
-    array_queue->initialize();
     _array_queues.register_queue(i, array_queue);
   }
 }


### PR DESCRIPTION
Simple refactoring of GenericTaskQueue initialization API.

Test: tier1_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272520](https://bugs.openjdk.java.net/browse/JDK-8272520): Inline GenericTaskQueue::initialize() to the constructor


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5125/head:pull/5125` \
`$ git checkout pull/5125`

Update a local copy of the PR: \
`$ git checkout pull/5125` \
`$ git pull https://git.openjdk.java.net/jdk pull/5125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5125`

View PR using the GUI difftool: \
`$ git pr show -t 5125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5125.diff">https://git.openjdk.java.net/jdk/pull/5125.diff</a>

</details>
