### PR TITLE
8272783: Epsilon: Refactor tests to improve performance

### DIFF
--- a/test/hotspot/jtreg/gc/epsilon/TestAlignment.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestAlignment.java
@@ -28,10 +28,24 @@ package gc.epsilon;
  * @requires vm.gc.Epsilon
  * @summary Check Epsilon runs fine with (un)usual alignments
  * @bug 8212005
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -Xmx128m -XX:+UseEpsilonGC -XX:+UseTLAB gc.epsilon.TestAlignment
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -Xmx128m -XX:+UseEpsilonGC -XX:-UseTLAB gc.epsilon.TestAlignment
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -Xmx128m -XX:+UseEpsilonGC -XX:+UseTLAB -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16 gc.epsilon.TestAlignment
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -Xmx128m -XX:+UseEpsilonGC -XX:-UseTLAB -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16 gc.epsilon.TestAlignment
+ *
+ * @run main/othervm -Xmx64m -XX:+UseTLAB
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestAlignment
+ *
+ * @run main/othervm -Xmx64m -XX:-UseTLAB
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestAlignment
+ *
+ * @run main/othervm -Xmx64m -XX:+UseTLAB
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16
+ *                   gc.epsilon.TestAlignment
+ *
+ * @run main/othervm -Xmx64m -XX:-UseTLAB
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16
+ *                   gc.epsilon.TestAlignment
  */
 
 public class TestAlignment {

--- a/test/hotspot/jtreg/gc/epsilon/TestAlwaysPretouch.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestAlwaysPretouch.java
@@ -24,13 +24,31 @@
 /**
  * @test TestAlwaysPretouch
  * @requires vm.gc.Epsilon
- * @summary Basic sanity test for Epsilon
- * @run main/othervm -Xms128m -Xmx1g                     -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestAlwaysPretouch
- * @run main/othervm -Xms128m -Xmx1g -XX:-AlwaysPreTouch -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestAlwaysPretouch
- * @run main/othervm -Xms128m -Xmx1g -XX:+AlwaysPreTouch -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestAlwaysPretouch
- * @run main/othervm          -Xmx1g                     -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestAlwaysPretouch
- * @run main/othervm          -Xmx1g -XX:-AlwaysPreTouch -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestAlwaysPretouch
- * @run main/othervm          -Xmx1g -XX:+AlwaysPreTouch -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestAlwaysPretouch
+ * @summary Test that pre-touch works
+ *
+ * @run main/othervm -Xms64m -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestAlwaysPretouch
+ *
+ * @run main/othervm -Xms64m -Xmx256m -XX:-AlwaysPreTouch
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestAlwaysPretouch
+ *
+ * @run main/othervm -Xms64m -Xmx256m -XX:+AlwaysPreTouch
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestAlwaysPretouch
+ *
+ * @run main/othervm -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestAlwaysPretouch
+ *
+ * @run main/othervm -Xmx256m -XX:-AlwaysPreTouch
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestAlwaysPretouch
+ *
+ * @run main/othervm -Xmx256m -XX:+AlwaysPreTouch
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestAlwaysPretouch
  */
 
 package gc.epsilon;

--- a/test/hotspot/jtreg/gc/epsilon/TestArraycopyCheckcast.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestArraycopyCheckcast.java
@@ -30,11 +30,24 @@ package gc.epsilon;
  * @library /test/lib
  * @bug 8215724
  *
- * @run main/othervm -Xmx1g                                        -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestArraycopyCheckcast
- * @run main/othervm -Xmx1g -Xint                                  -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestArraycopyCheckcast
- * @run main/othervm -Xmx1g -Xbatch -Xcomp                         -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestArraycopyCheckcast
- * @run main/othervm -Xmx1g -Xbatch -Xcomp -XX:TieredStopAtLevel=1 -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestArraycopyCheckcast
- * @run main/othervm -Xmx1g -Xbatch -Xcomp -XX:-TieredCompilation  -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestArraycopyCheckcast
+ * @run main/othervm -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestArraycopyCheckcast
+ *
+ * @run main/othervm -Xmx256m
+ *                   -Xint
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestArraycopyCheckcast
+ *
+ * @run main/othervm -Xmx256m
+ *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestArraycopyCheckcast
+ *
+ * @run main/othervm -Xmx256m
+ *                   -Xbatch -Xcomp -XX:-TieredCompilation
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestArraycopyCheckcast
  */
 
 public class TestArraycopyCheckcast {

--- a/test/hotspot/jtreg/gc/epsilon/TestByteArrays.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestByteArrays.java
@@ -26,28 +26,54 @@ package gc.epsilon;
 /**
  * @test TestByteArrays
  * @key randomness
- * @requires vm.gc.Epsilon & os.maxMemory > 1G
+ * @requires vm.gc.Epsilon
  * @summary Epsilon is able to allocate arrays, and does not corrupt their state
  * @library /test/lib
  *
- * @run main/othervm -Xmx1g                                        -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestByteArrays
- * @run main/othervm -Xmx1g -Xint                                  -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestByteArrays
- * @run main/othervm -Xmx1g -Xbatch -Xcomp                         -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestByteArrays
- * @run main/othervm -Xmx1g -Xbatch -Xcomp -XX:TieredStopAtLevel=1 -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestByteArrays
- * @run main/othervm -Xmx1g -Xbatch -Xcomp -XX:-TieredCompilation  -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestByteArrays
+ * @run main/othervm -XX:+UseTLAB -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestByteArrays
  *
- * @run main/othervm -Xmx1g                                        -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestByteArrays
- * @run main/othervm -Xmx1g -Xint                                  -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestByteArrays
- * @run main/othervm -Xmx1g -Xbatch -Xcomp                         -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestByteArrays
- * @run main/othervm -Xmx1g -Xbatch -Xcomp -XX:TieredStopAtLevel=1 -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestByteArrays
- * @run main/othervm -Xmx1g -Xbatch -Xcomp -XX:-TieredCompilation  -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestByteArrays
+ * @run main/othervm -XX:+UseTLAB -Xmx256m
+ *                   -Xint
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestByteArrays
+ *
+ * @run main/othervm -XX:+UseTLAB -Xmx256m
+ *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestByteArrays
+ *
+ * @run main/othervm -XX:+UseTLAB -Xmx256m
+ *                   -Xbatch -Xcomp -XX:-TieredCompilation
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestByteArrays
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestByteArrays
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m
+ *                   -Xint
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestByteArrays
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m
+ *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestByteArrays
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m
+ *                   -Xbatch -Xcomp -XX:-TieredCompilation
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestByteArrays
  */
 
 import java.util.Random;
 import jdk.test.lib.Utils;
 
 public class TestByteArrays {
-  static int COUNT = Integer.getInteger("count", 3000); // ~500 MB allocation
+  static int COUNT = Integer.getInteger("count", 500); // ~100 MB allocation
 
   static byte[][] arr;
 

--- a/test/hotspot/jtreg/gc/epsilon/TestClasses.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestClasses.java
@@ -31,7 +31,10 @@ package gc.epsilon;
  * @modules java.base/jdk.internal.org.objectweb.asm
  *          java.base/jdk.internal.misc
  *
- * @run main/othervm -Xmx1g -XX:MetaspaceSize=1m -XX:MaxMetaspaceSize=64m -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xlog:gc -Xlog:gc+metaspace gc.epsilon.TestClasses
+ * @run main/othervm -Xmx256m
+ *                   -XX:MetaspaceSize=1m -XX:MaxMetaspaceSize=64m -Xlog:gc -Xlog:gc+metaspace
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestClasses
  */
 
 import jdk.internal.org.objectweb.asm.ClassWriter;

--- a/test/hotspot/jtreg/gc/epsilon/TestDieDefault.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestDieDefault.java
@@ -53,31 +53,24 @@ public class TestDieDefault {
   }
 
   public static void main(String[] args) throws Exception {
-    passWith("-Xmx128m",
+    passWith("-Xmx64m",
              "-XX:+UnlockExperimentalVMOptions",
              "-XX:+UseEpsilonGC",
              "-Dcount=1",
              TestDieDefault.Workload.class.getName());
 
-    failWith("-Xmx128m",
+    failWith("-Xmx64m",
              "-XX:+UnlockExperimentalVMOptions",
              "-XX:+UseEpsilonGC",
              TestDieDefault.Workload.class.getName());
 
-    failWith("-Xmx128m",
+    failWith("-Xmx64m",
              "-Xint",
              "-XX:+UnlockExperimentalVMOptions",
              "-XX:+UseEpsilonGC",
              TestDieDefault.Workload.class.getName());
 
-    failWith("-Xmx128m",
-             "-Xbatch",
-             "-Xcomp",
-             "-XX:+UnlockExperimentalVMOptions",
-             "-XX:+UseEpsilonGC",
-             TestDieDefault.Workload.class.getName());
-
-    failWith("-Xmx128m",
+    failWith("-Xmx64m",
              "-Xbatch",
              "-Xcomp",
              "-XX:TieredStopAtLevel=1",
@@ -85,7 +78,7 @@ public class TestDieDefault {
              "-XX:+UseEpsilonGC",
              TestDieDefault.Workload.class.getName());
 
-    failWith("-Xmx128m",
+    failWith("-Xmx64m",
              "-Xbatch",
              "-Xcomp",
              "-XX:-TieredCompilation",

--- a/test/hotspot/jtreg/gc/epsilon/TestDieWithHeapDump.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestDieWithHeapDump.java
@@ -59,35 +59,27 @@ public class TestDieWithHeapDump {
   }
 
   public static void main(String[] args) throws Exception {
-    passWith("-Xmx128m",
+    passWith("-Xmx64m",
              "-XX:+UnlockExperimentalVMOptions",
              "-XX:+UseEpsilonGC",
              "-Dcount=1",
              "-XX:+HeapDumpOnOutOfMemoryError",
              TestDieWithHeapDump.Workload.class.getName());
 
-    failWith("-Xmx128m",
+    failWith("-Xmx64m",
              "-XX:+UnlockExperimentalVMOptions",
              "-XX:+UseEpsilonGC",
              "-XX:+HeapDumpOnOutOfMemoryError",
              TestDieWithHeapDump.Workload.class.getName());
 
-    failWith("-Xmx128m",
+    failWith("-Xmx64m",
              "-Xint",
              "-XX:+UnlockExperimentalVMOptions",
              "-XX:+UseEpsilonGC",
              "-XX:+HeapDumpOnOutOfMemoryError",
              TestDieWithHeapDump.Workload.class.getName());
 
-    failWith("-Xmx128m",
-             "-Xbatch",
-             "-Xcomp",
-             "-XX:+UnlockExperimentalVMOptions",
-             "-XX:+UseEpsilonGC",
-             "-XX:+HeapDumpOnOutOfMemoryError",
-             TestDieWithHeapDump.Workload.class.getName());
-
-    failWith("-Xmx128m",
+    failWith("-Xmx64m",
              "-Xbatch",
              "-Xcomp",
              "-XX:TieredStopAtLevel=1",
@@ -96,7 +88,7 @@ public class TestDieWithHeapDump {
              "-XX:+HeapDumpOnOutOfMemoryError",
              TestDieWithHeapDump.Workload.class.getName());
 
-    failWith("-Xmx128m",
+    failWith("-Xmx64m",
              "-Xbatch",
              "-Xcomp",
              "-XX:-TieredCompilation",

--- a/test/hotspot/jtreg/gc/epsilon/TestDieWithOnError.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestDieWithOnError.java
@@ -57,35 +57,27 @@ public class TestDieWithOnError {
   }
 
   public static void main(String[] args) throws Exception {
-    passWith("-Xmx128m",
+    passWith("-Xmx64m",
              "-XX:+UnlockExperimentalVMOptions",
              "-XX:+UseEpsilonGC",
              "-Dcount=1",
              "-XX:OnOutOfMemoryError=echo " + ON_ERR_MSG,
              TestDieWithOnError.Workload.class.getName());
 
-    failWith("-Xmx128m",
+    failWith("-Xmx64m",
              "-XX:+UnlockExperimentalVMOptions",
              "-XX:+UseEpsilonGC",
              "-XX:OnOutOfMemoryError=echo " + ON_ERR_MSG,
              TestDieWithOnError.Workload.class.getName());
 
-    failWith("-Xmx128m",
+    failWith("-Xmx64m",
              "-Xint",
              "-XX:+UnlockExperimentalVMOptions",
              "-XX:+UseEpsilonGC",
              "-XX:OnOutOfMemoryError=echo " + ON_ERR_MSG,
              TestDieWithOnError.Workload.class.getName());
 
-    failWith("-Xmx128m",
-             "-Xbatch",
-             "-Xcomp",
-             "-XX:+UnlockExperimentalVMOptions",
-             "-XX:+UseEpsilonGC",
-             "-XX:OnOutOfMemoryError=echo " + ON_ERR_MSG,
-             TestDieWithOnError.Workload.class.getName());
-
-    failWith("-Xmx128m",
+    failWith("-Xmx64m",
              "-Xbatch",
              "-Xcomp",
              "-XX:TieredStopAtLevel=1",
@@ -94,7 +86,7 @@ public class TestDieWithOnError {
              "-XX:OnOutOfMemoryError=echo " + ON_ERR_MSG,
              TestDieWithOnError.Workload.class.getName());
 
-    failWith("-Xmx128m",
+    failWith("-Xmx64m",
              "-Xbatch",
              "-Xcomp",
              "-XX:-TieredCompilation",

--- a/test/hotspot/jtreg/gc/epsilon/TestElasticTLAB.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestElasticTLAB.java
@@ -26,23 +26,41 @@ package gc.epsilon;
 /**
  * @test TestElasticTLAB
  * @key randomness
- * @requires vm.gc.Epsilon & os.maxMemory > 1G
+ * @requires vm.gc.Epsilon
  * @summary Epsilon is able to work with/without elastic TLABs
  * @library /test/lib
  *
- * @run main/othervm -Xmx1g -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -XX:-EpsilonElasticTLAB                               gc.epsilon.TestElasticTLAB
- * @run main/othervm -Xmx1g -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -XX:+EpsilonElasticTLAB -XX:EpsilonTLABElasticity=1   gc.epsilon.TestElasticTLAB
- * @run main/othervm -Xmx1g -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -XX:+EpsilonElasticTLAB -XX:EpsilonTLABElasticity=1.1 gc.epsilon.TestElasticTLAB
- * @run main/othervm -Xmx1g -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -XX:+EpsilonElasticTLAB -XX:EpsilonTLABElasticity=2.0 gc.epsilon.TestElasticTLAB
- * @run main/othervm -Xmx1g -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -XX:+EpsilonElasticTLAB -XX:EpsilonTLABElasticity=42  gc.epsilon.TestElasticTLAB
- * @run main/othervm -Xmx1g -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -XX:+EpsilonElasticTLAB -XX:EpsilonTLABElasticity=100 gc.epsilon.TestElasticTLAB
+ * @run main/othervm -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:-EpsilonElasticTLAB
+ *                   gc.epsilon.TestElasticTLAB
+ *
+ * @run main/othervm -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:+EpsilonElasticTLAB -XX:EpsilonTLABElasticity=1
+ *                   gc.epsilon.TestElasticTLAB
+ *
+ * @run main/othervm -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:+EpsilonElasticTLAB -XX:EpsilonTLABElasticity=1.1
+ *                   gc.epsilon.TestElasticTLAB
+ *
+ * @run main/othervm -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:+EpsilonElasticTLAB -XX:EpsilonTLABElasticity=2.0
+ *                   gc.epsilon.TestElasticTLAB
+ *
+ * @run main/othervm -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:+EpsilonElasticTLAB -XX:EpsilonTLABElasticity=100
+ *                   gc.epsilon.TestElasticTLAB
  */
 
 import java.util.Random;
 import jdk.test.lib.Utils;
 
 public class TestElasticTLAB {
-  static int COUNT = Integer.getInteger("count", 3000); // ~500 MB allocation
+  static int COUNT = Integer.getInteger("count", 500); // ~100 MB allocation
 
   static byte[][] arr;
 

--- a/test/hotspot/jtreg/gc/epsilon/TestElasticTLABDecay.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestElasticTLABDecay.java
@@ -26,20 +26,31 @@ package gc.epsilon;
 /**
  * @test TestElasticTLABDecay
  * @key randomness
- * @requires vm.gc.Epsilon & os.maxMemory > 1G
- * @summary Epsilon is able to work with/without elastic TLABs
+ * @requires vm.gc.Epsilon
+ * @summary Epsilon is able to work with/without elastic TLABs decay
  * @library /test/lib
  *
- * @run main/othervm -Xmx1g -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -XX:+EpsilonElasticTLAB -XX:-EpsilonElasticTLABDecay                               gc.epsilon.TestElasticTLABDecay
- * @run main/othervm -Xmx1g -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -XX:+EpsilonElasticTLAB -XX:+EpsilonElasticTLABDecay -XX:EpsilonTLABDecayTime=1    gc.epsilon.TestElasticTLABDecay
- * @run main/othervm -Xmx1g -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -XX:+EpsilonElasticTLAB -XX:+EpsilonElasticTLABDecay -XX:EpsilonTLABDecayTime=100  gc.epsilon.TestElasticTLABDecay
+ * @run main/othervm -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:+EpsilonElasticTLAB -XX:-EpsilonElasticTLABDecay
+ *                   gc.epsilon.TestElasticTLABDecay
+ *
+ * @run main/othervm -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:+EpsilonElasticTLAB -XX:+EpsilonElasticTLABDecay -XX:EpsilonTLABDecayTime=1
+ *                   gc.epsilon.TestElasticTLABDecay
+ *
+ * @run main/othervm -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:+EpsilonElasticTLAB -XX:+EpsilonElasticTLABDecay -XX:EpsilonTLABDecayTime=100
+ *                   gc.epsilon.TestElasticTLABDecay
  */
 
 import java.util.Random;
 import jdk.test.lib.Utils;
 
 public class TestElasticTLABDecay {
-  static int COUNT = Integer.getInteger("count", 3000); // ~500 MB allocation
+  static int COUNT = Integer.getInteger("count", 500); // ~100 MB allocation
 
   static byte[][] arr;
 

--- a/test/hotspot/jtreg/gc/epsilon/TestEpsilonEnabled.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestEpsilonEnabled.java
@@ -28,7 +28,10 @@ package gc.epsilon;
  * @requires vm.gc.Epsilon
  * @summary Basic sanity test for Epsilon
  * @library /test/lib
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestEpsilonEnabled
+ *
+ * @run main/othervm -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestEpsilonEnabled
  */
 
 import java.lang.management.GarbageCollectorMXBean;

--- a/test/hotspot/jtreg/gc/epsilon/TestHelloWorld.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestHelloWorld.java
@@ -27,7 +27,8 @@ package gc.epsilon;
  * @test TestHelloWorld
  * @requires vm.gc.Epsilon
  * @summary Basic sanity test for Epsilon
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestHelloWorld
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestHelloWorld
  */
 
 public class TestHelloWorld {

--- a/test/hotspot/jtreg/gc/epsilon/TestLogTrace.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestLogTrace.java
@@ -28,7 +28,10 @@ package gc.epsilon;
  * @test TestLogTrace
  * @requires vm.gc.Epsilon
  * @summary Test that tracing does not crash Epsilon
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xlog:gc*=trace gc.epsilon.TestLogTrace
+ *
+ * @run main/othervm -Xmx256m -Xlog:gc*=trace
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestLogTrace
  */
 
 public class TestLogTrace {

--- a/test/hotspot/jtreg/gc/epsilon/TestManyThreads.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestManyThreads.java
@@ -28,17 +28,43 @@ package gc.epsilon;
  * @requires vm.gc.Epsilon
  * @summary Test allocations from many threads
  *
- * @run main/othervm -Xmx128m -Xss512k                                        -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestManyThreads
- * @run main/othervm -Xmx128m -Xss512k -Xint                                  -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestManyThreads
- * @run main/othervm -Xmx128m -Xss512k -Xbatch -Xcomp                         -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestManyThreads
- * @run main/othervm -Xmx128m -Xss512k -Xbatch -Xcomp -XX:TieredStopAtLevel=1 -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestManyThreads
- * @run main/othervm -Xmx128m -Xss512k -Xbatch -Xcomp -XX:-TieredCompilation  -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestManyThreads
+ * @run main/othervm -XX:-UseTLAB -Xmx256m -Xss512k
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestManyThreads
  *
- * @run main/othervm -Xmx128m -Xss512k                                        -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestManyThreads
- * @run main/othervm -Xmx128m -Xss512k -Xint                                  -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestManyThreads
- * @run main/othervm -Xmx128m -Xss512k -Xbatch -Xcomp                         -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestManyThreads
- * @run main/othervm -Xmx128m -Xss512k -Xbatch -Xcomp -XX:TieredStopAtLevel=1 -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestManyThreads
- * @run main/othervm -Xmx128m -Xss512k -Xbatch -Xcomp -XX:-TieredCompilation  -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestManyThreads
+ * @run main/othervm -XX:-UseTLAB -Xmx256m -Xss512k
+ *                   -Xint
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestManyThreads
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m -Xss512k
+ *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestManyThreads
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m -Xss512k
+ *                   -Xbatch -Xcomp -XX:-TieredCompilation
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestManyThreads
+ *
+ * @run main/othervm -XX:+UseTLAB -Xmx256m -Xss512k
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestManyThreads
+ *
+ * @run main/othervm -XX:+UseTLAB -Xmx256m -Xss512k
+ *                   -Xint
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestManyThreads
+ *
+ * @run main/othervm -XX:+UseTLAB -Xmx256m -Xss512k
+ *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestManyThreads
+ *
+ * @run main/othervm -XX:+UseTLAB -Xmx256m -Xss512k
+ *                   -Xbatch -Xcomp -XX:-TieredCompilation
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestManyThreads
  */
 
 import java.util.concurrent.atomic.*;

--- a/test/hotspot/jtreg/gc/epsilon/TestMaxTLAB.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestMaxTLAB.java
@@ -29,15 +29,49 @@ package gc.epsilon;
  * @summary Check EpsilonMaxTLAB options
  * @bug 8212177
  *
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -Xmx128m -XX:+UseEpsilonGC -XX:EpsilonMaxTLABSize=1     gc.epsilon.TestMaxTLAB
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -Xmx128m -XX:+UseEpsilonGC -XX:EpsilonMaxTLABSize=1K    gc.epsilon.TestMaxTLAB
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -Xmx128m -XX:+UseEpsilonGC -XX:EpsilonMaxTLABSize=1M    gc.epsilon.TestMaxTLAB
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -Xmx128m -XX:+UseEpsilonGC -XX:EpsilonMaxTLABSize=12345 gc.epsilon.TestMaxTLAB
+ * @run main/othervm -Xmx64m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonMaxTLABSize=1
+ *                   gc.epsilon.TestMaxTLAB
  *
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -Xmx128m -XX:+UseEpsilonGC -XX:EpsilonMaxTLABSize=1     -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16 gc.epsilon.TestMaxTLAB
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -Xmx128m -XX:+UseEpsilonGC -XX:EpsilonMaxTLABSize=1K    -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16 gc.epsilon.TestMaxTLAB
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -Xmx128m -XX:+UseEpsilonGC -XX:EpsilonMaxTLABSize=1M    -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16 gc.epsilon.TestMaxTLAB
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -Xmx128m -XX:+UseEpsilonGC -XX:EpsilonMaxTLABSize=12345 -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16 gc.epsilon.TestMaxTLAB
+ * @run main/othervm -Xmx64m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonMaxTLABSize=1K
+ *                   gc.epsilon.TestMaxTLAB
+ *
+ * @run main/othervm -Xmx64m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonMaxTLABSize=1M
+ *                   gc.epsilon.TestMaxTLAB
+ *
+ * @run main/othervm -Xmx64m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonMaxTLABSize=12345
+ *                   gc.epsilon.TestMaxTLAB
+ *
+ * @run main/othervm -Xmx64m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonMaxTLABSize=1
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16
+ *                   gc.epsilon.TestMaxTLAB
+ *
+ * @run main/othervm -Xmx64m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonMaxTLABSize=1K
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16
+ *                   gc.epsilon.TestMaxTLAB
+ *
+ * @run main/othervm -Xmx64m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonMaxTLABSize=1M
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16
+ *                   gc.epsilon.TestMaxTLAB
+ *
+ * @run main/othervm -Xmx64m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonMaxTLABSize=12345
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16
+ *                   gc.epsilon.TestMaxTLAB
  */
 
 public class TestMaxTLAB {

--- a/test/hotspot/jtreg/gc/epsilon/TestMemoryMXBeans.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestMemoryMXBeans.java
@@ -30,9 +30,21 @@ package gc.epsilon;
  * @summary Test JMX memory beans
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC          -Xmx1g gc.epsilon.TestMemoryMXBeans   -1 1024
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xms1g   -Xmx1g gc.epsilon.TestMemoryMXBeans 1024 1024
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xms128m -Xmx1g gc.epsilon.TestMemoryMXBeans  128 1024
+ *
+ * @run main/othervm -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestMemoryMXBeans
+ *                   -1 256
+ *
+ * @run main/othervm -Xmx256m -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestMemoryMXBeans
+ *                   256 256
+ *
+ * @run main/othervm -Xms64m -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestMemoryMXBeans
+ *                   64 256
  */
 
 import java.lang.management.*;

--- a/test/hotspot/jtreg/gc/epsilon/TestMemoryPools.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestMemoryPools.java
@@ -26,11 +26,14 @@ package gc.epsilon;
 
 /**
  * @test TestMemoryPools
- * @requires vm.gc.Epsilon & os.maxMemory >= 2G
+ * @requires vm.gc.Epsilon
  * @summary Test JMX memory pools
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xmx1g -Xms1g gc.epsilon.TestMemoryPools
+ *
+ * @run main/othervm -Xms64m -Xmx64m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestMemoryPools
  */
 
 import java.lang.management.*;

--- a/test/hotspot/jtreg/gc/epsilon/TestObjects.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestObjects.java
@@ -30,17 +30,43 @@ package gc.epsilon;
  * @summary Epsilon is able to allocate objects, and does not corrupt their state
  * @library /test/lib
  *
- * @run main/othervm -Xmx128m                                        -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestObjects
- * @run main/othervm -Xmx128m -Xint                                  -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestObjects
- * @run main/othervm -Xmx128m -Xbatch -Xcomp                         -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestObjects
- * @run main/othervm -Xmx128m -Xbatch -Xcomp -XX:TieredStopAtLevel=1 -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestObjects
- * @run main/othervm -Xmx128m -Xbatch -Xcomp -XX:-TieredCompilation  -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestObjects
+ * @run main/othervm -XX:+UseTLAB -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestObjects
  *
- * @run main/othervm -Xmx128m                                        -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestObjects
- * @run main/othervm -Xmx128m -Xint                                  -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestObjects
- * @run main/othervm -Xmx128m -Xbatch -Xcomp                         -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestObjects
- * @run main/othervm -Xmx128m -Xbatch -Xcomp -XX:TieredStopAtLevel=1 -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestObjects
- * @run main/othervm -Xmx128m -Xbatch -Xcomp -XX:-TieredCompilation  -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestObjects
+ * @run main/othervm -XX:+UseTLAB -Xmx256m
+ *                   -Xint
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestObjects
+ *
+ * @run main/othervm -XX:+UseTLAB -Xmx256m
+ *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestObjects
+ *
+ * @run main/othervm -XX:+UseTLAB -Xmx256m
+ *                   -Xbatch -Xcomp -XX:-TieredCompilation
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestObjects
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestObjects
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m
+ *                   -Xint
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestObjects
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m
+ *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestObjects
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m
+ *                   -Xbatch -Xcomp -XX:-TieredCompilation
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestObjects
  */
 
 import java.util.Random;

--- a/test/hotspot/jtreg/gc/epsilon/TestPrintHeapSteps.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestPrintHeapSteps.java
@@ -27,9 +27,21 @@ package gc.epsilon;
  * @test TestPrintSteps
  * @requires vm.gc.Epsilon
  * @summary Tests -XX:EpsilonPrintHeapSteps works
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xlog:gc -XX:EpsilonPrintHeapSteps=0    gc.epsilon.TestPrintHeapSteps
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xlog:gc -XX:EpsilonPrintHeapSteps=1    gc.epsilon.TestPrintHeapSteps
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xlog:gc -XX:EpsilonPrintHeapSteps=1000 gc.epsilon.TestPrintHeapSteps
+ *
+ * @run main/othervm -Xmx64m -Xlog:gc
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonPrintHeapSteps=0
+ *                   gc.epsilon.TestPrintHeapSteps
+ *
+ * @run main/othervm -Xmx64m -Xlog:gc
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonPrintHeapSteps=1
+ *                   gc.epsilon.TestPrintHeapSteps
+ *
+ * @run main/othervm -Xmx64m -Xlog:gc
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonPrintHeapSteps=1000
+ *                   gc.epsilon.TestPrintHeapSteps
  */
 
 public class TestPrintHeapSteps {

--- a/test/hotspot/jtreg/gc/epsilon/TestRefArrays.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestRefArrays.java
@@ -30,24 +30,50 @@ package gc.epsilon;
  * @summary Epsilon is able to allocate arrays, and does not corrupt their state
  * @library /test/lib
  *
- * @run main/othervm -Xmx1g                                        -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestRefArrays
- * @run main/othervm -Xmx1g -Xint                                  -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestRefArrays
- * @run main/othervm -Xmx1g -Xbatch -Xcomp                         -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestRefArrays
- * @run main/othervm -Xmx1g -Xbatch -Xcomp -XX:TieredStopAtLevel=1 -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestRefArrays
- * @run main/othervm -Xmx1g -Xbatch -Xcomp -XX:-TieredCompilation  -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestRefArrays
+ * @run main/othervm -XX:+UseTLAB -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestRefArrays
  *
- * @run main/othervm -Xmx1g                                        -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestRefArrays
- * @run main/othervm -Xmx1g -Xint                                  -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestRefArrays
- * @run main/othervm -Xmx1g -Xbatch -Xcomp                         -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestRefArrays
- * @run main/othervm -Xmx1g -Xbatch -Xcomp -XX:TieredStopAtLevel=1 -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestRefArrays
- * @run main/othervm -Xmx1g -Xbatch -Xcomp -XX:-TieredCompilation  -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC gc.epsilon.TestRefArrays
+ * @run main/othervm -XX:+UseTLAB -Xmx256m
+ *                   -Xint
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestRefArrays
+ *
+ * @run main/othervm -XX:+UseTLAB -Xmx256m
+ *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestRefArrays
+ *
+ * @run main/othervm -XX:+UseTLAB -Xmx256m
+ *                   -Xbatch -Xcomp -XX:-TieredCompilation
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestRefArrays
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestRefArrays
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m
+ *                   -Xint
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestRefArrays
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m
+ *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestRefArrays
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m
+ *                   -Xbatch -Xcomp -XX:-TieredCompilation
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   gc.epsilon.TestRefArrays
  */
 
 import java.util.Random;
 import jdk.test.lib.Utils;
 
 public class TestRefArrays {
-  static int COUNT = Integer.getInteger("count", 1000); // ~500 MB allocation
+  static int COUNT = Integer.getInteger("count", 200); // ~100 MB allocation
 
   static MyObject[][] arr;
 

--- a/test/hotspot/jtreg/gc/epsilon/TestUpdateCountersSteps.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestUpdateCountersSteps.java
@@ -27,10 +27,26 @@ package gc.epsilon;
  * @test TestUpdateCountersSteps
  * @requires vm.gc.Epsilon
  * @summary Test EpsilonUpdateCountersStep works
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xlog:gc -XX:EpsilonUpdateCountersStep=1    gc.epsilon.TestUpdateCountersSteps
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xlog:gc -XX:EpsilonUpdateCountersStep=10   gc.epsilon.TestUpdateCountersSteps
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xlog:gc -XX:EpsilonUpdateCountersStep=100  gc.epsilon.TestUpdateCountersSteps
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xlog:gc -XX:EpsilonUpdateCountersStep=1000 gc.epsilon.TestUpdateCountersSteps
+ *
+ * @run main/othervm -Xmx64m -Xlog:gc
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonUpdateCountersStep=1
+ *                   gc.epsilon.TestUpdateCountersSteps
+ *
+ * @run main/othervm -Xmx64m -Xlog:gc
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonUpdateCountersStep=10
+ *                   gc.epsilon.TestUpdateCountersSteps
+ *
+ * @run main/othervm -Xmx64m -Xlog:gc
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonUpdateCountersStep=100
+ *                   gc.epsilon.TestUpdateCountersSteps
+ *
+ * @run main/othervm -Xmx64m -Xlog:gc
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonUpdateCountersStep=1000
+ *                   gc.epsilon.TestUpdateCountersSteps
  */
 
 public class TestUpdateCountersSteps {


### PR DESCRIPTION
Epsilon tests run in tier1, and they take considerable time, especially on low-core machines. We can refactor and simplify some of the tests for better performance.

The improvements are:
  - Dropping test heap sizes to 64M..256M, which saves time zeroing/zapping the heap area;
  - Dropping some configurations, notably out-of-box `-Xbatch -Xcomp` (which makes little sense, as C1/C2 paths would be taken by other configs)

Additionally, run configurations were reformatted to avoid long lines.

```
$ make run-test TEST=gc/epsilon

# Before
real	1m28.297s
user	9m2.689s
sys	0m18.370s

# After
real	1m0.396s
user	6m27.221s
sys	0m13.499s
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272783](https://bugs.openjdk.java.net/browse/JDK-8272783): Epsilon: Refactor tests to improve performance


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5202/head:pull/5202` \
`$ git checkout pull/5202`

Update a local copy of the PR: \
`$ git checkout pull/5202` \
`$ git pull https://git.openjdk.java.net/jdk pull/5202/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5202`

View PR using the GUI difftool: \
`$ git pr show -t 5202`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5202.diff">https://git.openjdk.java.net/jdk/pull/5202.diff</a>

</details>
