### PR TITLE
8272398: Update DockerTestUtils.buildJdkDockerImage()

### DIFF
--- a/test/hotspot/jtreg/containers/docker/DockerBasicTest.java
+++ b/test/hotspot/jtreg/containers/docker/DockerBasicTest.java
@@ -48,7 +48,7 @@ public class DockerBasicTest {
             return;
         }
 
-        DockerTestUtils.buildJdkDockerImage(imageNameAndTag, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageNameAndTag);
 
         try {
             testJavaVersion();

--- a/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
@@ -52,7 +52,7 @@ public class TestCPUAwareness {
         }
 
         System.out.println("Test Environment: detected availableCPUs = " + availableCPUs);
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
             // cpuset, period, shares, expected Active Processor Count

--- a/test/hotspot/jtreg/containers/docker/TestCPUSets.java
+++ b/test/hotspot/jtreg/containers/docker/TestCPUSets.java
@@ -57,7 +57,7 @@ public class TestCPUSets {
 
 
         Common.prepareWhiteBox();
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
             // Sanity test the cpu sets reader and parser

--- a/test/hotspot/jtreg/containers/docker/TestJFREvents.java
+++ b/test/hotspot/jtreg/containers/docker/TestJFREvents.java
@@ -58,7 +58,7 @@ public class TestJFREvents {
             return;
         }
 
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
 

--- a/test/hotspot/jtreg/containers/docker/TestJFRNetworkEvents.java
+++ b/test/hotspot/jtreg/containers/docker/TestJFRNetworkEvents.java
@@ -51,7 +51,7 @@ public class TestJFRNetworkEvents {
             return;
         }
 
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
             runTest("jdk.SocketWrite");

--- a/test/hotspot/jtreg/containers/docker/TestJFRWithJMX.java
+++ b/test/hotspot/jtreg/containers/docker/TestJFRWithJMX.java
@@ -80,7 +80,7 @@ public class TestJFRWithJMX {
             throw new SkippedException("test cannot be run under rootless podman configuration");
         }
 
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
             test();

--- a/test/hotspot/jtreg/containers/docker/TestJcmdWithSideCar.java
+++ b/test/hotspot/jtreg/containers/docker/TestJcmdWithSideCar.java
@@ -65,7 +65,7 @@ public class TestJcmdWithSideCar {
             return;
         }
 
-        DockerTestUtils.buildJdkDockerImage(IMAGE_NAME, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(IMAGE_NAME);
 
         try {
             // Start the loop process in the "main" container, then run test cases

--- a/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
@@ -50,7 +50,7 @@ public class TestMemoryAwareness {
         }
 
         Common.prepareWhiteBox();
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
             testMemoryLimit("100m", "104857600");

--- a/test/hotspot/jtreg/containers/docker/TestMisc.java
+++ b/test/hotspot/jtreg/containers/docker/TestMisc.java
@@ -50,7 +50,7 @@ public class TestMisc {
         }
 
         Common.prepareWhiteBox();
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
             testMinusContainerSupport();

--- a/test/hotspot/jtreg/containers/docker/TestPids.java
+++ b/test/hotspot/jtreg/containers/docker/TestPids.java
@@ -52,7 +52,7 @@ public class TestPids {
         }
 
         Common.prepareWhiteBox();
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
             testPids();

--- a/test/jdk/jdk/internal/platform/docker/TestDockerCpuMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerCpuMetrics.java
@@ -54,7 +54,7 @@ public class TestDockerCpuMetrics {
         // container include the Java test class to be run along with the
         // resource to be examined and expected result.
 
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
             int numCpus = CPUSetsReader.getNumCpus();

--- a/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
@@ -52,7 +52,7 @@ public class TestDockerMemoryMetrics {
         // container include the Java test class to be run along with the
         // resource to be examined and expected result.
 
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
         try {
             testMemoryLimit("200m");
             testMemoryLimit("1g");

--- a/test/jdk/jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java
+++ b/test/jdk/jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java
@@ -43,7 +43,7 @@ public class TestGetFreeSwapSpaceSize {
             return;
         }
 
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
             testGetFreeSwapSpaceSize(

--- a/test/jdk/jdk/internal/platform/docker/TestPidsLimit.java
+++ b/test/jdk/jdk/internal/platform/docker/TestPidsLimit.java
@@ -48,7 +48,7 @@ public class TestPidsLimit {
             return;
         }
 
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
             testPidsLimit("1000");

--- a/test/jdk/jdk/internal/platform/docker/TestSystemMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestSystemMetrics.java
@@ -45,7 +45,7 @@ public class TestSystemMetrics {
             return;
         }
 
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
             Common.logNewTestCase("Test SystemMetrics");

--- a/test/jdk/jdk/internal/platform/docker/TestUseContainerSupport.java
+++ b/test/jdk/jdk/internal/platform/docker/TestUseContainerSupport.java
@@ -44,7 +44,7 @@ public class TestUseContainerSupport {
             return;
         }
 
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
             testUseContainerSupport(true);

--- a/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
@@ -127,8 +127,8 @@ public class DockerTestUtils {
      * @param imageName name of the image to be created, including version tag
      * @throws Exception
      */
-    public static void buildJdkDockerImage(String imageName) throws Exception {
-        buildJdkDockerImage(imageName, null);
+    public static void buildJdkContainerImage(String imageName) throws Exception {
+        buildJdkContainerImage(imageName, null);
     }
 
      /**
@@ -139,7 +139,7 @@ public class DockerTestUtils {
      * @param dockerfileContent content of the Dockerfile; use null to generate default content
      * @throws Exception
      */
-    public static void buildJdkDockerImage(String imageName, String dockerfileContent) throws Exception {
+    public static void buildJdkContainerImage(String imageName, String dockerfileContent) throws Exception {
 
         // Create an image build/staging directory
         Path buildDir = Paths.get(".", "image-build");

--- a/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,59 +120,64 @@ public class DockerTestUtils {
         return true;
     }
 
-
-    /**
-     * Build a docker image that contains JDK under test.
-     * The jdk will be placed under the "/jdk/" folder inside the docker file system.
+     /**
+     * Build a container image that contains JDK under test.
+     * The jdk will be placed under the "/jdk/" folder inside the image/container file system.
      *
-     * @param imageName     name of the image to be created, including version tag
-     * @param dockerfile    name of the dockerfile residing in the test source;
-     *                      we check for a platform specific dockerfile as well
-     *                      and use this one in case it exists
-     * @param buildDirName  name of the docker build/staging directory, which will
-     *                      be created in the jtreg's scratch folder
+     * @param imageName name of the image to be created, including version tag
      * @throws Exception
      */
-    public static void
-        buildJdkDockerImage(String imageName, String dockerfile, String buildDirName)
-            throws Exception {
+    public static void buildJdkDockerImage(String imageName) throws Exception {
+        buildJdkDockerImage(imageName, null);
+    }
 
-        Path buildDir = Paths.get(".", buildDirName);
+     /**
+     * Build a container image that contains JDK under test.
+     * The jdk will be placed under the "/jdk/" folder inside the image/container file system.
+     *
+     * @param imageName         name of the image to be created, including version tag
+     * @param dockerfileContent content of the Dockerfile; use null to generate default content
+     * @throws Exception
+     */
+    public static void buildJdkDockerImage(String imageName, String dockerfileContent) throws Exception {
+
+        // Create an image build/staging directory
+        Path buildDir = Paths.get(".", "image-build");
         if (Files.exists(buildDir)) {
             throw new RuntimeException("The docker build directory already exists: " + buildDir);
         }
+        Files.createDirectories(buildDir);
 
-        Path jdkSrcDir = Paths.get(JDK_UNDER_TEST);
-        Path jdkDstDir = buildDir.resolve("jdk");
-
-        Files.createDirectories(jdkDstDir);
+        // Generate Dockerfile
+        if (dockerfileContent != null) {
+            Files.writeString(buildDir.resolve("Dockerfile"), dockerfileContent);
+        } else {
+            generateDockerFile(buildDir.resolve("Dockerfile"),
+                           DockerfileConfig.getBaseImageName(),
+                           DockerfileConfig.getBaseImageVersion());
+        }
 
         // Copy JDK-under-test tree to the docker build directory.
         // This step is required for building a docker image.
+        Path jdkSrcDir = Paths.get(JDK_UNDER_TEST);
+        Path jdkDstDir = buildDir.resolve("jdk");
+        Files.createDirectories(jdkDstDir);
         Files.walkFileTree(jdkSrcDir, new CopyFileVisitor(jdkSrcDir, jdkDstDir));
-        buildDockerImage(imageName, Paths.get(Utils.TEST_SRC, dockerfile), buildDir);
+
+        buildImage(imageName, buildDir);
     }
 
 
     /**
-     * Build a docker image based on given docker file and docker build directory.
+     * Build a container image based on given Dockerfile and image build directory.
      *
      * @param imageName  name of the image to be created, including version tag
-     * @param dockerfile  path to the Dockerfile to be used for building the docker
-     *        image. The specified dockerfile will be copied to the docker build
-     *        directory as 'Dockerfile'
-     * @param buildDir  build directory; it should already contain all the content
-     *        needed to build the docker image.
+     * @param buildDir   build directory; it should already contain all the content
+     *                   needed to build the image.
      * @throws Exception
      */
-    public static void
-        buildDockerImage(String imageName, Path dockerfile, Path buildDir) throws Exception {
-
-        generateDockerFile(buildDir.resolve("Dockerfile"),
-                           DockerfileConfig.getBaseImageName(),
-                           DockerfileConfig.getBaseImageVersion());
+    public static void buildImage(String imageName, Path buildDir) throws Exception {
         try {
-            // Build the docker
             execute(Container.ENGINE_COMMAND, "build", "--no-cache", "--tag", imageName, buildDir.toString())
                 .shouldHaveExitValue(0);
         } catch (Exception e) {

--- a/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
@@ -171,7 +171,7 @@ public class DockerTestUtils {
 
 
     /**
-     * Build a container image based on given Dockerfile and image build directory.
+     * Build a container image based on image build directory.
      *
      * @param imageName  name of the image to be created, including version tag
      * @param buildDir   build directory; it should already contain all the content

--- a/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
@@ -140,9 +140,11 @@ public class DockerTestUtils {
      * @throws Exception
      */
     public static void buildJdkContainerImage(String imageName, String dockerfileContent) throws Exception {
+        // image name may contain tag, hence replace ':'
+        String imageDirName = imageName.replace(":", "-");
 
         // Create an image build/staging directory
-        Path buildDir = Paths.get(".", "image-build");
+        Path buildDir = Paths.get(imageDirName);
         if (Files.exists(buildDir)) {
             throw new RuntimeException("The docker build directory already exists: " + buildDir);
         }
@@ -176,7 +178,7 @@ public class DockerTestUtils {
      *                   needed to build the image.
      * @throws Exception
      */
-    public static void buildImage(String imageName, Path buildDir) throws Exception {
+    private static void buildImage(String imageName, Path buildDir) throws Exception {
         try {
             execute(Container.ENGINE_COMMAND, "build", "--no-cache", "--tag", imageName, buildDir.toString())
                 .shouldHaveExitValue(0);


### PR DESCRIPTION
Please review this change that updates the buildJdkDockerImage() test library API.

This work originated while working on "8195809: [TESTBUG] jps and jcmd -l support for containers is not tested".
The initial intent was to extend the buildJdkDockerImage() API of DockerTestUtils to accept custom Dockerfile content.
As I analyzed the usage of buildJdkDockerImage() I realized that:
  - 2nd argument "dockerfile" is always the same: "Dockerfile-BasicTest"
      its use has been obsolete for some time, in favor of Dockerfile generated by DockerTestUtils
  - 3rd argument "buildDirName" is also always the same: "jdk-docker"

Hence I thought it would be a good idea to simplify this API and make it up-to-date.

Also, since the method signature is being updated, I thought it would be a good idea to also change the name to use more generic container terminology:
buildJdkDockerImage() --> buildJdkContainerImage()

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272398](https://bugs.openjdk.java.net/browse/JDK-8272398): Update DockerTestUtils.buildJdkDockerImage()


### Reviewers
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**) ⚠️ Review applies to d211c220f9ebd1ed29d24256936e40df05964bb3
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**) ⚠️ Review applies to d211c220f9ebd1ed29d24256936e40df05964bb3


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5134/head:pull/5134` \
`$ git checkout pull/5134`

Update a local copy of the PR: \
`$ git checkout pull/5134` \
`$ git pull https://git.openjdk.java.net/jdk pull/5134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5134`

View PR using the GUI difftool: \
`$ git pr show -t 5134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5134.diff">https://git.openjdk.java.net/jdk/pull/5134.diff</a>

</details>
