### PR TITLE
8274050: Unnecessary Vector usage in javax.crypto

### DIFF
--- a/src/java.base/share/classes/javax/crypto/CryptoPermissions.java
+++ b/src/java.base/share/classes/javax/crypto/CryptoPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,9 @@
 package javax.crypto;
 
 import java.security.*;
+import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Hashtable;
-import java.util.Vector;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.io.Serializable;
@@ -307,7 +307,7 @@ implements Serializable {
      */
     private CryptoPermission[] getMinimum(PermissionCollection thisPc,
                                           PermissionCollection thatPc) {
-        Vector<CryptoPermission> permVector = new Vector<>(2);
+        ArrayList<CryptoPermission> permList = new ArrayList<>(2);
 
         Enumeration<Permission> thisPcPermissions = thisPc.elements();
 
@@ -334,17 +334,17 @@ implements Serializable {
                     (CryptoPermission)thatPcPermissions.nextElement();
 
                 if (thatCp.implies(thisCp)) {
-                    permVector.addElement(thisCp);
+                    permList.add(thisCp);
                     break;
                 }
                 if (thisCp.implies(thatCp)) {
-                    permVector.addElement(thatCp);
+                    permList.add(thatCp);
                 }
             }
         }
 
-        CryptoPermission[] ret = new CryptoPermission[permVector.size()];
-        permVector.copyInto(ret);
+        CryptoPermission[] ret = new CryptoPermission[permList.size()];
+        permList.toArray(ret);
         return ret;
     }
 
@@ -363,7 +363,7 @@ implements Serializable {
      */
     private CryptoPermission[] getMinimum(int maxKeySize,
                                           PermissionCollection pc) {
-        Vector<CryptoPermission> permVector = new Vector<>(1);
+        ArrayList<CryptoPermission> permList = new ArrayList<>(1);
 
         Enumeration<Permission> enum_ = pc.elements();
 
@@ -371,16 +371,16 @@ implements Serializable {
             CryptoPermission cp =
                 (CryptoPermission)enum_.nextElement();
             if (cp.getMaxKeySize() <= maxKeySize) {
-                permVector.addElement(cp);
+                permList.add(cp);
             } else {
                 if (cp.getCheckParam()) {
-                    permVector.addElement(
+                    permList.add(
                            new CryptoPermission(cp.getAlgorithm(),
                                                 maxKeySize,
                                                 cp.getAlgorithmParameterSpec(),
                                                 cp.getExemptionMechanism()));
                 } else {
-                    permVector.addElement(
+                    permList.add(
                            new CryptoPermission(cp.getAlgorithm(),
                                                 maxKeySize,
                                                 cp.getExemptionMechanism()));
@@ -388,8 +388,8 @@ implements Serializable {
             }
         }
 
-        CryptoPermission[] ret = new CryptoPermission[permVector.size()];
-        permVector.copyInto(ret);
+        CryptoPermission[] ret = new CryptoPermission[permList.size()];
+        permList.toArray(ret);
         return ret;
     }
 

--- a/src/java.base/share/classes/javax/crypto/CryptoPermissions.java
+++ b/src/java.base/share/classes/javax/crypto/CryptoPermissions.java
@@ -343,8 +343,7 @@ implements Serializable {
             }
         }
 
-        CryptoPermission[] ret = new CryptoPermission[permList.size()];
-        permList.toArray(ret);
+        CryptoPermission[] ret = permList.toArray(new CryptoPermission[0]);
         return ret;
     }
 
@@ -388,8 +387,7 @@ implements Serializable {
             }
         }
 
-        CryptoPermission[] ret = new CryptoPermission[permList.size()];
-        permList.toArray(ret);
+        CryptoPermission[] ret = permList.toArray(new CryptoPermission[0]);
         return ret;
     }
 

--- a/src/java.base/share/classes/javax/crypto/CryptoPermissions.java
+++ b/src/java.base/share/classes/javax/crypto/CryptoPermissions.java
@@ -343,8 +343,7 @@ implements Serializable {
             }
         }
 
