### PR TITLE
8268084: [macos] Disabled JMenuItem arrow is not disabled

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaImageFactory.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaImageFactory.java
@@ -232,7 +232,7 @@ public class AquaImageFactory {
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     static class InvertableImageIcon extends ImageIcon implements InvertableIcon, UIResource {
         Icon invertedImage;
-        Icon disabledIcon;
+        private Icon disabledIcon;
         public InvertableImageIcon(final Image image) {
             super(image);
         }
@@ -241,7 +241,7 @@ public class AquaImageFactory {
         public void paintIcon(Component c, Graphics g, int x, int y) {
             if (!c.isEnabled()) {
                 if (disabledIcon == null) {
-                    disabledIcon = new ImageIconUIResource(GrayFilter.
+                    disabledIcon = new ImageIcon(GrayFilter.
                             createDisabledImage(((ImageIcon)this).getImage()));
                 }
                 disabledIcon.paintIcon(c, g, x, y);

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaImageFactory.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaImageFactory.java
@@ -253,7 +253,7 @@ public class AquaImageFactory {
         @Override
         public Icon getInvertedIcon() {
             if (invertedImage != null) return invertedImage;
-            return invertedImage = new IconUIResource(new ImageIcon(AquaUtils.generateLightenedImage(getImage(), 100)));
+            return invertedImage = new InvertableImageIcon(AquaUtils.generateLightenedImage(getImage(), 100));
         }
     }
 

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaImageFactory.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaImageFactory.java
@@ -48,6 +48,7 @@ import com.apple.laf.AquaUtils.RecyclableObject;
 import com.apple.laf.AquaUtils.RecyclableSingleton;
 import sun.awt.image.MultiResolutionCachedImage;
 import sun.lwawt.macosx.CImage;
+import sun.swing.ImageIconUIResource;
 
 public class AquaImageFactory {
     public static IconUIResource getConfirmImageIcon() {
@@ -231,8 +232,22 @@ public class AquaImageFactory {
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     static class InvertableImageIcon extends ImageIcon implements InvertableIcon, UIResource {
         Icon invertedImage;
+        Icon disabledIcon;
         public InvertableImageIcon(final Image image) {
             super(image);
+        }
+
+        @Override
+        public void paintIcon(Component c, Graphics g, int x, int y) {
+            if (!c.isEnabled()) {
+                if (disabledIcon == null) {
+                    disabledIcon = new ImageIconUIResource(GrayFilter.
+                            createDisabledImage(((ImageIcon)this).getImage()));
+                }
+                disabledIcon.paintIcon(c, g, x, y);
+            } else {
+                super.paintIcon(c, g, x, y);
+            }
         }
 
         @Override

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaMenuPainter.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaMenuPainter.java
@@ -74,7 +74,6 @@ public class AquaMenuPainter {
         kUCapsLockGlyph = 0x21EA;
 
     static final int ALT_GRAPH_MASK = 1 << 5; // New to Java2
-
     @SuppressWarnings("deprecation")
     static final int sUnsupportedModifiersMask =
             ~(InputEvent.CTRL_MASK | InputEvent.ALT_MASK | InputEvent.SHIFT_MASK

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaMenuPainter.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaMenuPainter.java
@@ -33,7 +33,6 @@ import javax.swing.border.Border;
 import javax.swing.plaf.basic.BasicHTML;
 import javax.swing.text.View;
 
-import sun.swing.ImageIconUIResource;
 import sun.swing.SwingUtilities2;
 
 import apple.laf.JRSUIConstants.*;
@@ -75,7 +74,6 @@ public class AquaMenuPainter {
         kUCapsLockGlyph = 0x21EA;
 
     static final int ALT_GRAPH_MASK = 1 << 5; // New to Java2
-    static Icon disabledIcon = null;
 
     @SuppressWarnings("deprecation")
     static final int sUnsupportedModifiersMask =

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaMenuPainter.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaMenuPainter.java
@@ -75,6 +75,8 @@ public class AquaMenuPainter {
         kUCapsLockGlyph = 0x21EA;
 
     static final int ALT_GRAPH_MASK = 1 << 5; // New to Java2
+    static Icon disabledIcon = null;
+
     @SuppressWarnings("deprecation")
     static final int sUnsupportedModifiersMask =
             ~(InputEvent.CTRL_MASK | InputEvent.ALT_MASK | InputEvent.SHIFT_MASK
@@ -158,7 +160,7 @@ public class AquaMenuPainter {
         selectedMenuItemPainter.get().paintBorder(null, g, 0, 0, width, height);
     }
 
-    protected void paintMenuItem(final Client client, final Graphics g, final JComponent c, final Icon checkIcon, Icon arrowIcon, final Color background, final Color foreground, final Color disabledForeground, final Color selectionForeground, final int defaultTextIconGap, final Font acceleratorFont) {
+    protected void paintMenuItem(final Client client, final Graphics g, final JComponent c, final Icon checkIcon, final Icon arrowIcon, final Color background, final Color foreground, final Color disabledForeground, final Color selectionForeground, final int defaultTextIconGap, final Font acceleratorFont) {
         final JMenuItem b = (JMenuItem)c;
         final ButtonModel model = b.getModel();
 
@@ -295,10 +297,6 @@ public class AquaMenuPainter {
 
         // Paint the Arrow
         if (arrowIcon != null) {
-            if (!isEnabled && (arrowIcon instanceof ImageIcon)) {
-                arrowIcon = new ImageIconUIResource(GrayFilter.
-                        createDisabledImage(((ImageIcon)arrowIcon).getImage()));
-            }
             paintArrow(g, b, model, arrowIcon, arrowIconRect);
         }
 
@@ -410,7 +408,15 @@ public class AquaMenuPainter {
         if (c instanceof JMenu && (model.isArmed() || model.isSelected()) && arrowIcon instanceof InvertableIcon) {
             ((InvertableIcon)arrowIcon).getInvertedIcon().paintIcon(c, g, arrowIconRect.x, arrowIconRect.y);
         } else {
-            arrowIcon.paintIcon(c, g, arrowIconRect.x, arrowIconRect.y);
+            if (!c.isEnabled() && arrowIcon instanceof ImageIcon) {
+                if (disabledIcon == null) {
+                    disabledIcon = new ImageIconUIResource(GrayFilter.
+                            createDisabledImage(((ImageIcon) arrowIcon).getImage()));
+                }
+                disabledIcon.paintIcon(c, g, arrowIconRect.x, arrowIconRect.y);
+            } else {
+                arrowIcon.paintIcon(c, g, arrowIconRect.x, arrowIconRect.y);
+            }
         }
     }
 

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaMenuPainter.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaMenuPainter.java
@@ -33,6 +33,7 @@ import javax.swing.border.Border;
 import javax.swing.plaf.basic.BasicHTML;
 import javax.swing.text.View;
 
+import sun.swing.ImageIconUIResource;
 import sun.swing.SwingUtilities2;
 
 import apple.laf.JRSUIConstants.*;
@@ -157,7 +158,7 @@ public class AquaMenuPainter {
         selectedMenuItemPainter.get().paintBorder(null, g, 0, 0, width, height);
     }
 
-    protected void paintMenuItem(final Client client, final Graphics g, final JComponent c, final Icon checkIcon, final Icon arrowIcon, final Color background, final Color foreground, final Color disabledForeground, final Color selectionForeground, final int defaultTextIconGap, final Font acceleratorFont) {
+    protected void paintMenuItem(final Client client, final Graphics g, final JComponent c, final Icon checkIcon, Icon arrowIcon, final Color background, final Color foreground, final Color disabledForeground, final Color selectionForeground, final int defaultTextIconGap, final Font acceleratorFont) {
         final JMenuItem b = (JMenuItem)c;
         final ButtonModel model = b.getModel();
 
@@ -294,6 +295,10 @@ public class AquaMenuPainter {
 
         // Paint the Arrow
         if (arrowIcon != null) {
+            if (!isEnabled && (arrowIcon instanceof ImageIcon)) {
+                arrowIcon = new ImageIconUIResource(GrayFilter.
+                        createDisabledImage(((ImageIcon)arrowIcon).getImage()));
+            }
             paintArrow(g, b, model, arrowIcon, arrowIconRect);
         }
 

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaMenuPainter.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaMenuPainter.java
@@ -408,15 +408,7 @@ public class AquaMenuPainter {
         if (c instanceof JMenu && (model.isArmed() || model.isSelected()) && arrowIcon instanceof InvertableIcon) {
             ((InvertableIcon)arrowIcon).getInvertedIcon().paintIcon(c, g, arrowIconRect.x, arrowIconRect.y);
         } else {
-            if (!c.isEnabled() && arrowIcon instanceof ImageIcon) {
-                if (disabledIcon == null) {
-                    disabledIcon = new ImageIconUIResource(GrayFilter.
-                            createDisabledImage(((ImageIcon) arrowIcon).getImage()));
-                }
-                disabledIcon.paintIcon(c, g, arrowIconRect.x, arrowIconRect.y);
-            } else {
-                arrowIcon.paintIcon(c, g, arrowIconRect.x, arrowIconRect.y);
-            }
+            arrowIcon.paintIcon(c, g, arrowIconRect.x, arrowIconRect.y);
         }
     }
 

--- a/test/jdk/javax/swing/plaf/aqua/JMenuItemDisableArrowButtonTest.java
+++ b/test/jdk/javax/swing/plaf/aqua/JMenuItemDisableArrowButtonTest.java
@@ -57,8 +57,11 @@ public class JMenuItemDisableArrowButtonTest {
 
     private static final String INSTRUCTIONS = "INSTRUCTIONS:\n\n"
             + "Click on \"SubMenuTest\" menu.\n "
-            + "If arrow icon is disabled along with \"Submenu\" menuitem\n"
-            + "and\n"
+            + "If in 1st menuitem\n"
+            + "arrow icon is disabled along with \"Submenu\" menuitem\n"
+            + "and in 2nd menuitem\n"
+            + " If selected arrow icon is disabled along with \"Submenu\" menuitem\n"
+            + "and in 3rd menuitem\n"
             + "If checkmark icon is disabled along with \"Submenu\" CheckBox menuitem\n"
             + "then press Pass \n"
             + "otherwise if arrow or checkmark icon is not disabled, press Fail.";
@@ -156,7 +159,12 @@ public class JMenuItemDisableArrowButtonTest {
         JMenu subMenuTestmenu = new JMenu("SubMenuTest");
         JMenu disabledSubmenu = new JMenu("Submenu");
         disabledSubmenu.setEnabled(false);
+
+        JMenu disabledSubmenu1 = new JMenu("Submenu");
+        disabledSubmenu1.setSelected(true);
+        disabledSubmenu1.setEnabled(false);
         subMenuTestmenu.add(disabledSubmenu);
+        subMenuTestmenu.add(disabledSubmenu1);
 
         JCheckBoxMenuItem myItem = new JCheckBoxMenuItem("Submenu");
         myItem.setSelected(true);

--- a/test/jdk/javax/swing/plaf/aqua/JMenuItemDisableArrowButtonTest.java
+++ b/test/jdk/javax/swing/plaf/aqua/JMenuItemDisableArrowButtonTest.java
@@ -39,6 +39,7 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import javax.swing.JButton;
 import javax.swing.JComponent;
+import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JTextArea;
@@ -57,8 +58,10 @@ public class JMenuItemDisableArrowButtonTest {
     private static final String INSTRUCTIONS = "INSTRUCTIONS:\n\n"
             + "Click on \"SubMenuTest\" menu.\n "
             + "If arrow icon is disabled along with \"Submenu\" menuitem\n"
+            + "and\n"
+            + "If checkmark icon is disabled along with \"Submenu\" CheckBox menuitem\n"
             + "then press Pass \n"
-            + "otherwise if arrow icon is not disabled,press Fail.";
+            + "otherwise if arrow or checkmark icon is not disabled, press Fail.";
 
     public static void main(String args[]) throws Exception{
         countDownLatch = new CountDownLatch(1);
@@ -67,7 +70,8 @@ public class JMenuItemDisableArrowButtonTest {
         countDownLatch.await(5, TimeUnit.MINUTES);
 
         if (!testResult) {
-            throw new RuntimeException("Disabled JMenuItem arrow is not disabled!");
+            throw new RuntimeException(
+                    "Disabled JMenuItem arrow or checkmark icon is not disabled!");
         }
     }
 
@@ -151,9 +155,14 @@ public class JMenuItemDisableArrowButtonTest {
         final JMenuBar menuBar = new JMenuBar();
         JMenu subMenuTestmenu = new JMenu("SubMenuTest");
         JMenu disabledSubmenu = new JMenu("Submenu");
-        disabledSubmenu.add(new JMenuItem("item"));
         disabledSubmenu.setEnabled(false);
         subMenuTestmenu.add(disabledSubmenu);
+
+        JCheckBoxMenuItem myItem = new JCheckBoxMenuItem("Submenu");
+        myItem.setSelected(true);
+        myItem.setEnabled(false);
+        subMenuTestmenu.add(myItem);
+
         menuBar.add(subMenuTestmenu);
         return menuBar;
     }

--- a/test/jdk/javax/swing/plaf/aqua/JMenuItemDisableArrowButtonTest.java
+++ b/test/jdk/javax/swing/plaf/aqua/JMenuItemDisableArrowButtonTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @requires (os.family == "mac")
+ * @bug 8268084
+ * @summary  Verifies disabled JMenuItem arrow is disabled
+ * @run main/manual JMenuItemDisableArrowButtonTest
+ */
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.awt.Color;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.GridBagConstraints;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JTextArea;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+public class JMenuItemDisableArrowButtonTest {
+
+    private static JFrame frame;
+    private static volatile CountDownLatch countDownLatch;
+    private static volatile boolean testResult;
+
+    private static final String INSTRUCTIONS = "INSTRUCTIONS:\n\n"
+            + "Click on \"SubMenuTest\" menu.\n "
+            + "If arrow icon is disabled along with \"Submenu\" menuitem\n"
+            + "then press Pass \n"
+            + "otherwise if arrow icon is not disabled,press Fail.";
+
+    public static void main(String args[]) throws Exception{
+        countDownLatch = new CountDownLatch(1);
+
+        SwingUtilities.invokeAndWait(JMenuItemDisableArrowButtonTest::createUI);
+        countDownLatch.await(5, TimeUnit.MINUTES);
+
+        if (!testResult) {
+            throw new RuntimeException("Disabled JMenuItem arrow is not disabled!");
+        }
+    }
+
+    private static void createUI() {
+        try {
+            UIManager.setLookAndFeel("com.apple.laf.AquaLookAndFeel");
+        } catch (Exception e) {
+            throw new RuntimeException("Cannot initialize Aqua L&F");
+        }
+
+        JFrame mainFrame = new JFrame();
+        GridBagLayout layout = new GridBagLayout();
+        JPanel mainControlPanel = new JPanel(layout);
+        JPanel resultButtonPanel = new JPanel(layout);
+
+        GridBagConstraints gbc = new GridBagConstraints();
+
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        gbc.insets = new Insets(5, 15, 5, 15);
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        mainControlPanel.add(createComponent(), gbc);
+
+        JTextArea instructionTextArea = new JTextArea();
+        instructionTextArea.setText(INSTRUCTIONS);
+        instructionTextArea.setEditable(false);
+        instructionTextArea.setBackground(Color.white);
+
+        gbc.gridx = 0;
+        gbc.gridy = 1;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        mainControlPanel.add(instructionTextArea, gbc);
+
+        JButton passButton = new JButton("Pass");
+        passButton.setActionCommand("Pass");
+        passButton.addActionListener((ActionEvent e) -> {
+            testResult = true;
+            mainFrame.dispose();
+            countDownLatch.countDown();
+
+        });
+
+        JButton failButton = new JButton("Fail");
+        failButton.setActionCommand("Fail");
+        failButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                mainFrame.dispose();
+                countDownLatch.countDown();
+            }
+        });
+
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+
+        resultButtonPanel.add(passButton, gbc);
+        gbc.gridx = 1;
+        gbc.gridy = 0;
+        resultButtonPanel.add(failButton, gbc);
+
+        gbc.gridx = 0;
+        gbc.gridy = 2;
+        mainControlPanel.add(resultButtonPanel, gbc);
+
+        mainFrame.add(mainControlPanel);
+        mainFrame.pack();
+
+        mainFrame.addWindowListener(new WindowAdapter() {
+
+            @Override
+            public void windowClosing(WindowEvent e) {
+                mainFrame.dispose();
+                countDownLatch.countDown();
+            }
+        });
+        mainFrame.setLocationRelativeTo(null);
+        mainFrame.setVisible(true);
+    }
+
+    private static JComponent createComponent() {
+        final JMenuBar menuBar = new JMenuBar();
+        JMenu subMenuTestmenu = new JMenu("SubMenuTest");
+        JMenu disabledSubmenu = new JMenu("Submenu");
+        disabledSubmenu.add(new JMenuItem("item"));
+        disabledSubmenu.setEnabled(false);
+        subMenuTestmenu.add(disabledSubmenu);
+        menuBar.add(subMenuTestmenu);
+        return menuBar;
+    }
+}
+

--- a/test/jdk/javax/swing/plaf/aqua/JMenuItemDisableArrowButtonTest.java
+++ b/test/jdk/javax/swing/plaf/aqua/JMenuItemDisableArrowButtonTest.java
@@ -24,7 +24,7 @@
  * @test
  * @requires (os.family == "mac")
  * @bug 8268084
- * @summary  Verifies disabled JMenuItem arrow is disabled
+ * @summary  Verifies disabled JMenuItem arrow and check is disabled
  * @run main/manual JMenuItemDisableArrowButtonTest
  */
 import java.util.concurrent.CountDownLatch;


### PR DESCRIPTION
It is seen in macos disabled JMenuItem arrow is not disabled even though JMenuItem itself is disabled.
In native app, same menuitem arrow is disabled for disabled menuitem.

Issue is when AquaMenuPainter#paintMenuItem() is called, it tries to draw a ImageIcon image of the arrow via ImageIcon#paintIcon which tries to generate MultiResolutionCachedImage via getResolutionVariant() by calling AquaUtils#generateFilteredImage.
It does not take into account if disabled arrow icon image needs to be drawn or not, so it is always enabled.

Proposed fix is to generate a disabled ImageIcon image of the same arrow icon and use it for disabled state.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268084](https://bugs.openjdk.java.net/browse/JDK-8268084): [macos] Disabled JMenuItem arrow is not disabled


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5310/head:pull/5310` \
`$ git checkout pull/5310`

Update a local copy of the PR: \
`$ git checkout pull/5310` \
`$ git pull https://git.openjdk.java.net/jdk pull/5310/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5310`

View PR using the GUI difftool: \
`$ git pr show -t 5310`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5310.diff">https://git.openjdk.java.net/jdk/pull/5310.diff</a>

</details>
