### PR TITLE
8223923: C2: Missing interference with mismatched unsafe accesses

### DIFF
--- a/test/hotspot/jtreg/compiler/unsafe/MismatchedUnsafeAccessTest.java
+++ b/test/hotspot/jtreg/compiler/unsafe/MismatchedUnsafeAccessTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8223923
+ * @modules java.base/jdk.internal.misc
+ * @run main/othervm -Xbatch compiler.unsafe.MismatchedUnsafeAccessTest
+ */
+package compiler.unsafe;
+
+import jdk.internal.misc.Unsafe;
+
+public class MismatchedUnsafeAccessTest {
+    private static final Unsafe UNSAFE = Unsafe.getUnsafe();
+
+    public static class Test {
+        public int x = 0;
+        public int y = 0;
+
+        public static final long offsetX;
+        public static final long offsetY;
+
+        static {
+            try {
+                offsetX = UNSAFE.objectFieldOffset(Test.class.getField("x"));
+                offsetY = UNSAFE.objectFieldOffset(Test.class.getField("y"));
+            } catch (NoSuchFieldException e) {
+                throw new InternalError(e);
+            }
+            // Validate offsets
+            if (offsetX >= offsetY || offsetY - offsetX != 4) {
+                throw new InternalError("Wrong offsets: " + offsetX + " " + offsetY);
+            }
+        }
+    }
+
+    public static int test(long l) {
+        Test a = new Test();
+        UNSAFE.putLong(a, Test.offsetX, l); // mismatched access; interferes with subsequent load
+        return UNSAFE.getInt(a, Test.offsetY);
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            int res = test(-1L);
+            if (res != -1) {
+                throw new AssertionError("Wrong result: " + res);
+            }
+        }
+        System.out.println("TEST PASSED");
+    }
+}


### PR DESCRIPTION
Memory effects of mixed or mismatched unsafe accesses aren't properly tracked, so every problematic access is wrapped into a pair of `MemBarCPUOrder` nodes to isolate it from the rest of the memory graph. But `MemNode::can_see_stored_value()` unconditionally steps over `MemBarCPUOrder` and exposes problematic `MergeMem` nodes.  

Proposed fix forbids stepping over `MemBarCPUOrder` nodes when looking for an earlier store into the same location.

Alternatively, a new kind of barrier could be introduced specifically for isolation purposes, but I didn't spot any issues during performance testing with the current patch to justify more complex solution. 

Testing: hs-tier1 - hs-tier6, performance testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8223923](https://bugs.openjdk.java.net/browse/JDK-8223923): C2: Missing interference with mismatched unsafe accesses


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5146/head:pull/5146` \
`$ git checkout pull/5146`

Update a local copy of the PR: \
`$ git checkout pull/5146` \
`$ git pull https://git.openjdk.java.net/jdk pull/5146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5146`

View PR using the GUI difftool: \
`$ git pr show -t 5146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5146.diff">https://git.openjdk.java.net/jdk/pull/5146.diff</a>

</details>
