### PR TITLE
8272856: DoubleFlagWithIntegerValue uses G1GC-only flag

### DIFF
--- a/test/hotspot/jtreg/runtime/CommandLine/DoubleFlagWithIntegerValue.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/DoubleFlagWithIntegerValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 public class DoubleFlagWithIntegerValue {
   public static void testDoubleFlagWithValue(String value) throws Exception {
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:G1ConcMarkStepDurationMillis=" + value, "-version");
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:SweeperThreshold=" + value, "-version");
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldNotContain("Improperly specified VM option");
     output.shouldHaveExitValue(0);


### PR DESCRIPTION
Hi all,

could you please review the patch which replaces the flag used by `DoubleFlagWithIntegerValue` to `SweeperThreshold`? 

from JBS:
> `runtime/CommandLine/DoubleFlagWithIntegerValue.java` test uses `G1ConcMarkStepDurationMillis` flag which is available only on the builds w/ G1 GC, hence this test might fail on the builds where G1 is disabled. 
> instead of adding `@requires` to exclude the test from running on builds w/o G1, the test can be updated to use the flag that is available in all builds.

testing: `runtime/CommandLine/DoubleFlagWithIntegerValue.java`  on `{linux,windows,macosx}-x64`

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272856](https://bugs.openjdk.java.net/browse/JDK-8272856): DoubleFlagWithIntegerValue uses G1GC-only flag


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5233/head:pull/5233` \
`$ git checkout pull/5233`

Update a local copy of the PR: \
`$ git checkout pull/5233` \
`$ git pull https://git.openjdk.java.net/jdk pull/5233/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5233`

View PR using the GUI difftool: \
`$ git pr show -t 5233`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5233.diff">https://git.openjdk.java.net/jdk/pull/5233.diff</a>

</details>
