### PR TITLE
JDK-8273176: handle latest VS2019 in abstract_vm_version

### DIFF
--- a/src/hotspot/share/runtime/abstract_vm_version.cpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.cpp
@@ -235,7 +235,9 @@ const char* Abstract_VM_Version::internal_vm_info_string() {
       #elif _MSC_VER == 1927
         #define HOTSPOT_BUILD_COMPILER "MS VC++ 16.7 (VS2019)"
       #elif _MSC_VER == 1928
-        #define HOTSPOT_BUILD_COMPILER "MS VC++ 16.8 (VS2019)"
+        #define HOTSPOT_BUILD_COMPILER "MS VC++ 16.8 / 16.9 (VS2019)"
+      #elif _MSC_VER == 1929
+        #define HOTSPOT_BUILD_COMPILER "MS VC++ 16.10 / 16.11 (VS2019)"
       #else
         #define HOTSPOT_BUILD_COMPILER "unknown MS VC++:" XSTR(_MSC_VER)
       #endif


### PR DESCRIPTION
Please review this small change.
It handles latest  VS2019 versions  in abstract_vm_version, e.g. 16.10.
See the _MSC_VER documentation at  https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-160

Thanks, Matthias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273176](https://bugs.openjdk.java.net/browse/JDK-8273176): handle latest VS2019 in abstract_vm_version


### Reviewers
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5317/head:pull/5317` \
`$ git checkout pull/5317`

Update a local copy of the PR: \
`$ git checkout pull/5317` \
`$ git pull https://git.openjdk.java.net/jdk pull/5317/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5317`

View PR using the GUI difftool: \
`$ git pr show -t 5317`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5317.diff">https://git.openjdk.java.net/jdk/pull/5317.diff</a>

</details>
