### PR TITLE
8273684: Replace usages of java.util.Stack with ArrayDeque

### DIFF
--- a/src/java.desktop/share/classes/com/sun/media/sound/DLSSoundbank.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/DLSSoundbank.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -305,7 +306,7 @@ public final class DLSSoundbank implements Soundbank {
         DLSID uuid;
         long x;
         long y;
-        Stack<Long> stack = new Stack<>();
+        ArrayDeque<Long> stack = new ArrayDeque<>();
 
         while (riff.available() != 0) {
             int opcode = riff.readUnsignedShort();

--- a/src/java.desktop/share/classes/com/sun/media/sound/DLSSoundbank.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/DLSSoundbank.java
@@ -37,7 +37,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
 import javax.sound.midi.Instrument;
 import javax.sound.midi.Patch;

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
@@ -2708,11 +2708,11 @@ public class HTMLDocument extends DefaultStyledDocument {
         }
 
         private Element[] getPathTo(int offset) {
-            ArrayDeque<Element> elements = new ArrayDeque<Element>();
+            ArrayList<Element> elements = new ArrayList<Element>();
             Element e = getDefaultRootElement();
             int index;
             while (!e.isLeaf()) {
-                elements.push(e);
+                elements.add(e);
                 e = e.getElement(e.getElementIndex(offset));
             }
             Element[] retValue = elements.toArray(new Element[0]);

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2708,7 +2708,7 @@ public class HTMLDocument extends DefaultStyledDocument {
         }
 
         private Element[] getPathTo(int offset) {
-            Stack<Element> elements = new Stack<Element>();
+            ArrayDeque<Element> elements = new ArrayDeque<Element>();
             Element e = getDefaultRootElement();
             int index;
             while (!e.isLeaf()) {
@@ -2716,7 +2716,7 @@ public class HTMLDocument extends DefaultStyledDocument {
                 e = e.getElement(e.getElementIndex(offset));
             }
             Element[] retValue = new Element[elements.size()];
-            elements.copyInto(retValue);
+            elements.toArray(retValue);
             return retValue;
         }
 

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
@@ -2715,8 +2715,7 @@ public class HTMLDocument extends DefaultStyledDocument {
                 elements.push(e);
                 e = e.getElement(e.getElementIndex(offset));
             }
-            Element[] retValue = new Element[elements.size()];
-            elements.toArray(retValue);
+            Element[] retValue = elements.toArray(new Element[0]);
             return retValue;
         }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
@@ -1393,7 +1393,7 @@ public class CommandProcessor {
                             pending.push(n);
                             n = n.getSuperclass();
                         }
-                        while (!pending.empty()) {
+                        while (!pending.isEmpty()) {
                             n = (Type)pending.pop();
                             dumpType(n);
                             emitted.add(n.getName());

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
@@ -33,6 +33,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -985,7 +986,7 @@ public class CommandProcessor {
                 Iterator i = agent.getTypeDataBase().getTypes();
                 // Make sure the types are emitted in an order than can be read back in
                 HashSet<String> emitted = new HashSet<>();
-                Stack<Type> pending = new Stack<>();
+                ArrayDeque<Type> pending = new ArrayDeque<>();
                 while (i.hasNext()) {
                     Type n = (Type)i.next();
                     if (emitted.contains(n.getName())) {
@@ -996,7 +997,7 @@ public class CommandProcessor {
                         pending.push(n);
                         n = n.getSuperclass();
                     }
-                    while (!pending.empty()) {
+                    while (!pending.isEmpty()) {
                         n = (Type)pending.pop();
                         dumpType(n);
                         emitted.add(n.getName());
@@ -1381,7 +1382,7 @@ public class CommandProcessor {
                     Iterator i = agent.getTypeDataBase().getTypes();
                     // Make sure the types are emitted in an order than can be read back in
                     HashSet<String> emitted = new HashSet<>();
-                    Stack<Type> pending = new Stack<>();
+                    ArrayDeque<Type> pending = new ArrayDeque<>();
                     while (i.hasNext()) {
                         Type n = (Type)i.next();
                         if (emitted.contains(n.getName())) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
@@ -41,7 +41,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Objects;
-import java.util.Stack;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/AnnotatedMemoryPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/AnnotatedMemoryPanel.java
@@ -214,7 +214,7 @@ public class AnnotatedMemoryPanel extends JPanel {
       ((Graphics2D) g).setStroke(stroke);
     }
 
-    Stack<AnnoX> drawStack = new Stack<>();
+    ArrayDeque<AnnoX> drawStack = new ArrayDeque<>();
 
     layoutAnnotations(va, g, curTextX, startAddr, lineHeight);
 
@@ -222,7 +222,7 @@ public class AnnotatedMemoryPanel extends JPanel {
       Annotation anno   = iter.next();
       Interval interval = anno.getInterval();
 
-      if (!drawStack.empty()) {
+      if (!drawStack.isEmpty()) {
         // See whether we can pop any items off the stack
         boolean shouldContinue = true;
         do {
@@ -230,7 +230,7 @@ public class AnnotatedMemoryPanel extends JPanel {
           if (annoX.highBound.lessThanOrEqual((Address) interval.getLowEndpoint())) {
             curLineX = annoX.lineX;
             drawStack.pop();
-            shouldContinue = !drawStack.empty();
+            shouldContinue = !drawStack.isEmpty();
           } else {
             shouldContinue = false;
           }


### PR DESCRIPTION
Usage of thread-safe collection Stack is unnecessary. It's recommended to use ArrayDequeue if a thread-safe implementation is not needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273684](https://bugs.openjdk.java.net/browse/JDK-8273684): Replace usages of java.util.Stack with ArrayDeque


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5294/head:pull/5294` \
`$ git checkout pull/5294`

Update a local copy of the PR: \
`$ git checkout pull/5294` \
`$ git pull https://git.openjdk.java.net/jdk pull/5294/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5294`

View PR using the GUI difftool: \
`$ git pr show -t 5294`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5294.diff">https://git.openjdk.java.net/jdk/pull/5294.diff</a>

</details>
