### PR TITLE
8137018: [JVMCI] Encapsulate new Thread fields for JVMCI

### DIFF
--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -596,11 +596,11 @@ void SharedRuntime::gen_i2c_adapter(MacroAssembler *masm,
 #if INCLUDE_JVMCI
   if (EnableJVMCI) {
     // check if this call should be routed towards a specific entry point
-    __ ldr(rscratch2, Address(rthread, in_bytes(JavaThread::jvmci_alternate_call_target_offset())));
+    __ ldr(rscratch2, Address(rthread, in_bytes(JVMCIThreadState::jvmci_alternate_call_target_offset())));
     Label no_alternative_target;
     __ cbz(rscratch2, no_alternative_target);
     __ mov(rscratch1, rscratch2);
-    __ str(zr, Address(rthread, in_bytes(JavaThread::jvmci_alternate_call_target_offset())));
+    __ str(zr, Address(rthread, in_bytes(JVMCIThreadState::jvmci_alternate_call_target_offset())));
     __ bind(no_alternative_target);
   }
 #endif // INCLUDE_JVMCI
@@ -2249,8 +2249,8 @@ void SharedRuntime::generate_deopt_blob() {
   if (EnableJVMCI) {
     implicit_exception_uncommon_trap_offset = __ pc() - start;
 
-    __ ldr(lr, Address(rthread, in_bytes(JavaThread::jvmci_implicit_exception_pc_offset())));
-    __ str(zr, Address(rthread, in_bytes(JavaThread::jvmci_implicit_exception_pc_offset())));
+    __ ldr(lr, Address(rthread, in_bytes(JVMCIThreadState::jvmci_implicit_exception_pc_offset())));
+    __ str(zr, Address(rthread, in_bytes(JVMCIThreadState::jvmci_implicit_exception_pc_offset())));
 
     uncommon_trap_offset = __ pc() - start;
 
@@ -2260,9 +2260,9 @@ void SharedRuntime::generate_deopt_blob() {
     Label retaddr;
     __ set_last_Java_frame(sp, noreg, retaddr, rscratch1);
 
-    __ ldrw(c_rarg1, Address(rthread, in_bytes(JavaThread::pending_deoptimization_offset())));
+    __ ldrw(c_rarg1, Address(rthread, in_bytes(JVMCIThreadState::pending_deoptimization_offset())));
     __ movw(rscratch1, -1);
-    __ strw(rscratch1, Address(rthread, in_bytes(JavaThread::pending_deoptimization_offset())));
+    __ strw(rscratch1, Address(rthread, in_bytes(JVMCIThreadState::pending_deoptimization_offset())));
 
     __ movw(rcpool, (int32_t)Deoptimization::Unpack_reexecute);
     __ mov(c_rarg0, rthread);

--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -504,10 +504,10 @@ address TemplateInterpreterGenerator::generate_deopt_entry_for(TosState state,
   // only occur on method entry so emit it only for vtos with step 0.
   if (EnableJVMCI && state == vtos && step == 0) {
     Label L;
-    __ ldrb(rscratch1, Address(rthread, JavaThread::pending_monitorenter_offset()));
+    __ ldrb(rscratch1, Address(rthread, JVMCIThreadState::pending_monitorenter_offset()));
     __ cbz(rscratch1, L);
     // Clear flag.
-    __ strb(zr, Address(rthread, JavaThread::pending_monitorenter_offset()));
+    __ strb(zr, Address(rthread, JVMCIThreadState::pending_monitorenter_offset()));
     // Take lock.
     lock_method();
     __ bind(L);
@@ -515,7 +515,7 @@ address TemplateInterpreterGenerator::generate_deopt_entry_for(TosState state,
 #ifdef ASSERT
     if (EnableJVMCI) {
       Label L;
-      __ ldrb(rscratch1, Address(rthread, JavaThread::pending_monitorenter_offset()));
+      __ ldrb(rscratch1, Address(rthread, JVMCIThreadState::pending_monitorenter_offset()));
       __ cbz(rscratch1, L);
       __ stop("unexpected pending monitor in deopt entry");
       __ bind(L);

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -852,11 +852,11 @@ void SharedRuntime::gen_i2c_adapter(MacroAssembler *masm,
 #if INCLUDE_JVMCI
   if (EnableJVMCI) {
     // check if this call should be routed towards a specific entry point
-    __ cmpptr(Address(r15_thread, in_bytes(JavaThread::jvmci_alternate_call_target_offset())), 0);
+    __ cmpptr(Address(r15_thread, in_bytes(JVMCIThreadState::jvmci_alternate_call_target_offset())), 0);
     Label no_alternative_target;
     __ jcc(Assembler::equal, no_alternative_target);
-    __ movptr(r11, Address(r15_thread, in_bytes(JavaThread::jvmci_alternate_call_target_offset())));
-    __ movptr(Address(r15_thread, in_bytes(JavaThread::jvmci_alternate_call_target_offset())), 0);
+    __ movptr(r11, Address(r15_thread, in_bytes(JVMCIThreadState::jvmci_alternate_call_target_offset())));
+    __ movptr(Address(r15_thread, in_bytes(JVMCIThreadState::jvmci_alternate_call_target_offset())), 0);
     __ bind(no_alternative_target);
   }
 #endif // INCLUDE_JVMCI
@@ -2528,8 +2528,8 @@ void SharedRuntime::generate_deopt_blob() {
   if (EnableJVMCI) {
     implicit_exception_uncommon_trap_offset = __ pc() - start;
 
-    __ pushptr(Address(r15_thread, in_bytes(JavaThread::jvmci_implicit_exception_pc_offset())));
-    __ movptr(Address(r15_thread, in_bytes(JavaThread::jvmci_implicit_exception_pc_offset())), (int32_t)NULL_WORD);
+    __ pushptr(Address(r15_thread, in_bytes(JVMCIThreadState::jvmci_implicit_exception_pc_offset())));
+    __ movptr(Address(r15_thread, in_bytes(JVMCIThreadState::jvmci_implicit_exception_pc_offset())), (int32_t)NULL_WORD);
 
     uncommon_trap_offset = __ pc() - start;
 
@@ -2538,8 +2538,8 @@ void SharedRuntime::generate_deopt_blob() {
     // fetch_unroll_info needs to call last_java_frame()
     __ set_last_Java_frame(noreg, noreg, NULL);
 
-    __ movl(c_rarg1, Address(r15_thread, in_bytes(JavaThread::pending_deoptimization_offset())));
-    __ movl(Address(r15_thread, in_bytes(JavaThread::pending_deoptimization_offset())), -1);
+    __ movl(c_rarg1, Address(r15_thread, in_bytes(JVMCIThreadState::pending_deoptimization_offset())));
+    __ movl(Address(r15_thread, in_bytes(JVMCIThreadState::pending_deoptimization_offset())), -1);
 
     __ movl(r14, (int32_t)Deoptimization::Unpack_reexecute);
     __ mov(c_rarg0, r15_thread);

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -263,10 +263,10 @@ address TemplateInterpreterGenerator::generate_deopt_entry_for(TosState state, i
   // only occur on method entry so emit it only for vtos with step 0.
   if (EnableJVMCI && state == vtos && step == 0) {
     Label L;
-    __ cmpb(Address(thread, JavaThread::pending_monitorenter_offset()), 0);
+    __ cmpb(Address(thread, JVMCIThreadState::pending_monitorenter_offset()), 0);
     __ jcc(Assembler::zero, L);
     // Clear flag.
-    __ movb(Address(thread, JavaThread::pending_monitorenter_offset()), 0);
+    __ movb(Address(thread, JVMCIThreadState::pending_monitorenter_offset()), 0);
     // Satisfy calling convention for lock_method().
     __ get_method(rbx);
     // Take lock.
@@ -276,7 +276,7 @@ address TemplateInterpreterGenerator::generate_deopt_entry_for(TosState state, i
 #ifdef ASSERT
     if (EnableJVMCI) {
       Label L;
-      __ cmpb(Address(r15_thread, JavaThread::pending_monitorenter_offset()), 0);
+      __ cmpb(Address(r15_thread, JVMCIThreadState::pending_monitorenter_offset()), 0);
       __ jcc(Assembler::zero, L);
       __ stop("unexpected pending monitor in deopt entry");
       __ bind(L);

--- a/src/hotspot/share/code/compiledMethod.cpp
+++ b/src/hotspot/share/code/compiledMethod.cpp
@@ -723,9 +723,9 @@ address CompiledMethod::continuation_for_implicit_exception(address pc, bool for
 #if INCLUDE_JVMCI
     Deoptimization::DeoptReason deopt_reason = for_div0_check ? Deoptimization::Reason_div0_check : Deoptimization::Reason_null_check;
     JavaThread *thread = JavaThread::current();
-    thread->set_jvmci_implicit_exception_pc(pc);
-    thread->set_pending_deoptimization(Deoptimization::make_trap_request(deopt_reason,
-                                                                         Deoptimization::Action_reinterpret));
+    thread->jvmci().set_jvmci_implicit_exception_pc(pc);
+    thread->jvmci().set_pending_deoptimization(Deoptimization::make_trap_request(deopt_reason,
+                                                                                 Deoptimization::Action_reinterpret));
     return (SharedRuntime::deopt_blob()->implicit_exception_uncommon_trap());
 #else
     ShouldNotReachHere();

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -3544,11 +3544,11 @@ void nmethod::print_statistics() {
 
 #if INCLUDE_JVMCI
 void nmethod::update_speculation(JavaThread* thread) {
-  jlong speculation = thread->pending_failed_speculation();
+  jlong speculation = thread->jvmci().pending_failed_speculation();
   if (speculation != 0) {
     guarantee(jvmci_nmethod_data() != NULL, "failed speculation in nmethod without failed speculation list");
     jvmci_nmethod_data()->add_failed_speculation(this, speculation);
-    thread->set_pending_failed_speculation(0);
+    thread->jvmci().set_pending_failed_speculation(0);
   }
 }
 

--- a/src/hotspot/share/jvmci/jvmci.cpp
+++ b/src/hotspot/share/jvmci/jvmci.cpp
@@ -385,7 +385,6 @@ bool JVMCI::resize_all_jvmci_counters(int new_size) {
   return !op.failed();
 }
 
-
 void JVMCI::free_counters(JavaThread* thread) {
   if (JVMCICounterSize > 0) {
     FREE_C_HEAP_ARRAY(jlong, thread->jvmci()._jvmci_counters);
@@ -402,7 +401,6 @@ void JVMCI::accumulate_counters(JavaThread* thread) {
   }
 }
 
-
 void JVMCI::init_counters() {
   if (JVMCICounterSize > 0) {
     JVMCI::_jvmci_old_thread_counters = NEW_C_HEAP_ARRAY(jlong, JVMCICounterSize, mtJVMCI);
@@ -412,13 +410,11 @@ void JVMCI::init_counters() {
   }
 }
 
-
 void JVMCI::free_counters() {
   if (JVMCICounterSize > 0) {
     FREE_C_HEAP_ARRAY(jlong, JVMCI::_jvmci_old_thread_counters);
   }
 }
-
 
 ByteSize JVMCIThreadState::pending_deoptimization_offset() {
  return JavaThread::jvmci_state_offset() + byte_offset_of(JVMCIThreadState, _pending_deoptimization);

--- a/src/hotspot/share/jvmci/jvmci.hpp
+++ b/src/hotspot/share/jvmci/jvmci.hpp
@@ -235,7 +235,7 @@ class JVMCIThreadState {
   jlong _jvmci_reserved1;
   oop _jvmci_reserved_oop0;
 
- public :
+ public:
   int  pending_deoptimization() const             { return _pending_deoptimization; }
   jlong pending_failed_speculation() const        { return _pending_failed_speculation; }
   bool has_pending_monitorenter() const           { return _pending_monitorenter; }

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -1102,7 +1102,7 @@ C2V_VMENTRY_NULL(jlongArray, collectCounters, (JNIEnv* env, jobject))
   JVMCIPrimitiveArray array = JVMCIENV->new_longArray(JVMCICounterSize, JVMCI_CHECK_NULL);
   if (JVMCICounterSize > 0) {
     jlong* temp_array = NEW_RESOURCE_ARRAY(jlong, JVMCICounterSize);
-    JavaThread::collect_counters(temp_array, JVMCICounterSize);
+    JVMCI::collect_counters(temp_array, JVMCICounterSize);
     JVMCIENV->copy_longs_from(temp_array, array, 0, JVMCICounterSize);
   }
   return (jlongArray) JVMCIENV->get_jobject(array);
@@ -1113,7 +1113,7 @@ C2V_VMENTRY_0(jint, getCountersSize, (JNIEnv* env, jobject))
 C2V_END
 
 C2V_VMENTRY_0(jboolean, setCountersSize, (JNIEnv* env, jobject, jint new_size))
-  return JavaThread::resize_all_jvmci_counters(new_size);
+  return JVMCI::resize_all_jvmci_counters(new_size);
 C2V_END
 
 C2V_VMENTRY_0(jint, allocateCompileId, (JNIEnv* env, jobject, jobject jvmci_method, int entry_bci))
@@ -2632,7 +2632,7 @@ C2V_VMENTRY(void, notifyCompilerInliningEvent, (JNIEnv* env, jobject, jint compi
 C2V_VMENTRY(void, setThreadLocalObject, (JNIEnv* env, jobject, jint id, jobject value))
   requireInHotSpot("setThreadLocalObject", JVMCI_CHECK);
   if (id == 0) {
-    thread->set_jvmci_reserved_oop0(JNIHandles::resolve(value));
+    thread->jvmci().set_jvmci_reserved_oop0(JNIHandles::resolve(value));
     return;
   }
   THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
@@ -2642,7 +2642,7 @@ C2V_VMENTRY(void, setThreadLocalObject, (JNIEnv* env, jobject, jint id, jobject 
 C2V_VMENTRY_NULL(jobject, getThreadLocalObject, (JNIEnv* env, jobject, jint id))
   requireInHotSpot("getThreadLocalObject", JVMCI_CHECK_NULL);
   if (id == 0) {
-    return JNIHandles::make_local(thread->get_jvmci_reserved_oop0());
+    return JNIHandles::make_local(thread->jvmci().get_jvmci_reserved_oop0());
   }
   THROW_MSG_0(vmSymbols::java_lang_IllegalArgumentException(),
               err_msg("%d is not a valid thread local id", id));
@@ -2651,9 +2651,9 @@ C2V_VMENTRY_NULL(jobject, getThreadLocalObject, (JNIEnv* env, jobject, jint id))
 C2V_VMENTRY(void, setThreadLocalLong, (JNIEnv* env, jobject, jint id, jlong value))
   requireInHotSpot("setThreadLocalLong", JVMCI_CHECK);
   if (id == 0) {
-    thread->set_jvmci_reserved0(value);
+    thread->jvmci().set_jvmci_reserved0(value);
   } else if (id == 1) {
-    thread->set_jvmci_reserved1(value);
+    thread->jvmci().set_jvmci_reserved1(value);
   } else {
     THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
               err_msg("%d is not a valid thread local id", id));
@@ -2663,9 +2663,9 @@ C2V_VMENTRY(void, setThreadLocalLong, (JNIEnv* env, jobject, jint id, jlong valu
 C2V_VMENTRY_0(jlong, getThreadLocalLong, (JNIEnv* env, jobject, jint id))
   requireInHotSpot("getThreadLocalLong", JVMCI_CHECK_0);
   if (id == 0) {
-    return thread->get_jvmci_reserved0();
+    return thread->jvmci().get_jvmci_reserved0();
   } else if (id == 1) {
-    return thread->get_jvmci_reserved1();
+    return thread->jvmci().get_jvmci_reserved1();
   } else {
     THROW_MSG_0(vmSymbols::java_lang_IllegalArgumentException(),
                 err_msg("%d is not a valid thread local id", id));

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -95,14 +95,14 @@ class RetryableAllocationMark: public StackObj {
     if (activate) {
       assert(!thread->in_retryable_allocation(), "retryable allocation scope is non-reentrant");
       _thread = thread;
-      _thread->set_in_retryable_allocation(true);
+      _thread->jvmci().set_in_retryable_allocation(true);
     } else {
       _thread = NULL;
     }
   }
   ~RetryableAllocationMark() {
     if (_thread != NULL) {
-      _thread->set_in_retryable_allocation(false);
+      _thread->jvmci().set_in_retryable_allocation(false);
       JavaThread* THREAD = _thread; // For exception macros.
       if (HAS_PENDING_EXCEPTION) {
         oop ex = PENDING_EXCEPTION;

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -44,7 +44,7 @@
 #include "gc/g1/g1ThreadLocalData.hpp"
 #endif
 
-#define VM_STRUCTS(nonstatic_field, static_field, unchecked_nonstatic_field, volatile_nonstatic_field) \
+#define VM_STRUCTS(nonstatic_field, nonstatic_field_alias, static_field, unchecked_nonstatic_field, volatile_nonstatic_field) \
   static_field(CompilerToVM::Data,             Klass_vtable_start_offset,              int)                                          \
   static_field(CompilerToVM::Data,             Klass_vtable_length_offset,             int)                                          \
                                                                                                                                      \
@@ -179,13 +179,13 @@
   volatile_nonstatic_field(JavaThread,         _is_method_handle_return,                      int)                                   \
   volatile_nonstatic_field(JavaThread,         _doing_unsafe_access,                          bool)                                  \
   nonstatic_field(JavaThread,                  _osthread,                                     OSThread*)                             \
-  nonstatic_field(JavaThread,                  _pending_deoptimization,                       int)                                   \
-  nonstatic_field(JavaThread,                  _pending_failed_speculation,                   jlong)                                 \
-  nonstatic_field(JavaThread,                  _pending_transfer_to_interpreter,              bool)                                  \
-  nonstatic_field(JavaThread,                  _jvmci_counters,                               jlong*)                                \
-  nonstatic_field(JavaThread,                  _jvmci_reserved0,                              jlong)                                 \
-  nonstatic_field(JavaThread,                  _jvmci_reserved1,                              jlong)                                 \
-  nonstatic_field(JavaThread,                  _jvmci_reserved_oop0,                          oop)                                   \
+  nonstatic_field_alias(JavaThread,            _jvmci_state._pending_deoptimization,          _pending_deoptimization,          int)    \
+  nonstatic_field_alias(JavaThread,            _jvmci_state._pending_failed_speculation,      _pending_failed_speculation,      jlong)  \
+  nonstatic_field_alias(JavaThread,            _jvmci_state._pending_transfer_to_interpreter, _pending_transfer_to_interpreter, bool)   \
+  nonstatic_field_alias(JavaThread,            _jvmci_state._jvmci_counters,                  _jvmci_counters,                  jlong*) \
+  nonstatic_field_alias(JavaThread,            _jvmci_state._jvmci_reserved0,                 _jvmci_reserved0,                 jlong)  \
+  nonstatic_field_alias(JavaThread,            _jvmci_state._jvmci_reserved1,                 _jvmci_reserved1,                 jlong)  \
+  nonstatic_field_alias(JavaThread,            _jvmci_state._jvmci_reserved_oop0,             _jvmci_reserved_oop0,             oop)    \
   nonstatic_field(JavaThread,                  _should_post_on_exceptions_flag,               int)                                   \
   nonstatic_field(JavaThread,                  _jni_environment,                              JNIEnv)                                \
   nonstatic_field(JavaThread,                  _poll_data,                                    SafepointMechanism::ThreadData)        \
@@ -788,6 +788,7 @@
 // as long as class VMStructs is a friend
 VMStructEntry JVMCIVMStructs::localHotSpotVMStructs[] = {
   VM_STRUCTS(GENERATE_NONSTATIC_VM_STRUCT_ENTRY,
+             GENERATE_NONSTATIC_VM_STRUCT_ENTRY_ALIAS,
              GENERATE_STATIC_VM_STRUCT_ENTRY,
              GENERATE_UNCHECKED_NONSTATIC_VM_STRUCT_ENTRY,
              GENERATE_NONSTATIC_VM_STRUCT_ENTRY)
@@ -901,6 +902,7 @@ JNIEXPORT VMAddressEntry* jvmciHotSpotVMAddresses = JVMCIVMStructs::localHotSpot
 // to ensure that all of the field types are present.
 void JVMCIVMStructs::init() {
   VM_STRUCTS(CHECK_NONSTATIC_VM_STRUCT_ENTRY,
+             CHECK_NONSTATIC_VM_STRUCT_ENTRY_ALIAS,
              CHECK_STATIC_VM_STRUCT_ENTRY,
              CHECK_NO_OP,
              CHECK_VOLATILE_NONSTATIC_VM_STRUCT_ENTRY);

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -585,7 +585,7 @@ Deoptimization::UnrollBlock* Deoptimization::fetch_unroll_info_helper(JavaThread
 
 #if INCLUDE_JVMCI
   if (current->frames_to_pop_failed_realloc() > 0) {
-    current->set_pending_monitorenter(false);
+    current->jvmci().set_pending_monitorenter(false);
   }
 #endif
 
@@ -1860,7 +1860,7 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
     methodHandle    trap_method(current, trap_scope->method());
     int             trap_bci    = trap_scope->bci();
 #if INCLUDE_JVMCI
-    jlong           speculation = current->pending_failed_speculation();
+    jlong           speculation = current->jvmci().pending_failed_speculation();
     if (nm->is_compiled_by_jvmci()) {
       nm->as_nmethod()->update_speculation(current);
     } else {
@@ -1869,11 +1869,11 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
 
     if (trap_bci == SynchronizationEntryBCI) {
       trap_bci = 0;
-      current->set_pending_monitorenter(true);
+      current->jvmci().set_pending_monitorenter(true);
     }
 
     if (reason == Deoptimization::Reason_transfer_to_interpreter) {
-      current->set_pending_transfer_to_interpreter(true);
+      current->jvmci().set_pending_transfer_to_interpreter(true);
     }
 #endif
 

--- a/src/hotspot/share/runtime/javaCalls.cpp
+++ b/src/hotspot/share/runtime/javaCalls.cpp
@@ -408,7 +408,7 @@ void JavaCalls::call_helper(JavaValue* result, const methodHandle& method, JavaC
         // respect to nmethod sweeping.
         address verified_entry_point = (address) HotSpotJVMCI::InstalledCode::entryPoint(NULL, alternative_target());
         if (verified_entry_point != NULL) {
-          thread->set_jvmci_alternate_call_target(verified_entry_point);
+          thread->jvmci().set_jvmci_alternate_call_target(verified_entry_point);
           entry_point = method->adapter()->get_i2c_entry();
         }
       }

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -944,7 +944,7 @@ JavaThread::JavaThread() :
   set_jni_functions(jni_functions());
 
 #if INCLUDE_JVMCI
-  assert(jvmci()._jvmci._implicit_exception_pc == nullptr, "must be");
+  assert(jvmci().implicit_exception_pc() == nullptr, "must be");
   if (JVMCICounterSize > 0) {
     JVMCI::resize_counters(this, 0, (int) JVMCICounterSize);
   }
@@ -1855,7 +1855,7 @@ void JavaThread::oops_do_no_frames(OopClosure* f, CodeBlobClosure* cf) {
   f->do_oop((oop*) &_exception_oop);
   f->do_oop((oop*) &_pending_async_exception);
 #if INCLUDE_JVMCI
-  f->do_oop((oop*) &_jvmci_state._jvmci_reserved_oop0);
+  f->do_oop((oop*) _jvmci_state.jvmci_reserved_oop0_addr());
 #endif
 
   if (jvmti_thread_state() != NULL) {

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -53,6 +53,9 @@
 #if INCLUDE_JFR
 #include "jfr/support/jfrThreadExtension.hpp"
 #endif
+#if INCLUDE_JVMCI
+#include "jvmci/jvmci.hpp"
+#endif
 
 class SafeThreadsListPtr;
 class ThreadSafepointState;
@@ -920,79 +923,11 @@ class JavaThread: public Thread {
   // of _attaching_via_jni and transitions to _attached_via_jni.
   volatile JNIAttachStates _jni_attach_state;
 
-
 #if INCLUDE_JVMCI
-  // The _pending_* fields below are used to communicate extra information
-  // from an uncommon trap in JVMCI compiled code to the uncommon trap handler.
-
-  // Communicates the DeoptReason and DeoptAction of the uncommon trap
-  int       _pending_deoptimization;
-
-  // Specifies whether the uncommon trap is to bci 0 of a synchronized method
-  // before the monitor has been acquired.
-  bool      _pending_monitorenter;
-
-  // Specifies if the DeoptReason for the last uncommon trap was Reason_transfer_to_interpreter
-  bool      _pending_transfer_to_interpreter;
-
-  // True if in a runtime call from compiled code that will deoptimize
-  // and re-execute a failed heap allocation in the interpreter.
-  bool      _in_retryable_allocation;
-
-  // An id of a speculation that JVMCI compiled code can use to further describe and
-  // uniquely identify the speculative optimization guarded by an uncommon trap.
-  // See JVMCINMethodData::SPECULATION_LENGTH_BITS for further details.
-  jlong     _pending_failed_speculation;
-
-  // These fields are mutually exclusive in terms of live ranges.
-  union {
-    // Communicates the pc at which the most recent implicit exception occurred
-    // from the signal handler to a deoptimization stub.
-    address   _implicit_exception_pc;
-
-    // Communicates an alternative call target to an i2c stub from a JavaCall .
-    address   _alternate_call_target;
-  } _jvmci;
-
-  // Support for high precision, thread sensitive counters in JVMCI compiled code.
-  jlong*    _jvmci_counters;
-
-  // Fast thread locals for use by JVMCI
-  jlong      _jvmci_reserved0;
-  jlong      _jvmci_reserved1;
-  oop        _jvmci_reserved_oop0;
+  JVMCIThreadState _jvmci_state;
 
  public:
-  static jlong* _jvmci_old_thread_counters;
-  static void collect_counters(jlong* array, int length);
-
-  bool resize_counters(int current_size, int new_size);
-
-  static bool resize_all_jvmci_counters(int new_size);
-
-  void set_jvmci_reserved_oop0(oop value) {
-    _jvmci_reserved_oop0 = value;
-  }
-
-  oop get_jvmci_reserved_oop0() {
-    return _jvmci_reserved_oop0;
-  }
-
-  void set_jvmci_reserved0(jlong value) {
-    _jvmci_reserved0 = value;
-  }
-
-  jlong get_jvmci_reserved0() {
-    return _jvmci_reserved0;
-  }
-
-  void set_jvmci_reserved1(jlong value) {
-    _jvmci_reserved1 = value;
-  }
-
-  jlong get_jvmci_reserved1() {
-    return _jvmci_reserved1;
-  }
+  JVMCIThreadState& jvmci() { return _jvmci_state; }
 
  private:
 #endif // INCLUDE_JVMCI
@@ -1225,18 +1160,7 @@ class JavaThread: public Thread {
   void set_deferred_card_mark(MemRegion mr)      { _deferred_card_mark = mr;   }
 
 #if INCLUDE_JVMCI
-  int  pending_deoptimization() const             { return _pending_deoptimization; }
-  jlong pending_failed_speculation() const        { return _pending_failed_speculation; }
-  bool has_pending_monitorenter() const           { return _pending_monitorenter; }
-  void set_pending_monitorenter(bool b)           { _pending_monitorenter = b; }
-  void set_pending_deoptimization(int reason)     { _pending_deoptimization = reason; }
-  void set_pending_failed_speculation(jlong failed_speculation) { _pending_failed_speculation = failed_speculation; }
-  void set_pending_transfer_to_interpreter(bool b) { _pending_transfer_to_interpreter = b; }
-  void set_jvmci_alternate_call_target(address a) { assert(_jvmci._alternate_call_target == NULL, "must be"); _jvmci._alternate_call_target = a; }
-  void set_jvmci_implicit_exception_pc(address a) { assert(_jvmci._implicit_exception_pc == NULL, "must be"); _jvmci._implicit_exception_pc = a; }
-
-  virtual bool in_retryable_allocation() const    { return _in_retryable_allocation; }
-  void set_in_retryable_allocation(bool b)        { _in_retryable_allocation = b; }
+  virtual bool in_retryable_allocation() const    { return _jvmci_state.in_retryable_allocation(); }
 #endif // INCLUDE_JVMCI
 
   // Exception handling for compiled methods
@@ -1291,12 +1215,7 @@ class JavaThread: public Thread {
   static ByteSize saved_exception_pc_offset()    { return byte_offset_of(JavaThread, _saved_exception_pc); }
   static ByteSize osthread_offset()              { return byte_offset_of(JavaThread, _osthread); }
 #if INCLUDE_JVMCI
-  static ByteSize pending_deoptimization_offset() { return byte_offset_of(JavaThread, _pending_deoptimization); }
-  static ByteSize pending_monitorenter_offset()  { return byte_offset_of(JavaThread, _pending_monitorenter); }
-  static ByteSize pending_failed_speculation_offset() { return byte_offset_of(JavaThread, _pending_failed_speculation); }
-  static ByteSize jvmci_alternate_call_target_offset() { return byte_offset_of(JavaThread, _jvmci._alternate_call_target); }
-  static ByteSize jvmci_implicit_exception_pc_offset() { return byte_offset_of(JavaThread, _jvmci._implicit_exception_pc); }
-  static ByteSize jvmci_counters_offset()        { return byte_offset_of(JavaThread, _jvmci_counters); }
+  static ByteSize jvmci_state_offset() { return byte_offset_of(JavaThread, _jvmci_state); }
 #endif // INCLUDE_JVMCI
   static ByteSize exception_oop_offset()         { return byte_offset_of(JavaThread, _exception_oop); }
   static ByteSize exception_pc_offset()          { return byte_offset_of(JavaThread, _exception_pc); }

--- a/src/hotspot/share/runtime/vmStructs.hpp
+++ b/src/hotspot/share/runtime/vmStructs.hpp
@@ -159,6 +159,11 @@ private:
 #define GENERATE_NONSTATIC_VM_STRUCT_ENTRY(typeName, fieldName, type)              \
  { QUOTE(typeName), QUOTE(fieldName), QUOTE(type), 0, offset_of(typeName, fieldName), NULL },
 
+// This macro generates a VMStructEntry line for a nonstatic field
+#define GENERATE_NONSTATIC_VM_STRUCT_ENTRY_ALIAS(typeName, fieldName, fieldAliasName, type) \
+ { QUOTE(typeName), QUOTE(fieldName), QUOTE(type), 0, offset_of(typeName, fieldName), NULL }, \
+ { QUOTE(typeName), QUOTE(fieldAliasName), QUOTE(type), 0, offset_of(typeName, fieldName), NULL },
+
 // This macro generates a VMStructEntry line for a static field
 #define GENERATE_STATIC_VM_STRUCT_ENTRY(typeName, fieldName, type)                 \
  { QUOTE(typeName), QUOTE(fieldName), QUOTE(type), 1, 0, &typeName::fieldName },
@@ -189,6 +194,10 @@ private:
 
 // This macro checks the type of a VMStructEntry by comparing pointer types
 #define CHECK_NONSTATIC_VM_STRUCT_ENTRY(typeName, fieldName, type)                 \
+ {typeName *dummyObj = NULL; type* dummy = &dummyObj->fieldName;                   \
+  assert(offset_of(typeName, fieldName) < sizeof(typeName), "Illegal nonstatic struct entry, field offset too large"); }
+
+#define CHECK_NONSTATIC_VM_STRUCT_ENTRY_ALIAS(typeName, fieldName, fieldAliasName, type) \
  {typeName *dummyObj = NULL; type* dummy = &dummyObj->fieldName;                   \
   assert(offset_of(typeName, fieldName) < sizeof(typeName), "Illegal nonstatic struct entry, field offset too large"); }
 


### PR DESCRIPTION
This evacuates all JVMCI related methods and fields into a separately declared struct.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8137018](https://bugs.openjdk.java.net/browse/JDK-8137018): [JVMCI] Encapsulate new Thread fields for JVMCI


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to 9af54d4b9a51265daf2e565c6593593c01e11256
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 9af54d4b9a51265daf2e565c6593593c01e11256
 * [Doug Simon](https://openjdk.java.net/census#dnsimon) (@dougxc - Committer) ⚠️ Review applies to 472073a726fc0b7e3f1e2da7ed23c7a1ea8f2a49


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5339/head:pull/5339` \
`$ git checkout pull/5339`

Update a local copy of the PR: \
`$ git checkout pull/5339` \
`$ git pull https://git.openjdk.java.net/jdk pull/5339/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5339`

View PR using the GUI difftool: \
`$ git pr show -t 5339`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5339.diff">https://git.openjdk.java.net/jdk/pull/5339.diff</a>

</details>
