### PR TITLE
8272720: Fix the implementation of loop unrolling heuristic with LoopPercentProfileLimit

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -905,7 +905,7 @@ bool IdealLoopTree::policy_unroll(PhaseIdealLoop *phase) {
   //   Progress defined as current size less than 20% larger than previous size.
   if (UseSuperWord && cl->node_count_before_unroll() > 0 &&
       future_unroll_cnt > LoopUnrollMin &&
-      (future_unroll_cnt - 1) * (100 / LoopPercentProfileLimit) > cl->profile_trip_cnt() &&
+      (future_unroll_cnt - 1) * (100.0 / LoopPercentProfileLimit) > cl->profile_trip_cnt() &&
       1.2 * cl->node_count_before_unroll() < (double)_body.size()) {
     return false;
   }


### PR DESCRIPTION
Hi all,

I'd like to fix the implementation of loop unrolling heuristic with `LoopPercentProfileLimit`.

The range of `LoopPercentProfileLimit` was designed as [10, 100] [1].
But in fact there is no difference when `LoopPercentProfileLimit > 50` for the current implementation.

This is because integer div `100 / LoopPercentProfileLimit` [2] will always return 1 when `LoopPercentProfileLimit > 50`.
It would be better to fix it.

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/c2_globals.hpp#L179
[2] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/loopTransform.cpp#L908

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272720](https://bugs.openjdk.java.net/browse/JDK-8272720): Fix the implementation of loop unrolling heuristic with LoopPercentProfileLimit


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Rickard Bäckman](https://openjdk.java.net/census#rbackman) (@rickard - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5183/head:pull/5183` \
`$ git checkout pull/5183`

Update a local copy of the PR: \
`$ git checkout pull/5183` \
`$ git pull https://git.openjdk.java.net/jdk pull/5183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5183`

View PR using the GUI difftool: \
`$ git pr show -t 5183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5183.diff">https://git.openjdk.java.net/jdk/pull/5183.diff</a>

</details>
