### PR TITLE
8272567: [IR Framework] Make AbstractInfo.getRandom() static

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/AbstractInfo.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/AbstractInfo.java
@@ -56,7 +56,7 @@ abstract public class AbstractInfo {
      *
      * @return the random object.
      */
-    public Random getRandom() {
+    public static Random getRandom() {
         return RANDOM;
     }
 

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/examples/CustomRunTestExample.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/examples/CustomRunTestExample.java
@@ -103,9 +103,9 @@ public class CustomRunTestExample {
 
     // This version of @Run passes the RunInfo object as an argument. No other arguments and combiniations are allowed.
     @Run(test = "test2")
-    public void runWithRunInfo(RunInfo info) {
+    public void runWithRunInfo() {
         // We could also skip some invocations. This might have an influence on possible @IR rules, need to be careful.
-        if (info.getRandom().nextBoolean()) {
+        if (RunInfo.getRandom().nextBoolean()) {
             int returnValue = test(34);
             if (returnValue != 34) {
                 throw new RuntimeException("Must match");


### PR DESCRIPTION
To use the dedicated (`private static final`) `Random` object of `AbstractInfo` one needs to use the non-static `getRandom()` method like this:

```
@Run(test = "myTest")
public void runMethodForMyTest(RunInfo info) {
   int x = info.getRandom().nextInt();
   myTest(x);
}
```

This simple patch makes `getRandom()` static to provide an easier access to it without the need to specify `RunInfo` as parameter:

```
@Run(test = "myTest")
public void runMethodForMyTest() {
   int x = RunInfo.getRandom().nextInt(); // or AbstractInfo.getRandom().nextInt()
   myTest(x);
}
```

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272567](https://bugs.openjdk.java.net/browse/JDK-8272567): [IR Framework] Make AbstractInfo.getRandom() static


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5139/head:pull/5139` \
`$ git checkout pull/5139`

Update a local copy of the PR: \
`$ git checkout pull/5139` \
`$ git pull https://git.openjdk.java.net/jdk pull/5139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5139`

View PR using the GUI difftool: \
`$ git pr show -t 5139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5139.diff">https://git.openjdk.java.net/jdk/pull/5139.diff</a>

</details>
