### PR TITLE
8272756: Remove unnecessary explicit initialization of volatile variables in java.desktop

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/LWLightweightFramePeer.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/LWLightweightFramePeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -119,7 +119,7 @@ public class LWLightweightFramePeer extends LWWindowPeer implements OverrideNati
     }
 
     // SwingNode
-    private volatile long overriddenWindowHandle = 0L;
+    private volatile long overriddenWindowHandle;
 
     @Override
     public void overrideWindowHandle(final long handle) {

--- a/src/java.desktop/macosx/classes/sun/lwawt/LWWindowPeer.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/LWWindowPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,7 +112,7 @@ public class LWWindowPeer
     private volatile int windowState = Frame.NORMAL;
 
     // check that the mouse is over the window
-    private volatile boolean isMouseOver = false;
+    private volatile boolean isMouseOver;
 
     // A peer where the last mouse event came to. Used by cursor manager to
     // find the component under cursor

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CCheckboxMenuItem.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CCheckboxMenuItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import sun.awt.SunToolkit;
 
 public class CCheckboxMenuItem extends CMenuItem implements CheckboxMenuItemPeer {
     volatile boolean fAutoToggle = true;
-    volatile boolean fIsIndeterminate = false;
+    volatile boolean fIsIndeterminate;
 
     private native void nativeSetState(long modelPtr, boolean state);
     private native void nativeSetIsCheckbox(long modelPtr);

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFIFD.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFIFD.java
@@ -56,12 +56,12 @@ public class TIFFIFD extends TIFFDirectory {
     // A set of tag numbers corresponding to tags essential to decoding
     // the image and metadata required to interpret its samples.
     //
-    private static volatile Set<Integer> essentialTags = null;
+    private static volatile Set<Integer> essentialTags;
 
     private static void initializeEssentialTags() {
         Set<Integer> tags = essentialTags;
         if (tags == null) {
-            essentialTags = tags = Set.of(
+            essentialTags = Set.of(
                 BaselineTIFFTagSet.TAG_BITS_PER_SAMPLE,
                 BaselineTIFFTagSet.TAG_COLOR_MAP,
                 BaselineTIFFTagSet.TAG_COMPRESSION,

--- a/src/java.desktop/share/classes/com/sun/media/sound/DirectAudioDevice.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/DirectAudioDevice.java
@@ -361,13 +361,13 @@ final class DirectAudioDevice extends AbstractMixer {
         protected final int deviceID;
         protected long id;
         protected int waitTime;
-        protected volatile boolean flushing = false;
+        protected volatile boolean flushing;
         protected final boolean isSource;         // true for SourceDataLine, false for TargetDataLine
         protected volatile long bytePosition;
-        protected volatile boolean doIO = false;     // true in between start() and stop() calls
-        protected volatile boolean stoppedWritten = false; // true if a write occurred in stopped state
-        protected volatile boolean drained = false; // set to true when drain function returns, set to false in write()
-        protected boolean monitoring = false;
+        protected volatile boolean doIO;     // true in between start() and stop() calls
+        protected volatile boolean stoppedWritten; // true if a write occurred in stopped state
+        protected volatile boolean drained; // set to true when drain function returns, set to false in write()
+        protected boolean monitoring;
 
         // if native needs to manually swap samples/convert sign, this
         // is set to the framesize
@@ -379,7 +379,7 @@ final class DirectAudioDevice extends AbstractMixer {
         private final Balance balanceControl = new Balance();
         private final Pan panControl = new Pan();
         private float leftGain, rightGain;
-        protected volatile boolean noService = false; // do not run the nService method
+        protected volatile boolean noService; // do not run the nService method
 
         // Guards all native calls.
         protected final Object lockNative = new Object();
@@ -975,7 +975,7 @@ final class DirectAudioDevice extends AbstractMixer {
             implements Clip, Runnable, AutoClosingClip {
 
         private volatile Thread thread;
-        private volatile byte[] audioData = null;
+        private volatile byte[] audioData;
         private volatile int frameSize;         // size of one frame in bytes
         private volatile int m_lengthInFrames;
         private volatile int loopCount;

--- a/src/java.desktop/share/classes/com/sun/media/sound/SoftAudioPusher.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/SoftAudioPusher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,8 +37,8 @@ import javax.sound.sampled.SourceDataLine;
  */
 public final class SoftAudioPusher implements Runnable {
 
-    private volatile boolean active = false;
-    private SourceDataLine sourceDataLine = null;
+    private volatile boolean active;
+    private SourceDataLine sourceDataLine;
     private Thread audiothread;
     private final AudioInputStream ais;
     private final byte[] buffer;

--- a/src/java.desktop/share/classes/java/awt/Component.java
+++ b/src/java.desktop/share/classes/java/awt/Component.java
@@ -395,7 +395,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
      * @see #validate
      * @see #invalidate
      */
-    private volatile boolean valid = false;
+    private volatile boolean valid;
 
     /**
      * The {@code DropTarget} associated with this component.
@@ -9340,7 +9340,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
          * to add/remove ComponentListener and FocusListener to track
          * target Component's state.
          */
-        private transient volatile int propertyListenersCount = 0;
+        private transient volatile int propertyListenersCount;
 
         /**
          * A component listener to track show/hide/resize events

--- a/src/java.desktop/share/classes/java/awt/Container.java
+++ b/src/java.desktop/share/classes/java/awt/Container.java
@@ -3861,7 +3861,7 @@ public class Container extends Component {
          * Number of PropertyChangeListener objects registered. It's used
          * to add/remove ContainerListener to track target Container's state.
          */
-        private transient volatile int propertyListenersCount = 0;
+        private transient volatile int propertyListenersCount;
 
         /**
          * The handler to fire {@code PropertyChange}

--- a/src/java.desktop/share/classes/java/awt/Dialog.java
+++ b/src/java.desktop/share/classes/java/awt/Dialog.java
@@ -301,7 +301,7 @@ public class Dialog extends Window {
      * @see #hideAndDisposeHandler()
      * @see #shouldBlock()
      */
-    transient volatile boolean isInHide = false;
+    transient volatile boolean isInHide;
 
     /*
      * Indicates that this dialog is being disposed. This flag is set to true at
@@ -312,7 +312,7 @@ public class Dialog extends Window {
      * @see #hideAndDisposeHandler()
      * @see #doDispose()
      */
-    transient volatile boolean isInDispose = false;
+    transient volatile boolean isInDispose;
 
     private static final String base = "dialog";
     private static int nameCounter = 0;

--- a/src/java.desktop/share/classes/java/awt/Window.java
+++ b/src/java.desktop/share/classes/java/awt/Window.java
@@ -404,8 +404,8 @@ public class Window extends Container implements Accessible {
      * These fields are initialized in the native peer code
      * or via AWTAccessor's WindowAccessor.
      */
-    private transient volatile int securityWarningWidth = 0;
-    private transient volatile int securityWarningHeight = 0;
+    private transient volatile int securityWarningWidth;
+    private transient volatile int securityWarningHeight;
 
     static {
         /* ensure that the necessary native libraries are loaded */

--- a/src/java.desktop/share/classes/java/awt/event/InvocationEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/InvocationEvent.java
@@ -116,7 +116,7 @@ public class InvocationEvent extends AWTEvent implements ActiveEvent {
      * @see #isDispatched
      * @since 1.7
      */
-    private volatile boolean dispatched = false;
+    private volatile boolean dispatched;
 
     /**
      * Set to true if dispatch() catches Throwable and stores it in the

--- a/src/java.desktop/share/classes/java/awt/font/NumericShaper.java
+++ b/src/java.desktop/share/classes/java/awt/font/NumericShaper.java
@@ -1364,7 +1364,7 @@ public final class NumericShaper implements java.io.Serializable {
 
     // use a binary search with a cache
 
-    private transient volatile int stCache = 0;
+    private transient volatile int stCache;
 
     private boolean isStrongDirectional(char c) {
         int cachedIndex = stCache;

--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -3742,7 +3742,7 @@ public abstract class JComponent extends Container implements Serializable,
          * to add/remove ContainerListener and FocusListener to track
          * target JComponent's state
          */
-        private transient volatile int propertyListenersCount = 0;
+        private transient volatile int propertyListenersCount;
 
         /**
          * This field duplicates the function of the accessibleAWTFocusHandler field

--- a/src/java.desktop/share/classes/sun/awt/AppContext.java
+++ b/src/java.desktop/share/classes/sun/awt/AppContext.java
@@ -161,7 +161,7 @@ public final class AppContext {
        contained in another AppContext. It is implicitly created for
        standalone apps only (i.e. not applets)
      */
-    private static volatile AppContext mainAppContext = null;
+    private static volatile AppContext mainAppContext;
 
     private static class GetAppContextLock {};
     private static final Object getAppContextLock = new GetAppContextLock();

--- a/src/java.desktop/share/classes/sun/awt/datatransfer/SunClipboard.java
+++ b/src/java.desktop/share/classes/sun/awt/datatransfer/SunClipboard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,7 @@ public abstract class SunClipboard extends Clipboard
      * A number of {@code FlavorListener}s currently registered
      * on this clipboard across all {@code AppContext}s.
      */
-    private volatile int numberOfFlavorListeners = 0;
+    private volatile int numberOfFlavorListeners;
 
     /**
      * A set of {@code DataFlavor}s that is available on this clipboard. It is

--- a/src/java.desktop/share/classes/sun/awt/dnd/SunDragSourceContextPeer.java
+++ b/src/java.desktop/share/classes/sun/awt/dnd/SunDragSourceContextPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,8 +74,8 @@ public abstract class SunDragSourceContextPeer implements DragSourceContextPeer 
     private DragSourceContext dragSourceContext;
     private int               sourceActions;
 
-    private static volatile boolean dragDropInProgress = false;
-    private static volatile boolean discardingMouseEvents = false;
+    private static volatile boolean dragDropInProgress;
+    private static volatile boolean discardingMouseEvents;
 
     /*
      * dispatch constants

--- a/src/java.desktop/share/classes/sun/java2d/Disposer.java
+++ b/src/java.desktop/share/classes/sun/java2d/Disposer.java
@@ -184,7 +184,7 @@ public class Disposer implements Runnable {
     /*
      * Set to indicate the queue is presently being polled.
      */
-    public static volatile boolean pollingQueue = false;
+    public static volatile boolean pollingQueue;
 
     /*
      * The pollRemove() method is called back from a dispose method

--- a/src/java.desktop/share/classes/sun/java2d/marlin/RendererStats.java
+++ b/src/java.desktop/share/classes/sun/java2d/marlin/RendererStats.java
@@ -334,7 +334,7 @@ public final class RendererStats implements MarlinConst {
     static final class RendererStatsHolder {
 
         // singleton
-        private static volatile RendererStatsHolder SINGLETON = null;
+        private static volatile RendererStatsHolder SINGLETON;
 
         static synchronized RendererStatsHolder getInstance() {
             if (SINGLETON == null) {

--- a/src/java.desktop/unix/classes/sun/awt/X11/GtkFileDialogPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/GtkFileDialogPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ final class GtkFileDialogPeer extends XDialogPeer implements FileDialogPeer {
     private final FileDialog fd;
 
     // A pointer to the native GTK FileChooser widget
-    private volatile long widget = 0L;
+    private volatile long widget;
     private long standaloneWindow;
     private volatile boolean quit;
 

--- a/src/java.desktop/unix/classes/sun/awt/X11/ListHelper.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/ListHelper.java
@@ -79,8 +79,8 @@ final class ListHelper implements XScrollbarClient {
     // Holds the true if mouse is dragging outside of the area of the list
     // The flag is used at the moment of the dragging and releasing mouse
     // See 6243382 for more information
-    private boolean mouseDraggedOutVertically = false;
-    private volatile boolean vsbVisibilityChanged = false;
+    private boolean mouseDraggedOutVertically;
+    private volatile boolean vsbVisibilityChanged;
 
     /*
      * Comment

--- a/src/java.desktop/unix/classes/sun/awt/X11/XInputMethod.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XInputMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,7 +73,7 @@ public class XInputMethod extends X11InputMethod {
     }
 
 
-    private static volatile long xicFocus = 0;
+    private static volatile long xicFocus;
 
     protected void setXICFocus(ComponentPeer peer,
                                     boolean value, boolean active) {

--- a/src/java.desktop/unix/classes/sun/awt/X11/XLightweightFramePeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XLightweightFramePeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,7 +82,7 @@ public class XLightweightFramePeer extends XFramePeer implements OverrideNativeW
         getLwTarget().removeDropTarget(dt);
     }
 
-    private volatile long overriddenWindowHandle = 0L;
+    private volatile long overriddenWindowHandle;
 
     @Override
     public void overrideWindowHandle(final long handle) {

--- a/src/java.desktop/unix/classes/sun/awt/X11/XWarningWindow.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XWarningWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ class XWarningWindow extends XWindow {
     /**
      * Animation stage.
      */
-    private volatile int currentIcon = 0;
+    private volatile int currentIcon;
 
     /* -1 - uninitialized.
      * 0 - 16x16

--- a/src/java.desktop/windows/classes/sun/awt/windows/ThemeReader.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/ThemeReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ public final class ThemeReader {
         new ReentrantReadWriteLock();
     private static final Lock readLock = readWriteLock.readLock();
     private static final Lock writeLock = readWriteLock.writeLock();
-    private static volatile boolean valid = false;
+    private static volatile boolean valid;
     private static volatile boolean isThemed;
 
     static volatile boolean xpStyleEnabled;

--- a/src/java.desktop/windows/classes/sun/awt/windows/WObjectPeer.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WObjectPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ abstract class WObjectPeer {
     private volatile boolean disposed;
 
     // set from JNI if any errors in creating the peer occur
-    volatile Error createError = null;
+    volatile Error createError;
 
     // used to synchronize the state of this peer
     private final Object stateLock = new Object();


### PR DESCRIPTION
This is a continuation of

- https://bugs.openjdk.java.net/browse/JDK-6736490
- https://bugs.openjdk.java.net/browse/JDK-8035284
- https://bugs.openjdk.java.net/browse/JDK-8145680
- https://bugs.openjdk.java.net/browse/JDK-8251548

As mentioned in JDK-6736490:

_An explicit initialization of a volatile class instance variable, such as private volatile Object = null; or private volatile int scale = 0; is unnecessary since the Java spec automatically initializes objects to null and primitive type short, int, long, float and double to 0 and boolean to false. Explicit initialization of volatile variable to a value the same as the default implicit initialized value results in an unnecessary store and membar operation._