### PR TITLE
Allow PATCH in HttpURLConnection

### DIFF
--- a/src/java.base/share/classes/java/net/HttpURLConnection.java
+++ b/src/java.base/share/classes/java/net/HttpURLConnection.java
@@ -358,7 +358,7 @@ public abstract class HttpURLConnection extends URLConnection {
 
     /* valid HTTP methods */
     private static final String[] methods = {
-        "GET", "POST", "HEAD", "OPTIONS", "PUT", "DELETE", "TRACE"
+        "GET", "POST", "PATCH", "HEAD", "OPTIONS", "PUT", "DELETE", "TRACE"
     };
 
     /**
@@ -448,6 +448,7 @@ public abstract class HttpURLConnection extends URLConnection {
      * <UL>
      *  <LI>GET
      *  <LI>POST
+     *  <LI>PATCH
      *  <LI>HEAD
      *  <LI>OPTIONS
      *  <LI>PUT


### PR DESCRIPTION
This fix makes it possible to make PATCH Requests using HttpURLConnection.

Aftern all, PATCH is RFC conform (https://datatracker.ietf.org/doc/html/rfc5789) and is widely used in APIs. It's also often requested (https://stackoverflow.com/questions/25163131/httpurlconnection-invalid-http-method-patch) with everyone building shady workarounds.

However, the fix appears to be fairly simple and straightforward, leading to this humble PR.