### PR TITLE
8272576: G1: Use more accurate integer type for collection set length

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectionSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.hpp
@@ -147,8 +147,8 @@ class G1CollectionSet {
   // concurrent readers. This means we are good with using storestore and loadload
   // barriers on the writer and reader respectively only.
   uint* _collection_set_regions;
-  volatile size_t _collection_set_cur_length;
-  size_t _collection_set_max_length;
+  volatile uint _collection_set_cur_length;
+  uint _collection_set_max_length;
 
   // When doing mixed collections we can add old regions to the collection set, which
   // will be collected only if there is enough time. We call these optional regions.


### PR DESCRIPTION
Simple change of using smaller integer type, `size_t` to `uint`. Also moved the bound-check assertion before array access.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272576](https://bugs.openjdk.java.net/browse/JDK-8272576): G1: Use more accurate integer type for collection set length


### Reviewers
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5148/head:pull/5148` \
`$ git checkout pull/5148`

Update a local copy of the PR: \
`$ git checkout pull/5148` \
`$ git pull https://git.openjdk.java.net/jdk pull/5148/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5148`

View PR using the GUI difftool: \
`$ git pr show -t 5148`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5148.diff">https://git.openjdk.java.net/jdk/pull/5148.diff</a>

</details>
