### PR TITLE
JDK-8272866 java.util.random package summary contains incorrect mixing function in table

### DIFF
--- a/src/java.base/share/classes/java/util/random/package-info.java
+++ b/src/java.base/share/classes/java/util/random/package-info.java
@@ -599,32 +599,32 @@
  *       <td style="text-align:right">{@code 0xd1342543de82ef95L}</td>
  *       <td style="text-align:left">{@code xoroshiro128}, version 1.0</td>
  *       <td style="text-align:left">{@code (24, 16, 37)}</td>
- *       <td style="text-align:left">mixLea32{@code (s+x0)}</td></tr>
+ *       <td style="text-align:left">mixLea64{@code (s+x0)}</td></tr>
  *   <tr><td style="text-align:left">"L64X256MixRandom"</td>
  *       <td style="text-align:right">{@code 0xd1342543de82ef95L}</td>
  *       <td style="text-align:left">{@code xoshiro256}, version 1.0</td>
  *       <td style="text-align:left">{@code (17, 45)}</td>
- *       <td style="text-align:left">mixLea32{@code (s+x0)}</td></tr>
+ *       <td style="text-align:left">mixLea64{@code (s+x0)}</td></tr>
  *   <tr><td style="text-align:left">"L64X1024MixRandom"</td>
  *       <td style="text-align:right">{@code 0xd1342543de82ef95L}</td>
  *       <td style="text-align:left">{@code xoroshiro1024}, version 1.0</td>
  *       <td style="text-align:left">{@code (25, 27, 36)}</td>
- *       <td style="text-align:left">mixLea32{@code (s+x0)}</td></tr>
+ *       <td style="text-align:left">mixLea64{@code (s+x0)}</td></tr>
  *   <tr><td style="text-align:left">"L128X128MixRandom"</td>
  *       <td style="text-align:right">{@code 0x1d605bbb58c8abbfdL}</td>
  *       <td style="text-align:left">{@code xoroshiro128}, version 1.0</td>
  *       <td style="text-align:left">{@code (24, 16, 37)}</td>
- *       <td style="text-align:left">mixLea32{@code (sh+x0)}</td></tr>
+ *       <td style="text-align:left">mixLea64{@code (sh+x0)}</td></tr>
  *   <tr><td style="text-align:left">"L128X256MixRandom"</td>
  *       <td style="text-align:right">{@code 0x1d605bbb58c8abbfdL}</td>
  *       <td style="text-align:left">{@code xoshiro256}, version 1.0</td>
  *       <td style="text-align:left">{@code (17, 45)}</td>
- *       <td style="text-align:left">mixLea32{@code (sh+x0)}</td></tr>
+ *       <td style="text-align:left">mixLea64{@code (sh+x0)}</td></tr>
  *   <tr><td style="text-align:left">"L128X1024MixRandom"</td>
  *       <td style="text-align:right">{@code 0x1d605bbb58c8abbfdL}</td>
  *       <td style="text-align:left">{@code xoroshiro1024}, version 1.0</td>
  *       <td style="text-align:left">{@code (25, 27, 36)}</td>
- *       <td style="text-align:left">mixLea32{@code (sh+x0)}</td></tr>
+ *       <td style="text-align:left">mixLea64{@code (sh+x0)}</td></tr>
  * </tbody>
  * </table>
  *


### PR DESCRIPTION
The table 'LXM Multipliers' at the end of the javadoc for the java.util.random package states that the mixing function is mixLea32 for all the 64/128-bit LCG based generators. This should be updated to mixLea64 for the 64/128-bit LCG generators. Only the L32X64MixRandom which uses a 32-bit LCG will use the mixLea32 mixing function.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272866](https://bugs.openjdk.java.net/browse/JDK-8272866): java.util.random package summary contains incorrect mixing function in table


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5279/head:pull/5279` \
`$ git checkout pull/5279`

Update a local copy of the PR: \
`$ git checkout pull/5279` \
`$ git pull https://git.openjdk.java.net/jdk pull/5279/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5279`

View PR using the GUI difftool: \
`$ git pr show -t 5279`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5279.diff">https://git.openjdk.java.net/jdk/pull/5279.diff</a>

</details>
