### PR TITLE
7188098 : TEST_BUG: closed/javax/sound/midi/Synthesizer/Receiver/bug6186488.java fails

### DIFF
--- a/test/jdk/javax/sound/midi/Synthesizer/Receiver/bug6186488.java
+++ b/test/jdk/javax/sound/midi/Synthesizer/Receiver/bug6186488.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/sound/midi/Synthesizer/Receiver/bug6186488.java
+++ b/test/jdk/javax/sound/midi/Synthesizer/Receiver/bug6186488.java
@@ -100,7 +100,9 @@ public class bug6186488 {
     }
 
     private static void createAndShowTestDialog() {
-        String testInstruction = "This test verify that software Java Syntesizer processed non-ShortMessage-derived messages. \n" +
+        String testInstruction = "This test verify that software Java Syntesizer processed non-ShortMessage-derived messages.\n" +
+                "Close all other programs that may use the sound card.\n" +
+                "Make sure that the speakers are connected and the volume is up.\n" +
                 "Click on 'Start Test' button. If you listen a sound then test pass else test fail.";
 
         final JDialog dialog = new JDialog();

--- a/test/jdk/javax/sound/midi/Synthesizer/Receiver/bug6186488.java
+++ b/test/jdk/javax/sound/midi/Synthesizer/Receiver/bug6186488.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,52 +21,181 @@
  * questions.
  */
 
+import java.awt.BorderLayout;
+import java.awt.FlowLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import javax.sound.midi.MidiDevice;
 import javax.sound.midi.MidiMessage;
 import javax.sound.midi.MidiSystem;
+import javax.sound.midi.MidiUnavailableException;
+import javax.swing.JDialog;
+import javax.swing.SwingUtilities;
+import javax.swing.JTextArea;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.Timer;
+import javax.swing.JPanel;
+import javax.swing.WindowConstants;
 
-/**
+/*
  * @test
  * @bug 6186488
  * @summary Tests that software Java Syntesizer processed
  *          non-ShortMessage-derived messages
- * @run main/manual=yesno bug6186488
+ * @run main/manual bug6186488
  */
 public class bug6186488 {
-    public static void main(String[] args) throws Exception {
-        MidiDevice/*Synthesizer*/ synth = null;
+    private static final CountDownLatch countDownLatch = new CountDownLatch(1);
+    private static final int testTimeout = 300000;
+    private static volatile String testFailureMsg;
+    private static volatile boolean testPassed;
+    private static volatile boolean testFinished;
 
+    public static void main(String[] args) throws InterruptedException, InvocationTargetException {
+        SwingUtilities.invokeAndWait(() -> createAndShowTestDialog());
         try {
-            synth = MidiSystem.getSynthesizer();
-            //synth = MidiSystem.getMidiDevice(infos[0]);
+            if (!countDownLatch.await(testTimeout, TimeUnit.MILLISECONDS)) {
+                throw new RuntimeException(String.format("Test timeout '%d ms' elapsed.", testTimeout));
+            }
+            if (!testPassed) {
+                String failureMsg = testFailureMsg;
+                if ((failureMsg != null) && (!failureMsg.trim().isEmpty())) {
+                    throw new RuntimeException(failureMsg);
+                } else {
+                    throw new RuntimeException("Test failed.");
+                }
+            }
+        } catch (InterruptedException ie) {
+            throw new RuntimeException(ie);
+        } finally {
+            testFinished = true;
+        }
+    }
 
+    private static void pass() {
+        testPassed = true;
+        countDownLatch.countDown();
+    }
+
+    private static void fail(String failureMsg) {
+        testFailureMsg = failureMsg;
+        testPassed = false;
+        countDownLatch.countDown();
+    }
+
+    private static String convertMillisToTimeStr(int millis) {
+        if (millis < 0) {
+            return "00:00:00";
+        }
+        int hours = millis / 3600000;
+        int minutes = (millis - hours * 3600000) / 60000;
+        int seconds = (millis - hours * 3600000 - minutes * 60000) / 1000;
+        return String.format("%02d:%02d:%02d", hours, minutes, seconds);
+    }
+
+    private static void createAndShowTestDialog() {
+        String testInstruction = "This test verify that software Java Syntesizer processed non-ShortMessage-derived messages. \n" +
+                "Click on 'Start Test' button. If you listen a sound then test pass else test fail.";
+
+        final JDialog dialog = new JDialog();
+        dialog.setTitle("Test Sound");
+        dialog.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+        dialog.addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent e) {
+                dialog.dispose();
+                fail("Main dialog was closed.");
+            }
+        });
+
+        final JLabel testTimeoutLabel = new JLabel(String.format("Test timeout: %s", convertMillisToTimeStr(testTimeout)));
+        final long startTime = System.currentTimeMillis();
+        final Timer timer = new Timer(0, null);
+        timer.setDelay(1000);
+        timer.addActionListener((e) -> {
+            int leftTime = testTimeout - (int) (System.currentTimeMillis() - startTime);
+            if ((leftTime < 0) || testFinished) {
+                timer.stop();
+                dialog.dispose();
+            }
+            testTimeoutLabel.setText(String.format("Test timeout: %s", convertMillisToTimeStr(leftTime)));
+        });
+        timer.start();
+
+        JTextArea textArea = new JTextArea(testInstruction);
+        textArea.setEditable(false);
+
+        final JButton startTestButton = new JButton("Start Test");
+        final JButton passButton = new JButton("PASS");
+        final JButton failButton = new JButton("FAIL");
+        startTestButton.addActionListener((e) -> {
+            new Thread(() -> {
+                try {
+                    doTest();
+
+                    SwingUtilities.invokeLater(() -> {
+                        passButton.setEnabled(true);
+                        failButton.setEnabled(true);
+                    });
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                    dialog.dispose();
+                    fail("Exception occurred in a thread executing the test.");
+                }
+            }).start();
+        });
+        passButton.setEnabled(false);
+        passButton.addActionListener((e) -> {
+            dialog.dispose();
+            pass();
+        });
+        failButton.setEnabled(false);
+        failButton.addActionListener((e) -> {
+            dialog.dispose();
+            fail("Expected that sound will be heard but did not hear sound");
+        });
+
+        JPanel mainPanel = new JPanel(new BorderLayout());
+        JPanel labelPanel = new JPanel(new FlowLayout());
+        labelPanel.add(testTimeoutLabel);
+        mainPanel.add(labelPanel, BorderLayout.NORTH);
+        mainPanel.add(textArea, BorderLayout.CENTER);
+        JPanel buttonPanel = new JPanel(new FlowLayout());
+        buttonPanel.add(startTestButton);
+        buttonPanel.add(passButton);
+        buttonPanel.add(failButton);
+        mainPanel.add(buttonPanel, BorderLayout.SOUTH);
+        dialog.add(mainPanel);
+        dialog.pack();
+        dialog.setVisible(true);
+    }
+
+    public static void waitForSynToOpen(MidiDevice synth) throws InterruptedException {
+        int count = 0;
+        do {
+            if (synth.isOpen()) {
+                System.out.println("synth is opened");
+                return;
+            }
+            TimeUnit.SECONDS.sleep(1);
+        } while( ++count >= 5);
+        throw new RuntimeException(synth + " did not open even after 5 seconds");
+    }
+
+    private static void doTest() throws MidiUnavailableException, InterruptedException {
+        try (MidiDevice synth = MidiSystem.getSynthesizer()) {
             System.out.println("Synthesizer: " + synth.getDeviceInfo());
             synth.open();
+            waitForSynToOpen(synth);
             MidiMessage msg = new GenericMidiMessage(0x90, 0x3C, 0x40);
-            //ShortMessage msg = new ShortMessage();
-            //msg.setMessage(0x90, 0x3C, 0x40);
-
             synth.getReceiver().send(msg, 0);
             Thread.sleep(2000);
-
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            throw ex;
-        } finally {
-            if (synth != null && synth.isOpen())
-                synth.close();
-        }
-        System.out.print("Did you heard a note? (enter 'y' or 'n') ");
-        int result = System.in.read();
-        System.in.skip(1000);
-        if (result == 'y' || result == 'Y')
-        {
-            System.out.println("Test passed sucessfully.");
-        }
-        else
-        {
-            System.out.println("Test FAILED.");
-            throw new RuntimeException("Test failed.");
         }
     }
 


