### PR TITLE
8267894: Skip work for empty regions in G1 Full GC

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -224,8 +224,7 @@ void G1FullCollector::complete_collection() {
 
 void G1FullCollector::before_marking_update_attribute_table(HeapRegion* hr) {
   if (hr->is_free()) {
-    // Set as Invalid by default.
-    _region_attr_table.verify_is_invalid(hr->hrm_index());
+    _region_attr_table.set_free(hr->hrm_index());
   } else if (hr->is_closed_archive()) {
     _region_attr_table.set_skip_marking(hr->hrm_index());
   } else if (hr->is_pinned()) {

--- a/src/hotspot/share/gc/g1/g1FullCollector.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.hpp
@@ -110,6 +110,7 @@ public:
   inline bool is_skip_marking(oop obj) const;
 
   inline void set_invalid(uint region_idx);
+  inline bool is_invalid(uint region_idx) const;
   inline void update_from_compacting_to_skip_compacting(uint region_idx);
 
 private:

--- a/src/hotspot/share/gc/g1/g1FullCollector.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.hpp
@@ -109,8 +109,8 @@ public:
   inline bool is_skip_compacting(uint region_index) const;
   inline bool is_skip_marking(oop obj) const;
 
-  inline void set_invalid(uint region_idx);
-  inline bool is_invalid(uint region_idx) const;
+  inline void set_free(uint region_idx);
+  inline bool is_free(uint region_idx) const;
   inline void update_from_compacting_to_skip_compacting(uint region_idx);
 
 private:

--- a/src/hotspot/share/gc/g1/g1FullCollector.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.inline.hpp
@@ -43,12 +43,12 @@ bool G1FullCollector::is_skip_marking(oop obj) const {
   return _region_attr_table.is_skip_marking(cast_from_oop<HeapWord*>(obj));
 }
 
-void G1FullCollector::set_invalid(uint region_idx) {
-  _region_attr_table.set_invalid(region_idx);
+void G1FullCollector::set_free(uint region_idx) {
+  _region_attr_table.set_free(region_idx);
 }
 
-bool G1FullCollector::is_invalid(uint region_idx) const {
-  return _region_attr_table.is_invalid(region_idx);
+bool G1FullCollector::is_free(uint region_idx) const {
+  return _region_attr_table.is_free(region_idx);
 }
 
 void G1FullCollector::update_from_compacting_to_skip_compacting(uint region_idx) {

--- a/src/hotspot/share/gc/g1/g1FullCollector.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.inline.hpp
@@ -47,6 +47,10 @@ void G1FullCollector::set_invalid(uint region_idx) {
   _region_attr_table.set_invalid(region_idx);
 }
 
+bool G1FullCollector::is_invalid(uint region_idx) const {
+  return _region_attr_table.is_invalid(region_idx);
+}
+
 void G1FullCollector::update_from_compacting_to_skip_compacting(uint region_idx) {
   _region_attr_table.verify_is_compacting(region_idx);
   _region_attr_table.set_skip_compacting(region_idx);

--- a/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
@@ -79,13 +79,17 @@ size_t G1FullGCCompactTask::G1CompactRegionClosure::apply(oop obj) {
 void G1FullGCCompactTask::compact_region(HeapRegion* hr) {
   assert(!hr->is_pinned(), "Should be no pinned region in compaction queue");
   assert(!hr->is_humongous(), "Should be no humongous regions in compaction queue");
-  G1CompactRegionClosure compact(collector()->mark_bitmap());
-  hr->apply_to_marked_objects(collector()->mark_bitmap(), &compact);
-  // Clear the liveness information for this region if necessary i.e. if we actually look at it
-  // for bitmap verification. Otherwise it is sufficient that we move the TAMS to bottom().
-  if (G1VerifyBitmaps) {
-    collector()->mark_bitmap()->clear_region(hr);
+
+  if (!collector()->is_invalid(hr->hrm_index())) {
+    G1CompactRegionClosure compact(collector()->mark_bitmap());
+    hr->apply_to_marked_objects(collector()->mark_bitmap(), &compact);
+    // Clear the liveness information for this region if necessary i.e. if we actually look at it
+    // for bitmap verification. Otherwise it is sufficient that we move the TAMS to bottom().
+    if (G1VerifyBitmaps) {
+      collector()->mark_bitmap()->clear_region(hr);
+    }
   }
+
   hr->reset_compacted_after_full_gc();
 }
 

--- a/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
@@ -80,7 +80,7 @@ void G1FullGCCompactTask::compact_region(HeapRegion* hr) {
   assert(!hr->is_pinned(), "Should be no pinned region in compaction queue");
   assert(!hr->is_humongous(), "Should be no humongous regions in compaction queue");
 
-  if (!collector()->is_invalid(hr->hrm_index())) {
+  if (!collector()->is_free(hr->hrm_index())) {
     G1CompactRegionClosure compact(collector()->mark_bitmap());
     hr->apply_to_marked_objects(collector()->mark_bitmap(), &compact);
     // Clear the liveness information for this region if necessary i.e. if we actually look at it

--- a/src/hotspot/share/gc/g1/g1FullGCHeapRegionAttr.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCHeapRegionAttr.hpp
@@ -41,11 +41,12 @@ class G1FullGCHeapRegionAttr : public G1BiasedMappedArray<uint8_t> {
   static const uint8_t Compacting = 0;       // Region will be compacted.
   static const uint8_t SkipCompacting = 1;   // Region should not be compacted, but otherwise handled as usual.
   static const uint8_t SkipMarking = 2;      // Region contents are not even marked through, but contain live objects.
+  static const uint8_t Free = 3;             // Regions is free.
 
   static const uint8_t Invalid = 255;
 
-  bool is_invalid(HeapWord* obj) const {
-    return get_by_address(obj) == Invalid;
+  bool is_free(HeapWord* obj) const {
+    return get_by_address(obj) == Free;
   }
 
 protected:
@@ -57,14 +58,15 @@ public:
   void set_compacting(uint idx) { set_by_index(idx, Compacting); }
   void set_skip_marking(uint idx) { set_by_index(idx, SkipMarking); }
   void set_skip_compacting(uint idx) { set_by_index(idx, SkipCompacting); }
+  void set_free(uint idx) { set_by_index(idx, Free); }
 
   bool is_skip_marking(HeapWord* obj) const {
-    assert(!is_invalid(obj), "not initialized yet");
+    assert(!is_free(obj), "Should not have objects in free regions.");
     return get_by_address(obj) == SkipMarking;
   }
 
   bool is_compacting(HeapWord* obj) const {
-    assert(!is_invalid(obj), "not initialized yet");
+    assert(!is_free(obj), "Should not have objects in free regions.");
     return get_by_address(obj) == Compacting;
   }
 
@@ -72,8 +74,8 @@ public:
     return get_by_index(idx) == SkipCompacting;
   }
 
-  bool is_invalid(uint idx) const {
-    return get_by_index(idx) == Invalid;
+  bool is_free(uint idx) const {
+    return get_by_index(idx) == Free;
   }
 
   void verify_is_compacting(uint idx) { assert(get_by_index(idx) == Compacting, "invariant"); }

--- a/src/hotspot/share/gc/g1/g1FullGCHeapRegionAttr.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCHeapRegionAttr.hpp
@@ -72,6 +72,10 @@ public:
     return get_by_index(idx) == SkipCompacting;
   }
 
+  bool is_invalid(uint idx) const {
+    return get_by_index(idx) == Invalid;
+  }
+
   void verify_is_compacting(uint idx) { assert(get_by_index(idx) == Compacting, "invariant"); }
 
   void verify_is_invalid(uint idx) { assert(get_by_index(idx) == Invalid, "invariant"); }

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
@@ -47,7 +47,7 @@ void G1FullGCPrepareTask::G1CalculatePointersClosure::free_pinned_region(HeapReg
   } else {
     _g1h->free_region(hr, nullptr);
   }
-  _collector->set_invalid(hr->hrm_index());
+  _collector->set_free(hr->hrm_index());
   prepare_for_compaction(hr);
 }
 
@@ -183,7 +183,7 @@ size_t G1FullGCPrepareTask::G1RePrepareClosure::apply(oop obj) {
 void G1FullGCPrepareTask::G1CalculatePointersClosure::prepare_for_compaction_work(G1FullGCCompactionPoint* cp,
                                                                                   HeapRegion* hr) {
   hr->set_compaction_top(hr->bottom());
-  if (!_collector->is_invalid(hr->hrm_index())) {
+  if (!_collector->is_free(hr->hrm_index())) {
     G1PrepareCompactLiveClosure prepare_compact(cp);
     hr->apply_to_marked_objects(_bitmap, &prepare_compact);
   }

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
@@ -47,8 +47,8 @@ void G1FullGCPrepareTask::G1CalculatePointersClosure::free_pinned_region(HeapReg
   } else {
     _g1h->free_region(hr, nullptr);
   }
-  prepare_for_compaction(hr);
   _collector->set_invalid(hr->hrm_index());
+  prepare_for_compaction(hr);
 }
 
 bool G1FullGCPrepareTask::G1CalculatePointersClosure::do_heap_region(HeapRegion* hr) {
@@ -182,9 +182,11 @@ size_t G1FullGCPrepareTask::G1RePrepareClosure::apply(oop obj) {
 
 void G1FullGCPrepareTask::G1CalculatePointersClosure::prepare_for_compaction_work(G1FullGCCompactionPoint* cp,
                                                                                   HeapRegion* hr) {
-  G1PrepareCompactLiveClosure prepare_compact(cp);
   hr->set_compaction_top(hr->bottom());
-  hr->apply_to_marked_objects(_bitmap, &prepare_compact);
+  if (!_collector->is_invalid(hr->hrm_index())) {
+    G1PrepareCompactLiveClosure prepare_compact(cp);
+    hr->apply_to_marked_objects(_bitmap, &prepare_compact);
+  }
 }
 
 void G1FullGCPrepareTask::G1CalculatePointersClosure::prepare_for_compaction(HeapRegion* hr) {


### PR DESCRIPTION
Hi all,

Please review this change to skip doing work on regions that were empty at the beginning of the Full GC in phases that execute on a per-region basis.

Testing: Tier 1-3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267894](https://bugs.openjdk.java.net/browse/JDK-8267894): Skip work for empty regions in G1 Full GC


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5143/head:pull/5143` \
`$ git checkout pull/5143`

Update a local copy of the PR: \
`$ git checkout pull/5143` \
`$ git pull https://git.openjdk.java.net/jdk pull/5143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5143`

View PR using the GUI difftool: \
`$ git pr show -t 5143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5143.diff">https://git.openjdk.java.net/jdk/pull/5143.diff</a>

</details>
