### PR TITLE
8236176: Parallel GC SplitInfo comment should be updated for shadow regions

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -1789,7 +1789,7 @@ bool PSParallelCompact::invoke_no_policy(bool maximum_heap_compaction) {
     ref_processor()->start_discovery(maximum_heap_compaction);
 
     marking_start.update();
-    marking_phase(vmthread_cm, maximum_heap_compaction, &_gc_tracer);
+    marking_phase(vmthread_cm, &_gc_tracer);
 
     bool max_on_system_gc = UseMaximumCompactionOnSystemGC
       && GCCause::is_user_requested_gc(gc_cause);
@@ -2074,7 +2074,6 @@ public:
 };
 
 void PSParallelCompact::marking_phase(ParCompactionManager* cm,
-                                      bool maximum_heap_compaction,
                                       ParallelOldTracer *gc_tracer) {
   // Recursively traverse all live objects and mark them
   GCTraceTime(Info, gc, phases) tm("Marking Phase", &_gc_timer);
@@ -3089,12 +3088,6 @@ bool PSParallelCompact::steal_unavailable_region(ParCompactionManager* cm, size_
 // the shadow region by copying live objects from source regions of the unavailable one. Once
 // the unavailable region becomes available, the data in the shadow region will be copied back.
 // Shadow regions are empty regions in the to-space and regions between top and end of other spaces.
-//
-// For more details, please refer to §4.2 of the VEE'19 paper:
-// Haoyu Li, Mingyu Wu, Binyu Zang, and Haibo Chen. 2019. ScissorGC: scalable and efficient
-// compaction for Java full garbage collection. In Proceedings of the 15th ACM SIGPLAN/SIGOPS
-// International Conference on Virtual Execution Environments (VEE 2019). ACM, New York, NY, USA,
-// 108-121. DOI: https://doi.org/10.1145/3313808.3313820
 void PSParallelCompact::initialize_shadow_regions(uint parallel_gc_threads)
 {
   const ParallelCompactData& sd = PSParallelCompact::summary_data();

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -2278,7 +2278,6 @@ void PSParallelCompact::prepare_region_draining_tasks(uint parallel_gc_threads)
   FillableRegionLogger region_logger;
   for (unsigned int id = to_space_id; id + 1 > old_space_id; --id) {
     SpaceInfo* const space_info = _space_info + id;
-    MutableSpace* const space = space_info->space();
     HeapWord* const new_top = space_info->new_top();
 
     const size_t beg_region = sd.addr_to_region_idx(space_info->dense_prefix());

--- a/src/hotspot/share/gc/parallel/psParallelCompact.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.hpp
@@ -950,7 +950,6 @@ inline void ParMarkBitMapClosure::decrement_words_remaining(size_t words) {
 // has been updated.  KKK likely resides in a region to the left of the region
 // containing AAA.  These AAA's have there references updated at the end in a
 // clean up phase.  See the method PSParallelCompact::update_deferred_objects().
-// An alternate strategy is being investigated for this deferral of updating.
 //
 // Compaction is done on a region basis.  A region that is ready to be filled is
 // put on a ready list and GC threads take region off the list and fill them.  A
@@ -965,20 +964,20 @@ inline void ParMarkBitMapClosure::decrement_words_remaining(size_t words) {
 // During compaction, there is a natural task dependency among regions because
 // destination regions may also be source regions themselves.  Consequently, the
 // destination regions are not available for processing until all live objects
-// within them are evacuated to their destinations. These dependencies lead to
+// within them are evacuated to their destinations.  These dependencies lead to
 // limited thread utilization as threads spin waiting on regions to be ready.
-// Shadow regions are utilized to address these region dependencies. The basic
+// Shadow regions are utilized to address these region dependencies.  The basic
 // idea is that, if a region is unavailable because it still contains live
-// objects  and thus cannot serve as a destination momentarily, the GC thread
+// objects and thus cannot serve as a destination momentarily, the GC thread
 // may allocate a shadow region as a substitute destination and directly copy
-// live objects into this shadow region. Live objects in the shadow region will
+// live objects into this shadow region.  Live objects in the shadow region will
 // be copied into the target destination region when it becomes available.
 //
 // For more details on shadow regions, please refer to §4.2 of the VEE'19 paper:
-// Haoyu Li, Mingyu Wu, Binyu Zang, and Haibo Chen. 2019. ScissorGC: scalable
-// and efficient compaction for Java full garbage collection. In Proceedings of
+// Haoyu Li, Mingyu Wu, Binyu Zang, and Haibo Chen.  2019.  ScissorGC: scalable
+// and efficient compaction for Java full garbage collection.  In Proceedings of
 // the 15th ACM SIGPLAN/SIGOPS International Conference on Virtual Execution
-// Environments (VEE 2019). ACM, New York, NY, USA, 108-121. DOI:
+// Environments (VEE 2019).  ACM, New York, NY, USA, 108-121.  DOI:
 // https://doi.org/10.1145/3313808.3313820
 
 class TaskQueue;

--- a/src/hotspot/share/gc/parallel/psParallelCompact.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.hpp
@@ -968,7 +968,7 @@ inline void ParMarkBitMapClosure::decrement_words_remaining(size_t words) {
 // within them are evacuated to their destinations. These dependencies lead to
 // limited thread utilization as threads spin waiting on regions to be ready.
 // Shadow regions are utilized to address these region dependencies. The basic
-// is idea is that, if a region is unavailable because it still contains live
+// idea is that, if a region is unavailable because it still contains live
 // objects  and thus cannot serve as a destination momentarily, the GC thread
 // may allocate a shadow region as a substitute destination and directly copy
 // live objects into this shadow region. Live objects in the shadow region will

--- a/src/hotspot/share/gc/parallel/psParallelCompact.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.hpp
@@ -961,6 +961,25 @@ inline void ParMarkBitMapClosure::decrement_words_remaining(size_t words) {
 // regions and regions compacting into themselves.  There is always at least 1
 // region that can be put on the ready list.  The regions are atomically added
 // and removed from the ready list.
+//
+// During compaction, there is a natural task dependency among regions because
+// destination regions may also be source regions themselves.  Consequently, the
+// destination regions are not available for processing until all live objects
+// within them are evacuated to their destinations. These dependencies lead to
+// limited thread utilization as threads spin waiting on regions to be ready.
+// Shadow regions are utilized to address these region dependencies. The basic
+// is idea is that, if a region is unavailable because it still contains live
+// objects  and thus cannot serve as a destination momentarily, the GC thread
+// may allocate a shadow region as a substitute destination and directly copy
+// live objects into this shadow region. Live objects in the shadow region will
+// be copied into the target destination region when it becomes available.
+//
+// For more details on shadow regions, please refer to §4.2 of the VEE'19 paper:
+// Haoyu Li, Mingyu Wu, Binyu Zang, and Haibo Chen. 2019. ScissorGC: scalable
+// and efficient compaction for Java full garbage collection. In Proceedings of
+// the 15th ACM SIGPLAN/SIGOPS International Conference on Virtual Execution
+// Environments (VEE 2019). ACM, New York, NY, USA, 108-121. DOI:
+// https://doi.org/10.1145/3313808.3313820
 
 class TaskQueue;
 
@@ -1045,7 +1064,6 @@ class PSParallelCompact : AllStatic {
 
   // Mark live objects
   static void marking_phase(ParCompactionManager* cm,
-                            bool maximum_heap_compaction,
                             ParallelOldTracer *gc_tracer);
 
   // Compute the dense prefix for the designated space.  This is an experimental
@@ -1114,7 +1132,6 @@ class PSParallelCompact : AllStatic {
   DEBUG_ONLY(static void write_block_fill_histogram();)
 
   // Move objects to new locations.
-  static void compact_perm(ParCompactionManager* cm);
   static void compact();
 
   // Add available regions to the stack and draining tasks to the task queue.


### PR DESCRIPTION
Hi all,

Please review this small change to add a high-level description of how shadow regions are utilized during the compact phase of the parallel GC. There is no special handling of Splitinfo by the shadow regions; the destination computation and the handling of partial_objects are done during the summary phase while the shadow regions optimization only applies to compaction. 

Additionally, some unused variables are cleaned up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8236176](https://bugs.openjdk.java.net/browse/JDK-8236176): Parallel GC SplitInfo comment should be updated for shadow regions


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 52fbb6fafd0ca2870c251be06193a344a1a30cdc
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5195/head:pull/5195` \
`$ git checkout pull/5195`

Update a local copy of the PR: \
`$ git checkout pull/5195` \
`$ git pull https://git.openjdk.java.net/jdk pull/5195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5195`

View PR using the GUI difftool: \
`$ git pr show -t 5195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5195.diff">https://git.openjdk.java.net/jdk/pull/5195.diff</a>

</details>