### PR DESCRIPTION
1) Testcase was failing with Parse Exception: Arguments to `manual' option not supported: yesno due to yesno
2) After removing =yesno once again test case was failing with following exception
----------System.err:(15/782)----------
java.io.IOException: Illegal seek
at java.io.FileInputStream.skip(Native Method)
at java.io.BufferedInputStream.skip(BufferedInputStream.java:366)
at bug6186488.main(bug6186488.java:36)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.lang.reflect.Method.invoke(Method.java:474)
at com.sun.javatest.regtest.MainWrapper$MainThread.run(MainWrapper.java:96)
at java.lang.Thread.run(Thread.java:722)

3) If test case is run independently user has to enter y or n to make the test case pass or fail that is when user heard the sound or no. The same action was able to perform via JTREG.  
4) Rewrote the testcase . Now user can listen to sound when he press "Start Test" and press "pass"  button if user hears the sound  and press "fail" button when user does not hear the sound. Test UI also shows a timer that get timeout if user does not perform any action.
5) Add try-with-resource to close the synth.

@shurymury

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-7188098](https://bugs.openjdk.java.net/browse/JDK-7188098): TEST_BUG: closed/javax/sound/midi/Synthesizer/Receiver/bug6186488.java fails


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5338/head:pull/5338` \
`$ git checkout pull/5338`

Update a local copy of the PR: \
`$ git checkout pull/5338` \
`$ git pull https://git.openjdk.java.net/jdk pull/5338/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5338`

View PR using the GUI difftool: \
`$ git pr show -t 5338`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5338.diff">https://git.openjdk.java.net/jdk/pull/5338.diff</a>

</details>
