### PR TITLE
8272863: Replace usages of Collections.sort with List.sort call in public java modules

### DIFF
--- a/src/java.base/share/classes/java/net/CookieManager.java
+++ b/src/java.base/share/classes/java/net/CookieManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package java.net;
 
 import java.util.Map;
 import java.util.List;
-import java.util.Collections;
 import java.util.Comparator;
 import java.io.IOException;
 import sun.util.logging.PlatformLogger;
@@ -407,7 +406,7 @@ public class CookieManager extends CookieHandler
      * path are distinguished by creation time (older first). Method made PP to enable testing.
      */
     static List<String> sortByPathAndAge(List<HttpCookie> cookies) {
-        Collections.sort(cookies, new CookieComparator());
+        cookies.sort(new CookieComparator());
 
         List<String> cookieHeader = new java.util.ArrayList<>();
         for (HttpCookie cookie : cookies) {

--- a/src/java.base/share/classes/java/time/format/DateTimeTextProvider.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeTextProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,7 +75,6 @@ import java.time.temporal.TemporalField;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -553,12 +552,12 @@ class DateTimeTextProvider {
                     }
                 }
                 List<Entry<String, Long>> list = new ArrayList<>(reverse.values());
-                Collections.sort(list, COMPARATOR);
+                list.sort(COMPARATOR);
                 map.put(vtmEntry.getKey(), list);
                 allList.addAll(list);
                 map.put(null, allList);
             }
-            Collections.sort(allList, COMPARATOR);
+            allList.sort(COMPARATOR);
             this.parsable = map;
         }
 

--- a/src/java.base/share/classes/sun/net/www/protocol/file/FileURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/file/FileURLConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -198,7 +198,7 @@ public class FileURLConnection extends URLConnection {
                     throw new FileNotFoundException(filename);
                 }
 
-                Collections.sort(files, Collator.getInstance());
+                files.sort(Collator.getInstance());
 
                 for (int i = 0 ; i < files.size() ; i++) {
                     String fileName = files.get(i);

--- a/src/java.base/share/classes/sun/security/provider/certpath/PKIX.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/PKIX.java
@@ -239,7 +239,7 @@ class PKIX {
             if (stores == null) {
                 // reorder CertStores so that local CertStores are tried first
                 stores = new ArrayList<>(params.getCertStores());
-                Collections.sort(stores, new CertStoreComparator());
+                stores.sort(new CertStoreComparator());
             }
             return stores;
         }

--- a/src/java.base/windows/classes/java/lang/ProcessEnvironment.java
+++ b/src/java.base/windows/classes/java/lang/ProcessEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,6 @@
 
 package java.lang;
 
-import java.io.*;
 import java.util.*;
 
 final class ProcessEnvironment extends HashMap<String,String>
@@ -301,7 +300,7 @@ final class ProcessEnvironment extends HashMap<String,String>
     String toEnvironmentBlock() {
         // Sort Unicode-case-insensitively by name
         List<Map.Entry<String,String>> list = new ArrayList<>(entrySet());
-        Collections.sort(list, entryComparator);
+        list.sort(entryComparator);
 
         StringBuilder sb = new StringBuilder(size()*30);
         int cmp = -1;

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTreeUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTreeUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,6 @@ import java.beans.*;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.UIResource;
@@ -3751,7 +3750,7 @@ public class BasicTreeUI extends TreeUI
             for (TreePath path : paths) {
                 selOrder.add(path);
             }
-            Collections.sort(selOrder, this);
+            selOrder.sort(this);
             int n = selOrder.size();
             TreePath[] displayPaths = new TreePath[n];
             for (int i = 0; i < n; i++) {

--- a/src/java.desktop/share/classes/javax/swing/plaf/nimbus/NimbusStyle.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/nimbus/NimbusStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,6 @@ import java.awt.Font;
 import java.awt.Insets;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -463,7 +462,7 @@ public final class NimbusStyle extends SynthStyle {
 
         //now that I've collected all the runtime states, I'll sort them based
         //on their integer "state" (see SynthState for how this works).
-        Collections.sort(runtimeStates, STATE_COMPARATOR);
+        runtimeStates.sort(STATE_COMPARATOR);
 
         //finally, set the array of runtime states on the values object
         values.states = runtimeStates.toArray(new RuntimeState[runtimeStates.size()]);

--- a/src/java.desktop/share/classes/sun/awt/shell/ShellFolder.java
+++ b/src/java.desktop/share/classes/sun/awt/shell/ShellFolder.java
@@ -34,7 +34,6 @@ import java.io.Serial;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
@@ -346,7 +345,7 @@ public abstract class ShellFolder extends File {
                 if (commonParent instanceof ShellFolder) {
                     ((ShellFolder) commonParent).sortChildren(files);
                 } else {
-                    Collections.sort(files, FILE_COMPARATOR);
+                    files.sort(FILE_COMPARATOR);
                 }
 
                 return null;
@@ -359,7 +358,7 @@ public abstract class ShellFolder extends File {
         // synchronize the whole code of the sort method once
         invoke(new Callable<Void>() {
             public Void call() {
-                Collections.sort(files, FILE_COMPARATOR);
+                files.sort(FILE_COMPARATOR);
 
                 return null;
             }

--- a/src/java.desktop/unix/classes/sun/font/XRGlyphCache.java
+++ b/src/java.desktop/unix/classes/sun/font/XRGlyphCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -246,7 +246,7 @@ public class XRGlyphCache implements GlyphDisposedListener {
          * something not that stupid ;)
          */
         ArrayList<XRGlyphCacheEntry> cacheList = new ArrayList<XRGlyphCacheEntry>(cacheMap.values());
-        Collections.sort(cacheList, new Comparator<XRGlyphCacheEntry>() {
+        cacheList.sort(new Comparator<XRGlyphCacheEntry>() {
             public int compare(XRGlyphCacheEntry e1, XRGlyphCacheEntry e2) {
                 return e2.getLastUsed() - e1.getLastUsed();
             }

--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
@@ -26,7 +26,6 @@
 package sun.awt.shell;
 
 import java.awt.Image;
-import java.awt.Toolkit;
 import java.awt.image.AbstractMultiResolutionImage;
 import java.awt.image.BufferedImage;
 import java.awt.image.ImageObserver;
@@ -36,7 +35,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Serial;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -1333,7 +1331,7 @@ final class Win32ShellFolder2 extends ShellFolder {
         // synchronize the whole code of the sort method once
         invoke(new Callable<Void>() {
             public Void call() {
-                Collections.sort(files, new ColumnComparator(Win32ShellFolder2.this, 0));
+                files.sort(new ColumnComparator(Win32ShellFolder2.this, 0));
 
                 return null;
             }


### PR DESCRIPTION
Collections.sort is just a wrapper, so it is better to use an instance method directly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272863](https://bugs.openjdk.java.net/browse/JDK-8272863): Replace usages of Collections.sort with List.sort call in public java modules


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5229/head:pull/5229` \
`$ git checkout pull/5229`

Update a local copy of the PR: \
`$ git checkout pull/5229` \
`$ git pull https://git.openjdk.java.net/jdk pull/5229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5229`

View PR using the GUI difftool: \
`$ git pr show -t 5229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5229.diff">https://git.openjdk.java.net/jdk/pull/5229.diff</a>

</details>
