### PR TITLE
8268885: duplicate checkcast when destination type is not first type of intersection type

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
@@ -784,7 +784,7 @@ public class TransTypes extends TreeTranslator {
             Type.IntersectionClassType ict = (Type.IntersectionClassType)originalTarget;
             for (Type c : ict.getExplicitComponents()) {
                 Type ec = erasure(c);
-                if (!types.isSameType(ec, tree.type)) {
+                if (!types.isSameType(ec, tree.type) && (!types.isSameType(ec, pt))) {
                     tree.expr = coerce(tree.expr, ec);
                 }
             }


### PR DESCRIPTION
Please review this PR which is fixing the following bug: javac is generating duplicate checkcast for cases like:

```
class IntersectionTypeTest {
    interface I1 {}
    interface I2 {}
    static class C {}
    void test() {
        I2 i = (I1 & I2) new C();
    }
}
```
basically when an intersection type is used in a cast expression and the target is not the type in the intersection.

TIA

PS. I also ran the JCK tests for this patch, same results as without the patch

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268885](https://bugs.openjdk.java.net/browse/JDK-8268885): duplicate checkcast when destination type is not first type of intersection type


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5235/head:pull/5235` \
`$ git checkout pull/5235`

Update a local copy of the PR: \
`$ git checkout pull/5235` \
`$ git pull https://git.openjdk.java.net/jdk pull/5235/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5235`

View PR using the GUI difftool: \
`$ git pr show -t 5235`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5235.diff">https://git.openjdk.java.net/jdk/pull/5235.diff</a>

</details>
