### PR TITLE
[PATCH] Replace usages of Collections.sort with List.sort call in jdk.* modules

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/basic/BasicCDebugInfoDataBase.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/basic/BasicCDebugInfoDataBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -137,7 +137,7 @@ public class BasicCDebugInfoDataBase implements CDebugInfoDataBase {
 
     // Sort blocks in ascending order of starting address (but do not
     // change ordering among blocks with the same starting address)
-    Collections.sort(blocks, new Comparator<>() {
+    blocks.sort(new Comparator<>() {
         public int compare(BlockSym b1, BlockSym b2) {
           Address a1 = b1.getAddress();
           Address a2 = b2.getAddress();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/basic/BasicLineNumberMapping.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/basic/BasicLineNumberMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public class BasicLineNumberMapping {
       counter. This must be done before any queries are made. */
   public void sort() {
     if (infoList == null) return;
-    Collections.sort(infoList, new Comparator<>() {
+    infoList.sort(new Comparator<>() {
         public int compare(BasicLineNumberInfo l1, BasicLineNumberInfo l2) {
           Address a1 = l1.getStartPC();
           Address a2 = l2.getStartPC();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHeap.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -365,7 +365,7 @@ public class ObjectHeap {
   }
 
   private void sortLiveRegions(List<Address> liveRegions) {
-    Collections.sort(liveRegions, new Comparator<Address>() {
+    liveRegions.sort(new Comparator<Address>() {
         public int compare(Address a1, Address a2) {
           if (AddressOps.lt(a1, a2)) {
             return -1;

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHistogram.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHistogram.java
@@ -50,7 +50,7 @@ public class ObjectHistogram implements HeapVisitor {
   public List<ObjectHistogramElement> getElements() {
     List<ObjectHistogramElement> list = new ArrayList<>();
     list.addAll(map.values());
-    Collections.sort(list, new Comparator<>() {
+    list.sort(new Comparator<>() {
       public int compare(ObjectHistogramElement o1, ObjectHistogramElement o2) {
         return o1.compare(o2);
       }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/FinalizerInfo.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/FinalizerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ import sun.jvm.hotspot.oops.*;
 import sun.jvm.hotspot.utilities.SystemDictionaryHelper;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 
@@ -126,7 +125,7 @@ public class FinalizerInfo extends Tool {
              */
             ArrayList<ObjectHistogramElement> list = new ArrayList<>();
             list.addAll(map.values());
-            Collections.sort(list, new Comparator<>() {
+            list.sort(new Comparator<>() {
               public int compare(ObjectHistogramElement o1, ObjectHistogramElement o2) {
                   return o1.compare(o2);
               }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/ProcessListPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/ProcessListPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ import java.awt.*;
 import java.awt.event.*;
 import java.util.*;
 import javax.swing.*;
-import javax.swing.event.*;
 import javax.swing.table.*;
 
 import sun.jvm.hotspot.debugger.*;
@@ -202,7 +201,7 @@ public class ProcessListPanel extends JPanel {
           }
         };
     }
-    Collections.sort(els, c);
+    els.sort(c);
   }
 
   private javax.swing.Timer getTimer() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/table/SortableTableModel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/table/SortableTableModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,6 @@
  */
 
 package sun.jvm.hotspot.ui.table;
-
-import java.util.Collections;
-import java.util.List;
 
 import javax.swing.event.TableModelEvent;
 import javax.swing.table.AbstractTableModel;
@@ -55,7 +52,7 @@ public abstract class SortableTableModel<T> extends AbstractTableModel {
         comparator.addColumn(column);
         comparator.setAscending(ascending);
 
-        Collections.sort(elements, comparator);
+        elements.sort(comparator);
 
         fireTableChanged(new TableModelEvent(this));
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassUseWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassUseWriter.java
@@ -26,7 +26,6 @@
 package jdk.javadoc.internal.doclets.formats.html;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,7 +43,6 @@ import jdk.javadoc.internal.doclets.formats.html.markup.HtmlStyle;
 import jdk.javadoc.internal.doclets.formats.html.markup.TagName;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlTree;
 import jdk.javadoc.internal.doclets.formats.html.Navigation.PageMode;
-import jdk.javadoc.internal.doclets.formats.html.markup.Text;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 import jdk.javadoc.internal.doclets.toolkit.util.ClassTree;
 import jdk.javadoc.internal.doclets.toolkit.util.ClassUseMapper;
@@ -178,7 +176,7 @@ public class ClassUseWriter extends SubWriterHolderWriter {
         Map<PackageElement, List<Element>> map = new HashMap<>();
         List<? extends Element> elements = (List<? extends Element>) classMap.get(typeElement);
         if (elements != null) {
-            Collections.sort(elements, comparators.makeClassUseComparator());
+            elements.sort(comparators.makeClassUseComparator());
             for (Element e : elements) {
                 PackageElement pkg = utils.containingPackage(e);
                 pkgSet.add(pkg);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Group.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Group.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -147,7 +147,7 @@ public class Group {
                 elementNameGroupMap.put(mdlPattern, groupname);
             }
         }
-        Collections.sort(sortedRegExpList, new MapKeyComparator());
+        sortedRegExpList.sort(new MapKeyComparator());
         return true;
     }
 
@@ -193,7 +193,7 @@ public class Group {
                 elementNameGroupMap.put(pkgPattern, groupname);
             }
         }
-        Collections.sort(sortedRegExpList, new MapKeyComparator());
+        sortedRegExpList.sort(new MapKeyComparator());
         return true;
     }
 

--- a/src/jdk.jcmd/share/classes/sun/tools/jstat/JStatLogger.java
+++ b/src/jdk.jcmd/share/classes/sun/tools/jstat/JStatLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package sun.tools.jstat;
 import java.util.*;
 import java.io.*;
 import sun.jvmstat.monitor.*;
-import sun.jvmstat.monitor.event.*;
 import java.util.regex.PatternSyntaxException;
 
 /**
@@ -56,7 +55,7 @@ public class JStatLogger {
 
         // get the set of all monitors
         List<Monitor> items = monitoredVm.findByPattern(names);
-        Collections.sort(items, comparator);
+        items.sort(comparator);
 
         for (Monitor m: items) {
             if (!(m.isSupported() || showUnsupported)) {
@@ -76,7 +75,7 @@ public class JStatLogger {
 
         // get the set of all monitors
         List<Monitor> items = monitoredVm.findByPattern(names);
-        Collections.sort(items, comparator);
+        items.sort(comparator);
 
         printList(items, verbose, showUnsupported, out);
     }

--- a/src/jdk.jcmd/share/classes/sun/tools/jstat/Jstat.java
+++ b/src/jdk.jcmd/share/classes/sun/tools/jstat/Jstat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,7 +113,7 @@ public class Jstat {
             formatter = new OptionOutputFormatter(monitoredVm, format);
         } else {
             List<Monitor> logged = monitoredVm.findByPattern(arguments.counterNames());
-            Collections.sort(logged, arguments.comparator());
+            logged.sort(arguments.comparator());
             List<Monitor> constants = new ArrayList<Monitor>();
 
             for (Iterator<Monitor> i = logged.iterator(); i.hasNext(); /* empty */) {

--- a/src/jdk.jconsole/share/classes/sun/tools/jconsole/inspector/XOpenTypeViewer.java
+++ b/src/jdk.jconsole/share/classes/sun/tools/jconsole/inspector/XOpenTypeViewer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -281,7 +281,7 @@ public class XOpenTypeViewer extends JPanel implements ActionListener {
                 // Order tabular data elements using index names
                 List<CompositeData> data = new ArrayList<CompositeData>(
                         (Collection<CompositeData>) tabular.values());
-                Collections.sort(data, new TabularDataComparator(type));
+                data.sort(new TabularDataComparator(type));
                 elements = data.toArray();
                 loadCompositeData((CompositeData) elements[0]);
             } else {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataReader.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,6 @@ import static jdk.jfr.internal.MetadataDescriptor.ELEMENT_TYPE;
 import java.io.DataInput;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -84,7 +83,7 @@ final class MetadataReader {
         descriptor.root = root;
         if (Logger.shouldLog(LogTag.JFR_SYSTEM_PARSER, LogLevel.TRACE)) {
              List<Type> ts = new ArrayList<>(types.values());
-             Collections.sort(ts, (x,y) -> x.getName().compareTo(y.getName()));
+             ts.sort((x, y) -> x.getName().compareTo(y.getName()));
              for (Type t : ts) {
                  t.log("Found", LogTag.JFR_SYSTEM_PARSER, LogLevel.TRACE);
              }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
@@ -36,7 +36,6 @@ import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -437,7 +436,7 @@ public final class PlatformRecorder {
             }
             // n*log(n), should be able to do n*log(k) with a priority queue,
             // where k = number of recordings, n = number of chunks
-            Collections.sort(chunks, RepositoryChunk.END_TIME_COMPARATOR);
+            chunks.sort(RepositoryChunk.END_TIME_COMPARATOR);
             return chunks;
         }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/SettingsManager.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/SettingsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package jdk.jfr.internal;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -140,7 +139,7 @@ final class SettingsManager {
             }
         } else {
             if (Logger.shouldLog(LogTag.JFR_SETTING, LogLevel.INFO)) {
-                Collections.sort(eventControls, (x,y) -> x.getEventType().getName().compareTo(y.getEventType().getName()));
+                eventControls.sort((x, y) -> x.getEventType().getName().compareTo(y.getEventType().getName()));
             }
             for (EventControl ec : eventControls) {
                 setEventControl(ec);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/TypeLibrary.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/TypeLibrary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,7 +108,7 @@ public final class TypeLibrary {
                 List<Type> jvmTypes;
                 try {
                     jvmTypes = MetadataLoader.createTypes();
-                    Collections.sort(jvmTypes, (a,b) -> Long.compare(a.getId(), b.getId()));
+                    jvmTypes.sort((a, b) -> Long.compare(a.getId(), b.getId()));
                 } catch (IOException e) {
                     throw new Error("JFR: Could not read metadata");
                 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/RepositoryFiles.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/RepositoryFiles.java
@@ -30,7 +30,6 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -213,7 +212,7 @@ public final class RepositoryFiles {
                 pathSet.remove(time);
                 pathLookup.remove(remove);
             }
-            Collections.sort(added, (p1, p2) -> p1.compareTo(p2));
+            added.sort((p1, p2) -> p1.compareTo(p2));
             for (Path p : added) {
                 // Only add files that have a complete header
                 // as the JVM may be in progress writing the file

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
@@ -32,7 +32,6 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
@@ -170,7 +169,7 @@ abstract class AbstractDCmd {
 
     protected final List<Recording> getRecordings() {
         List<Recording> list = new ArrayList<>(getFlightRecorder().getRecordings());
-        Collections.sort(list, Comparator.comparing(Recording::getId));
+        list.sort(Comparator.comparing(Recording::getId));
         return list;
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdCheck.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package jdk.jfr.internal.dcmd;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -135,7 +134,7 @@ final class DCmdCheck extends AbstractDCmd {
     private static List<EventType> sortByEventPath(Collection<EventType> events) {
         List<EventType> sorted = new ArrayList<>();
         sorted.addAll(events);
-        Collections.sort(sorted, new Comparator<EventType>() {
+        sorted.sort(new Comparator<EventType>() {
             @Override
             public int compare(EventType e1, EventType e2) {
                 return e1.getName().compareTo(e2.getName());

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/EventPrintWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/EventPrintWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,7 +76,7 @@ abstract class EventPrintWriter extends StructuredWriter {
                     events.add(event);
                 }
                 if (PRIVATE_ACCESS.isLastEventInChunk(file)) {
-                    Collections.sort(events, PRIVATE_ACCESS.eventComparator());
+                    events.sort(PRIVATE_ACCESS.eventComparator());
                     print(events);
                     events.clear();
                 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Metadata.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Metadata.java
@@ -32,7 +32,6 @@ import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Deque;
 import java.util.List;
@@ -205,7 +204,7 @@ final class Metadata extends Command {
             }
 
             List<Type> types = findTypes(file);
-            Collections.sort(types, new TypeComparator());
+            types.sort(new TypeComparator());
             for (Type type : types) {
                 if (filter != null) {
                     // If --events or --categories, only operate on events

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Summary.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Summary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
@@ -143,7 +142,7 @@ final class Summary extends Command {
             println(" Start: " + DATE_FORMAT.format(Instant.ofEpochSecond(epochSeconds, adjustNanos)) + " (UTC)");
             println(" Duration: " + (totalDuration + 500_000_000) / 1_000_000_000 + " s");
             List<Statistics> statsList = new ArrayList<>(stats.values());
-            Collections.sort(statsList, (u, v) -> Long.compare(v.count, u.count));
+            statsList.sort((u, v) -> Long.compare(v.count, u.count));
             println();
             String header = "      Count  Size (bytes) ";
             String typeHeader = " Event Type";


### PR DESCRIPTION
Collections.sort is just a wrapper, so it is better to use an instance method directly.