### PR TITLE
8247980: Exclusive execution of java/util/stream tests slows down tier1

### DIFF
--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -27,7 +27,7 @@ exclusiveAccess.dirs=java/math/BigInteger/largeMemory \
 java/rmi/Naming java/util/prefs sun/management/jmxremote \
 sun/tools/jstatd sun/tools/jcmd \
 sun/tools/jinfo sun/tools/jmap sun/tools/jps sun/tools/jstack sun/tools/jstat \
-com/sun/tools/attach sun/security/mscapi java/util/stream java/util/Arrays/largeMemory \
+com/sun/tools/attach sun/security/mscapi java/util/Arrays/largeMemory \
 java/util/BitSet/stream javax/rmi java/net/httpclient/websocket
 
 # Group definitions


### PR DESCRIPTION
See the bug report for more details. I would appreciate if people with their corporate testing systems would run this through their systems to avoid surprises. (ping @RealCLanger, @iignatev).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8247980](https://bugs.openjdk.java.net/browse/JDK-8247980): Exclusive execution of java/util/stream tests slows down tier1


### Reviewers
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5189/head:pull/5189` \
`$ git checkout pull/5189`

Update a local copy of the PR: \
`$ git checkout pull/5189` \
`$ git pull https://git.openjdk.java.net/jdk pull/5189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5189`

View PR using the GUI difftool: \
`$ git pr show -t 5189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5189.diff">https://git.openjdk.java.net/jdk/pull/5189.diff</a>

</details>
