### PR TITLE
8078641: MethodHandle.asTypeCache can retain classes from unloading

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -924,9 +924,7 @@ public abstract class MethodHandle implements Constable {
 
     /* Returns true when {@code loader} keeps {@code cls} either directly or indirectly through the loader delegation chain. */
     private static boolean keepsAlive(Class<?> cls, ClassLoader loader) {
-        boolean result = keepsAlive(cls.getClassLoader(), loader);
-        assert result : cls.getName() + ":" + cls.getClassLoader() + " </= " + loader;
-        return result;
+        return keepsAlive(cls.getClassLoader(), loader);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -873,9 +873,10 @@ public abstract class MethodHandle implements Constable {
         if (atc != null && newType == atc.type) {
             return atc; // cache hit
         }
-        if (asTypeSoftCache != null) {
-            atc = asTypeSoftCache.get();
-            if (newType == atc.type) {
+        SoftReference<MethodHandle> softCache = asTypeSoftCache;
+        if (softCache != null) {
+            atc = softCache.get();
+            if (atc != null && newType == atc.type) {
                 return atc; // soft cache hit
             }
         }
@@ -930,7 +931,7 @@ public abstract class MethodHandle implements Constable {
         return loader;
     }
 
-    /* Returns true when {@code loader} keeps {@code mt} either directly or indirectly through the loader delegation chain. */
+    /* Returns true when {@code loader} keeps components of {@code mt} reachable either directly or indirectly through the loader delegation chain. */
     private static boolean keepsAlive(MethodType mt, ClassLoader loader) {
         for (Class<?> ptype : mt.ptypes()) {
             if (!keepsAlive(ptype, loader)) {

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -493,12 +493,12 @@ abstract class MethodHandleImpl {
             if (newArity == collectArg+1 &&
                 type.parameterType(collectArg).isAssignableFrom(newType.parameterType(collectArg))) {
                 // if arity and trailing parameter are compatible, do normal thing
-                return asTypeCache = asFixedArity().asType(newType);
+                return asFixedArity().asType(newType);
             }
             // check cache
             MethodHandle acc = asCollectorCache;
             if (acc != null && acc.type().parameterCount() == newArity)
-                return asTypeCache = acc.asType(newType);
+                return acc.asType(newType);
             // build and cache a collector
             int arrayLength = newArity - collectArg;
             MethodHandle collector;
@@ -509,7 +509,7 @@ abstract class MethodHandleImpl {
                 throw new WrongMethodTypeException("cannot build collector", ex);
             }
             asCollectorCache = collector;
-            return asTypeCache = collector.asType(newType);
+            return collector.asType(newType);
         }
 
         @Override
@@ -737,7 +737,7 @@ abstract class MethodHandleImpl {
             } else {
                 wrapper = newTarget; // no need for a counting wrapper anymore
             }
-            return (asTypeCache = wrapper);
+            return wrapper;
         }
 
         boolean countDown() {
@@ -1213,7 +1213,7 @@ abstract class MethodHandleImpl {
         public MethodHandle asTypeUncached(MethodType newType) {
             // This MH is an alias for target, except for the MemberName
             // Drop the MemberName if there is any conversion.
-            return asTypeCache = target.asType(newType);
+            return target.asType(newType);
         }
     }
 
@@ -1276,7 +1276,7 @@ abstract class MethodHandleImpl {
         public MethodHandle asTypeUncached(MethodType newType) {
             // This MH is an alias for target, except for the intrinsic name
             // Drop the name if there is any conversion.
-            return asTypeCache = target.asType(newType);
+            return target.asType(newType);
         }
 
         @Override


### PR DESCRIPTION
`MethodHandle.asTypeCache` keeps a strong reference to adapted `MethodHandle` and it can introduce a class loader leak through its `MethodType`.

Proposed fix introduces a 2-level cache (1 element each) where 1st level can only contain `MethodHandle`s which are guaranteed to not introduce any dependencies on new class loaders compared to the original `MethodHandle`. 2nd level is backed by a `SoftReference` and is used as a backup when the result of `MethodHandle.asType()` conversion can't populate the higher level cache.  

The fix is based on [the work](http://cr.openjdk.java.net/~plevart/jdk9-dev/MethodHandle.asTypeCacheLeak/) made by Peter Levart @plevart back in 2015.

Testing: tier1 - tier6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8078641](https://bugs.openjdk.java.net/browse/JDK-8078641): MethodHandle.asTypeCache can retain classes from unloading


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to 871548170c5f0013e3881089f2ffb0a8c0214bb2
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to 871548170c5f0013e3881089f2ffb0a8c0214bb2
 * [Peter Levart](https://openjdk.java.net/census#plevart) (@plevart - **Reviewer**)


### Contributors
 * Peter Levart `<plevart@openjdk.org>`
 * Vladimir Ivanov `<vlivanov@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5246/head:pull/5246` \
`$ git checkout pull/5246`

Update a local copy of the PR: \
`$ git checkout pull/5246` \
`$ git pull https://git.openjdk.java.net/jdk pull/5246/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5246`

View PR using the GUI difftool: \
`$ git pr show -t 5246`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5246.diff">https://git.openjdk.java.net/jdk/pull/5246.diff</a>

</details>
