### PR TITLE
8273239: Standardize Ticks APIs return type

### DIFF
--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -561,7 +561,7 @@ class G1RemSetSamplingTask : public G1ServiceTask {
   // 0 is returned.
   jlong reschedule_delay_ms() {
     Tickspan since_last_gc = G1CollectedHeap::heap()->time_since_last_collection();
-    jlong delay = (jlong) (G1ConcRefinementServiceIntervalMillis - (uintx)since_last_gc.milliseconds());
+    jlong delay = (jlong) (G1ConcRefinementServiceIntervalMillis - since_last_gc.milliseconds());
     return MAX2<jlong>(0L, delay);
   }
 

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -561,7 +561,7 @@ class G1RemSetSamplingTask : public G1ServiceTask {
   // 0 is returned.
   jlong reschedule_delay_ms() {
     Tickspan since_last_gc = G1CollectedHeap::heap()->time_since_last_collection();
-    jlong delay = (jlong) (G1ConcRefinementServiceIntervalMillis - since_last_gc.milliseconds());
+    jlong delay = (jlong) (G1ConcRefinementServiceIntervalMillis - (uintx)since_last_gc.milliseconds());
     return MAX2<jlong>(0L, delay);
   }
 

--- a/src/hotspot/share/jfr/periodic/jfrThreadCPULoadEvent.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrThreadCPULoadEvent.cpp
@@ -132,7 +132,7 @@ void JfrThreadCPULoadEvent::send_events() {
     }
   }
   log_trace(jfr)("Measured CPU usage for %d threads in %.3f milliseconds", number_of_threads,
-    (double)(JfrTicks::now() - event_time).milliseconds());
+    (JfrTicks::now() - event_time).milliseconds());
   // Restore this thread's thread id
   periodic_thread_tl->set_thread_id(periodic_thread_id);
 }

--- a/src/hotspot/share/jfr/periodic/jfrThreadCPULoadEvent.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrThreadCPULoadEvent.cpp
@@ -132,7 +132,7 @@ void JfrThreadCPULoadEvent::send_events() {
     }
   }
   log_trace(jfr)("Measured CPU usage for %d threads in %.3f milliseconds", number_of_threads,
-    (JfrTicks::now() - event_time).milliseconds());
+    (JfrTicks::now() - event_time).milliseconds<double>());
   // Restore this thread's thread id
   periodic_thread_tl->set_thread_id(periodic_thread_id);
 }

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -275,6 +275,7 @@ const int NANOUNITS_PER_MILLIUNIT = NANOUNITS / MILLIUNITS;
 
 const jlong NANOSECS_PER_SEC      = CONST64(1000000000);
 const jint  NANOSECS_PER_MILLISEC = 1000000;
+const jint  NANOSECS_PER_MICROSEC = 1000;
 
 
 // Unit conversion functions

