### PR TITLE
8237567: Refactor G1-specific code in shared VM_CollectForMetadataAllocation

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2245,6 +2245,18 @@ bool G1CollectedHeap::try_collect(GCCause::Cause cause,
   }
 }
 
+void G1CollectedHeap::initiate_conc_gc_for_metadata_allocation(GCCause::Cause gc_cause) {
+  GCCauseSetter x(this, gc_cause);
+
+  // At this point we are supposed to start a concurrent cycle. We
+  // will do so if one is not already in progress.
+  bool should_start = policy()->force_concurrent_start_if_outside_cycle(gc_cause);
+  if (should_start) {
+    double pause_target = policy()->max_pause_time_ms();
+    do_collection_pause_at_safepoint(pause_target);
+  }
+}
+
 bool G1CollectedHeap::is_in(const void* p) const {
   return is_in_reserved(p) && _hrm.is_available(addr_to_region((HeapWord*)p));
 }

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2245,7 +2245,7 @@ bool G1CollectedHeap::try_collect(GCCause::Cause cause,
   }
 }
 
-void G1CollectedHeap::initiate_conc_gc_for_metadata_allocation(GCCause::Cause gc_cause) {
+void G1CollectedHeap::start_concurrent_gc_for_metadata_allocation(GCCause::Cause gc_cause) {
   GCCauseSetter x(this, gc_cause);
 
   // At this point we are supposed to start a concurrent cycle. We

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1134,7 +1134,7 @@ public:
   // Returns whether this collection actually executed.
   bool try_collect(GCCause::Cause cause, const G1GCCounters& counters_before);
 
-  void initiate_conc_gc_for_metadata_allocation(GCCause::Cause gc_cause);
+  void start_concurrent_gc_for_metadata_allocation(GCCause::Cause gc_cause);
 
   // True iff an evacuation has failed in the most-recent collection.
   inline bool evacuation_failed() const;

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -137,7 +137,6 @@ class G1RegionMappingChangedListener : public G1MappingChangedListener {
 };
 
 class G1CollectedHeap : public CollectedHeap {
-  friend class VM_CollectForMetadataAllocation;
   friend class VM_G1CollectForAllocation;
   friend class VM_G1CollectFull;
   friend class VM_G1TryInitiateConcMark;
@@ -1134,6 +1133,8 @@ public:
   // Perform a collection of the heap with the given cause.
   // Returns whether this collection actually executed.
   bool try_collect(GCCause::Cause cause, const G1GCCounters& counters_before);
+
+  void initiate_conc_gc_for_metadata_allocation(GCCause::Cause gc_cause);
 
   // True iff an evacuation has failed in the most-recent collection.
   inline bool evacuation_failed() const;

--- a/src/hotspot/share/gc/shared/gcVMOperations.cpp
+++ b/src/hotspot/share/gc/shared/gcVMOperations.cpp
@@ -221,7 +221,7 @@ void VM_CollectForMetadataAllocation::doit() {
 
 #if INCLUDE_G1GC
   if (UseG1GC && ClassUnloadingWithConcurrentMark) {
-    G1CollectedHeap::heap()->initiate_conc_gc_for_metadata_allocation(_gc_cause);
+    G1CollectedHeap::heap()->start_concurrent_gc_for_metadata_allocation(_gc_cause);
     // For G1 expand since the collection is going to be concurrent.
     _result = _loader_data->metaspace_non_null()->expand_and_allocate(_size, _mdtype);
     if (_result != NULL) {

--- a/src/hotspot/share/gc/shared/gcVMOperations.cpp
+++ b/src/hotspot/share/gc/shared/gcVMOperations.cpp
@@ -203,30 +203,6 @@ VM_CollectForMetadataAllocation::VM_CollectForMetadataAllocation(ClassLoaderData
   AllocTracer::send_allocation_requiring_gc_event(_size * HeapWordSize, GCId::peek());
 }
 
-// Returns true iff concurrent GCs unloads metadata.
-bool VM_CollectForMetadataAllocation::initiate_concurrent_GC() {
-#if INCLUDE_G1GC
-  if (UseG1GC && ClassUnloadingWithConcurrentMark) {
-    G1CollectedHeap* g1h = G1CollectedHeap::heap();
-    g1h->policy()->collector_state()->set_initiate_conc_mark_if_possible(true);
-
-    GCCauseSetter x(g1h, _gc_cause);
-
-    // At this point we are supposed to start a concurrent cycle. We
-    // will do so if one is not already in progress.
-    bool should_start = g1h->policy()->force_concurrent_start_if_outside_cycle(_gc_cause);
-
-    if (should_start) {
-      double pause_target = g1h->policy()->max_pause_time_ms();
-      g1h->do_collection_pause_at_safepoint(pause_target);
-    }
-    return true;
-  }
-#endif
-
-  return false;
-}
-
 void VM_CollectForMetadataAllocation::doit() {
   SvcGCMarker sgcm(SvcGCMarker::FULL);
 
@@ -243,7 +219,8 @@ void VM_CollectForMetadataAllocation::doit() {
     }
   }
 
-  if (initiate_concurrent_GC()) {
+  if (UseG1GC && ClassUnloadingWithConcurrentMark) {
+    G1CollectedHeap::heap()->initiate_conc_gc_for_metadata_allocation(_gc_cause);
     // For G1 expand since the collection is going to be concurrent.
     _result = _loader_data->metaspace_non_null()->expand_and_allocate(_size, _mdtype);
     if (_result != NULL) {

--- a/src/hotspot/share/gc/shared/gcVMOperations.cpp
+++ b/src/hotspot/share/gc/shared/gcVMOperations.cpp
@@ -219,6 +219,7 @@ void VM_CollectForMetadataAllocation::doit() {
     }
   }
 
+#if INCLUDE_G1GC
   if (UseG1GC && ClassUnloadingWithConcurrentMark) {
     G1CollectedHeap::heap()->initiate_conc_gc_for_metadata_allocation(_gc_cause);
     // For G1 expand since the collection is going to be concurrent.
@@ -229,6 +230,7 @@ void VM_CollectForMetadataAllocation::doit() {
 
     log_debug(gc)("G1 full GC for Metaspace");
   }
+#endif
 
   // Don't clear the soft refs yet.
   heap->collect_as_vm_thread(GCCause::_metadata_GC_threshold);

--- a/src/hotspot/share/gc/shared/gcVMOperations.hpp
+++ b/src/hotspot/share/gc/shared/gcVMOperations.hpp
@@ -244,8 +244,6 @@ class VM_CollectForMetadataAllocation: public VM_GC_Operation {
   virtual VMOp_Type type() const { return VMOp_CollectForMetadataAllocation; }
   virtual void doit();
   MetaWord* result() const       { return _result; }
-
-  bool initiate_concurrent_GC();
 };
 
 class SvcGCMarker : public StackObj {


### PR DESCRIPTION
Hi all,

Please review this refactoring change to move G1 specific code out of VM_CollectForMetadataAllocation. 

Testing: Tier 1-3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8237567](https://bugs.openjdk.java.net/browse/JDK-8237567): Refactor G1-specific code in shared VM_CollectForMetadataAllocation


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to b8827b667798cf6f92d8f5237cf6526cf72123ba
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to b8827b667798cf6f92d8f5237cf6526cf72123ba


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5282/head:pull/5282` \
`$ git checkout pull/5282`

Update a local copy of the PR: \
`$ git checkout pull/5282` \
`$ git pull https://git.openjdk.java.net/jdk pull/5282/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5282`

View PR using the GUI difftool: \
`$ git pr show -t 5282`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5282.diff">https://git.openjdk.java.net/jdk/pull/5282.diff</a>

</details>
