### PR TITLE
8273043: [TEST_BUG] Automate NimbusJTreeSelTextColor.java

### DIFF
--- a/test/jdk/javax/swing/plaf/nimbus/NimbusJTreeSelTextColor.java
+++ b/test/jdk/javax/swing/plaf/nimbus/NimbusJTreeSelTextColor.java
@@ -23,7 +23,6 @@
 /*
  * @test
  * @bug 8266510 8271315 8273043
- * @key headful
  * @summary  Verifies Nimbus JTree default tree cell renderer uses selected text color
  * @run main/othervm -Dawt.useSystemAAFontSettings=off NimbusJTreeSelTextColor
  */

--- a/test/jdk/javax/swing/plaf/nimbus/NimbusJTreeSelTextColor.java
+++ b/test/jdk/javax/swing/plaf/nimbus/NimbusJTreeSelTextColor.java
@@ -25,105 +25,114 @@
  * @bug 8266510 8271315 8273043
  * @key headful
  * @summary  Verifies Nimbus JTree default tree cell renderer uses selected text color
- * @run main/othervm -Dawt.useSystemAAFontSettings=off -Dsun.java2d.uiScale=1.0 NimbusJTreeSelTextColor
+ * @run main/othervm -Dawt.useSystemAAFontSettings=off NimbusJTreeSelTextColor
  */
 
 import java.awt.Color;
-import java.awt.Rectangle;
-import java.awt.Robot;
+import java.awt.Dimension;
+import java.awt.Graphics;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import javax.imageio.ImageIO;
-import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JTree;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.tree.DefaultTreeCellRenderer;
 
