### PR TITLE
8244675: assert(IncrementalInline || (_late_inlines.length() == 0 && !has_mh_late_inlines()))

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -327,9 +327,7 @@ class LateInlineCallGenerator : public DirectCallGenerator {
 
  public:
   LateInlineCallGenerator(ciMethod* method, CallGenerator* inline_cg, bool is_pure_call = false) :
-    DirectCallGenerator(method, true), _unique_id(0), _is_pure_call(is_pure_call), _inline_cg(inline_cg) {
-    assert(IncrementalInline, "required");
-  }
+    DirectCallGenerator(method, true), _unique_id(0), _is_pure_call(is_pure_call), _inline_cg(inline_cg) {}
 
   virtual bool is_late_inline() const { return true; }
 

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -327,7 +327,9 @@ class LateInlineCallGenerator : public DirectCallGenerator {
 
  public:
   LateInlineCallGenerator(ciMethod* method, CallGenerator* inline_cg, bool is_pure_call = false) :
-    DirectCallGenerator(method, true), _unique_id(0), _is_pure_call(is_pure_call), _inline_cg(inline_cg) {}
+    DirectCallGenerator(method, true), _unique_id(0), _is_pure_call(is_pure_call), _inline_cg(inline_cg) {
+    assert(IncrementalInline, "required");
+  }
 
   virtual bool is_late_inline() const { return true; }
 
@@ -459,7 +461,9 @@ class LateInlineVirtualCallGenerator : public VirtualCallGenerator {
  public:
   LateInlineVirtualCallGenerator(ciMethod* method, int vtable_index, float prof_factor)
   : VirtualCallGenerator(method, vtable_index, true /*separate_io_projs*/),
-    _unique_id(0), _inline_cg(NULL), _callee(NULL), _is_pure_call(false), _prof_factor(prof_factor) {}
+    _unique_id(0), _inline_cg(NULL), _callee(NULL), _is_pure_call(false), _prof_factor(prof_factor) {
+    assert(IncrementalInlineVirtual, "required");
+  }
 
   virtual bool is_late_inline() const { return true; }
 

--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -136,7 +136,7 @@ CallGenerator* Compile::call_generator(ciMethod* callee, int vtable_index, bool 
       if (cg->does_virtual_dispatch()) {
         cg_intrinsic = cg;
         cg = NULL;
-      } else if (should_delay_vector_inlining(callee, jvms)) {
+      } else if (IncrementalInline && should_delay_vector_inlining(callee, jvms)) {
         return CallGenerator::for_late_inline(callee, cg);
       } else {
         return cg;

--- a/test/hotspot/jtreg/compiler/vectorapi/TestNoInline.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestNoInline.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import jdk.incubator.vector.IntVector;
+import jdk.incubator.vector.VectorSpecies;
+
+/*
+ * @test
+ * @bug 8244675
+ * @modules jdk.incubator.vector
+ *
+ * @run main/othervm -Xbatch -XX:-Inline            compiler.vectorapi.TestNoInline
+ * @run main/othervm -Xbatch -XX:-IncrementalInline compiler.vectorapi.TestNoInline
+ */
+public class TestNoInline {
+    static final VectorSpecies<Integer> I_SPECIES = IntVector.SPECIES_PREFERRED;
+
+    static IntVector test(int[] arr) {
+        return IntVector.fromArray(I_SPECIES, arr, 0);
+    }
+    public static void main(String[] args) {
+        int[] arr = new int[64];
+        for (int i = 0; i < 20_000; i++) {
+            test(arr);
+        }
+    }
+}


### PR DESCRIPTION
Avoid populating late inline candidates list when post-parse inlining is disabled.  

Testing: hs-tier1 - hs-tier4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244675](https://bugs.openjdk.java.net/browse/JDK-8244675): assert(IncrementalInline || (_late_inlines.length() == 0 && !has_mh_late_inlines()))


### Reviewers
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to b80d2464b03fea69fa0c2a965737aefcd075b310


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5249/head:pull/5249` \
`$ git checkout pull/5249`

Update a local copy of the PR: \
`$ git checkout pull/5249` \
`$ git pull https://git.openjdk.java.net/jdk pull/5249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5249`

View PR using the GUI difftool: \
`$ git pr show -t 5249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5249.diff">https://git.openjdk.java.net/jdk/pull/5249.diff</a>

</details>
