### PR TITLE
8273186: Remove leftover comment about sparse remembered set in G1 HeapRegionRemSet

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegionRemSet.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.hpp
@@ -56,7 +56,6 @@ class HeapRegionRemSet : public CHeapObj<mtGC> {
 public:
   HeapRegionRemSet(HeapRegion* hr, G1CardSetConfiguration* config);
 
-  // Setup sparse and fine-grain tables sizes.
   bool cardset_is_empty() const {
     return _card_set.is_empty();
   }


### PR DESCRIPTION
Hi all,

  please review this trivial one-line obsolete comment about sparse remembered sets which do not exist any more.

Testing: local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273186](https://bugs.openjdk.java.net/browse/JDK-8273186): Remove leftover comment about sparse remembered set in G1 HeapRegionRemSet


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5319/head:pull/5319` \
`$ git checkout pull/5319`

Update a local copy of the PR: \
`$ git checkout pull/5319` \
`$ git pull https://git.openjdk.java.net/jdk pull/5319/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5319`

View PR using the GUI difftool: \
`$ git pr show -t 5319`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5319.diff">https://git.openjdk.java.net/jdk/pull/5319.diff</a>

</details>
