### PR TITLE
8272884: Make VoidClosure::do_void pure virtual

### DIFF
--- a/src/hotspot/share/memory/iterator.cpp
+++ b/src/hotspot/share/memory/iterator.cpp
@@ -40,10 +40,6 @@ void ObjectToOopClosure::do_object(oop obj) {
   obj->oop_iterate(_cl);
 }
 
-void VoidClosure::do_void() {
-  ShouldNotCallThis();
-}
-
 void CodeBlobToOopClosure::do_nmethod(nmethod* nm) {
   nm->oops_do(_cl);
   if (_fix_relocations) {

--- a/src/hotspot/share/memory/iterator.hpp
+++ b/src/hotspot/share/memory/iterator.hpp
@@ -283,9 +283,7 @@ class MonitorClosure : public StackObj {
 // A closure that is applied without any arguments.
 class VoidClosure : public StackObj {
  public:
-  // I would have liked to declare this a pure virtual, but that breaks
-  // in mysterious ways, for unknown reasons.
-  virtual void do_void();
+  virtual void do_void() = 0;
 };
 
 


### PR DESCRIPTION
Simple change of making VoidClosure::do_void pure virtual.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272884](https://bugs.openjdk.java.net/browse/JDK-8272884): Make VoidClosure::do_void pure virtual


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5237/head:pull/5237` \
`$ git checkout pull/5237`

Update a local copy of the PR: \
`$ git checkout pull/5237` \
`$ git pull https://git.openjdk.java.net/jdk pull/5237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5237`

View PR using the GUI difftool: \
`$ git pr show -t 5237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5237.diff">https://git.openjdk.java.net/jdk/pull/5237.diff</a>

</details>
