### PR TITLE
8273021: C2: Improve Add and Xor ideal optimizations

### DIFF
--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -397,6 +397,22 @@ Node *AddINode::Ideal(PhaseGVN *phase, bool can_reshape) {
     }
   }
 
+  // Convert (~x+1) into -x. Note there isn't a bitwise not bytecode,
+  // "~x" would typically represented as "x^(-1)", so (~x+1) will
+  // be (x^(-1))+1
+  if (op1 == Op_XorI && phase->type(in2) == TypeInt::ONE) {
+    if (phase->type(in1->in(1)) == TypeInt::MINUS_1) {
+      return new SubINode(phase->makecon(TypeInt::ZERO), in1->in(2));
+    } else if (phase->type(in1->in(2)) == TypeInt::MINUS_1) {
+      return new SubINode(phase->makecon(TypeInt::ZERO), in1->in(1));
+    }
+  } else if (op2 == Op_XorI && phase->type(in1) == TypeInt::ONE) {
+    if (phase->type(in2->in(1)) == TypeInt::MINUS_1) {
+      return new SubINode(phase->makecon(TypeInt::ZERO), in2->in(2));
+    } else if (phase->type(in2->in(2)) == TypeInt::MINUS_1) {
+      return new SubINode(phase->makecon(TypeInt::ZERO), in2->in(1));
+    }
+  }
   return AddNode::Ideal(phase, can_reshape);
 }
 
@@ -554,7 +570,22 @@ Node *AddLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     }
   }
 
-
+  // Convert (~x+1) into -x. Note there isn't a bitwise not bytecode,
+  // "~x" would typically represented as "x^(-1)", so (~x+1) will
+  // be (x^(-1))+1
+  if (op1 == Op_XorL && phase->type(in2) == TypeLong::ONE) {
+    if (phase->type(in1->in(1)) == TypeLong::MINUS_1) {
+      return new SubLNode(phase->makecon(TypeLong::ZERO), in1->in(2));
+    } else if (phase->type(in1->in(2)) == TypeLong::MINUS_1) {
+      return new SubLNode(phase->makecon(TypeLong::ZERO), in1->in(1));
+    }
+  } else if (op2 == Op_XorL && phase->type(in1) == TypeLong::ONE) {
+    if (phase->type(in2->in(1)) == TypeLong::MINUS_1) {
+      return new SubLNode(phase->makecon(TypeLong::ZERO), in2->in(2));
+    } else if (phase->type(in2->in(2)) == TypeLong::MINUS_1) {
+      return new SubLNode(phase->makecon(TypeLong::ZERO), in2->in(1));
+    }
+  }
   return AddNode::Ideal(phase, can_reshape);
 }
 
@@ -967,6 +998,26 @@ const Type *OrLNode::add_ring( const Type *t0, const Type *t1 ) const {
 }
 
 //=============================================================================
