### PR TITLE
8273059: Redundant Math.min call in Http2ClientImpl#getConnectionWindowSize

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2ClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2ClientImpl.java
@@ -237,8 +237,7 @@ class Http2ClientImpl {
 
         // The default is the max between the stream window size
         // and the connection window size.
-        int defaultValue = Math.min(Integer.MAX_VALUE,
-                Math.max(streamWindow, K*K*32));
+        int defaultValue = Math.max(streamWindow, K*K*32);
 
         return getParameter(
                 "jdk.httpclient.connectionWindowSize",

--- a/src/java.net.http/share/classes/jdk/internal/net/http/ResponseContent.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ResponseContent.java
@@ -489,7 +489,6 @@ class ResponseContent {
                     debug.log("already closed: " + closedExceptionally);
                 return;
             }
-            boolean completed = false;
             try {
                 if (debug.on())
                     debug.log("Parser got %d bytes ", b.remaining());
@@ -506,9 +505,6 @@ class ResponseContent {
             } catch (Throwable t) {
                 if (debug.on()) debug.log("Unexpected exception", t);
                 closedExceptionally = t;
-                if (!completed) {
-                    onComplete.accept(t);
-                }
             }
         }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/ResponseContent.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ResponseContent.java
@@ -505,6 +505,7 @@ class ResponseContent {
             } catch (Throwable t) {
                 if (debug.on()) debug.log("Unexpected exception", t);
                 closedExceptionally = t;
+                onComplete.accept(t);
             }
         }
 


### PR DESCRIPTION
Hi,

Could I get the following trivial change reviewed please?
It removes a redundant call to Math.min(Integer.MAX_VALUE, ....)

Thanks,
Michael.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273059](https://bugs.openjdk.java.net/browse/JDK-8273059): Redundant Math.min call in Http2ClientImpl#getConnectionWindowSize


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5277/head:pull/5277` \
`$ git checkout pull/5277`

Update a local copy of the PR: \
`$ git checkout pull/5277` \
`$ git pull https://git.openjdk.java.net/jdk pull/5277/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5277`

View PR using the GUI difftool: \
`$ git pr show -t 5277`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5277.diff">https://git.openjdk.java.net/jdk/pull/5277.diff</a>

</details>
