### PR TITLE
8273104: Refactoring option parser for UL

### DIFF
--- a/src/hotspot/share/logging/logFileOutput.cpp
+++ b/src/hotspot/share/logging/logFileOutput.cpp
@@ -190,6 +190,7 @@ bool LogFileOutput::set_option(const char* key, const char* value, outputStream*
       if (!success || (longval > SIZE_MAX)) {
         errstream->print_cr("Invalid option: %s must be in range [0, "
                             SIZE_FORMAT "]", FileSizeOptionKey, (size_t)SIZE_MAX);
+        success = false;
       } else {
         _rotate_size = static_cast<size_t>(longval);
         success = true;

--- a/src/hotspot/share/logging/logFileOutput.hpp
+++ b/src/hotspot/share/logging/logFileOutput.hpp
@@ -65,7 +65,6 @@ class LogFileOutput : public LogFileStreamOutput {
 
   void archive();
   void rotate();
-  bool parse_options(const char* options, outputStream* errstream);
   char *make_file_name(const char* file_name, const char* pid_string, const char* timestamp_string);
 
   bool should_rotate() {
@@ -83,6 +82,7 @@ class LogFileOutput : public LogFileStreamOutput {
   LogFileOutput(const char *name);
   virtual ~LogFileOutput();
   virtual bool initialize(const char* options, outputStream* errstream);
+  virtual bool set_option(const char* key, const char* value, outputStream* errstream);
   virtual int write(const LogDecorations& decorations, const char* msg);
   virtual int write(LogMessageBuffer::Iterator msg_iterator);
   int write_blocking(const LogDecorations& decorations, const char* msg);

--- a/src/hotspot/share/logging/logFileStreamOutput.cpp
+++ b/src/hotspot/share/logging/logFileStreamOutput.cpp
@@ -53,6 +53,22 @@ LogFileStreamInitializer::LogFileStreamInitializer() {
   }
 }
 
+bool LogFileStreamOutput::set_option(const char* key, const char* value, outputStream* errstream) {
+  bool success = false;
+  if (strcmp(FoldMultilinesOptionKey, key) == 0) {
+    if (strcmp(value, "true") == 0) {
+      _fold_multilines = true;
+      success = true;
+    } else if (strcmp(value, "false") == 0) {
+      _fold_multilines = false;
+      success = true;
+    } else {
+      errstream->print_cr("Invalid option: %s must be 'true' or 'false'.", key);
+    }
+  }
+  return success;
+}
+
 int LogFileStreamOutput::write_decorations(const LogDecorations& decorations) {
   int total_written = 0;
   char buf[LogDecorations::max_decoration_size + 1];

--- a/src/hotspot/share/logging/logFileStreamOutput.hpp
+++ b/src/hotspot/share/logging/logFileStreamOutput.hpp
@@ -42,16 +42,16 @@ static LogFileStreamInitializer log_stream_initializer;
 // Base class for all FileStream-based log outputs.
 class LogFileStreamOutput : public LogOutput {
  private:
+  static const char* const FoldMultilinesOptionKey;
+  bool                _fold_multilines;
   bool                _write_error_is_shown;
 
   int write_internal(const char* msg);
  protected:
-  static const char* const FoldMultilinesOptionKey;
   FILE*               _stream;
   size_t              _decorator_padding[LogDecorators::Count];
-  bool                _fold_multilines;
 
-  LogFileStreamOutput(FILE *stream) : _write_error_is_shown(false), _stream(stream), _fold_multilines(false) {
+  LogFileStreamOutput(FILE *stream) : _fold_multilines(false), _write_error_is_shown(false), _stream(stream) {
     for (size_t i = 0; i < LogDecorators::Count; i++) {
       _decorator_padding[i] = 0;
     }
@@ -61,6 +61,7 @@ class LogFileStreamOutput : public LogOutput {
   bool flush();
 
  public:
+  virtual bool set_option(const char* key, const char* value, outputStream* errstream);
   virtual int write(const LogDecorations& decorations, const char* msg);
   virtual int write(LogMessageBuffer::Iterator msg_iterator);
 };

--- a/src/hotspot/share/logging/logOutput.cpp
+++ b/src/hotspot/share/logging/logOutput.cpp
@@ -339,3 +339,40 @@ void LogOutput::update_config_string(const size_t on_level[LogLevel::Count]) {
   FREE_C_HEAP_ARRAY(Selection, selections);
 }
 
+bool LogOutput::parse_options(const char* options, outputStream* errstream) {
+  if (options == NULL || strlen(options) == 0) {
+    return true;
+  }
+  bool success = false;
+  char* opts = os::strdup_check_oom(options, mtLogging);
+
+  char* comma_pos;
+  char* pos = opts;
+  do {
+    comma_pos = strchr(pos, ',');
+    if (comma_pos != NULL) {
+      *comma_pos = '\0';
+    }
+    char* equals_pos = strchr(pos, '=');
+    if (equals_pos == NULL) {
+      errstream->print_cr("Invalid option '%s' for log output (%s).", pos, name());
+      break;
+    }
+
+    char* key = pos;
+    char* value_str = equals_pos + 1;
+    *equals_pos = '\0';
+    julong errstream_count_before = errstream->count();
+    success = set_option(key, value_str, errstream);
+    if (!success) {
+      if (errstream->count() > errstream_count_before) {
+        errstream->print_cr("Invalid option '%s' for log output (%s).", key, name());
+      }
+      break;
+    }
+    pos = comma_pos + 1;
+  } while (comma_pos != NULL);
+
+  os::free(opts);
+  return success;
+}

--- a/src/hotspot/share/logging/logOutput.cpp
+++ b/src/hotspot/share/logging/logOutput.cpp
@@ -366,7 +366,7 @@ bool LogOutput::parse_options(const char* options, outputStream* errstream) {
     julong errstream_count_before = errstream->count();
     success = set_option(key, value_str, errstream);
     if (!success) {
-      if (errstream->count() > errstream_count_before) {
+      if (errstream->count() == errstream_count_before) {
         errstream->print_cr("Invalid option '%s' for log output (%s).", key, name());
       }
       break;

--- a/src/hotspot/share/logging/logOutput.cpp
+++ b/src/hotspot/share/logging/logOutput.cpp
@@ -343,7 +343,7 @@ bool LogOutput::parse_options(const char* options, outputStream* errstream) {
   if (options == NULL || strlen(options) == 0) {
     return true;
   }
-  bool success = false;
+  bool success = true;
   char* opts = os::strdup_check_oom(options, mtLogging);
 
   char* comma_pos;
@@ -356,6 +356,7 @@ bool LogOutput::parse_options(const char* options, outputStream* errstream) {
     char* equals_pos = strchr(pos, '=');
     if (equals_pos == NULL) {
       errstream->print_cr("Invalid option '%s' for log output (%s).", pos, name());
+      success = false;
       break;
     }
 

--- a/src/hotspot/share/logging/logOutput.hpp
+++ b/src/hotspot/share/logging/logOutput.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,10 +93,13 @@ class LogOutput : public CHeapObj<mtLogging> {
     // Do nothing by default.
   }
 
+  bool parse_options(const char* options, outputStream* errstream);
+
   virtual void describe(outputStream *out);
 
   virtual const char* name() const = 0;
   virtual bool initialize(const char* options, outputStream* errstream) = 0;
+  virtual bool set_option(const char* key, const char* value, outputStream* errstream) = 0;
   virtual int write(const LogDecorations& decorations, const char* msg) = 0;
   virtual int write(LogMessageBuffer::Iterator msg_iterator) = 0;
 };

--- a/test/hotspot/jtreg/runtime/logging/FoldMultilinesTest.java
+++ b/test/hotspot/jtreg/runtime/logging/FoldMultilinesTest.java
@@ -61,7 +61,7 @@ public class FoldMultilinesTest {
 
     private static void analyzeFoldMultilinesInvalid(ProcessBuilder pb) throws Exception {
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        output.shouldContain("Invalid option 'invalid' for foldmultilines.");
+        output.shouldContain("Invalid option: foldmultilines must be 'true' or 'false'.");
         output.shouldNotHaveExitValue(0);
     }
 


### PR DESCRIPTION
As we discussed in PR #4885 and in [its CSR](https://bugs.openjdk.java.net/browse/JDK-8271188), we want to introduce `foldmultilines` to stdout/err UL output. However we have no chance to configure `LogOutput` for stdout/err (`LogStdoutOutput`/`LogStderrOutput`) becasuse they will be instantiated statically in logFileStreamOutput.cpp.

So we need to refactor UL option parser to propagate options to all extended classes of `LogOutput`.

* Move `parse_option()` to `LogOutput` from `LogFileOutput`, then it becames public member.
* Introduce `set_option()` in `LogOutput` as a pure virtual member to apply options to each log output, then it is implemented in both `LogFileStreamOutput` and `LogFileOutput`.
* Move both `FoldMultilinesOptionKey` and `_fold_mulilines` in `LogFileStreamOutput` to private member because they are no longer to need to be public.

I want to send PR to introduce `foldmultilines` to stdout/err like https://github.com/YaSuenag/jdk/compare/ul-refactoring...YaSuenag:foldmultilines-for-stdout after this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273104](https://bugs.openjdk.java.net/browse/JDK-8273104): Refactoring option parser for UL


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to e1f098e04bf384e438c216d8fc216f8cf1895788
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5293/head:pull/5293` \
`$ git checkout pull/5293`

Update a local copy of the PR: \
`$ git checkout pull/5293` \
`$ git pull https://git.openjdk.java.net/jdk pull/5293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5293`

View PR using the GUI difftool: \
`$ git pr show -t 5293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5293.diff">https://git.openjdk.java.net/jdk/pull/5293.diff</a>

</details>
