### PR TITLE
8274161: Cleanup redundant casts in jdk.compiler

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -3946,14 +3946,14 @@ public class Attr extends JCTree.Visitor {
             : chk.checkNonVoid(tree.arg.pos(), attribExpr(tree.arg, env));
 
         // Find operator.
-        Symbol operator = tree.operator = operators.resolveUnary(tree, tree.getTag(), argtype);
+        OperatorSymbol operator = tree.operator = operators.resolveUnary(tree, tree.getTag(), argtype);
         Type owntype = types.createErrorType(tree.type);
         if (operator != operators.noOpSymbol &&
                 !argtype.isErroneous()) {
             owntype = (tree.getTag().isIncOrDecUnaryOp())
                 ? tree.arg.type
                 : operator.type.getReturnType();
-            int opc = ((OperatorSymbol)operator).opcode;
+            int opc = operator.opcode;
 
             // If the argument is constant, fold it.
             if (argtype.constValue() != null) {
@@ -4000,13 +4000,13 @@ public class Attr extends JCTree.Visitor {
         matchBindings = matchBindingsComputer.binary(tree, lhsBindings, matchBindings);
 
         // Find operator.
-        Symbol operator = tree.operator = operators.resolveBinary(tree, tree.getTag(), left, right);
+        OperatorSymbol operator = tree.operator = operators.resolveBinary(tree, tree.getTag(), left, right);
         Type owntype = types.createErrorType(tree.type);
         if (operator != operators.noOpSymbol &&
                 !left.isErroneous() &&
                 !right.isErroneous()) {
             owntype = operator.type.getReturnType();
-            int opc = ((OperatorSymbol)operator).opcode;
+            int opc = operator.opcode;
             // If both arguments are constants, fold them.
             if (left.constValue() != null && right.constValue() != null) {
                 Type ctype = cfolder.fold2(opc, left, right);
@@ -5483,11 +5483,11 @@ public class Attr extends JCTree.Visitor {
                     c.owner.kind != PCK &&
                     ((c.flags() & STATIC) == 0 || c.name == names.empty) &&
                     (TreeInfo.flags(l.head) & (STATIC | INTERFACE)) != 0) {
-                Symbol sym = null;
+                VarSymbol sym = null;
                 if (l.head.hasTag(VARDEF)) sym = ((JCVariableDecl) l.head).sym;
                 if (sym == null ||
                         sym.kind != VAR ||
-                        ((VarSymbol) sym).getConstValue() == null)
+                        sym.getConstValue() == null)
                     log.error(l.head.pos(), Errors.IclsCantHaveStaticDecl(c));
             }
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -424,14 +424,14 @@ public class LambdaToMethod extends TreeTranslator {
         //add captured locals
         for (Symbol fv : localContext.getSymbolMap(CAPTURED_VAR).keySet()) {
             if (fv != localContext.self) {
-                JCTree captured_local = make.Ident(fv).setType(fv.type);
-                syntheticInits.append((JCExpression) captured_local);
+                JCExpression captured_local = make.Ident(fv).setType(fv.type);
+                syntheticInits.append(captured_local);
             }
         }
         // add captured outer this instances (used only when `this' capture itself is illegal)
         for (Symbol fv : localContext.getSymbolMap(CAPTURED_OUTER_THIS).keySet()) {
-            JCTree captured_local = make.QualThis(fv.type);
-            syntheticInits.append((JCExpression) captured_local);
+            JCExpression captured_local = make.QualThis(fv.type);
+            syntheticInits.append(captured_local);
         }
 
         //then, determine the arguments to the indy call
@@ -1184,13 +1184,13 @@ public class LambdaToMethod extends TreeTranslator {
                 syms.stringType,
                 syms.methodTypeType).appendList(staticArgs.map(types::constantType));
 
-            Symbol bsm = rs.resolveInternalMethod(pos, attrEnv, site,
+            MethodSymbol bsm = rs.resolveInternalMethod(pos, attrEnv, site,
                     bsmName, bsm_staticArgs, List.nil());
 
             DynamicMethodSymbol dynSym =
                     new DynamicMethodSymbol(methName,
                                             syms.noSymbol,
-                                            ((MethodSymbol)bsm).asHandle(),
+                                            bsm.asHandle(),
                                             indyType,
                                             staticArgs.toArray(new LoadableConstant[staticArgs.length()]));
             JCFieldAccess qualifier = make.Select(make.QualIdent(site.tsym), bsmName);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -2315,7 +2315,7 @@ public class Lower extends TreeTranslator {
         enumDefs.append(make.VarDef(valuesVar, make.App(make.QualIdent(valuesMethod))));
         tree.sym.members().enter(valuesVar);
 
-        Symbol valuesSym = lookupMethod(tree.pos(), names.values,
+        MethodSymbol valuesSym = lookupMethod(tree.pos(), names.values,
                                         tree.type, List.nil());
         List<JCStatement> valuesBody;
         if (useClone()) {
@@ -2366,7 +2366,7 @@ public class Lower extends TreeTranslator {
         }
 
         JCMethodDecl valuesDef =
-             make.MethodDef((MethodSymbol)valuesSym, make.Block(0, valuesBody));
+             make.MethodDef(valuesSym, make.Block(0, valuesBody));
 
         enumDefs.append(valuesDef);
 
@@ -2581,7 +2581,7 @@ public class Lower extends TreeTranslator {
             Name bootstrapName,
             Name argName,
             boolean isStatic) {
-        Symbol bsm = rs.resolveInternalMethod(tree.pos(), attrEnv, site,
+        MethodSymbol bsm = rs.resolveInternalMethod(tree.pos(), attrEnv, site,
                 bootstrapName, staticArgTypes, List.nil());
 
         MethodType indyType = msym.type.asMethodType();
@@ -2593,7 +2593,7 @@ public class Lower extends TreeTranslator {
         );
         DynamicMethodSymbol dynSym = new DynamicMethodSymbol(argName,
                 syms.noSymbol,
-                ((MethodSymbol)bsm).asHandle(),
+                bsm.asHandle(),
                 indyType,
                 staticArgValues);
         JCFieldAccess qualifier = make.Select(make.QualIdent(site.tsym), argName);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -371,7 +371,7 @@ public class TransPatterns extends TreeTranslator {
 
             boolean enumSelector = seltype.tsym.isEnum();
             Name bootstrapName = enumSelector ? names.enumSwitch : names.typeSwitch;
-            Symbol bsm = rs.resolveInternalMethod(tree.pos(), env, syms.switchBootstrapsType,
+            MethodSymbol bsm = rs.resolveInternalMethod(tree.pos(), env, syms.switchBootstrapsType,
                     bootstrapName, staticArgTypes, List.nil());
 
             MethodType indyType = new MethodType(
@@ -382,7 +382,7 @@ public class TransPatterns extends TreeTranslator {
             );
             DynamicMethodSymbol dynSym = new DynamicMethodSymbol(bootstrapName,
                     syms.noSymbol,
-                    ((MethodSymbol)bsm).asHandle(),
+                    bsm.asHandle(),
                     indyType,
                     staticArgValues);
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/StringConcat.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/StringConcat.java
@@ -371,7 +371,7 @@ public abstract class StringConcat {
                         syms.stringType,
                         syms.methodTypeType);
 
-                Symbol bsm = rs.resolveInternalMethod(pos,
+                MethodSymbol bsm = rs.resolveInternalMethod(pos,
                         gen.getAttrEnv(),
                         syms.stringConcatFactory,
                         names.makeConcat,
@@ -380,7 +380,7 @@ public abstract class StringConcat {
 
                 Symbol.DynamicMethodSymbol dynSym = new Symbol.DynamicMethodSymbol(names.makeConcat,
                         syms.noSymbol,
-                        ((MethodSymbol)bsm).asHandle(),
+                        bsm.asHandle(),
                         indyType,
                         List.nil().toArray(new LoadableConstant[0]));
 
@@ -487,7 +487,7 @@ public abstract class StringConcat {
                         .append(syms.stringType)
                         .appendList(constTypes);
 
-                Symbol bsm = rs.resolveInternalMethod(pos,
+                MethodSymbol bsm = rs.resolveInternalMethod(pos,
                         gen.getAttrEnv(),
                         syms.stringConcatFactory,
                         names.makeConcatWithConstants,
@@ -496,7 +496,7 @@ public abstract class StringConcat {
 
                 Symbol.DynamicMethodSymbol dynSym = new Symbol.DynamicMethodSymbol(names.makeConcatWithConstants,
                         syms.noSymbol,
-                        ((MethodSymbol)bsm).asHandle(),
+                        bsm.asHandle(),
                         indyType,
                         List.of(LoadableConstant.String(recipe))
                                 .appendList(constants).toArray(new LoadableConstant[constants.size()]));


### PR DESCRIPTION
Such casts are actually redundant, but they are inserted, because variable is declared with too weak type.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274161](https://bugs.openjdk.java.net/browse/JDK-8274161): Cleanup redundant casts in jdk.compiler


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5283/head:pull/5283` \
`$ git checkout pull/5283`

Update a local copy of the PR: \
`$ git checkout pull/5283` \
`$ git pull https://git.openjdk.java.net/jdk pull/5283/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5283`

View PR using the GUI difftool: \
`$ git pr show -t 5283`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5283.diff">https://git.openjdk.java.net/jdk/pull/5283.diff</a>

</details>
