### PR TITLE
8272985: Reference discovery is confused about atomicity and degree of parallelism

### DIFF
--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -875,9 +875,9 @@ inline void ReferenceProcessor::add_to_discovered_list(DiscoveredList& refs_list
 
 inline bool ReferenceProcessor::set_discovered_link_st(HeapWord* discovered_addr,
                                                        oop next_discovered) {
-  assert(!_discovery_is_mt, "must be");
+  assert(!discovery_is_mt(), "must be");
 
-  if (_discovery_is_atomic) {
+  if (discovery_is_atomic()) {
     // Do a raw store here: the field will be visited later when processing
     // the discovered references.
     RawAccess<>::oop_store(discovered_addr, next_discovered);
@@ -890,11 +890,11 @@ inline bool ReferenceProcessor::set_discovered_link_st(HeapWord* discovered_addr
 
 inline bool ReferenceProcessor::set_discovered_link_mt(HeapWord* discovered_addr,
                                                        oop next_discovered) {
-  assert(_discovery_is_mt, "must be");
+  assert(discovery_is_mt(), "must be");
 
   // We must make sure this object is only enqueued once. Try to CAS into the discovered_addr.
   oop retest;
-  if (_discovery_is_atomic) {
+  if (discovery_is_atomic()) {
     // Try a raw store here, still making sure that we enqueue only once: the field
     // will be visited later when processing the discovered references.
     retest = RawAccess<>::oop_atomic_cmpxchg(discovered_addr, oop(NULL), next_discovered);

--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -847,6 +847,11 @@ inline DiscoveredList* ReferenceProcessor::get_discovered_list(ReferenceType rt)
   return list;
 }
 
+inline bool ReferenceProcessor::set_discovered_link(HeapWord* discovered_addr, oop next_discovered) {
+  return discovery_is_mt() ? set_discovered_link_mt(discovered_addr, next_discovered)
+                           : set_discovered_link_st(discovered_addr, next_discovered);
+}
+
 inline void ReferenceProcessor::add_to_discovered_list(DiscoveredList& refs_list,
                                                        oop obj,
                                                        HeapWord* discovered_addr) {
@@ -855,8 +860,7 @@ inline void ReferenceProcessor::add_to_discovered_list(DiscoveredList& refs_list
   // discovered field pointing to itself.
   oop next_discovered = (current_head != NULL) ? current_head : obj;
 
-  bool added = discovery_is_mt() ? set_discovered_link_mt(discovered_addr, next_discovered)
-                                 : set_discovered_link_st(discovered_addr, next_discovered);
+  bool added = set_discovered_link(discovered_addr, next_discovered);
   if (added) {
     // We can always add the object without synchronization: every thread has its
     // own list head.

--- a/src/hotspot/share/gc/shared/referenceProcessor.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.hpp
@@ -329,6 +329,7 @@ private:
     return id;
   }
   DiscoveredList* get_discovered_list(ReferenceType rt);
+  inline bool set_discovered_link(HeapWord* discovered_addr, oop next_discovered);
   inline void add_to_discovered_list(DiscoveredList& refs_list, oop obj,
                                      HeapWord* discovered_addr);
   inline bool set_discovered_link_st(HeapWord* discovered_addr,

--- a/src/hotspot/share/gc/shared/referenceProcessor.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.hpp
@@ -331,10 +331,10 @@ private:
   DiscoveredList* get_discovered_list(ReferenceType rt);
   inline void add_to_discovered_list(DiscoveredList& refs_list, oop obj,
                                      HeapWord* discovered_addr);
-  inline void add_to_discovered_list_st(DiscoveredList& refs_list, oop obj,
-                                        HeapWord* discovered_addr);
-  inline void add_to_discovered_list_mt(DiscoveredList& refs_list, oop obj,
-                                        HeapWord* discovered_addr);
+  inline bool set_discovered_link_st(HeapWord* discovered_addr,
+                                     oop next_discovered);
+  inline bool set_discovered_link_mt(HeapWord* discovered_addr,
+                                     oop next_discovered);
 
   void clear_discovered_references(DiscoveredList& refs_list);
 

--- a/src/hotspot/share/gc/shared/referenceProcessor.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.hpp
@@ -47,6 +47,7 @@ public:
     return UseCompressedOops ? (HeapWord*)&_compressed_head :
                                (HeapWord*)&_oop_head;
   }
+  inline void add_as_head(oop o);
   inline void set_head(oop o);
   inline bool is_empty() const;
   size_t length()               { return _len; }
@@ -328,6 +329,10 @@ private:
     return id;
   }
   DiscoveredList* get_discovered_list(ReferenceType rt);
+  inline void add_to_discovered_list(DiscoveredList& refs_list, oop obj,
+                                     HeapWord* discovered_addr);
+  inline void add_to_discovered_list_st(DiscoveredList& refs_list, oop obj,
+                                        HeapWord* discovered_addr);
   inline void add_to_discovered_list_mt(DiscoveredList& refs_list, oop obj,
                                         HeapWord* discovered_addr);
 

--- a/src/hotspot/share/gc/shared/referenceProcessor.inline.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.inline.hpp
@@ -35,6 +35,11 @@ oop DiscoveredList::head() const {
     _oop_head;
 }
 
+void DiscoveredList::add_as_head(oop o) {
+  set_head(o);
+  inc_length(1);
+}
+
 void DiscoveredList::set_head(oop o) {
   if (UseCompressedOops) {
     // Must compress the head ptr.


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that fixes some (apparent) confusion between atomicity (of the discovery in the `ReferenceProcessor` sense) vs. the currently selected degree of parallelism?

For all four different combinations of atomicity and parallelism the `discovered` link in the `java.lang.ref.Reference` needs to be updated differently using a different kind of access, instead of just two based on atomicity.

I'll fix the use of `atomic` in `ReferenceProcessor` in a separate CR to hopefully remove the confusion for the reader too.

Testing: tier1-5, internal perf benchmarks without regressions

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272985](https://bugs.openjdk.java.net/browse/JDK-8272985): Reference discovery is confused about atomicity and degree of parallelism


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5314/head:pull/5314` \
`$ git checkout pull/5314`

Update a local copy of the PR: \
`$ git checkout pull/5314` \
`$ git pull https://git.openjdk.java.net/jdk pull/5314/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5314`

View PR using the GUI difftool: \
`$ git pr show -t 5314`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5314.diff">https://git.openjdk.java.net/jdk/pull/5314.diff</a>

</details>
