### PR TITLE
8272600: (test) Use native "sleep" in Basic.java

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -2449,8 +2449,10 @@ public class Basic {
             long start = System.nanoTime();
 
             if (p.waitFor(10, TimeUnit.MILLISECONDS)) {
-                System.out.println("WaitFor didn't wait long enough: " + (System.nanoTime() - start));
-            };
+                var msg = "External sleep process terminated early: exitValue: %d, (%dns)%n"
+                        .formatted(p.exitValue(), (System.nanoTime() - start));
+                fail(msg);
+            }
 
             long end = System.nanoTime();
             if ((end - start) < TimeUnit.MILLISECONDS.toNanos(10))

--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -83,7 +83,7 @@ public class Basic {
     static final String PERMISSION_DENIED_ERROR_MSG = "(Permission denied|error=13)";
     static final String NO_SUCH_FILE_ERROR_MSG = "(No such file|error=2)";
 
-    /* Path to native executables;  sleepmillis */
+    /* Path to native executables;  basicsleep */
     static final Path TEST_NATIVEPATH = Path.of(System.getProperty("test.nativepath", "."));
 
     /**
@@ -2627,17 +2627,22 @@ public class Basic {
 
     /**
      * Return the list of process arguments for a child to sleep 10 minutes (600000 milliseconds).
+     *
      * @return A list of process arguments to sleep 10 minutes.
      */
     private static List<String> getSleepArgs() {
         List<String> childArgs = null;
-        Path sleepExe = TEST_NATIVEPATH.resolve("sleepmillis");
-        if (sleepExe.toFile().canExecute()) {
-            childArgs = List.of(sleepExe.toString(), "600000");
+        String exeName = "BasicSleep" + (Windows.is() ? ".exe" : "");
+        Path exePath = TEST_NATIVEPATH.resolve(exeName);
+        if (exePath.toFile().canExecute()) {
+            childArgs = List.of(exePath.toString(), "600");
         } else {
             // Fallback to the JavaChild sleep does a sleep for 10 minutes.
+            // The fallback the Java child is used if the test is run without building
+            // the basicsleep native executable.
             childArgs = new ArrayList<>(javaChildArgs);
             childArgs.add("sleep");
+            System.out.println("Using fallback to JavaChild: " + childArgs);
         }
         return childArgs;
     }

--- a/test/jdk/java/lang/ProcessBuilder/exeBasicSleep.c
+++ b/test/jdk/java/lang/ProcessBuilder/exeBasicSleep.c
@@ -22,28 +22,32 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
-#include <time.h>
 
+#ifdef _WIN32
+    #include <windows.h>
+#else
+    #include <unistd.h>
+#endif
 /**
  * Command line program to sleep at least given number of seconds.
+ * Actual time sleeping may vary if interrupted, the remaining time
+ * returned from sleep has limited accuracy.
  *
  * Note: the file name prefix "exe" identifies the source should be built into SleepMillis(.exe).
  */
 int main(int argc, char** argv) {
-    // Use higher resolution nanosleep to be able to retry accurately if interrupted
-    struct timespec sleeptime;
-    int millis;
+    int seconds;
 
-    if (argc < 2 || (millis = atoi(argv[1])) < 0) {
-        fprintf(stderr, "usage: sleepmillis <non-negative milli-seconds>\n");
+    if (argc < 2 || (seconds = atoi(argv[1])) < 0) {
+        fprintf(stderr, "usage: basicsleep <non-negative seconds>\n");
         exit(1);
     }
 
-    sleeptime.tv_sec = millis / 1000;
-    sleeptime.tv_nsec = (millis % 1000) * 1000 * 1000;
-    int rc;
-    while ((rc = nanosleep(&sleeptime, &sleeptime)) > 0) {
-        // Repeat until == 0 or negative (error)
+#ifdef _WIN32
+    Sleep(seconds * 1000);
+#else
+    while ((seconds = sleep(seconds)) > 0) {
+        // until no more to sleep
     }
-    exit(rc == 0 ? 0 : 1);
+#endif
 }

--- a/test/jdk/java/lang/ProcessBuilder/exeBasicSleep.c
+++ b/test/jdk/java/lang/ProcessBuilder/exeBasicSleep.c
@@ -30,6 +30,7 @@
 #endif
 /**
  * Command line program to sleep at least given number of seconds.
+ * The behavior should equivalent to the Unix sleep command.
  * Actual time sleeping may vary if interrupted, the remaining time
  * returned from sleep has limited accuracy.
  *
@@ -39,7 +40,7 @@ int main(int argc, char** argv) {
     int seconds;
 
     if (argc < 2 || (seconds = atoi(argv[1])) < 0) {
-        fprintf(stderr, "usage: basicsleep <non-negative seconds>\n");
+        fprintf(stderr, "usage: BasicSleep <non-negative seconds>\n");
         exit(1);
     }
 

--- a/test/jdk/java/lang/ProcessBuilder/exeBasicSleep.c
+++ b/test/jdk/java/lang/ProcessBuilder/exeBasicSleep.c
@@ -34,7 +34,7 @@
  * Actual time sleeping may vary if interrupted, the remaining time
  * returned from sleep has limited accuracy.
  *
- * Note: the file name prefix "exe" identifies the source should be built into SleepMillis(.exe).
+ * Note: the file name prefix "exe" identifies the source should be built into BasicSleep(.exe).
  */
 int main(int argc, char** argv) {
     int seconds;

--- a/test/jdk/java/lang/ProcessBuilder/exeSleepMillis.c
+++ b/test/jdk/java/lang/ProcessBuilder/exeSleepMillis.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+/**
+ * Command line program to sleep at least given number of seconds.
+ *
+ * Note: the file name prefix "exe" identifies the source should be built into SleepMillis(.exe).
+ */
+int main(int argc, char** argv) {
+    // Use higher resolution nanosleep to be able to retry accurately if interrupted
+    struct timespec sleeptime;
+    int millis;
+
+    if (argc < 2 || (millis = atoi(argv[1])) < 0) {
+        fprintf(stderr, "usage: sleepmillis <non-negative milli-seconds>\n");
+        exit(1);
+    }
+
+    sleeptime.tv_sec = millis / 1000;
+    sleeptime.tv_nsec = (millis % 1000) * 1000 * 1000;
+    int rc;
+    while ((rc = nanosleep(&sleeptime, &sleeptime)) > 0) {
+        // Repeat until == 0 or negative (error)
+    }
+    exit(rc == 0 ? 0 : 1);
+}


### PR DESCRIPTION
The intermittent test in java/lang/ProcessBuilder/Basic.java has identified unexpected messages from a child Java VM
as the cause of the test failure.  Attempts to control the output of the child VM have failed, the VM is unrepentant .

There is no functionality in the child except to wait long enough for the test to finish and the child is destroyed.
The fix is to switch from using a Java child to using a native child; a new executable `sleepmillis`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272600](https://bugs.openjdk.java.net/browse/JDK-8272600): (test) Use native "sleep" in Basic.java


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to 2a9c33fbaeb71748bb1d12b5b26520d0353a8072
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5239/head:pull/5239` \
`$ git checkout pull/5239`

Update a local copy of the PR: \
`$ git checkout pull/5239` \
`$ git pull https://git.openjdk.java.net/jdk pull/5239/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5239`

View PR using the GUI difftool: \
`$ git pr show -t 5239`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5239.diff">https://git.openjdk.java.net/jdk/pull/5239.diff</a>

</details>
