### PR TITLE
8272551: mark hotspot runtime/modules tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/modules/ClassLoaderNoUnnamedModuleTest.java
+++ b/test/hotspot/jtreg/runtime/modules/ClassLoaderNoUnnamedModuleTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8202758
  * @summary Ensure that if the JVM encounters a ClassLoader whose unnamedModule field is not set an InternalError results.
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile ClassLoaderNoUnnamedModule.java

--- a/test/hotspot/jtreg/runtime/modules/IgnoreModulePropertiesTest.java
+++ b/test/hotspot/jtreg/runtime/modules/IgnoreModulePropertiesTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8136930
  * @summary Test that the VM ignores explicitly specified module internal properties.
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver IgnoreModulePropertiesTest

--- a/test/hotspot/jtreg/runtime/modules/ModuleOptionsTest.java
+++ b/test/hotspot/jtreg/runtime/modules/ModuleOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/modules/ModuleOptionsTest.java
+++ b/test/hotspot/jtreg/runtime/modules/ModuleOptionsTest.java
@@ -26,6 +26,7 @@
  * @bug 8136930
  * @summary Test that the VM only recognizes the last specified --list-modules
  *          options but accumulates --add-module values.
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver ModuleOptionsTest

--- a/test/hotspot/jtreg/runtime/modules/ModuleOptionsWarn.java
+++ b/test/hotspot/jtreg/runtime/modules/ModuleOptionsWarn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/modules/ModuleOptionsWarn.java
+++ b/test/hotspot/jtreg/runtime/modules/ModuleOptionsWarn.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8162415
  * @summary Test warnings for ignored properties.
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver ModuleOptionsWarn

--- a/test/hotspot/jtreg/runtime/modules/ModuleStress/ExportModuleStressTest.java
+++ b/test/hotspot/jtreg/runtime/modules/ModuleStress/ExportModuleStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/modules/ModuleStress/ExportModuleStressTest.java
+++ b/test/hotspot/jtreg/runtime/modules/ModuleStress/ExportModuleStressTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8156871
  * @summary package in the boot layer is repeatedly exported to unique module created in layers on top of the boot layer
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile ../CompilerUtils.java

--- a/test/hotspot/jtreg/runtime/modules/ModuleStress/ModuleStress.java
+++ b/test/hotspot/jtreg/runtime/modules/ModuleStress/ModuleStress.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8159262
  * @summary Test differing scenarios where a module's readability list and a package's exportability list should be walked
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile ../AccessCheck/ModuleLibrary.java

--- a/test/hotspot/jtreg/runtime/modules/ModuleStress/ModuleStressGC.java
+++ b/test/hotspot/jtreg/runtime/modules/ModuleStress/ModuleStressGC.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8159262
  * @summary layers over the boot layer are repeatedly created, during this iteration, GCs are forced to verify correct walk of module and package lists.
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile ../CompilerUtils.java

--- a/test/hotspot/jtreg/runtime/modules/ModulesSymLink.java
+++ b/test/hotspot/jtreg/runtime/modules/ModulesSymLink.java
@@ -28,6 +28,7 @@
  * @summary Test with symbolic linked lib/modules
  * @bug 8220095
  * @requires os.family == "linux" | os.family == "mac"
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.management
  *          jdk.jlink

--- a/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModule2Dirs.java
+++ b/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModule2Dirs.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @summary Make sure --patch-module works with multiple directories.
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile PatchModule2DirsMain.java

--- a/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleCDS.java
+++ b/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleCDS.java
@@ -25,6 +25,7 @@
  * @test
  * @requires vm.cds
  * @summary test that --patch-module works with CDS
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          jdk.jartool/sun.tools.jar

--- a/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleDupJavaBase.java
+++ b/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleDupJavaBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleDupJavaBase.java
+++ b/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleDupJavaBase.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @summary VM exit initialization results if java.base is specificed more than once to --patch-module.
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver PatchModuleDupJavaBase

--- a/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleDupModule.java
+++ b/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleDupModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleDupModule.java
+++ b/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleDupModule.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @summary Module system initialization exception results if a module is specificed twice to --patch-module.
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver PatchModuleDupModule

--- a/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleJavaBase.java
+++ b/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleJavaBase.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8130399
  * @summary Make sure --patch-module works for java.base.
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile PatchModuleMain.java

--- a/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleTest.java
+++ b/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8130399
  * @summary Make sure --patch-module works for modules besides java.base.
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile PatchModuleMain.java

--- a/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleTestJar.java
+++ b/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleTestJar.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @summary Make sure --patch-module works when a jar file is specified for a module
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          jdk.jartool/sun.tools.jar

--- a/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleTestJarDir.java
+++ b/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleTestJarDir.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @summary Make sure --patch-module works when a jar file and a directory is specified for a module
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          jdk.jartool/sun.tools.jar

--- a/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleTraceCL.java
+++ b/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleTraceCL.java
@@ -26,6 +26,7 @@
  * @bug 8069469
  * @summary Make sure -Xlog:class+load=info works properly with "modules" jimage,
             --patch-module, and with -Xbootclasspath/a
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile PatchModuleMain.java

--- a/test/hotspot/jtreg/runtime/modules/Visibility/PatchModuleVisibility.java
+++ b/test/hotspot/jtreg/runtime/modules/Visibility/PatchModuleVisibility.java
@@ -26,6 +26,7 @@
  * @summary Ensure that a newly introduced java.base package placed within the --patch-module
  *          directory is considered part of the boot loader's visibility boundary
  * @requires !(os.family == "windows")
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/modules/Visibility/XbootcpNoVisibility.java
+++ b/test/hotspot/jtreg/runtime/modules/Visibility/XbootcpNoVisibility.java
@@ -25,6 +25,7 @@
  * @test
  * @summary Ensure that a class defined within a java.base package can not
  *          be located via -Xbootclasspath/a
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/modules/Visibility/XbootcpVisibility.java
+++ b/test/hotspot/jtreg/runtime/modules/Visibility/XbootcpVisibility.java
@@ -26,6 +26,7 @@
  * @summary Ensure that a package whose module has not been defined to the boot loader
  *          is correctly located with -Xbootclasspath/a
  * @requires !(os.family == "windows")
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management


### PR DESCRIPTION
Hi all,

could you please review the patch that adds `@requires vm.flagless` to `runtime/modules` tests that ignore external flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272551](https://bugs.openjdk.java.net/browse/JDK-8272551): mark hotspot runtime/modules tests which ignore external VM flags


### Reviewers
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5131/head:pull/5131` \
`$ git checkout pull/5131`

Update a local copy of the PR: \
`$ git checkout pull/5131` \
`$ git pull https://git.openjdk.java.net/jdk pull/5131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5131`

View PR using the GUI difftool: \
`$ git pr show -t 5131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5131.diff">https://git.openjdk.java.net/jdk/pull/5131.diff</a>

</details>
