### PR TITLE
8272915: (doc) package-info typo in extLink

### DIFF
--- a/src/java.base/share/classes/java/security/interfaces/package-info.java
+++ b/src/java.base/share/classes/java/security/interfaces/package-info.java
@@ -60,7 +60,7 @@
  *
  * For further documentation, please see:
  * <ul>
- *   <li> {extLink security_guide_jca
+ *   <li> {@extLink security_guide_jca
  *       Java Cryptography Architecture Reference Guide}</li>
  * </ul>
  *

--- a/src/java.base/share/classes/java/security/interfaces/package-info.java
+++ b/src/java.base/share/classes/java/security/interfaces/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Added missing @.  Link now works.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272915](https://bugs.openjdk.java.net/browse/JDK-8272915): (doc) package-info typo in extLink


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**) ⚠️ Review applies to 7700c788f62072b60a4ffbd93036f0ed26529861


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5284/head:pull/5284` \
`$ git checkout pull/5284`

Update a local copy of the PR: \
`$ git checkout pull/5284` \
`$ git pull https://git.openjdk.java.net/jdk pull/5284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5284`

View PR using the GUI difftool: \
`$ git pr show -t 5284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5284.diff">https://git.openjdk.java.net/jdk/pull/5284.diff</a>

</details>
