### PR TITLE
8271954: C2: assert(false) failed: Bad graph detected in build_loop_late

### DIFF
--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -222,6 +222,7 @@ ProjNode* PhaseIdealLoop::create_new_if_for_predicate(ProjNode* cont_proj, Node*
       Node* data = uncommon_proj->fast_out(j);
       if (!data->is_CFG()) {
         _igvn.replace_input_of(data, 0, if_uct);
+        set_ctrl(data, if_uct);
         --j;
         --jmax;
       }

--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -243,7 +243,7 @@ ProjNode* PhaseIdealLoop::create_new_if_for_predicate(ProjNode* cont_proj, Node*
 Node* PhaseIdealLoop::clone_data_nodes_for_fast_loop(Node* phi_input, ProjNode* uncommon_proj, Node* if_uct, Node_List* old_new) {
   // Step 1: Clone all nodes on the data chain but do not rewire anything, yet. Keep track of the cloned nodes
   // by using the old_new mapping. This mapping is then used in step 2 to rewire the cloned nodes accordingly.
-  uint last_idx = C->unique();
+  DEBUG_ONLY(uint last_idx = C->unique();)
   Unique_Node_List list;
   list.push(phi_input);
   for (uint j = 0; j < list.size(); j++) {
@@ -277,7 +277,8 @@ Node* PhaseIdealLoop::clone_data_nodes_for_fast_loop(Node* phi_input, ProjNode* 
       if (!in->is_Phi()) {
         assert(!in->is_CFG(), "must be data node");
         Node* in_clone = old_new->at(in->_idx);
-        if (in_clone != NULL && in_clone->_idx >= last_idx) {
+        if (in_clone != NULL) {
+          assert(in_clone->_idx >= last_idx, "must be a valid clone");
           _igvn.replace_input_of(clone, k, in_clone);
           set_ctrl(clone, if_uct);
         }

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1275,10 +1275,17 @@ public:
   // Return true if exp is a scaled induction var plus (or minus) constant
   bool is_scaled_iv_plus_offset(Node* exp, Node* iv, int* p_scale, Node** p_offset, int depth = 0);
 
+  // Enum to determine the action to be performed in create_new_if_for_predicate() when processing phis of UCT regions.
+  enum class UnswitchingAction {
+    None,            // No special action.
+    FastLoopCloning, // Need to clone nodes for the fast loop.
+    SlowLoopRewiring // Need to rewire nodes for the slow loop.
+  };
+
   // Create a new if above the uncommon_trap_if_pattern for the predicate to be promoted
   ProjNode* create_new_if_for_predicate(ProjNode* cont_proj, Node* new_entry, Deoptimization::DeoptReason reason,
-                                        int opcode, bool if_cont_is_true_proj = true, bool unswitch_is_slow_loop = false,
-                                        Node_List* old_new = NULL);
+                                        int opcode, bool if_cont_is_true_proj = true, Node_List* old_new = NULL,
+                                        UnswitchingAction unswitching_action = UnswitchingAction::None);
 
   // Clone data nodes for the fast loop while creating a new If with create_new_if_for_predicate.
   Node* clone_data_nodes_for_fast_loop(Node* phi_input, ProjNode* uncommon_proj, Node* if_uct, Node_List* old_new);

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1277,7 +1277,11 @@ public:
 
   // Create a new if above the uncommon_trap_if_pattern for the predicate to be promoted
   ProjNode* create_new_if_for_predicate(ProjNode* cont_proj, Node* new_entry, Deoptimization::DeoptReason reason,
-                                        int opcode, bool if_cont_is_true_proj = true);
+                                        int opcode, bool if_cont_is_true_proj = true, bool unswitch_is_slow_loop = false,
+                                        Node_List* old_new = NULL);
+
+  // Clone data nodes for the fast loop while creating a new If with create_new_if_for_predicate.
+  Node* clone_data_nodes_for_fast_loop(Node* phi_input, ProjNode* uncommon_proj, Node* if_uct, Node_List* old_new);
 
   void register_control(Node* n, IdealLoopTree *loop, Node* pred, bool update_body = true);
 
@@ -1563,13 +1567,14 @@ private:
   }
 
   // Clone loop predicates to slow and fast loop when unswitching a loop
-  void clone_predicates_to_unswitched_loop(IdealLoopTree* loop, const Node_List& old_new, ProjNode*& iffast_pred, ProjNode*& ifslow_pred);
-  ProjNode* clone_predicate_to_unswitched_loop(ProjNode* predicate_proj, Node* new_entry, Deoptimization::DeoptReason reason);
+  void clone_predicates_to_unswitched_loop(IdealLoopTree* loop, Node_List& old_new, ProjNode*& iffast_pred, ProjNode*& ifslow_pred);
+  ProjNode* clone_predicate_to_unswitched_loop(ProjNode* predicate_proj, Node* new_entry, Deoptimization::DeoptReason reason,
+                                               Node_List* old_new = NULL);
   void clone_skeleton_predicates_to_unswitched_loop(IdealLoopTree* loop, const Node_List& old_new, Deoptimization::DeoptReason reason,
                                                     ProjNode* old_predicate_proj, ProjNode* iffast_pred, ProjNode* ifslow_pred);
   ProjNode* clone_skeleton_predicate_for_unswitched_loops(Node* iff, ProjNode* predicate, Node* uncommon_proj, Deoptimization::DeoptReason reason,
                                                           ProjNode* output_proj, IdealLoopTree* loop);
-  void check_created_predicate_for_unswitching(const Node* new_entry) const PRODUCT_RETURN;
+  static void check_created_predicate_for_unswitching(const Node* new_entry) PRODUCT_RETURN;
 
   bool _created_loop_node;
 #ifdef ASSERT

--- a/test/hotspot/jtreg/compiler/loopopts/TestUnswitchWithSunkNodes.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestUnswitchWithSunkNodes.java
@@ -28,14 +28,14 @@
  * @summary A pinned Cast node on the UCT projection of a predicate is as input for the UCT phi node for the original
  *          loop, the fast and slow loop resulting in a dominance failure. These data nodes need to be updated while
  *          unswitching a loop.
- * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileCommand=compileonly,compiler.loopopts.TestUnswitchWithSunkNodes::*
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileCommand=compileonly,compiler.loopopts.TestUnswitchWithSunkNodes::test*
  *                   compiler.loopopts.TestUnswitchWithSunkNodes
  */
 
 package compiler.loopopts;
 
 public class TestUnswitchWithSunkNodes {
-    static int iFld, iFld2, iFld3 = 4, iFld4;
+    static int iFld, iFld2, iFld3 = 1, iFld4 = 1;
     static long instanceCount;
     static double dFld;
     static boolean bFld;
@@ -46,10 +46,15 @@ public class TestUnswitchWithSunkNodes {
     }
 
     public static void main(String[] strArr) {
+        // The testcases with Divisions have additional control inputs which need to be taken care of
         testNoDiamond();
+        testNoDiamondDiv();
         testWithDiamond();
+        testWithDiamondDiv1();
+        testWithDiamondDiv2();
         testWithDiamondOneLongOneShortPath();
         testWithDiamondComplex();
+        testWithDiamondComplexDiv();
     }
 
     static void testNoDiamond() {
@@ -72,7 +77,37 @@ public class TestUnswitchWithSunkNodes {
                         }
                     }
                     for (i24 = 1; 2 > i24; i24++) {
-                        switch (((i))) {
+                        switch (i) {
+                            case 88:
+                                i26 += (i24);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    static void testNoDiamondDiv() {
+        int i, i2 = 10, i21, i22, i24, i26 = 41724, iArr2[] = new int[10];
+        double d;
+        float f2;
+        init(iArr2);
+        i = 1;
+        while (++i < 219) {
+            for (d = 15; 305 > d; ++d) {
+                if (bFld) {
+                    instanceCount = i2;
+                    i2 = (((i2 + 3) + iFld2) + iFld3) / iFld4;
+                }
+                for (f2 = 5; 87 > f2; ++f2) {
+                    i2 = (int) instanceCount;
+                    for (i22 = 1; 2 > i22; i22++) {
+                        if (bFld) {
+                            iArr2[1] += 190L;
+                        }
+                    }
+                    for (i24 = 1; 2 > i24; i24++) {
+                        switch (i) {
                             case 88:
                                 i26 += (i24);
                         }
@@ -103,7 +138,67 @@ public class TestUnswitchWithSunkNodes {
                         }
                     }
                     for (i24 = 1; 2 > i24; i24++) {
-                        switch (((i))) {
+                        switch (i) {
+                            case 88:
+                                i26 += (i24);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    static void testWithDiamondDiv1() {
+        int i, i2 = 10, i21, i22, i24, i26 = 41724, iArr2[] = new int[10];
+        double d;
+        float f2;
+        init(iArr2);
+        i = 1;
+        while (++i < 219) {
+            for (d = 15; 305 > d; ++d) {
+                if (bFld) {
+                    i2 = (i2 / iFld4) - (i2 / iFld3);
+                }
+                for (f2 = 5; 87 > f2; ++f2) {
+                    i2 = (int) instanceCount;
+                    for (i22 = 1; 2 > i22; i22++) {
+                        if (bFld) {
+                            iArr2[1] += 190L;
+                        }
+                    }
+                    for (i24 = 1; 2 > i24; i24++) {
+                        switch (i) {
+                            case 88:
+                                i26 += (i24);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    static void testWithDiamondDiv2() {
+        int i, i2 = 10, i21, i22, i24, i26 = 41724, iArr2[] = new int[10];
+        double d;
+        float f2;
+        init(iArr2);
+        i = 1;
+        while (++i < 219) {
+            for (d = 15; 305 > d; ++d) {
+                if (bFld) {
+                    instanceCount = i2;
+                    int i3 = (int)d;
+                    i2 = (i3 / iFld4) - (i3 / iFld3);
+                }
+                for (f2 = 5; 87 > f2; ++f2) {
+                    i2 = (int) instanceCount;
+                    for (i22 = 1; 2 > i22; i22++) {
+                        if (bFld) {
+                            iArr2[1] += 190L;
+                        }
+                    }
+                    for (i24 = 1; 2 > i24; i24++) {
+                        switch (i) {
                             case 88:
                                 i26 += (i24);
                         }
@@ -134,7 +229,7 @@ public class TestUnswitchWithSunkNodes {
                         }
                     }
                     for (i24 = 1; 2 > i24; i24++) {
-                        switch (((i))) {
+                        switch (i) {
                             case 88:
                                 i26 += (i24);
                         }
@@ -178,7 +273,41 @@ public class TestUnswitchWithSunkNodes {
                         }
                     }
                     for (i24 = 1; 2 > i24; i24++) {
-                        switch (((i))) {
+                        switch (i) {
+                            case 88:
+                                i26 += (i24);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    static void testWithDiamondComplexDiv() {
+        int i, i2 = 10, i21, i22, i24, i26 = 41724, iArr2[] = new int[10];
+        double d;
+        float f2;
+        init(iArr2);
+        i = 1;
+        while (++i < 219) {
+            for (d = 15; 305 > d; ++d) {
+                if (bFld) {
+                    instanceCount = i2;
+                    int i3 = (int)d;
+                    i2 = (i3 / iFld4) - (i3 / iFld3);
+                    double d1 = (double) i2;
+                    i3 = (int)((d1 + iFld4) - (d1 + iFld));
+                    i2 = (i3 / iFld4) - (i3 / iFld3);
+                }
+                for (f2 = 5; 87 > f2; ++f2) {
+                    i2 = (int) instanceCount;
+                    for (i22 = 1; 2 > i22; i22++) {
+                        if (bFld) {
+                            iArr2[1] += 190L;
+                        }
+                    }
+                    for (i24 = 1; 2 > i24; i24++) {
+                        switch (i) {
                             case 88:
                                 i26 += (i24);
                         }

--- a/test/hotspot/jtreg/compiler/loopopts/TestUnswitchWithSunkNodes.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestUnswitchWithSunkNodes.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8271954
+ * @requires vm.compiler2.enabled
+ * @summary A pinned Cast node on the UCT projection of a predicate is as input for the UCT phi node for the original
+ *          loop, the fast and slow loop resulting in a dominance failure. These data nodes need to be updated while
+ *          unswitching a loop.
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileCommand=compileonly,compiler.loopopts.TestUnswitchWithSunkNodes::*
+ *                   compiler.loopopts.TestUnswitchWithSunkNodes
+ */
+
+package compiler.loopopts;
+
+public class TestUnswitchWithSunkNodes {
+    static int iFld, iFld2, iFld3 = 4, iFld4;
+    static long instanceCount;
+    static double dFld;
+    static boolean bFld;
+    static int iArrFld[] = new int[10];
+
+    static {
+        init(iArrFld);
+    }
+
+    public static void main(String[] strArr) {
+        testNoDiamond();
+        testWithDiamond();
+        testWithDiamondOneLongOneShortPath();
+        testWithDiamondComplex();
+    }
+
+    static void testNoDiamond() {
+        int i, i2 = 10, i21, i22, i24, i26 = 41724, iArr2[] = new int[10];
+        double d;
+        float f2;
+        init(iArr2);
+        i = 1;
+        while (++i < 219) {
+            for (d = 15; 305 > d; ++d) {
+                if (bFld) {
+                    instanceCount = i2;
+                    i2 = (((i2 + 3) + iFld2) + iFld3) - iFld4;
+                }
+                for (f2 = 5; 87 > f2; ++f2) {
+                    i2 = (int) instanceCount;
+                    for (i22 = 1; 2 > i22; i22++) {
+                        if (bFld) {
+                            iArr2[1] += 190L;
+                        }
+                    }
+                    for (i24 = 1; 2 > i24; i24++) {
+                        switch (((i))) {
+                            case 88:
+                                i26 += (i24);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    static void testWithDiamond() {
+        int i, i2 = 10, i21, i22, i24, i26 = 41724, iArr2[] = new int[10];
+        double d;
+        float f2;
+        init(iArr2);
+        i = 1;
+        while (++i < 219) {
+            for (d = 15; 305 > d; ++d) {
+                if (bFld) {
+                    instanceCount = i2;
+                    double d1 = (double) i2;
+                    i2 = (int)((d1 + iFld4) - (d1 + iFld));
+                }
+                for (f2 = 5; 87 > f2; ++f2) {
+                    i2 = (int) instanceCount;
+                    for (i22 = 1; 2 > i22; i22++) {
+                        if (bFld) {
+                            iArr2[1] += 190L;
+                        }
+                    }
+                    for (i24 = 1; 2 > i24; i24++) {
+                        switch (((i))) {
+                            case 88:
+                                i26 += (i24);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    static void testWithDiamondOneLongOneShortPath() {
+        int i, i2 = 10, i21, i22, i24, i26 = 41724, iArr2[] = new int[10];
+        double d;
+        float f2;
+        init(iArr2);
+        i = 1;
+        while (++i < 219) {
+            for (d = 15; 305 > d; ++d) {
+                if (bFld) {
+                    instanceCount = i2;
+                    double d1 = (double)i2;
+                    i2 = (int)((d1 + 3 + iFld2 + iFld3 + iFld4) - (d1 + iFld));
+                }
+                for (f2 = 5; 87 > f2; ++f2) {
+                    i2 = (int) instanceCount;
+                    for (i22 = 1; 2 > i22; i22++) {
+                        if (bFld) {
+                            iArr2[1] += 190L;
+                        }
+                    }
+                    for (i24 = 1; 2 > i24; i24++) {
+                        switch (((i))) {
+                            case 88:
+                                i26 += (i24);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    static void testWithDiamondComplex() {
+        int i, i2 = 10, i21, i22, i24, i26 = 41724, iArr2[] = new int[10];
+        double d;
+        float f2;
+        init(iArr2);
+        i = 1;
+        while (++i < 219) {
+            for (d = 15; 305 > d; ++d) {
+                if (bFld) {
+                    instanceCount = i2;
+                    i2 += 4;
+                    float l = (float)i2;
+                    i2 = (int)((l + 3) - (l + iFld));
+                    double d1 = (double)i2;
+                    i2 = (int)((d1 + 3) - (d1 + iFld) - (d1 * iFld2));
+                    i2 = (int)((l + 3) - (l + iFld) - (l * iFld2) + (d1 - iFld2) + (d1 / iFld3));
+                    d1 = (double)i2;
+                    i2 = (int)((d1 + 3) - (d1 + iFld) - (d1 * iFld2) + (d1 - iFld2) + (d1 / iFld3));
+                    i2 += dFld;
+                    l = (float)i2;
+                    i2 = (int)((l + 3) - (l + iFld) - (l * iFld2) + (d1 - iFld2) + (d1 / iFld3) - (d1 + iFld) - (d1 * iFld2) + (d1 - iFld2) + (d1 / iFld3));
+                    d1 = (double)i2;
+                    i2 = (int)((d1 + 3) - (d1 + iFld) - (d1 * iFld2) + (d1 - iFld2) + (d1 / iFld3) + (d1 + 3) - (d1 + iFld) - (d1 * iFld2) + (d1 - iFld2) + (d1 / iFld3));
+                    d1 = (double) i2;
+                    i2 = (int) ((d1 + 3 + iFld2 + iFld3 + iFld4) - (d1 + iFld));
+                }
+                for (f2 = 5; 87 > f2; ++f2) {
+                    i2 = (int) instanceCount;
+                    for (i22 = 1; 2 > i22; i22++) {
+                        if (bFld) {
+                            iArr2[1] += 190L;
+                        }
+                    }
+                    for (i24 = 1; 2 > i24; i24++) {
+                        switch (((i))) {
+                            case 88:
+                                i26 += (i24);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public static void init(int[] a) {
+        for (int j = 0; j < a.length; j++) {
+            a[j] = j;
+        }
+    }
+}


### PR DESCRIPTION
Since [JDK-8252372](https://bugs.openjdk.java.net/browse/JDK-8252372), data nodes are sunk out of a loop with the help of pinned `CastXX` nodes to ensure that the data nodes do not float back into the loop. Such a chain of sunk data nodes  is now pinned to the uncommon projection of a loop predicate in the testcase. Loop unswitching is then applied and this loop predicate is cloned down to the fast and the slow loop in `PhaseIdealLoop::clone_predicates_to_unswitched_loop()`. Internally, it uses `PhaseIdealLoop::create_new_if_for_predicate()` to create the new `If` node and the uncommon projection to the uncommon trap region. The UCT region has a phi node from an earlier split-if optimization. The code in `create_new_if_for_predicate()` updates this phi by just setting the data node of the old uncommon projection path as input for the new uncommon projection path:
https://github.com/openjdk/jdk/blob/e8f1219d6f471c89fe15b19c56e3062dd668466f/src/hotspot/share/opto/loopPredicate.cpp#L196

It does this for both the slow and the fast loop. The graph looks like this afterwards (for method `testNoDiamond()`):

![wrong_update](https://user-images.githubusercontent.com/17833009/129887401-05ea8311-c420-444d-b7bb-e2480b7570b6.png)

The data node `1226 AddI` is used for the new uncommon projection paths of the slow loop and the fast loop while still also being used for the old uncommon projection path of `986 IfFalse`. When later determining the earliest and latest control, we find that the early control is `986 IfFalse` for `1226 Addl` while the LCA is `376 IfTrue` (dominates `1347 IfFalse`, `1352 IfFalse` and `986 IfFalse`) which leads to the bad graph assertion failure.

An easy way to fix this is to just set the control to the LCA when cloning the predicates down in loop unswitching but this would revert the work of JDK-8252372 as the nodes could float back into the loop. Therefore, I suggest to improve `create_new_if_for_predicate()` to clone the sunk data node chain to the slow loop and the fast loop. Since the old predicate will die anyways once IGVN is applied after the useless predicates are eliminated in `PhaseIdealLoop::eliminate_useless_predicates()`, I propose to only clone the sunk data node chain for the fast loop once and reuse the old data nodes for the slow loop. I replace the old uncommon projection data input into the phi by TOP which should be fine because the control will die. The graph looks like this after applying these changes:

![fixed_update](https://user-images.githubusercontent.com/17833009/129887382-5724745e-4b7a-49c2-ae06-5be559ae294f.png)

The algorithm also handles diamonds in the sunk data node chains. 

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271954](https://bugs.openjdk.java.net/browse/JDK-8271954): C2: assert(false) failed: Bad graph detected in build_loop_late


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**) ⚠️ Review applies to 93e2ecd6de90334724e9801ef61ed2948d8ffd35
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5185/head:pull/5185` \
`$ git checkout pull/5185`

Update a local copy of the PR: \
`$ git checkout pull/5185` \
`$ git pull https://git.openjdk.java.net/jdk pull/5185/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5185`

View PR using the GUI difftool: \
`$ git pr show -t 5185`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5185.diff">https://git.openjdk.java.net/jdk/pull/5185.diff</a>

</details>
