### PR TITLE
8262095: NPE in Flow$FlowAnalyzer.visitApply: Cannot invoke getThrownTypes because tree.meth.type is null

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -613,7 +613,10 @@ public class Attr extends JCTree.Visitor {
                 }
                 @Override
                 public void report(DiagnosticPosition pos, JCDiagnostic details) {
-                    if (pt == Type.recoveryType) {
+                    boolean needsReport = pt == Type.recoveryType ||
+                            (details.getDiagnosticPosition() != null &&
+                            details.getDiagnosticPosition().getTree().hasTag(LAMBDA));
+                    if (needsReport) {
                         chk.basicHandler.report(pos, details);
                     }
                 }

--- a/test/langtools/tools/javac/lambda/8262095/T8262095.java
+++ b/test/langtools/tools/javac/lambda/8262095/T8262095.java
@@ -1,0 +1,20 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8262095
+ * @summary Report diagnostics produced by incorrect lambdas
+ * @compile/fail/ref=T8262095.out -XDrawDiagnostics T8262095.java
+ */
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Stream;
+
+class T8262095 {
+
+    void f(Stream<Entry<Long, List<String>>> stream) {
+        stream.sorted(Entry.comparingByKey()
+                           .thenComparing((Map.Entry<Long, List<String>> e) -> e.getValue().hashCode()))
+              .count();
+    }
+}

--- a/test/langtools/tools/javac/lambda/8262095/T8262095.out
+++ b/test/langtools/tools/javac/lambda/8262095/T8262095.out
@@ -1,0 +1,2 @@
+T8262095.java:17:42: compiler.err.prob.found.req: (compiler.misc.infer.no.conforming.assignment.exists: U, (compiler.misc.inconvertible.types: java.util.function.Function<java.util.Map.Entry<java.lang.Long,java.util.List<java.lang.String>>,java.lang.Integer>, java.util.function.Function<? super java.util.Map.Entry<K,java.lang.Object>,? extends java.lang.Integer>))
+1 error


### PR DESCRIPTION
Please review this PR which is not filtering errors for cases when the error is reported in a lambda expression. Before the fix for [JDK-8205418](https://bugs.openjdk.java.net/browse/JDK-8205418) javac was a bit more aggressive reporting errors found during recovery. 

After the fix mentioned above, the intention was to try to generate better error messages by attributing deferred nodes with more precise targets. But for some cases like the one reported in the bug entry, javac would swallow the error report. This fix is just reporting the errors right away if its position is a lambda expression.

Thanks,
Vicente

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262095](https://bugs.openjdk.java.net/browse/JDK-8262095): NPE in Flow$FlowAnalyzer.visitApply: Cannot invoke getThrownTypes because tree.meth.type is null


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Contributors
 * Jan Lahoda `<jlahoda@openjdk.org>`
 * Vicente Romero `<vromero@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5307/head:pull/5307` \
`$ git checkout pull/5307`

Update a local copy of the PR: \
`$ git checkout pull/5307` \
`$ git pull https://git.openjdk.java.net/jdk pull/5307/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5307`

View PR using the GUI difftool: \
`$ git pr show -t 5307`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5307.diff">https://git.openjdk.java.net/jdk/pull/5307.diff</a>

</details>
