### PR TITLE
8272608: java_lang_System::allow_security_manager() doesn't set its initialization flag

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -4438,6 +4438,7 @@ bool java_lang_System::allow_security_manager() {
     oop base = vmClasses::System_klass()->static_field_base_raw();
     int never = base->int_field(_static_never_offset);
     allowed = (base->int_field(_static_allow_security_offset) != never);
+    initialized = true;
   }
   return allowed;
 }


### PR DESCRIPTION
Originally the initialized flag was always false causing the System fields to be read each time the method is called. The flag is now set the first time it runs.
Tested with tier1, specifically with runtime/logging/ProtectionDomainVerificationTest.java.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272608](https://bugs.openjdk.java.net/browse/JDK-8272608): java_lang_System::allow_security_manager() doesn't set its initialization flag


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5268/head:pull/5268` \
`$ git checkout pull/5268`

Update a local copy of the PR: \
`$ git checkout pull/5268` \
`$ git pull https://git.openjdk.java.net/jdk pull/5268/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5268`

View PR using the GUI difftool: \
`$ git pr show -t 5268`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5268.diff">https://git.openjdk.java.net/jdk/pull/5268.diff</a>

</details>
