### PR TITLE
8273165: GraphKit::combine_exception_states fails with "matching stack sizes" assert

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -516,8 +516,7 @@ bool LateInlineVirtualCallGenerator::do_late_inline_check(Compile* C, JVMState* 
   // Implicit receiver null checks introduce problems when exception states are combined.
   Node* receiver = jvms->map()->argument(jvms, 0);
   const Type* recv_type = C->initial_gvn()->type(receiver);
-  bool recv_can_be_null = TypePtr::NULL_PTR->higher_equal(recv_type);
-  if (recv_can_be_null) {
+  if (recv_type->maybe_null()) {
     return false;
   }
   // Even if inlining is not allowed, a virtual call can be strength-reduced to a direct call.

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -513,6 +513,13 @@ bool LateInlineVirtualCallGenerator::do_late_inline_check(Compile* C, JVMState* 
   // Method handle linker case is handled in CallDynamicJavaNode::Ideal().
   // Unless inlining is performed, _override_symbolic_info bit will be set in DirectCallGenerator::generate().
 
+  // Implicit receiver null checks introduce problems when exception states are combined.
+  Node* receiver = jvms->map()->argument(jvms, 0);
+  const Type* recv_type = C->initial_gvn()->type(receiver);
+  bool recv_can_be_null = TypePtr::NULL_PTR->higher_equal(recv_type);
+  if (recv_can_be_null) {
+    return false;
+  }
   // Even if inlining is not allowed, a virtual call can be strength-reduced to a direct call.
   bool allow_inline = C->inlining_incrementally();
   if (!allow_inline && _callee->holder()->is_interface()) {


### PR DESCRIPTION
The fix for JDK-8271276 uncovered another problem with incremental inlining through 
virtual call sites: receiver null check breaks exception state combining in `GraphKit::replace_call()`
because the associtated exception path has the JVM state representing the point
right before the call (arguments are on stack).

I propose a conservative fix which bails out the inlining attempt when receiver is not provably non-null.

IMO the proper fix is to always add explicit receiver null check and teach
`Block::implicit_null_check()` about CallDynamicJava nodes. But that's for a
separate change.

Testing: failing tests, hs-tier1 - hs-tier4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273165](https://bugs.openjdk.java.net/browse/JDK-8273165): GraphKit::combine_exception_states fails with "matching stack sizes" assert


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5330/head:pull/5330` \
`$ git checkout pull/5330`

Update a local copy of the PR: \
`$ git checkout pull/5330` \
`$ git pull https://git.openjdk.java.net/jdk pull/5330/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5330`

View PR using the GUI difftool: \
`$ git pr show -t 5330`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5330.diff">https://git.openjdk.java.net/jdk/pull/5330.diff</a>

</details>
