### PR TITLE
JDK-8265253: javac -Xdoclint:all gives "no comment" warning for code that can't be commented

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
@@ -45,9 +45,12 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Name;
+import javax.lang.model.element.NestingKind;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
 import javax.tools.Diagnostic.Kind;
 import javax.tools.JavaFileObject;
 
@@ -188,7 +191,7 @@ public class Checker extends DocTreePathScanner<Void, Void> {
                     if (isNormalClass(p.getParentPath())) {
                         reportMissing("dc.default.constructor");
                     }
-                } else if (!isOverridingMethod) {
+                } else if (!isOverridingMethod && !isSynthetic() && !isAnonymous()) {
                     reportMissing("dc.missing.comment");
                 }
                 return null;
@@ -1156,6 +1159,15 @@ public class Checker extends DocTreePathScanner<Void, Void> {
     private boolean isCheckedException(TypeMirror t) {
         return !(env.types.isAssignable(t, env.java_lang_Error)
                 || env.types.isAssignable(t, env.java_lang_RuntimeException));
+    }
+
+    private boolean isSynthetic() {
+        return env.elements.getOrigin(env.currElement) == Elements.Origin.SYNTHETIC;
+    }
+
+    private boolean isAnonymous() {
+        return (env.currElement instanceof TypeElement te)
+                && te.getNestingKind() == NestingKind.ANONYMOUS;
     }
 
     private boolean isDefaultConstructor() {

--- a/test/langtools/tools/doclint/AnonClassTest.java
+++ b/test/langtools/tools/doclint/AnonClassTest.java
@@ -1,0 +1,37 @@
+/*
+ * @test /nodynamiccopyright/
+ * @modules jdk.javadoc/jdk.javadoc.internal.doclint
+ * @build DocLintTester
+ * @run main DocLintTester -Xmsgs:-missing AnonClassTest.java
+ * @run main DocLintTester -Xmsgs:missing -ref AnonClassTest.out AnonClassTest.java
+ */
+
+/** Class comment. */
+public enum AnonClassTest {
+
+    /**
+     * E1 comment.
+     * This member uses an anonymous class, which should not trigger a warning.
+     */
+    E1 {
+        // no comment: should give warning
+        int field;
+
+        // no comment: should give warning
+        void m() { }
+
+        // no comment required: should not give warning
+        @java.lang.Override
+        public void m1() { }
+    },
+
+    // This member also uses an anonymous class,
+    // but there should only be a single warning for the member itself.
+    E2 { },
+
+    /** E3 comment. This member does not use an anonymous class. */
+    E3;
+
+    /** Method comment. */
+    public void m1() { }
+}

--- a/test/langtools/tools/doclint/AnonClassTest.out
+++ b/test/langtools/tools/doclint/AnonClassTest.out
@@ -1,0 +1,10 @@
+AnonClassTest.java:18: warning: no comment
+        int field;
+            ^
+AnonClassTest.java:21: warning: no comment
+        void m() { }
+             ^
+AnonClassTest.java:30: warning: no comment
+    E2 { },
+    ^
+3 warnings


### PR DESCRIPTION
Please review a simple update for doclint, to suppress "missing comment" warnings on the internally-synthesized class resulting from use of an anonymous class body in a member declaration in an enum class..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265253](https://bugs.openjdk.java.net/browse/JDK-8265253): javac -Xdoclint:all gives "no comment" warning for code that can't be commented


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.java.net/census#hannesw) (@hns - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5206/head:pull/5206` \
`$ git checkout pull/5206`

Update a local copy of the PR: \
`$ git checkout pull/5206` \
`$ git pull https://git.openjdk.java.net/jdk pull/5206/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5206`

View PR using the GUI difftool: \
`$ git pr show -t 5206`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5206.diff">https://git.openjdk.java.net/jdk/pull/5206.diff</a>

</details>
