### PR TITLE
[PATCH] Remove redundant variable 'completed' check in UnknownLengthBodyParser.accept

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/ResponseContent.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ResponseContent.java
@@ -489,7 +489,6 @@ class ResponseContent {
                     debug.log("already closed: " + closedExceptionally);
                 return;
             }
-            boolean completed = false;
             try {
                 if (debug.on())
                     debug.log("Parser got %d bytes ", b.remaining());
@@ -506,9 +505,7 @@ class ResponseContent {
             } catch (Throwable t) {
                 if (debug.on()) debug.log("Unexpected exception", t);
                 closedExceptionally = t;
-                if (!completed) {
-                    onComplete.accept(t);
-                }
+                onComplete.accept(t);
             }
         }
 


### PR DESCRIPTION
The UnknownLengthBodyParser will parse the bytes until the connection is closed (or an exception occurs) - so `completed` is not really needed there.
See https://mail.openjdk.java.net/pipermail/net-dev/2021-August/016396.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5169/head:pull/5169` \
`$ git checkout pull/5169`

Update a local copy of the PR: \
`$ git checkout pull/5169` \
`$ git pull https://git.openjdk.java.net/jdk pull/5169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5169`

View PR using the GUI difftool: \
`$ git pr show -t 5169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5169.diff">https://git.openjdk.java.net/jdk/pull/5169.diff</a>

</details>
