### PR TITLE
8274048 IGV: Replace usages of Collections.sort with List.sort call

### DIFF
--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputGraph.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/InputGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,7 +96,7 @@ public class InputGraph extends Properties.Entity implements FolderElement {
 
         for(InputNode n : this.getNodes()) {
             List<InputEdge> list = result.get(n);
-            Collections.sort(list, InputEdge.OUTGOING_COMPARATOR);
+            list.sort(InputEdge.OUTGOING_COMPARATOR);
         }
 
         return result;
@@ -118,7 +118,7 @@ public class InputGraph extends Properties.Entity implements FolderElement {
 
         for(InputNode n : this.getNodes()) {
             List<InputEdge> list = result.get(n);
-            Collections.sort(list, InputEdge.INGOING_COMPARATOR);
+            list.sort(InputEdge.INGOING_COMPARATOR);
         }
 
         return result;
@@ -133,7 +133,7 @@ public class InputGraph extends Properties.Entity implements FolderElement {
             }
         }
 
-        Collections.sort(result, InputEdge.OUTGOING_COMPARATOR);
+        result.sort(InputEdge.OUTGOING_COMPARATOR);
 
         return result;
     }

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Properties.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/Properties.java
@@ -312,7 +312,7 @@ public class Properties implements Serializable, Iterable<Property> {
             }
         }
 
