### PR TITLE
8272776: NullPointerException not reported

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -340,9 +340,8 @@ public class TransPatterns extends TreeTranslator {
             JCCase lastCase = cases.last();
 
             if (hasTotalPattern && !hasNullCase) {
-                JCCase last = lastCase;
-                if (last.labels.stream().noneMatch(l -> l.hasTag(Tag.DEFAULTCASELABEL))) {
-                    last.labels = last.labels.prepend(makeLit(syms.botType, null));
+                if (cases.stream().flatMap(c -> c.labels.stream()).noneMatch(l -> l.hasTag(Tag.DEFAULTCASELABEL))) {
+                    lastCase.labels = lastCase.labels.prepend(makeLit(syms.botType, null));
                     hasNullCase = true;
                 }
             }

--- a/test/langtools/tools/javac/patterns/NullSwitch.java
+++ b/test/langtools/tools/javac/patterns/NullSwitch.java
@@ -1,6 +1,6 @@
 /*
  * @test /nodynamiccopyright/
- * @bug 8262891
+ * @bug 8262891 8272776
  * @summary Check null handling for non-pattern switches.
  * @compile --enable-preview -source ${jdk.version} NullSwitch.java
  * @run main/othervm --enable-preview NullSwitch
@@ -57,6 +57,9 @@ public class NullSwitch {
         assertEquals(0, matchingSwitch12(""));
         assertEquals(2, matchingSwitch12(null));
         assertEquals(1, matchingSwitch12(0.0));
+        assertEquals(0, matchingSwitch13(""));
+        assertEquals(1, matchingSwitch13(0.0));
+        assertEquals(2, matchingSwitch13(null));
     }
 
     private int matchingSwitch1(Object obj) {
@@ -153,6 +156,17 @@ public class NullSwitch {
             switch (obj) {
                 case String s: return 0;
                 default: return 1;
+            }
+        } catch (NullPointerException ex) {
+            return 2;
+        }
+    }
+
+    private int matchingSwitch13(Object obj) {
+        try {
+            switch (obj) {
+                default: return 1;
+                case String s: return 0;
             }
         } catch (NullPointerException ex) {
             return 2;


### PR DESCRIPTION
Code like:
```
public void foo(Object o) {
        switch (o) {
          default: break;
          case String s :System.out.println(s); break;
        } 
}
public static void main(String[] args) {
        (new X()).foo(null); // NPE expected, but prints null
}
```

Should lead to a NPE when executed, because `default` does not cover `null` and there is no total pattern in the switch, but the NPE is not thrown. The reason is that when generating the code, a `hasTotalPattern` flag is used, which means "has a total pattern or default". The code needs to check whether there is a real total pattern (which covers `null`) or not. That is done by looking for the `default` case label, but the code only checks the last case for `default`. It needs to check all cases to differentiate between a switch with a real total pattern and a switch with a `default`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272776](https://bugs.openjdk.java.net/browse/JDK-8272776): NullPointerException not reported


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5312/head:pull/5312` \
`$ git checkout pull/5312`

Update a local copy of the PR: \
`$ git checkout pull/5312` \
`$ git pull https://git.openjdk.java.net/jdk pull/5312/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5312`

View PR using the GUI difftool: \
`$ git pr show -t 5312`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5312.diff">https://git.openjdk.java.net/jdk/pull/5312.diff</a>

</details>
