### PR TITLE
8272873: Inlining should not depend on absolute call site counts

### DIFF
--- a/src/hotspot/cpu/aarch64/globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globals_aarch64.hpp
@@ -39,7 +39,6 @@ define_pd_global(bool, UncommonNullCast,         true);  // Uncommon-trap NULLs 
 define_pd_global(uintx, CodeCacheSegmentSize,    64 COMPILER1_AND_COMPILER2_PRESENT(+64)); // Tiered compilation has large code-entry alignment.
 define_pd_global(intx, CodeEntryAlignment,       64);
 define_pd_global(intx, OptoLoopAlignment,        16);
-define_pd_global(intx, InlineFrequencyCount,     100);
 
 #define DEFAULT_STACK_YELLOW_PAGES (2)
 #define DEFAULT_STACK_RED_PAGES (1)

--- a/src/hotspot/cpu/arm/globals_arm.hpp
+++ b/src/hotspot/cpu/arm/globals_arm.hpp
@@ -53,7 +53,6 @@ define_pd_global(intx,  StackRedPages,            DEFAULT_STACK_RED_PAGES);
 define_pd_global(intx,  StackShadowPages,         DEFAULT_STACK_SHADOW_PAGES);
 define_pd_global(intx,  StackReservedPages,       DEFAULT_STACK_RESERVED_PAGES);
 
-define_pd_global(intx,  InlineFrequencyCount,     50);
 #if  defined(COMPILER1) || defined(COMPILER2)
 define_pd_global(intx,  InlineSmallCode,          1500);
 #endif

--- a/src/hotspot/cpu/ppc/globals_ppc.hpp
+++ b/src/hotspot/cpu/ppc/globals_ppc.hpp
@@ -58,7 +58,6 @@ define_pd_global(intx, StackReservedPages,    DEFAULT_STACK_RESERVED_PAGES);
 define_pd_global(uintx, CodeCacheSegmentSize,  128);
 define_pd_global(intx,  CodeEntryAlignment,    128);
 define_pd_global(intx,  OptoLoopAlignment,     16);
-define_pd_global(intx,  InlineFrequencyCount,  100);
 define_pd_global(intx,  InlineSmallCode,       1500);
 
 // Flags for template interpreter.

--- a/src/hotspot/cpu/s390/globals_s390.hpp
+++ b/src/hotspot/cpu/s390/globals_s390.hpp
@@ -43,7 +43,6 @@ define_pd_global(uintx, CodeCacheSegmentSize,        256);
 // code size significantly by padding nops between IVC and second UEP.
 define_pd_global(intx,  CodeEntryAlignment,          64);
 define_pd_global(intx,  OptoLoopAlignment,           2);
-define_pd_global(intx,  InlineFrequencyCount,        100);
 define_pd_global(intx,  InlineSmallCode,             2000);
 
 #define DEFAULT_STACK_YELLOW_PAGES   (2)

--- a/src/hotspot/cpu/x86/globals_x86.hpp
+++ b/src/hotspot/cpu/x86/globals_x86.hpp
@@ -49,7 +49,6 @@ define_pd_global(intx, CodeEntryAlignment,       32);
 define_pd_global(intx, CodeEntryAlignment,       16);
 #endif // COMPILER2_OR_JVMCI
 define_pd_global(intx, OptoLoopAlignment,        16);
-define_pd_global(intx, InlineFrequencyCount,     100);
 define_pd_global(intx, InlineSmallCode,          1000);
 
 #define DEFAULT_STACK_YELLOW_PAGES (NOT_WINDOWS(2) WINDOWS_ONLY(3))

--- a/src/hotspot/cpu/zero/globals_zero.hpp
+++ b/src/hotspot/cpu/zero/globals_zero.hpp
@@ -39,7 +39,6 @@ define_pd_global(bool,  UncommonNullCast,     true);
 define_pd_global(uintx, CodeCacheSegmentSize, 64 COMPILER1_AND_COMPILER2_PRESENT(+64)); // Tiered compilation has large code-entry alignment.
 define_pd_global(intx,  CodeEntryAlignment,   32);
 define_pd_global(intx,  OptoLoopAlignment,    16);
-define_pd_global(intx,  InlineFrequencyCount, 100);
 define_pd_global(intx,  InlineSmallCode,      1000);
 
 // not used, but must satisfy following constraints:

