### PR TITLE
[PATCH] Cleanup Optional usage in HttpResponse.BodySubscribers.discarding

### DIFF
--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1273,7 +1273,7 @@ public interface HttpResponse<T> {
          * @return a response body subscriber
          */
         public static BodySubscriber<Void> discarding() {
-            return new ResponseSubscribers.NullSubscriber<>(Optional.ofNullable(null));
+            return new ResponseSubscribers.NullSubscriber<>(Optional.empty());
         }
 
         /**


### PR DESCRIPTION
Usage of `Optional.ofNullable` is unnecessary when value is known. If it's `null` value Optional.empty() should be preferred, as it doesn't perform redundant `null` check.