### PR TITLE
8272554: Add help message about the named pipe support of UL.

### DIFF
--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -562,7 +562,8 @@ void LogConfiguration::print_command_line_help(outputStream* out) {
   out->print_cr("\nAvailable log outputs:");
   out->print_cr(" stdout/stderr");
   out->print_cr(" file=<filename>");
-  out->print_cr("  If the filename contains %%p and/or %%t, they will expand to the JVM's PID and startup timestamp, respectively.");
+  out->print_cr("  If the filename contains %%p and/or %%t, they will expand to the JVM's PID and startup timestamp, respectively."
+                " The filename can be a named pipe when log rotation is disabled.");
   out->print_cr("  Additional output-options for file outputs:");
   out->print_cr("   filesize=..  - Target byte size for log rotation (supports K/M/G suffix)."
                                     " If set to 0, log rotation will not trigger automatically,"

--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -4500,6 +4500,7 @@ Files are rotated by default with up to 5 rotated files of target size
 20 MB, unless configured otherwise.
 Specifying \f[CB]filecount=0\f[R] means that the log file shouldn\[aq]t be
 rotated.
+The filename can be a named pipe when log rotation is disabled.
 There\[aq]s a possibility of the pre\-existing log file getting
 overwritten.
 .SS \-Xlog Output Mode


### PR DESCRIPTION
This patch adds a help message about the named pipe support of the Unified Logging to -Xlog:help and manpage.

For -Xlog:help, here is the new help message:
```
Available log outputs:
 stdout/stderr
 file=<filename>
  If the filename contains %p and/or %t, they will expand to the JVM's PID and startup timestamp, respectively. The filename can be a named pipe when log rotation is disabled.  
```

Here is the new manpage content.
```
 When using file=filename, specifying %p and/or %t in the file name expands to the JVM's PID and startup timestamp, respectively.  You can also configure text files to handle file rotation based on file size and a number of files to rotate.  For example, to rotate the log file every 10 MB and  keep  5
 files  in rotation, specify the options filesize=10M, filecount=5.  The target size of the files isn't guaranteed to be exact, it's just an approximate value.  Files are rotated by default with up to 5 rotated files of target size 20 MB, unless configured otherwise.  Specifying filecount=0 means that
 the log file shouldn't be rotated.  The filename can be a named pipe when log rotation is disabled.  There's a possibility of the pre-existing log file getting overwritten.
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8272554](https://bugs.openjdk.java.net/browse/JDK-8272554): Add help message about the named pipe support of UL.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5205/head:pull/5205` \
`$ git checkout pull/5205`

Update a local copy of the PR: \
`$ git checkout pull/5205` \
`$ git pull https://git.openjdk.java.net/jdk pull/5205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5205`

View PR using the GUI difftool: \
`$ git pr show -t 5205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5205.diff">https://git.openjdk.java.net/jdk/pull/5205.diff</a>

</details>
