### PR TITLE
8276779: (ch) InputStream returned by Channels.newInputStream should have fast path for SelectableChannels

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/Channels.java
+++ b/src/java.base/share/classes/java/nio/channels/Channels.java
@@ -69,9 +69,12 @@ public final class Channels {
     /**
      * Constructs a stream that reads bytes from the given channel.
      *
-     * <p> The {@code read} methods of the resulting stream will throw an
-     * {@link IllegalBlockingModeException} if invoked while the underlying
-     * channel is in non-blocking mode.  The stream will not be buffered, and
+     * <p> The {@code read} and {@code transferTo} methods of the resulting stream
+     * will throw an {@link IllegalBlockingModeException} if invoked while the
+     * underlying channel is in non-blocking mode. The {@code transferTo} method
+     * will also throw an {@code IllegalBlockingModeException} if invoked to
+     * transfer bytes to an output stream that writes to an underlying channel in
+     * non-blocking mode.  The stream will not be buffered, and
      * it will not support the {@link InputStream#mark mark} or {@link
      * InputStream#reset reset} methods.  The stream will be safe for access by
      * multiple concurrent threads.  Closing the stream will in turn cause the

--- a/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
@@ -34,6 +34,7 @@ import java.nio.channels.IllegalBlockingModeException;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.channels.SelectableChannel;
+import java.nio.channels.WritableByteChannel;
 import java.util.Arrays;
 import java.util.Objects;
 import jdk.internal.util.ArraysSupport;
@@ -238,15 +239,28 @@ public class ChannelInputStream
         Objects.requireNonNull(out, "out");
 
         if (out instanceof ChannelOutputStream cos
-                && ch instanceof FileChannel fc
-                && cos.channel() instanceof FileChannel dst) {
-            return transfer(fc, dst);
+                && ch instanceof FileChannel fc) {
+            WritableByteChannel wbc = cos.channel();
+
+            if (wbc instanceof FileChannel dst) {
+                return transfer(fc, dst);
+            }
+
+            if (wbc instanceof SelectableChannel sc) {
+                synchronized (sc.blockingLock()) {
+                    if (!sc.isBlocking())
+                        throw new IllegalBlockingModeException();
+                    return transfer(fc, wbc);
+                }
+            }
+
+            return transfer(fc, wbc);
         }
 
         return super.transferTo(out);
     }
 
-    private static long transfer(FileChannel src, FileChannel dst) throws IOException {
+    private static long transfer(FileChannel src, WritableByteChannel dst) throws IOException {
         long initialPos = src.position();
         long pos = initialPos;
         try {

--- a/test/jdk/java/nio/channels/Channels/TransferTo.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo.java
@@ -78,6 +78,8 @@ public class TransferTo {
 
     private static final Random RND = RandomFactory.getRandom();
 
+    private static final Path CWD = Path.of(".");
+
     /*
      * Provides test scenarios, i. e. combinations of input and output streams to be tested.
      */
@@ -191,7 +193,7 @@ public class TransferTo {
         Pipe pipe = Pipe.open();
         try {
             // testing arbitrary input (here: empty file) to non-blocking selectable output
-            try (FileChannel fc = FileChannel.open(Files.createTempFile(null, null));
+            try (FileChannel fc = FileChannel.open(Files.createTempFile(CWD, "testIllegalBlockingMode", null));
                     InputStream is = Channels.newInputStream(fc);
                     SelectableChannel sc = pipe.sink().configureBlocking(false);
                     OutputStream os = Channels.newOutputStream((WritableByteChannel) sc)) {

--- a/test/jdk/java/nio/channels/Channels/TransferTo.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo.java
@@ -214,7 +214,7 @@ public class TransferTo {
             pipe.source().close();
             pipe.sink().close();
         }
-}
+    }
 
     /*
      * Asserts that the transferred content is correct, i. e. compares the actually transferred bytes

--- a/test/jdk/java/nio/channels/Channels/TransferTo.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo.java
@@ -188,22 +188,24 @@ public class TransferTo {
      */
     @Test
     public void testIllegalBlockingMode() throws IOException {
-        // preparing empty file input and non-blocking selectable output
-        FileChannel fc = FileChannel.open(Files.createTempFile(null, null));
-        InputStream is1 = Channels.newInputStream(fc);
-        SelectableChannel sc = Pipe.open().sink().configureBlocking(false);
-        OutputStream os1 = Channels.newOutputStream((WritableByteChannel) sc);
+        // testing arbitrary input (here: empty file) to non-blocking selectable output
+        try (FileChannel fc = FileChannel.open(Files.createTempFile(null, null));
+                InputStream is = Channels.newInputStream(fc);
+                SelectableChannel sc = Pipe.open().sink().configureBlocking(false);
+                OutputStream os = Channels.newOutputStream((WritableByteChannel) sc)) {
 
-        // IllegalBlockingMode must be thrown when trying to perform a transfer
-        assertThrows(IllegalBlockingModeException.class, () -> is1.transferTo(os1));
+            // IllegalBlockingMode must be thrown when trying to perform a transfer
+            assertThrows(IllegalBlockingModeException.class, () -> is.transferTo(os));
+        }
 
-        // preparing non-blocking selectable input and some arbitrary output
-        sc = Pipe.open().source().configureBlocking(false);
-        InputStream is2 = Channels.newInputStream((ReadableByteChannel) sc);
-        OutputStream os2 = new ByteArrayOutputStream();
+        // testing non-blocking selectable input to arbitrary output (here: byte array)
+        try (SelectableChannel sc = Pipe.open().source().configureBlocking(false);
+                InputStream is = Channels.newInputStream((ReadableByteChannel) sc);
+                OutputStream os = new ByteArrayOutputStream()) {
 
-        // IllegalBlockingMode must be thrown when trying to perform a transfer
-        assertThrows(IllegalBlockingModeException.class, () -> is2.transferTo(os2));
+            // IllegalBlockingMode must be thrown when trying to perform a transfer
+            assertThrows(IllegalBlockingModeException.class, () -> is.transferTo(os));
+        }
     }
 
     /*

--- a/test/jdk/java/nio/channels/Channels/TransferTo.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo.java
@@ -154,10 +154,10 @@ public class TransferTo {
      */
     @Test
     public void testMoreThanTwoGB() throws IOException {
-        Path sourceFile = Files.createTempFile("test2GBSource", null);
+        Path sourceFile = Files.createTempFile(CWD, "test2GBSource", null);
         try {
             // preparing two temporary files which will be compared at the end of the test
-            Path targetFile = Files.createTempFile("test2GBtarget", null);
+            Path targetFile = Files.createTempFile(CWD, "test2GBtarget", null);
             try {
                 // writing 3 GB of random bytes into source file
                 for (int i = 0; i < NUM_WRITES; i++)
@@ -289,7 +289,7 @@ public class TransferTo {
         return new InputStreamProvider() {
             @Override
             public InputStream input(byte... bytes) throws Exception {
-                Path path = Files.createTempFile(null, null);
+                Path path = Files.createTempFile(CWD, "fileChannelInput", null);
                 Files.write(path, bytes);
                 FileChannel fileChannel = FileChannel.open(path);
                 return Channels.newInputStream(fileChannel);
@@ -315,7 +315,7 @@ public class TransferTo {
     private static OutputStreamProvider fileChannelOutput() {
         return new OutputStreamProvider() {
             public OutputStream output(Consumer<Supplier<byte[]>> spy) throws Exception {
-                Path path = Files.createTempFile(null, null);
+                Path path = Files.createTempFile(CWD, "fileChannelOutput", null);
                 FileChannel fileChannel = FileChannel.open(path, StandardOpenOption.WRITE);
                 spy.accept(() -> {
                     try {


### PR DESCRIPTION
As proposed in JDK-8265891, this PR provides an implementation for `Channels.newInputStream().transferTo()` which provide superior performance compared to the current implementation. This PR is a spin-off from https://github.com/openjdk/jdk/pull/4263 and deliberately concentrates **only** on `FileChannel`s. Other types of channels will be discussed in future PRs.

* Prevents transfers through the JVM heap as much as possibly by offloading to deeper levels via NIO, hence allowing the operating system to optimize the transfer.

Using JMH I have benchmarked both, the original implementation and this implementation, and (depending on the used hardware and use case) performance change was approx. doubled performance. A rather similar approach in different use casse was recently implemented by https://github.com/openjdk/jdk/pull/5097 which was reported by even provide 5x performance (https://github.com/openjdk/jdk/pull/5097#issuecomment-897271997).

**Update:** This sub-issue *only* defines the work to be done to implement JDK-8265891 *solely* for the particular case of FileChannel.transferTo(WriteableByteChannel), including special treatment of SelectableByteChannel, as the `master` branch already contains code to handle the specific case of FileChannel.transferTo(FileChannel).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8276779](https://bugs.openjdk.java.net/browse/JDK-8276779): (ch) InputStream returned by Channels.newInputStream should have fast path for SelectableChannels
 * [JDK-8276968](https://bugs.openjdk.java.net/browse/JDK-8276968): (ch) InputStream returned by Channels.newInputStream should have fast path for SelectableChannels (**CSR**)


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to 50044c82630882d7f21c11140ebded25b5762ecb


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5179/head:pull/5179` \
`$ git checkout pull/5179`

Update a local copy of the PR: \
`$ git checkout pull/5179` \
`$ git pull https://git.openjdk.java.net/jdk pull/5179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5179`

View PR using the GUI difftool: \
`$ git pr show -t 5179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5179.diff">https://git.openjdk.java.net/jdk/pull/5179.diff</a>

</details>
