### PR TITLE
JDK-8271227: Missing `{@code }` in com.sun.source.*

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/source/doctree/DocTreeVisitor.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/doctree/DocTreeVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ package com.sun.source.doctree;
 public interface DocTreeVisitor<R,P> {
 
     /**
-     * Visits an AttributeTree node.
+     * Visits an {@code AttributeTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -65,7 +65,7 @@ public interface DocTreeVisitor<R,P> {
     R visitAttribute(AttributeTree node, P p);
 
     /**
-     * Visits an AuthorTree node.
+     * Visits an {@code AuthorTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -73,7 +73,7 @@ public interface DocTreeVisitor<R,P> {
     R visitAuthor(AuthorTree node, P p);
 
     /**
-     * Visits a CommentTree node.
+     * Visits a {@code CommentTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -81,7 +81,7 @@ public interface DocTreeVisitor<R,P> {
     R visitComment(CommentTree node, P p);
 
     /**
-     * Visits a DeprecatedTree node.
+     * Visits a {@code DeprecatedTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -89,7 +89,7 @@ public interface DocTreeVisitor<R,P> {
     R visitDeprecated(DeprecatedTree node, P p);
 
     /**
-     * Visits a DocCommentTree node.
+     * Visits a {@code DocCommentTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -97,7 +97,7 @@ public interface DocTreeVisitor<R,P> {
     R visitDocComment(DocCommentTree node, P p);
 
     /**
-     * Visits a DocRootTree node.
+     * Visits a {@code DocRootTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -105,7 +105,7 @@ public interface DocTreeVisitor<R,P> {
     R visitDocRoot(DocRootTree node, P p);
 
     /**
-     * Visits a DocTypeTree node.
+     * Visits a {@code DocTypeTree} node.
      *
      * @implSpec Visits the provided {@code DocTypeTree} node
      * by calling {@code visitOther(node, p)}.
@@ -120,7 +120,7 @@ public interface DocTreeVisitor<R,P> {
     }
 
     /**
-     * Visits an EndElementTree node.
+     * Visits an {@code EndElementTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -128,7 +128,7 @@ public interface DocTreeVisitor<R,P> {
     R visitEndElement(EndElementTree node, P p);
 
     /**
-     * Visits an EntityTree node.
+     * Visits an {@code EntityTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -136,7 +136,7 @@ public interface DocTreeVisitor<R,P> {
     R visitEntity(EntityTree node, P p);
 
     /**
-     * Visits an ErroneousTree node.
+     * Visits an {@code ErroneousTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -144,7 +144,7 @@ public interface DocTreeVisitor<R,P> {
     R visitErroneous(ErroneousTree node, P p);
 
     /**
-     * Visits a HiddenTree node.
+     * Visits a {@code HiddenTree} node.
      *
      * @implSpec Visits the provided {@code HiddenTree} node
      * by calling {@code visitOther(node, p)}.
@@ -160,7 +160,7 @@ public interface DocTreeVisitor<R,P> {
     }
 
     /**
-     * Visits an IdentifierTree node.
+     * Visits an {@code IdentifierTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -168,7 +168,7 @@ public interface DocTreeVisitor<R,P> {
     R visitIdentifier(IdentifierTree node, P p);
 
     /**
-     * Visits an IndexTree node.
+     * Visits an {@code IndexTree} node.
      *
      * @implSpec Visits the provided {@code IndexTree} node
      * by calling {@code visitOther(node, p)}.
@@ -184,7 +184,7 @@ public interface DocTreeVisitor<R,P> {
     }
 
     /**
-     * Visits an InheritDocTree node.
+     * Visits an {@code InheritDocTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -192,7 +192,7 @@ public interface DocTreeVisitor<R,P> {
     R visitInheritDoc(InheritDocTree node, P p);
 
     /**
-     * Visits a LinkTree node.
+     * Visits a {@code LinkTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -200,7 +200,7 @@ public interface DocTreeVisitor<R,P> {
     R visitLink(LinkTree node, P p);
 
     /**
-     * Visits an LiteralTree node.
+     * Visits an {@code LiteralTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -208,7 +208,7 @@ public interface DocTreeVisitor<R,P> {
     R visitLiteral(LiteralTree node, P p);
 
     /**
-     * Visits a ParamTree node.
+     * Visits a {@code ParamTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -216,7 +216,7 @@ public interface DocTreeVisitor<R,P> {
     R visitParam(ParamTree node, P p);
 
     /**
-     * Visits a ProvidesTree node.
+     * Visits a {@code ProvidesTree} node.
      *
      * @implSpec Visits the provided {@code ProvidesTree} node
      * by calling {@code visitOther(node, p)}.
@@ -232,7 +232,7 @@ public interface DocTreeVisitor<R,P> {
     }
 
     /**
-     * Visits a ReferenceTree node.
+     * Visits a {@code ReferenceTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -240,7 +240,7 @@ public interface DocTreeVisitor<R,P> {
     R visitReference(ReferenceTree node, P p);
 
     /**
-     * Visits a ReturnTree node.
+     * Visits a {@code ReturnTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -248,7 +248,7 @@ public interface DocTreeVisitor<R,P> {
     R visitReturn(ReturnTree node, P p);
 
     /**
-     * Visits a SeeTree node.
+     * Visits a {@code SeeTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -256,7 +256,7 @@ public interface DocTreeVisitor<R,P> {
     R visitSee(SeeTree node, P p);
 
     /**
-     * Visits a SerialTree node.
+     * Visits a {@code SerialTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -264,7 +264,7 @@ public interface DocTreeVisitor<R,P> {
     R visitSerial(SerialTree node, P p);
 
     /**
-     * Visits a SerialDataTree node.
+     * Visits a {@code SerialDataTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -272,7 +272,7 @@ public interface DocTreeVisitor<R,P> {
     R visitSerialData(SerialDataTree node, P p);
 
     /**
-     * Visits a SerialFieldTree node.
+     * Visits a {@code SerialFieldTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -280,7 +280,7 @@ public interface DocTreeVisitor<R,P> {
     R visitSerialField(SerialFieldTree node, P p);
 
     /**
-     * Visits a SinceTree node.
+     * Visits a {@code SinceTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -288,7 +288,7 @@ public interface DocTreeVisitor<R,P> {
     R visitSince(SinceTree node, P p);
 
     /**
-     * Visits a StartElementTree node.
+     * Visits a {@code StartElementTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -296,7 +296,7 @@ public interface DocTreeVisitor<R,P> {
     R visitStartElement(StartElementTree node, P p);
 
     /**
-     * Visits a SummaryTree node.
+     * Visits a {@code SummaryTree} node.
      *
      * @implSpec Visits the provided {@code SummaryTree} node
      * by calling {@code visitOther(node, p)}.
@@ -311,7 +311,7 @@ public interface DocTreeVisitor<R,P> {
     }
 
     /**
-     * Visits a SystemPropertyTree node.
+     * Visits a {@code SystemPropertyTree} node.
      *
      * @implSpec Visits the provided {@code SystemPropertyTree} node
      * by calling {@code visitOther(node, p)}.
@@ -326,7 +326,7 @@ public interface DocTreeVisitor<R,P> {
     }
 
     /**
-     * Visits a TextTree node.
+     * Visits a {@code TextTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -334,7 +334,7 @@ public interface DocTreeVisitor<R,P> {
     R visitText(TextTree node, P p);
 
     /**
-     * Visits a ThrowsTree node.
+     * Visits a {@code ThrowsTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -342,7 +342,7 @@ public interface DocTreeVisitor<R,P> {
     R visitThrows(ThrowsTree node, P p);
 
     /**
-     * Visits an UnknownBlockTagTree node.
+     * Visits an {@code UnknownBlockTagTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -350,7 +350,7 @@ public interface DocTreeVisitor<R,P> {
     R visitUnknownBlockTag(UnknownBlockTagTree node, P p);
 
     /**
-     * Visits an UnknownInlineTagTree node.
+     * Visits an {@code UnknownInlineTagTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -358,7 +358,7 @@ public interface DocTreeVisitor<R,P> {
     R visitUnknownInlineTag(UnknownInlineTagTree node, P p);
 
     /**
-     * Visits a UsesTree node.
+     * Visits a {@code UsesTree} node.
      *
      * @implSpec Visits a {@code UsesTree} node
      * by calling {@code visitOther(node, p)}.
@@ -374,7 +374,7 @@ public interface DocTreeVisitor<R,P> {
     }
 
     /**
-     * Visits a ValueTree node.
+     * Visits a {@code ValueTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -382,7 +382,7 @@ public interface DocTreeVisitor<R,P> {
     R visitValue(ValueTree node, P p);
 
     /**
-     * Visits a VersionTree node.
+     * Visits a {@code VersionTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -390,7 +390,7 @@ public interface DocTreeVisitor<R,P> {
     R visitVersion(VersionTree node, P p);
 
     /**
-     * Visits an unknown type of DocTree node.
+     * Visits an unknown type of {@code DocTree} node.
      * This can occur if the set of tags evolves and new kinds
      * of nodes are added to the {@code DocTree} hierarchy.
      * @param node the node being visited

--- a/src/jdk.compiler/share/classes/com/sun/source/tree/TreeVisitor.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/tree/TreeVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ import jdk.internal.javac.PreviewFeature;
  */
 public interface TreeVisitor<R,P> {
     /**
-     * Visits an AnnotatedTypeTree node.
+     * Visits an {@code AnnotatedTypeTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -68,7 +68,7 @@ public interface TreeVisitor<R,P> {
     R visitAnnotatedType(AnnotatedTypeTree node, P p);
 
     /**
-     * Visits an AnnotatedTree node.
+     * Visits an {@code AnnotatedTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -76,7 +76,7 @@ public interface TreeVisitor<R,P> {
     R visitAnnotation(AnnotationTree node, P p);
 
     /**
-     * Visits a MethodInvocationTree node.
+     * Visits a {@code MethodInvocationTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -84,7 +84,7 @@ public interface TreeVisitor<R,P> {
     R visitMethodInvocation(MethodInvocationTree node, P p);
 
     /**
-     * Visits an AssertTree node.
+     * Visits an {@code AssertTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -92,7 +92,7 @@ public interface TreeVisitor<R,P> {
     R visitAssert(AssertTree node, P p);
 
     /**
-     * Visits an AssignmentTree node.
+     * Visits an {@code AssignmentTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -100,7 +100,7 @@ public interface TreeVisitor<R,P> {
     R visitAssignment(AssignmentTree node, P p);
 
     /**
-     * Visits a CompoundAssignmentTree node.
+     * Visits a {@code CompoundAssignmentTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -108,7 +108,7 @@ public interface TreeVisitor<R,P> {
     R visitCompoundAssignment(CompoundAssignmentTree node, P p);
 
     /**
-     * Visits a BinaryTree node.
+     * Visits a {@code BinaryTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -116,7 +116,7 @@ public interface TreeVisitor<R,P> {
     R visitBinary(BinaryTree node, P p);
 
     /**
-     * Visits a BlockTree node.
+     * Visits a {@code BlockTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -124,7 +124,7 @@ public interface TreeVisitor<R,P> {
     R visitBlock(BlockTree node, P p);
 
     /**
-     * Visits a BreakTree node.
+     * Visits a {@code BreakTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -132,7 +132,7 @@ public interface TreeVisitor<R,P> {
     R visitBreak(BreakTree node, P p);
 
     /**
-     * Visits a CaseTree node.
+     * Visits a {@code CaseTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -140,7 +140,7 @@ public interface TreeVisitor<R,P> {
     R visitCase(CaseTree node, P p);
 
     /**
-     * Visits a CatchTree node.
+     * Visits a {@code CatchTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -148,7 +148,7 @@ public interface TreeVisitor<R,P> {
     R visitCatch(CatchTree node, P p);
 
     /**
-     * Visits a ClassTree node.
+     * Visits a {@code ClassTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -156,7 +156,7 @@ public interface TreeVisitor<R,P> {
     R visitClass(ClassTree node, P p);
 
     /**
-     * Visits a ConditionalExpressionTree node.
+     * Visits a {@code ConditionalExpressionTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -164,7 +164,7 @@ public interface TreeVisitor<R,P> {
     R visitConditionalExpression(ConditionalExpressionTree node, P p);
 
     /**
-     * Visits a ContinueTree node.
+     * Visits a {@code ContinueTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -172,7 +172,7 @@ public interface TreeVisitor<R,P> {
     R visitContinue(ContinueTree node, P p);
 
     /**
-     * Visits a DoWhileTree node.
+     * Visits a {@code DoWhileTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -180,7 +180,7 @@ public interface TreeVisitor<R,P> {
     R visitDoWhileLoop(DoWhileLoopTree node, P p);
 
     /**
-     * Visits an ErroneousTree node.
+     * Visits an {@code ErroneousTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -188,7 +188,7 @@ public interface TreeVisitor<R,P> {
     R visitErroneous(ErroneousTree node, P p);
 
     /**
-     * Visits an ExpressionStatementTree node.
+     * Visits an {@code ExpressionStatementTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -196,7 +196,7 @@ public interface TreeVisitor<R,P> {
     R visitExpressionStatement(ExpressionStatementTree node, P p);
 
     /**
-     * Visits an EnhancedForLoopTree node.
+     * Visits an {@code EnhancedForLoopTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -204,7 +204,7 @@ public interface TreeVisitor<R,P> {
     R visitEnhancedForLoop(EnhancedForLoopTree node, P p);
 
     /**
-     * Visits a ForLoopTree node.
+     * Visits a {@code ForLoopTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -212,7 +212,7 @@ public interface TreeVisitor<R,P> {
     R visitForLoop(ForLoopTree node, P p);
 
     /**
-     * Visits an IdentifierTree node.
+     * Visits an {@code IdentifierTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -220,7 +220,7 @@ public interface TreeVisitor<R,P> {
     R visitIdentifier(IdentifierTree node, P p);
 
     /**
-     * Visits an IfTree node.
+     * Visits an {@code IfTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -228,7 +228,7 @@ public interface TreeVisitor<R,P> {
     R visitIf(IfTree node, P p);
 
     /**
-     * Visits an ImportTree node.
+     * Visits an {@code ImportTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -236,7 +236,7 @@ public interface TreeVisitor<R,P> {
     R visitImport(ImportTree node, P p);
 
     /**
-     * Visits an ArrayAccessTree node.
+     * Visits an {@code ArrayAccessTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -244,7 +244,7 @@ public interface TreeVisitor<R,P> {
     R visitArrayAccess(ArrayAccessTree node, P p);
 
     /**
-     * Visits a LabeledStatementTree node.
+     * Visits a {@code LabeledStatementTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -252,7 +252,7 @@ public interface TreeVisitor<R,P> {
     R visitLabeledStatement(LabeledStatementTree node, P p);
 
     /**
-     * Visits a LiteralTree node.
+     * Visits a {@code LiteralTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -260,7 +260,7 @@ public interface TreeVisitor<R,P> {
     R visitLiteral(LiteralTree node, P p);
 
     /**
-     * Visits an BindingPattern node.
+     * Visits a {@code BindingPatternTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -269,7 +269,7 @@ public interface TreeVisitor<R,P> {
     R visitBindingPattern(BindingPatternTree node, P p);
 
     /**
-     * Visits a DefaultCaseLabelTree node.
+     * Visits a {@code DefaultCaseLabelTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -279,7 +279,7 @@ public interface TreeVisitor<R,P> {
     R visitDefaultCaseLabel(DefaultCaseLabelTree node, P p);
 
     /**
-     * Visits a MethodTree node.
+     * Visits a {@code MethodTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -287,7 +287,7 @@ public interface TreeVisitor<R,P> {
     R visitMethod(MethodTree node, P p);
 
     /**
-     * Visits a ModifiersTree node.
+     * Visits a {@code ModifiersTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -295,7 +295,7 @@ public interface TreeVisitor<R,P> {
     R visitModifiers(ModifiersTree node, P p);
 
     /**
-     * Visits a NewArrayTree node.
+     * Visits a {@code NewArrayTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -303,7 +303,7 @@ public interface TreeVisitor<R,P> {
     R visitNewArray(NewArrayTree node, P p);
 
     /**
-     * Visits a GuardPatternTree node.
+     * Visits a {@code GuardPatternTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -313,7 +313,7 @@ public interface TreeVisitor<R,P> {
     R visitGuardedPattern(GuardedPatternTree node, P p);
 
     /**
-     * Visits a ParenthesizedPatternTree node.
+     * Visits a {@code ParenthesizedPatternTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -323,7 +323,7 @@ public interface TreeVisitor<R,P> {
     R visitParenthesizedPattern(ParenthesizedPatternTree node, P p);
 
     /**
-     * Visits a NewClassTree node.
+     * Visits a {@code NewClassTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -331,7 +331,7 @@ public interface TreeVisitor<R,P> {
     R visitNewClass(NewClassTree node, P p);
 
     /**
-     * Visits a LambdaExpressionTree node.
+     * Visits a {@code LambdaExpressionTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -339,7 +339,7 @@ public interface TreeVisitor<R,P> {
     R visitLambdaExpression(LambdaExpressionTree node, P p);
 
     /**
-     * Visits a PackageTree node.
+     * Visits a {@code PackageTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -347,7 +347,7 @@ public interface TreeVisitor<R,P> {
     R visitPackage(PackageTree node, P p);
 
     /**
-     * Visits a ParenthesizedTree node.
+     * Visits a {@code ParenthesizedTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -355,7 +355,7 @@ public interface TreeVisitor<R,P> {
     R visitParenthesized(ParenthesizedTree node, P p);
 
     /**
-     * Visits a ReturnTree node.
+     * Visits a {@code ReturnTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -363,7 +363,7 @@ public interface TreeVisitor<R,P> {
     R visitReturn(ReturnTree node, P p);
 
     /**
-     * Visits a MemberSelectTree node.
+     * Visits a {@code MemberSelectTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -371,7 +371,7 @@ public interface TreeVisitor<R,P> {
     R visitMemberSelect(MemberSelectTree node, P p);
 
     /**
-     * Visits a MemberReferenceTree node.
+     * Visits a {@code MemberReferenceTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -379,7 +379,7 @@ public interface TreeVisitor<R,P> {
     R visitMemberReference(MemberReferenceTree node, P p);
 
     /**
-     * Visits an EmptyStatementTree node.
+     * Visits an {@code EmptyStatementTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -387,7 +387,7 @@ public interface TreeVisitor<R,P> {
     R visitEmptyStatement(EmptyStatementTree node, P p);
 
     /**
-     * Visits a SwitchTree node.
+     * Visits a {@code SwitchTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -395,7 +395,7 @@ public interface TreeVisitor<R,P> {
     R visitSwitch(SwitchTree node, P p);
 
     /**
-     * Visits a SwitchExpressionTree node.
+     * Visits a {@code SwitchExpressionTree} node.
      *
      * @param node the node being visited
      * @param p a parameter value
@@ -405,7 +405,7 @@ public interface TreeVisitor<R,P> {
     R visitSwitchExpression(SwitchExpressionTree node, P p);
 
     /**
-     * Visits a SynchronizedTree node.
+     * Visits a {@code SynchronizedTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -413,7 +413,7 @@ public interface TreeVisitor<R,P> {
     R visitSynchronized(SynchronizedTree node, P p);
 
     /**
-     * Visits a ThrowTree node.
+     * Visits a {@code ThrowTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -421,7 +421,7 @@ public interface TreeVisitor<R,P> {
     R visitThrow(ThrowTree node, P p);
 
     /**
-     * Visits a CompilationUnitTree node.
+     * Visits a {@code CompilationUnitTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -429,7 +429,7 @@ public interface TreeVisitor<R,P> {
     R visitCompilationUnit(CompilationUnitTree node, P p);
 
     /**
-     * Visits a TryTree node.
+     * Visits a {@code TryTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -437,7 +437,7 @@ public interface TreeVisitor<R,P> {
     R visitTry(TryTree node, P p);
 
     /**
-     * Visits a ParameterizedTypeTree node.
+     * Visits a {@code ParameterizedTypeTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -445,7 +445,7 @@ public interface TreeVisitor<R,P> {
     R visitParameterizedType(ParameterizedTypeTree node, P p);
 
     /**
-     * Visits a UnionTypeTree node.
+     * Visits a {@code UnionTypeTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -453,7 +453,7 @@ public interface TreeVisitor<R,P> {
     R visitUnionType(UnionTypeTree node, P p);
 
     /**
-     * Visits an IntersectionTypeTree node.
+     * Visits an {@code IntersectionTypeTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -461,7 +461,7 @@ public interface TreeVisitor<R,P> {
     R visitIntersectionType(IntersectionTypeTree node, P p);
 
     /**
-     * Visits an ArrayTypeTree node.
+     * Visits an {@code ArrayTypeTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -469,7 +469,7 @@ public interface TreeVisitor<R,P> {
     R visitArrayType(ArrayTypeTree node, P p);
 
     /**
-     * Visits a TypeCastTree node.
+     * Visits a {@code TypeCastTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -477,7 +477,7 @@ public interface TreeVisitor<R,P> {
     R visitTypeCast(TypeCastTree node, P p);
 
     /**
-     * Visits a PrimitiveTypeTree node.
+     * Visits a {@code PrimitiveTypeTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -485,7 +485,7 @@ public interface TreeVisitor<R,P> {
     R visitPrimitiveType(PrimitiveTypeTree node, P p);
 
     /**
-     * Visits a TypeParameterTree node.
+     * Visits a {@code TypeParameterTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -493,7 +493,7 @@ public interface TreeVisitor<R,P> {
     R visitTypeParameter(TypeParameterTree node, P p);
 
     /**
-     * Visits an InstanceOfTree node.
+     * Visits an {@code InstanceOfTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -501,7 +501,7 @@ public interface TreeVisitor<R,P> {
     R visitInstanceOf(InstanceOfTree node, P p);
 
     /**
-     * Visits a UnaryTree node.
+     * Visits a {@code UnaryTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -509,7 +509,7 @@ public interface TreeVisitor<R,P> {
     R visitUnary(UnaryTree node, P p);
 
     /**
-     * Visits a VariableTree node.
+     * Visits a {@code VariableTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -517,7 +517,7 @@ public interface TreeVisitor<R,P> {
     R visitVariable(VariableTree node, P p);
 
     /**
-     * Visits a WhileLoopTree node.
+     * Visits a {@code WhileLoopTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -525,7 +525,7 @@ public interface TreeVisitor<R,P> {
     R visitWhileLoop(WhileLoopTree node, P p);
 
     /**
-     * Visits a WildcardTypeTree node.
+     * Visits a {@code WildcardTypeTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -533,7 +533,7 @@ public interface TreeVisitor<R,P> {
     R visitWildcard(WildcardTree node, P p);
 
     /**
-     * Visits a ModuleTree node.
+     * Visits a {@code ModuleTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -541,7 +541,7 @@ public interface TreeVisitor<R,P> {
     R visitModule(ModuleTree node, P p);
 
     /**
-     * Visits an ExportsTree node.
+     * Visits an {@code ExportsTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -549,7 +549,7 @@ public interface TreeVisitor<R,P> {
     R visitExports(ExportsTree node, P p);
 
     /**
-     * Visits an OpensTree node.
+     * Visits an {@code OpensTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -557,7 +557,7 @@ public interface TreeVisitor<R,P> {
     R visitOpens(OpensTree node, P p);
 
     /**
-     * Visits a ProvidesTree node.
+     * Visits a {@code ProvidesTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -565,7 +565,7 @@ public interface TreeVisitor<R,P> {
     R visitProvides(ProvidesTree node, P p);
 
     /**
-     * Visits a RequiresTree node.
+     * Visits a {@code RequiresTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -573,7 +573,7 @@ public interface TreeVisitor<R,P> {
     R visitRequires(RequiresTree node, P p);
 
     /**
-     * Visits a UsesTree node.
+     * Visits a {@code UsesTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
@@ -581,7 +581,7 @@ public interface TreeVisitor<R,P> {
     R visitUses(UsesTree node, P p);
 
     /**
-     * Visits an unknown type of Tree node.
+     * Visits an unknown type of {@code Tree} node.
      * This can occur if the language evolves and new kinds
      * of nodes are added to the {@code Tree} hierarchy.
      * @param node the node being visited
@@ -591,7 +591,7 @@ public interface TreeVisitor<R,P> {
     R visitOther(Tree node, P p);
 
     /**
-     * Visits a YieldTree node.
+     * Visits a {@code YieldTree} node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value

--- a/src/jdk.compiler/share/classes/com/sun/source/util/Trees.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/Trees.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,10 +58,10 @@ public abstract class Trees {
     public Trees() {}
 
     /**
-     * Returns a Trees object for a given CompilationTask.
-     * @param task the compilation task for which to get the Trees object
-     * @throws IllegalArgumentException if the task does not support the Trees API.
-     * @return the Trees object
+     * Returns a {@code Trees} object for a given {@code CompilationTask}.
+     * @param task the compilation task for which to get the {@code Trees} object
+     * @throws IllegalArgumentException if the task does not support the Tree API.
+     * @return the {@code Trees} object
      */
     public static Trees instance(CompilationTask task) {
         String taskClassName = task.getClass().getName();
@@ -72,10 +72,10 @@ public abstract class Trees {
     }
 
     /**
-     * Returns a Trees object for a given ProcessingEnvironment.
-     * @param env the processing environment for which to get the Trees object
-     * @throws IllegalArgumentException if the env does not support the Trees API.
-     * @return the Trees object
+     * Returns a {code Trees} object for a given {@code ProcessingEnvironment}.
+     * @param env the processing environment for which to get the {@code Trees} object
+     * @throws IllegalArgumentException if the env does not support the Tree API.
+     * @return the {@code Trees} object
      */
     public static Trees instance(ProcessingEnvironment env) {
         if (!env.getClass().getName().equals("com.sun.tools.javac.processing.JavacProcessingEnvironment"))
@@ -102,7 +102,7 @@ public abstract class Trees {
     public abstract SourcePositions getSourcePositions();
 
     /**
-     * Returns the Tree node for a given Element.
+     * Returns the {@code Tree} node for a given {@code Element}.
      * Returns {@code null} if the node can not be found.
      * @param element the element
      * @return the tree node
@@ -110,7 +110,7 @@ public abstract class Trees {
     public abstract Tree getTree(Element element);
 
     /**
-     * Returns the ClassTree node for a given TypeElement.
+     * Returns the {@code ClassTree} node for a given {@code TypeElement}.
      * Returns {@code null} if the node can not be found.
      * @param element the element
      * @return the class tree node
@@ -118,7 +118,7 @@ public abstract class Trees {
     public abstract ClassTree getTree(TypeElement element);
 
     /**
-     * Returns the MethodTree node for a given ExecutableElement.
+     * Returns the {@code MethodTree} node for a given {@code ExecutableElement}.
      * Returns {@code null} if the node can not be found.
      * @param method the executable element
      * @return the method tree node
@@ -126,7 +126,7 @@ public abstract class Trees {
     public abstract MethodTree getTree(ExecutableElement method);
 
     /**
-     * Returns the Tree node for an AnnotationMirror on a given Element.
+     * Returns the {@code Tree} node for an {@code AnnotationMirror} on a given {@code Element}.
      * Returns {@code null} if the node can not be found.
      * @param e the element
      * @param a the annotation mirror
@@ -135,7 +135,7 @@ public abstract class Trees {
     public abstract Tree getTree(Element e, AnnotationMirror a);
 
     /**
-     * Returns the Tree node for an AnnotationValue for an AnnotationMirror on a given Element.
+     * Returns the {@code Tree} node for an {@code AnnotationValue} for an {@code AnnotationMirror} on a given {@code Element}.
      * Returns {@code null} if the node can not be found.
      * @param e the element
      * @param a the annotation mirror
@@ -153,7 +153,7 @@ public abstract class Trees {
     public abstract TreePath getPath(CompilationUnitTree unit, Tree node);
 
     /**
-     * Returns the TreePath node for a given Element.
+     * Returns the {@code TreePath} node for a given {@code Element}.
      * Returns {@code null} if the node can not be found.
      * @param e the element
      * @return the tree path
@@ -161,7 +161,7 @@ public abstract class Trees {
     public abstract TreePath getPath(Element e);
 
     /**
-     * Returns the TreePath node for an AnnotationMirror on a given Element.
+     * Returns the {@code TreePath} node for an {@code AnnotationMirror} on a given {@code Element}.
      * Returns {@code null} if the node can not be found.
      * @param e the element
      * @param a the annotation mirror
@@ -170,7 +170,7 @@ public abstract class Trees {
     public abstract TreePath getPath(Element e, AnnotationMirror a);
 
     /**
-     * Returns the TreePath node for an AnnotationValue for an AnnotationMirror on a given Element.
+     * Returns the {@code TreePath} node for an {@code AnnotationValue} for an {@code AnnotationMirror} on a given {@code Element}.
      * Returns {@code null} if the node can not be found.
      * @param e the element
      * @param a the annotation mirror
@@ -180,35 +180,35 @@ public abstract class Trees {
     public abstract TreePath getPath(Element e, AnnotationMirror a, AnnotationValue v);
 
     /**
-     * Returns the Element for the Tree node identified by a given TreePath.
+     * Returns the {@code Element} for the {@code Tree} node identified by a given {@code TreePath}.
      * Returns {@code null} if the element is not available.
      * @param path the tree path
      * @return the element
-     * @throws IllegalArgumentException is the TreePath does not identify
-     * a Tree node that might have an associated Element.
+     * @throws IllegalArgumentException is the {@code TreePath} does not identify
+     * a {@code Tree} node that might have an associated {@code Element}.
      */
     public abstract Element getElement(TreePath path);
 
     /**
-     * Returns the TypeMirror for the Tree node identified by a given TreePath.
-     * Returns {@code null} if the TypeMirror is not available.
+     * Returns the {@code TypeMirror} for the {@code Tree} node identified by a given {@code TreePath}.
+     * Returns {@code null} if the {@code TypeMirror} is not available.
      * @param path the tree path
      * @return the type mirror
-     * @throws IllegalArgumentException is the TreePath does not identify
-     * a Tree node that might have an associated TypeMirror.
+     * @throws IllegalArgumentException is the {@code TreePath} does not identify
+     * a {@code Tree} node that might have an associated {@code TypeMirror}.
      */
     public abstract TypeMirror getTypeMirror(TreePath path);
 
     /**
-     * Returns the Scope for the Tree node identified by a given TreePath.
-     * Returns {@code null} if the Scope is not available.
+     * Returns the {@code Scope} for the {@code Tree} node identified by a given {@code TreePath}.
+     * Returns {@code null} if the {@code Scope} is not available.
      * @param path the tree path
      * @return the scope
      */
     public abstract Scope getScope(TreePath path);
 
     /**
-     * Returns the doc comment, if any, for the Tree node identified by a given TreePath.
+     * Returns the doc comment, if any, for the {@code Tree} node identified by a given {@code TreePath}.
      * Returns {@code null} if no doc comment was found.
      * @see DocTrees#getDocCommentTree(TreePath)
      * @param path the tree path
@@ -235,9 +235,9 @@ public abstract class Trees {
     public abstract boolean isAccessible(Scope scope, Element member, DeclaredType type);
 
     /**
-      * Returns the original type from the ErrorType object.
+      * Returns the original type from the {@code ErrorType} object.
       * @param errorType the errorType for which we want to get the original type
-      * @return the type mirror corresponding to the original type, replaced by the ErrorType
+      * @return the type mirror corresponding to the original type, replaced by the {@code ErrorType}
       */
     public abstract TypeMirror getOriginalType(ErrorType errorType);
 


### PR DESCRIPTION
Please review a simple `noreg-doc` update to files in the `com.sun.source.*` API, to enclose type names in the descriptions in doc comments with `{@code }`. 

Apart from fixing one typo, the changes are all formatting changes, with no changes to the content of the spec, so no CSR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271227](https://bugs.openjdk.java.net/browse/JDK-8271227): Missing `{@code }` in com.sun.source.*


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5133/head:pull/5133` \
`$ git checkout pull/5133`

Update a local copy of the PR: \
`$ git checkout pull/5133` \
`$ git pull https://git.openjdk.java.net/jdk pull/5133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5133`

View PR using the GUI difftool: \
`$ git pr show -t 5133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5133.diff">https://git.openjdk.java.net/jdk/pull/5133.diff</a>

</details>
