### PR TITLE
8271600: C2: CheckCastPP which should closely follow Allocate is sunk of a loop

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1444,7 +1444,7 @@ void PhaseIdealLoop::try_sink_out_of_loop(Node* n) {
       !n->is_Proj() &&
       !n->is_MergeMem() &&
       !n->is_CMove() &&
-      !is_raw_to_oop_cast && // don't extend live ranges of raw pointers
+      !is_raw_to_oop_cast && // don't extend live ranges of raw oops
       n->Opcode() != Op_Opaque4) {
     Node *n_ctrl = get_ctrl(n);
     IdealLoopTree *n_loop = get_loop(n_ctrl);

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1435,13 +1435,16 @@ void PhaseIdealLoop::split_if_with_blocks_post(Node *n) {
 // like various versions of induction variable+offset.  Clone the
 // computation per usage to allow it to sink out of the loop.
 void PhaseIdealLoop::try_sink_out_of_loop(Node* n) {
+  bool is_raw_to_oop_cast = n->is_ConstraintCast() &&
+                            n->in(1)->bottom_type()->isa_rawptr() &&
+                            !n->bottom_type()->isa_rawptr();
   if (has_ctrl(n) &&
       !n->is_Phi() &&
       !n->is_Bool() &&
       !n->is_Proj() &&
       !n->is_MergeMem() &&
       !n->is_CMove() &&
-      !n->is_ConstraintCast() &&
+      !is_raw_to_oop_cast && // don't extend live ranges of raw pointers
       n->Opcode() != Op_Opaque4) {
     Node *n_ctrl = get_ctrl(n);
     IdealLoopTree *n_loop = get_loop(n_ctrl);

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1441,6 +1441,7 @@ void PhaseIdealLoop::try_sink_out_of_loop(Node* n) {
       !n->is_Proj() &&
       !n->is_MergeMem() &&
       !n->is_CMove() &&
+      !n->is_ConstraintCast() &&
       n->Opcode() != Op_Opaque4) {
     Node *n_ctrl = get_ctrl(n);
     IdealLoopTree *n_loop = get_loop(n_ctrl);


### PR DESCRIPTION
`PhaseIdealLoop::try_sink_out_of_loop()` tries to move nodes outside a loop. It doesn't work well for cast nodes which accompany `Allocate` nodes:  the cast reifies the effect instance initialization and turns a raw pointer into an oop. Once the cast node doesn't immediately follow the corresponding `Initialize`, it creates a window where the raw pointer is observed. And it can become so wide that the raw pointer crosses a safepoint and has to be recorded in the oop map (that's the case when the reported assertion failure happens). 

Proposed fix is to keep such cast nodes intact. Moreover, I propose to disable the optimization for all flavors of cast nodes. 
Cast nodes usually accompany runtime checks and I don't see much benefit in moving the cast node away while leaving the runtime check inside the loop.  

Testing: hs-tier1 - hs-tier6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271600](https://bugs.openjdk.java.net/browse/JDK-8271600): C2: CheckCastPP which should closely follow Allocate is sunk of a loop


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to 4081f893605ef730334c21000365451818e9d752
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5199/head:pull/5199` \
`$ git checkout pull/5199`

Update a local copy of the PR: \
`$ git checkout pull/5199` \
`$ git pull https://git.openjdk.java.net/jdk pull/5199/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5199`

View PR using the GUI difftool: \
`$ git pr show -t 5199`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5199.diff">https://git.openjdk.java.net/jdk/pull/5199.diff</a>

</details>
