### PR TITLE
8271315: Redo: Nimbus JTree renderer properties persist across L&F changes

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/nimbus/NimbusIcon.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/nimbus/NimbusIcon.java
@@ -43,7 +43,7 @@ import java.awt.image.BufferedImage;
  * An icon that delegates to a painter.
  * @author rbair
  */
-class NimbusIcon implements SynthIcon {
+class NimbusIcon implements SynthIcon, UIResource {
     private int width;
     private int height;
     private String prefix;

--- a/src/java.desktop/share/classes/javax/swing/plaf/nimbus/skin.laf
+++ b/src/java.desktop/share/classes/javax/swing/plaf/nimbus/skin.laf
@@ -27352,10 +27352,10 @@
          <contentMargins top="0" bottom="0" left="0" right="0"/>
          <style>
             <textForeground>
-               <matte red="0" green="0" blue="0" alpha="0" uiDefaultParentName="text" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0" uiResource="false"/>
+               <matte red="0" green="0" blue="0" alpha="0" uiDefaultParentName="text" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0" uiResource="true"/>
             </textForeground>
             <textBackground>
-               <matte red="255" green="255" blue="255" alpha="255" uiDefaultParentName="nimbusLightBackground" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0" uiResource="false"/>
+               <matte red="255" green="255" blue="255" alpha="255" uiDefaultParentName="nimbusLightBackground" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0" uiResource="true"/>
             </textBackground>
             <background>
                <matte red="255" green="255" blue="255" alpha="255" uiDefaultParentName="nimbusLightBackground" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0"/>
@@ -27379,10 +27379,10 @@
                    <insets top="2" left="0" bottom="1" right="5"/>
                </uiProperty>
                <uiProperty name="selectionForeground" type="COLOR">
-                  <matte red="255" green="255" blue="255" alpha="255" uiDefaultParentName="nimbusSelectedText" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0" uiResource="false"/>
+                  <matte red="255" green="255" blue="255" alpha="255" uiDefaultParentName="nimbusSelectedText" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0" uiResource="true"/>
                </uiProperty>
                <uiProperty name="selectionBackground" type="COLOR">
-                  <matte red="57" green="105" blue="138" alpha="255" uiDefaultParentName="nimbusSelectionBackground" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0" uiResource="false"/>
+                  <matte red="57" green="105" blue="138" alpha="255" uiDefaultParentName="nimbusSelectionBackground" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0" uiResource="true"/>
                </uiProperty>
                <uiProperty name="dropLineColor" type="COLOR">
                   <matte red="242" green="242" blue="242" alpha="255" uiDefaultParentName="nimbusFocus" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0" alphaOffset="0"/>
@@ -27621,7 +27621,9 @@
                <stateTypes/>
                <contentMargins top="0" bottom="0" left="0" right="0"/>
                <style>
-                  <textForeground/>
+                  <textForeground>
+                    <matte red="255" green="255" blue="255" alpha="255" uiDefaultParentName="nimbusSelectedText" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0" uiResource="true"/>
+                  </textForeground>
                   <textBackground/>
                   <background/>
                   <uiproperties/>

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLabelUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthLabelUI.java
@@ -29,6 +29,7 @@ import javax.swing.*;
 import javax.swing.plaf.*;
 import javax.swing.plaf.basic.*;
 import javax.swing.text.View;
+import javax.swing.tree.DefaultTreeCellRenderer;
 import java.awt.Dimension;
 import java.awt.Rectangle;
 import java.awt.Insets;
@@ -207,8 +208,14 @@ public class SynthLabelUI extends BasicLabelUI implements SynthUI {
         Icon icon = (label.isEnabled()) ? label.getIcon() :
                                           label.getDisabledIcon();
 
-        g.setColor(context.getStyle().getColor(context,
-                                               ColorType.TEXT_FOREGROUND));
+        if (label instanceof DefaultTreeCellRenderer &&
+                label.getForeground() instanceof UIResource) {
+            g.setColor(label.getForeground());
+        } else {
+            g.setColor(context.getStyle().getColor(context,
+                    ColorType.TEXT_FOREGROUND));
+        }
+
         g.setFont(style.getFont(context));
         context.getStyle().getGraphicsUtils(context).paintText(
             context, g, label.getText(), icon,

--- a/test/jdk/javax/swing/plaf/nimbus/NimbusPropertiesDoNotImplUIResource.java
+++ b/test/jdk/javax/swing/plaf/nimbus/NimbusPropertiesDoNotImplUIResource.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+import javax.swing.plaf.UIResource;
+import javax.swing.plaf.nimbus.NimbusLookAndFeel;
+import java.awt.Color;
+
+/**
+ * @test
+ * @bug 8271315
+ * @summary  Nimbus JTree renderer properties persist across L&F changes
+ * @key headful
+ * @run main NimbusPropertiesDoNotImplUIResource
+ */
+
+public class NimbusPropertiesDoNotImplUIResource {
+    private static final String[] defPropertyKeys = new String[] {
+            "Tree.leafIcon", "Tree.closedIcon",
+            "Tree.openIcon", "Tree.selectionForeground",
+            "Tree.textForeground", "Tree.selectionBackground",
+            "Tree.textBackground", "Tree.selectionBorderColor"};
+
+    private static String failedKeys = null;
+
+    public static void main(String[] args) throws Exception {
+        UIManager.LookAndFeelInfo[] installedLookAndFeels;
+        installedLookAndFeels = UIManager.getInstalledLookAndFeels();
+
+        for (UIManager.LookAndFeelInfo LF : installedLookAndFeels) {
+            try {
+                UIManager.setLookAndFeel(LF.getClassName());
+                failedKeys = null;
+                for (String propertyKey : defPropertyKeys) {
+                    verifyProperty(propertyKey);
+                }
+                if(failedKeys != null) {
+                    throw new RuntimeException("JTree renderer Properties " +
+                            failedKeys + " are not instance of UIResource for "
+                            + LF.getClassName());
+                }
+            } catch(UnsupportedLookAndFeelException e) {
+                System.out.println("Note: LookAndFeel " + LF.getClassName()
+                        + " is not supported on this configuration");
+            }
+        }
+
+        //Check that the both uiResource option true and false are working for
+        //getDerivedColor method of NimbusLookAndFeel
+        UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
+        Color color1 = ((NimbusLookAndFeel)UIManager.getLookAndFeel())
+                .getDerivedColor("text", 0, 0, 0, 0, false);
+        if(color1 instanceof UIResource) {
+            throw new RuntimeException("color1 should not be instance of " +
+                    "UIResource");
+        }
+
+        Color color2 = ((NimbusLookAndFeel)UIManager.getLookAndFeel())
+                .getDerivedColor("text", 0, 0, 0, 0, true);
+        if(!(color2 instanceof UIResource)) {
+            throw new RuntimeException("color2 should be instance of " +
+                    "UIResource");
+        }
+
+    }
+
+    private static void verifyProperty(String propertyKey) {
+        Object property = UIManager.get(propertyKey);
+        if (property == null) {
+            return;
+        }
+        if (!(property instanceof UIResource)) {
+            if(failedKeys == null) {
+                failedKeys = ":" + propertyKey;
+            } else {
+                failedKeys += "," + propertyKey;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is another attempt of fixing JDK-8249674 which created a regression JDK-8266510 for which it was backed out.
This fix reinstates the UIResource properties  for "Tree.leafIcon", "Tree.closedIcon",  "Tree.openIcon", "Tree.selectionForeground",
 "Tree.textForeground", "Tree.selectionBackground", "Tree.textBackground", "Tree.selectionBorderColor" for NimbusLookAndFeel.

The regression which was "when a JTree node is selected, the text should be painted using the selected text color (white), matching the color of the expansion control. Instead, it is painted using the standard color (black)"  is also fixed by this fix, although I could not find any mention of this behaviour in the spec that selected text color should match the expanded icon color
but it's a long standing behaviour, so catered to it.
It was happening because SynthLabelUI#paint when it tries to paint textForeground for cell label, it calls
```
g.setColor(context.getStyle().getColor(context,
                    ColorType.TEXT_FOREGROUND));
```

which then calls SynthStyle#getColor where even though cell renderer correctly gets the foreground color, it gets overridden by getColorForState()  because the color is a UIResource and there's no corresponding color defined for that state for Tree.CellRenderer so it uses default "black" color for "text" as defined in skin.laf
```
else if (type == ColorType.TEXT_FOREGROUND) {
                color = c.getForeground();
            }
        }

        if (color == null || color instanceof UIResource) {
            // Then use what we've locally defined
            color = getColorForState(context, type);
        }
```

Proposed fix is to check if current foregroundColor for DefaultTreeCellRenderer is UIResouce, then use that color itself.