### PR TITLE
8270380: Change the default value of the java.security.manager system property to disallow

### DIFF
--- a/src/java.base/share/classes/java/lang/SecurityManager.java
+++ b/src/java.base/share/classes/java/lang/SecurityManager.java
@@ -28,7 +28,6 @@ package java.lang;
 import java.lang.module.ModuleDescriptor;
 import java.lang.module.ModuleDescriptor.Exports;
 import java.lang.module.ModuleDescriptor.Opens;
-import java.lang.reflect.Member;
 import java.io.FileDescriptor;
 import java.io.File;
 import java.io.FilePermission;
@@ -48,7 +47,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import jdk.internal.module.ModuleLoaderMap;
-import jdk.internal.reflect.CallerSensitive;
 import sun.security.util.SecurityConstants;
 
 /**
@@ -96,13 +94,13 @@ import sun.security.util.SecurityConstants;
  * {@link System#setSecurityManager(SecurityManager) setSecurityManager} method.
  * In the JDK implementation, if the Java virtual machine is started with
  * the {@code java.security.manager} system property set to the special token
- * "{@code disallow}" then a security manager will not be set at startup and
- * cannot be set dynamically (the
+ * "{@code allow}", then a security manager will not be set at startup but can
+ * be set dynamically. If the Java virtual machine is started with the
+ * {@code java.security.manager} system property not set or set to the special
+ * token "{@code disallow}", then a security manager will not be set at startup
+ * and cannot be set dynamically (the
  * {@link System#setSecurityManager(SecurityManager) setSecurityManager}
- * method will throw an {@code UnsupportedOperationException}). If the
- * {@code java.security.manager} system property is not set or is set to the
- * special token "{@code allow}", then a security manager will not be set at
- * startup but can be set dynamically. Finally, if the
+ * method will throw an {@code UnsupportedOperationException}). Finally, if the
  * {@code java.security.manager} system property is set to the class name of
  * the security manager, or to the empty String ("") or the special token
  * "{@code default}", then a security manager is set at startup (as described
@@ -127,8 +125,7 @@ import sun.security.util.SecurityConstants;
  * <tr>
  *   <th scope="row">null</th>
  *   <td>None</td>
- *   <td>Success or throws {@code SecurityException} if not permitted by
- * the currently installed security manager</td>
+ *   <td>Always throws {@code UnsupportedOperationException}</td>
  * </tr>
  *
  * <tr>
@@ -167,8 +164,6 @@ import sun.security.util.SecurityConstants;
  *
  * </tbody>
  * </table>
- * <p> A future release of the JDK may change the default value of the
- * {@code java.security.manager} system property to "{@code disallow}".
  * <p>
  * The current security manager is returned by the
  * {@link System#getSecurityManager() getSecurityManager} method.

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -361,7 +361,7 @@ public final class System {
      * the method simply returns.
      *
      * @implNote In the JDK implementation, if the Java virtual machine is
-     * started with the system property {@code java.security.manager} set to
+     * started with the system property {@code java.security.manager} not set or set to
      * the special token "{@code disallow}" then the {@code setSecurityManager}
      * method cannot be used to set a security manager.
      *
@@ -2228,7 +2228,7 @@ public final class System {
                     allowSecurityManager = MAYBE;
             }
         } else {
-            allowSecurityManager = MAYBE;
+            allowSecurityManager = NEVER;
         }
 
         if (needWarning) {

--- a/test/jdk/java/lang/System/AllowSecurityManager.java
+++ b/test/jdk/java/lang/System/AllowSecurityManager.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8191053
+ * @bug 8191053 8270380
  * @summary Test that the allow/disallow options of the java.security.manager
  *          system property work correctly
  * @run main/othervm AllowSecurityManager
@@ -35,7 +35,7 @@ public class AllowSecurityManager {
 
     public static void main(String args[]) throws Exception {
         String prop = System.getProperty("java.security.manager");
-        boolean disallow = "disallow".equals(prop);
+        boolean disallow = !"allow".equals(prop);
         try {
             System.setSecurityManager(new SecurityManager());
             if (disallow) {

--- a/test/jdk/java/lang/System/SecurityManagerWarnings.java
+++ b/test/jdk/java/lang/System/SecurityManagerWarnings.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8266459 8268349 8269543
+ * @bug 8266459 8268349 8269543 8270380
  * @summary check various warnings
  * @library /test/lib
  */
@@ -53,7 +53,7 @@ public class SecurityManagerWarnings {
 
             String testClasses = System.getProperty("test.classes");
 
-            allowTest(null, testClasses);
+            disallowTest(null, testClasses);
             allowTest("allow", testClasses);
             disallowTest("disallow", testClasses);
             enableTest("", testClasses);
@@ -66,7 +66,7 @@ public class SecurityManagerWarnings {
                     Path.of("A.class"),
                     Path.of("B.class"));
 
-            allowTest(null, "a.jar");
+            disallowTest(null, "a.jar");
         } else {
             System.out.println("SM is enabled: " + (System.getSecurityManager() != null));
             PrintStream oldErr = System.err;

--- a/test/jdk/sun/security/pkcs11/KeyStore/Basic.java
+++ b/test/jdk/sun/security/pkcs11/KeyStore/Basic.java
@@ -33,7 +33,7 @@
  *    . 'list' lists the token aliases
  *    . 'basic' does not run with activcard,
  * @library /test/lib ..
- * @run testng/othervm Basic
+ * @run testng/othervm -Djava.security.manager=allow Basic
  */
 
 import java.io.*;

--- a/test/jdk/sun/security/pkcs11/Provider/MultipleLogins.sh
+++ b/test/jdk/sun/security/pkcs11/Provider/MultipleLogins.sh
@@ -129,7 +129,7 @@ TEST_ARGS="${TESTVMOPTS} -classpath ${TESTCLASSPATH} \
 ${TESTJAVA}${FS}bin${FS}java ${TEST_ARGS} MultipleLogins || exit 10
 
 # run test with security manager
-${TESTJAVA}${FS}bin${FS}java ${TEST_ARGS} MultipleLogins useSimplePolicy || exit 11
+${TESTJAVA}${FS}bin${FS}java ${TEST_ARGS} -Djava.security.manager=allow MultipleLogins useSimplePolicy || exit 11
 
 echo Done
 exit 0


### PR DESCRIPTION
This change modifies the default value of the `java.security.manager` system property from "allow" to "disallow". This means unless it's explicitly set to "allow", any call to `System.setSecurityManager()` would throw an UOE.

The `AllowSecurityManager.java` and `SecurityManagerWarnings.java` tests are updated to confirm this behavior change. Two other tests are updated because they were added after JDK-8267184 and do not have `-Djava.security.manager=allow` on its `@run` line even it they need to install one at runtime.
