### PR TITLE
8272973: Incorrect compile command used by TestIllegalArrayCopyBeforeInfiniteLoop

### DIFF
--- a/test/hotspot/jtreg/compiler/arraycopy/TestIllegalArrayCopyBeforeInfiniteLoop.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestIllegalArrayCopyBeforeInfiniteLoop.java
@@ -27,7 +27,7 @@
  * @requires vm.compiler2.enabled
  * @summary ArrayCopy with negative index before infinite loop
  * @run main/othervm -Xbatch -XX:-TieredCompilation
- *                   -XX:CompileCommand=compileonly,"*TestIllegalArrayCopyBeforeInfiniteLoop::foo"
+ *                   -XX:CompileCommand=compileonly,compiler.arraycopy.TestIllegalArrayCopyBeforeInfiniteLoop::foo
  *                   compiler.arraycopy.TestIllegalArrayCopyBeforeInfiniteLoop
  */
 
@@ -38,7 +38,7 @@ import java.util.Arrays;
 public class TestIllegalArrayCopyBeforeInfiniteLoop {
     private static char src[] = new char[10];
     private static int count = 0;
-    private static final int iter = 10_000;
+    private static final int iter = 20_000;
 
     public static void main(String[] args) throws Exception {
         for (int i = 0; i < iter; ++i) {


### PR DESCRIPTION
Fixed the `Embedded * not allowed` compile command error and increased number of iterations to reliably trigger C2 compilation.

Thanks,
Tobias
