### PR TITLE
8271287: jdk/jshell/CommandCompletionTest.java fails with "lists don't have the same size expected"

### DIFF
--- a/test/langtools/jdk/jshell/CommandCompletionTest.java
+++ b/test/langtools/jdk/jshell/CommandCompletionTest.java
@@ -332,14 +332,22 @@ public class CommandCompletionTest extends ReplToolTesting {
     public void testUserHome() throws IOException {
         List<String> completions;
         Path home = Paths.get(System.getProperty("user.home"));
+        String selectedFile;
+        try (Stream<Path> content = Files.list(home)) {
+            selectedFile = content.filter(CLASSPATH_FILTER)
+                                  .findAny()
+                                  .map(file -> file.getFileName().toString())
+                                  .get();
+        }
         try (Stream<Path> content = Files.list(home)) {
             completions = content.filter(CLASSPATH_FILTER)
+                                 .filter(file -> file.getFileName().toString().startsWith(selectedFile))
                                  .map(file -> file.getFileName().toString() + (Files.isDirectory(file) ? "/" : ""))
                                  .sorted()
                                  .collect(Collectors.toList());
         }
         testNoStartUp(
-                a -> assertCompletion(a, "/env --class-path ~/|", false, completions.toArray(new String[completions.size()]))
+                a -> assertCompletion(a, "/env --class-path ~/" + selectedFile + "|", false, completions.toArray(new String[completions.size()]))
         );
     }
 


### PR DESCRIPTION
JShell has a test that verifies the file completion understands `~` is a home directory, by testing the completions after:
```
/env --classpath ~/
```

The issue is that the content of the home directory may change between the time the snapshot of the home directory content is taken and the time the JShell computes the completions, leading to a test failure.

The proposed workaround is to pick one file/directory in the home directory, and let the completion only show results that have the selected file/directory name as a prefix. The content of the home directory might theoretically still change in a way that the test would fail, but it is presumably very highly unlikely. So seems acceptable for a test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271287](https://bugs.openjdk.java.net/browse/JDK-8271287): jdk/jshell/CommandCompletionTest.java fails with "lists don't have the same size expected"


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5318/head:pull/5318` \
`$ git checkout pull/5318`

Update a local copy of the PR: \
`$ git checkout pull/5318` \
`$ git pull https://git.openjdk.java.net/jdk pull/5318/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5318`

View PR using the GUI difftool: \
`$ git pr show -t 5318`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5318.diff">https://git.openjdk.java.net/jdk/pull/5318.diff</a>

</details>