--- a/src/hotspot/share/opto/bytecodeInfo.cpp
+++ b/src/hotspot/share/opto/bytecodeInfo.cpp
@@ -156,18 +156,17 @@ bool InlineTree::should_inline(ciMethod* callee_method, ciMethod* caller_method,
   int invoke_count     = method()->interpreter_invocation_count();
 
   assert(invoke_count != 0, "require invocation count greater than zero");
-  int freq = call_site_count / invoke_count;
+  double freq = (double)call_site_count / (double)invoke_count;
 
   // bump the max size if the call is frequent
   if ((freq >= InlineFrequencyRatio) ||
-      (call_site_count >= InlineFrequencyCount) ||
       is_unboxing_method(callee_method, C) ||
       is_init_with_ea(callee_method, caller_method, C)) {
 
     max_inline_size = C->freq_inline_size();
     if (size <= max_inline_size && TraceFrequencyInlining) {
       CompileTask::print_inline_indent(inline_level());
-      tty->print_cr("Inlined frequent method (freq=%d count=%d):", freq, call_site_count);
+      tty->print_cr("Inlined frequent method (freq=%lf):", freq);
       CompileTask::print_inline_indent(inline_level());
       callee_method->print();
       tty->cr();

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -534,6 +534,7 @@ static SpecialFlag const special_jvm_flags[] = {
 
   // -------------- Obsolete Flags - sorted by expired_in --------------
   { "CriticalJNINatives",           JDK_Version::jdk(16), JDK_Version::jdk(18), JDK_Version::jdk(19) },
+  { "InlineFrequencyCount",         JDK_Version::undefined(), JDK_Version::jdk(18), JDK_Version::jdk(19) },
   { "G1RSetRegionEntries",          JDK_Version::undefined(), JDK_Version::jdk(18), JDK_Version::jdk(19) },
   { "G1RSetSparseRegionEntries",    JDK_Version::undefined(), JDK_Version::jdk(18), JDK_Version::jdk(19) },
   { "AlwaysLockClassLoader",        JDK_Version::jdk(17), JDK_Version::jdk(18), JDK_Version::jdk(19) },

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1400,14 +1400,8 @@ const intx ObjectAlignmentInBytes = 8;
   product(intx, SpecTrapLimitExtraEntries,  3, EXPERIMENTAL,                \
           "Extra method data trap entries for speculation")                 \
                                                                             \
-  develop(intx, InlineFrequencyRatio,    20,                                \
+  product(double, InlineFrequencyRatio, 0.25, DIAGNOSTIC,                   \
           "Ratio of call site execution to caller method invocation")       \
-          range(0, max_jint)                                                \
-                                                                            \
-  product_pd(intx, InlineFrequencyCount, DIAGNOSTIC,                        \
-          "Count of call site execution necessary to trigger frequent "     \
-          "inlining")                                                       \
-          range(0, max_jint)                                                \
                                                                             \
   develop(intx, InlineThrowCount,    50,                                    \
           "Force inlining of interpreted methods that throw this often")    \

--- a/test/lib-test/jdk/test/whitebox/vm_flags/IntxTest.java
+++ b/test/lib-test/jdk/test/whitebox/vm_flags/IntxTest.java
@@ -36,7 +36,7 @@
 import jdk.test.lib.Platform;
 public class IntxTest {
     private static final String FLAG_NAME = "OnStackReplacePercentage";
-    private static final String FLAG_DEBUG_NAME = "InlineFrequencyCount";
+    private static final String FLAG_DEBUG_NAME = "BciProfileWidth";
     private static final long COMPILE_THRESHOLD = VmFlagTest.WHITE_BOX.getIntxVMFlag("CompileThreshold");
     private static final Long[] TESTS = {0L, 100L, (long)(Integer.MAX_VALUE>>3)*100L};
 


### PR DESCRIPTION
C2 considers absolute call site counts in its inlining decisions, which seems very wrong considering the asynchronous nature of profiling and background compilation (See InlineTree::should_inline()). It causes substantial over-inlining, which in presence of a depth-first inlining can lead to an early cut off. It also is inherently unstable. C2 already uses call frequency as an additional factor and it's better to consider only that in the inlining heuristic. I did extensive benchmarking it yielded almost no losses and single-digit wins (up to 5%) on some benchmarks. I think it's safe to remove/deprecate InlineFrequencyCount and continue using InlineFrequencyRatio instead. I found that converting the frequency computation to FP and setting InlineFrequencyRatio=0.25 (inline a method that is called a least 25% of the time) works best.