### PR TITLE
8273098: Unnecessary Vector usage in java.naming

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapSchemaParser.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapSchemaParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@ package com.sun.jndi.ldap;
 
 import javax.naming.*;
 import javax.naming.directory.*;
-import java.util.Vector;
+import java.util.ArrayList;
 
 /**
  * Netscape's 3.1 servers have some schema bugs:
@@ -519,7 +519,7 @@ final class LdapSchemaParser {
         throws NamingException {
 
         int begin, end;
-        Vector<String> values = new Vector<>(5);
+        ArrayList<String> values = new ArrayList<>(5);
 
         if (debug) {
             System.err.println("ReadQDescrList: pos="+pos[0]);
@@ -543,7 +543,7 @@ final class LdapSchemaParser {
                                    "' at begin=" + begin + " end =" + end);
             }
 
-            values.addElement(one[0]);
+            values.add(one[0]);
             skipWhitespace(string, pos);
             begin = pos[0];
         }
@@ -552,7 +552,7 @@ final class LdapSchemaParser {
 
         String[] answer = new String[values.size()];
         for (int i = 0; i < answer.length; i++) {
-            answer[i] = values.elementAt(i);
+            answer[i] = values.get(i);
         }
         return answer;
     }
@@ -613,7 +613,7 @@ final class LdapSchemaParser {
 
         int     begin, cur, end;
         String  oidName = null;
-        Vector<String> values = new Vector<>(5);
+        ArrayList<String> values = new ArrayList<>(5);
 
         if (debug) {
             System.err.println("ReadOIDList: pos="+pos[0]);
@@ -641,7 +641,7 @@ final class LdapSchemaParser {
                 System.err.println("ReadOIDList: found '" + oidName +
                                    "' at begin=" + begin + " end =" + end);
             }
-            values.addElement(oidName);
+            values.add(oidName);
             pos[0] = cur + 1;
             skipWhitespace(string, pos);
             begin = pos[0];
@@ -656,13 +656,13 @@ final class LdapSchemaParser {
 
         int wsBegin = findTrailingWhitespace(string, end - 1);
         oidName = string.substring(begin, wsBegin);
-        values.addElement(oidName);
+        values.add(oidName);
 
         pos[0] = end+1;
 
         String[] answer = new String[values.size()];
         for (int i = 0; i < answer.length; i++) {
-            answer[i] = values.elementAt(i);
+            answer[i] = values.get(i);
         }
         return answer;
     }

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/Obj.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/Obj.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,9 +38,9 @@ import java.io.ObjectOutputStream;
 import java.io.ObjectStreamClass;
 import java.io.InputStream;
 
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Hashtable;
-import java.util.Vector;
 import java.util.StringTokenizer;
 
 import java.lang.reflect.Proxy;
@@ -205,13 +205,13 @@ final class Obj {
         } else {
             StringTokenizer parser =
                 new StringTokenizer((String)codebaseAttr.get());
-            Vector<String> vec = new Vector<>(10);
+            ArrayList<String> list = new ArrayList<>(10);
             while (parser.hasMoreTokens()) {
-                vec.addElement(parser.nextToken());
+                list.add(parser.nextToken());
             }
-            String[] answer = new String[vec.size()];
+            String[] answer = new String[list.size()];
             for (int i = 0; i < answer.length; i++) {
-                answer[i] = vec.elementAt(i);
+                answer[i] = list.get(i);
             }
             return answer;
         }
@@ -409,11 +409,10 @@ final class Obj {
             ClassLoader cl = helper.getURLClassLoader(codebases);
 
             /*
-             * Temporary Vector for decoded RefAddr addresses - used to ensure
+             * Temporary array for decoded RefAddr addresses - used to ensure
              * unordered addresses are correctly re-ordered.
              */
-            Vector<RefAddr> refAddrList = new Vector<>();
-            refAddrList.setSize(attr.size());
+            RefAddr[] refAddrList = new RefAddr[attr.size()];
 
             for (NamingEnumeration<?> vals = attr.getAll(); vals.hasMore(); ) {
 
@@ -464,7 +463,7 @@ final class Obj {
                 // extract content
                 if (start == val.length()) {
                     // Empty content
-                    refAddrList.setElementAt(new StringRefAddr(type, null), posn);
+                    refAddrList[posn] = new StringRefAddr(type, null);
                 } else if (val.charAt(start) == separator) {
                     // Double separators indicate a non-StringRefAddr
                     // Content is a Base64-encoded serialized RefAddr
@@ -480,17 +479,17 @@ final class Obj {
                             decoder.decode(val.substring(start).getBytes()),
                             cl);
 
-                    refAddrList.setElementAt(ra, posn);
+                    refAddrList[posn] = ra;
                 } else {
                     // Single separator indicates a StringRefAddr
-                    refAddrList.setElementAt(new StringRefAddr(type,
-                        val.substring(start)), posn);
+                    refAddrList[posn] = new StringRefAddr(type,
+                        val.substring(start));
                 }
             }
 
             // Copy to real reference
-            for (int i = 0; i < refAddrList.size(); i++) {
-                ref.add(refAddrList.elementAt(i));
+            for (int i = 0; i < refAddrList.length; i++) {
+                ref.add(refAddrList[i]);
             }
         }
 

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/sasl/LdapSasl.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/sasl/LdapSasl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@ package com.sun.jndi.ldap.sasl;
 
 import java.io.*;
 import java.security.cert.X509Certificate;
-import java.util.Vector;
+import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.StringTokenizer;
 
@@ -216,13 +216,13 @@ public final class LdapSasl {
       */
     private static String[] getSaslMechanismNames(String str) {
         StringTokenizer parser = new StringTokenizer(str);
-        Vector<String> mechs = new Vector<>(10);
+        ArrayList<String> mechs = new ArrayList<>(10);
         while (parser.hasMoreTokens()) {
-            mechs.addElement(parser.nextToken());
+            mechs.add(parser.nextToken());
         }
         String[] mechNames = new String[mechs.size()];
         for (int i = 0; i < mechs.size(); i++) {
-            mechNames[i] = mechs.elementAt(i);
+            mechNames[i] = mechs.get(i);
         }
         return mechNames;
     }


### PR DESCRIPTION
Usage of thread-safe collection Vector is unnecessary. It's recommended to use ArrayList/array if a thread-safe implementation is not needed. In post-BiasedLocking times, this is gets worse, as every access is synchronized.
I checked only places where Vector was used as local variable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273098](https://bugs.openjdk.java.net/browse/JDK-8273098): Unnecessary Vector usage in java.naming


### Reviewers
 * [Aleksei Efimov](https://openjdk.java.net/census#aefimov) (@AlekseiEfimov - Committer)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5262/head:pull/5262` \
`$ git checkout pull/5262`

Update a local copy of the PR: \
`$ git checkout pull/5262` \
`$ git pull https://git.openjdk.java.net/jdk pull/5262/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5262`

View PR using the GUI difftool: \
`$ git pr show -t 5262`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5262.diff">https://git.openjdk.java.net/jdk/pull/5262.diff</a>

</details>
