### PR TITLE
8272413: Incorrect num of element count calculation for vector cast

### DIFF
--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -1747,8 +1747,7 @@ bool LibraryCallKit::inline_vector_convert() {
     if (num_elem_from < num_elem_to) {
       // Since input and output number of elements are not consistent, we need to make sure we
       // properly size. Thus, first make a cast that retains the number of elements from source.
-      // In case the size exceeds the arch size, we do the minimum.
-      int num_elem_for_cast = MIN2(num_elem_from, Matcher::max_vector_size(elem_bt_to));
+      int num_elem_for_cast = num_elem_from;
 
       // It is possible that arch does not support this intermediate vector size
       // TODO More complex logic required here to handle this corner case for the sizes.
@@ -1767,7 +1766,7 @@ bool LibraryCallKit::inline_vector_convert() {
     } else if (num_elem_from > num_elem_to) {
       // Since number elements from input is larger than output, simply reduce size of input (we are supposed to
       // drop top elements anyway).
-      int num_elem_for_resize = MAX2(num_elem_to, Matcher::min_vector_size(elem_bt_from));
+      int num_elem_for_resize = num_elem_to;
 
       // It is possible that arch does not support this intermediate vector size
       // TODO More complex logic required here to handle this corner case for the sizes.


### PR DESCRIPTION
Dear all, 
Closed JDK-8265244 has split into two issues : JDK-8268966 and this issue. During this issue, I will fix the mid-end comparsion.
This patch is easy to understand.  It is split from https://github.com/openjdk/jdk/pull/3507. I only fix the mid-end problem because the back-end problem has fixed in JDK-8268966 by @theRealELiu .
Thank you for your review. 

Yours,
WANG Huang

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272413](https://bugs.openjdk.java.net/browse/JDK-8272413): Incorrect num of element count calculation for vector cast


### Reviewers
 * [Eric Liu](https://openjdk.java.net/census#eliu) (@theRealELiu - Author)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Contributors
 * Wang Huang `<whuang@openjdk.org>`
 * Miu Zhuojun `<mouzhuojun@huawei.com>`
 * Wu Yan `<wuyan@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5160/head:pull/5160` \
`$ git checkout pull/5160`

Update a local copy of the PR: \
`$ git checkout pull/5160` \
`$ git pull https://git.openjdk.java.net/jdk pull/5160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5160`

View PR using the GUI difftool: \
`$ git pr show -t 5160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5160.diff">https://git.openjdk.java.net/jdk/pull/5160.diff</a>

</details>
