### PR TITLE
8271923: [macos] the text color on the selected disabled tabbed pane button remains white making text unreadable

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaLookAndFeel.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaLookAndFeel.java
@@ -327,7 +327,8 @@ public class AquaLookAndFeel extends BasicLookAndFeel {
         // Contrast tab UI colors
 
         final ColorUIResource selectedTabTitlePressedColor = new ColorUIResource(240, 240, 240);
-        final ColorUIResource selectedTabTitleDisabledColor = black;
+        final ColorUIResource selectedTabTitleDisabledColor = new ColorUIResource(new Color(1, 1, 1, 0.55f));
+        final ColorUIResource selectedTabTitleNonFocusColor = black;
         final ColorUIResource selectedTabTitleNormalColor = white;
         final Color selectedControlTextColor = AquaImageFactory.getSelectedControlColorUIResource();
         final ColorUIResource selectedTabTitleShadowDisabledColor = new ColorUIResource(new Color(0, 0, 0, 0.25f));
@@ -871,6 +872,7 @@ public class AquaLookAndFeel extends BasicLookAndFeel {
             "TabbedPane.tabsOverlapBorder", Boolean.TRUE,
             "TabbedPane.selectedTabTitlePressedColor", selectedTabTitlePressedColor,
             "TabbedPane.selectedTabTitleDisabledColor", selectedTabTitleDisabledColor,
+            "TabbedPane.selectedTabTitleNonFocusColor", selectedTabTitleNonFocusColor,
             "TabbedPane.selectedTabTitleNormalColor", JRSUIUtils.isMacOSXBigSurOrAbove() ? selectedControlTextColor : selectedTabTitleNormalColor,
             "TabbedPane.selectedTabTitleShadowDisabledColor", selectedTabTitleShadowDisabledColor,
             "TabbedPane.selectedTabTitleShadowNormalColor", selectedTabTitleShadowNormalColor,

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaLookAndFeel.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaLookAndFeel.java
@@ -327,7 +327,7 @@ public class AquaLookAndFeel extends BasicLookAndFeel {
         // Contrast tab UI colors
 
         final ColorUIResource selectedTabTitlePressedColor = new ColorUIResource(240, 240, 240);
-        final ColorUIResource selectedTabTitleDisabledColor = new ColorUIResource(new Color(1, 1, 1, 0.55f));
+        final ColorUIResource selectedTabTitleDisabledColor = black;
         final ColorUIResource selectedTabTitleNormalColor = white;
         final Color selectedControlTextColor = AquaImageFactory.getSelectedControlColorUIResource();
         final ColorUIResource selectedTabTitleShadowDisabledColor = new ColorUIResource(new Color(0, 0, 0, 0.25f));

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTabbedPaneContrastUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTabbedPaneContrastUI.java
@@ -80,8 +80,10 @@ public class AquaTabbedPaneContrastUI extends AquaTabbedPaneUI {
     protected static Color getSelectedTabTitleColor(boolean enabled, boolean pressed) {
         if (enabled && pressed) {
             return UIManager.getColor("TabbedPane.selectedTabTitlePressedColor");
-        } else if (!enabled || (!JRSUIUtils.isMacOSXBigSurOrAbove() && !isFrameActive)) {
+        } else if (!enabled) {
             return UIManager.getColor("TabbedPane.selectedTabTitleDisabledColor");
+        } else if (!JRSUIUtils.isMacOSXBigSurOrAbove() && !isFrameActive) {
+            return UIManager.getColor("TabbedPane.selectedTabTitleNonFocusColor");
         } else {
             return UIManager.getColor("TabbedPane.selectedTabTitleNormalColor");
         }

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTabbedPaneContrastUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTabbedPaneContrastUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTabbedPaneContrastUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTabbedPaneContrastUI.java
@@ -38,9 +38,12 @@ import javax.swing.text.View;
 
 import sun.swing.SwingUtilities2;
 
+import apple.laf.JRSUIUtils;
 import apple.laf.JRSUIConstants.*;
 
 public class AquaTabbedPaneContrastUI extends AquaTabbedPaneUI {
+    private static boolean isFrameActive = false;
+
     public static ComponentUI createUI(final JComponent c) {
         return new AquaTabbedPaneContrastUI();
     }
@@ -77,7 +80,7 @@ public class AquaTabbedPaneContrastUI extends AquaTabbedPaneUI {
     protected static Color getSelectedTabTitleColor(boolean enabled, boolean pressed) {
         if (enabled && pressed) {
             return UIManager.getColor("TabbedPane.selectedTabTitlePressedColor");
-        } else if (!enabled) {
+        } else if (!enabled || (!JRSUIUtils.isMacOSXBigSurOrAbove() && !isFrameActive)) {
             return UIManager.getColor("TabbedPane.selectedTabTitleDisabledColor");
         } else {
             return UIManager.getColor("TabbedPane.selectedTabTitleNormalColor");
@@ -101,6 +104,7 @@ public class AquaTabbedPaneContrastUI extends AquaTabbedPaneUI {
     }
 
     protected State getState(final int index, final boolean frameActive, final boolean isSelected) {
+        isFrameActive = frameActive;;
         if (!frameActive) return State.INACTIVE;
         if (!tabPane.isEnabled()) return State.DISABLED;
         if (pressedTab == index) return State.PRESSED;


### PR DESCRIPTION
It is seen that  if a JTabbedPane is unfocused, it's title is painted with **white** text on grey background 
as opposed to **black** text on grey background in unfoucsed native app on macOSX Catalina
and is somewhat not legible. 
This can be seen with SwingSet2 demo with InternalFrame or JTabbedPane demo and any native app, making focus toggle between the two.

Issue was TabbedPane always draw with "selectedTabTitleNormalColor" which is white. Although Aqua L&F defined selectedTabTitleDisabledColor but it is not used as TabbedPane does not check if focus is there in current frame and draw accordingly, which native app does.

Proposed fix is to check for frame is active or not and draw text color accordingly. 
Since it is not affecting BigSur (where even if native app active or not text is always drawn in same color), it is only restricted to Catalina and lower.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271923](https://bugs.openjdk.java.net/browse/JDK-8271923): [macos] the text color on the selected disabled tabbed pane button remains white making text unreadable


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5217/head:pull/5217` \
`$ git checkout pull/5217`

Update a local copy of the PR: \
`$ git checkout pull/5217` \
`$ git pull https://git.openjdk.java.net/jdk pull/5217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5217`

View PR using the GUI difftool: \
`$ git pr show -t 5217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5217.diff">https://git.openjdk.java.net/jdk/pull/5217.diff</a>

</details>
