### PR TITLE
8272343: Remove MetaspaceClosure::FLAG_MASK

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -115,20 +115,16 @@ public:
     _builder(builder), _dumped_obj(dumped_obj), _start_idx(start_idx) {}
 
   bool do_bit(BitMap::idx_t bit_offset) {
-    uintx FLAG_MASK = 0x03; // See comments around MetaspaceClosure::FLAG_MASK
     size_t field_offset = size_t(bit_offset - _start_idx) * sizeof(address);
     address* ptr_loc = (address*)(_dumped_obj + field_offset);
 
-    uintx old_p_and_bits = (uintx)(*ptr_loc);
-    uintx flag_bits = (old_p_and_bits & FLAG_MASK);
-    address old_p = (address)(old_p_and_bits & (~FLAG_MASK));
+    address old_p = *ptr_loc;
     address new_p = _builder->get_dumped_addr(old_p);
-    uintx new_p_and_bits = ((uintx)new_p) | flag_bits;
 
     log_trace(cds)("Ref: [" PTR_FORMAT "] -> " PTR_FORMAT " => " PTR_FORMAT,
                    p2i(ptr_loc), p2i(old_p), p2i(new_p));
 
-    ArchivePtrMarker::set_and_mark_pointer(ptr_loc, (address)(new_p_and_bits));
+    ArchivePtrMarker::set_and_mark_pointer(ptr_loc, new_p);
     return true; // keep iterating the bitmap
   }
 };

--- a/src/hotspot/share/memory/metaspaceClosure.cpp
+++ b/src/hotspot/share/memory/metaspaceClosure.cpp
@@ -29,9 +29,7 @@
 void MetaspaceClosure::Ref::update(address new_loc) const {
   log_trace(cds)("Ref: [" PTR_FORMAT "] -> " PTR_FORMAT " => " PTR_FORMAT,
                  p2i(mpp()), p2i(obj()), p2i(new_loc));
-  uintx p = (uintx)new_loc;
-  p |= flag_bits(); // Make sure the flag bits are copied to the new pointer.
-  *(address*)mpp() = (address)p;
+  *addr() = new_loc;
 }
 
 void MetaspaceClosure::push_impl(MetaspaceClosure::Ref* ref) {

--- a/src/hotspot/share/memory/metaspaceClosure.hpp
+++ b/src/hotspot/share/memory/metaspaceClosure.hpp
@@ -128,10 +128,7 @@ public:
     virtual ~Ref() {}
 
     address obj() const {
-      // In some rare cases we store some flags in the lowest 2 bits of a
-      // MetaspaceObj pointer. Unmask these when manipulating the pointer.
-      uintx p = (uintx)*mpp();
-      return (address)(p & (~FLAG_MASK));
+      return *addr();
     }
 
     address* addr() const {
@@ -147,14 +144,6 @@ public:
     void* user_data()               { return _user_data; }
     void set_next(Ref* n)           { _next = n; }
     Ref* next() const               { return _next; }
-
-  private:
-    static const uintx FLAG_MASK = 0x03;
-
-    int flag_bits() const {
-      uintx p = (uintx)*mpp();
-      return (int)(p & FLAG_MASK);
-    }
   };
 
 private:


### PR DESCRIPTION
Please review this simple fix. `MetaspaceClosure::FLAG_MASK` is no longer needed after https://bugs.openjdk.java.net/browse/JDK-8272107

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272343](https://bugs.openjdk.java.net/browse/JDK-8272343): Remove MetaspaceClosure::FLAG_MASK


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5245/head:pull/5245` \
`$ git checkout pull/5245`

Update a local copy of the PR: \
`$ git checkout pull/5245` \
`$ git pull https://git.openjdk.java.net/jdk pull/5245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5245`

View PR using the GUI difftool: \
`$ git pr show -t 5245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5245.diff">https://git.openjdk.java.net/jdk/pull/5245.diff</a>

</details>
