### PR TITLE
8272564: Incorrect attribution of method invocations of Object methods on interfaces

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -2585,7 +2585,7 @@ public class Attr extends JCTree.Visitor {
     //where
         Type adjustMethodReturnType(Symbol msym, Type qualifierType, Name methodName, List<Type> argtypes, Type restype) {
             if (msym != null &&
-                    msym.owner == syms.objectType.tsym &&
+                    (msym.owner == syms.objectType.tsym || msym.owner.isInterface()) &&
                     methodName == names.getClass &&
                     argtypes.isEmpty()) {
                 // as a special case, x.getClass() has type Class<? extends |X|>

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -1896,6 +1896,15 @@ public class Resolve {
         if (isInterface && bestSoFar.kind.isResolutionError()) {
             bestSoFar = findMethodInScope(env, site, name, argtypes, typeargtypes,
                     syms.objectType.tsym.members(), bestSoFar, allowBoxing, useVarargs, true);
+            if (bestSoFar.kind.isValid()) {
+                Symbol baseSymbol = bestSoFar;
+                bestSoFar = new MethodSymbol(bestSoFar.flags_field, bestSoFar.name, bestSoFar.type, intype.tsym) {
+                    @Override
+                    public Symbol baseSymbol() {
+                        return baseSymbol;
+                    }
+                };
+            }
         }
         return bestSoFar;
     }

--- a/test/langtools/tools/javac/api/TestGetElementReference.java
+++ b/test/langtools/tools/javac/api/TestGetElementReference.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8012929 8243074 8266281
+ * @bug 8012929 8243074 8266281 8272564
  * @summary Trees.getElement should work not only for declaration trees, but also for use-trees
  * @modules jdk.compiler
  * @build TestGetElementReference

--- a/test/langtools/tools/javac/api/TestGetElementReferenceData.java
+++ b/test/langtools/tools/javac/api/TestGetElementReferenceData.java
@@ -37,6 +37,10 @@ public class TestGetElementReferenceData {
         target(TestGetElementReferenceData :: test/*getElement:METHOD:test.nested.TestGetElementReferenceData.test()*/);
         Object/*getElement:CLASS:java.lang.Object*/ o = null;
         if (o/*getElement:LOCAL_VARIABLE:o*/ instanceof String/*getElement:CLASS:java.lang.String*/ str/*getElement:BINDING_VARIABLE:str*/) ;
+        I i = null;
+        i.toString/*getElement:METHOD:test.nested.TestGetElementReferenceData.I.toString()*/();
+        J j = null;
+        j.toString/*getElement:METHOD:test.nested.TestGetElementReferenceData.I.toString()*/();
     }
     private static void target(Runnable r) { r.run(); }
     public static class Base {
@@ -50,4 +54,8 @@ public class TestGetElementReferenceData {
     @Target(ElementType.TYPE_USE)
     @interface TypeAnnotation {
     }
+    interface I {
+        public String toString();
+    }
+    interface J extends I {}
 }

--- a/test/langtools/tools/javac/api/TestIsAccessible.java
+++ b/test/langtools/tools/javac/api/TestIsAccessible.java
@@ -58,7 +58,6 @@ public class TestIsAccessible {
         if (trees.isAccessible(s, name)) {
             for (Element member : ct.getElements().getAllMembers(name)) {
                 if (!trees.isAccessible(s, member, (DeclaredType) name.asType())) {
-                    trees.isAccessible(s, member, (DeclaredType) name.asType());
                     throw new IllegalStateException("Inaccessible Name member: " + member);
                 }
             }

--- a/test/langtools/tools/javac/api/TestIsAccessible.java
+++ b/test/langtools/tools/javac/api/TestIsAccessible.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug     8272564
+ * @summary Verify accessibility of Object-based methods inherited from super interfaces.
+ * @modules jdk.compiler
+ */
+
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.Scope;
+import com.sun.source.util.JavacTask;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.Trees;
+import java.net.URI;
+import java.util.Arrays;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.ToolProvider;
+
+public class TestIsAccessible {
+    public static void main(String[] args) throws Exception {
+        final JavaCompiler tool = ToolProvider.getSystemJavaCompiler();
+        assert tool != null;
+        final JavacTask ct = (JavacTask)tool.getTask(null, null, null, null, null, Arrays.asList(new MyFileObject()));
+
+        CompilationUnitTree cut = ct.parse().iterator().next();
+        TreePath tp = new TreePath(new TreePath(cut), cut.getTypeDecls().get(0));
+        Scope s = Trees.instance(ct).getScope(tp);
+        TypeElement name = ct.getElements().getTypeElement("javax.lang.model.element.Name");
+        Trees trees = Trees.instance(ct);
+
+        if (trees.isAccessible(s, name)) {
+            for (Element member : ct.getElements().getAllMembers(name)) {
+                if (!trees.isAccessible(s, member, (DeclaredType) name.asType())) {
+                    trees.isAccessible(s, member, (DeclaredType) name.asType());
+                    throw new IllegalStateException("Inaccessible Name member: " + member);
+                }
+            }
+        }
+    }
+
+    static class MyFileObject extends SimpleJavaFileObject {
+        public MyFileObject() {
+            super(URI.create("myfo:/Test.java"), JavaFileObject.Kind.SOURCE);
+        }
+        public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+            return "public class Test { }";
+        }
+    }
+}

--- a/test/langtools/tools/javac/resolve/NoObjectToString.java
+++ b/test/langtools/tools/javac/resolve/NoObjectToString.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8272564
+ * @summary Correct resolution of toString() (and other similar calls) on interfaces
+ * @modules jdk.jdeps/com.sun.tools.classfile
+ * @compile NoObjectToString.java
+ * @run main NoObjectToString
+ */
+
+import java.io.*;
+import com.sun.tools.classfile.*;
+import com.sun.tools.classfile.ConstantPool.CONSTANT_Methodref_info;
+
+public class NoObjectToString {
+    public static void main(String... args) throws Exception {
+        NoObjectToString c = new NoObjectToString();
+        c.run(args);
+    }
+
+    void run(String... args) throws Exception {
+         //Verify there are no references to Object.toString() in a Test:
+        InputStream in = NoObjectToString.class.getResourceAsStream("NoObjectToString$Test.class");
+        try {
+            ClassFile cf = ClassFile.read(in);
+            for (ConstantPool.CPInfo cpinfo: cf.constant_pool.entries()) {
+                if (cpinfo.getTag() == ConstantPool.CONSTANT_Methodref) {
+                    CONSTANT_Methodref_info ref = (CONSTANT_Methodref_info) cpinfo;
+                    String methodDesc = ref.getClassInfo().getName() + "." + ref.getNameAndTypeInfo().getName() + ":" + ref.getNameAndTypeInfo().getType();
+
+                    if ("java/lang/Object.toString:()Ljava/lang/String;".equals(methodDesc)) {
+                        throw new AssertionError("Found call to j.l.Object.toString");
+                    }
+                }
+            }
+        } catch (ConstantPoolException ignore) {
+            throw new AssertionError(ignore);
+        } finally {
+            in.close();
+        }
+    }
+
+    class Test {
+        void test(I i, J j) {
+            i.toString();
+            j.toString();
+        }
+    }
+
+    interface I {
+        public String toString();
+    }
+    interface J extends I {}
+
+}

--- a/test/langtools/tools/javac/resolve/NoObjectToString.java
+++ b/test/langtools/tools/javac/resolve/NoObjectToString.java
@@ -63,9 +63,10 @@ public class NoObjectToString {
     }
 
     class Test {
-        void test(I i, J j) {
+        void test(I i, J j, K k) {
             i.toString();
             j.toString();
+            k.toString();
         }
     }
 
@@ -73,5 +74,6 @@ public class NoObjectToString {
         public String toString();
     }
     interface J extends I {}
+    interface K {}
 
 }


### PR DESCRIPTION
Consider these declarations:
```
    interface I {
        public String toString();
    }
    interface J extends I {}
```

There are two issues with the `toString` inherited from `I` into `J`:
-`Trees.isAccessible(..., I.toString, J)` will return false, because `Resolve.isAccessible` will return false, because `Resolve.notOverriddenIn` returns false, because the `Object.toString` method is found as an implementation of `I.toString` in the context of `J`. This is unfortunate, because `Elements.getAllMembers(J)` will return `I.toString` as a member, not `Object.toString`, so any API client listing all members and then validating them using `Trees.isAccessible` will filter `toString` out. The proposed solution is to avoid using the methods from `java.lang.Object` as implementations of interface methods in `Resolve.notOverriddenIn`. (Interfaces don't inherit from `j.l.Object` per my understanding of JLS.)
-as a slightly less problematic case, consider:
```
I i = null;
i.toString(); //AST and classfile contain call to I.toString()
J j = null;
j.toString(); //AST and classfile contain call to j.l.Object.toString()
```

I believe the second invocation should also preferably be a call to `I.toString()`, not a call to `j.l.Object.toString()`. The reason for this behavior is that in javac, interfaces have `j.l.Object` as a supertype, so method lookups over interfaces will look into `j.l.Object` before looking into the superinterfaces, and the concrete method will prevail over the super interface method found later. The proposal is, for interfaces, to only look into `j.l.Object` is a method is not found in the interface and its superinterfaces.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272564](https://bugs.openjdk.java.net/browse/JDK-8272564): Incorrect attribution of method invocations of Object methods on interfaces


### Reviewers
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**) ⚠️ Review applies to 1a672ceffca500a76c16eb3886721a5d76905e60
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5165/head:pull/5165` \
`$ git checkout pull/5165`

Update a local copy of the PR: \
`$ git checkout pull/5165` \
`$ git pull https://git.openjdk.java.net/jdk pull/5165/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5165`

View PR using the GUI difftool: \
`$ git pr show -t 5165`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5165.diff">https://git.openjdk.java.net/jdk/pull/5165.diff</a>

</details>
