### PR TITLE
8229031: Exporting CLASSPATH from shell can result in build failures

### DIFF
--- a/make/autoconf/boot-jdk.m4
+++ b/make/autoconf/boot-jdk.m4
@@ -298,6 +298,28 @@ AC_DEFUN([BOOTJDK_CHECK_TOOL_IN_BOOTJDK],
     ])
 ])
 
+# Setup CLASSPATH environment variable
+AC_DEFUN([BOOTJDK_SETUP_CLASSPATH],
+[
+  AC_ARG_WITH([classpath], [AS_HELP_STRING([--with-classpath],
+      [Optional classpath to set as CLASSPATH to all Java invocations @<:@none@:>@])])
+
+  if test "x$CLASSPATH" != x; then
+    AC_MSG_WARN([CLASSPATH is set in the environment. This will be ignored. Use --with-classpath instead.])
+  fi
+
+  CLASSPATH=
+
+  if test "x$with_classpath" != x && test "x$with_classpath" != xyes &&
+      test "x$with_classpath" != xno ; then
+    CLASSPATH="$with_classpath"
+    AC_MSG_CHECKING([for classpath to use for all Java invocations])
+    AC_MSG_RESULT([$CLASSPATH])
+  fi
+
+  AC_SUBST(CLASSPATH)
+])
+
 ###############################################################################
 #
 # We need a Boot JDK to bootstrap the build.
@@ -394,6 +416,8 @@ AC_DEFUN_ONCE([BOOTJDK_SETUP_BOOT_JDK],
     BOOTJDK_USE_LOCAL_CDS=false
     AC_MSG_RESULT([no, -XX:SharedArchiveFile not supported])
   fi
+
+  BOOTJDK_SETUP_CLASSPATH
 ])
 
 AC_DEFUN_ONCE([BOOTJDK_SETUP_BOOT_JDK_ARGUMENTS],

--- a/make/autoconf/spec.gmk.in
+++ b/make/autoconf/spec.gmk.in
@@ -54,6 +54,9 @@ MAKE := @MAKE@
 # Make sure all shell commands are executed with the C locale
 export LC_ALL := C
 
+# Make sure we override any local CLASSPATH variable
+export CLASSPATH := @CLASSPATH@
+
 # The default make arguments
 MAKE_ARGS = $(MAKE_LOG_FLAGS) -r -R -I $(TOPDIR)/make/common SPEC=$(SPEC) \
     MAKE_LOG_FLAGS="$(MAKE_LOG_FLAGS)" $(MAKE_LOG_VARS)


### PR DESCRIPTION
Having the environment variable CLASSPATH set when building can cause hard-to-diagnose build errors. We should not silently accept the CLASSPATH variable when building. Normally, the classpath should be correctly setup for all invocations of java during the build. If the user wants to have a hard-coded value for CLASSPATH, they must set it explicitly in `configure`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8229031](https://bugs.openjdk.java.net/browse/JDK-8229031): Exporting CLASSPATH from shell can result in build failures


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5280/head:pull/5280` \
`$ git checkout pull/5280`

Update a local copy of the PR: \
`$ git checkout pull/5280` \
`$ git pull https://git.openjdk.java.net/jdk pull/5280/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5280`

View PR using the GUI difftool: \
`$ git pr show -t 5280`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5280.diff">https://git.openjdk.java.net/jdk/pull/5280.diff</a>

</details>
