### PR TITLE
8273169: java/util/regex/NegativeArraySize.java failed after JDK-8271302

### DIFF
--- a/test/jdk/java/util/regex/NegativeArraySize.java
+++ b/test/jdk/java/util/regex/NegativeArraySize.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8223174
  * @summary Pattern.compile() can throw confusing NegativeArraySizeException
- * @requires os.maxMemory >= 5g
+ * @requires os.maxMemory >= 5g & vm.bits == 64
  * @run testng/othervm -Xms5G -Xmx5G NegativeArraySize
  */
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273169](https://bugs.openjdk.java.net/browse/JDK-8273169): java/util/regex/NegativeArraySize.java failed after JDK-8271302


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5315/head:pull/5315` \
`$ git checkout pull/5315`

Update a local copy of the PR: \
`$ git checkout pull/5315` \
`$ git pull https://git.openjdk.java.net/jdk pull/5315/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5315`

View PR using the GUI difftool: \
`$ git pr show -t 5315`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5315.diff">https://git.openjdk.java.net/jdk/pull/5315.diff</a>

</details>
