### PR TITLE
8242847: G1 should not clear mark bitmaps with no marks

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -616,7 +616,7 @@ private:
           assert(_bitmap->get_next_marked_addr(r->bottom(), r->end()) == r->end(), "Should not have marked bits");
           return r->bottom();
         }
-        assert(_bitmap->get_next_marked_addr(r->next_top_at_mark_start(), r->end()) == r->end(), "Should not have marked bits above ntams"); 
+        assert(_bitmap->get_next_marked_addr(r->next_top_at_mark_start(), r->end()) == r->end(), "Should not have marked bits above ntams");
       }
       return r->end();
     }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -629,7 +629,7 @@ private:
         assert(_cm == NULL || _cm->cm_thread()->in_progress(), "invariant");
         assert(_cm == NULL || !G1CollectedHeap::heap()->collector_state()->mark_or_rebuild_in_progress(), "invariant");
       }
-      assert(cur >= end, "Must have completed iteration over the bitmap for region %u. ", r->hrm_index());
+      assert(cur >= end, "Must have completed iteration over the bitmap for region %u.", r->hrm_index());
 
       return false;
     }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -444,9 +444,9 @@ class G1ConcurrentMark : public CHeapObj<mtGC> {
   void enter_first_sync_barrier(uint worker_id);
   void enter_second_sync_barrier(uint worker_id);
 
-  // Clear the given bitmap in parallel using the given WorkGang. If may_yield is
+  // Clear the next marking bitmap in parallel using the given WorkGang. If may_yield is
   // true, periodically insert checks to see if this method should exit prematurely.
-  void clear_bitmap(G1CMBitMap* bitmap, WorkGang* workers, bool may_yield);
+  void clear_next_bitmap(WorkGang* workers, bool may_yield);
 
   // Region statistics gathered during marking.
   G1RegionMarkStats* _region_mark_stats;

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
@@ -324,6 +324,8 @@ void G1ConcurrentMarkThread::concurrent_undo_cycle_do() {
   // some reason.
   if (_cm->has_aborted()) { return; }
 
+  _cm->flush_all_task_caches();
+
   // Phase 1: Clear bitmap for next mark.
   phase_clear_bitmap_for_next_mark();
 }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.hpp
@@ -108,6 +108,8 @@ class G1ConcurrentMarkThread: public ConcurrentGCThread {
   // marking bitmap has been cleared and in_progress() is
   // cleared).
   bool in_progress() const;
+
+  bool in_undo_mark() const;
 };
 
 #endif // SHARE_GC_G1_G1CONCURRENTMARKTHREAD_HPP

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.inline.hpp
@@ -60,4 +60,8 @@ inline bool G1ConcurrentMarkThread::in_progress() const {
   return !idle();
 }
 
+inline bool G1ConcurrentMarkThread::in_undo_mark() const {
+  return _state == UndoMark;
+}
+
 #endif // SHARE_GC_G1_G1CONCURRENTMARKTHREAD_INLINE_HPP


### PR DESCRIPTION
Hi all,

Please review this change to bound the range of bitmap clearing for each region using the liveness data collected during marking. For the Concurrent Undo Mark cycle, the liveness information (next_top_at_mark_start and live_words) is in sync wrt. the _next_mark_bitmap that needs clearing. Hence, we use these details to clear only bitmaps for regions that were dirtied and need clearing i.e. only clear between [bottom, ntams), and only clear bitmaps for regions that had at least one bit set (i.e. have some live data).

Testing: Tier 1-3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242847](https://bugs.openjdk.java.net/browse/JDK-8242847): G1 should not clear mark bitmaps with no marks


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5213/head:pull/5213` \
`$ git checkout pull/5213`

Update a local copy of the PR: \
`$ git checkout pull/5213` \
`$ git pull https://git.openjdk.java.net/jdk pull/5213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5213`

View PR using the GUI difftool: \
`$ git pr show -t 5213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5213.diff">https://git.openjdk.java.net/jdk/pull/5213.diff</a>

</details>
