### PR TITLE
8273148: Shouldn't increment _ifop_count when IfOp is created

### DIFF
--- a/src/hotspot/share/c1/c1_Optimizer.cpp
+++ b/src/hotspot/share/c1/c1_Optimizer.cpp
@@ -284,8 +284,8 @@ Value CE_Eliminator::make_ifop(Value x, Instruction::Condition cond, Value y, Va
           Value new_tval = t_compare_res == Constant::cond_true ? tval : fval;
           Value new_fval = f_compare_res == Constant::cond_true ? tval : fval;
 
-          _ifop_count++;
           if (new_tval == new_fval) {
+            _ifop_count++;
             return new_tval;
           } else {
             return new IfOp(x_ifop->x(), x_ifop_cond, x_ifop->y(), new_tval, new_fval);


### PR DESCRIPTION
Hi,

Please help review this small fix.

IIUC, _ifop_count is incremented when IfOp is no need to create, but there is a wrong increment operation in the current implementation(CE_Eliminator::make_ifop).

Thanks,
Denghui

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8273148](https://bugs.openjdk.java.net/browse/JDK-8273148): Shouldn't increment _ifop_count when IfOp is created


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5305/head:pull/5305` \
`$ git checkout pull/5305`

Update a local copy of the PR: \
`$ git checkout pull/5305` \
`$ git pull https://git.openjdk.java.net/jdk pull/5305/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5305`

View PR using the GUI difftool: \
`$ git pr show -t 5305`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5305.diff">https://git.openjdk.java.net/jdk/pull/5305.diff</a>

</details>
