### PR TITLE
8272700: [macos] Build failure with Xcode 13.0 after JDK-8264848

### DIFF
--- a/make/autoconf/flags-other.m4
+++ b/make/autoconf/flags-other.m4
@@ -89,11 +89,11 @@ AC_DEFUN([FLAGS_SETUP_ASFLAGS],
 
     # Fix linker warning.
     # Code taken from make/autoconf/flags-cflags.m4 and adapted.
-    JVM_BASIC_ASFLAGS+="-DMAC_OS_X_VERSION_MIN_REQUIRED=$MACOSX_VERSION_MIN_NODOTS \
+    JVM_BASIC_ASFLAGS+=" -DMAC_OS_X_VERSION_MIN_REQUIRED=$MACOSX_VERSION_MIN_NODOTS \
         -mmacosx-version-min=$MACOSX_VERSION_MIN"
 
     if test -n "$MACOSX_VERSION_MAX"; then
-        JVM_BASIC_ASFLAGS+="$OS_CFLAGS \
+        JVM_BASIC_ASFLAGS+=" $OS_CFLAGS \
             -DMAC_OS_X_VERSION_MAX_ALLOWED=$MACOSX_VERSION_MAX_NODOTS"
     fi
   fi


### PR DESCRIPTION
Hi all,

May I get reviews for this small change?

The failure is caused by incorrect flag `-mstack-alignment=16-DMAC_OS_X_VERSION_MIN_REQUIRED=10120`.

The following command works fine with Xcode 12.0 but fails with Xcode 13.0.
```
clang++ -mstack-alignment=16-DMAC_OS_X_VERSION_MIN_REQUIRED=10120 a.cpp
```

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272700](https://bugs.openjdk.java.net/browse/JDK-8272700): [macos] Build failure with Xcode 13.0 after JDK-8264848


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5180/head:pull/5180` \
`$ git checkout pull/5180`

Update a local copy of the PR: \
`$ git checkout pull/5180` \
`$ git pull https://git.openjdk.java.net/jdk pull/5180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5180`

View PR using the GUI difftool: \
`$ git pr show -t 5180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5180.diff">https://git.openjdk.java.net/jdk/pull/5180.diff</a>

</details>
