### PR TITLE
8272836: Optimize run time for java/lang/invoke/LFCaching tests

### DIFF
--- a/test/jdk/java/lang/invoke/LFCaching/LambdaFormTestCase.java
+++ b/test/jdk/java/lang/invoke/LFCaching/LambdaFormTestCase.java
@@ -45,8 +45,7 @@ import java.util.function.Function;
  */
 public abstract class LambdaFormTestCase {
 
-    private static final long TIMEOUT = Helper.IS_THOROUGH ?
-            0L : (long) (Utils.adjustTimeout(Utils.DEFAULT_TEST_TIMEOUT) * 0.9);
+    private static final long TIMEOUT = Helper.IS_THOROUGH ? 0L : 60_000L;
 
     /**
      * Reflection link to {@code j.l.i.MethodHandle.internalForm} method. It is


### PR DESCRIPTION
See the RFE for discussion.

Current PR improves the test time like this:

```
$  make run-test TEST=java/lang/invoke/LFCaching/

# Before
real	3m51.608s
user	5m21.612s
sys	0m5.391s

# After
real	1m13.606s
user	2m26.827s
sys	0m4.761s
```