### PR TITLE
8272481: [macos] javax/swing/JFrame/NSTexturedJFrame/NSTexturedJFrame java fails

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/LWWindowPeer.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/LWWindowPeer.java
@@ -521,7 +521,7 @@ public class LWWindowPeer
     public final void setTextured(final boolean isTextured) {
         if (textured != isTextured) {
             textured = isTextured;
-            updateOpaque();
+            if (isVisible()) updateOpaque();
         }
     }
 


### PR DESCRIPTION

Update opacity only if the component is visible