### PR TITLE
8273153: Consolidate file_exists into os:file_exists

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -1382,14 +1382,6 @@ const char* os::dll_file_extension() { return ".so"; }
 // directory not the java application's temp directory, ala java.io.tmpdir.
 const char* os::get_temp_directory() { return "/tmp"; }
 
-static bool file_exists(const char* filename) {
-  struct stat statbuf;
-  if (filename == NULL || strlen(filename) == 0) {
-    return false;
-  }
-  return os::stat(filename, &statbuf) == 0;
-}
-
 // check if addr is inside libjvm.so
 bool os::address_is_in_vm(address addr) {
   static address libjvm_base_addr;
@@ -2433,7 +2425,7 @@ static void print_sys_devices_cpu_info(outputStream* st, char* buf, size_t bufle
       snprintf(hbuf_type, 60, "/sys/devices/system/cpu/cpu0/cache/index%u/type", i);
       snprintf(hbuf_size, 60, "/sys/devices/system/cpu/cpu0/cache/index%u/size", i);
       snprintf(hbuf_coherency_line_size, 80, "/sys/devices/system/cpu/cpu0/cache/index%u/coherency_line_size", i);
-      if (file_exists(hbuf_level)) {
+      if (os::file_exists(hbuf_level)) {
         _print_ascii_file_h("cache level", hbuf_level, st);
         _print_ascii_file_h("cache type", hbuf_type, st);
         _print_ascii_file_h("cache size", hbuf_size, st);

--- a/src/hotspot/share/logging/logFileOutput.cpp
+++ b/src/hotspot/share/logging/logFileOutput.cpp
@@ -92,11 +92,6 @@ static size_t parse_value(const char* value_str) {
   return value;
 }
 
-static bool file_exists(const char* filename) {
-  struct stat dummy_stat;
-  return os::stat(filename, &dummy_stat) == 0;
-}
-
 static uint number_of_digits(uint number) {
   return number < 10 ? 1 : (number < 100 ? 2 : 3);
 }
@@ -139,7 +134,7 @@ static uint next_file_number(const char* filename,
     assert(ret > 0 && static_cast<size_t>(ret) == len - 1,
            "incorrect buffer length calculation");
 
-    if (file_exists(archive_name) && !is_regular_file(archive_name)) {
+    if (os::file_exists(archive_name) && !is_regular_file(archive_name)) {
       // We've encountered something that's not a regular file among the
       // possible file rotation targets. Fail immediately to prevent
       // problems later.
@@ -150,7 +145,7 @@ static uint next_file_number(const char* filename,
     }
 
     // Stop looking if we find an unused file name
-    if (!file_exists(archive_name)) {
+    if (!os::file_exists(archive_name)) {
       next_num = i;
       found = true;
       break;
@@ -243,7 +238,7 @@ bool LogFileOutput::initialize(const char* options, outputStream* errstream) {
     return false;
   }
 
-  bool file_exist = file_exists(_file_name);
+  bool file_exist = os::file_exists(_file_name);
   if (file_exist && _is_default_file_count && is_fifo_file(_file_name)) {
     _file_count = 0; // Prevent file rotation for fifo's such as named pipes.
   }

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1395,6 +1395,14 @@ bool os::set_boot_path(char fileSep, char pathSep) {
   return false;
 }
 
+bool os::file_exists(const char* filename) {
+  struct stat statbuf;
+  if (filename == NULL || strlen(filename) == 0) {
+    return false;
+  }
+  return os::stat(filename, &statbuf) == 0;
+}
+
 // Splits a path, based on its separator, the number of
 // elements is returned back in "elements".
 // file_name_length is used as a modifier for each path's

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -547,6 +547,7 @@ class os: AllStatic {
   static FILE* fopen(const char* path, const char* mode);
   static int close(int fd);
   static jlong lseek(int fd, jlong offset, int whence);
+  static bool file_exists(const char* file);
   // This function, on Windows, canonicalizes a given path (see os_windows.cpp for details).
   // On Posix, this function is a noop: it does not change anything and just returns
   // the input pointer.


### PR DESCRIPTION
This are several places to check if file exists using local similar function, file_exists. They should be consolidated into one version. The patch added a function os::file_exists to do so.

Tests: tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273153](https://bugs.openjdk.java.net/browse/JDK-8273153): Consolidate file_exists into os:file_exists


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5308/head:pull/5308` \
`$ git checkout pull/5308`

Update a local copy of the PR: \
`$ git checkout pull/5308` \
`$ git pull https://git.openjdk.java.net/jdk pull/5308/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5308`

View PR using the GUI difftool: \
`$ git pr show -t 5308`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5308.diff">https://git.openjdk.java.net/jdk/pull/5308.diff</a>

</details>
