### PR TITLE
8273197: ProblemList 2 jtools tests due to JDK-8273187

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -564,6 +564,8 @@ java/lang/invoke/RicochetTest.java                              8251969 generic-
 java/lang/instrument/RedefineBigClass.sh                        8065756 generic-all
 java/lang/instrument/RetransformBigClass.sh                     8065756 generic-all
 
+java/lang/instrument/BootClassPath/BootClassPathTest.sh         8273188 linux-x64,macosx-x64
+
 java/lang/management/MemoryMXBean/Pending.java                  8158837 generic-all
 java/lang/management/MemoryMXBean/PendingAllGC.sh               8158837 generic-all
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -809,6 +809,9 @@ sun/tools/jstat/jstatLineCounts2.sh                             8268211 linux-aa
 sun/tools/jstat/jstatLineCounts3.sh                             8268211 linux-aarch64
 sun/tools/jstat/jstatLineCounts4.sh                             8268211 linux-aarch64
 
+sun/tools/jcmd/JcmdOutputEncodingTest.java                      8273187 generic-all
+sun/tools/jstack/BasicJStackTest.java                           8273187 generic-all
+
 ############################################################################
 
 # jdk_other


### PR DESCRIPTION
Trivial fixes to reduce the noise in the JDK18 CI:
JDK-8273197 ProblemList 2 jtools tests due to JDK-8273187
JDK-8273198 ProblemList java/lang/instrument/BootClassPath/BootClassPathTest.sh due to JDK-8273188

These failures happen in Tier5 so I'm ProblemListing them now to give @naotoj time to
work on the issues introduced by JDK-8260265 UTF-8 by Default.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8273197](https://bugs.openjdk.java.net/browse/JDK-8273197): ProblemList 2 jtools tests due to JDK-8273187
 * [JDK-8273198](https://bugs.openjdk.java.net/browse/JDK-8273198): ProblemList java/lang/instrument/BootClassPath/BootClassPathTest.sh due to JDK-8273188


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5321/head:pull/5321` \
`$ git checkout pull/5321`

Update a local copy of the PR: \
`$ git checkout pull/5321` \
`$ git pull https://git.openjdk.java.net/jdk pull/5321/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5321`

View PR using the GUI difftool: \
`$ git pr show -t 5321`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5321.diff">https://git.openjdk.java.net/jdk/pull/5321.diff</a>

</details>
