### PR TITLE
8272806: [macOS] "Apple AWT Internal Exception" when input method is changed

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CInputMethod.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CInputMethod.m
@@ -115,9 +115,7 @@ static void initializeInputMethodController() {
     AWT_ASSERT_APPKIT_THREAD;
 
     if (!view) return;
-    if (!inputMethod) return;
-
-    [view setInputMethod:inputMethod]; // inputMethod is a GlobalRef
+    [view setInputMethod:inputMethod]; // inputMethod is a GlobalRef or null to disable.
 }
 
 + (void) _nativeEndComposition:(AWTView *)view {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/LWCToolkit.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/LWCToolkit.m
@@ -259,6 +259,7 @@ BOOL isSWTInWebStart(JNIEnv* env) {
 
 static void AWT_NSUncaughtExceptionHandler(NSException *exception) {
     NSLog(@"Apple AWT Internal Exception: %@", [exception description]);
+    NSLog(@"trace: %@", [exception callStackSymbols]);
 }
 
 @interface AWTStarter : NSObject


### PR DESCRIPTION
There's a long eval in the bug report : https://bugs.openjdk.java.net/browse/JDK-8272806 but here's the summary

When focus is lost by the app a message is sent down to native setting a native reference to the input method to null
which is a sort of signal not to notify upwards anything to the input method (which internally will NPE if there's
no focused component as is the case after focus is lost).
But we aren't actually setting it to null because of a check for null which previously checked the wrapper for
the JNI ref was not null but is now obsolete.  So just remove the check for null.

The steps to reproduce this bug are very manual and involve installing additional input methods and toggling them
at the system level. So I didn't see a way to write a useful regression test but if you follow the bug report steps you
should be able to verify the fix.

I've run all automated tests just for good measure and they all pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272806](https://bugs.openjdk.java.net/browse/JDK-8272806): [macOS] "Apple AWT Internal Exception" when input method is changed


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Dmitry Markov](https://openjdk.java.net/census#dmarkov) (@dmarkov20 - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5211/head:pull/5211` \
`$ git checkout pull/5211`

Update a local copy of the PR: \
`$ git checkout pull/5211` \
`$ git pull https://git.openjdk.java.net/jdk pull/5211/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5211`

View PR using the GUI difftool: \
`$ git pr show -t 5211`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5211.diff">https://git.openjdk.java.net/jdk/pull/5211.diff</a>

</details>
