### PR TITLE
8272626: Avoid C-style array declarations in java.*

### DIFF
--- a/src/java.base/share/classes/java/io/BufferedInputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedInputStream.java
@@ -328,7 +328,7 @@ public class BufferedInputStream extends FilterInputStream {
      *                          invoking its {@link #close()} method,
      *                          or an I/O error occurs.
      */
-    public synchronized int read(byte b[], int off, int len)
+    public synchronized int read(byte[] b, int off, int len)
         throws IOException
     {
         getBufIfOpen(); // Check for closed stream

--- a/src/java.base/share/classes/java/io/BufferedOutputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedOutputStream.java
@@ -114,7 +114,7 @@ public class BufferedOutputStream extends FilterOutputStream {
      * @throws     IOException  if an I/O error occurs.
      */
     @Override
-    public synchronized void write(byte b[], int off, int len) throws IOException {
+    public synchronized void write(byte[] b, int off, int len) throws IOException {
         if (len >= buf.length) {
             /* If the request length exceeds the size of the output buffer,
                flush the output buffer and then write the data directly.

--- a/src/java.base/share/classes/java/io/BufferedWriter.java
+++ b/src/java.base/share/classes/java/io/BufferedWriter.java
@@ -166,7 +166,7 @@ public class BufferedWriter extends Writer {
      *
      * @throws  IOException  If an I/O error occurs
      */
-    public void write(char cbuf[], int off, int len) throws IOException {
+    public void write(char[] cbuf, int off, int len) throws IOException {
         synchronized (lock) {
             ensureOpen();
             if ((off < 0) || (off > cbuf.length) || (len < 0) ||

--- a/src/java.base/share/classes/java/io/ByteArrayInputStream.java
+++ b/src/java.base/share/classes/java/io/ByteArrayInputStream.java
@@ -102,7 +102,7 @@ public class ByteArrayInputStream extends InputStream {
      *
      * @param   buf   the input buffer.
      */
-    public ByteArrayInputStream(byte buf[]) {
+    public ByteArrayInputStream(byte[] buf) {
         this.buf = buf;
         this.pos = 0;
         this.count = buf.length;
@@ -122,7 +122,7 @@ public class ByteArrayInputStream extends InputStream {
      * @param   offset   the offset in the buffer of the first byte to read.
      * @param   length   the maximum number of bytes to read from the buffer.
      */
-    public ByteArrayInputStream(byte buf[], int offset, int length) {
+    public ByteArrayInputStream(byte[] buf, int offset, int length) {
         this.buf = buf;
         this.pos = offset;
         this.count = Math.min(offset + length, buf.length);
@@ -173,7 +173,7 @@ public class ByteArrayInputStream extends InputStream {
      * {@code len} is negative, or {@code len} is greater than
      * {@code b.length - off}
      */
-    public synchronized int read(byte b[], int off, int len) {
+    public synchronized int read(byte[] b, int off, int len) {
         Objects.checkFromIndexSize(off, len, b.length);
 
         if (pos >= count) {

--- a/src/java.base/share/classes/java/io/ByteArrayOutputStream.java
+++ b/src/java.base/share/classes/java/io/ByteArrayOutputStream.java
@@ -125,7 +125,7 @@ public class ByteArrayOutputStream extends OutputStream {
      * {@code len} is negative, or {@code len} is greater than
      * {@code b.length - off}
      */
-    public synchronized void write(byte b[], int off, int len) {
+    public synchronized void write(byte[] b, int off, int len) {
         Objects.checkFromIndexSize(off, len, b.length);
         ensureCapacity(count + len);
         System.arraycopy(b, off, buf, count, len);
@@ -144,7 +144,7 @@ public class ByteArrayOutputStream extends OutputStream {
      * @throws  NullPointerException if {@code b} is {@code null}.
      * @since   11
      */
-    public void writeBytes(byte b[]) {
+    public void writeBytes(byte[] b) {
         write(b, 0, b.length);
     }
 

--- a/src/java.base/share/classes/java/io/CharArrayWriter.java
+++ b/src/java.base/share/classes/java/io/CharArrayWriter.java
@@ -96,7 +96,7 @@ public class CharArrayWriter extends Writer {
      *          or {@code off + len} is negative or greater than the length
      *          of the given array
      */
-    public void write(char c[], int off, int len) {
+    public void write(char[] c, int off, int len) {
         if ((off < 0) || (off > c.length) || (len < 0) ||
             ((off + len) > c.length) || ((off + len) < 0)) {
             throw new IndexOutOfBoundsException();

--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -475,7 +475,7 @@ public final class Console implements Flushable
             return in.ready();
         }
 
-        public int read(char cbuf[], int offset, int length)
+        public int read(char[] cbuf, int offset, int length)
             throws IOException
         {
             int off = offset;

--- a/src/java.base/share/classes/java/io/DataInput.java
+++ b/src/java.base/share/classes/java/io/DataInput.java
@@ -196,7 +196,7 @@ public interface DataInput {
      *          all the bytes.
      * @throws  IOException   if an I/O error occurs.
      */
-    void readFully(byte b[]) throws IOException;
+    void readFully(byte[] b) throws IOException;
 
     /**
      *
@@ -246,7 +246,7 @@ public interface DataInput {
      *          all the bytes.
      * @throws  IOException   if an I/O error occurs.
      */
-    void readFully(byte b[], int off, int len) throws IOException;
+    void readFully(byte[] b, int off, int len) throws IOException;
 
     /**
      * Makes an attempt to skip over

--- a/src/java.base/share/classes/java/io/DataInputStream.java
+++ b/src/java.base/share/classes/java/io/DataInputStream.java
@@ -98,7 +98,7 @@ public class DataInputStream extends FilterInputStream implements DataInput {
      * @see        java.io.FilterInputStream#in
      * @see        java.io.InputStream#read(byte[], int, int)
      */
-    public final int read(byte b[]) throws IOException {
+    public final int read(byte[] b) throws IOException {
         return in.read(b, 0, b.length);
     }
 
@@ -147,7 +147,7 @@ public class DataInputStream extends FilterInputStream implements DataInput {
      * @see        java.io.FilterInputStream#in
      * @see        java.io.InputStream#read(byte[], int, int)
      */
-    public final int read(byte b[], int off, int len) throws IOException {
+    public final int read(byte[] b, int off, int len) throws IOException {
         return in.read(b, off, len);
     }
 
@@ -168,7 +168,7 @@ public class DataInputStream extends FilterInputStream implements DataInput {
      *          another I/O error occurs.
      * @see     java.io.FilterInputStream#in
      */
-    public final void readFully(byte b[]) throws IOException {
+    public final void readFully(byte[] b) throws IOException {
         readFully(b, 0, b.length);
     }
 
@@ -194,7 +194,7 @@ public class DataInputStream extends FilterInputStream implements DataInput {
      *             another I/O error occurs.
      * @see        java.io.FilterInputStream#in
      */
-    public final void readFully(byte b[], int off, int len) throws IOException {
+    public final void readFully(byte[] b, int off, int len) throws IOException {
         Objects.checkFromIndexSize(off, len, b.length);
         int n = 0;
         while (n < len) {

--- a/src/java.base/share/classes/java/io/DataOutput.java
+++ b/src/java.base/share/classes/java/io/DataOutput.java
@@ -71,7 +71,7 @@ public interface DataOutput {
      * @param      b   the data.
      * @throws     IOException  if an I/O error occurs.
      */
-    void write(byte b[]) throws IOException;
+    void write(byte[] b) throws IOException;
 
     /**
      * Writes {@code len} bytes from array
@@ -93,7 +93,7 @@ public interface DataOutput {
      * @param      len   the number of bytes to write.
      * @throws     IOException  if an I/O error occurs.
      */
-    void write(byte b[], int off, int len) throws IOException;
+    void write(byte[] b, int off, int len) throws IOException;
 
     /**
      * Writes a {@code boolean} value to this output stream.

--- a/src/java.base/share/classes/java/io/DataOutputStream.java
+++ b/src/java.base/share/classes/java/io/DataOutputStream.java
@@ -106,7 +106,7 @@ public class DataOutputStream extends FilterOutputStream implements DataOutput {
      * @throws     IOException  if an I/O error occurs.
      * @see        java.io.FilterOutputStream#out
      */
-    public synchronized void write(byte b[], int off, int len)
+    public synchronized void write(byte[] b, int off, int len)
         throws IOException
     {
         out.write(b, off, len);

--- a/src/java.base/share/classes/java/io/FileInputStream.java
+++ b/src/java.base/share/classes/java/io/FileInputStream.java
@@ -237,7 +237,7 @@ public class FileInputStream extends InputStream
      * @param     len the number of bytes that are written
      * @throws    IOException If an I/O error has occurred.
      */
-    private native int readBytes(byte b[], int off, int len) throws IOException;
+    private native int readBytes(byte[] b, int off, int len) throws IOException;
 
     /**
      * Reads up to {@code b.length} bytes of data from this input
@@ -250,7 +250,7 @@ public class FileInputStream extends InputStream
      *             the file has been reached.
      * @throws     IOException  if an I/O error occurs.
      */
-    public int read(byte b[]) throws IOException {
+    public int read(byte[] b) throws IOException {
         return readBytes(b, 0, b.length);
     }
 
@@ -272,7 +272,7 @@ public class FileInputStream extends InputStream
      *             {@code b.length - off}
      * @throws     IOException  if an I/O error occurs.
      */
-    public int read(byte b[], int off, int len) throws IOException {
+    public int read(byte[] b, int off, int len) throws IOException {
         return readBytes(b, off, len);
     }
 

--- a/src/java.base/share/classes/java/io/FileOutputStream.java
+++ b/src/java.base/share/classes/java/io/FileOutputStream.java
@@ -322,7 +322,7 @@ public class FileOutputStream extends OutputStream
      *     end of file
      * @throws    IOException If an I/O error has occurred.
      */
-    private native void writeBytes(byte b[], int off, int len, boolean append)
+    private native void writeBytes(byte[] b, int off, int len, boolean append)
         throws IOException;
 
     /**
@@ -332,7 +332,7 @@ public class FileOutputStream extends OutputStream
      * @param      b   the data.
      * @throws     IOException  if an I/O error occurs.
      */
-    public void write(byte b[]) throws IOException {
+    public void write(byte[] b) throws IOException {
         writeBytes(b, 0, b.length, fdAccess.getAppend(fd));
     }
 
@@ -345,7 +345,7 @@ public class FileOutputStream extends OutputStream
      * @param      len   the number of bytes to write.
      * @throws     IOException  if an I/O error occurs.
      */
-    public void write(byte b[], int off, int len) throws IOException {
+    public void write(byte[] b, int off, int len) throws IOException {
         writeBytes(b, off, len, fdAccess.getAppend(fd));
     }
 

--- a/src/java.base/share/classes/java/io/FilterInputStream.java
+++ b/src/java.base/share/classes/java/io/FilterInputStream.java
@@ -102,7 +102,7 @@ public class FilterInputStream extends InputStream {
      * @throws     IOException  if an I/O error occurs.
      * @see        java.io.FilterInputStream#read(byte[], int, int)
      */
-    public int read(byte b[]) throws IOException {
+    public int read(byte[] b) throws IOException {
         return read(b, 0, b.length);
     }
 
@@ -128,7 +128,7 @@ public class FilterInputStream extends InputStream {
      * @throws     IOException  if an I/O error occurs.
      * @see        java.io.FilterInputStream#in
      */
-    public int read(byte b[], int off, int len) throws IOException {
+    public int read(byte[] b, int off, int len) throws IOException {
         return in.read(b, off, len);
     }
 

--- a/src/java.base/share/classes/java/io/FilterOutputStream.java
+++ b/src/java.base/share/classes/java/io/FilterOutputStream.java
@@ -104,7 +104,7 @@ public class FilterOutputStream extends OutputStream {
      * @see        java.io.FilterOutputStream#write(byte[], int, int)
      */
     @Override
-    public void write(byte b[]) throws IOException {
+    public void write(byte[] b) throws IOException {
         write(b, 0, b.length);
     }
 
@@ -129,7 +129,7 @@ public class FilterOutputStream extends OutputStream {
      * @see        java.io.FilterOutputStream#write(int)
      */
     @Override
-    public void write(byte b[], int off, int len) throws IOException {
+    public void write(byte[] b, int off, int len) throws IOException {
         if ((off | len | (b.length - (len + off)) | (off + len)) < 0)
             throw new IndexOutOfBoundsException();
 

--- a/src/java.base/share/classes/java/io/FilterWriter.java
+++ b/src/java.base/share/classes/java/io/FilterWriter.java
@@ -79,7 +79,7 @@ public abstract class FilterWriter extends Writer {
      *
      * @throws  IOException  If an I/O error occurs
      */
-    public void write(char cbuf[], int off, int len) throws IOException {
+    public void write(char[] cbuf, int off, int len) throws IOException {
         out.write(cbuf, off, len);
     }
 

--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -214,7 +214,7 @@ public abstract class InputStream implements Closeable {
      * @throws     NullPointerException  if {@code b} is {@code null}.
      * @see        java.io.InputStream#read(byte[], int, int)
      */
-    public int read(byte b[]) throws IOException {
+    public int read(byte[] b) throws IOException {
         return read(b, 0, b.length);
     }
 
@@ -275,7 +275,7 @@ public abstract class InputStream implements Closeable {
      *             {@code b.length - off}
      * @see        java.io.InputStream#read()
      */
-    public int read(byte b[], int off, int len) throws IOException {
+    public int read(byte[] b, int off, int len) throws IOException {
         Objects.checkFromIndexSize(off, len, b.length);
         if (len == 0) {
             return 0;

--- a/src/java.base/share/classes/java/io/LineNumberInputStream.java
+++ b/src/java.base/share/classes/java/io/LineNumberInputStream.java
@@ -126,7 +126,7 @@ public class LineNumberInputStream extends FilterInputStream {
      * @throws     IOException  if an I/O error occurs.
      * @see        java.io.LineNumberInputStream#read()
      */
-    public int read(byte b[], int off, int len) throws IOException {
+    public int read(byte[] b, int off, int len) throws IOException {
         if (b == null) {
             throw new NullPointerException();
         } else if ((off < 0) || (off > b.length) || (len < 0) ||

--- a/src/java.base/share/classes/java/io/LineNumberReader.java
+++ b/src/java.base/share/classes/java/io/LineNumberReader.java
@@ -187,7 +187,7 @@ public class LineNumberReader extends BufferedReader {
      * @throws  IOException {@inheritDoc}
      */
     @SuppressWarnings("fallthrough")
-    public int read(char cbuf[], int off, int len) throws IOException {
+    public int read(char[] cbuf, int off, int len) throws IOException {
         synchronized (lock) {
             int n = super.read(cbuf, off, len);
 

--- a/src/java.base/share/classes/java/io/ObjectInput.java
+++ b/src/java.base/share/classes/java/io/ObjectInput.java
@@ -66,7 +66,7 @@ public interface ObjectInput extends DataInput, AutoCloseable {
      *          returned when the end of the stream is reached.
      * @throws  IOException If an I/O error has occurred.
      */
-    public int read(byte b[]) throws IOException;
+    public int read(byte[] b) throws IOException;
 
     /**
      * Reads into an array of bytes.  This method will
@@ -78,7 +78,7 @@ public interface ObjectInput extends DataInput, AutoCloseable {
      *          returned when the end of the stream is reached.
      * @throws  IOException If an I/O error has occurred.
      */
-    public int read(byte b[], int off, int len) throws IOException;
+    public int read(byte[] b, int off, int len) throws IOException;
 
     /**
      * Skips n bytes of input.

--- a/src/java.base/share/classes/java/io/ObjectOutput.java
+++ b/src/java.base/share/classes/java/io/ObjectOutput.java
@@ -61,7 +61,7 @@ public interface ObjectOutput extends DataOutput, AutoCloseable {
      * @param     b the data to be written
      * @throws    IOException If an I/O error has occurred.
      */
-    public void write(byte b[]) throws IOException;
+    public void write(byte[] b) throws IOException;
 
     /**
      * Writes a sub array of bytes.
@@ -70,7 +70,7 @@ public interface ObjectOutput extends DataOutput, AutoCloseable {
      * @param     len       the number of bytes that are written
      * @throws    IOException If an I/O error has occurred.
      */
-    public void write(byte b[], int off, int len) throws IOException;
+    public void write(byte[] b, int off, int len) throws IOException;
 
     /**
      * Flushes the stream. This will write any buffered

--- a/src/java.base/share/classes/java/io/OutputStream.java
+++ b/src/java.base/share/classes/java/io/OutputStream.java
@@ -84,7 +84,7 @@ public abstract class OutputStream implements Closeable, Flushable {
             }
 
             @Override
-            public void write(byte b[], int off, int len) throws IOException {
+            public void write(byte[] b, int off, int len) throws IOException {
                 Objects.checkFromIndexSize(off, len, b.length);
                 ensureOpen();
             }
@@ -123,7 +123,7 @@ public abstract class OutputStream implements Closeable, Flushable {
      * @throws     IOException  if an I/O error occurs.
      * @see        java.io.OutputStream#write(byte[], int, int)
      */
-    public void write(byte b[]) throws IOException {
+    public void write(byte[] b) throws IOException {
         write(b, 0, b.length);
     }
 
@@ -155,7 +155,7 @@ public abstract class OutputStream implements Closeable, Flushable {
      *             an {@code IOException} is thrown if the output
      *             stream is closed.
      */
-    public void write(byte b[], int off, int len) throws IOException {
+    public void write(byte[] b, int off, int len) throws IOException {
         Objects.checkFromIndexSize(off, len, b.length);
         // len == 0 condition implicitly handled by loop bounds
         for (int i = 0 ; i < len ; i++) {

--- a/src/java.base/share/classes/java/io/OutputStreamWriter.java
+++ b/src/java.base/share/classes/java/io/OutputStreamWriter.java
@@ -201,7 +201,7 @@ public class OutputStreamWriter extends Writer {
      *
      * @throws  IOException  If an I/O error occurs
      */
-    public void write(char cbuf[], int off, int len) throws IOException {
+    public void write(char[] cbuf, int off, int len) throws IOException {
         se.write(cbuf, off, len);
     }
 

--- a/src/java.base/share/classes/java/io/PipedInputStream.java
+++ b/src/java.base/share/classes/java/io/PipedInputStream.java
@@ -222,7 +222,7 @@ public class PipedInputStream extends InputStream {
      *           {@link #connect(java.io.PipedOutputStream) unconnected},
      *           closed,or if an I/O error occurs.
      */
-    synchronized void receive(byte b[], int off, int len)  throws IOException {
+    synchronized void receive(byte[] b, int off, int len)  throws IOException {
         checkStateForReceive();
         writeSide = Thread.currentThread();
         int bytesToTransfer = len;
@@ -364,7 +364,7 @@ public class PipedInputStream extends InputStream {
      *           {@link #connect(java.io.PipedOutputStream) unconnected},
      *           closed, or if an I/O error occurs.
      */
-    public synchronized int read(byte b[], int off, int len)  throws IOException {
+    public synchronized int read(byte[] b, int off, int len)  throws IOException {
         if (b == null) {
             throw new NullPointerException();
         } else if (off < 0 || len < 0 || len > b.length - off) {

--- a/src/java.base/share/classes/java/io/PipedOutputStream.java
+++ b/src/java.base/share/classes/java/io/PipedOutputStream.java
@@ -135,7 +135,7 @@ public class PipedOutputStream extends OutputStream {
      *          {@link #connect(java.io.PipedInputStream) unconnected},
      *          closed, or if an I/O error occurs.
      */
-    public void write(byte b[], int off, int len) throws IOException {
+    public void write(byte[] b, int off, int len) throws IOException {
         var sink = this.sink;
         if (sink == null) {
             throw new IOException("Pipe not connected");

--- a/src/java.base/share/classes/java/io/PipedReader.java
+++ b/src/java.base/share/classes/java/io/PipedReader.java
@@ -202,7 +202,7 @@ public class PipedReader extends Reader {
      * Receives data into an array of characters.  This method will
      * block until some input is available.
      */
-    synchronized void receive(char c[], int off, int len)  throws IOException {
+    synchronized void receive(char[] c, int off, int len)  throws IOException {
         while (--len >= 0) {
             receive(c[off++]);
         }
@@ -288,7 +288,7 @@ public class PipedReader extends Reader {
      *             {@link #connect(java.io.PipedWriter) unconnected}, closed,
      *             or an I/O error occurs.
      */
-    public synchronized int read(char cbuf[], int off, int len)  throws IOException {
+    public synchronized int read(char[] cbuf, int off, int len)  throws IOException {
         if (!connected) {
             throw new IOException("Pipe not connected");
         } else if (closedByReader) {

--- a/src/java.base/share/classes/java/io/PipedWriter.java
+++ b/src/java.base/share/classes/java/io/PipedWriter.java
@@ -147,7 +147,7 @@ public class PipedWriter extends Writer {
      *          {@link #connect(java.io.PipedReader) unconnected}, closed
      *          or an I/O error occurs.
      */
-    public void write(char cbuf[], int off, int len) throws IOException {
+    public void write(char[] cbuf, int off, int len) throws IOException {
         if (sink == null) {
             throw new IOException("Pipe not connected");
         } else if ((off | len | (off + len) | (cbuf.length - (off + len))) < 0) {

--- a/src/java.base/share/classes/java/io/PrintStream.java
+++ b/src/java.base/share/classes/java/io/PrintStream.java
@@ -561,7 +561,7 @@ public class PrintStream extends FilterOutputStream
      * @param  len   Number of bytes to write
      */
     @Override
-    public void write(byte buf[], int off, int len) {
+    public void write(byte[] buf, int off, int len) {
         try {
             synchronized (this) {
                 ensureOpen();
@@ -612,7 +612,7 @@ public class PrintStream extends FilterOutputStream
      * @since 14
      */
     @Override
-    public void write(byte buf[]) throws IOException {
+    public void write(byte[] buf) throws IOException {
         this.write(buf, 0, buf.length);
     }
 
@@ -634,7 +634,7 @@ public class PrintStream extends FilterOutputStream
      *
      * @since 14
      */
-    public void writeBytes(byte buf[]) {
+    public void writeBytes(byte[] buf) {
         this.write(buf, 0, buf.length);
     }
 
@@ -845,7 +845,7 @@ public class PrintStream extends FilterOutputStream
      *
      * @throws  NullPointerException  If {@code s} is {@code null}
      */
-    public void print(char s[]) {
+    public void print(char[] s) {
         write(s);
     }
 

--- a/src/java.base/share/classes/java/io/PrintWriter.java
+++ b/src/java.base/share/classes/java/io/PrintWriter.java
@@ -499,7 +499,7 @@ public class PrintWriter extends Writer {
      *          cause the corresponding method of the underlying {@code Writer}
      *          to throw an {@code IndexOutOfBoundsException}
      */
-    public void write(char buf[], int off, int len) {
+    public void write(char[] buf, int off, int len) {
         try {
             synchronized (lock) {
                 ensureOpen();
@@ -519,7 +519,7 @@ public class PrintWriter extends Writer {
      * Writer class because it must suppress I/O exceptions.
      * @param buf Array of characters to be written
      */
-    public void write(char buf[]) {
+    public void write(char[] buf) {
         write(buf, 0, buf.length);
     }
 
@@ -668,7 +668,7 @@ public class PrintWriter extends Writer {
      *
      * @throws  NullPointerException  If {@code s} is {@code null}
      */
-    public void print(char s[]) {
+    public void print(char[] s) {
         write(s);
     }
 
@@ -801,7 +801,7 @@ public class PrintWriter extends Writer {
      *
      * @param x the array of {@code char} values to be printed
      */
-    public void println(char x[]) {
+    public void println(char[] x) {
         synchronized (lock) {
             print(x);
             println();

--- a/src/java.base/share/classes/java/io/RandomAccessFile.java
+++ b/src/java.base/share/classes/java/io/RandomAccessFile.java
@@ -374,7 +374,7 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * @param     len the number of bytes to read.
      * @throws    IOException If an I/O error has occurred.
      */
-    private native int readBytes(byte b[], int off, int len) throws IOException;
+    private native int readBytes(byte[] b, int off, int len) throws IOException;
 
     /**
      * Reads up to {@code len} bytes of data from this file into an
@@ -401,7 +401,7 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      *             {@code len} is negative, or {@code len} is greater than
      *             {@code b.length - off}
      */
-    public int read(byte b[], int off, int len) throws IOException {
+    public int read(byte[] b, int off, int len) throws IOException {
         return readBytes(b, off, len);
     }
 
@@ -424,7 +424,7 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      *             or if some other I/O error occurs.
      * @throws     NullPointerException If {@code b} is {@code null}.
      */
-    public int read(byte b[]) throws IOException {
+    public int read(byte[] b) throws IOException {
         return readBytes(b, 0, b.length);
     }
 
@@ -441,7 +441,7 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      *              all the bytes.
      * @throws  IOException   if an I/O error occurs.
      */
-    public final void readFully(byte b[]) throws IOException {
+    public final void readFully(byte[] b) throws IOException {
         readFully(b, 0, b.length);
     }
 
@@ -463,7 +463,7 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      *                all the bytes.
      * @throws  IOException   if an I/O error occurs.
      */
-    public final void readFully(byte b[], int off, int len) throws IOException {
+    public final void readFully(byte[] b, int off, int len) throws IOException {
         int n = 0;
         do {
             int count = this.read(b, off + n, len - n);
@@ -532,7 +532,7 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * @param     len the number of bytes that are written
      * @throws    IOException If an I/O error has occurred.
      */
-    private native void writeBytes(byte b[], int off, int len) throws IOException;
+    private native void writeBytes(byte[] b, int off, int len) throws IOException;
 
     /**
      * Writes {@code b.length} bytes from the specified byte array
@@ -541,7 +541,7 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * @param      b   the data.
      * @throws     IOException  if an I/O error occurs.
      */
-    public void write(byte b[]) throws IOException {
+    public void write(byte[] b) throws IOException {
         writeBytes(b, 0, b.length);
     }
 
@@ -554,7 +554,7 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * @param      len   the number of bytes to write.
      * @throws     IOException  if an I/O error occurs.
      */
-    public void write(byte b[], int off, int len) throws IOException {
+    public void write(byte[] b, int off, int len) throws IOException {
         writeBytes(b, off, len);
     }
 

--- a/src/java.base/share/classes/java/io/SequenceInputStream.java
+++ b/src/java.base/share/classes/java/io/SequenceInputStream.java
@@ -184,7 +184,7 @@ public class SequenceInputStream extends InputStream {
      *             greater than {@code b.length - off}
      * @throws     IOException  if an I/O error occurs.
      */
-    public int read(byte b[], int off, int len) throws IOException {
+    public int read(byte[] b, int off, int len) throws IOException {
         if (in == null) {
             return -1;
         } else if (b == null) {

--- a/src/java.base/share/classes/java/io/StringBufferInputStream.java
+++ b/src/java.base/share/classes/java/io/StringBufferInputStream.java
@@ -108,7 +108,7 @@ public class StringBufferInputStream extends InputStream {
      *             the stream has been reached.
      */
     @SuppressWarnings("deprecation")
-    public synchronized int read(byte b[], int off, int len) {
+    public synchronized int read(byte[] b, int off, int len) {
         if (b == null) {
             throw new NullPointerException();
         } else if ((off < 0) || (off > b.length) || (len < 0) ||

--- a/src/java.base/share/classes/java/io/StringWriter.java
+++ b/src/java.base/share/classes/java/io/StringWriter.java
@@ -89,7 +89,7 @@ public class StringWriter extends Writer {
      *          or {@code off + len} is negative or greater than the length
      *          of the given array
      */
-    public void write(char cbuf[], int off, int len) {
+    public void write(char[] cbuf, int off, int len) {
         if ((off < 0) || (off > cbuf.length) || (len < 0) ||
             ((off + len) > cbuf.length) || ((off + len) < 0)) {
             throw new IndexOutOfBoundsException();

--- a/src/java.base/share/classes/java/io/Writer.java
+++ b/src/java.base/share/classes/java/io/Writer.java
@@ -209,7 +209,7 @@ public abstract class Writer implements Appendable, Closeable, Flushable {
      * @throws  IOException
      *          If an I/O error occurs
      */
-    public void write(char cbuf[]) throws IOException {
+    public void write(char[] cbuf) throws IOException {
         write(cbuf, 0, cbuf.length);
     }
 
@@ -234,7 +234,7 @@ public abstract class Writer implements Appendable, Closeable, Flushable {
      * @throws  IOException
      *          If an I/O error occurs
      */
-    public abstract void write(char cbuf[], int off, int len) throws IOException;
+    public abstract void write(char[] cbuf, int off, int len) throws IOException;
 
     /**
      * Writes a string.

--- a/src/java.base/share/classes/java/lang/Runtime.java
+++ b/src/java.base/share/classes/java/lang/Runtime.java
@@ -449,7 +449,7 @@ public class Runtime {
      *
      * @see     ProcessBuilder
      */
-    public Process exec(String cmdarray[]) throws IOException {
+    public Process exec(String[] cmdarray) throws IOException {
         return exec(cmdarray, null, null);
     }
 

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -272,7 +272,7 @@ public final class String
      * @param  value
      *         The initial value of the string
      */
-    public String(char value[]) {
+    public String(char[] value) {
         this(value, 0, value.length, null);
     }
 
@@ -297,7 +297,7 @@ public final class String
      *          If {@code offset} is negative, {@code count} is negative, or
      *          {@code offset} is greater than {@code value.length - count}
      */
-    public String(char value[], int offset, int count) {
+    public String(char[] value, int offset, int count) {
         this(value, offset, count, rangeCheck(value, offset, count));
     }
 
@@ -394,7 +394,7 @@ public final class String
      * @see  #String(byte[])
      */
     @Deprecated(since="1.1")
-    public String(byte ascii[], int hibyte, int offset, int count) {
+    public String(byte[] ascii, int hibyte, int offset, int count) {
         checkBoundsOffCount(offset, count, ascii.length);
         if (count == 0) {
             this.value = "".value;
@@ -446,7 +446,7 @@ public final class String
      * @see  #String(byte[])
      */
     @Deprecated(since="1.1")
-    public String(byte ascii[], int hibyte) {
+    public String(byte[] ascii, int hibyte) {
         this(ascii, hibyte, 0, ascii.length);
     }
 
@@ -1354,7 +1354,7 @@ public final class String
      *
      * @since  1.1
      */
-    public String(byte bytes[], String charsetName)
+    public String(byte[] bytes, String charsetName)
             throws UnsupportedEncodingException {
         this(bytes, 0, bytes.length, charsetName);
     }
@@ -1379,7 +1379,7 @@ public final class String
      *
      * @since  1.6
      */
-    public String(byte bytes[], Charset charset) {
+    public String(byte[] bytes, Charset charset) {
         this(bytes, 0, bytes.length, charset);
     }
 
@@ -1665,7 +1665,7 @@ public final class String
      *            <li>{@code dstBegin+(srcEnd-srcBegin)} is larger than
      *                {@code dst.length}</ul>
      */
-    public void getChars(int srcBegin, int srcEnd, char dst[], int dstBegin) {
+    public void getChars(int srcBegin, int srcEnd, char[] dst, int dstBegin) {
         checkBoundsBeginEnd(srcBegin, srcEnd, length());
         checkBoundsOffCount(dstBegin, srcEnd - srcBegin, dst.length);
         if (isLatin1()) {
@@ -1719,7 +1719,7 @@ public final class String
      *          </ul>
      */
     @Deprecated(since="1.1")
-    public void getBytes(int srcBegin, int srcEnd, byte dst[], int dstBegin) {
+    public void getBytes(int srcBegin, int srcEnd, byte[] dst, int dstBegin) {
         checkBoundsBeginEnd(srcBegin, srcEnd, length());
         Objects.requireNonNull(dst);
         checkBoundsOffCount(dstBegin, srcEnd - srcBegin, dst.length);
@@ -4221,7 +4221,7 @@ public final class String
      * @return  a {@code String} that contains the characters of the
      *          character array.
      */
-    public static String valueOf(char data[]) {
+    public static String valueOf(char[] data) {
         return new String(data);
     }
 
@@ -4245,7 +4245,7 @@ public final class String
      *          {@code offset+count} is larger than
      *          {@code data.length}.
      */
-    public static String valueOf(char data[], int offset, int count) {
+    public static String valueOf(char[] data, int offset, int count) {
         return new String(data, offset, count);
     }
 
@@ -4262,7 +4262,7 @@ public final class String
      *          {@code offset+count} is larger than
      *          {@code data.length}.
      */
-    public static String copyValueOf(char data[], int offset, int count) {
+    public static String copyValueOf(char[] data, int offset, int count) {
         return new String(data, offset, count);
     }
 
@@ -4273,7 +4273,7 @@ public final class String
      * @return  a {@code String} that contains the characters of the
      *          character array.
      */
-    public static String copyValueOf(char data[]) {
+    public static String copyValueOf(char[] data) {
         return new String(data);
     }
 

--- a/src/java.base/share/classes/java/lang/StringBuffer.java
+++ b/src/java.base/share/classes/java/lang/StringBuffer.java
@@ -773,7 +773,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
         count = fields.get("count", 0);
     }
 
-    synchronized void getBytes(byte dst[], int dstBegin, byte coder) {
+    synchronized void getBytes(byte[] dst, int dstBegin, byte coder) {
         super.getBytes(dst, dstBegin, coder);
     }
 }

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -79,11 +79,11 @@ final class StringLatin1 {
         return ret;
     }
 
-    public static void getChars(byte[] value, int srcBegin, int srcEnd, char dst[], int dstBegin) {
+    public static void getChars(byte[] value, int srcBegin, int srcEnd, char[] dst, int dstBegin) {
         inflate(value, srcBegin, dst, dstBegin, srcEnd - srcBegin);
     }
 
-    public static void getBytes(byte[] value, int srcBegin, int srcEnd, byte dst[], int dstBegin) {
+    public static void getBytes(byte[] value, int srcBegin, int srcEnd, byte[] dst, int dstBegin) {
         System.arraycopy(value, srcBegin, dst, dstBegin, srcEnd - srcBegin);
     }
 

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -247,7 +247,7 @@ final class StringUTF16 {
     }
 
     @IntrinsicCandidate
-    public static void getChars(byte[] value, int srcBegin, int srcEnd, char dst[], int dstBegin) {
+    public static void getChars(byte[] value, int srcBegin, int srcEnd, char[] dst, int dstBegin) {
         // We need a range check here because 'getChar' has no checks
         if (srcBegin < srcEnd) {
             checkBoundsOffCount(srcBegin, srcEnd - srcBegin, value);
@@ -258,7 +258,7 @@ final class StringUTF16 {
     }
 
     /* @see java.lang.String.getBytes(int, int, byte[], int) */
-    public static void getBytes(byte[] value, int srcBegin, int srcEnd, byte dst[], int dstBegin) {
+    public static void getBytes(byte[] value, int srcBegin, int srcEnd, byte[] dst, int dstBegin) {
         srcBegin <<= 1;
         srcEnd <<= 1;
         for (int i = srcBegin + (1 >> LO_BYTE_SHIFT); i < srcEnd; i += 2) {

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -1247,7 +1247,7 @@ public class Thread implements Runnable {
      *          if {@link java.lang.ThreadGroup#checkAccess} determines that
      *          the current thread cannot access its thread group
      */
-    public static int enumerate(Thread tarray[]) {
+    public static int enumerate(Thread[] tarray) {
         return currentThread().getThreadGroup().enumerate(tarray);
     }
 

--- a/src/java.base/share/classes/java/lang/ThreadGroup.java
+++ b/src/java.base/share/classes/java/lang/ThreadGroup.java
@@ -399,7 +399,7 @@ public class ThreadGroup implements Thread.UncaughtExceptionHandler {
      *
      * @since   1.0
      */
-    public int enumerate(Thread list[]) {
+    public int enumerate(Thread[] list) {
         checkAccess();
         return enumerate(list, 0, true);
     }
@@ -437,12 +437,12 @@ public class ThreadGroup implements Thread.UncaughtExceptionHandler {
      *
      * @since   1.0
      */
-    public int enumerate(Thread list[], boolean recurse) {
+    public int enumerate(Thread[] list, boolean recurse) {
         checkAccess();
         return enumerate(list, 0, recurse);
     }
 
-    private int enumerate(Thread list[], int n, boolean recurse) {
+    private int enumerate(Thread[] list, int n, boolean recurse) {
         int ngroupsSnapshot = 0;
         ThreadGroup[] groupsSnapshot = null;
         synchronized (this) {
@@ -533,7 +533,7 @@ public class ThreadGroup implements Thread.UncaughtExceptionHandler {
      *
      * @since   1.0
      */
-    public int enumerate(ThreadGroup list[]) {
+    public int enumerate(ThreadGroup[] list) {
         checkAccess();
         return enumerate(list, 0, true);
     }
@@ -571,12 +571,12 @@ public class ThreadGroup implements Thread.UncaughtExceptionHandler {
      *
      * @since   1.0
      */
-    public int enumerate(ThreadGroup list[], boolean recurse) {
+    public int enumerate(ThreadGroup[] list, boolean recurse) {
         checkAccess();
         return enumerate(list, 0, recurse);
     }
 
-    private int enumerate(ThreadGroup list[], int n, boolean recurse) {
+    private int enumerate(ThreadGroup[] list, int n, boolean recurse) {
         int ngroupsSnapshot = 0;
         ThreadGroup[] groupsSnapshot = null;
         synchronized (this) {

--- a/src/java.base/share/classes/java/math/BigInteger.java
+++ b/src/java.base/share/classes/java/math/BigInteger.java
@@ -1221,7 +1221,7 @@ public class BigInteger extends Number implements Comparable<BigInteger> {
      * Assumes that the input array will not be modified (the returned
      * BigInteger will reference the input array if feasible).
      */
-    private static BigInteger valueOf(int val[]) {
+    private static BigInteger valueOf(int[] val) {
         return (val[0] > 0 ? new BigInteger(val, 1) : new BigInteger(val));
     }
 
@@ -4412,7 +4412,7 @@ public class BigInteger extends Number implements Comparable<BigInteger> {
     /**
      * Returns a copy of the input array stripped of any leading zero bytes.
      */
-    private static int[] stripLeadingZeroInts(int val[]) {
+    private static int[] stripLeadingZeroInts(int[] val) {
         int vlen = val.length;
         int keep;
 
@@ -4426,7 +4426,7 @@ public class BigInteger extends Number implements Comparable<BigInteger> {
      * Returns the input array stripped of any leading zero bytes.
      * Since the source is trusted the copying may be skipped.
      */
-    private static int[] trustedStripLeadingZeroInts(int val[]) {
+    private static int[] trustedStripLeadingZeroInts(int[] val) {
         int vlen = val.length;
         int keep;
 
@@ -4439,7 +4439,7 @@ public class BigInteger extends Number implements Comparable<BigInteger> {
     /**
      * Returns a copy of the input array stripped of any leading zero bytes.
      */
-    private static int[] stripLeadingZeroBytes(byte a[], int off, int len) {
+    private static int[] stripLeadingZeroBytes(byte[] a, int off, int len) {
         int indexBound = off + len;
         int keep;
 
@@ -4465,7 +4465,7 @@ public class BigInteger extends Number implements Comparable<BigInteger> {
      * Takes an array a representing a negative 2's-complement number and
      * returns the minimal (no leading zero bytes) unsigned whose value is -a.
      */
-    private static int[] makePositive(byte a[], int off, int len) {
+    private static int[] makePositive(byte[] a, int off, int len) {
         int keep, k;
         int indexBound = off + len;
 
@@ -4513,7 +4513,7 @@ public class BigInteger extends Number implements Comparable<BigInteger> {
      * Takes an array a representing a negative 2's-complement number and
      * returns the minimal (no leading zero ints) unsigned whose value is -a.
      */
-    private static int[] makePositive(int a[]) {
+    private static int[] makePositive(int[] a) {
         int keep, j;
 
         // Find first non-sign (0xffffffff) int of input

--- a/src/java.base/share/classes/java/net/DatagramPacket.java
+++ b/src/java.base/share/classes/java/net/DatagramPacket.java
@@ -80,7 +80,7 @@ class DatagramPacket {
      *
      * @since   1.2
      */
-    public DatagramPacket(byte buf[], int offset, int length) {
+    public DatagramPacket(byte[] buf, int offset, int length) {
         setData(buf, offset, length);
     }
 
@@ -98,7 +98,7 @@ class DatagramPacket {
      *          or if the length is greater than the length of the
      *          packet's given buffer.
      */
-    public DatagramPacket(byte buf[], int length) {
+    public DatagramPacket(byte[] buf, int length) {
         this (buf, 0, length);
     }
 
@@ -124,7 +124,7 @@ class DatagramPacket {
      *
      * @since   1.2
      */
-    public DatagramPacket(byte buf[], int offset, int length,
+    public DatagramPacket(byte[] buf, int offset, int length,
                           InetAddress address, int port) {
         setData(buf, offset, length);
         setAddress(address);
@@ -152,7 +152,7 @@ class DatagramPacket {
      *
      * @since   1.4
      */
-    public DatagramPacket(byte buf[], int offset, int length, SocketAddress address) {
+    public DatagramPacket(byte[] buf, int offset, int length, SocketAddress address) {
         setData(buf, offset, length);
         setSocketAddress(address);
     }
@@ -174,7 +174,7 @@ class DatagramPacket {
      *
      * @see     java.net.InetAddress
      */
-    public DatagramPacket(byte buf[], int length,
+    public DatagramPacket(byte[] buf, int length,
                           InetAddress address, int port) {
         this(buf, 0, length, address, port);
     }
@@ -198,7 +198,7 @@ class DatagramPacket {
      *
      * @since   1.4
      */
-    public DatagramPacket(byte buf[], int length, SocketAddress address) {
+    public DatagramPacket(byte[] buf, int length, SocketAddress address) {
         this(buf, 0, length, address);
     }
 

--- a/src/java.base/share/classes/java/net/Inet4Address.java
+++ b/src/java.base/share/classes/java/net/Inet4Address.java
@@ -106,7 +106,7 @@ class Inet4Address extends InetAddress {
         holder().family = IPv4;
     }
 
-    Inet4Address(String hostName, byte addr[]) {
+    Inet4Address(String hostName, byte[] addr) {
         holder().hostName = hostName;
         holder().family = IPv4;
         if (addr != null) {

--- a/src/java.base/share/classes/java/net/Inet6Address.java
+++ b/src/java.base/share/classes/java/net/Inet6Address.java
@@ -223,13 +223,13 @@ class Inet6Address extends InetAddress {
          */
         boolean scope_ifname_set; // false;
 
-        void setAddr(byte addr[]) {
+        void setAddr(byte[] addr) {
             if (addr.length == INADDRSZ) { // normal IPv6 address
                 System.arraycopy(addr, 0, ipaddress, 0, INADDRSZ);
             }
         }
 
-        void init(byte addr[], int scope_id) {
+        void init(byte[] addr, int scope_id) {
             setAddr(addr);
 
             if (scope_id >= 0) {
@@ -238,7 +238,7 @@ class Inet6Address extends InetAddress {
             }
         }
 
-        void init(byte addr[], NetworkInterface nif)
+        void init(byte[] addr, NetworkInterface nif)
             throws UnknownHostException
         {
             setAddr(addr);
@@ -377,27 +377,27 @@ class Inet6Address extends InetAddress {
     /* checking of value for scope_id should be done by caller
      * scope_id must be >= 0, or -1 to indicate not being set
      */
-    Inet6Address(String hostName, byte addr[], int scope_id) {
+    Inet6Address(String hostName, byte[] addr, int scope_id) {
         holder.init(hostName, IPv6);
         holder6 = new Inet6AddressHolder();
         holder6.init(addr, scope_id);
     }
 
-    Inet6Address(String hostName, byte addr[]) {
+    Inet6Address(String hostName, byte[] addr) {
         holder6 = new Inet6AddressHolder();
         try {
             initif (hostName, addr, null);
         } catch (UnknownHostException e) {} /* cant happen if ifname is null */
     }
 
-    Inet6Address (String hostName, byte addr[], NetworkInterface nif)
+    Inet6Address (String hostName, byte[] addr, NetworkInterface nif)
         throws UnknownHostException
     {
         holder6 = new Inet6AddressHolder();
         initif (hostName, addr, nif);
     }
 
-    Inet6Address (String hostName, byte addr[], String ifname)
+    Inet6Address (String hostName, byte[] addr, String ifname)
         throws UnknownHostException
     {
         holder6 = new Inet6AddressHolder();
@@ -474,7 +474,7 @@ class Inet6Address extends InetAddress {
         throw new UnknownHostException("addr is of illegal length");
     }
 
-    private void initstr(String hostName, byte addr[], String ifname)
+    private void initstr(String hostName, byte[] addr, String ifname)
         throws UnknownHostException
     {
         try {
@@ -488,7 +488,7 @@ class Inet6Address extends InetAddress {
         }
     }
 
-    private void initif(String hostName, byte addr[], NetworkInterface nif)
+    private void initif(String hostName, byte[] addr, NetworkInterface nif)
         throws UnknownHostException
     {
         int family = -1;

--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -962,7 +962,7 @@ public class Socket implements java.io.Closeable {
             return (n > 0) ? (a[0] & 0xff) : -1;
         }
         @Override
-        public int read(byte b[], int off, int len) throws IOException {
+        public int read(byte[] b, int off, int len) throws IOException {
             return in.read(b, off, len);
         }
         @Override
@@ -1031,7 +1031,7 @@ public class Socket implements java.io.Closeable {
             write(a, 0, 1);
         }
         @Override
-        public void write(byte b[], int off, int len) throws IOException {
+        public void write(byte[] b, int off, int len) throws IOException {
             out.write(b, off, len);
         }
 

--- a/src/java.base/share/classes/java/net/URLConnection.java
+++ b/src/java.base/share/classes/java/net/URLConnection.java
@@ -1818,7 +1818,7 @@ public abstract class URLConnection {
      * Returns -1, If EOF is reached before len bytes are read, returns 0
      * otherwise
      */
-    private static int readBytes(int c[], int len, InputStream is)
+    private static int readBytes(int[] c, int len, InputStream is)
                 throws IOException {
 
         byte buf[] = new byte[len];

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -350,7 +350,7 @@ public class ChoiceFormat extends NumberFormat {
      * @throws    NullPointerException if {@code limits} or
      *            {@code formats} is {@code null}
      */
-    public void setChoices(double[] limits, String formats[]) {
+    public void setChoices(double[] limits, String[] formats) {
         if (limits.length != formats.length) {
             throw new IllegalArgumentException(
                 "Array and limit arrays must be of the same length.");

--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -2285,7 +2285,7 @@ public class DecimalFormat extends NumberFormat {
     private final boolean subparse(String text, ParsePosition parsePosition,
                                    String positivePrefix, String negativePrefix,
                                    DigitList digits, boolean isExponent,
-                                   boolean status[]) {
+                                   boolean[] status) {
         int position = parsePosition.index;
         int oldStart = parsePosition.index;
         boolean gotPositive, gotNegative;
@@ -2377,7 +2377,7 @@ public class DecimalFormat extends NumberFormat {
      */
     int subparseNumber(String text, int position,
                        DigitList digits, boolean checkExponent,
-                       boolean isExponent, boolean status[]) {
+                       boolean isExponent, boolean[] status) {
         // process digits or Inf, find decimal position
         status[STATUS_INFINITE] = false;
         if (!isExponent && text.regionMatches(position,symbols.getInfinity(),0,

--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -4265,7 +4265,7 @@ public class Arrays {
      * @return a content-based hash code for {@code a}
      * @since 1.5
      */
-    public static int hashCode(long a[]) {
+    public static int hashCode(long[] a) {
         if (a == null)
             return 0;
 
@@ -4294,7 +4294,7 @@ public class Arrays {
      * @return a content-based hash code for {@code a}
      * @since 1.5
      */
-    public static int hashCode(int a[]) {
+    public static int hashCode(int[] a) {
         if (a == null)
             return 0;
 
@@ -4321,7 +4321,7 @@ public class Arrays {
      * @return a content-based hash code for {@code a}
      * @since 1.5
      */
-    public static int hashCode(short a[]) {
+    public static int hashCode(short[] a) {
         if (a == null)
             return 0;
 
@@ -4348,7 +4348,7 @@ public class Arrays {
      * @return a content-based hash code for {@code a}
      * @since 1.5
      */
-    public static int hashCode(char a[]) {
+    public static int hashCode(char[] a) {
         if (a == null)
             return 0;
 
@@ -4375,7 +4375,7 @@ public class Arrays {
      * @return a content-based hash code for {@code a}
      * @since 1.5
      */
-    public static int hashCode(byte a[]) {
+    public static int hashCode(byte[] a) {
         if (a == null)
             return 0;
 
@@ -4402,7 +4402,7 @@ public class Arrays {
      * @return a content-based hash code for {@code a}
      * @since 1.5
      */
-    public static int hashCode(boolean a[]) {
+    public static int hashCode(boolean[] a) {
         if (a == null)
             return 0;
 
@@ -4429,7 +4429,7 @@ public class Arrays {
      * @return a content-based hash code for {@code a}
      * @since 1.5
      */
-    public static int hashCode(float a[]) {
+    public static int hashCode(float[] a) {
         if (a == null)
             return 0;
 
@@ -4456,7 +4456,7 @@ public class Arrays {
      * @return a content-based hash code for {@code a}
      * @since 1.5
      */
-    public static int hashCode(double a[]) {
+    public static int hashCode(double[] a) {
         if (a == null)
             return 0;
 
@@ -4489,7 +4489,7 @@ public class Arrays {
      * @see #deepHashCode(Object[])
      * @since 1.5
      */
-    public static int hashCode(Object a[]) {
+    public static int hashCode(Object[] a) {
         if (a == null)
             return 0;
 
@@ -4530,7 +4530,7 @@ public class Arrays {
      * @see #hashCode(Object[])
      * @since 1.5
      */
-    public static int deepHashCode(Object a[]) {
+    public static int deepHashCode(Object[] a) {
         if (a == null)
             return 0;
 

--- a/src/java.base/share/classes/java/util/jar/JarVerifier.java
+++ b/src/java.base/share/classes/java/util/jar/JarVerifier.java
@@ -96,7 +96,7 @@ class JarVerifier {
     /** collect -DIGEST-MANIFEST values for deny list */
     private List<Object> manifestDigests;
 
-    public JarVerifier(String name, byte rawBytes[]) {
+    public JarVerifier(String name, byte[] rawBytes) {
         manifestName = name;
         manifestRawBytes = rawBytes;
         sigFileSigners = new Hashtable<>();
@@ -466,7 +466,7 @@ class JarVerifier {
             }
         }
 
-        public int read(byte b[], int off, int len) throws IOException {
+        public int read(byte[] b, int off, int len) throws IOException {
             ensureOpen();
             if ((numLeft > 0) && (numLeft < len)) {
                 len = (int)numLeft;

--- a/src/java.base/share/classes/java/util/regex/Matcher.java
+++ b/src/java.base/share/classes/java/util/regex/Matcher.java
@@ -289,7 +289,7 @@ public final class Matcher implements MatchResult {
         private final String text;
 
         ImmutableMatchResult(int first, int last, int groupCount,
-                             int groups[], String text)
+                             int[] groups, String text)
         {
             this.first = first;
             this.last = last;

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -925,7 +925,7 @@ public class ZipFile implements ZipConstants, Closeable {
             return pos;
         }
 
-        public int read(byte b[], int off, int len) throws IOException {
+        public int read(byte[] b, int off, int len) throws IOException {
             synchronized (ZipFile.this) {
                 ensureOpenOrZipException();
                 initDataOffset();

--- a/src/java.base/share/classes/java/util/zip/ZipUtils.java
+++ b/src/java.base/share/classes/java/util/zip/ZipUtils.java
@@ -165,7 +165,7 @@ class ZipUtils {
      * Fetches unsigned 16-bit value from byte array at specified offset.
      * The bytes are assumed to be in Intel (little-endian) byte order.
      */
-    public static final int get16(byte b[], int off) {
+    public static final int get16(byte[] b, int off) {
         return (b[off] & 0xff) | ((b[off + 1] & 0xff) << 8);
     }
 
@@ -173,7 +173,7 @@ class ZipUtils {
      * Fetches unsigned 32-bit value from byte array at specified offset.
      * The bytes are assumed to be in Intel (little-endian) byte order.
      */
-    public static final long get32(byte b[], int off) {
+    public static final long get32(byte[] b, int off) {
         return (get16(b, off) | ((long)get16(b, off+2) << 16)) & 0xffffffffL;
     }
 
@@ -181,7 +181,7 @@ class ZipUtils {
      * Fetches signed 64-bit value from byte array at specified offset.
      * The bytes are assumed to be in Intel (little-endian) byte order.
      */
-    public static final long get64(byte b[], int off) {
+    public static final long get64(byte[] b, int off) {
         return get32(b, off) | (get32(b, off+4) << 32);
     }
 
@@ -190,7 +190,7 @@ class ZipUtils {
      * The bytes are assumed to be in Intel (little-endian) byte order.
      *
      */
-    public static final int get32S(byte b[], int off) {
+    public static final int get32S(byte[] b, int off) {
         return (get16(b, off) | (get16(b, off+2) << 16));
     }
 


### PR DESCRIPTION
C-style array declarations generate noisy warnings in IDEs, et.c. This patch cleans up all java.* packages.

(Copyrights intentionally not updated due the triviality of most changes)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272626](https://bugs.openjdk.java.net/browse/JDK-8272626): Avoid C-style array declarations in java.*


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5161/head:pull/5161` \
`$ git checkout pull/5161`

Update a local copy of the PR: \
`$ git checkout pull/5161` \
`$ git pull https://git.openjdk.java.net/jdk pull/5161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5161`

View PR using the GUI difftool: \
`$ git pr show -t 5161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5161.diff">https://git.openjdk.java.net/jdk/pull/5161.diff</a>

</details>
