### PR TITLE
8272878: JEP 381 cleanup: Remove unused Solaris code in sun.font.TrueTypeGlyphMapper

### DIFF
--- a/src/java.desktop/share/classes/sun/font/TrueTypeGlyphMapper.java
+++ b/src/java.desktop/share/classes/sun/font/TrueTypeGlyphMapper.java
@@ -30,15 +30,6 @@ import java.util.Locale;
 
 public class TrueTypeGlyphMapper extends CharToGlyphMapper {
 
-    static final char REVERSE_SOLIDUS = 0x005c; // the backslash char.
-    static final char JA_YEN = 0x00a5;
-
-    /* if running on Solaris and default Locale is ja_JP then
-     * we map need to remap reverse solidus (backslash) to Yen as
-     * apparently expected there.
-     */
-    static final boolean isJAlocale = Locale.JAPAN.equals(Locale.getDefault());
-
     TrueTypeFont font;
     CMap cmap;
     int numGlyphs;
@@ -123,14 +114,6 @@ public class TrueTypeGlyphMapper extends CharToGlyphMapper {
          * are gone.
          */
         cmap = CMap.theNullCmap;
-    }
-
-    private char remapJAChar(char unicode) {
-        return (unicode == REVERSE_SOLIDUS) ? JA_YEN : unicode;
-    }
-
-    private int remapJAIntChar(int unicode) {
-        return (unicode == REVERSE_SOLIDUS) ? JA_YEN : unicode;
     }
 
     public int charToGlyph(char unicode) {


### PR DESCRIPTION
During the recent JEP 381 removal of Solaris code, a few Solaris-specific constants and private methods were left behind in sun.font.TrueTypeGlyphMapper. This PR removes these unused odds and ends.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272878](https://bugs.openjdk.java.net/browse/JDK-8272878): JEP 381 cleanup: Remove unused Solaris code in sun.font.TrueTypeGlyphMapper


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5232/head:pull/5232` \
`$ git checkout pull/5232`

Update a local copy of the PR: \
`$ git checkout pull/5232` \
`$ git pull https://git.openjdk.java.net/jdk pull/5232/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5232`

View PR using the GUI difftool: \
`$ git pr show -t 5232`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5232.diff">https://git.openjdk.java.net/jdk/pull/5232.diff</a>

</details>
