### PR TITLE
8272859: Javadoc external links should only have feature version number in URL

### DIFF
--- a/make/conf/javadoc.conf
+++ b/make/conf/javadoc.conf
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,9 @@
 #
 
 # URLs
-JAVADOC_BASE_URL=https://docs.oracle.com/pls/topic/lookup?ctx=javase$(VERSION_NUMBER)&amp;id=homepage
+JAVADOC_BASE_URL=https://docs.oracle.com/pls/topic/lookup?ctx=javase$(VERSION_FEATURE)&amp;id=homepage
 BUG_SUBMIT_URL=https://bugreport.java.com/bugreport/
 COPYRIGHT_URL=legal/copyright.html
-LICENSE_URL=https://www.oracle.com/java/javase/terms/license/java$(VERSION_NUMBER)speclicense.html
+LICENSE_URL=https://www.oracle.com/java/javase/terms/license/java$(VERSION_FEATURE)speclicense.html
 REDISTRIBUTION_URL=https://www.oracle.com/technetwork/java/redist-137594.html
 OTHER_JDK_VERSIONS_URL=https://docs.oracle.com/en/java/javase/index.html


### PR DESCRIPTION
Link to license terms from the JavaDoc API footer is broken in point releases (for example, 16.0.2). 

Instead of using VERSION_NUMBER, VERSION_FEATURE should be used,