### PR TITLE
8159979: During initial mark, preparing all regions for marking may take a significant amount of time

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3446,13 +3446,12 @@ class G1PrepareEvacuationTask : public AbstractGangTask {
         _g1h->set_humongous_reclaim_candidate(index, false);
         _g1h->register_region_with_region_attr(hr);
       }
-      log_debug(gc, humongous)("Humongous region %u (object size " SIZE_FORMAT " @ " PTR_FORMAT ") remset " SIZE_FORMAT " code roots " SIZE_FORMAT " marked (prev/next) %d/%d reclaim candidate %d type array %d",
+      log_debug(gc, humongous)("Humongous region %u (object size " SIZE_FORMAT " @ " PTR_FORMAT ") remset " SIZE_FORMAT " code roots " SIZE_FORMAT " marked %d reclaim candidate %d type array %d",
                                index,
                                (size_t)cast_to_oop(hr->bottom())->size() * HeapWordSize,
                                p2i(hr->bottom()),
                                hr->rem_set()->occupied(),
                                hr->rem_set()->strong_code_roots_list_length(),
-                               _g1h->concurrent_mark()->prev_mark_bitmap()->is_marked(hr->bottom()),
                                _g1h->concurrent_mark()->next_mark_bitmap()->is_marked(hr->bottom()),
                                _g1h->is_humongous_reclaim_candidate(index),
                                cast_to_oop(hr->bottom())->is_typeArray()

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3425,6 +3425,11 @@ class G1PrepareEvacuationTask : public AbstractGangTask {
 
       sample_card_set_size(hr);
 
+      if (_g1h->collector_state()->in_concurrent_start_gc()) {
+        // Prepare region for marking.
+        hr->note_start_of_marking();
+      }
+
       // Now check if region is a humongous candidate
       if (!hr->is_starts_humongous()) {
         _g1h->register_region_with_region_attr(hr);
@@ -3441,12 +3446,13 @@ class G1PrepareEvacuationTask : public AbstractGangTask {
         _g1h->set_humongous_reclaim_candidate(index, false);
         _g1h->register_region_with_region_attr(hr);
       }
-      log_debug(gc, humongous)("Humongous region %u (object size " SIZE_FORMAT " @ " PTR_FORMAT ") remset " SIZE_FORMAT " code roots " SIZE_FORMAT " marked %d reclaim candidate %d type array %d",
+      log_debug(gc, humongous)("Humongous region %u (object size " SIZE_FORMAT " @ " PTR_FORMAT ") remset " SIZE_FORMAT " code roots " SIZE_FORMAT " marked (prev/next) %d/%d reclaim candidate %d type array %d",
                                index,
                                (size_t)cast_to_oop(hr->bottom())->size() * HeapWordSize,
                                p2i(hr->bottom()),
                                hr->rem_set()->occupied(),
                                hr->rem_set()->strong_code_roots_list_length(),
+                               _g1h->concurrent_mark()->prev_mark_bitmap()->is_marked(hr->bottom()),
                                _g1h->concurrent_mark()->next_mark_bitmap()->is_marked(hr->bottom()),
                                _g1h->is_humongous_reclaim_candidate(index),
                                cast_to_oop(hr->bottom())->is_typeArray()

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -702,10 +702,6 @@ void G1ConcurrentMark::pre_concurrent_start(GCCause::Cause cause) {
   // Reset marking state.
   reset();
 
-  // For each region note start of marking.
-  NoteStartOfMarkHRClosure startcl;
-  _g1h->heap_region_iterate(&startcl);
-
   _root_regions.reset();
 
   _gc_tracer_cm->set_gc_cause(cause);

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -688,14 +688,6 @@ void G1ConcurrentMark::clear_next_bitmap(WorkGang* workers) {
   clear_bitmap(_next_mark_bitmap, workers, false);
 }
 
-class NoteStartOfMarkHRClosure : public HeapRegionClosure {
-public:
-  bool do_heap_region(HeapRegion* r) {
-    r->note_start_of_marking();
-    return false;
-  }
-};
-
 void G1ConcurrentMark::pre_concurrent_start(GCCause::Cause cause) {
   assert_at_safepoint_on_vm_thread();
 


### PR DESCRIPTION
Hi all,

Please review this change to move preparing regions for marking to the multithreaded execution in G1PrepareEvacuationTask.

Testing: Tier 1-3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8159979](https://bugs.openjdk.java.net/browse/JDK-8159979): During initial mark, preparing all regions for marking may take a significant amount of time


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5251/head:pull/5251` \
`$ git checkout pull/5251`

Update a local copy of the PR: \
`$ git checkout pull/5251` \
`$ git pull https://git.openjdk.java.net/jdk pull/5251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5251`

View PR using the GUI difftool: \
`$ git pr show -t 5251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5251.diff">https://git.openjdk.java.net/jdk/pull/5251.diff</a>

</details>
