### PR TITLE
8273127: Shenandoah: Adopt relaxed order for update oop

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -184,20 +184,20 @@ inline void ShenandoahHeap::conc_update_with_forwarded(T* p) {
 
 inline void ShenandoahHeap::atomic_update_oop(oop update, oop* addr, oop compare) {
   assert(is_aligned(addr, HeapWordSize), "Address should be aligned: " PTR_FORMAT, p2i(addr));
-  Atomic::cmpxchg(addr, compare, update, memory_order_release);
+  Atomic::cmpxchg(addr, compare, update, memory_order_relaxed);
 }
 
 inline void ShenandoahHeap::atomic_update_oop(oop update, narrowOop* addr, narrowOop compare) {
   assert(is_aligned(addr, sizeof(narrowOop)), "Address should be aligned: " PTR_FORMAT, p2i(addr));
   narrowOop u = CompressedOops::encode(update);
-  Atomic::cmpxchg(addr, compare, u, memory_order_release);
+  Atomic::cmpxchg(addr, compare, u, memory_order_relaxed);
 }
 
 inline void ShenandoahHeap::atomic_update_oop(oop update, narrowOop* addr, oop compare) {
   assert(is_aligned(addr, sizeof(narrowOop)), "Address should be aligned: " PTR_FORMAT, p2i(addr));
   narrowOop c = CompressedOops::encode(compare);
   narrowOop u = CompressedOops::encode(update);
-  Atomic::cmpxchg(addr, c, u, memory_order_release);
+  Atomic::cmpxchg(addr, c, u, memory_order_relaxed);
 }
 
 inline bool ShenandoahHeap::atomic_update_oop_check(oop update, oop* addr, oop compare) {


### PR DESCRIPTION
Shenandoah evacuates object and then updates the reference in load barriers. Currently, memory order release is adopted in atomic_update_oop(), and we propose to use relaxed instead. Since memory order conservative is adopted in updating forwardee, this membar ensures that object copy is finished before updating the reference. In the scenario when a thread reads self-healed address from forwardee, relaxed is also fine due to the data dependency of the self-healed address.
This relaxation of memory order brings us some performance improvement. We have run specjbb2015 on AArch64. Critical-JOPS increases by 3% while max-JOPS maintains almost the same.
```
baseline_1:RUN RESULT: hbIR (max attempted) = 122581, hbIR (settled) = 107513, max-jOPS = 102968, critical-jOPS = 37913
baseline_2:RUN RESULT: hbIR (max attempted) = 122581, hbIR (settled) = 106769, max-jOPS = 101742, critical-jOPS = 37151
baseline_3:RUN RESULT: hbIR (max attempted) = 122581, hbIR (settled) = 110118, max-jOPS = 101742, critical-jOPS = 37041

optimized_1:RUN RESULT: hbIR (max attempted) = 122581, hbIR (settled) = 111708, max-jOPS = 101742, critical-jOPS = 37687
optimized_2:RUN RESULT: hbIR (max attempted) = 147077, hbIR (settled) = 122581, max-jOPS = 104425, critical-jOPS = 39663
optimized_3:RUN RESULT: hbIR (max attempted) = 122581, hbIR (settled) = 107286, max-jOPS = 102968, critical-jOPS = 38579
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8273127](https://bugs.openjdk.java.net/browse/JDK-8273127): Shenandoah: Adopt relaxed order for update oop


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5299/head:pull/5299` \
`$ git checkout pull/5299`

Update a local copy of the PR: \
`$ git checkout pull/5299` \
`$ git pull https://git.openjdk.java.net/jdk pull/5299/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5299`

View PR using the GUI difftool: \
`$ git pr show -t 5299`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5299.diff">https://git.openjdk.java.net/jdk/pull/5299.diff</a>

</details>
