### PR TITLE
8258951: java/net/httpclient/HandshakeFailureTest.java failed with "RuntimeException: Not found expected SSLHandshakeException in java.io.IOException"

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -468,12 +468,11 @@ class Http2Connection  {
             CompletableFuture<Void> cf = new MinimalFuture<>();
             SSLEngine engine = aconn.getEngine();
             String engineAlpn = engine.getApplicationProtocol();
-            assert alpn == null || Objects.equals(alpn, engineAlpn)
-                    : "alpn: %s, engine: %s".formatted(alpn, engineAlpn);
+            DEBUG_LOGGER.log("checkSSLConfig: alpn: '%s', engine: '%s'", alpn, engineAlpn);
             if (alpn == null && engineAlpn != null) {
                 alpn = engineAlpn;
             }
-            DEBUG_LOGGER.log("checkSSLConfig: alpn: %s", alpn );
+            DEBUG_LOGGER.log("checkSSLConfig: alpn: '%s'", alpn );
 
             if (alpn == null || !alpn.equals("h2")) {
                 String msg;
@@ -496,6 +495,8 @@ class Http2Connection  {
                 cf.completeExceptionally(new ALPNException(msg, aconn));
                 return cf;
             }
+            assert Objects.equals(alpn, engineAlpn)
+                    : "alpn: %s, engine: %s".formatted(alpn, engineAlpn);
             cf.complete(null);
             return cf;
         };

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -468,9 +468,11 @@ class Http2Connection  {
             CompletableFuture<Void> cf = new MinimalFuture<>();
             SSLEngine engine = aconn.getEngine();
             String engineAlpn = engine.getApplicationProtocol();
-            assert Objects.equals(alpn, engineAlpn)
+            assert alpn == null || Objects.equals(alpn, engineAlpn)
                     : "alpn: %s, engine: %s".formatted(alpn, engineAlpn);
-
+            if (alpn == null && engineAlpn != null) {
+                alpn = engineAlpn;
+            }
             DEBUG_LOGGER.log("checkSSLConfig: alpn: %s", alpn );
 
             if (alpn == null || !alpn.equals("h2")) {

--- a/test/jdk/java/net/httpclient/HandshakeFailureTest.java
+++ b/test/jdk/java/net/httpclient/HandshakeFailureTest.java
@@ -49,7 +49,7 @@ import javax.net.ssl.SSLSocket;
 
 /**
  * @test
- * @bug 8238990
+ * @bug 8238990 8258951
  * @run main/othervm -Djdk.internal.httpclient.debug=true HandshakeFailureTest TLSv1.2
  * @run main/othervm -Djdk.internal.httpclient.debug=true HandshakeFailureTest TLSv1.3
  * @summary Verify SSLHandshakeException is received when the handshake fails,


### PR DESCRIPTION
Please find here a patch that fixes intermittent failures in HandshakeFailureTest.java. The test expects an SSLException but finds an AssertionError instead. The AssertionError was too strong and was fired before the Http2Connection had a chance to raise the proper ALPNException.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258951](https://bugs.openjdk.java.net/browse/JDK-8258951): java/net/httpclient/HandshakeFailureTest.java failed with "RuntimeException: Not found expected SSLHandshakeException in java.io.IOException"


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5184/head:pull/5184` \
`$ git checkout pull/5184`

Update a local copy of the PR: \
`$ git checkout pull/5184` \
`$ git pull https://git.openjdk.java.net/jdk pull/5184/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5184`

View PR using the GUI difftool: \
`$ git pr show -t 5184`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5184.diff">https://git.openjdk.java.net/jdk/pull/5184.diff</a>

</details>
