### PR TITLE
8273261: Replace 'while' cycles with iterator with enhanced-for in java.base

### DIFF
--- a/src/java.base/share/classes/java/security/cert/X509CRLSelector.java
+++ b/src/java.base/share/classes/java/security/cert/X509CRLSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -314,9 +314,7 @@ public class X509CRLSelector implements CRLSelector {
         throws IOException
     {
         HashSet<Object> namesCopy = new HashSet<>();
-        Iterator<?> i = names.iterator();
-        while (i.hasNext()) {
-            Object nameObject = i.next();
+        for (Object nameObject : names) {
             if (!(nameObject instanceof byte []) &&
                 !(nameObject instanceof String))
                 throw new IOException("name not byte array or String");
@@ -573,9 +571,8 @@ public class X509CRLSelector implements CRLSelector {
         sb.append("X509CRLSelector: [\n");
         if (issuerNames != null) {
             sb.append("  IssuerNames:\n");
-            Iterator<Object> i = issuerNames.iterator();
-            while (i.hasNext())
-                sb.append("    " + i.next() + "\n");
+            for (Object issuerName : issuerNames)
+                sb.append("    " + issuerName + "\n");
         }
         if (minCRL != null)
             sb.append("  minCRLNumber: " + minCRL + "\n");

--- a/src/java.base/share/classes/java/security/cert/X509CertSelector.java
+++ b/src/java.base/share/classes/java/security/cert/X509CertSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1778,9 +1778,7 @@ public class X509CertSelector implements CertSelector {
                   + String.valueOf(matchAllSubjectAltNames) + "\n");
         if (subjectAlternativeNames != null) {
             sb.append("  SubjectAlternativeNames:\n");
-            Iterator<List<?>> i = subjectAlternativeNames.iterator();
-            while (i.hasNext()) {
-                List<?> list = i.next();
+            for (List<?> list : subjectAlternativeNames) {
                 sb.append("    type " + list.get(0) +
                           ", name " + list.get(1) + "\n");
             }
@@ -1823,9 +1821,8 @@ public class X509CertSelector implements CertSelector {
         }
         if (pathToGeneralNames != null) {
             sb.append("  Path to names:\n");
-            Iterator<GeneralNameInterface> i = pathToGeneralNames.iterator();
-            while (i.hasNext()) {
-                sb.append("    " + i.next() + "\n");
+            for (GeneralNameInterface pathToGeneralName : pathToGeneralNames) {
+                sb.append("    " + pathToGeneralName + "\n");
             }
         }
         sb.append("]");
@@ -2399,10 +2396,8 @@ public class X509CertSelector implements CertSelector {
             }
             if ((debug != null) && Debug.isOn("certpath")) {
                 debug.println("X509CertSelector.match pathToNames:\n");
-                Iterator<GeneralNameInterface> i =
-                                        pathToGeneralNames.iterator();
-                while (i.hasNext()) {
-                    debug.println("    " + i.next() + "\n");
+                for (GeneralNameInterface pathToGeneralName : pathToGeneralNames) {
+                    debug.println("    " + pathToGeneralName + "\n");
                 }
             }
 
@@ -2439,9 +2434,7 @@ public class X509CertSelector implements CertSelector {
         for (Iterator<GeneralSubtree> t = excluded.iterator(); t.hasNext(); ) {
             GeneralSubtree tree = t.next();
             GeneralNameInterface excludedName = tree.getName().getName();
-            Iterator<GeneralNameInterface> i = pathToGeneralNames.iterator();
-            while (i.hasNext()) {
-                GeneralNameInterface pathToName = i.next();
+            for (GeneralNameInterface pathToName : pathToGeneralNames) {
                 if (excludedName.getType() == pathToName.getType()) {
                     switch (pathToName.constrains(excludedName)) {
                     case GeneralNameInterface.NAME_WIDENS:
@@ -2468,9 +2461,7 @@ public class X509CertSelector implements CertSelector {
          * If not, return false. However, if no subtrees of a given type
          * are listed, all names of that type are permitted.
          */
-        Iterator<GeneralNameInterface> i = pathToGeneralNames.iterator();
-        while (i.hasNext()) {
-            GeneralNameInterface pathToName = i.next();
+        for (GeneralNameInterface pathToName : pathToGeneralNames) {
             Iterator<GeneralSubtree> t = permitted.iterator();
             boolean permittedNameFound = false;
             boolean nameTypeFound = false;

--- a/src/java.base/share/classes/java/text/AttributedString.java
+++ b/src/java.base/share/classes/java/text/AttributedString.java
@@ -158,9 +158,7 @@ public class AttributedString {
             runAttributes[0] = newRunAttributes;
             runAttributeValues[0] = newRunAttributeValues;
 
-            Iterator<? extends Map.Entry<? extends Attribute, ?>> iterator = attributes.entrySet().iterator();
-            while (iterator.hasNext()) {
-                Map.Entry<? extends Attribute, ?> entry = iterator.next();
+            for (Map.Entry<? extends Attribute, ?> entry : attributes.entrySet()) {
                 newRunAttributes.addElement(entry.getKey());
                 newRunAttributeValues.addElement(entry.getValue());
             }
@@ -264,9 +262,7 @@ public class AttributedString {
         // Get and set attribute runs for each attribute name. Need to
         // scan from the top of the text so that we can discard any
         // Annotation that is no longer applied to a subset text segment.
-        Iterator<Attribute> itr = keys.iterator();
-        while (itr.hasNext()) {
-            Attribute attributeKey = itr.next();
+        for (Attribute attributeKey : keys) {
             text.setIndex(textBeginIndex);
             while (text.getIndex() < endIndex) {
                 int start = text.getRunStart(attributeKey);
@@ -388,10 +384,7 @@ public class AttributedString {
         int beginRunIndex = ensureRunBreak(beginIndex);
         int endRunIndex = ensureRunBreak(endIndex);
 
-        Iterator<? extends Map.Entry<? extends Attribute, ?>> iterator =
-            attributes.entrySet().iterator();
-        while (iterator.hasNext()) {
-            Map.Entry<? extends Attribute, ?> entry = iterator.next();
+        for (Map.Entry<? extends Attribute, ?> entry : attributes.entrySet()) {
             addAttributeRunData(entry.getKey(), entry.getValue(), beginRunIndex, endRunIndex);
         }
     }
@@ -656,10 +649,8 @@ public class AttributedString {
 
     // returns whether all specified attributes have equal values in the runs with the given indices
     private boolean attributeValuesMatch(Set<? extends Attribute> attributes, int runIndex1, int runIndex2) {
-        Iterator<? extends Attribute> iterator = attributes.iterator();
-        while (iterator.hasNext()) {
-            Attribute key = iterator.next();
-           if (!valuesMatch(getAttribute(key, runIndex1), getAttribute(key, runIndex2))) {
+        for (Attribute key : attributes) {
+            if (!valuesMatch(getAttribute(key, runIndex1), getAttribute(key, runIndex2))) {
                 return false;
             }
         }
@@ -706,11 +697,8 @@ public class AttributedString {
         if (attrs != null && (size = attrs.size()) > 0) {
             Vector<Attribute> runAttrs = new Vector<>(size);
             Vector<Object> runValues = new Vector<>(size);
-            Iterator<Map.Entry<Attribute, Object>> iterator = attrs.entrySet().iterator();
 
-            while (iterator.hasNext()) {
-                Map.Entry<Attribute, Object> entry = iterator.next();
-
+            for (Map.Entry<Attribute, Object> entry : attrs.entrySet()) {
                 runAttrs.add(entry.getKey());
                 runValues.add(entry.getValue());
             }

--- a/src/java.base/share/classes/javax/security/auth/PrivateCredentialPermission.java
+++ b/src/java.base/share/classes/javax/security/auth/PrivateCredentialPermission.java
@@ -145,9 +145,7 @@ public final class PrivateCredentialPermission extends Permission {
             } else {
                 this.credOwners = new CredOwner[principals.size()];
                 int index = 0;
-                Iterator<Principal> i = principals.iterator();
-                while (i.hasNext()) {
-                    Principal p = i.next();
+                for (Principal p : principals) {
                     this.credOwners[index++] = new CredOwner
                                                 (p.getClass().getName(),
                                                 p.getName());

--- a/src/java.base/share/classes/javax/security/auth/Subject.java
+++ b/src/java.base/share/classes/javax/security/auth/Subject.java
@@ -886,18 +886,14 @@ public final class Subject implements java.io.Serializable {
         String suffix = "";
 
         synchronized(principals) {
-            Iterator<Principal> pI = principals.iterator();
-            while (pI.hasNext()) {
-                Principal p = pI.next();
+            for (Principal p : principals) {
                 suffix = suffix + ResourcesMgr.getString(".Principal.") +
                         p.toString() + ResourcesMgr.getString("NEWLINE");
             }
         }
 
         synchronized(pubCredentials) {
-            Iterator<Object> pI = pubCredentials.iterator();
-            while (pI.hasNext()) {
-                Object o = pI.next();
+            for (Object o : pubCredentials) {
                 suffix = suffix +
                         ResourcesMgr.getString(".Public.Credential.") +
                         o.toString() + ResourcesMgr.getString("NEWLINE");
@@ -951,17 +947,14 @@ public final class Subject implements java.io.Serializable {
         int hashCode = 0;
 
         synchronized(principals) {
-            Iterator<Principal> pIterator = principals.iterator();
-            while (pIterator.hasNext()) {
-                Principal p = pIterator.next();
+            for (Principal p : principals) {
                 hashCode ^= p.hashCode();
             }
         }
 
         synchronized(pubCredentials) {
-            Iterator<Object> pubCIterator = pubCredentials.iterator();
-            while (pubCIterator.hasNext()) {
-                hashCode ^= getCredHashCode(pubCIterator.next());
+            for (Object pubCredential : pubCredentials) {
+                hashCode ^= getCredHashCode(pubCredential);
             }
         }
         return hashCode;
@@ -1308,13 +1301,12 @@ public final class Subject implements java.io.Serializable {
                     });
                 }
 
-                Iterator<?> ce = c.iterator();
-                while (ce.hasNext()) {
-                    if (next.equals(ce.next())) {
-                            e.remove();
-                            modified = true;
-                            break;
-                        }
+                for (Object o : c) {
+                    if (next.equals(o)) {
+                        e.remove();
+                        modified = true;
+                        break;
+                    }
                 }
             }
             return modified;

--- a/src/java.base/share/classes/jdk/internal/util/jar/JarIndex.java
+++ b/src/java.base/share/classes/jdk/internal/util/jar/JarIndex.java
@@ -263,9 +263,8 @@ public class JarIndex {
                 bw.write(jar + "\n");
                 List<String> jarlist = jarMap.get(jar);
                 if (jarlist != null) {
-                    Iterator<String> listitr = jarlist.iterator();
-                    while(listitr.hasNext()) {
-                        bw.write(listitr.next() + "\n");
+                    for (String s : jarlist) {
+                        bw.write(s + "\n");
                     }
                 }
                 bw.write("\n");
@@ -320,14 +319,10 @@ public class JarIndex {
      *
      */
     public void merge(JarIndex toIndex, String path) {
-        Iterator<Map.Entry<String, List<String>>> itr = indexMap.entrySet().iterator();
-        while(itr.hasNext()) {
-            Map.Entry<String, List<String>> e = itr.next();
+        for (Map.Entry<String, List<String>> e : indexMap.entrySet()) {
             String packageName = e.getKey();
             List<String> from_list = e.getValue();
-            Iterator<String> listItr = from_list.iterator();
-            while(listItr.hasNext()) {
-                String jarName = listItr.next();
+            for (String jarName : from_list) {
                 if (path != null) {
                     jarName = path.concat(jarName);
                 }

--- a/src/java.base/share/classes/sun/net/www/protocol/ftp/FtpURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/ftp/FtpURLConnection.java
@@ -46,7 +46,6 @@ import java.net.Proxy;
 import java.net.ProxySelector;
 import java.util.List;
 import java.util.StringTokenizer;
-import java.util.Iterator;
 import java.security.Permission;
 import java.util.Properties;
 import sun.net.NetworkClient;
@@ -250,9 +249,8 @@ public class FtpURLConnection extends URLConnection {
                 } catch (IllegalArgumentException iae) {
                     throw new IOException("Failed to select a proxy", iae);
                 }
-                final Iterator<Proxy> it = proxies.iterator();
-                while (it.hasNext()) {
-                    p = it.next();
+                for (Proxy proxy : proxies) {
+                    p = proxy;
                     if (p == null || p == Proxy.NO_PROXY ||
                         p.type() == Proxy.Type.SOCKS) {
                         break;

--- a/src/java.base/share/classes/sun/net/www/protocol/http/AuthCacheImpl.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/AuthCacheImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,9 +79,8 @@ public class AuthCacheImpl implements AuthCache {
             // list should contain only one element
             return (AuthenticationInfo)list.get (0);
         }
-        ListIterator<AuthCacheValue> iter = list.listIterator();
-        while (iter.hasNext()) {
-            AuthenticationInfo inf = (AuthenticationInfo)iter.next();
+        for (AuthCacheValue authCacheValue : list) {
+            AuthenticationInfo inf = (AuthenticationInfo) authCacheValue;
             if (skey.startsWith (inf.path)) {
                 return inf;
             }

--- a/src/java.base/share/classes/sun/security/provider/SubjectCodeSource.java
+++ b/src/java.base/share/classes/sun/security/provider/SubjectCodeSource.java
@@ -384,9 +384,7 @@ class SubjectCodeSource extends CodeSource implements java.io.Serializable {
             }
         }
         if (principals != null) {
-            ListIterator<PrincipalEntry> li = principals.listIterator();
-            while (li.hasNext()) {
-                PrincipalEntry pppe = li.next();
+            for (PrincipalEntry pppe : principals) {
                 returnMe = returnMe + ResourcesMgr.getAuthResourceString("NEWLINE") +
                         pppe.getPrincipalClass() + " " +
                         pppe.getPrincipalName();

--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -1489,9 +1489,7 @@ public final class Main {
         info.set(X509CertInfo.SUBJECT,
                     dname==null?req.getSubjectName():new X500Name(dname));
         CertificateExtensions reqex = null;
-        Iterator<PKCS10Attribute> attrs = req.getAttributes().getAttributes().iterator();
-        while (attrs.hasNext()) {
-            PKCS10Attribute attr = attrs.next();
+        for (PKCS10Attribute attr : req.getAttributes().getAttributes()) {
             if (attr.getAttributeId().equals(PKCS9Attribute.EXTENSION_REQUEST_OID)) {
                 reqex = (CertificateExtensions)attr.getAttributeValue();
             }

--- a/src/java.base/share/classes/sun/security/x509/PolicyInformation.java
+++ b/src/java.base/share/classes/sun/security/x509/PolicyInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.security.cert.PolicyQualifierInfo;
 import java.util.Collections;
 import java.util.Enumeration;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -201,9 +200,7 @@ public class PolicyInformation {
                     "PolicyQualifierInfo can be set.");
             }
             if (obj instanceof Set) {
-                Iterator<?> i = ((Set<?>)obj).iterator();
-                while (i.hasNext()) {
-                    Object obj1 = i.next();
+                for (Object obj1 : (Set<?>) obj) {
                     if (!(obj1 instanceof PolicyQualifierInfo)) {
                         throw new IOException("Attribute value must be a" +
                                     "Set of PolicyQualifierInfo objects.");


### PR DESCRIPTION
There are few places in code where manual while loop is used with Iterator to iterate over Collection.
Instead of manual while cycles it's preferred to use enhanced-for cycle instead: it's less verbose, makes code easier to read and it's less error-prone.
It doesn't have any performance impact: java compiler generates similar code when compiling enhanced-for cycle.

Similar cleanups:
* https://bugs.openjdk.java.net/browse/JDK-8258006
* https://bugs.openjdk.java.net/browse/JDK-8257912

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273261](https://bugs.openjdk.java.net/browse/JDK-8273261): Replace 'while' cycles with iterator with enhanced-for in java.base


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5328/head:pull/5328` \
`$ git checkout pull/5328`

Update a local copy of the PR: \
`$ git checkout pull/5328` \
`$ git pull https://git.openjdk.java.net/jdk pull/5328/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5328`

View PR using the GUI difftool: \
`$ git pr show -t 5328`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5328.diff">https://git.openjdk.java.net/jdk/pull/5328.diff</a>

</details>
