### PR TITLE
8273062: Generation::refs_discovery_is_xxx functions are unused

### DIFF
--- a/src/hotspot/share/gc/shared/generation.hpp
+++ b/src/hotspot/share/gc/shared/generation.hpp
@@ -126,11 +126,6 @@ class Generation: public CHeapObj<mtGC> {
 
   virtual Generation::Name kind() { return Generation::Other; }
 
-  // This properly belongs in the collector, but for now this
-  // will do.
-  virtual bool refs_discovery_is_atomic() const { return true;  }
-  virtual bool refs_discovery_is_mt()     const { return false; }
-
   // Space inquiries (results in bytes)
   size_t initial_size();
   virtual size_t capacity() const = 0;  // The maximum number of object bytes the


### PR DESCRIPTION
Please review this trivial cleanup, removing a couple of unused virtual
function declarations from the Generation class:

  virtual bool refs_discovery_is_atomic() const { return true;  }
  virtual bool refs_discovery_is_mt()     const { return false; }

These functions are not called or overridden.

Testing:
local (linux-x64) build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273062](https://bugs.openjdk.java.net/browse/JDK-8273062): Generation::refs_discovery_is_xxx functions are unused


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5275/head:pull/5275` \
`$ git checkout pull/5275`

Update a local copy of the PR: \
`$ git checkout pull/5275` \
`$ git pull https://git.openjdk.java.net/jdk pull/5275/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5275`

View PR using the GUI difftool: \
`$ git pr show -t 5275`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5275.diff">https://git.openjdk.java.net/jdk/pull/5275.diff</a>

</details>
