### PR TITLE
[PATCH] Hashtable usages can be replaced with HashMap in java.desktop

### DIFF
--- a/src/java.desktop/share/classes/java/awt/font/TextMeasurer.java
+++ b/src/java.desktop/share/classes/java/awt/font/TextMeasurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,21 +44,17 @@ import java.awt.Font;
 
 import java.text.AttributedCharacterIterator;
 import java.text.AttributedCharacterIterator.Attribute;
-import java.text.AttributedString;
 import java.text.Bidi;
 import java.text.BreakIterator;
 import java.text.CharacterIterator;
 
-import java.awt.font.FontRenderContext;
-
-import java.util.Hashtable;
+import java.util.Collections;
 import java.util.Map;
 
 import sun.font.AttributeValues;
 import sun.font.BidiUtils;
 import sun.font.TextLineComponent;
 import sun.font.TextLabelFactory;
-import sun.font.FontResolver;
 
 /**
  * The {@code TextMeasurer} class provides the primitive operations
@@ -247,8 +243,7 @@ public final class TextMeasurer implements Cloneable {
                 GraphicAttribute graphic = (GraphicAttribute)
                                 paragraphAttrs.get(TextAttribute.CHAR_REPLACEMENT);
                 fBaseline = TextLayout.getBaselineFromGraphic(graphic);
-                Hashtable<Attribute, ?> fmap = new Hashtable<>(5, (float)0.9);
-                Font dummyFont = new Font(fmap);
+                Font dummyFont = new Font(Collections.emptyMap());
                 LineMetrics lm = dummyFont.getLineMetrics(" ", 0, 1, fFrc);
                 fBaselineOffsets = lm.getBaselineOffsets();
             }

--- a/src/java.desktop/share/classes/java/awt/font/TextMeasurer.java
+++ b/src/java.desktop/share/classes/java/awt/font/TextMeasurer.java
@@ -48,7 +48,6 @@ import java.text.Bidi;
 import java.text.BreakIterator;
 import java.text.CharacterIterator;
 
-import java.util.Collections;
 import java.util.Map;
 
 import sun.font.AttributeValues;
@@ -243,7 +242,7 @@ public final class TextMeasurer implements Cloneable {
                 GraphicAttribute graphic = (GraphicAttribute)
                                 paragraphAttrs.get(TextAttribute.CHAR_REPLACEMENT);
                 fBaseline = TextLayout.getBaselineFromGraphic(graphic);
-                Font dummyFont = new Font(Collections.emptyMap());
+                Font dummyFont = new Font(null);
                 LineMetrics lm = dummyFont.getLineMetrics(" ", 0, 1, fFrc);
                 fBaselineOffsets = lm.getBaselineOffsets();
             }

--- a/src/java.desktop/share/classes/javax/swing/JSlider.java
+++ b/src/java.desktop/share/classes/javax/swing/JSlider.java
@@ -39,6 +39,7 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.util.Dictionary;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.Hashtable;
 
 import javax.accessibility.Accessible;
@@ -981,14 +982,14 @@ public class JSlider extends JComponent implements SwingConstants, Accessible {
                      e.getPropertyName().equals( "maximum" ) ) {
 
                     Enumeration<?> keys = getLabelTable().keys();
-                    Hashtable<Integer, JComponent> hashtable = new Hashtable<>();
+                    HashMap<Integer, JComponent> labels = new HashMap<>();
 
                     // Save the labels that were added by the developer
                     while ( keys.hasMoreElements() ) {
                         Integer key = (Integer) keys.nextElement();
                         JComponent value = (JComponent) labelTable.get(key);
                         if ( !(value instanceof LabelUIResource) ) {
-                            hashtable.put( key, value );
+                            labels.put( key, value );
                         }
                     }
 
@@ -996,11 +997,7 @@ public class JSlider extends JComponent implements SwingConstants, Accessible {
                     createLabels();
 
                     // Add the saved labels
-                    keys = hashtable.keys();
-                    while ( keys.hasMoreElements() ) {
-                        Integer key = (Integer) keys.nextElement();
-                        put( key, hashtable.get( key ) );
-                    }
+                    this.putAll(labels);
 
                     ((JSlider)e.getSource()).setLabelTable( this );
                 }

--- a/src/java.desktop/share/classes/javax/swing/text/JTextComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/text/JTextComponent.java
@@ -1195,7 +1195,7 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
      * @param actions the set of actions
      */
     public static void loadKeymap(Keymap map, KeyBinding[] bindings, Action[] actions) {
-        Hashtable<String, Action> h = new Hashtable<String, Action>();
+        HashMap<String, Action> h = new HashMap<String, Action>();
         for (Action a : actions) {
             String value = (String)a.getValue(Action.NAME);
             h.put((value!=null ? value:""), a);

--- a/src/java.desktop/share/classes/javax/swing/text/TextAction.java
+++ b/src/java.desktop/share/classes/javax/swing/text/TextAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,9 @@
 package javax.swing.text;
 
 import java.awt.event.ActionEvent;
-import java.awt.KeyboardFocusManager;
-import java.awt.Component;
-import java.util.Hashtable;
-import java.util.Enumeration;
+import java.util.HashMap;
 import javax.swing.Action;
 import javax.swing.AbstractAction;
-import javax.swing.KeyStroke;
 
 /**
  * An Action implementation useful for key bindings that are
@@ -104,7 +100,7 @@ public abstract class TextAction extends AbstractAction {
      * @return the augmented list
      */
     public static final Action[] augmentList(Action[] list1, Action[] list2) {
-        Hashtable<String, Action> h = new Hashtable<String, Action>();
+        HashMap<String, Action> h = new HashMap<String, Action>();
         for (Action a : list1) {
             String value = (String)a.getValue(Action.NAME);
             h.put((value!=null ? value:""), a);
@@ -113,11 +109,7 @@ public abstract class TextAction extends AbstractAction {
             String value = (String)a.getValue(Action.NAME);
             h.put((value!=null ? value:""), a);
         }
-        Action[] actions = new Action[h.size()];
-        int index = 0;
-        for (Enumeration<Action> e = h.elements() ; e.hasMoreElements() ;) {
-            actions[index++] = e.nextElement();
-        }
+        Action[] actions = h.values().toArray(new Action[0]);
         return actions;
     }
 


### PR DESCRIPTION
If a thread-safe implementation is not needed, it is recommended to use HashMap in place of Hashtable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5296/head:pull/5296` \
`$ git checkout pull/5296`

Update a local copy of the PR: \
`$ git checkout pull/5296` \
`$ git pull https://git.openjdk.java.net/jdk pull/5296/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5296`

View PR using the GUI difftool: \
`$ git pr show -t 5296`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5296.diff">https://git.openjdk.java.net/jdk/pull/5296.diff</a>

</details>
