### PR TITLE
JDK-8273194: Document the two possible cases when Lookup::ensureInitialized returns

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -2781,8 +2781,14 @@ assertEquals("[x, y, z]", pb.command().toString());
          * to be initialized if it has not been already initialized,
          * as specified in JVMS {@jvms 5.5}.
          *
+         * <p>
+         * This method returns when {@code targetClass} is fully initialized, or
+         * when {@code targetClass} is being initialized if this method is called
+         * by the initializing thread.
+         *
          * @param targetClass the class to be initialized
-         * @return {@code targetClass} that has been initialized
+         * @return {@code targetClass} that has been initialized, or that is being
+         *         initialized if this method is called by the initializing thread.
          *
          * @throws  IllegalArgumentException if {@code targetClass} is a primitive type or {@code void}
          *          or array class

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -2783,12 +2783,11 @@ assertEquals("[x, y, z]", pb.command().toString());
          *
          * <p>
          * This method returns when {@code targetClass} is fully initialized, or
-         * when {@code targetClass} is being initialized if this method is called
-         * by the initializing thread.
+         * when {@code targetClass} is being initialized by the current thread.
          *
          * @param targetClass the class to be initialized
          * @return {@code targetClass} that has been initialized, or that is being
-         *         initialized if this method is called by the initializing thread.
+         *         initialized by the current thread.
          *
          * @throws  IllegalArgumentException if {@code targetClass} is a primitive type or {@code void}
          *          or array class


### PR DESCRIPTION
Improve the specification to document the cases when `Lookup::ensureInitialized` returns as specified JVMS 5.5 and matches the implementation.

Please also review CSR: https://bugs.openjdk.java.net/browse/JDK-8273253

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273194](https://bugs.openjdk.java.net/browse/JDK-8273194): Document the two possible cases when Lookup::ensureInitialized returns


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5343/head:pull/5343` \
`$ git checkout pull/5343`

Update a local copy of the PR: \
`$ git checkout pull/5343` \
`$ git pull https://git.openjdk.java.net/jdk pull/5343/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5343`

View PR using the GUI difftool: \
`$ git pr show -t 5343`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5343.diff">https://git.openjdk.java.net/jdk/pull/5343.diff</a>

</details>
