### PR TITLE
8264322: Generate CDS archive when creating custom JDK image

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/builder/ImageBuilder.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/builder/ImageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ import java.io.DataOutputStream;
 import java.util.Properties;
 
 import jdk.tools.jlink.internal.ExecutableImage;
+import jdk.tools.jlink.internal.Platform;
 import jdk.tools.jlink.plugin.PluginException;
 import jdk.tools.jlink.plugin.ResourcePool;
 
@@ -74,4 +75,13 @@ public interface ImageBuilder {
      * @throws PluginException
      */
     public ExecutableImage getExecutableImage();
+
+    /**
+     * Gets the target image platform.
+     *
+     * @return Platform
+     */
+    public default Platform getTargetPlatform() {
+        return Platform.UNKNOWN;
+    }
 }

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/builder/ImageBuilder.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/builder/ImageBuilder.java
@@ -77,9 +77,9 @@ public interface ImageBuilder {
     public ExecutableImage getExecutableImage();
 
     /**
-     * Gets the target image platform.
+     * Gets the platform of the image.
      *
-     * @return Platform
+     * @return {@code Platform} object representing the platform of the image
      */
     public default Platform getTargetPlatform() {
         return Platform.UNKNOWN;

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ExecutableImage.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ExecutableImage.java
@@ -63,23 +63,9 @@ public interface ExecutableImage {
     public void storeLaunchArgs(List<String> args);
 
     /**
-     * Set the Platform of the image.
-     *
-     * @param p
-     */
-    public void setTargetPlatform(Platform p);
-
-    /**
      * The Platform of the image.
      *
      * @return Platform
      */
     public Platform getTargetPlatform();
-
-    /**
-     * Checks if the image is 64-bit.
-     *
-     * @return boolean
-     */
-    public boolean is64Bit();
 }

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ExecutableImage.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ExecutableImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,4 +61,25 @@ public interface ExecutableImage {
      * @param args Additional arguments
      */
     public void storeLaunchArgs(List<String> args);
+
+    /**
+     * Set the Platform of the image.
+     *
+     * @param p
+     */
+    public void setTargetPlatform(Platform p);
+
+    /**
+     * The Platform of the image.
+     *
+     * @return Platform
+     */
+    public Platform getTargetPlatform();
+
+    /**
+     * Checks if the image is 64-bit.
+     *
+     * @return boolean
+     */
+    public boolean is64Bit();
 }

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImagePluginStack.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImagePluginStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -192,6 +192,7 @@ public final class ImagePluginStack {
 
     public void operate(ImageProvider provider) throws Exception {
         ExecutableImage img = provider.retrieve(this);
+        img.setTargetPlatform(imageBuilder.getTargetPlatform());
         List<String> arguments = new ArrayList<>();
         plugins.stream()
                 .filter(PostProcessor.class::isInstance)

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImagePluginStack.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImagePluginStack.java
@@ -192,7 +192,6 @@ public final class ImagePluginStack {
 
     public void operate(ImageProvider provider) throws Exception {
         ExecutableImage img = provider.retrieve(this);
-        img.setTargetPlatform(imageBuilder.getTargetPlatform());
         List<String> arguments = new ArrayList<>();
         plugins.stream()
                 .filter(PostProcessor.class::isInstance)

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/Platform.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/Platform.java
@@ -52,7 +52,7 @@ public record Platform(OperatingSystem os, Architecture arch) {
     /*
      * Returns the {@code Platform} based on the platformString of the form <operating system>-<arch>.
      */
-    public static Platform parseTargetPlatform(String platformString) {
+    public static Platform parsePlatform(String platformString) {
         String osName;
         String archName;
         int index = platformString.indexOf("-");
@@ -71,6 +71,14 @@ public record Platform(OperatingSystem os, Architecture arch) {
         }
         Architecture arch = toArch(archName);
         return new Platform(os, arch);
+    }
+
+    /**
+     * @return true is it's a 64-bit platform
+     */
+    public boolean is64Bit() {
+        return (arch() == Platform.Architecture.x64 ||
+                arch() == Platform.Architecture.AARCH64);
     }
 
     /**

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/Platform.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,48 +24,104 @@
  */
 package jdk.tools.jlink.internal;
 
-import jdk.tools.jlink.plugin.ResourcePoolModule;
-
 import java.util.Locale;
 
 /**
  * Supported platforms
  */
-public enum Platform {
-    WINDOWS,
-    LINUX,
-    MACOS,
-    AIX,
-    UNKNOWN;
+public record Platform(OperatingSystem os, Architecture arch) {
 
-    /**
-     * Returns the {@code Platform} derived from the target platform
-     * in the {@code ModuleTarget} attribute.
+    public enum OperatingSystem {
+        WINDOWS,
+        LINUX,
+        MACOS,
+        AIX,
+        UNKNOWN;
+    }
+
+    public enum Architecture {
+        X86,
+        x64,
+        ARM,
+        AARCH64,
+        UNKNOWN;
+    }
+
+    public static final Platform UNKNOWN = new Platform(OperatingSystem.UNKNOWN, Architecture.UNKNOWN);
+
+    /*
+     * Returns the {@code Platform} based on the platformString of the form <operating system>-<arch>.
      */
-    public static Platform toPlatform(String targetPlatform) {
+    public static Platform parseTargetPlatform(String platformString) {
         String osName;
-        int index = targetPlatform.indexOf("-");
+        String archName;
+        int index = platformString.indexOf("-");
         if (index < 0) {
-            osName = targetPlatform;
+            osName = platformString;
+            archName = "UNKNOWN";
         } else {
-            osName = targetPlatform.substring(0, index);
+            osName = platformString.substring(0, index);
+            archName = platformString.substring(index + 1);
         }
+        OperatingSystem os;
         try {
-            return Platform.valueOf(osName.toUpperCase(Locale.ENGLISH));
+            os = OperatingSystem.valueOf(osName.toUpperCase(Locale.ENGLISH));
         } catch (IllegalArgumentException e) {
-            return Platform.UNKNOWN;
+            os = OperatingSystem.UNKNOWN;
         }
+        Architecture arch = toArch(archName);
+        return new Platform(os, arch);
     }
 
     /**
-     * Returns the {@code Platform} to which the given module is target to.
+     * Returns the runtime {@code Platform}.
      */
-    public static Platform getTargetPlatform(ResourcePoolModule module) {
-        String targetPlatform = module.targetPlatform();
-        if (targetPlatform != null) {
-            return toPlatform(targetPlatform);
-        } else {
-            return Platform.UNKNOWN;
-        }
+    public static Platform runtime() {
+        return new Platform(runtimeOS(), runtimeArch());
+    }
+
+    /**
+     * Returns a {@code String} representation of a {@code Platform} in the format of <os>-<arch>
+     */
+    @Override
+    public String toString() {
+        return os.toString().toLowerCase() + "-" + arch.toString().toLowerCase();
+    }
+
+    /**
+     * Returns the runtime {@code Platform.OperatingSystem}.
+     */
+    private static OperatingSystem runtimeOS() {
+        String osName = System.getProperty("os.name").substring(0, 3).toLowerCase();
+        OperatingSystem os = switch (osName) {
+            case "win" -> OperatingSystem.WINDOWS;
+            case "lin" -> OperatingSystem.LINUX;
+            case "mac" -> OperatingSystem.MACOS;
+            case "aix" -> OperatingSystem.AIX;
+            default    -> OperatingSystem.UNKNOWN;
+        };
+        return os;
+    }
+
+    /**
+     * Returns the runtime {@code Platform.Architechrure}.
+     */
+    private static Architecture runtimeArch() {
+        String archName = System.getProperty("os.arch");
+        return toArch(archName);
+    }
+
+    /**
+     * Returns the {@code Platform.Architecture} based on the archName.
+     */
+    private static Architecture toArch(String archName) {
+        Architecture arch = switch (archName) {
+            case "x86"             -> Architecture.X86;
+            case "amd64", "x86_64" -> Architecture.x64;
+            case "arm"             -> Architecture.ARM;
+            case "aarch64"         -> Architecture.AARCH64;
+            default                -> Architecture.UNKNOWN;
+        };
+        return arch;
     }
 }

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/CDSPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/CDSPlugin.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.tools.jlink.internal.plugins;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import jdk.tools.jlink.internal.ExecutableImage;
+import jdk.tools.jlink.internal.Platform;
+import jdk.tools.jlink.internal.PostProcessor;
+import jdk.tools.jlink.plugin.PluginException;
+import jdk.tools.jlink.plugin.ResourcePool;
+import jdk.tools.jlink.plugin.ResourcePoolBuilder;
+
+/**
+ *
+ * CDS plugin
+ */
+public final class CDSPlugin extends AbstractPlugin implements PostProcessor {
+    private static final String NAME = "generate-cds-archive";
+    private Platform targetPlatform;
+    private Platform runtimePlatform;
+
+    public CDSPlugin() {
+        super(NAME);
+    }
+
+
+    private String javaExecutableName() {
+        if (targetPlatform.os() == Platform.OperatingSystem.WINDOWS) {
+            return "java.exe";
+        } else {
+            return "java";
+        }
+    }
+
+    private void generateCDSArchive(ExecutableImage image, boolean noCoops) {
+        List<String> javaCmd = new ArrayList<String>();
+        Path javaPath = image.getHome().resolve("bin").resolve(javaExecutableName());
+        if (!Files.exists(javaPath)) {
+            throw new PluginException("Cannot find java executable at: " + javaPath.toString());
+        }
+        javaCmd.add(javaPath.toString());
+        javaCmd.add("-Xshare:dump");
+        String archiveMsg = "CDS";
+        if (noCoops) {
+            javaCmd.add("-XX:-UseCompressedOops");
+            archiveMsg += "-NOCOOPS";
+        }
+        ProcessBuilder builder = new ProcessBuilder(javaCmd);
+        int status = -1;
+        try {
+            Process p = builder.inheritIO().start();
+            status = p.waitFor();
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+        if (status == 0) {
+            System.out.println("Created " + archiveMsg + " archive successfully");
+        } else {
+            throw new PluginException("Failed creating " + archiveMsg + " archive!");
+        }
+    }
+
+    @Override
+    public List<String> process(ExecutableImage image) {
+        targetPlatform = image.getTargetPlatform();
+        runtimePlatform = Platform.runtime();
+
+        if (!targetPlatform.equals(runtimePlatform)) {
+            throw new PluginException("Cannot generate CDS archives: target image platform " +
+                    targetPlatform.toString() + " is different from runtime platform " +
+                    runtimePlatform.toString());
+        }
+
+        Path classListPath = image.getHome().resolve("lib").resolve("classlist");
+        if (Files.exists(classListPath)) {
+            generateCDSArchive(image,false);
+
+            if (image.is64Bit()) {
+                generateCDSArchive(image,true);
+            }
+        } else {
+            throw new PluginException("Cannot generate CDS archives: classlist not found: " +
+                                      classListPath.toString());
+        }
+        return null;
+    }
+
+    @Override
+    public Category getType() {
+        return Category.PROCESSOR;
+    }
+
+    @Override
+    public ResourcePool transform(ResourcePool in, ResourcePoolBuilder out) {
+        in.transformAndCopy((file) -> {
+            return file;
+            }, out);
+        return out.build();
+    }
+
+}

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ExcludeVMPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ExcludeVMPlugin.java
@@ -246,7 +246,7 @@ public final class ExcludeVMPlugin extends AbstractPlugin {
 
     private static String[] jvmlibs(ResourcePoolModule module) {
         String targetPlatform = module.targetPlatform();
-        Platform platform = Platform.parseTargetPlatform(targetPlatform);
+        Platform platform = Platform.parsePlatform(targetPlatform);
         switch (platform.os()) {
             case WINDOWS:
                 return new String[] { "jvm.dll" };

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ExcludeVMPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ExcludeVMPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -245,8 +245,9 @@ public final class ExcludeVMPlugin extends AbstractPlugin {
     }
 
     private static String[] jvmlibs(ResourcePoolModule module) {
-        Platform platform = Platform.getTargetPlatform(module);
-        switch (platform) {
+        String targetPlatform = module.targetPlatform();
+        Platform platform = Platform.parseTargetPlatform(targetPlatform);
+        switch (platform.os()) {
             case WINDOWS:
                 return new String[] { "jvm.dll" };
             case MACOS:

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/jlink.properties
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/jlink.properties
@@ -87,9 +87,6 @@ main.opt.ignore-signing-information=\
 \                                        signed modular JARs are not copied to\n\
 \                                        the runtime image.
 
-main.opt.generate-cds-archive=\
-\      --generate-cds-archive            Generate CDS archives (classes.jsa, classes_nocoops.jsa)
-
 main.opt.verbose=\
 \  -v, --verbose                         Enable verbose tracing
 

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/jlink.properties
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/jlink.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -86,6 +86,9 @@ main.opt.ignore-signing-information=\
 \                                        The signature related files of the\n\
 \                                        signed modular JARs are not copied to\n\
 \                                        the runtime image.
+
+main.opt.generate-cds-archive=\
+\      --generate-cds-archive            Generate CDS archives (classes.jsa, classes_nocoops.jsa)
 
 main.opt.verbose=\
 \  -v, --verbose                         Enable verbose tracing

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/plugins.properties
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/plugins.properties
@@ -137,15 +137,12 @@ exclude-jmod-section.usage=\
 \                            Specify a JMOD section to exclude.\n\
 \                            Where <section-name> is \"man\" or \"headers\".
 
-generate-cds-archive.argument=
 
 generate-cds-archive.description=\
-CDS plugin: generate cds archives (classes.jsa, classes_nocoops.jsa).\n\
-Applicable to JDK images built with the CDS feature.
+CDS plugin: generate cds archives if the runtime image supports CDS feature.\n\
 
 generate-cds-archive.usage=\
-\  --generate-cds-archive    Generate CDS archives (classes.jsa, classes_nocoops.jsa).\n\
-\                            Applicable to JDK images built with the CDS feature.
+\  --generate-cds-archive    Generate CDS archives if the runtime image supports CDS feature.
 
 generate-jli-classes.argument=@filename
 

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/plugins.properties
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/plugins.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -136,6 +136,16 @@ exclude-jmod-section.usage=\
 \  --exclude-jmod-section <section-name>\n\
 \                            Specify a JMOD section to exclude.\n\
 \                            Where <section-name> is \"man\" or \"headers\".
+
+generate-cds-archive.argument=
+
+generate-cds-archive.description=\
+CDS plugin: generate cds archives (classes.jsa, classes_nocoops.jsa).\n\
+Applicable to JDK images built with the CDS feature.
+
+generate-cds-archive.usage=\
+\  --generate-cds-archive    Generate CDS archives (classes.jsa, classes_nocoops.jsa).\n\
+\                            Applicable to JDK images built with the CDS feature.
 
 generate-jli-classes.argument=@filename
 

--- a/src/jdk.jlink/share/classes/module-info.java
+++ b/src/jdk.jlink/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,6 +76,7 @@ module jdk.jlink {
         jdk.tools.jlink.internal.plugins.AddOptionsPlugin,
         jdk.tools.jlink.internal.plugins.VendorBugURLPlugin,
         jdk.tools.jlink.internal.plugins.VendorVMBugURLPlugin,
-        jdk.tools.jlink.internal.plugins.VendorVersionPlugin;
+        jdk.tools.jlink.internal.plugins.VendorVersionPlugin,
+        jdk.tools.jlink.internal.plugins.CDSPlugin;
 
 }

--- a/test/jdk/tools/jlink/plugins/CDSPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/CDSPluginTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.File;
+
+import jdk.test.lib.JDKToolFinder;
+import jdk.test.lib.process.*;
+
+import tests.Helper;
+
+/* @test
+ * @bug 8264322
+ * @summary Test the --generate-cds-archive plugin
+ * @requires vm.cds
+ * @library ../../lib
+ * @library /test/lib
+ * @modules java.base/jdk.internal.jimage
+ *          jdk.jdeps/com.sun.tools.classfile
+ *          jdk.jlink/jdk.tools.jlink.internal
+ *          jdk.jlink/jdk.tools.jmod
+ *          jdk.jlink/jdk.tools.jimage
+ *          jdk.compiler
+ * @build tests.*
+ * @run main CDSPluginTest
+ */
+
+public class CDSPluginTest {
+
+    public static void main(String[] args) throws Throwable {
+
+        Helper helper = Helper.newHelper();
+        if (helper == null) {
+            System.err.println("Test not run");
+            return;
+        }
+
+        var module = "cds";
+        helper.generateDefaultJModule(module);
+        var image = helper.generateDefaultImage(new String[] { "--generate-cds-archive" },
+                                                module)
+            .assertSuccess();
+
+        String subDir;
+        String sep = File.separator;
+        String osName = System.getProperty("os.name");
+        if (System.getProperty("os.name").startsWith("Windows")) {
+            subDir = "bin" + sep;
+        } else {
+            subDir = "lib" + sep;
+        }
+        subDir += "server" + sep;
+        helper.checkImage(image, module, null, null,
+                          new String[] { subDir + "classes.jsa", subDir + "classes_nocoops.jsa" });
+
+       // Simulate different platforms between current runtime and target image.
+       if (osName.toLowerCase().startsWith("linux")) {
+           System.out.println("---- Test different platforms scenario ----");
+           String jlinkPath = JDKToolFinder.getJDKTool("jlink");
+           String[] cmd = {jlinkPath, "--add-modules", "java.base,java.logging",
+                           "-J-Dos.name=windows", "--generate-cds-archive",
+                           "--output", System.getProperty("test.classes") + sep + "module" + "-tmp"}; 
+           StringBuilder cmdLine = new StringBuilder();
+           for (String s : cmd) {
+               cmdLine.append(s).append(' ');
+           }
+           System.out.println("Command line: [" + cmdLine.toString() + "]");
+           ProcessBuilder pb = new ProcessBuilder(cmd);
+           OutputAnalyzer out = new OutputAnalyzer(pb.start());
+           System.out.println("    stdout: " + out.getStdout());
+           out.shouldMatch("Error: Cannot generate CDS archives: target image platform linux-.*is different from runtime platform windows-.*");
+           out.shouldHaveExitValue(1);
+       }
+    }
+
+}

--- a/test/jdk/tools/jlink/plugins/CDSPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/CDSPluginTest.java
@@ -78,7 +78,7 @@ public class CDSPluginTest {
            String jlinkPath = JDKToolFinder.getJDKTool("jlink");
            String[] cmd = {jlinkPath, "--add-modules", "java.base,java.logging",
                            "-J-Dos.name=windows", "--generate-cds-archive",
-                           "--output", System.getProperty("test.classes") + sep + "module" + "-tmp"}; 
+                           "--output", System.getProperty("test.classes") + sep + "module" + "-tmp"};
            StringBuilder cmdLine = new StringBuilder();
            for (String s : cmd) {
                cmdLine.append(s).append(' ');
@@ -91,5 +91,4 @@ public class CDSPluginTest {
            out.shouldHaveExitValue(1);
        }
     }
-
 }

--- a/test/jdk/tools/jlink/plugins/CDSPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/CDSPluginTest.java
@@ -24,6 +24,7 @@
 import java.io.File;
 
 import jdk.test.lib.JDKToolFinder;
+import jdk.test.lib.Platform;
 import jdk.test.lib.process.*;
 
 import tests.Helper;
@@ -62,8 +63,7 @@ public class CDSPluginTest {
 
         String subDir;
         String sep = File.separator;
-        String osName = System.getProperty("os.name");
-        if (System.getProperty("os.name").startsWith("Windows")) {
+        if (Platform.isWindows()) {
             subDir = "bin" + sep;
         } else {
             subDir = "lib" + sep;
@@ -73,12 +73,12 @@ public class CDSPluginTest {
                           new String[] { subDir + "classes.jsa", subDir + "classes_nocoops.jsa" });
 
        // Simulate different platforms between current runtime and target image.
-       if (osName.toLowerCase().startsWith("linux")) {
+       if (Platform.isLinux()) {
            System.out.println("---- Test different platforms scenario ----");
            String jlinkPath = JDKToolFinder.getJDKTool("jlink");
            String[] cmd = {jlinkPath, "--add-modules", "java.base,java.logging",
                            "-J-Dos.name=windows", "--generate-cds-archive",
-                           "--output", System.getProperty("test.classes") + sep + "module" + "-tmp"};
+                           "--output", System.getProperty("test.classes") + sep + module + "-tmp"};
            StringBuilder cmdLine = new StringBuilder();
            for (String s : cmd) {
                cmdLine.append(s).append(' ');


### PR DESCRIPTION
Please review this change for adding a `jlink` command line option `--generate-cds-archive` for generating CDS archives as a post processing step during the creation of a custom JDK image.

Details can be found in the corresponding CSR [JDK-8269178](https://bugs.openjdk.java.net/browse/JDK-8269178).

Testing:

- [x] tiers 1,2 (including the new test)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264322](https://bugs.openjdk.java.net/browse/JDK-8264322): Generate CDS archive when creating custom JDK image


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5174/head:pull/5174` \
`$ git checkout pull/5174`

Update a local copy of the PR: \
`$ git checkout pull/5174` \
`$ git pull https://git.openjdk.java.net/jdk pull/5174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5174`

View PR using the GUI difftool: \
`$ git pr show -t 5174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5174.diff">https://git.openjdk.java.net/jdk/pull/5174.diff</a>

</details>
