### PR TITLE
8272725: G1: add documentation on needs_remset_update_t vs bool

### DIFF
--- a/src/hotspot/share/gc/g1/g1HeapRegionAttr.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionAttr.hpp
@@ -39,6 +39,8 @@ public:
 #else
   typedef int8_t region_type_t;
 #endif
+  // _needs_remset_update_t is essentially bool, but we need precise control
+  // on the size, and sizeof(bool) is implementation specific.
   typedef uint8_t needs_remset_update_t;
 
 private:

--- a/src/hotspot/share/gc/g1/g1HeapRegionAttr.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionAttr.hpp
@@ -39,9 +39,10 @@ public:
 #else
   typedef int8_t region_type_t;
 #endif
+  typedef uint8_t needs_remset_update_t;
 
 private:
-  bool _needs_remset_update;
+  needs_remset_update_t _needs_remset_update;
   region_type_t _type;
 
 public:
@@ -80,14 +81,14 @@ public:
     }
   }
 
-  bool needs_remset_update() const     { return _needs_remset_update; }
+  bool needs_remset_update() const     { return _needs_remset_update != 0; }
 
   void set_old()                       { _type = Old; }
   void clear_humongous()               {
     assert(is_humongous() || !is_in_cset(), "must be");
     _type = NotInCSet;
   }
-  void set_has_remset(bool value)      { _needs_remset_update = value; }
+  void set_has_remset(bool value)      { _needs_remset_update = value ? 1 : 0; }
 
   bool is_in_cset_or_humongous() const { return is_in_cset() || is_humongous(); }
   bool is_in_cset() const              { return type() >= Young; }

--- a/src/hotspot/share/gc/g1/g1HeapRegionAttr.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionAttr.hpp
@@ -39,10 +39,9 @@ public:
 #else
   typedef int8_t region_type_t;
 #endif
-  typedef uint8_t needs_remset_update_t;
 
 private:
-  needs_remset_update_t _needs_remset_update;
+  bool _needs_remset_update;
   region_type_t _type;
 
 public:
@@ -81,14 +80,14 @@ public:
     }
   }
 
-  bool needs_remset_update() const     { return _needs_remset_update != 0; }
+  bool needs_remset_update() const     { return _needs_remset_update; }
 
   void set_old()                       { _type = Old; }
   void clear_humongous()               {
     assert(is_humongous() || !is_in_cset(), "must be");
     _type = NotInCSet;
   }
-  void set_has_remset(bool value)      { _needs_remset_update = value ? 1 : 0; }
+  void set_has_remset(bool value)      { _needs_remset_update = value; }
 
   bool is_in_cset_or_humongous() const { return is_in_cset() || is_humongous(); }
   bool is_in_cset() const              { return type() >= Young; }


### PR DESCRIPTION
Simple type change in `struct G1HeapRegionAttr`.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272725](https://bugs.openjdk.java.net/browse/JDK-8272725): G1: add documentation on needs_remset_update_t vs bool


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5188/head:pull/5188` \
`$ git checkout pull/5188`

Update a local copy of the PR: \
`$ git checkout pull/5188` \
`$ git pull https://git.openjdk.java.net/jdk pull/5188/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5188`

View PR using the GUI difftool: \
`$ git pr show -t 5188`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5188.diff">https://git.openjdk.java.net/jdk/pull/5188.diff</a>

</details>
