### PR TITLE
8272905: Consolidate discovered lists processing

### DIFF
--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -424,7 +424,7 @@ void RefProcTask::process_discovered_list(uint worker_id,
                                           OopClosure* keep_alive) {
   ReferenceProcessor::RefProcSubPhases subphase;
   DiscoveredList* dl;
-  switch(ref_type) {
+  switch (ref_type) {
     case ReferenceType::REF_SOFT:
       subphase = ReferenceProcessor::ProcessSoftRefSubPhase;
       dl = _ref_processor._discoveredSoftRefs;
@@ -445,7 +445,7 @@ void RefProcTask::process_discovered_list(uint worker_id,
       ShouldNotReachHere();
   }
 
-  // Only Final refs are not enqueued.
+  // Only Final refs are not enqueued and cleared here.
   bool do_enqueue_and_clear = (ref_type != REF_FINAL);
 
   {

--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -424,33 +424,29 @@ void RefProcTask::process_discovered_list(uint worker_id,
                                           OopClosure* keep_alive) {
   ReferenceProcessor::RefProcSubPhases subphase;
   DiscoveredList* dl;
-  bool do_enqueue_and_clear;
   switch(ref_type) {
     case ReferenceType::REF_SOFT:
       subphase = ReferenceProcessor::ProcessSoftRefSubPhase;
       dl = _ref_processor._discoveredSoftRefs;
-      do_enqueue_and_clear = true;
       break;
     case ReferenceType::REF_WEAK:
       subphase = ReferenceProcessor::ProcessWeakRefSubPhase;
       dl = _ref_processor._discoveredWeakRefs;
-      do_enqueue_and_clear = true;
       break;
     case ReferenceType::REF_FINAL:
       subphase = ReferenceProcessor::ProcessFinalRefSubPhase;
       dl = _ref_processor._discoveredFinalRefs;
-      do_enqueue_and_clear = false;
       break;
     case ReferenceType::REF_PHANTOM:
       subphase = ReferenceProcessor::ProcessPhantomRefsSubPhase;
       dl = _ref_processor._discoveredPhantomRefs;
-      do_enqueue_and_clear = true;
       break;
     default:
       ShouldNotReachHere();
   }
 
-  assert(do_enqueue_and_clear != (ref_type == REF_FINAL), "Only Final refs are not enqueued");
+  // Only Final refs are not enqueued.
+  bool do_enqueue_and_clear = (ref_type != REF_FINAL);
 
   {
     RefProcSubPhasesWorkerTimeTracker tt(subphase, _phase_times, tracker_id(worker_id));

--- a/src/hotspot/share/gc/shared/referenceProcessor.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.hpp
@@ -160,9 +160,8 @@ public:
 // straightforward manner in a general, non-generational, non-contiguous generation
 // (or heap) setting.
 class ReferenceProcessor : public ReferenceDiscoverer {
-  friend class RefProcSoftWeakFinalPhaseTask;
+  friend class RefProcTask;
   friend class RefProcKeepAliveFinalPhaseTask;
-  friend class RefProcPhantomPhaseTask;
 public:
   // Names of sub-phases of reference processing. Indicates the type of the reference
   // processed and the associated phase number at the end.
@@ -253,21 +252,15 @@ private:
   // Traverse the list and remove any Refs whose referents are alive,
   // or NULL if discovery is not atomic. Enqueue and clear the reference for
   // others if do_enqueue_and_clear is set.
-  size_t process_soft_weak_final_refs_work(DiscoveredList&    refs_list,
-                                           BoolObjectClosure* is_alive,
-                                           OopClosure*        keep_alive,
-                                           bool               do_enqueue_and_clear);
+  size_t process_discovered_list_work(DiscoveredList&    refs_list,
+                                      BoolObjectClosure* is_alive,
+                                      OopClosure*        keep_alive,
+                                      bool               do_enqueue_and_clear);
 
   // Keep alive followers of referents for FinalReferences. Must only be called for
   // those.
-  size_t process_final_keep_alive_work(DiscoveredList&    refs_list,
-                                       OopClosure*        keep_alive,
-                                       VoidClosure*       complete_gc);
-
-  size_t process_phantom_refs_work(DiscoveredList&    refs_list,
-                                   BoolObjectClosure* is_alive,
-                                   OopClosure*        keep_alive,
-                                   VoidClosure*       complete_gc);
+  size_t process_final_keep_alive_work(DiscoveredList& refs_list,
+                                       OopClosure* keep_alive);
 
 
   void setup_policy(bool always_clear) {
@@ -539,6 +532,11 @@ protected:
   uint tracker_id(uint worker_id) const {
     return _ref_processor.processing_is_mt() ? worker_id : 0;
   }
+
+  void process_discovered_list(uint worker_id,
+                               ReferenceType ref_type,
+                               BoolObjectClosure* is_alive,
+                               OopClosure* keep_alive);
 public:
   RefProcTask(ReferenceProcessor& ref_processor,
               ReferenceProcessorPhaseTimes* phase_times)

--- a/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
@@ -240,7 +240,7 @@ void ReferenceProcessorPhaseTimes::set_sub_phase_total_phase_time_ms(ReferencePr
 
 void ReferenceProcessorPhaseTimes::add_ref_cleared(ReferenceType ref_type, size_t count) {
   ASSERT_REF_TYPE(ref_type);
-  Atomic::add(&_ref_cleared[ref_type_2_index(ref_type)], count);
+  Atomic::add(&_ref_cleared[ref_type_2_index(ref_type)], count, memory_order_relaxed);
 }
 
 void ReferenceProcessorPhaseTimes::set_ref_discovered(ReferenceType ref_type, size_t count) {


### PR DESCRIPTION
Simple change of merging discovered list processing for four kinds of non-strong refs and some general cleanup around.

Test: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272905](https://bugs.openjdk.java.net/browse/JDK-8272905): Consolidate discovered lists processing


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to cfcbad70efeee223fac22634eaea7607d04c3cb0
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to 3650b5d60bf877b69831f6ab2352e3d7d8452b06


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5242/head:pull/5242` \
`$ git checkout pull/5242`

Update a local copy of the PR: \
`$ git checkout pull/5242` \
`$ git pull https://git.openjdk.java.net/jdk pull/5242/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5242`

View PR using the GUI difftool: \
`$ git pr show -t 5242`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5242.diff">https://git.openjdk.java.net/jdk/pull/5242.diff</a>

</details>