--- a/src/hotspot/share/utilities/spinYield.cpp
+++ b/src/hotspot/share/utilities/spinYield.cpp
@@ -66,7 +66,7 @@ void SpinYield::report(outputStream* s) const {
   if (_sleep_time.value() != 0) { // Report sleep duration, if slept.
     separator = print_separator(s, separator);
     s->print("sleep = " UINT64_FORMAT " usecs",
-             _sleep_time.milliseconds());
+             (uint64_t)_sleep_time.microseconds());
   }
   if (separator == initial_separator) {
     s->print("no waiting");

--- a/src/hotspot/share/utilities/spinYield.cpp
+++ b/src/hotspot/share/utilities/spinYield.cpp
@@ -66,7 +66,7 @@ void SpinYield::report(outputStream* s) const {
   if (_sleep_time.value() != 0) { // Report sleep duration, if slept.
     separator = print_separator(s, separator);
     s->print("sleep = " UINT64_FORMAT " usecs",
-             (uint64_t)_sleep_time.microseconds());
+             _sleep_time.microseconds());
   }
   if (separator == initial_separator) {
     s->print("no waiting");

--- a/src/hotspot/share/utilities/ticks.cpp
+++ b/src/hotspot/share/utilities/ticks.cpp
@@ -32,11 +32,6 @@
 
 #include OS_CPU_HEADER(os)
 
-template <typename TimeSource, const int unit>
-inline double conversion(typename TimeSource::Type& value) {
-  return (double)value * ((double)unit / (double)TimeSource::frequency());
-}
-
 uint64_t ElapsedCounterSource::frequency() {
   static const uint64_t freq = (uint64_t)os::elapsed_frequency();
   return freq;
@@ -44,22 +39,6 @@ uint64_t ElapsedCounterSource::frequency() {
 
 ElapsedCounterSource::Type ElapsedCounterSource::now() {
   return os::elapsed_counter();
-}
-
-double ElapsedCounterSource::seconds(Type value) {
-  return conversion<ElapsedCounterSource, 1>(value);
-}
-
-double ElapsedCounterSource::milliseconds(Type value) {
-  return conversion<ElapsedCounterSource, MILLIUNITS>(value);
-}
-
-double ElapsedCounterSource::microseconds(Type value) {
-  return conversion<ElapsedCounterSource, MICROUNITS>(value);
-}
-
-double ElapsedCounterSource::nanoseconds(Type value) {
-  return conversion<ElapsedCounterSource, NANOUNITS>(value);
 }
 
 uint64_t FastUnorderedElapsedCounterSource::frequency() {
@@ -84,22 +63,6 @@ FastUnorderedElapsedCounterSource::Type FastUnorderedElapsedCounterSource::now()
   return os::elapsed_counter();
 }
 
-double FastUnorderedElapsedCounterSource::seconds(Type value) {
-  return conversion<FastUnorderedElapsedCounterSource, 1>(value);
-}
-
-double FastUnorderedElapsedCounterSource::milliseconds(Type value) {
-  return conversion<FastUnorderedElapsedCounterSource, MILLIUNITS>(value);
-}
-
-double FastUnorderedElapsedCounterSource::microseconds(Type value) {
-  return conversion<FastUnorderedElapsedCounterSource, MICROUNITS>(value);
-}
-
-double FastUnorderedElapsedCounterSource::nanoseconds(Type value) {
-  return conversion<FastUnorderedElapsedCounterSource, NANOUNITS>(value);
-}
-
 uint64_t CompositeElapsedCounterSource::frequency() {
   return ElapsedCounterSource::frequency();
 }
@@ -119,20 +82,4 @@ CompositeElapsedCounterSource::Type CompositeElapsedCounterSource::now() {
   }
 #endif
   return ct;
-}
-
-double CompositeElapsedCounterSource::seconds(Type value) {
-  return conversion<ElapsedCounterSource, 1>(value.val1);
-}
-
-double CompositeElapsedCounterSource::milliseconds(Type value) {
-  return conversion<ElapsedCounterSource, MILLIUNITS>(value.val1);
-}
-
-double CompositeElapsedCounterSource::microseconds(Type value) {
-  return conversion<ElapsedCounterSource, MICROUNITS>(value.val1);
-}
-
-double CompositeElapsedCounterSource::nanoseconds(Type value) {
-  return conversion<ElapsedCounterSource, NANOUNITS>(value.val1);
 }

--- a/src/hotspot/share/utilities/ticks.cpp
+++ b/src/hotspot/share/utilities/ticks.cpp
@@ -50,16 +50,16 @@ double ElapsedCounterSource::seconds(Type value) {
   return conversion<ElapsedCounterSource, 1>(value);
 }
 
-uint64_t ElapsedCounterSource::milliseconds(Type value) {
-  return (uint64_t)conversion<ElapsedCounterSource, MILLIUNITS>(value);
+double ElapsedCounterSource::milliseconds(Type value) {
+  return conversion<ElapsedCounterSource, MILLIUNITS>(value);
 }
 
-uint64_t ElapsedCounterSource::microseconds(Type value) {
-  return (uint64_t)conversion<ElapsedCounterSource, MICROUNITS>(value);
+double ElapsedCounterSource::microseconds(Type value) {
+  return conversion<ElapsedCounterSource, MICROUNITS>(value);
 }
 
-uint64_t ElapsedCounterSource::nanoseconds(Type value) {
-  return (uint64_t)conversion<ElapsedCounterSource, NANOUNITS>(value);
+double ElapsedCounterSource::nanoseconds(Type value) {
+  return conversion<ElapsedCounterSource, NANOUNITS>(value);
 }
 
 uint64_t FastUnorderedElapsedCounterSource::frequency() {
@@ -88,16 +88,16 @@ double FastUnorderedElapsedCounterSource::seconds(Type value) {
   return conversion<FastUnorderedElapsedCounterSource, 1>(value);
 }
 
-uint64_t FastUnorderedElapsedCounterSource::milliseconds(Type value) {
-  return (uint64_t)conversion<FastUnorderedElapsedCounterSource, MILLIUNITS>(value);
+double FastUnorderedElapsedCounterSource::milliseconds(Type value) {
+  return conversion<FastUnorderedElapsedCounterSource, MILLIUNITS>(value);
 }
 
-uint64_t FastUnorderedElapsedCounterSource::microseconds(Type value) {
-  return (uint64_t)conversion<FastUnorderedElapsedCounterSource, MICROUNITS>(value);
+double FastUnorderedElapsedCounterSource::microseconds(Type value) {
+  return conversion<FastUnorderedElapsedCounterSource, MICROUNITS>(value);
 }
 
-uint64_t FastUnorderedElapsedCounterSource::nanoseconds(Type value) {
-  return (uint64_t)conversion<FastUnorderedElapsedCounterSource, NANOUNITS>(value);
+double FastUnorderedElapsedCounterSource::nanoseconds(Type value) {
+  return conversion<FastUnorderedElapsedCounterSource, NANOUNITS>(value);
 }
 
 uint64_t CompositeElapsedCounterSource::frequency() {
@@ -125,14 +125,14 @@ double CompositeElapsedCounterSource::seconds(Type value) {
   return conversion<ElapsedCounterSource, 1>(value.val1);
 }
 
-uint64_t CompositeElapsedCounterSource::milliseconds(Type value) {
-  return (uint64_t)conversion<ElapsedCounterSource, MILLIUNITS>(value.val1);
+double CompositeElapsedCounterSource::milliseconds(Type value) {
+  return conversion<ElapsedCounterSource, MILLIUNITS>(value.val1);
 }
 
-uint64_t CompositeElapsedCounterSource::microseconds(Type value) {
-  return (uint64_t)conversion<ElapsedCounterSource, MICROUNITS>(value.val1);
+double CompositeElapsedCounterSource::microseconds(Type value) {
+  return conversion<ElapsedCounterSource, MICROUNITS>(value.val1);
 }
 
-uint64_t CompositeElapsedCounterSource::nanoseconds(Type value) {
-  return (uint64_t)conversion<ElapsedCounterSource, NANOUNITS>(value.val1);
+double CompositeElapsedCounterSource::nanoseconds(Type value) {
+  return conversion<ElapsedCounterSource, NANOUNITS>(value.val1);
 }

--- a/src/hotspot/share/utilities/ticks.hpp
+++ b/src/hotspot/share/utilities/ticks.hpp
@@ -36,9 +36,9 @@ class ElapsedCounterSource {
   static uint64_t frequency();
   static Type now();
   static double seconds(Type value);
-  static uint64_t milliseconds(Type value);
-  static uint64_t microseconds(Type value);
-  static uint64_t nanoseconds(Type value);
+  static double milliseconds(Type value);
+  static double microseconds(Type value);
+  static double nanoseconds(Type value);
 };
 
 // Not guaranteed to be synchronized across hardware threads and
@@ -52,9 +52,9 @@ class FastUnorderedElapsedCounterSource {
   static uint64_t frequency();
   static Type now();
   static double seconds(Type value);
-  static uint64_t milliseconds(Type value);
-  static uint64_t microseconds(Type value);
-  static uint64_t nanoseconds(Type value);
+  static double milliseconds(Type value);
+  static double microseconds(Type value);
+  static double nanoseconds(Type value);
 };
 
 template <typename T1, typename T2>
@@ -101,9 +101,9 @@ class CompositeElapsedCounterSource {
   static uint64_t frequency();
   static Type now();
   static double seconds(Type value);
-  static uint64_t milliseconds(Type value);
-  static uint64_t microseconds(Type value);
-  static uint64_t nanoseconds(Type value);
+  static double milliseconds(Type value);
+  static double microseconds(Type value);
+  static double nanoseconds(Type value);
 };
 
 template <typename TimeSource>
@@ -142,13 +142,13 @@ class Representation {
   double seconds() const {
     return TimeSource::seconds(_rep);
   }
-  uint64_t milliseconds() const {
+  double milliseconds() const {
     return TimeSource::milliseconds(_rep);
   }
-  uint64_t microseconds() const {
+  double microseconds() const {
     return TimeSource::microseconds(_rep);
   }
-  uint64_t nanoseconds() const {
+  double nanoseconds() const {
     return TimeSource::nanoseconds(_rep);
   }
 };

--- a/test/hotspot/gtest/jfr/test_networkUtilization.cpp
+++ b/test/hotspot/gtest/jfr/test_networkUtilization.cpp
@@ -56,8 +56,9 @@ namespace {
     static Type now() {
       return current_ticks;
     }
-    static uint64_t nanoseconds(Type value) {
-      return value;
+    template<typename T>
+    static T nanoseconds(Type value) {
+      return (T)value;
     }
   };
 


### PR DESCRIPTION
Simple change on return types of Ticks API.

The call of `milliseconds()` in `spinYield.cpp` seems a bug to me, because the unit in the message is `usecs`. Therefore, I changed it to `microseconds()`.

Test: tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273239](https://bugs.openjdk.java.net/browse/JDK-8273239): Standardize Ticks APIs return type


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5332/head:pull/5332` \
`$ git checkout pull/5332`

Update a local copy of the PR: \
`$ git checkout pull/5332` \
`$ git pull https://git.openjdk.java.net/jdk pull/5332/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5332`

View PR using the GUI difftool: \
`$ git pr show -t 5332`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5332.diff">https://git.openjdk.java.net/jdk/pull/5332.diff</a>

</details>
