### PR TITLE
8272739: Misformatted error message in EventHandlerCreator

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventHandlerCreator.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventHandlerCreator.java
@@ -121,7 +121,7 @@ final class EventHandlerCreator {
                 if (internalName != null) {
                     fieldInfos.add(new FieldInfo(fieldName, fieldDescriptor, internalName));
                 } else {
-                    throw new InternalError("Could not locate field " + fieldName + " for event type" + type.getName());
+                    throw new InternalError("Could not locate field " + fieldName + " for event type " + type.getName());
                 }
             }
         }


### PR DESCRIPTION
Please review this trivial patch to add a missing space in error message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272739](https://bugs.openjdk.java.net/browse/JDK-8272739): Misformatted error message in EventHandlerCreator


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5193/head:pull/5193` \
`$ git checkout pull/5193`

Update a local copy of the PR: \
`$ git checkout pull/5193` \
`$ git pull https://git.openjdk.java.net/jdk pull/5193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5193`

View PR using the GUI difftool: \
`$ git pr show -t 5193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5193.diff">https://git.openjdk.java.net/jdk/pull/5193.diff</a>

</details>
