### PR TITLE
8272563: assert(is_double_stack() && !is_virtual()) failed: type check

### DIFF
--- a/src/hotspot/share/gc/shared/c1/cardTableBarrierSetC1.cpp
+++ b/src/hotspot/share/gc/shared/c1/cardTableBarrierSetC1.cpp
@@ -67,10 +67,8 @@ void CardTableBarrierSetC1::post_barrier(LIRAccess& access, LIR_OprDesc* addr, L
 #else
   LIR_Opr tmp = gen->new_pointer_register();
   if (TwoOperandLIRForm) {
-    if (addr->is_oop()) {
-      LIR_Opr addr_opr = LIR_OprFact::address(new LIR_Address(addr, addr->type()));
-      __ leal(addr_opr, tmp);
-    }
+    LIR_Opr addr_opr = LIR_OprFact::address(new LIR_Address(addr, addr->type()));
+    __ leal(addr_opr, tmp);
     __ move(addr, tmp);
     __ unsigned_shift_right(tmp, CardTable::card_shift, tmp);
   } else {

--- a/src/hotspot/share/gc/shared/c1/cardTableBarrierSetC1.cpp
+++ b/src/hotspot/share/gc/shared/c1/cardTableBarrierSetC1.cpp
@@ -67,7 +67,13 @@ void CardTableBarrierSetC1::post_barrier(LIRAccess& access, LIR_OprDesc* addr, L
 #else
   LIR_Opr tmp = gen->new_pointer_register();
   if (TwoOperandLIRForm) {
-    __ move(addr, tmp);
+    if (addr->is_oop()) {
+      LIR_Opr tmp2 = gen->new_register(T_OBJECT);
+      __ move(addr, tmp2);
+      __ move(tmp2, tmp);
+    } else {
+      __ move(addr, tmp);
+    }
     __ unsigned_shift_right(tmp, CardTable::card_shift, tmp);
   } else {
     __ unsigned_shift_right(addr, CardTable::card_shift, tmp);

--- a/src/hotspot/share/gc/shared/c1/cardTableBarrierSetC1.cpp
+++ b/src/hotspot/share/gc/shared/c1/cardTableBarrierSetC1.cpp
@@ -68,12 +68,10 @@ void CardTableBarrierSetC1::post_barrier(LIRAccess& access, LIR_OprDesc* addr, L
   LIR_Opr tmp = gen->new_pointer_register();
   if (TwoOperandLIRForm) {
     if (addr->is_oop()) {
-      LIR_Opr tmp2 = gen->new_register(T_OBJECT);
-      __ move(addr, tmp2);
-      __ move(tmp2, tmp);
-    } else {
-      __ move(addr, tmp);
+      LIR_Opr addr_opr = LIR_OprFact::address(new LIR_Address(addr, addr->type()));
+      __ leal(addr_opr, tmp);
     }
+    __ move(addr, tmp);
     __ unsigned_shift_right(tmp, CardTable::card_shift, tmp);
   } else {
     __ unsigned_shift_right(addr, CardTable::card_shift, tmp);

--- a/src/hotspot/share/gc/shared/c1/cardTableBarrierSetC1.cpp
+++ b/src/hotspot/share/gc/shared/c1/cardTableBarrierSetC1.cpp
@@ -69,7 +69,6 @@ void CardTableBarrierSetC1::post_barrier(LIRAccess& access, LIR_OprDesc* addr, L
   if (TwoOperandLIRForm) {
     LIR_Opr addr_opr = LIR_OprFact::address(new LIR_Address(addr, addr->type()));
     __ leal(addr_opr, tmp);
-    __ move(addr, tmp);
     __ unsigned_shift_right(tmp, CardTable::card_shift, tmp);
   } else {
     __ unsigned_shift_right(addr, CardTable::card_shift, tmp);


### PR DESCRIPTION
This patch is proposed by the submitter of the bug - ugawa@ci.i.u-tokyo.ac.jp

The method CardTableBarrierSetC1::post_barrier generates a move LIR when TwoOperandLIRForm flag is true to move the address to be marked in the card table to a temporary register.
> __ move(addr, tmp);
However, this code only guarantees that `addr` is a valid register for LIR, which can be a virtual register. If the virtual register for `addr` is spilled to the stack by chance, the `move(addr, tmp)` is compiled to a memory-to-register which causes an assertion failure because a memory-to-register move requires their arguments to have the same size. 
The fix is to check if it is is_oop() and call the mov appropriately.

No issues found in local testing and Mach5 tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272563](https://bugs.openjdk.java.net/browse/JDK-8272563): assert(is_double_stack() && !is_virtual()) failed: type check


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Igor Veresov](https://openjdk.java.net/census#iveresov) (@veresov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5164/head:pull/5164` \
`$ git checkout pull/5164`

Update a local copy of the PR: \
`$ git checkout pull/5164` \
`$ git pull https://git.openjdk.java.net/jdk pull/5164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5164`

View PR using the GUI difftool: \
`$ git pr show -t 5164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5164.diff">https://git.openjdk.java.net/jdk/pull/5164.diff</a>

</details>
