### PR TITLE
8273278: Support XSLT on GraalVM Native Image--deterministic bytecode generation in XSLT

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/LiteralElement.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/LiteralElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -33,6 +33,7 @@ import com.sun.org.apache.xml.internal.serializer.ElemDesc;
 import com.sun.org.apache.xml.internal.serializer.ToHTMLStream;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
@@ -42,7 +43,7 @@ import java.util.Set;
  * @author Jacek Ambroziak
  * @author Santiago Pericas-Geertsen
  * @author Morten Jorgensen
- * @LastModified: Oct 2017
+ * @LastModified: Sep 2021
  */
 final class LiteralElement extends Instruction {
 
@@ -202,7 +203,7 @@ final class LiteralElement extends Instruction {
      * to _ANY_ namespace URI. Used by literal result elements to determine
      */
     public Set<Map.Entry<String, String>> getNamespaceScope(SyntaxTreeNode node) {
-        Map<String, String> all = new HashMap<>();
+        Map<String, String> all = new LinkedHashMap<>();
 
         while (node != null) {
             Map<String, String> mapping = node.getPrefixMapping();

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/Mode.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/Mode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -48,6 +48,7 @@ import com.sun.org.apache.xml.internal.dtm.Axis;
 import com.sun.org.apache.xml.internal.dtm.DTM;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -62,7 +63,7 @@ import java.util.Set;
  * @author Morten Jorgensen
  * @author Erwin Bolwidt <ejb@klomp.org>
  * @author G. Todd Miller
- * @LastModified: Nov 2017
+ * @LastModified: Sep 2021
  */
 final class Mode implements Constants {
 
@@ -129,13 +130,15 @@ final class Mode implements Constants {
 
     /**
      * A mapping between templates and test sequences.
+     * {@link LinkedHashMap} is necessary to make traversal order consistent across runs.
      */
-    private Map<Template, Object> _neededTemplates = new HashMap<>();
+    private Map<Template, Object> _neededTemplates = new LinkedHashMap<>();
 
     /**
      * A mapping between named templates and Mode objects.
+     * {@link LinkedHashMap} is necessary to make traversal order consistent across runs.
      */
-    private Map<Template, Mode> _namedTemplates = new HashMap<>();
+    private Map<Template, Mode> _namedTemplates = new LinkedHashMap<>();
 
     /**
      * A mapping between templates and instruction handles.
@@ -198,7 +201,7 @@ final class Mode implements Constants {
 
     public String functionName(int min, int max) {
         if (_importLevels == null) {
-            _importLevels = new HashMap<>();
+            _importLevels = new LinkedHashMap<>();
         }
         _importLevels.put(max, min);
         return _methodName + '_' + max;
@@ -1053,8 +1056,8 @@ final class Mode implements Constants {
         final List<String> names = xsltc.getNamesIndex();
 
         // Clear some datastructures
-        _namedTemplates = new HashMap<>();
-        _neededTemplates = new HashMap<>();
+        _namedTemplates = new LinkedHashMap<>();
+        _neededTemplates = new LinkedHashMap<>();
         _templateIHs = new HashMap<>();
         _templateILs = new HashMap<>();
         _patternGroups = (List<LocationPathPattern>[])new ArrayList[32];

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/Number.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/Number.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -53,7 +53,7 @@ import java.util.List;
 /**
  * @author Jacek Ambroziak
  * @author Santiago Pericas-Geertsen
- * @LastModified: Nov 2017
+ * @LastModified: Sep 2021
  */
 final class Number extends Instruction implements Closure {
     private static final int LEVEL_SINGLE   = 0;
@@ -383,7 +383,7 @@ final class Number extends Instruction implements Closure {
         _className = getXSLTC().getHelperClassName();
         nodeCounterGen = new NodeCounterGenerator(_className,
                                                   ClassNames[_level],
-                                                  toString(),
+                                                  getClass().getName(), // Name of this node should be consistent across runs.
                                                   ACC_PUBLIC | ACC_SUPER,
                                                   null,
                                                   classGen.getStylesheet());

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/MethodGenerator.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/MethodGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -67,6 +67,7 @@ import com.sun.org.apache.xalan.internal.xsltc.compiler.XSLTC;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -75,7 +76,7 @@ import java.util.Stack;
 /**
  * @author Jacek Ambroziak
  * @author Santiago Pericas-Geertsen
- * @LastModified: July 2019
+ * @LastModified: Sep 2021
  */
 public class MethodGenerator extends MethodGen
     implements com.sun.org.apache.xalan.internal.xsltc.compiler.Constants {
@@ -283,7 +284,7 @@ public class MethodGenerator extends MethodGen
         /**
          * Maps a name to a {@link LocalVariableGen}
          */
-        protected Map<String, Object> _nameToLVGMap = new HashMap<>();
+        protected Map<String, Object> _nameToLVGMap = new LinkedHashMap<>();
 
         /**
          * Registers a {@link org.apache.bcel.generic.LocalVariableGen}
@@ -1330,8 +1331,8 @@ public class MethodGenerator extends MethodGen
         // to local variables in the outlined method.
         HashMap<LocalVariableGen, LocalVariableGen> localVarMap = new HashMap<>();
 
-        HashMap<LocalVariableGen, InstructionHandle> revisedLocalVarStart = new HashMap<>();
-        HashMap<LocalVariableGen, InstructionHandle> revisedLocalVarEnd = new HashMap<>();
+        HashMap<LocalVariableGen, InstructionHandle> revisedLocalVarStart = new LinkedHashMap<>();
+        HashMap<LocalVariableGen, InstructionHandle> revisedLocalVarEnd = new LinkedHashMap<>();
 
         // Pass 1: Make copies of all instructions, append them to the new list
         // and associate old instruction references with the new ones, i.e.,


### PR DESCRIPTION
GraalVM Native Image supports loading classes at runtime if they are known during image build (class predefinition). This is achieved by the JVMTI agent that registers dynamically generated classes in a regular HotSpot run. The Native Image build uses these registered classes to embed them into the produced binary so they can be loaded at runtime. Loading at runtime is achieved by matching the unique hash of generated classes.

If the generated bytecode is unstable across runs, the generated native image can not match the hash of the runtime-generated bytecode to the pre-defined classes. The execution failure happens here:
 https://github.com/oracle/graal/blob/master/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/hub/PredefinedClassesSupport.java#L127-L131.

In XSLT the produced bytecode is unstable for the following reasons:

- Methods like ` HashMap#values` and `HashMap#keySet` result in different traversal orders of its elements yielding a different order of methods and fields.

- The default `Object#toString` includes the current memory reference of `com.sun.org.apache.xalan.internal.xsltc.compiler.Number` in the generated class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273278](https://bugs.openjdk.java.net/browse/JDK-8273278): Support XSLT on GraalVM Native Image--deterministic bytecode generation in XSLT


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5331/head:pull/5331` \
`$ git checkout pull/5331`

Update a local copy of the PR: \
`$ git checkout pull/5331` \
`$ git pull https://git.openjdk.java.net/jdk pull/5331/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5331`

View PR using the GUI difftool: \
`$ git pr show -t 5331`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5331.diff">https://git.openjdk.java.net/jdk/pull/5331.diff</a>

</details>
