### PR TITLE
8273111: Default timezone should return zone ID if /etc/localtime is valid but not canonicalization on linux

### DIFF
--- a/src/java.base/unix/native/libjava/TimeZone_md.c
+++ b/src/java.base/unix/native/libjava/TimeZone_md.c
@@ -287,16 +287,17 @@ getPlatformTimeZoneID()
      * from /etc/localtime.)
      */
     if (S_ISLNK(statbuf.st_mode)) {
-        char linkbuf[PATH_MAX+1];
-        int len;
-
-        if ((len = readlink(DEFAULT_ZONEINFO_FILE, linkbuf, sizeof(linkbuf)-1)) == -1) {
-            jio_fprintf(stderr, (const char *) "can't get a symlink of %s\n",
-                        DEFAULT_ZONEINFO_FILE);
+        /* canonicalize the path */
+        char resolvedpath[PATH_MAX + 1];
+        char *path = realpath(DEFAULT_ZONEINFO_FILE, resolvedpath);
+        if (path == NULL) {
+            if (errno != ENOTDIR) {
+                jio_fprintf(stderr, (const char *) "can't to get a symlink of %s\n",
+                              DEFAULT_ZONEINFO_FILE);
+            }
             return NULL;
         }
-        linkbuf[len] = '\0';
-        tz = getZoneName(linkbuf);
+        tz = getZoneName(resolvedpath);
         if (tz != NULL) {
             tz = strdup(tz);
             return tz;


### PR DESCRIPTION
Hi,
Please help me review the change to enhance getting  time zone ID from /etc/localtime on linux.

We use `realpath` instead of `readlink` to obtain the link name of /etc/localtime, because `readlink` can only read the value of a symbolic of link, not the canonicalized absolute pathname.

For example, the value of /etc/localtime is "../usr/share/zoneinfo//Asia/Shanghai", then the linkbuf obtained by `readlink` is "../usr/share/zoneinfo//Asia/Shanghai", and then the call of `getZoneName(linkbuf)` will get "/Asia/Shanghai", not "Asia/Shanghai", which consider as invalid in `ZoneInfoFile.getZoneInfo()`. Using `realpath`, you can get “/usr/share/zoneinfo/Asia/Shanghai“ directly from “/etc/localtime“.

Thanks,
wuyan