### PR TITLE
8272579: G1: remove unnecesary null check for G1ParScanThreadStateSet::_states slots

### DIFF
--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -558,10 +558,7 @@ void G1ParScanThreadStateSet::flush() {
 
   for (uint worker_id = 0; worker_id < _n_workers; ++worker_id) {
     G1ParScanThreadState* pss = _states[worker_id];
-
-    if (pss == NULL) {
-      continue;
-    }
+    assert(pss != nullptr, "must be initialized");
 
     G1GCPhaseTimes* p = _g1h->phase_times();
 

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -581,10 +581,7 @@ void G1ParScanThreadStateSet::flush() {
 void G1ParScanThreadStateSet::record_unused_optional_region(HeapRegion* hr) {
   for (uint worker_index = 0; worker_index < _n_workers; ++worker_index) {
     G1ParScanThreadState* pss = _states[worker_index];
-
-    if (pss == NULL) {
-      continue;
-    }
+    assert(pss != nullptr, "must be initialized");
 
     size_t used_memory = pss->oops_into_optional_region(hr)->used_memory();
     _g1h->phase_times()->record_or_add_thread_work_item(G1GCPhaseTimes::OptScanHR, worker_index, used_memory, G1GCPhaseTimes::ScanHRUsedMemory);


### PR DESCRIPTION
Simple change of replacing a null-check with an assertion.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272579](https://bugs.openjdk.java.net/browse/JDK-8272579): G1: remove unnecesary null check for G1ParScanThreadStateSet::_states slots


### Reviewers
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer) ⚠️ Review applies to 301f00870e1535f5c33c3c5364c586ec2feed8a6
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5145/head:pull/5145` \
`$ git checkout pull/5145`

Update a local copy of the PR: \
`$ git checkout pull/5145` \
`$ git pull https://git.openjdk.java.net/jdk pull/5145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5145`

View PR using the GUI difftool: \
`$ git pr show -t 5145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5145.diff">https://git.openjdk.java.net/jdk/pull/5145.diff</a>

</details>
