### PR TITLE
8273000: Remove WeakReference-based class initialisation barrier implementation

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
@@ -33,7 +33,6 @@ import sun.invoke.util.VerifyAccess;
 import sun.invoke.util.VerifyType;
 import sun.invoke.util.Wrapper;
 
-import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Function;
@@ -363,25 +362,10 @@ class DirectMethodHandle extends MethodHandle {
             VerifyAccess.isSamePackage(ValueConversions.class, cls)) {
             // It is a system class.  It is probably in the process of
             // being initialized, but we will help it along just to be safe.
-            if (UNSAFE.shouldBeInitialized(cls)) {
-                UNSAFE.ensureClassInitialized(cls);
-            }
+            UNSAFE.ensureClassInitialized(cls);
             return false;
         }
         return UNSAFE.shouldBeInitialized(cls);
-    }
-
-    private static class EnsureInitialized extends ClassValue<WeakReference<Thread>> {
-        @Override
-        protected WeakReference<Thread> computeValue(Class<?> type) {
-            UNSAFE.ensureClassInitialized(type);
-            if (UNSAFE.shouldBeInitialized(type))
-                // If the previous call didn't block, this can happen.
-                // We are executing inside <clinit>.
-                return new WeakReference<>(Thread.currentThread());
-            return null;
-        }
-        static final EnsureInitialized INSTANCE = new EnsureInitialized();
     }
 
     private void ensureInitialized() {
@@ -397,24 +381,8 @@ class DirectMethodHandle extends MethodHandle {
     }
     private static boolean checkInitialized(MemberName member) {
         Class<?> defc = member.getDeclaringClass();
-        WeakReference<Thread> ref = EnsureInitialized.INSTANCE.get(defc);
-        if (ref == null) {
-            return true;  // the final state
-        }
-        // Somebody may still be running defc.<clinit>.
-        if (ref.refersTo(Thread.currentThread())) {
-            // If anybody is running defc.<clinit>, it is this thread.
-            if (UNSAFE.shouldBeInitialized(defc))
-                // Yes, we are running it; keep the barrier for now.
-                return false;
-        } else {
-            // We are in a random thread.  Block.
-            UNSAFE.ensureClassInitialized(defc);
-        }
-        assert(!UNSAFE.shouldBeInitialized(defc));
-        // put it into the final state
-        EnsureInitialized.INSTANCE.remove(defc);
-        return true;
+        UNSAFE.ensureClassInitialized(defc); // initialization barrier; blocks unless called by the initializing thread
+        return !UNSAFE.shouldBeInitialized(defc); // keep the barrier if the initialization is still in progress
     }
 
     /*non-public*/

--- a/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
@@ -381,8 +381,12 @@ class DirectMethodHandle extends MethodHandle {
     }
     private static boolean checkInitialized(MemberName member) {
         Class<?> defc = member.getDeclaringClass();
-        UNSAFE.ensureClassInitialized(defc); // initialization barrier; blocks unless called by the initializing thread
-        return !UNSAFE.shouldBeInitialized(defc); // keep the barrier if the initialization is still in progress
+        UNSAFE.ensureClassInitialized(defc);
+        // Once we get here either defc was fully initialized by another thread, or
+        // defc was already being initialized by the current thread. In the latter case
+        // the barrier must remain. We can detect this simply by checking if initialization
+        // is still needed.
+        return !UNSAFE.shouldBeInitialized(defc);
     }
 
     /*non-public*/

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -1143,9 +1143,13 @@ public final class Unsafe {
     }
 
     /**
-     * Ensures the given class has been initialized. This is often
-     * needed in conjunction with obtaining the static field base of a
-     * class.
+     * Ensures the given class has been initialized (see JVMS-5.5 for details).
+     * This is often needed in conjunction with obtaining the static field base
+     * of a class.
+     *
+     * The call returns when either class {@code c} is fully initialized or
+     * class {@code c} is being initialized and the call is performed from
+     * the initializing thread.
      */
     public void ensureClassInitialized(Class<?> c) {
         if (c == null) {

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -1149,7 +1149,8 @@ public final class Unsafe {
      *
      * The call returns when either class {@code c} is fully initialized or
      * class {@code c} is being initialized and the call is performed from
-     * the initializing thread.
+     * the initializing thread. In the latter case a subsequent call to
+     * {@link #shouldBeInitialized} will return {@code true}.
      */
     public void ensureClassInitialized(Class<?> c) {
         if (c == null) {


### PR DESCRIPTION
Get rid of WeakReference-based logic in DirectMethodHandle::checkInitialized() and reimplement it with `Unsafe::ensureClassInitialized()`/`shouldBeInitialized()`. 

The key observation is that `Unsafe::ensureClassInitialized()` does not block the initializing thread. 

Also, removed `Unsafe::shouldBeInitialized()` in `DMH::shouldBeInitialized(MemberName)` to save on calling into the VM.
`Unsafe::ensureClassInitialized()` already has a fast-path check which checks whether the class is fully initialized or not.

Testing: tier1 - tier6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273000](https://bugs.openjdk.java.net/browse/JDK-8273000): Remove WeakReference-based class initialisation barrier implementation


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to 64f2de83abe834cdbf2c6c3511274a73c3f64756
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to 9fc921675840daa8c94a4a666eb6480d654a7428


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5258/head:pull/5258` \
`$ git checkout pull/5258`

Update a local copy of the PR: \
`$ git checkout pull/5258` \
`$ git pull https://git.openjdk.java.net/jdk pull/5258/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5258`

View PR using the GUI difftool: \
`$ git pr show -t 5258`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5258.diff">https://git.openjdk.java.net/jdk/pull/5258.diff</a>

</details>
