### PR TITLE
8270438: "Cores to use" output in configure is misleading

### DIFF
--- a/make/autoconf/help.m4
+++ b/make/autoconf/help.m4
@@ -274,7 +274,7 @@ AC_DEFUN_ONCE([HELP_PRINT_SUMMARY_AND_WARNINGS],
 
   printf "\n"
   printf "Build performance summary:\n"
-  printf "* Cores to use:   $JOBS\n"
+  printf "* Build jobs:     $JOBS\n"
   printf "* Memory limit:   $MEMORY_SIZE MB\n"
   if test "x$CCACHE_STATUS" != "x"; then
     printf "* ccache status:  $CCACHE_STATUS\n"


### PR DESCRIPTION
Description from the bug:

When building the JDK and running `configure` the output includes (example): 
```
Build performance summary: 
 * Cores to use: 4 
 * Memory limit: 32768 MB 
```

The "Cores to use" value is misleading; it is not actually the number of cores specified using `--with-num-cores`, but instead the number of jobs, which (unless explicitly specified), is calculated based on the available memory and the number of cores.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270438](https://bugs.openjdk.java.net/browse/JDK-8270438): "Cores to use" output in configure is misleading


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5301/head:pull/5301` \
`$ git checkout pull/5301`

Update a local copy of the PR: \
`$ git checkout pull/5301` \
`$ git pull https://git.openjdk.java.net/jdk pull/5301/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5301`

View PR using the GUI difftool: \
`$ git pr show -t 5301`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5301.diff">https://git.openjdk.java.net/jdk/pull/5301.diff</a>

</details>
