### PR TITLE
[PATCH] Cleanup Stream.anyMatch/nonMatch usage

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -6759,7 +6759,7 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
                     loopReturnType + ")");
         }
 
-        if (!pred.stream().filter(Objects::nonNull).findFirst().isPresent()) {
+        if (pred.stream().noneMatch(Objects::nonNull)) {
             throw newIllegalArgumentException("no predicate found", pred);
         }
         if (pred.stream().filter(Objects::nonNull).map(MethodHandle::type).map(MethodType::returnType).

--- a/src/java.base/share/classes/jdk/internal/module/DefaultRoots.java
+++ b/src/java.base/share/classes/jdk/internal/module/DefaultRoots.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,8 +74,6 @@ public final class DefaultRoots {
     private static boolean exportsAPI(ModuleDescriptor descriptor) {
         return descriptor.exports()
                 .stream()
-                .filter(e -> !e.isQualified())
-                .findAny()
-                .isPresent();
+                .anyMatch(e -> !e.isQualified());
     }
 }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpConnection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpConnection.java
@@ -219,7 +219,7 @@ abstract class HttpConnection implements Closeable {
    private static final boolean hasRequiredHTTP2TLSVersion(HttpClient client) {
        String[] protos = client.sslParameters().getProtocols();
        if (protos != null) {
-           return Arrays.stream(protos).filter(testRequiredHTTP2TLSVersion).findAny().isPresent();
+           return Arrays.stream(protos).anyMatch(testRequiredHTTP2TLSVersion);
        } else {
            return false;
        }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -743,9 +743,9 @@ public class Types {
                     abstracts.append(sym);
                 } else if ((sym.name == abstracts.first().name &&
                         overrideEquivalent(mtype, memberType(origin.type, abstracts.first())))) {
-                    if (!abstracts.stream().filter(msym -> msym.owner.isSubClass(sym.enclClass(), Types.this))
+                    if (abstracts.stream().filter(msym -> msym.owner.isSubClass(sym.enclClass(), Types.this))
                             .map(msym -> memberType(origin.type, msym))
-                            .anyMatch(abstractMType -> isSubSignature(abstractMType, mtype))) {
+                            .noneMatch(abstractMType -> isSubSignature(abstractMType, mtype))) {
                         abstracts.append(sym);
                     }
                 } else {

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsConfiguration.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -433,9 +433,7 @@ public class JdepsConfiguration implements AutoCloseable {
                 .map(ModuleReference::descriptor)
                 .filter(descriptor -> descriptor.exports()
                         .stream()
-                        .filter(e -> !e.isQualified())
-                        .findAny()
-                        .isPresent())
+                        .anyMatch(e -> !e.isQualified()))
                 .map(ModuleDescriptor::name)
                 .collect(Collectors.toSet());
         }

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/SystemModulesPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/SystemModulesPlugin.java
@@ -672,9 +672,7 @@ public final class SystemModulesPlugin extends AbstractPlugin {
         private void genIncubatorModules(ClassWriter cw) {
             boolean hasIncubatorModules = moduleInfos.stream()
                     .map(ModuleInfo::moduleResolution)
-                    .filter(mres -> (mres != null && mres.hasIncubatingWarning()))
-                    .findFirst()
-                    .isPresent();
+                    .anyMatch(mres -> (mres != null && mres.hasIncubatingWarning()));
 
             mv = cw.visitMethod(ACC_PUBLIC,
                                 "hasIncubatorModules",

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/Feedback.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/Feedback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -895,7 +895,7 @@ class Feedback {
             if (suspicious
                     // Super simple might not define typeKind, otherwise check for JDK-14 presence of record
                     && ((tk = fields.get("typeKind")) == null
-                    || !tk.stream().anyMatch(tkc -> tkc.selector.equals(RECORD_TYPEKIND_SELECTOR)))
+                    || tk.stream().noneMatch(tkc -> tkc.selector.equals(RECORD_TYPEKIND_SELECTOR)))
                     // no record typeKind, now check for corruption
                     && ((errf = fields.get("err")) == null
                     || errf.stream().anyMatch(tkc -> tkc.selector.equals(Selector.OLD_ALWAYS)))) {


### PR DESCRIPTION
I propose to cleanup Stream usages which can be written more shorter and cleaner with help of `anyMatch`/`nonMatch` methods.
Found by IntelliJ IDEA inspection `Stream API call chain can be simplified`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5273/head:pull/5273` \
`$ git checkout pull/5273`

Update a local copy of the PR: \
`$ git checkout pull/5273` \
`$ git pull https://git.openjdk.java.net/jdk pull/5273/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5273`

View PR using the GUI difftool: \
`$ git pr show -t 5273`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5273.diff">https://git.openjdk.java.net/jdk/pull/5273.diff</a>

</details>
