### PR TITLE
8273020: LibraryCallKit::sharpen_unsafe_type does not handle narrow oop array

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2172,7 +2172,7 @@ const TypeOopPtr* LibraryCallKit::sharpen_unsafe_type(Compile::AliasType* alias_
   // See if it is a narrow oop array.
   if (adr_type->isa_aryptr()) {
     if (adr_type->offset() >= objArrayOopDesc::base_offset_in_bytes()) {
-      const TypeOopPtr *elem_type = adr_type->is_aryptr()->elem()->isa_oopptr();
+      const TypeOopPtr* elem_type = adr_type->is_aryptr()->elem()->make_oopptr();
       if (elem_type != NULL) {
         sharpened_klass = elem_type->klass();
       }


### PR DESCRIPTION
The array handling code in `LibraryCallKit::sharpen_unsafe_type` does not work with narrow oop arrays because `isa_oopptr` returns `NULL`. Instead, `make_oopptr` should be used.

I've only noticed this while working on Valhalla, I don't think there is any impact on mainline code.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273020](https://bugs.openjdk.java.net/browse/JDK-8273020): LibraryCallKit::sharpen_unsafe_type does not handle narrow oop array


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5265/head:pull/5265` \
`$ git checkout pull/5265`

Update a local copy of the PR: \
`$ git checkout pull/5265` \
`$ git pull https://git.openjdk.java.net/jdk pull/5265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5265`

View PR using the GUI difftool: \
`$ git pr show -t 5265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5265.diff">https://git.openjdk.java.net/jdk/pull/5265.diff</a>

</details>
