### PR TITLE
8273217: Make ParHeapInspectTask _safepoint_check_never

### DIFF
--- a/src/hotspot/share/memory/heapInspection.cpp
+++ b/src/hotspot/share/memory/heapInspection.cpp
@@ -561,7 +561,7 @@ void ParHeapInspectTask::work(uint worker_id) {
   _poi->object_iterate(&ric, worker_id);
   missed_count = ric.missed_count();
   {
-    MutexLocker x(&_mutex);
+    MutexLocker x(&_mutex, Mutex::_no_safepoint_check_flag);
     merge_success = _shared_cit->merge(&cit);
   }
   if (merge_success) {

--- a/src/hotspot/share/memory/heapInspection.hpp
+++ b/src/hotspot/share/memory/heapInspection.hpp
@@ -245,7 +245,7 @@ class ParHeapInspectTask : public AbstractGangTask {
       _filter(filter),
       _missed_count(0),
       _success(true),
-      _mutex(Mutex::leaf, "Parallel heap iteration data merge lock", Mutex::_safepoint_check_always) {}
+      _mutex(Mutex::leaf, "ParHeapInspectTask_lock", Mutex::_safepoint_check_never) {}
 
   uintx missed_count() const {
     return _missed_count;


### PR DESCRIPTION
Make lock be declared as safepoint_check_never.
Ran tier1-3 tests and test that uses this code: serviceability/dcmd/gc/ClassHistogramTest.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273217](https://bugs.openjdk.java.net/browse/JDK-8273217): Make ParHeapInspectTask _safepoint_check_never


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Patricio Chilano Mateo](https://openjdk.java.net/census#pchilanomate) (@pchilano - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5323/head:pull/5323` \
`$ git checkout pull/5323`

Update a local copy of the PR: \
`$ git checkout pull/5323` \
`$ git pull https://git.openjdk.java.net/jdk pull/5323/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5323`

View PR using the GUI difftool: \
`$ git pr show -t 5323`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5323.diff">https://git.openjdk.java.net/jdk/pull/5323.diff</a>

</details>
