### PR TITLE
8273435: Remove redundant zero-length check in ClassDesc.of

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/ClassDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/ClassDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -99,7 +99,7 @@ public sealed interface ClassDesc
         }
         validateMemberName(requireNonNull(className), false);
         return ofDescriptor("L" + binaryToInternal(packageName) +
-                (packageName.length() > 0 ? "/" : "") + className + ";");
+                "/" + className + ";");
     }
 
     /**


### PR DESCRIPTION
After [JDK-8215510](https://bugs.openjdk.java.net/browse/JDK-8215510) (eed3a536c0) this condition is always `false`. Empty package name is handled separately.
Found by IntelliJ inspection.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273435](https://bugs.openjdk.java.net/browse/JDK-8273435): Remove redundant zero-length check in ClassDesc.of


### Reviewers
 * @stsypanov (no known github.com user name / role)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5157/head:pull/5157` \
`$ git checkout pull/5157`

Update a local copy of the PR: \
`$ git checkout pull/5157` \
`$ git pull https://git.openjdk.java.net/jdk pull/5157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5157`

View PR using the GUI difftool: \
`$ git pr show -t 5157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5157.diff">https://git.openjdk.java.net/jdk/pull/5157.diff</a>

</details>
