### PR TITLE
8270835: regression after JDK-8261006

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -2475,7 +2475,9 @@ public class Attr extends JCTree.Visitor {
             localEnv.info.isSelfCall = true;
 
             // Attribute arguments, yielding list of argument types.
+            localEnv.info.constructorArgs = true;
             KindSelector kind = attribArgs(KindSelector.MTH, tree.args, localEnv, argtypesBuf);
+            localEnv.info.constructorArgs = false;
             argtypes = argtypesBuf.toList();
             typeargtypes = attribTypes(tree.typeargs, localEnv);
 
@@ -4346,7 +4348,7 @@ public class Attr extends JCTree.Visitor {
                 if (env.info.isSelfCall &&
                         ((sym.name == names._this &&
                         site.tsym == env.enclClass.sym) ||
-                        sym.name == names._super)) {
+                        sym.name == names._super && env.info.constructorArgs)) {
                     chk.earlyRefError(tree.pos(), sym);
                 }
             } else {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/AttrContext.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/AttrContext.java
@@ -53,6 +53,10 @@ public class AttrContext {
      */
     boolean isSelfCall = false;
 
+    /** are we analyzing the arguments for a constructor invocation?
+     */
+    boolean constructorArgs = false;
+
     /** Are we evaluating the selector of a `super' or type name?
      */
     boolean selectSuper = false;
@@ -129,6 +133,7 @@ public class AttrContext {
         info.scope = scope;
         info.staticLevel = staticLevel;
         info.isSelfCall = isSelfCall;
+        info.constructorArgs = constructorArgs;
         info.selectSuper = selectSuper;
         info.pendingResolutionPhase = pendingResolutionPhase;
         info.lint = lint;

--- a/test/langtools/tools/javac/cantReferenceBeforeCtor/CantReferenceBeforeConstructorTest.java
+++ b/test/langtools/tools/javac/cantReferenceBeforeCtor/CantReferenceBeforeConstructorTest.java
@@ -1,0 +1,42 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8270835
+ * @summary regression after JDK-8261006
+ * @compile/fail/ref=CantReferenceBeforeConstructorTest.out -XDrawDiagnostics CantReferenceBeforeConstructorTest.java
+ */
+
+public class CantReferenceBeforeConstructorTest {
+    // test case I
+    class A extends B {
+        A(int i) {}
+
+        class C extends B {
+            class D extends S {
+                D(float f) {
+                    C.super.ref.super(); // ok
+                }
+            }
+        }
+    }
+
+    class B {
+        B ref;
+        class S {}
+    }
+
+    // test case II
+    class AA extends BB.CC {
+        AA() {
+            this.super();    // error
+        }
+    }
+
+    class BB {
+        class CC extends BB {
+            void m() {
+                BB.this.f();
+            }
+        }
+        void f() {}
+    }
+}

--- a/test/langtools/tools/javac/cantReferenceBeforeCtor/CantReferenceBeforeConstructorTest.out
+++ b/test/langtools/tools/javac/cantReferenceBeforeCtor/CantReferenceBeforeConstructorTest.out
@@ -1,0 +1,2 @@
+CantReferenceBeforeConstructorTest.java:30:13: compiler.err.cant.ref.before.ctor.called: this
+1 error


### PR DESCRIPTION
This patch is fixing a regression introduced by the fix for [JDK-8261006](https://bugs.openjdk.java.net/browse/JDK-8261006), which was trying to fix a long standing bug in javac. These are the related sections in the spec:

```
According to: 8.1.3 Inner Classes and Enclosing Instances:

A construct (statement, local variable declaration statement, local class declaration,
local interface declaration, or expression) occurs in a static context if the innermost:
...
    • explicit constructor invocation statement

which encloses the construct is one of the following:
    • an explicit constructor invocation statement (§8.8.7.1)
...
...
The purpose of a static context is to demarcate code that must not refer explicitly or
implicitly to the current instance of the class whose declaration lexically encloses the static
context. Consequently, code that occurs in a static context is restricted in the following
ways:
    • Field accesses, method invocations, and method references may not be qualified by super (§15.11.2, §15.12.3, §15.13.1).

also from: 15.13 Method Reference Expressions:

If a method reference expression has the form super :: [TypeArguments] Identifier
or TypeName . super :: [TypeArguments] Identifier, it is a compile-time error if
the expression occurs in a static context (§8.1.3).
```
Meaning that code like:
```
this(Feature.super::getString); or
this(Feature.super.getString());
```
should be rejected by the compiler and it wasn't before the fix for [JDK-8261006](https://bugs.openjdk.java.net/browse/JDK-8261006). The regression was introduced because after [JDK-8261006](https://bugs.openjdk.java.net/browse/JDK-8261006) this code was rejected when it shouldn't:
```
    class A extends B {
        A(int i) {}

        class C extends B {
            class D extends S {
                D(float f) {
                    C.super.ref.super(); // ok
                }
            }
        }
    }

    class B {
        B ref;
        class S {}
    }
```
so it is OK to use `super` in the constructor's invocation qualifier but not in its arguments. So while processing the arguments or the qualifier of a constructor invocation, the compiler needs to know precisely what portion of the expression it is dealing with as different rules apply for the use of `this` or `super` in them. This is why this fix is adding a new flag to AttrContext to indicate if we are dealing with a constructor invocation argument or not.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270835](https://bugs.openjdk.java.net/browse/JDK-8270835): regression after JDK-8261006


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5149/head:pull/5149` \
`$ git checkout pull/5149`

Update a local copy of the PR: \
`$ git checkout pull/5149` \
`$ git pull https://git.openjdk.java.net/jdk pull/5149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5149`

View PR using the GUI difftool: \
`$ git pr show -t 5149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5149.diff">https://git.openjdk.java.net/jdk/pull/5149.diff</a>

</details>
