### PR TITLE
8272964: java/nio/file/Files/InterruptCopy.java fails with java.lang.RuntimeException: Copy was not interrupted

### DIFF
--- a/test/jdk/java/nio/file/Files/InterruptCopy.java
+++ b/test/jdk/java/nio/file/Files/InterruptCopy.java
@@ -45,7 +45,6 @@ public class InterruptCopy {
 
     private static final long FILE_SIZE_TO_COPY = 1024L * 1024L * 1024L;
     private static final int INTERRUPT_DELAY_IN_MS = 50;
-    private static final int DURATION_MAX_IN_MS = 3*INTERRUPT_DELAY_IN_MS;
     private static final int CANCEL_DELAY_IN_MS = 10;
 
     public static void main(String[] args) throws Exception {
@@ -109,8 +108,15 @@ public class InterruptCopy {
                 long theEnd = System.currentTimeMillis();
                 System.out.printf("Done copying at %d ms...%n", theEnd);
                 long duration = theEnd - theBeginning;
-                if (duration > DURATION_MAX_IN_MS)
-                    throw new RuntimeException("Copy was not interrupted");
+
+                // If the copy was interrupted the target file should have been
+                // deleted, so if the file does not exist, then the copy must
+                // have been interrupted without throwing an exception; if the
+                // file exists, then the copy finished before being interrupted
+                // so not throwing an exception is not considered a failure
+                if (Files.notExists(target))
+                    throw new RuntimeException("Copy was not interrupted in " +
+                        duration + " ms");
             } catch (IOException e) {
                 boolean interrupted = Thread.interrupted();
                 if (!interrupted)


### PR DESCRIPTION
In the interrupt case, if the copy does not throw an `IOException`, rather than using the copy duration versus a threshold as the criterion for failure, instead check whether the target file does **not** exist, and if it does not, then make the test fail as this would indicate that the copy was in fact interrupted but did not throw an exception in response.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272964](https://bugs.openjdk.java.net/browse/JDK-8272964): java/nio/file/Files/InterruptCopy.java fails with java.lang.RuntimeException: Copy was not interrupted


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5260/head:pull/5260` \
`$ git checkout pull/5260`

Update a local copy of the PR: \
`$ git checkout pull/5260` \
`$ git pull https://git.openjdk.java.net/jdk pull/5260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5260`

View PR using the GUI difftool: \
`$ git pr show -t 5260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5260.diff">https://git.openjdk.java.net/jdk/pull/5260.diff</a>

</details>
