### PR TITLE
8273140: Replace usages of Enum.class.getEnumConstants() with Enum.values() where possible

### DIFF
--- a/src/java.desktop/share/classes/sun/font/AttributeValues.java
+++ b/src/java.desktop/share/classes/sun/font/AttributeValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -211,7 +211,7 @@ public final class AttributeValues implements Cloneable {
     }
 
     public static final int MASK_ALL =
-        getMask(EAttribute.class.getEnumConstants());
+        getMask(EAttribute.values());
 
     public void unsetDefault() {
         defined &= nondefault;

--- a/src/java.desktop/share/classes/sun/font/AttributeValues.java
+++ b/src/java.desktop/share/classes/sun/font/AttributeValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/sun/font/EAttribute.java
+++ b/src/java.desktop/share/classes/sun/font/EAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,7 +75,7 @@ public enum EAttribute {
         att = ta;
     }
 
-    /* package */ static final EAttribute[] atts = EAttribute.class.getEnumConstants();
+    /* package */ static final EAttribute[] atts = EAttribute.values();
 
     public static EAttribute forAttribute(Attribute ta) {
         for (EAttribute ea: atts) {

--- a/src/java.desktop/share/classes/sun/font/EAttribute.java
+++ b/src/java.desktop/share/classes/sun/font/EAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.sql/share/classes/java/sql/JDBCType.java
+++ b/src/java.sql/share/classes/java/sql/JDBCType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -206,7 +206,7 @@ public enum JDBCType implements SQLType {
      * The Integer value for the JDBCType.  It maps to a value in
      * {@code Types.java}
      */
-    private Integer type;
+    private final Integer type;
 
     /**
      * Constructor to specify the data type value from {@code Types) for
@@ -251,8 +251,8 @@ public enum JDBCType implements SQLType {
      * @see Types
      */
     public static JDBCType valueOf(int type) {
-        for( JDBCType sqlType : JDBCType.class.getEnumConstants()) {
-            if(type == sqlType.type)
+        for (JDBCType sqlType : JDBCType.values()) {
+            if (type == sqlType.type)
                 return sqlType;
         }
         throw new IllegalArgumentException("Type:" + type + " is not a valid "

--- a/src/java.sql/share/classes/java/sql/JDBCType.java
+++ b/src/java.sql/share/classes/java/sql/JDBCType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/bytecode/SourceGenerator.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/bytecode/SourceGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/bytecode/SourceGenerator.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/bytecode/SourceGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -169,7 +169,7 @@ enum AccessModifier {
     };
 
     public static AccessModifier getRandomAccessModifier(Random rnd) {
-        AccessModifier[] a = AccessModifier.class.getEnumConstants();
+        AccessModifier[] a = AccessModifier.values();
         return a[rnd.nextInt(a.length)];
     }
 }
@@ -198,8 +198,6 @@ enum Type {
         }
     }
 
-    ;
-
     public String init(Random rnd) {
         switch (this) {
             case LONG:
@@ -222,7 +220,7 @@ enum Type {
     }
 
     public static Type getRandomType(Random rnd) {
-        Type[] a = Type.class.getEnumConstants();
+        Type[] a = Type.values();
         return a[rnd.nextInt(a.length)];
     }
 }


### PR DESCRIPTION
Just a very tiny clean-up.

There are some places in JDK code base where we call `Enum.class.getEnumConstants()` to get all the values of the referenced `enum`. This is excessive, less-readable and slower than just calling `Enum.values()` as in `getEnumConstants()` we have volatile access:
```java
public T[] getEnumConstants() {
    T[] values = getEnumConstantsShared();
    return (values != null) ? values.clone() : null;
}

private transient volatile T[] enumConstants;

T[] getEnumConstantsShared() {
    T[] constants = enumConstants;
    if (constants == null) { /* ... */ }
    return constants;
}
```
Calling values() method is slightly faster:
```java
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@Fork(jvmArgsAppend = {"-Xms2g", "-Xmx2g"})
public class EnumBenchmark {

  @Benchmark
  public Enum[] values() {
    return Enum.values();
  }

  @Benchmark
  public Enum[] getEnumConstants() {
    return Enum.class.getEnumConstants();
  }

  private enum Enum {
    A,
    B
  }
}
```
```
Benchmark                                                        Mode  Cnt     Score     Error   Units
EnumBenchmark.getEnumConstants                                   avgt   15     6,265 ±   0,051   ns/op
EnumBenchmark.getEnumConstants:·gc.alloc.rate                    avgt   15  2434,075 ±  19,568  MB/sec
EnumBenchmark.getEnumConstants:·gc.alloc.rate.norm               avgt   15    24,002 ±   0,001    B/op
EnumBenchmark.getEnumConstants:·gc.churn.G1_Eden_Space           avgt   15  2433,709 ±  70,216  MB/sec
EnumBenchmark.getEnumConstants:·gc.churn.G1_Eden_Space.norm      avgt   15    23,998 ±   0,659    B/op
EnumBenchmark.getEnumConstants:·gc.churn.G1_Survivor_Space       avgt   15     0,009 ±   0,003  MB/sec
EnumBenchmark.getEnumConstants:·gc.churn.G1_Survivor_Space.norm  avgt   15    ≈ 10⁻⁴              B/op
EnumBenchmark.getEnumConstants:·gc.count                         avgt   15   210,000            counts
EnumBenchmark.getEnumConstants:·gc.time                          avgt   15   119,000                ms

EnumBenchmark.values                                             avgt   15     4,164 ±   0,134   ns/op
EnumBenchmark.values:·gc.alloc.rate                              avgt   15  3665,341 ± 120,721  MB/sec
EnumBenchmark.values:·gc.alloc.rate.norm                         avgt   15    24,002 ±   0,001    B/op
EnumBenchmark.values:·gc.churn.G1_Eden_Space                     avgt   15  3660,512 ± 137,250  MB/sec
EnumBenchmark.values:·gc.churn.G1_Eden_Space.norm                avgt   15    23,972 ±   0,529    B/op
EnumBenchmark.values:·gc.churn.G1_Survivor_Space                 avgt   15     0,017 ±   0,003  MB/sec
EnumBenchmark.values:·gc.churn.G1_Survivor_Space.norm            avgt   15    ≈ 10⁻⁴              B/op
EnumBenchmark.values:·gc.count                                   avgt   15   262,000            counts
EnumBenchmark.values:·gc.time                                    avgt   15   155,000                ms
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273140](https://bugs.openjdk.java.net/browse/JDK-8273140): Replace usages of Enum.class.getEnumConstants() with Enum.values() where possible


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 90319b2f321e703be760b40d291a89a279972eb0


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5303/head:pull/5303` \
`$ git checkout pull/5303`

Update a local copy of the PR: \
`$ git checkout pull/5303` \
`$ git pull https://git.openjdk.java.net/jdk pull/5303/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5303`

View PR using the GUI difftool: \
`$ git pr show -t 5303`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5303.diff">https://git.openjdk.java.net/jdk/pull/5303.diff</a>

</details>