-        Collections.sort(pairs, new Comparator<String[]>() {
+        pairs.sort(new Comparator<String[]>() {
             @Override
             public int compare(String[] o1, String[] o2) {
                 assert o1.length == 2;

--- a/src/utils/IdealGraphVisualizer/FilterWindow/src/main/java/com/sun/hotspot/igv/filterwindow/FilterTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/FilterWindow/src/main/java/com/sun/hotspot/igv/filterwindow/FilterTopComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -175,7 +175,7 @@ public final class FilterTopComponent extends TopComponent implements LookupList
             filterSettings.add(setting);
 
             // Sort alphabetically
-            Collections.sort(filterSettings, new Comparator<FilterSetting>() {
+            filterSettings.sort(new Comparator<FilterSetting>() {
 
                 @Override
                 public int compare(FilterSetting o1, FilterSetting o2) {

--- a/src/utils/IdealGraphVisualizer/Graph/src/main/java/com/sun/hotspot/igv/graph/Diagram.java
+++ b/src/utils/IdealGraphVisualizer/Graph/src/main/java/com/sun/hotspot/igv/graph/Diagram.java
@@ -284,7 +284,7 @@ public class Diagram {
         System.out.println("Number of connections: " + connections.size());
 
         List<Figure> figuresSorted = new ArrayList<>(tmpFigures);
-        Collections.sort(figuresSorted, new Comparator<Figure>() {
+        figuresSorted.sort(new Comparator<Figure>() {
 
             @Override
             public int compare(Figure a, Figure b) {

--- a/src/utils/IdealGraphVisualizer/Graph/src/main/java/com/sun/hotspot/igv/graph/Figure.java
+++ b/src/utils/IdealGraphVisualizer/Graph/src/main/java/com/sun/hotspot/igv/graph/Figure.java
@@ -213,7 +213,7 @@ public class Figure extends Properties.Entity implements Source.Provider, Vertex
     public InputSlot createInputSlot(int index) {
         InputSlot slot = new InputSlot(this, index);
         inputSlots.add(slot);
-        Collections.sort(inputSlots, Slot.slotIndexComparator);
+        inputSlots.sort(Slot.slotIndexComparator);
         return slot;
     }
 
@@ -242,7 +242,7 @@ public class Figure extends Properties.Entity implements Source.Provider, Vertex
     public OutputSlot createOutputSlot(int index) {
         OutputSlot slot = new OutputSlot(this, index);
         outputSlots.add(slot);
-        Collections.sort(outputSlots, Slot.slotIndexComparator);
+        outputSlots.sort(Slot.slotIndexComparator);
         return slot;
     }
 

--- a/src/utils/IdealGraphVisualizer/HierarchicalLayout/src/main/java/com/sun/hotspot/igv/hierarchicallayout/HierarchicalLayoutManager.java
+++ b/src/utils/IdealGraphVisualizer/HierarchicalLayout/src/main/java/com/sun/hotspot/igv/hierarchicallayout/HierarchicalLayoutManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -614,8 +614,8 @@ public class HierarchicalLayoutManager implements LayoutManager {
                     upProcessingOrder[i].add(n);
                 }
 
-                Collections.sort(downProcessingOrder[i], nodeProcessingDownComparator);
-                Collections.sort(upProcessingOrder[i], nodeProcessingUpComparator);
+                downProcessingOrder[i].sort(nodeProcessingDownComparator);
+                upProcessingOrder[i].sort(nodeProcessingUpComparator);
             }
 
             initialPositions();
@@ -924,7 +924,7 @@ public class HierarchicalLayoutManager implements LayoutManager {
                 }
 
                 updateCrossingNumbers(i, true);
-                Collections.sort(layers[i], crossingNodeComparator);
+                layers[i].sort(crossingNodeComparator);
                 updateXOfLayer(i);
 
                 int z = 0;
@@ -995,7 +995,7 @@ public class HierarchicalLayoutManager implements LayoutManager {
                 }
 
                 updateCrossingNumbers(i, false);
-                Collections.sort(layers[i], crossingNodeComparator);
+                layers[i].sort(crossingNodeComparator);
                 updateXOfLayer(i);
 
                 int z = 0;
@@ -1185,7 +1185,7 @@ public class HierarchicalLayoutManager implements LayoutManager {
                         if (portHash.containsKey(i)) {
 
                             List<LayoutEdge> list = portHash.get(i);
-                            Collections.sort(list, comparator);
+                            list.sort(comparator);
 
                             if (list.size() == 1) {
                                 processSingleEdge(list.get(0));
@@ -1749,7 +1749,7 @@ public class HierarchicalLayoutManager implements LayoutManager {
 
             // Set up edges
             List<Link> links = new ArrayList<>(graph.getLinks());
-            Collections.sort(links, linkComparator);
+            links.sort(linkComparator);
             for (Link l : links) {
                 LayoutEdge edge = new LayoutEdge();
                 assert vertexToLayoutNode.containsKey(l.getFrom().getVertex());

--- a/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/java/com/sun/hotspot/igv/servercompiler/ServerCompilerScheduler.java
+++ b/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/java/com/sun/hotspot/igv/servercompiler/ServerCompilerScheduler.java
@@ -637,7 +637,7 @@ public class ServerCompilerScheduler implements Scheduler {
         for (Integer i : edgeMap.keySet()) {
 
             List<InputEdge> list = edgeMap.get(i);
-            Collections.sort(list, edgeComparator);
+            list.sort(edgeComparator);
 
             int to = i;
             InputNode toInputNode = graph.getNode(to);

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/NodeQuickSearch.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/NodeQuickSearch.java
@@ -30,7 +30,6 @@ import com.sun.hotspot.igv.data.Properties.RegexpPropertyMatcher;
 import com.sun.hotspot.igv.data.services.InputGraphProvider;
 import com.sun.hotspot.igv.settings.Settings;
 import com.sun.hotspot.igv.util.LookupHistory;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -135,11 +134,10 @@ public class NodeQuickSearch implements SearchProvider {
                 }
 
                 // Rank the matches.
-                Collections.sort(matches,
-                                 (InputNode a, InputNode b) ->
-                                 compareByRankThenNumVal(rawValue,
-                                                         a.getProperties().get(name),
-                                                         b.getProperties().get(name)));
+                matches.sort((InputNode a, InputNode b) ->
+                        compareByRankThenNumVal(rawValue,
+                                a.getProperties().get(name),
+                                b.getProperties().get(name)));
 
                 // Single matches
                 for (final InputNode n : matches) {


### PR DESCRIPTION
Collections.sort is just a wrapper, so it is better to use an instance method directly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274048](https://bugs.openjdk.java.net/browse/JDK-8274048): IGV: Replace usages of Collections.sort with List.sort call


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5228/head:pull/5228` \
`$ git checkout pull/5228`

Update a local copy of the PR: \
`$ git checkout pull/5228` \
`$ git pull https://git.openjdk.java.net/jdk pull/5228/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5228`

View PR using the GUI difftool: \
`$ git pr show -t 5228`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5228.diff">https://git.openjdk.java.net/jdk/pull/5228.diff</a>

</details>
