### PR TITLE
8272807: Permit use of memory concurrent with pretouch

### DIFF
--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -368,10 +368,11 @@ class os: AllStatic {
   static void print_memory_mappings(outputStream* st);
 
   // Touch memory pages that cover the memory range from start to end (exclusive)
-  // to make the OS back the memory range with actual memory.
-  // Current implementation may not touch the last page if unaligned addresses
-  // are passed.
-  static void   pretouch_memory(void* start, void* end, size_t page_size = vm_page_size());
+  // to make the OS back the memory range with actual memory.  Touching does not
+  // affect the values in memory; other threads may use the pages while the
+  // pretouch operation is in progress.
+  // precondition: page_size is a power of 2 and >= sizeof(int).
+  static void pretouch_memory(void* start, void* end, size_t page_size = vm_page_size());
 
   enum ProtType { MEM_PROT_NONE, MEM_PROT_READ, MEM_PROT_RW, MEM_PROT_RWX };
   static bool   protect_memory(char* addr, size_t bytes, ProtType prot,


### PR DESCRIPTION
Please review this change to os::pretouch_memory to permit use of the memory
concurrently with the pretouch operation.  This is accomplished by using an
atomic add of zero as the operation for touching the memory, ensuring the
virtual location is backed by physical memory while not changing any values
being read or written by the application.

While I was there, fixed some other lurking issues in os::pretouch_memory.
There was a potential overflow in the iteration that has been fixed.  And if
the range arguments weren't page aligned then the last page might not get
touched.  The latter was even mentioned in the function's description.  Both
of those have been fixed by careful alignment and some extra checks.  The
resulting code is a little more complicated, but more robust and complete.

This change doesn't make use of the new capability; I have some other
changes in development to do that.

Testing:
mach5 tier1-3.

I've been using this change while developing uses of the new capability.
Performance testing hasn't found any regressions related to this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272807](https://bugs.openjdk.java.net/browse/JDK-8272807): Permit use of memory concurrent with pretouch


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5215/head:pull/5215` \
`$ git checkout pull/5215`

Update a local copy of the PR: \
`$ git checkout pull/5215` \
`$ git pull https://git.openjdk.java.net/jdk pull/5215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5215`

View PR using the GUI difftool: \
`$ git pr show -t 5215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5215.diff">https://git.openjdk.java.net/jdk/pull/5215.diff</a>

</details>
