### PR TITLE
8273100: Improve AbstractStringBuilder.append(String) when using CompactStrings

### DIFF
--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -579,7 +579,7 @@ abstract class AbstractStringBuilder implements Appendable, CharSequence {
         }
         int len = str.length();
         ensureCapacityInternal(count + len);
-        putStringAt(count, str, len);
+        putStringAt(count, str);
         count += len;
         return this;
     }
@@ -1000,7 +1000,7 @@ abstract class AbstractStringBuilder implements Appendable, CharSequence {
         ensureCapacityInternal(newCount);
         shift(end, newCount - count);
         this.count = newCount;
-        putStringAt(start, str, len);
+        putStringAt(start, str);
         return this;
     }
 
@@ -1172,7 +1172,7 @@ abstract class AbstractStringBuilder implements Appendable, CharSequence {
         ensureCapacityInternal(count + len);
         shift(offset, len);
         count += len;
-        putStringAt(offset, str, len);
+        putStringAt(offset, str);
         return this;
     }
 
@@ -1727,9 +1727,9 @@ abstract class AbstractStringBuilder implements Appendable, CharSequence {
         str.getBytes(value, off, index, coder, end - off);
     }
 
-    private void putStringAt(int index, String str, int len) {
+    private void putStringAt(int index, String str) {
         inflateIfNeededFor(str);
-        str.getBytes(value, 0, index, coder, len);
+        str.getBytes(value, index, coder);
     }
 
     private final void appendChars(char[] s, int off, int end) {


### PR DESCRIPTION
Refactor to improve inlining, which helps some microbenchmarks exer StringBuilder.append(String)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273100](https://bugs.openjdk.java.net/browse/JDK-8273100): Improve AbstractStringBuilder.append(String) when using CompactStrings


### Reviewers
 * @stsypanov (no known github.com user name / role)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5291/head:pull/5291` \
`$ git checkout pull/5291`

Update a local copy of the PR: \
`$ git checkout pull/5291` \
`$ git pull https://git.openjdk.java.net/jdk pull/5291/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5291`

View PR using the GUI difftool: \
`$ git pr show -t 5291`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5291.diff">https://git.openjdk.java.net/jdk/pull/5291.diff</a>

</details>
