### PR TITLE
8272521: Remove unused PSPromotionManager::_claimed_stack_breadth

### DIFF
--- a/src/hotspot/share/gc/parallel/psPromotionManager.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.hpp
@@ -81,7 +81,6 @@ class PSPromotionManager {
   bool                                _old_gen_is_full;
 
   PSScannerTasksQueue                 _claimed_stack_depth;
-  OverflowTaskQueue<oop, mtGC>        _claimed_stack_breadth;
 
   bool                                _totally_drain;
   uint                                _target_stack_size;


### PR DESCRIPTION
Trivial change of removing an unused field.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272521](https://bugs.openjdk.java.net/browse/JDK-8272521): Remove unused PSPromotionManager::_claimed_stack_breadth


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5126/head:pull/5126` \
`$ git checkout pull/5126`

Update a local copy of the PR: \
`$ git checkout pull/5126` \
`$ git pull https://git.openjdk.java.net/jdk pull/5126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5126`

View PR using the GUI difftool: \
`$ git pr show -t 5126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5126.diff">https://git.openjdk.java.net/jdk/pull/5126.diff</a>

</details>
