### PR TITLE
JDK-8271258: @param with non-ascii variable names produces incorrect results

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,10 +67,9 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
     }
 
     /**
-     * Given an array of <code>Parameter</code>s, return
-     * a name/rank number map.  If the array is null, then
-     * null is returned.
-     * @param params The array of parameters (from type or executable member) to
+     * Given a list of parameters, return a name/rank number map.
+     * If the list is null, then null is returned.
+     * @param params The list of parameters (from type or executable member) to
      *               check.
      * @return a name-rank number map.
      */
@@ -245,28 +244,24 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
             CommentHelper ch = writer.configuration().utils.getCommentHelper(e);
             for (ParamTree dt : paramTags) {
                 String name = ch.getParameterName(dt);
-                String paramName = kind != ParamKind.TYPE_PARAMETER
-                        ? name.toString()
-                        : "<" + name + ">";
+                String paramName = kind == ParamKind.TYPE_PARAMETER ? "<" + name + ">" : name;
                 if (!rankMap.containsKey(name)) {
-                    String key;
-                    switch (kind) {
-                        case PARAMETER:       key = "doclet.Parameters_warn" ; break;
-                        case TYPE_PARAMETER:  key = "doclet.TypeParameters_warn" ; break;
-                        case RECORD_COMPONENT: key = "doclet.RecordComponents_warn" ; break;
-                        default: throw new IllegalArgumentException(kind.toString());
-                }
+                    String key = switch (kind) {
+                        case PARAMETER        -> "doclet.Parameters_warn";
+                        case TYPE_PARAMETER   -> "doclet.TypeParameters_warn";
+                        case RECORD_COMPONENT -> "doclet.RecordComponents_warn";
+                        default -> throw new IllegalArgumentException(kind.toString());
+                    };
                     messages.warning(ch.getDocTreePath(dt), key, paramName);
                 }
                 String rank = rankMap.get(name);
                 if (rank != null && alreadyDocumented.contains(rank)) {
-                    String key;
-                    switch (kind) {
-                        case PARAMETER:       key = "doclet.Parameters_dup_warn" ; break;
-                        case TYPE_PARAMETER:  key = "doclet.TypeParameters_dup_warn" ; break;
-                        case RECORD_COMPONENT: key = "doclet.RecordComponents_dup_warn" ; break;
-                        default: throw new IllegalArgumentException(kind.toString());
-                }
+                    String key = switch (kind) {
+                        case PARAMETER        -> "doclet.Parameters_dup_warn";
+                        case TYPE_PARAMETER   -> "doclet.TypeParameters_dup_warn";
+                        case RECORD_COMPONENT -> "doclet.RecordComponents_dup_warn";
+                        default -> throw new IllegalArgumentException(kind.toString());
+                    };
                     messages.warning(ch.getDocTreePath(dt), key, paramName);
                 }
                 result.add(processParamTag(e, kind, writer, dt,

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/CommentHelper.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/CommentHelper.java
@@ -139,7 +139,7 @@ public class CommentHelper {
 
     public String getParameterName(DocTree dtree) {
         if (dtree.getKind() == PARAM) {
-            return ((ParamTree) dtree).getName().toString();
+            return ((ParamTree) dtree).getName().getName().toString();
         } else {
             return null;
         }

--- a/test/langtools/jdk/javadoc/doclet/testUnicode/TestUnicode.java
+++ b/test/langtools/jdk/javadoc/doclet/testUnicode/TestUnicode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug      8203176
+ * @bug      8203176 8271258
  * @summary  javadoc handles non-ASCII characters incorrectly
  * @library  /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -33,7 +33,6 @@
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import javadoc.tester.JavadocTester;
 import toolbox.ToolBox;
@@ -42,27 +41,90 @@ public class TestUnicode extends JavadocTester {
 
     public static void main(String... args) throws Exception {
         TestUnicode tester = new TestUnicode();
-        tester.runTests();
+        tester.runTests(m -> new Object[] { Path.of(m.getName())});
     }
 
     ToolBox tb = new ToolBox();
 
     @Test
-    public void test() throws Exception {
+    public void testUnicode(Path base) throws Exception {
         char ellipsis = '\u2026';
-        Path src = Files.createDirectories(Paths.get("src"));
+        Path src = Files.createDirectories(base.resolve("src"));
         tb.writeJavaFiles(src,
                 "/** Hel" + ellipsis + "lo {@code World(" + ellipsis + ")}. */\n"
                 + "public class Code { }\n");
 
-        javadoc("-d", "out",
+        javadoc("-d", base.resolve("out").toString(),
                 "-encoding", "utf-8",
                 src.resolve("Code.java").toString());
         checkExit(Exit.OK);
 
         checkOutput("Code.html", true,
-                "<div class=\"block\">Hel" + ellipsis + "lo <code>World(" + ellipsis + ")</code>.</div>");
+                """
+                        """);
         checkOutput("Code.html", false,
                 "\\u");
+    }
+
+    @Test
+    public void testParam(Path base) throws Exception {
+        String chineseElephant = "\u5927\u8c61"; // taken from JDK-8271258
+        Path src = Files.createDirectories(base.resolve("src"));
+        tb.writeJavaFiles(src,
+                """
+                    /**
+                     * Comment. ##.
+                     * @param <##> the ##
+                     */
+                    public class Code<##> {
+                        /**
+                         * Comment. ##.
+                         * @param ## the ##
+                         */
+                         public void set##(int ##) { }
+                    }""".replaceAll("##", chineseElephant));
+
+        javadoc("-d", base.resolve("out").toString(),
+                "-encoding", "utf-8",
+                "--no-platform-links",
+                src.resolve("Code.java").toString());
+        checkExit(Exit.OK);
+
+        checkOutput("Code.html", true,
+                """
+                    <h1 title="Class Code" class="title">Class Code&lt;##&gt;</h1>
+                    """.replaceAll("##", chineseElephant),
+                """
+                    <div class="inheritance" title="Inheritance Tree">java.lang.Object
+                    <div class="inheritance">Code&lt;##&gt;</div>
+                    </div>
+                    """.replaceAll("##", chineseElephant),
+                """
+                    <dl class="notes">
+                    <dt>Type Parameters:</dt>
+                    <dd><code>##</code> - the ##</dd>
+                    </dl>
+                    """.replaceAll("##", chineseElephant),
+                """
+                    <section class="detail" id="set##(int)">
+                    <h3>set##</h3>
+                    <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
+                    lass="return-type">void</span>&nbsp;<span class="element-name">set##</span><wbr>\
+                    <span class="parameters">(int&nbsp;##)</span></div>
+                    <div class="block">Comment. ##.</div>
+                    <dl class="notes">
+                    <dt>Parameters:</dt>
+                    <dd><code>##</code> - the ##</dd>
+                    </dl>
+                    </section>
+                    """.replaceAll("##", chineseElephant)
+                );
+
+        // The following checks for the numeric forms of the Unicode characters being tested:
+        // these numeric forms should not show up as literal character sequences.
+        checkOutput("Code.html", false,
+                Integer.toHexString(chineseElephant.charAt(0)),
+                Integer.toHexString(chineseElephant.charAt(1))
+                );
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testUnicode/TestUnicode.java
+++ b/test/langtools/jdk/javadoc/doclet/testUnicode/TestUnicode.java
@@ -60,8 +60,7 @@ public class TestUnicode extends JavadocTester {
         checkExit(Exit.OK);
 
         checkOutput("Code.html", true,
-                """
-                        """);
+                "<div class=\"block\">Hel" + ellipsis + "lo <code>World(" + ellipsis + ")</code>.</div>");
         checkOutput("Code.html", false,
                 "\\u");
     }


### PR DESCRIPTION
Please review a simple change to fix the use of non-ASCII characters in @param names.

The underlying problem was accidentally relying on `DocTree.toString()` for an `IdentifierTree` in `CommentHelper`.  The fix is simply to get the underlying `Name` and call `toString` on that.

There is some loosely related cleanup in `ParamTaglet`. I did see if it was possible to avoid excessive use of `String` in this part of the code, but that quickly became a rat-hole.

The existing related test is updated to include this new case, of a Chinese identifier occurring in various places, similar to the test case in the original bug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271258](https://bugs.openjdk.java.net/browse/JDK-8271258): @param with non-ascii variable names produces incorrect results


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.java.net/census#hannesw) (@hns - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5168/head:pull/5168` \
`$ git checkout pull/5168`

Update a local copy of the PR: \
`$ git checkout pull/5168` \
`$ git pull https://git.openjdk.java.net/jdk pull/5168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5168`

View PR using the GUI difftool: \
`$ git pr show -t 5168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5168.diff">https://git.openjdk.java.net/jdk/pull/5168.diff</a>

</details>
