### PR TITLE
8268148: unchecked warnings handle ? and ? extends Object differently

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -877,7 +877,9 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
                 kind == UNBOUND;
         }
         public boolean isUnbound() {
-            return kind == UNBOUND;
+            // is it `?` or `? extends Object`?
+            return kind == UNBOUND ||
+                    (kind == EXTENDS && type.hasTag(CLASS) && ((ClassType)type).supertype_field == Type.noType);
         }
 
         @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -879,7 +879,7 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
         public boolean isUnbound() {
             // is it `?` or `? extends Object`?
             return kind == UNBOUND ||
-                    (kind == EXTENDS && type.hasTag(CLASS) && ((ClassType)type).supertype_field == Type.noType);
+                    (kind == EXTENDS && type.tsym.flatName() == type.tsym.name.table.names.java_lang_Object);
         }
 
         @Override

--- a/test/langtools/tools/javac/generics/inference/8176534/T8176534.out
+++ b/test/langtools/tools/javac/generics/inference/8176534/T8176534.out
@@ -1,8 +1,7 @@
 T8176534.java:12:43: compiler.warn.unchecked.meth.invocation.applied: kindname.method, forEnumeration, java.util.Enumeration<T>, java.util.Enumeration, kindname.class, T8176534
 T8176534.java:12:44: compiler.warn.prob.found.req: (compiler.misc.unchecked.assign), java.util.Enumeration, java.util.Enumeration<T>
 T8176534.java:12:28: compiler.warn.unchecked.meth.invocation.applied: kindname.method, newArrayList, java.util.Iterator<? extends E>, java.util.Iterator, kindname.class, T8176534
-T8176534.java:12:43: compiler.warn.prob.found.req: (compiler.misc.unchecked.assign), java.util.Iterator, java.util.Iterator<? extends E>
 T8176534.java:12:28: compiler.warn.prob.found.req: (compiler.misc.unchecked.assign), java.util.ArrayList, java.util.List<java.lang.String>
 - compiler.err.warnings.and.werror
 1 error
-5 warnings
+4 warnings

--- a/test/langtools/tools/javac/warnings/UnboundAndBoundByObjectTest.java
+++ b/test/langtools/tools/javac/warnings/UnboundAndBoundByObjectTest.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8268148
  * @summary unchecked warnings handle ? and ? extends Object differently
- * @compile -Xlint:all UnboundAndBoundByObjectTest.java
+ * @compile -Xlint:all -Werror UnboundAndBoundByObjectTest.java
  */
 
 import java.util.List;

--- a/test/langtools/tools/javac/warnings/UnboundAndBoundByObjectTest.java
+++ b/test/langtools/tools/javac/warnings/UnboundAndBoundByObjectTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8268148
+ * @summary unchecked warnings handle ? and ? extends Object differently
+ * @compile -Xlint:all UnboundAndBoundByObjectTest.java
+ */
+
+import java.util.List;
+
+class UnboundAndBoundByObjectTest {
+    void f(List<? extends Object> x) {}
+    void g(List<?> x) {}
+
+    void h(List<String> x) {
+        f((List) x);
+        g((List) x);
+    }
+}


### PR DESCRIPTION
Please review this PR. Currently javac handles differently `?` and `? extends Object` when reporting unchecked warnings when according to the spec they should be handled the same way. This PR is fixing this.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268148](https://bugs.openjdk.java.net/browse/JDK-8268148): unchecked warnings handle ? and ? extends Object differently


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5224/head:pull/5224` \
`$ git checkout pull/5224`

Update a local copy of the PR: \
`$ git checkout pull/5224` \
`$ git pull https://git.openjdk.java.net/jdk pull/5224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5224`

View PR using the GUI difftool: \
`$ git pr show -t 5224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5224.diff">https://git.openjdk.java.net/jdk/pull/5224.diff</a>

</details>
