### PR TITLE
8273243: Fix indentations in java.net.InetAddress methods

### DIFF
--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -686,7 +686,7 @@ public class InetAddress implements java.io.Serializable {
                 }
             }
 
-            //XXX: if it looks a spoof just return the address?
+            //XXX: if it looks like a spoof just return the address?
             if (!ok) {
                 host = addr.getHostAddress();
                 return host;

--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -657,46 +657,46 @@ public class InetAddress implements java.io.Serializable {
      */
     private static String getHostFromNameService(InetAddress addr, boolean check) {
         String host = null;
-            try {
-                // first lookup the hostname
-                host = nameService.getHostByAddr(addr.getAddress());
+        try {
+            // first lookup the hostname
+            host = nameService.getHostByAddr(addr.getAddress());
 
-                /* check to see if calling code is allowed to know
-                 * the hostname for this IP address, ie, connect to the host
-                 */
-                if (check) {
-                    @SuppressWarnings("removal")
-                    SecurityManager sec = System.getSecurityManager();
-                    if (sec != null) {
-                        sec.checkConnect(host, -1);
-                    }
+            /* check to see if calling code is allowed to know
+             * the hostname for this IP address, ie, connect to the host
+             */
+            if (check) {
+                @SuppressWarnings("removal")
+                SecurityManager sec = System.getSecurityManager();
+                if (sec != null) {
+                    sec.checkConnect(host, -1);
                 }
-
-                /* now get all the IP addresses for this hostname,
-                 * and make sure one of them matches the original IP
-                 * address. We do this to try and prevent spoofing.
-                 */
-
-                InetAddress[] arr = InetAddress.getAllByName0(host, check);
-                boolean ok = false;
-
-                if(arr != null) {
-                    for(int i = 0; !ok && i < arr.length; i++) {
-                        ok = addr.equals(arr[i]);
-                    }
-                }
-
-                //XXX: if it looks a spoof just return the address?
-                if (!ok) {
-                    host = addr.getHostAddress();
-                    return host;
-                }
-            } catch (SecurityException e) {
-                host = addr.getHostAddress();
-            } catch (UnknownHostException e) {
-                host = addr.getHostAddress();
-                // let next provider resolve the hostname
             }
+
+            /* now get all the IP addresses for this hostname,
+             * and make sure one of them matches the original IP
+             * address. We do this to try and prevent spoofing.
+             */
+
+            InetAddress[] arr = InetAddress.getAllByName0(host, check);
+            boolean ok = false;
+
+            if (arr != null) {
+                for (int i = 0; !ok && i < arr.length; i++) {
+                    ok = addr.equals(arr[i]);
+                }
+            }
+
+            //XXX: if it looks a spoof just return the address?
+            if (!ok) {
+                host = addr.getHostAddress();
+                return host;
+            }
+        } catch (SecurityException e) {
+            host = addr.getHostAddress();
+        } catch (UnknownHostException e) {
+            host = addr.getHostAddress();
+            // let next provider resolve the hostname
+        }
         return host;
     }
 
@@ -1136,7 +1136,7 @@ public class InetAddress implements java.io.Serializable {
 
         // create name service
         nameService = createNameService();
-        }
+    }
 
     /**
      * Create an instance of the NameService interface based on
@@ -1510,21 +1510,19 @@ public class InetAddress implements java.io.Serializable {
     }
 
     static InetAddress[] getAddressesFromNameService(String host, InetAddress reqAddr)
-        throws UnknownHostException
-    {
+            throws UnknownHostException {
         InetAddress[] addresses = null;
         UnknownHostException ex = null;
 
-            try {
-                addresses = nameService.lookupAllHostAddr(host);
-            } catch (UnknownHostException uhe) {
-                if (host.equalsIgnoreCase("localhost")) {
-                    addresses = new InetAddress[] { impl.loopbackAddress() };
-                }
-                else {
-                    ex = uhe;
-                }
+        try {
+            addresses = nameService.lookupAllHostAddr(host);
+        } catch (UnknownHostException uhe) {
+            if (host.equalsIgnoreCase("localhost")) {
+                addresses = new InetAddress[]{impl.loopbackAddress()};
+            } else {
+                ex = uhe;
             }
+        }
 
         if (addresses == null) {
             throw ex == null ? new UnknownHostException(host) : ex;


### PR DESCRIPTION
Hi,

The fix changes indentations in the following `java.net.InetAddress` methods:
- getAddressesFromNameService
- getHostFromNameService

It helps to improve code readability. Can't say the same about `getHostFromNameService` diffs shown in this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273243](https://bugs.openjdk.java.net/browse/JDK-8273243): Fix indentations in java.net.InetAddress methods


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to 27c03f4d329ecd47d09d890bc9f3a0b8011fcd8f


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5336/head:pull/5336` \
`$ git checkout pull/5336`

Update a local copy of the PR: \
`$ git checkout pull/5336` \
`$ git pull https://git.openjdk.java.net/jdk pull/5336/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5336`

View PR using the GUI difftool: \
`$ git pr show -t 5336`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5336.diff">https://git.openjdk.java.net/jdk/pull/5336.diff</a>

</details>