-        CryptoPermission[] ret = permList.toArray(new CryptoPermission[0]);
-        return ret;
+        return permList.toArray(new CryptoPermission[0]);
     }
 
     /**
@@ -387,8 +386,7 @@ implements Serializable {
             }
         }
 
-        CryptoPermission[] ret = permList.toArray(new CryptoPermission[0]);
-        return ret;
+        return permList.toArray(new CryptoPermission[0]);
     }
 
     /**

--- a/src/java.base/share/classes/javax/crypto/CryptoPolicyParser.java
+++ b/src/java.base/share/classes/javax/crypto/CryptoPolicyParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package javax.crypto;
 
 import java.io.*;
+import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.Vector;
@@ -254,15 +255,15 @@ final class CryptoPolicyParser {
             // AlgorithmParameterSpec class name.
             String algParamSpecClassName = match("quoted string");
 
-            Vector<Integer> paramsV = new Vector<>(1);
+            ArrayList<Integer> paramsV = new ArrayList<>(1);
             while (peek(",")) {
                 match(",");
                 if (peek("number")) {
-                    paramsV.addElement(match());
+                    paramsV.add(match());
                 } else {
                     if (peek("*")) {
                         match("*");
-                        paramsV.addElement(Integer.MAX_VALUE);
+                        paramsV.add(Integer.MAX_VALUE);
                     } else {
                         throw new ParsingException(st.lineno(),
                                                    "Expecting an integer");
@@ -271,7 +272,7 @@ final class CryptoPolicyParser {
             }
 
             Integer[] params = new Integer[paramsV.size()];
-            paramsV.copyInto(params);
+            paramsV.toArray(params);
 
             e.checkParam = true;
             e.algParamSpec = getInstance(algParamSpecClassName, params);
@@ -458,7 +459,7 @@ final class CryptoPolicyParser {
     }
 
     CryptoPermission[] getPermissions() {
-        Vector<CryptoPermission> result = new Vector<>();
+        ArrayList<CryptoPermission> result = new ArrayList<>();
 
         Enumeration<GrantEntry> grantEnum = grantEntries.elements();
         while (grantEnum.hasMoreElements()) {
@@ -469,16 +470,16 @@ final class CryptoPolicyParser {
                 CryptoPermissionEntry pe = permEnum.nextElement();
                 if (pe.cryptoPermission.equals(
                                         "javax.crypto.CryptoAllPermission")) {
-                    result.addElement(CryptoAllPermission.INSTANCE);
+                    result.add(CryptoAllPermission.INSTANCE);
                 } else {
                     if (pe.checkParam) {
-                        result.addElement(new CryptoPermission(
+                        result.add(new CryptoPermission(
                                                 pe.alg,
                                                 pe.maxKeySize,
                                                 pe.algParamSpec,
                                                 pe.exemptionMechanism));
                     } else {
-                        result.addElement(new CryptoPermission(
+                        result.add(new CryptoPermission(
                                                 pe.alg,
                                                 pe.maxKeySize,
                                                 pe.exemptionMechanism));
@@ -488,7 +489,7 @@ final class CryptoPolicyParser {
         }
 
         CryptoPermission[] ret = new CryptoPermission[result.size()];
-        result.copyInto(ret);
+        result.toArray(ret);
 
         return ret;
     }

--- a/src/java.base/share/classes/javax/crypto/CryptoPolicyParser.java
+++ b/src/java.base/share/classes/javax/crypto/CryptoPolicyParser.java
@@ -271,8 +271,7 @@ final class CryptoPolicyParser {
                 }
             }
 
-            Integer[] params = new Integer[paramsV.size()];
-            paramsV.toArray(params);
+            Integer[] params = paramsV.toArray(new Integer[0]);
 
             e.checkParam = true;
             e.algParamSpec = getInstance(algParamSpecClassName, params);
@@ -488,9 +487,7 @@ final class CryptoPolicyParser {
             }
         }
 
-        CryptoPermission[] ret = new CryptoPermission[result.size()];
-        result.toArray(ret);
-
+        CryptoPermission[] ret = result.toArray(new CryptoPermission[0]);
         return ret;
     }
 

--- a/src/java.base/share/classes/javax/crypto/CryptoPolicyParser.java
+++ b/src/java.base/share/classes/javax/crypto/CryptoPolicyParser.java
@@ -487,8 +487,7 @@ final class CryptoPolicyParser {
             }
         }
 
-        CryptoPermission[] ret = result.toArray(new CryptoPermission[0]);
-        return ret;
+        return result.toArray(new CryptoPermission[0]);
     }
 
     private boolean isConsistent(String alg, String exemptionMechanism,


### PR DESCRIPTION
In [JDK-8268873](https://bugs.openjdk.java.net/browse/JDK-8268873) I missed a few places, where Vector could be replaced with ArrayList.
Usage of thread-safe collection `Vector` is unnecessary. It's recommended to use `ArrayList` if a thread-safe implementation is not needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274050](https://bugs.openjdk.java.net/browse/JDK-8274050): Unnecessary Vector usage in javax.crypto


### Reviewers
 * [Valerie Peng](https://openjdk.java.net/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5261/head:pull/5261` \
`$ git checkout pull/5261`

Update a local copy of the PR: \
`$ git checkout pull/5261` \
`$ git pull https://git.openjdk.java.net/jdk pull/5261/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5261`

View PR using the GUI difftool: \
`$ git pr show -t 5261`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5261.diff">https://git.openjdk.java.net/jdk/pull/5261.diff</a>

</details>
