### PR TITLE
8272552: mark hotspot runtime/cds tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/MaxMetaspaceSize.java
+++ b/test/hotspot/jtreg/runtime/cds/MaxMetaspaceSize.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @requires vm.cds
+ * @requires vm.flagless
  * @bug 8067187 8200078
  * @summary Testing CDS dumping with the -XX:MaxMetaspaceSize=<size> option
  * @library /test/lib

--- a/test/hotspot/jtreg/runtime/cds/SharedStrings.java
+++ b/test/hotspot/jtreg/runtime/cds/SharedStrings.java
@@ -26,6 +26,7 @@
  * @summary Check to make sure that shared strings in the bootstrap CDS archive
  *          are actually shared
  * @requires vm.cds.archived.java.heap
+ * @requires vm.flagless
  * @library /test/lib
  * @build SharedStringsWb sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar whitebox.jar sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/appcds/MoveJDKTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/MoveJDKTest.java
@@ -27,6 +27,7 @@
  * @summary Test that CDS still works when the JDK is moved to a new directory
  * @bug 8272345
  * @requires vm.cds
+ * @requires vm.flagless
  * @comment This test doesn't work on Windows because it depends on symlinks
  * @requires os.family != "windows"
  * @library /test/lib

--- a/test/hotspot/jtreg/runtime/cds/appcds/VerifyWithDefaultArchive.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/VerifyWithDefaultArchive.java
@@ -26,6 +26,7 @@
  * @test
  * @bug 8264337
  * @summary test default cds archive when turning on VerifySharedSpaces
+ * @requires vm.flagless
  * @requires vm.cds
  * @library /test/lib
  * @run driver VerifyWithDefaultArchive

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleWithCustomImageTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleWithCustomImageTest.java
@@ -25,6 +25,7 @@
  * @test
  * @summary Test archived module graph with custom runtime image
  * @requires vm.cds.archived.java.heap
+ * @requires vm.flagless
  * @library /test/jdk/lib/testlibrary /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build sun.hotspot.WhiteBox
  * @compile CheckArchivedModuleApp.java

--- a/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDynamicDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDynamicDump.java
@@ -27,6 +27,7 @@
  * @bug 8259070
  * @summary Test jcmd to dump dynamic shared archive.
  * @requires vm.cds
+ * @requires vm.flagless
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @modules jdk.jcmd/sun.tools.common:+open
  * @compile ../test-classes/Hello.java JCmdTestDumpBase.java


### PR DESCRIPTION
Hi all,

could you please review this patch that adds `@requires vm.flagless` to `runtime/cds` tests that ignore external flags?

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272552](https://bugs.openjdk.java.net/browse/JDK-8272552): mark hotspot runtime/cds tests which ignore external VM flags


### Reviewers
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5132/head:pull/5132` \
`$ git checkout pull/5132`

Update a local copy of the PR: \
`$ git checkout pull/5132` \
`$ git pull https://git.openjdk.java.net/jdk pull/5132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5132`

View PR using the GUI difftool: \
`$ git pr show -t 5132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5132.diff">https://git.openjdk.java.net/jdk/pull/5132.diff</a>

</details>