+import static java.awt.image.BufferedImage.TYPE_INT_RGB;
+
 public class NimbusJTreeSelTextColor {
 
-    private static JFrame frame;
-    private static JTree tree;
+    private static int iconOffset;
+    private static Color foregroundColor;
+    private static Color backgroundColor;
 
-    private static volatile Rectangle treeBounds;
-    private static volatile int iconOffset;
-    private static volatile Color foregroundColor;
-    private static volatile Color backgroundColor;
+    private static volatile Exception testFailed;
 
     private static final String FILENAME = "image.png";
 
     public static void main(String[] args) throws Exception {
-        try {
-            SwingUtilities.invokeAndWait(NimbusJTreeSelTextColor::createUI);
+        final boolean showFrame = args.length >= 1 && args[0].equals("-show");
 
-            Robot robot = new Robot();
-            robot.waitForIdle();
-            robot.delay(500);
+        // Disable text antialiasing
+        System.setProperty("awt.useSystemAAFontSettings", "off");
 
-            SwingUtilities.invokeAndWait(NimbusJTreeSelTextColor::getTreeBounds);
-            treeBounds.height /= 4; // height of one row
-            treeBounds.x += iconOffset;
-            treeBounds.width -= iconOffset;
-            treeBounds.width -= 2; // crop selection border on the right
-            BufferedImage image = robot.createScreenCapture(treeBounds);
-            checkColors(image);
-        } finally {
-            SwingUtilities.invokeAndWait(frame::dispose);
+        SwingUtilities.invokeAndWait(() -> runTest(showFrame));
+
+        if (testFailed != null) {
+            throw testFailed;
         }
     }
 
-    private static void createUI() {
+    private static void runTest(final boolean showFrame) {
         try {
             UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
 
-        frame = new JFrame("Nimbus Tree selected color");
+        final JTree tree = createTree();
+        Dimension size = tree.getPreferredSize();
+        tree.setSize(size);
+
+        BufferedImage im = new BufferedImage(size.width, size.height,
+                                             TYPE_INT_RGB);
+        Graphics g = im.getGraphics();
+        tree.paint(g);
+        g.dispose();
+
+        if (showFrame) {
+            showFrame(tree);
+        }
+
+        size.height /= 4; // height of one row
+        size.width -= iconOffset;
+        size.width -= 2; // crop selection border on the right
+        checkColors(im, iconOffset, size.height / 2, size.width);
+    }
+
+    private static void showFrame(final JTree tree) {
+        JFrame frame = new JFrame("Nimbus Tree selected color");
         frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
 
-        frame.getContentPane().add(createTree());
+        frame.getContentPane().add(tree);
 
         frame.pack();
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
 
-    private static void checkColors(final BufferedImage image) throws IOException {
-        final int y = treeBounds.height / 2;
+    private static void checkColors(final BufferedImage image,
+                                    final int iconOffset,
+                                    final int y,
+                                    final int width) {
         final int foreground = foregroundColor.getRGB();
         final int background = backgroundColor.getRGB();
 
-        for (int x = 0; x < treeBounds.width; x++) {
+        for (int x = iconOffset; x < width; x++) {
             int rgb = image.getRGB(x, y);
             if (rgb != foreground && rgb != background) {
-                save(image);
-                throw new RuntimeException(
+                testFailed = new RuntimeException(
                         "Unexpected color found: " + Integer.toHexString(rgb)
                         + " at (" + x + ", " + y + ");"
                         + " foreground: " + Integer.toHexString(foreground) + ";"
                         + " background: " + Integer.toHexString(background)
                         + " - check " + FILENAME);
+                save(image);
             }
         }
     }
 
-    private static void getTreeBounds() {
-        treeBounds = new Rectangle(tree.getLocationOnScreen(),
-                                   tree.getSize());
-    }
-
-    private static JComponent createTree() {
-        tree = new JTree();
-
+    private static JTree createTree() {
         DefaultTreeCellRenderer cellRenderer = new DefaultTreeCellRenderer();
         iconOffset = cellRenderer.getOpenIcon().getIconWidth()
                      + cellRenderer.getIconTextGap();
         foregroundColor = (Color) UIManager.get("Tree.selectionForeground");
         backgroundColor = (Color) UIManager.get("Tree.selectionBackground");
 
+        JTree tree = new JTree();
         tree.setRootVisible(true);
         tree.setShowsRootHandles(false);
         tree.setCellRenderer(cellRenderer);
@@ -131,8 +140,12 @@ public class NimbusJTreeSelTextColor {
         return tree;
     }
 
-    private static void save(final BufferedImage img) throws IOException {
-        ImageIO.write(img, "png", new File(FILENAME));
+    private static void save(final BufferedImage img) {
+        try {
+            ImageIO.write(img, "png", new File(FILENAME));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
 }

--- a/test/jdk/javax/swing/plaf/nimbus/NimbusJTreeSelTextColor.java
+++ b/test/jdk/javax/swing/plaf/nimbus/NimbusJTreeSelTextColor.java
@@ -24,6 +24,7 @@
  * @test
  * @bug 8266510 8271315 8273043
  * @summary  Verifies Nimbus JTree default tree cell renderer uses selected text color
+ * @requires os.family != "mac"
  * @run main/othervm -Dawt.useSystemAAFontSettings=off NimbusJTreeSelTextColor
  */
 


### PR DESCRIPTION
Automated NimbusJTreeSelTextColor.java test which is added under [JDK-8271315](https://bugs.openjdk.java.net/browse/JDK-8271315).

It passes with the recent build of JDK 18.  
It fails with JDK 18 build 7 where [JDK-8266510](https://bugs.openjdk.java.net/browse/JDK-8266510) is not fixed yet:

```
Exception in thread "main" java.lang.RuntimeException: Unexpected color found: ff000000 at (4, 9);
foreground: ffffffff; background: ff39698a - check image.png
        at NimbusJTreeSelTextColor.checkColors(NimbusJTreeSelTextColor.java:106)
        at NimbusJTreeSelTextColor.main(NimbusJTreeSelTextColor.java:70)
```

The line is wrapped for readability. In this case the text is black instead of white.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273043](https://bugs.openjdk.java.net/browse/JDK-8273043): [TEST_BUG] Automate NimbusJTreeSelTextColor.java


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5269/head:pull/5269` \
`$ git checkout pull/5269`

Update a local copy of the PR: \
`$ git checkout pull/5269` \
`$ git pull https://git.openjdk.java.net/jdk pull/5269/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5269`

View PR using the GUI difftool: \
`$ git pr show -t 5269`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5269.diff">https://git.openjdk.java.net/jdk/pull/5269.diff</a>

</details>