+Node* XorINode::Ideal(PhaseGVN* phase, bool can_reshape) {
+  Node* in1 = in(1);
+  Node* in2 = in(2);
+  int op1 = in1->Opcode();
+  int op2 = in2->Opcode();
+  // Convert ~(x-1) into -x. Note there isn't a bitwise not bytecode,
+  // "~x" would typically represented as "x^(-1)", and "x-c0" would
+  // convert into "x+ -c0" in SubXNode::Ideal. So ~(x-1) will eventually
+  // be -1^(x+(-1)).
+  if (op1 == Op_AddI && phase->type(in2) == TypeInt::MINUS_1) {
+    if (phase->type(in1->in(2)) == TypeInt::MINUS_1) {
+      return new SubINode(phase->makecon(TypeInt::ZERO), in1->in(1));
+    }
+  } else if (op2 == Op_AddI && phase->type(in1) == TypeInt::MINUS_1) {
+    if (phase->type(in2->in(2)) == TypeInt::MINUS_1) {
+      return new SubINode(phase->makecon(TypeInt::ZERO), in2->in(1));
+    }
+  }
+  return AddNode::Ideal(phase, can_reshape);
+}
 
 const Type* XorINode::Value(PhaseGVN* phase) const {
   Node* in1 = in(1);
@@ -1030,6 +1081,27 @@ const Type *XorLNode::add_ring( const Type *t0, const Type *t1 ) const {
 
   // Otherwise just OR them bits.
   return TypeLong::make( r0->get_con() ^ r1->get_con() );
+}
+
+Node* XorLNode::Ideal(PhaseGVN* phase, bool can_reshape) {
+  Node* in1 = in(1);
+  Node* in2 = in(2);
+  int op1 = in1->Opcode();
+  int op2 = in2->Opcode();
+  // Convert ~(x-1) into -x. Note there isn't a bitwise not bytecode,
+  // "~x" would typically represented as "x^(-1)", and "x-c0" would
+  // convert into "x+ -c0" in SubXNode::Ideal. So ~(x-1) will eventually
+  // be -1^(x+(-1)).
+  if (op1 == Op_AddL && phase->type(in2) == TypeLong::MINUS_1) {
+    if (phase->type(in1->in(2)) == TypeLong::MINUS_1) {
+      return new SubLNode(phase->makecon(TypeLong::ZERO), in1->in(1));
+    }
+  } else if (op2 == Op_AddL && phase->type(in1) == TypeLong::MINUS_1) {
+    if (phase->type(in2->in(2)) == TypeLong::MINUS_1) {
+      return new SubLNode(phase->makecon(TypeLong::ZERO), in2->in(1));
+    }
+  }
+  return AddNode::Ideal(phase, can_reshape);
 }
 
 const Type* XorLNode::Value(PhaseGVN* phase) const {

--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -399,19 +399,10 @@ Node *AddINode::Ideal(PhaseGVN *phase, bool can_reshape) {
 
   // Convert (~x+1) into -x. Note there isn't a bitwise not bytecode,
   // "~x" would typically represented as "x^(-1)", so (~x+1) will
-  // be (x^(-1))+1
-  if (op1 == Op_XorI && phase->type(in2) == TypeInt::ONE) {
-    if (phase->type(in1->in(1)) == TypeInt::MINUS_1) {
-      return new SubINode(phase->makecon(TypeInt::ZERO), in1->in(2));
-    } else if (phase->type(in1->in(2)) == TypeInt::MINUS_1) {
-      return new SubINode(phase->makecon(TypeInt::ZERO), in1->in(1));
-    }
-  } else if (op2 == Op_XorI && phase->type(in1) == TypeInt::ONE) {
-    if (phase->type(in2->in(1)) == TypeInt::MINUS_1) {
-      return new SubINode(phase->makecon(TypeInt::ZERO), in2->in(2));
-    } else if (phase->type(in2->in(2)) == TypeInt::MINUS_1) {
-      return new SubINode(phase->makecon(TypeInt::ZERO), in2->in(1));
-    }
+  // be (x^(-1))+1.
+  if (op1 == Op_XorI && phase->type(in2) == TypeInt::ONE &&
+      phase->type(in1->in(2)) == TypeInt::MINUS_1) {
+    return new SubINode(phase->makecon(TypeInt::ZERO), in1->in(1));
   }
   return AddNode::Ideal(phase, can_reshape);
 }
@@ -573,18 +564,9 @@ Node *AddLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   // Convert (~x+1) into -x. Note there isn't a bitwise not bytecode,
   // "~x" would typically represented as "x^(-1)", so (~x+1) will
   // be (x^(-1))+1
-  if (op1 == Op_XorL && phase->type(in2) == TypeLong::ONE) {
-    if (phase->type(in1->in(1)) == TypeLong::MINUS_1) {
-      return new SubLNode(phase->makecon(TypeLong::ZERO), in1->in(2));
-    } else if (phase->type(in1->in(2)) == TypeLong::MINUS_1) {
-      return new SubLNode(phase->makecon(TypeLong::ZERO), in1->in(1));
-    }
-  } else if (op2 == Op_XorL && phase->type(in1) == TypeLong::ONE) {
-    if (phase->type(in2->in(1)) == TypeLong::MINUS_1) {
-      return new SubLNode(phase->makecon(TypeLong::ZERO), in2->in(2));
-    } else if (phase->type(in2->in(2)) == TypeLong::MINUS_1) {
-      return new SubLNode(phase->makecon(TypeLong::ZERO), in2->in(1));
-    }
+  if (op1 == Op_XorL && phase->type(in2) == TypeLong::ONE &&
+      phase->type(in1->in(2)) == TypeLong::MINUS_1) {
+    return new SubLNode(phase->makecon(TypeLong::ZERO), in1->in(1));
   }
   return AddNode::Ideal(phase, can_reshape);
 }
@@ -998,23 +980,18 @@ const Type *OrLNode::add_ring( const Type *t0, const Type *t1 ) const {
 }
 
 //=============================================================================
+//------------------------------Idealize---------------------------------------
 Node* XorINode::Ideal(PhaseGVN* phase, bool can_reshape) {
   Node* in1 = in(1);
   Node* in2 = in(2);
   int op1 = in1->Opcode();
-  int op2 = in2->Opcode();
   // Convert ~(x-1) into -x. Note there isn't a bitwise not bytecode,
   // "~x" would typically represented as "x^(-1)", and "x-c0" would
   // convert into "x+ -c0" in SubXNode::Ideal. So ~(x-1) will eventually
-  // be -1^(x+(-1)).
-  if (op1 == Op_AddI && phase->type(in2) == TypeInt::MINUS_1) {
-    if (phase->type(in1->in(2)) == TypeInt::MINUS_1) {
-      return new SubINode(phase->makecon(TypeInt::ZERO), in1->in(1));
-    }
-  } else if (op2 == Op_AddI && phase->type(in1) == TypeInt::MINUS_1) {
-    if (phase->type(in2->in(2)) == TypeInt::MINUS_1) {
-      return new SubINode(phase->makecon(TypeInt::ZERO), in2->in(1));
-    }
+  // be (x+(-1))^-1.
+  if (op1 == Op_AddI && phase->type(in2) == TypeInt::MINUS_1 &&
+      phase->type(in1->in(2)) == TypeInt::MINUS_1) {
+    return new SubINode(phase->makecon(TypeInt::ZERO), in1->in(1));
   }
   return AddNode::Ideal(phase, can_reshape);
 }
@@ -1087,19 +1064,13 @@ Node* XorLNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   Node* in1 = in(1);
   Node* in2 = in(2);
   int op1 = in1->Opcode();
-  int op2 = in2->Opcode();
   // Convert ~(x-1) into -x. Note there isn't a bitwise not bytecode,
   // "~x" would typically represented as "x^(-1)", and "x-c0" would
   // convert into "x+ -c0" in SubXNode::Ideal. So ~(x-1) will eventually
-  // be -1^(x+(-1)).
-  if (op1 == Op_AddL && phase->type(in2) == TypeLong::MINUS_1) {
-    if (phase->type(in1->in(2)) == TypeLong::MINUS_1) {
-      return new SubLNode(phase->makecon(TypeLong::ZERO), in1->in(1));
-    }
-  } else if (op2 == Op_AddL && phase->type(in1) == TypeLong::MINUS_1) {
-    if (phase->type(in2->in(2)) == TypeLong::MINUS_1) {
-      return new SubLNode(phase->makecon(TypeLong::ZERO), in2->in(1));
-    }
+  // be (x+(-1))^-1.
+  if (op1 == Op_AddL && phase->type(in2) == TypeLong::MINUS_1 &&
+      phase->type(in1->in(2)) == TypeLong::MINUS_1) {
+    return new SubLNode(phase->makecon(TypeLong::ZERO), in1->in(1));
   }
   return AddNode::Ideal(phase, can_reshape);
 }

--- a/src/hotspot/share/opto/addnode.hpp
+++ b/src/hotspot/share/opto/addnode.hpp
@@ -227,6 +227,7 @@ class XorINode : public AddNode {
 public:
   XorINode( Node *in1, Node *in2 ) : AddNode(in1,in2) {}
   virtual int Opcode() const;
+  virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
   virtual const Type *add_ring( const Type *, const Type * ) const;
   virtual const Type *add_id() const { return TypeInt::ZERO; }
   virtual const Type *bottom_type() const { return TypeInt::INT; }
@@ -242,6 +243,7 @@ class XorLNode : public AddNode {
 public:
   XorLNode( Node *in1, Node *in2 ) : AddNode(in1,in2) {}
   virtual int Opcode() const;
+  virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
   virtual const Type *add_ring( const Type *, const Type * ) const;
   virtual const Type *add_id() const { return TypeLong::ZERO; }
   virtual const Type *bottom_type() const { return TypeLong::LONG; }

--- a/test/hotspot/jtreg/compiler/c2/TestAddXorIdeal.java
+++ b/test/hotspot/jtreg/compiler/c2/TestAddXorIdeal.java
@@ -27,9 +27,14 @@
  * @bug 8273021
  * @summary C2: Improve Add and Xor ideal optimizations
  * @library /test/lib
- * @run main/othervm -XX:-Inline -XX:-TieredCompilation -XX:TieredStopAtLevel=4 -XX:CompileCommand=compileonly,compiler.c2.TestAddXorIdeal::* compiler.c2.TestAddXorIdeal
+ * @run main/othervm -XX:-TieredCompilation -XX:TieredStopAtLevel=4
+ *                   -XX:CompileCommand=dontinline,compiler.c2.TestAddXorIdeal::test*
+ *                   -XX:CompileCommand=compileonly,compiler.c2.TestAddXorIdeal::test*
+ *                   compiler.c2.TestAddXorIdeal
  */
 package compiler.c2;
+
+import java.util.Random;
 
 import jdk.test.lib.Asserts;
 
@@ -51,12 +56,36 @@ public class TestAddXorIdeal {
         return ~(x - 1L);
     }
 
+    public static int test5(int x) {
+        return 1 + ~x;
+    }
+
+    public static int test6(int x) {
+        return ~(-1 + x);
+    }
+
+    public static long test7(long x) {
+        return 1L + ~x;
+    }
+
+    public static long test8(long x) {
+        return ~(-1L + x);
+    }
+
     public static void main(String... args) {
+        Random random = new Random();
+
         for (int i = -5_000; i < 5_000; i++) {
-            Asserts.assertTrue(test1(i + 5) == -(i + 5));
-            Asserts.assertTrue(test2(i - 7) == -(i - 7));
-            Asserts.assertTrue(test3(i + 100) == -(i + 100));
-            Asserts.assertTrue(test4(i - 1024) == -(i - 1024));
+            int n = random.nextInt();
+            long n1 = random.nextLong();
+            Asserts.assertTrue(test1(i + n) == -(i + n));
+            Asserts.assertTrue(test2(i - n) == -(i - n));
+            Asserts.assertTrue(test3(i + n1) == -(i + n1));
+            Asserts.assertTrue(test4(i - n1) == -(i - n1));
+            Asserts.assertTrue(test5(i + n) == -(i + n));
+            Asserts.assertTrue(test6(i - n) == -(i - n));
+            Asserts.assertTrue(test7(i + n1) == -(i + n1));
+            Asserts.assertTrue(test8(i - n1) == -(i - n1));
         }
     }
 }

--- a/test/hotspot/jtreg/compiler/c2/TestAddXorIdeal.java
+++ b/test/hotspot/jtreg/compiler/c2/TestAddXorIdeal.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8273021
+ * @summary C2: Improve Add and Xor ideal optimizations
+ * @library /test/lib
+ * @run main/othervm -XX:-Inline -XX:-TieredCompilation -XX:TieredStopAtLevel=4 -XX:CompileCommand=compileonly,compiler.c2.TestAddXorIdeal::* compiler.c2.TestAddXorIdeal
+ */
+package compiler.c2;
+
+import jdk.test.lib.Asserts;
+
+public class TestAddXorIdeal {
+
+    public static int test1(int x) {
+        return ~x + 1;
+    }
+
+    public static int test2(int x) {
+        return ~(x - 1);
+    }
+
+    public static long test3(long x) {
+        return ~x + 1L;
+    }
+
+    public static long test4(long x) {
+        return ~(x - 1L);
+    }
+
+    public static void main(String... args) {
+        for (int i = -5_000; i < 5_000; i++) {
+            Asserts.assertTrue(test1(i + 5) == -(i + 5));
+            Asserts.assertTrue(test2(i - 7) == -(i - 7));
+            Asserts.assertTrue(test3(i + 100) == -(i + 100));
+            Asserts.assertTrue(test4(i - 1024) == -(i - 1024));
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/TestAddXorIdeal.java
+++ b/test/hotspot/jtreg/compiler/c2/TestAddXorIdeal.java
@@ -74,17 +74,24 @@ public class TestAddXorIdeal {
 
     public static void main(String... args) {
         Random random = new Random();
-
+        int n = 0;
+        long n1 = 0;
         for (int i = -5_000; i < 5_000; i++) {
-            int n = random.nextInt();
-            long n1 = random.nextLong();
+            n = random.nextInt();
             Asserts.assertTrue(test1(i + n) == -(i + n));
+            n = random.nextInt();
             Asserts.assertTrue(test2(i - n) == -(i - n));
+            n1 = random.nextLong();
             Asserts.assertTrue(test3(i + n1) == -(i + n1));
+            n1 = random.nextLong();
             Asserts.assertTrue(test4(i - n1) == -(i - n1));
+            n = random.nextInt();
             Asserts.assertTrue(test5(i + n) == -(i + n));
+            n = random.nextInt();
             Asserts.assertTrue(test6(i - n) == -(i - n));
+            n1 = random.nextLong();
             Asserts.assertTrue(test7(i + n1) == -(i + n1));
+            n1 = random.nextLong();
             Asserts.assertTrue(test8(i - n1) == -(i - n1));
         }
     }

--- a/test/hotspot/jtreg/compiler/c2/TestAddXorIdeal.java
+++ b/test/hotspot/jtreg/compiler/c2/TestAddXorIdeal.java
@@ -75,25 +75,17 @@ public class TestAddXorIdeal {
 
     public static void main(String... args) {
         Random random = Utils.getRandomInstance();
-        for (int i = -5_000; i < 5_000; i++) {
-            int n = 0;
-            long n1 = 0;
-            n = random.nextInt();
-            Asserts.assertTrue(test1(n) == -n);
-            n = random.nextInt();
-            Asserts.assertTrue(test2(n) == -n);
-            n1 = random.nextLong();
-            Asserts.assertTrue(test3(n1) == -n1);
-            n1 = random.nextLong();
-            Asserts.assertTrue(test4(n1) == -n1);
-            n = random.nextInt();
-            Asserts.assertTrue(test5(n) == -n);
-            n = random.nextInt();
-            Asserts.assertTrue(test6(n) ==  -n);
-            n1 = random.nextLong();
-            Asserts.assertTrue(test7(n1) == -n1);
-            n1 = random.nextLong();
-            Asserts.assertTrue(test8(n1) == -n1);
+        for (int i = 0; i < 50_000; i++) {
+            int a = random.nextInt();
+            long b = random.nextLong();
+            Asserts.assertTrue(test1(a) == -a);
+            Asserts.assertTrue(test2(a) == -a);
+            Asserts.assertTrue(test3(b) == -b);
+            Asserts.assertTrue(test4(b) == -b);
+            Asserts.assertTrue(test5(a) == -a);
+            Asserts.assertTrue(test6(a) ==  -a);
+            Asserts.assertTrue(test7(b) == -b);
+            Asserts.assertTrue(test8(b) == -b);
         }
     }
 }

--- a/test/hotspot/jtreg/compiler/c2/TestAddXorIdeal.java
+++ b/test/hotspot/jtreg/compiler/c2/TestAddXorIdeal.java
@@ -29,7 +29,6 @@
  * @library /test/lib
  * @run main/othervm -XX:-TieredCompilation -XX:TieredStopAtLevel=4
  *                   -XX:CompileCommand=dontinline,compiler.c2.TestAddXorIdeal::test*
- *                   -XX:CompileCommand=compileonly,compiler.c2.TestAddXorIdeal::test*
  *                   compiler.c2.TestAddXorIdeal
  */
 package compiler.c2;

--- a/test/hotspot/jtreg/compiler/c2/TestAddXorIdeal.java
+++ b/test/hotspot/jtreg/compiler/c2/TestAddXorIdeal.java
@@ -24,10 +24,11 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8273021
  * @summary C2: Improve Add and Xor ideal optimizations
  * @library /test/lib
- * @run main/othervm -XX:-TieredCompilation -XX:TieredStopAtLevel=4
+ * @run main/othervm -XX:-TieredCompilation
  *                   -XX:CompileCommand=dontinline,compiler.c2.TestAddXorIdeal::test*
  *                   compiler.c2.TestAddXorIdeal
  */
@@ -36,6 +37,7 @@ package compiler.c2;
 import java.util.Random;
 
 import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
 
 public class TestAddXorIdeal {
 
@@ -72,26 +74,26 @@ public class TestAddXorIdeal {
     }
 
     public static void main(String... args) {
-        Random random = new Random();
-        int n = 0;
-        long n1 = 0;
+        Random random = Utils.getRandomInstance();
         for (int i = -5_000; i < 5_000; i++) {
+            int n = 0;
+            long n1 = 0;
             n = random.nextInt();
-            Asserts.assertTrue(test1(i + n) == -(i + n));
+            Asserts.assertTrue(test1(n) == -n);
             n = random.nextInt();
-            Asserts.assertTrue(test2(i - n) == -(i - n));
+            Asserts.assertTrue(test2(n) == -n);
             n1 = random.nextLong();
-            Asserts.assertTrue(test3(i + n1) == -(i + n1));
+            Asserts.assertTrue(test3(n1) == -n1);
             n1 = random.nextLong();
-            Asserts.assertTrue(test4(i - n1) == -(i - n1));
+            Asserts.assertTrue(test4(n1) == -n1);
             n = random.nextInt();
-            Asserts.assertTrue(test5(i + n) == -(i + n));
+            Asserts.assertTrue(test5(n) == -n);
             n = random.nextInt();
-            Asserts.assertTrue(test6(i - n) == -(i - n));
+            Asserts.assertTrue(test6(n) ==  -n);
             n1 = random.nextLong();
-            Asserts.assertTrue(test7(i + n1) == -(i + n1));
+            Asserts.assertTrue(test7(n1) == -n1);
             n1 = random.nextLong();
-            Asserts.assertTrue(test8(i - n1) == -(i - n1));
+            Asserts.assertTrue(test8(n1) == -n1);
         }
     }
 }


### PR DESCRIPTION
Greetings. This patch adds the following identical equations for Add and Xor node, respectively, which probably drives further optimizations.

```
~(x-1) => -x
~x + 1 => -x
```


Verified by generated opto assembly, maybe an IR verification test can be added later.
```
Compiled method (c2)      71    1             compiler.c2.TestAddXorIdeal::test1 (6 bytes)
  0x00007f9e11514800:   sub    $0x18,%rsp
  0x00007f9e11514807:   mov    %rbp,0x10(%rsp)              ;*synchronization entry
                                                            ; - compiler.c2.TestAddXorIdeal::test1@-1 (line 39)
  0x00007f9e1151480c:   mov    %esi,%eax
  0x00007f9e1151480e:   neg    %eax                         ;*iadd {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - compiler.c2.TestAddXorIdeal::test1@4 (line 39)
  0x00007f9e11514810:   add    $0x10,%rsp
  0x00007f9e11514814:   pop    %rbp
  0x00007f9e11514815:   cmp    0x338(%r15),%rsp             ;   {poll_return}
  0x00007f9e1151481c:   ja     0x00007f9e11514823
  0x00007f9e11514822:   retq   

Compiled method (c2)      73    2             compiler.c2.TestAddXorIdeal::test2 (6 bytes)
  0x00007f9e11512480:   sub    $0x18,%rsp
  0x00007f9e11512487:   mov    %rbp,0x10(%rsp)              ;*synchronization entry
                                                            ; - compiler.c2.TestAddXorIdeal::test2@-1 (line 43)
  0x00007f9e1151248c:   mov    %esi,%eax
  0x00007f9e1151248e:   neg    %eax                         ;*ixor {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - compiler.c2.TestAddXorIdeal::test2@4 (line 43)
  0x00007f9e11512490:   add    $0x10,%rsp
  0x00007f9e11512494:   pop    %rbp
  0x00007f9e11512495:   cmp    0x338(%r15),%rsp             ;   {poll_return}
  0x00007f9e1151249c:   ja     0x00007f9e115124a3
  0x00007f9e115124a2:   retq 

Compiled method (c2)      72    3             compiler.c2.TestAddXorIdeal::test3 (8 bytes)
  0x00007f9e11514b00:   sub    $0x18,%rsp
  0x00007f9e11514b07:   mov    %rbp,0x10(%rsp)              ;*synchronization entry
                                                            ; - compiler.c2.TestAddXorIdeal::test3@-1 (line 47)
  0x00007f9e11514b0c:   mov    %rsi,%rax
  0x00007f9e11514b0f:   neg    %rax                         ;*ladd {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - compiler.c2.TestAddXorIdeal::test3@6 (line 47)
  0x00007f9e11514b12:   add    $0x10,%rsp
  0x00007f9e11514b16:   pop    %rbp
  0x00007f9e11514b17:   cmp    0x338(%r15),%rsp             ;   {poll_return}
  0x00007f9e11514b1e:   ja     0x00007f9e11514b25
  0x00007f9e11514b24:   retq  

Compiled method (c2)      72    4             compiler.c2.TestAddXorIdeal::test4 (8 bytes)
  0x00007f9e11514500:   sub    $0x18,%rsp
  0x00007f9e11514507:   mov    %rbp,0x10(%rsp)              ;*synchronization entry
                                                            ; - compiler.c2.TestAddXorIdeal::test4@-1 (line 51)
  0x00007f9e1151450c:   mov    %rsi,%rax
  0x00007f9e1151450f:   neg    %rax                         ;*lxor {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - compiler.c2.TestAddXorIdeal::test4@6 (line 51)
  0x00007f9e11514512:   add    $0x10,%rsp
  0x00007f9e11514516:   pop    %rbp
  0x00007f9e11514517:   cmp    0x338(%r15),%rsp             ;   {poll_return}
  0x00007f9e1151451e:   ja     0x00007f9e11514525
  0x00007f9e11514524:   retq  

Compiled method (c2)      72    5             compiler.c2.TestAddXorIdeal::test5 (6 bytes)
  0x00007f9e11518500:   sub    $0x18,%rsp
  0x00007f9e11518507:   mov    %rbp,0x10(%rsp)              ;*synchronization entry
                                                            ; - compiler.c2.TestAddXorIdeal::test5@-1 (line 55)
  0x00007f9e1151850c:   mov    %esi,%eax
  0x00007f9e1151850e:   neg    %eax                         ;*iadd {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - compiler.c2.TestAddXorIdeal::test5@4 (line 55)
  0x00007f9e11518510:   add    $0x10,%rsp
  0x00007f9e11518514:   pop    %rbp
  0x00007f9e11518515:   cmp    0x338(%r15),%rsp             ;   {poll_return}
  0x00007f9e1151851c:   ja     0x00007f9e11518523
  0x00007f9e11518522:   retq  

Compiled method (c2)      74    6             compiler.c2.TestAddXorIdeal::test6 (6 bytes)
  0x00007f9e11512180:   sub    $0x18,%rsp
  0x00007f9e11512187:   mov    %rbp,0x10(%rsp)              ;*synchronization entry
                                                            ; - compiler.c2.TestAddXorIdeal::test6@-1 (line 59)
  0x00007f9e1151218c:   mov    %esi,%eax
  0x00007f9e1151218e:   neg    %eax                         ;*ixor {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - compiler.c2.TestAddXorIdeal::test6@4 (line 59)
  0x00007f9e11512190:   add    $0x10,%rsp
  0x00007f9e11512194:   pop    %rbp
  0x00007f9e11512195:   cmp    0x338(%r15),%rsp             ;   {poll_return}
  0x00007f9e1151219c:   ja     0x00007f9e115121a3
  0x00007f9e115121a2:   retq  

Compiled method (c2)      74    7             compiler.c2.TestAddXorIdeal::test7 (8 bytes)
  0x00007f9e11511e80:   sub    $0x18,%rsp
  0x00007f9e11511e87:   mov    %rbp,0x10(%rsp)              ;*synchronization entry
                                                            ; - compiler.c2.TestAddXorIdeal::test7@-1 (line 63)
  0x00007f9e11511e8c:   mov    %rsi,%rax
  0x00007f9e11511e8f:   neg    %rax                         ;*ladd {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - compiler.c2.TestAddXorIdeal::test7@6 (line 63)
  0x00007f9e11511e92:   add    $0x10,%rsp
  0x00007f9e11511e96:   pop    %rbp
  0x00007f9e11511e97:   cmp    0x338(%r15),%rsp             ;   {poll_return}
  0x00007f9e11511e9e:   ja     0x00007f9e11511ea5
  0x00007f9e11511ea4:   retq 


Compiled method (c2)      73    8             compiler.c2.TestAddXorIdeal::test8 (10 bytes)
  0x00007f9e11512780:   sub    $0x18,%rsp
  0x00007f9e11512787:   mov    %rbp,0x10(%rsp)              ;*synchronization entry
                                                            ; - compiler.c2.TestAddXorIdeal::test8@-1 (line 67)
  0x00007f9e1151278c:   mov    %rsi,%rax
  0x00007f9e1151278f:   neg    %rax                         ;*lxor {reexecute=0 rethrow=0 return_oop=0}
                                                            ; - compiler.c2.TestAddXorIdeal::test8@8 (line 67)
  0x00007f9e11512792:   add    $0x10,%rsp
  0x00007f9e11512796:   pop    %rbp
  0x00007f9e11512797:   cmp    0x338(%r15),%rsp             ;   {poll_return}
  0x00007f9e1151279e:   ja     0x00007f9e115127a5
  0x00007f9e115127a4:   retq 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273021](https://bugs.openjdk.java.net/browse/JDK-8273021): C2: Improve Add and Xor ideal optimizations


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Contributors
 * yulei `<lei.yul@alibaba-inc.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5266/head:pull/5266` \
`$ git checkout pull/5266`

Update a local copy of the PR: \
`$ git checkout pull/5266` \
`$ git pull https://git.openjdk.java.net/jdk pull/5266/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5266`

View PR using the GUI difftool: \
`$ git pr show -t 5266`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5266.diff">https://git.openjdk.java.net/jdk/pull/5266.diff</a>

</details>
