### PR TITLE
8258465: Headless build fails due to missing X11 headers on linux

### DIFF
--- a/make/autoconf/libraries.m4
+++ b/make/autoconf/libraries.m4
@@ -43,11 +43,9 @@ AC_DEFUN_ONCE([LIB_DETERMINE_DEPENDENCIES],
   if test "x$OPENJDK_TARGET_OS" = xwindows || test "x$OPENJDK_TARGET_OS" = xmacosx; then
     # No X11 support on windows or macosx
     NEEDS_LIB_X11=false
-  elif test "x$ENABLE_HEADLESS_ONLY" = xtrue; then
-    # No X11 support needed when building headless only
-    NEEDS_LIB_X11=false
   else
-    # All other instances need X11
+    # All other instances need X11, even if building headless only, libawt still
+    # needs X11 headers.
     NEEDS_LIB_X11=true
   fi
 


### PR DESCRIPTION
It turned out that JDK-8255785 was incorrectly verified, and headless do indeed need X headers. This fix is a revert (anti-delta) of JDK-8255785.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258465](https://bugs.openjdk.java.net/browse/JDK-8258465): Headless build fails due to missing X11 headers on linux


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5278/head:pull/5278` \
`$ git checkout pull/5278`

Update a local copy of the PR: \
`$ git checkout pull/5278` \
`$ git pull https://git.openjdk.java.net/jdk pull/5278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5278`

View PR using the GUI difftool: \
`$ git pr show -t 5278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5278.diff">https://git.openjdk.java.net/jdk/pull/5278.diff</a>

</details>
