### PR TITLE
8272229: BasicSplitPaneDivider:oneTouchExpandableChanged() returns letButton and rightButton as null with GTKLookAndFeel.

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
@@ -376,9 +376,10 @@ public class BasicSplitPaneDivider extends Container
 
     /**
      * Messaged when the oneTouchExpandable value of the JSplitPane the
-     * receiver is contained in changes. Will create the
-     * <code>leftButton</code> and <code>rightButton</code> if they
-     * are null. invalidates the receiver as well.
+     * receiver is contained in changes. If the Look and Feel does not
+     * support the one touch buttons, this will do nothing. Otherwise, this
+     * will create the <code>leftButton</code> and <code>rightButton</code>
+     * if they are null and invalidate the receiver as well.
      */
     protected void oneTouchExpandableChanged() {
         if (!DefaultLookup.getBoolean(splitPane, splitPaneUI,


### PR DESCRIPTION
The function documentation for oneTouchExpandableChanged states that the function does couple of things, but in reality  it only does those things if the Look and Feel supports the supportsOneTouchButtons. In case the Look and Feel does not support supportsOneTouchButtons, this functions just returns in beginning and does not do anything.
This change clarifies the above in function documentation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8272229](https://bugs.openjdk.java.net/browse/JDK-8272229)

### Issue
 * [JDK-8272229](https://bugs.openjdk.java.net/browse/JDK-8272229): BasicSplitPaneDivider:oneTouchExpandableChanged() returns leftButton and rightButton as null with GTKLookAndFeel. ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5263/head:pull/5263` \
`$ git checkout pull/5263`

Update a local copy of the PR: \
`$ git checkout pull/5263` \
`$ git pull https://git.openjdk.java.net/jdk pull/5263/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5263`

View PR using the GUI difftool: \
`$ git pr show -t 5263`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5263.diff">https://git.openjdk.java.net/jdk/pull/5263.diff</a>

</details>
