### PR TITLE
8265261: java/nio/file/Files/InterruptCopy.java fails with java.lang.RuntimeException: Copy was not interrupted

### DIFF
--- a/test/jdk/java/nio/file/Files/InterruptCopy.java
+++ b/test/jdk/java/nio/file/Files/InterruptCopy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,15 +28,24 @@
  * @library ..
  */
 
-import java.nio.file.*;
-import java.io.*;
-import java.util.concurrent.*;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.FileStore;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
 import com.sun.nio.file.ExtendedCopyOption;
 
 public class InterruptCopy {
 
     private static final long FILE_SIZE_TO_COPY = 512L * 1024L * 1024L;
-    private static final int DELAY_IN_MS = 500;
+    private static final int INTERRUPT_DELAY_IN_MS = 10;
+    private static final int CANCEL_DELAY_IN_MS = 500;
     private static final int DURATION_MAX_IN_MS = 5000;
 
     public static void main(String[] args) throws Exception {
@@ -76,13 +85,22 @@ public class InterruptCopy {
             Executors.newSingleThreadScheduledExecutor();
         try {
             // copy source to target in main thread, interrupting it after a delay
+            final CountDownLatch latch = new CountDownLatch(2);
             final Thread me = Thread.currentThread();
-            Future<?> wakeup = pool.schedule(new Runnable() {
+            Future<?> wakeup = pool.submit(new Runnable() {
                 public void run() {
+                    latch.countDown();
+                    try {
+                        latch.await();
+                        Thread.sleep(INTERRUPT_DELAY_IN_MS);
+                    } catch (InterruptedException ignored) {
+                    }
                     me.interrupt();
-                }}, DELAY_IN_MS, TimeUnit.MILLISECONDS);
+                }});
             System.out.println("Copying file...");
             try {
+                latch.countDown();
+                latch.await();
                 long start = System.currentTimeMillis();
                 Files.copy(source, target, ExtendedCopyOption.INTERRUPTIBLE);
                 long duration = System.currentTimeMillis() - start;
@@ -109,7 +127,7 @@ public class InterruptCopy {
                     return null;
                 }
             });
-            Thread.sleep(DELAY_IN_MS);
+            Thread.sleep(CANCEL_DELAY_IN_MS);
             boolean cancelled = result.cancel(true);
             if (!cancelled)
                 result.get();


### PR DESCRIPTION
This proposal suggests to change the timing of testing whether a file copy is terminated by an interrupt.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265261](https://bugs.openjdk.java.net/browse/JDK-8265261): java/nio/file/Files/InterruptCopy.java fails with java.lang.RuntimeException: Copy was not interrupted


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5154/head:pull/5154` \
`$ git checkout pull/5154`

Update a local copy of the PR: \
`$ git checkout pull/5154` \
`$ git pull https://git.openjdk.java.net/jdk pull/5154/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5154`

View PR using the GUI difftool: \
`$ git pr show -t 5154`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5154.diff">https://git.openjdk.java.net/jdk/pull/5154.diff</a>

</details>
