### PR TITLE
8272472: StackGuardPages test doesn't build with glibc 2.34 

### DIFF
--- a/test/hotspot/jtreg/runtime/StackGuardPages/exeinvoke.c
+++ b/test/hotspot/jtreg/runtime/StackGuardPages/exeinvoke.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,8 +68,17 @@ static void handler(int sig, siginfo_t *si, void *unused) {
   longjmp(context, 1);
 }
 
+static char* altstack = NULL;
+
 void set_signal_handler() {
-  static char altstack[SIGSTKSZ];
+  if (altstack == NULL) {
+    // Dynamically allocated in case SIGSTKSZ is not constant
+    altstack = malloc(SIGSTKSZ);
+    if (altstack == NULL) {
+      fprintf(stderr, "Test ERROR. Unable to malloc altstack space\n");
+      exit(7);
+    }
+  }
 
   stack_t ss = {
     .ss_size = SIGSTKSZ,


### PR DESCRIPTION
Please review this simple test fix to address an issue that will prevent this test source from building on more recent Linux distributions with Glibc 2.34. When building under _GNU_SOURCE the value of SIGSTKSZ is no longer a constant and so cannot be used in an array declaration. The simple fix is to malloc the array instead.

Testing: local & mach5 tiers 1-3

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272472](https://bugs.openjdk.java.net/browse/JDK-8272472): StackGuardPages test doesn't build with glibc 2.34


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5200/head:pull/5200` \
`$ git checkout pull/5200`

Update a local copy of the PR: \
`$ git checkout pull/5200` \
`$ git pull https://git.openjdk.java.net/jdk pull/5200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5200`

View PR using the GUI difftool: \
`$ git pr show -t 5200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5200.diff">https://git.openjdk.java.net/jdk/pull/5200.diff</a>

</details>
