### PR TITLE
8273960: Redundant condition in Metadata.TypeComparator.compare

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Metadata.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Metadata.java
@@ -68,7 +68,7 @@ final class Metadata extends Command {
                 } else {
                     // Ensure that jdk.* are printed first
                     // This makes it easier to find user defined events at the end.
-                    if (Type.SUPER_TYPE_EVENT.equals(t1.getSuperType()) && !package1.equals(package2)) {
+                    if (Type.SUPER_TYPE_EVENT.equals(t1.getSuperType())) {
                         if (package1.equals("jdk.jfr")) {
                             return -1;
                         }


### PR DESCRIPTION
This condition is always `true`, as there is already check above:
```
                if (package1.equals(package2)) {
                    return n1.compareTo(n2);
                } else {
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273960](https://bugs.openjdk.java.net/browse/JDK-8273960): Redundant condition in Metadata.TypeComparator.compare


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5207/head:pull/5207` \
`$ git checkout pull/5207`

Update a local copy of the PR: \
`$ git checkout pull/5207` \
`$ git pull https://git.openjdk.java.net/jdk pull/5207/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5207`

View PR using the GUI difftool: \
`$ git pr show -t 5207`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5207.diff">https://git.openjdk.java.net/jdk/pull/5207.diff</a>

</details>
