### PR TITLE
JDK-8272667: substandard error messages from the docs build

### DIFF
--- a/make/common/ProcessMarkdown.gmk
+++ b/make/common/ProcessMarkdown.gmk
@@ -103,7 +103,7 @@ define ProcessMarkdown
 	$$(call LogInfo, Post-processing markdown file $2)
 	$$(call MakeDir, $$(SUPPORT_OUTPUTDIR)/markdown $$($1_$2_TARGET_DIR))
 	$$(call ExecuteWithLog, $$(SUPPORT_OUTPUTDIR)/markdown/$$($1_$2_MARKER)_post, \
-	    ( $$($1_POST_PROCESS) < $$($1_$2_PANDOC_OUTPUT) > $$($1_$2_OUTPUT_FILE) ) )
+	    ( $$($1_POST_PROCESS) $$($1_$2_PANDOC_OUTPUT) > $$($1_$2_OUTPUT_FILE) ) )
   endif
 
   $1 += $$($1_$2_OUTPUT_FILE)


### PR DESCRIPTION
Please review a small (delete one character) change to improve the error messages reported when bad HTML is detected when post-processing the output from pandoc to generate the docs.

The change is just to pass the filename as an argument to the command, instead of just piping the input to stdin. As a result, the name of any file containing bad input is reported in the message, instead of the message simply referring to `<stdin>`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272667](https://bugs.openjdk.java.net/browse/JDK-8272667): substandard error messages from the docs build


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5175/head:pull/5175` \
`$ git checkout pull/5175`

Update a local copy of the PR: \
`$ git checkout pull/5175` \
`$ git pull https://git.openjdk.java.net/jdk pull/5175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5175`

View PR using the GUI difftool: \
`$ git pr show -t 5175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5175.diff">https://git.openjdk.java.net/jdk/pull/5175.diff</a>

</details>
