### PR TITLE
8273251: Call check_possible_safepoint() from SafepointMechanism::process_if_requested()

### DIFF
--- a/src/hotspot/share/runtime/safepointMechanism.inline.hpp
+++ b/src/hotspot/share/runtime/safepointMechanism.inline.hpp
@@ -85,15 +85,8 @@ bool SafepointMechanism::should_process(JavaThread* thread, bool allow_suspend) 
 }
 
 void SafepointMechanism::process_if_requested(JavaThread* thread, bool allow_suspend) {
-
-  // Macos/aarch64 should be in the right state for safepoint (e.g.
-  // deoptimization needs WXWrite).  Crashes caused by the wrong state rarely
-  // happens in practice, making such issues hard to find and reproduce.
-#if defined(ASSERT) && defined(__APPLE__) && defined(AARCH64)
-  if (AssertWXAtThreadSync) {
-    thread->assert_wx_state(WXWrite);
-  }
-#endif
+  // Check NoSafepointVerifier. This also clears unhandled oops if CheckUnhandledOops is used.
+  thread->check_possible_safepoint();
 
   if (local_poll_armed(thread)) {
     process(thread, allow_suspend);

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -948,6 +948,15 @@ void JavaThread::check_possible_safepoint() {
   // Clear unhandled oops in JavaThreads so we get a crash right away.
   clear_unhandled_oops();
 #endif // CHECK_UNHANDLED_OOPS
+
+  // Macos/aarch64 should be in the right state for safepoint (e.g.
+  // deoptimization needs WXWrite).  Crashes caused by the wrong state rarely
+  // happens in practice, making such issues hard to find and reproduce.
+#if defined(__APPLE__) && defined(AARCH64)
+  if (AssertWXAtThreadSync) {
+    assert_wx_state(WXWrite);
+  }
+#endif
 }
 
 void JavaThread::check_for_valid_safepoint_state() {


### PR DESCRIPTION
Hi,

Please review this small fix to call check_possible_safepoint() from SafepointMechanism::process_if_requested() and remove the same call from transition_and_process(). See the bug description for more detail.
Since there were only two lines left of common code from transition_from_native() and transition_from_vm() I just removed transition_and_process() altogether. This also saves an unneeded extra transition to _thread_in_vm when transitioning from vm to Java.

Testing tiers 1-6.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273251](https://bugs.openjdk.java.net/browse/JDK-8273251): Call check_possible_safepoint() from SafepointMechanism::process_if_requested()


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5342/head:pull/5342` \
`$ git checkout pull/5342`

Update a local copy of the PR: \
`$ git checkout pull/5342` \
`$ git pull https://git.openjdk.java.net/jdk pull/5342/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5342`

View PR using the GUI difftool: \
`$ git pr show -t 5342`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5342.diff">https://git.openjdk.java.net/jdk/pull/5342.diff</a>

</details>
