### PR TITLE
8273221: Guard GCIdMark against nested calls

### DIFF
--- a/src/hotspot/share/gc/shared/gcId.cpp
+++ b/src/hotspot/share/gc/shared/gcId.cpp
@@ -67,14 +67,16 @@ size_t GCId::print_prefix(char* buf, size_t len) {
   return 0;
 }
 
-GCIdMark::GCIdMark() : _previous_gc_id(currentNamedthread()->gc_id()) {
+GCIdMark::GCIdMark() {
+  assert(currentNamedthread()->gc_id() == GCId::undefined(), "nested");
   currentNamedthread()->set_gc_id(GCId::create());
 }
 
-GCIdMark::GCIdMark(uint gc_id) : _previous_gc_id(currentNamedthread()->gc_id()) {
+GCIdMark::GCIdMark(uint gc_id) {
+  assert(currentNamedthread()->gc_id() == GCId::undefined(), "nested");
   currentNamedthread()->set_gc_id(gc_id);
 }
 
 GCIdMark::~GCIdMark() {
-  currentNamedthread()->set_gc_id(_previous_gc_id);
+  currentNamedthread()->set_gc_id(GCId::undefined());
 }

--- a/src/hotspot/share/gc/shared/gcId.hpp
+++ b/src/hotspot/share/gc/shared/gcId.hpp
@@ -47,9 +47,6 @@ public:
 };
 
 class GCIdMark : public StackObj {
-private:
-  const uint _previous_gc_id;
-
 public:
   GCIdMark();
   GCIdMark(uint gc_id);


### PR DESCRIPTION
Simple change of forbidding nested GC ids.

Test: tier1-6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273221](https://bugs.openjdk.java.net/browse/JDK-8273221): Guard GCIdMark against nested calls


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5329/head:pull/5329` \
`$ git checkout pull/5329`

Update a local copy of the PR: \
`$ git checkout pull/5329` \
`$ git pull https://git.openjdk.java.net/jdk pull/5329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5329`

View PR using the GUI difftool: \
`$ git pr show -t 5329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5329.diff">https://git.openjdk.java.net/jdk/pull/5329.diff</a>

</details>
