### PR TITLE
8273240: Dynamic test ArchiveConsistency.java should use CDSArchiveUtils

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchiveConsistency.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchiveConsistency.java
@@ -35,23 +35,10 @@
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.channels.FileChannel;
-import java.nio.file.StandardOpenOption;
-import static java.nio.file.StandardOpenOption.READ;
-import static java.nio.file.StandardOpenOption.WRITE;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import sun.hotspot.WhiteBox;
+import jdk.test.lib.cds.CDSArchiveUtils;
 import jdk.test.lib.helpers.ClassFileInstaller;
 
 public class ArchiveConsistency extends DynamicArchiveTestBase {
-    public static WhiteBox wb;
-    public static int int_size;        // size of int
-    public static String[] shared_region_name = {"ReadWrite", "ReadOnly", "BitMap"};
-    public static int num_regions = shared_region_name.length;
 
     public static void main(String[] args) throws Exception {
         runTest(ArchiveConsistency::testCustomBase);
@@ -63,73 +50,6 @@ public class ArchiveConsistency extends DynamicArchiveTestBase {
         String baseArchiveName = getNewArchiveName("base");
         TestCommon.dumpBaseArchive(baseArchiveName);
         doTest(baseArchiveName, topArchiveName);
-    }
-
-    public static void setReadWritePermission(File file) throws Exception {
-        if (!file.canRead()) {
-            if (!file.setReadable(true)) {
-                throw new IOException("Cannot modify file " + file + " as readable");
-            }
-        }
-        if (!file.canWrite()) {
-            if (!file.setWritable(true)) {
-                throw new IOException("Cannot modify file " + file + " as writable");
-            }
-        }
-    }
-
-    public static long readInt(FileChannel fc, long offset, int nbytes) throws Exception {
-        ByteBuffer bb = ByteBuffer.allocate(nbytes);
-        bb.order(ByteOrder.nativeOrder());
-        fc.position(offset);
-        fc.read(bb);
-        return  (nbytes > 4 ? bb.getLong(0) : bb.getInt(0));
-    }
-
-    public static long align_up_page(long l) throws Exception {
-        // wb is obtained in getFileOffsetInfo() which is called first in main() else we should call
-        // WhiteBox.getWhiteBox() here first.
-        int pageSize = wb.getVMPageSize();
-        return (l + pageSize -1) & (~ (pageSize - 1));
-    }
-
-    public static void writeData(FileChannel fc, long offset, ByteBuffer bb) throws Exception {
-        fc.position(offset);
-        fc.write(bb);
-        fc.force(true);
-    }
-
-    public static FileChannel getFileChannel(File jsa) throws Exception {
-        List<StandardOpenOption> arry = new ArrayList<StandardOpenOption>();
-        arry.add(READ);
-        arry.add(WRITE);
-        return FileChannel.open(jsa.toPath(), new HashSet<StandardOpenOption>(arry));
-    }
-
-   public static void modifyJsaHeaderCRC(File jsa) throws Exception {
-        FileChannel fc = getFileChannel(jsa);
-        int_size = wb.getOffsetForName("int_size");
-        System.out.println("    int_size " + int_size);
-        ByteBuffer bbuf = ByteBuffer.allocateDirect(int_size);
-        for (int i = 0; i < int_size; i++) {
-            bbuf.put((byte)0);
-        }
-
-        int baseArchiveCRCOffset = wb.getOffsetForName("DynamicArchiveHeader::_base_region_crc");
-        int crc = 0;
-        System.out.printf("%-12s%-12s\n", "Space name", "CRC");
-        for (int i = 0; i < num_regions; i++) {
-            baseArchiveCRCOffset += int_size * i;
-            System.out.println("    baseArchiveCRCOffset " + baseArchiveCRCOffset);
-            crc = (int)readInt(fc, baseArchiveCRCOffset, int_size );
-            System.out.printf("%-11s%-12d\n", shared_region_name[i], crc);
-            bbuf.rewind();
-            writeData(fc, baseArchiveCRCOffset, bbuf);
-        }
-        fc.force(true);
-        if (fc.isOpen()) {
-            fc.close();
-        }
     }
 
     private static void doTest(String baseArchiveName, String topArchiveName) throws Exception {
@@ -149,11 +69,11 @@ public class ArchiveConsistency extends DynamicArchiveTestBase {
         }
 
         // Modify the CRC values in the header of the top archive.
-        wb = WhiteBox.getWhiteBox();
-        setReadWritePermission(jsa);
-        modifyJsaHeaderCRC(jsa);
+        String modTop = getNewArchiveName("modTopRegionsCrc");
+        File copiedJsa = CDSArchiveUtils.copyArchiveFile(jsa, modTop);
+        CDSArchiveUtils.modifyAllRegionsCrc(copiedJsa);
 
-        run2(baseArchiveName, topArchiveName,
+        run2(baseArchiveName, modTop,
             "-Xlog:class+load",
             "-Xlog:cds+dynamic=debug,cds=debug",
             "-XX:+VerifySharedSpaces",

--- a/test/lib/jdk/test/lib/cds/CDSArchiveUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSArchiveUtils.java
@@ -213,6 +213,24 @@ public class CDSArchiveUtils {
         return true;
     }
 
+    public static void modifyRegionCrc(File jsaFile, int region, int value) throws Exception {
+        long regionCrcOffset = spOffset + region * spOffsetCrc;
+        writeData(jsaFile, regionCrcOffset, value);
+    }
+
+    public static void  modifyAllRegionsCrc(File jsaFile) throws Exception {
+        int value = 0xbadebabe;
+        long[] used = new long[num_regions];
+        for (int i = 0; i < num_regions; i++) {
+            used[i] = usedRegionSizeAligned(jsaFile, i);
+            if (used[i] == 0) {
+                // skip empty region
+                continue;
+            }
+            modifyRegionCrc(jsaFile, i, value);
+        }
+    }
+
     public static void modifyFileHeader(File jsaFile) throws Exception {
         // screw up header info
         byte[] buf = new byte[fileHeaderSize];
@@ -272,6 +290,13 @@ public class CDSArchiveUtils {
     public static long writeData(File file, long offset, byte[] array) throws Exception {
         try (FileChannel fc = getFileChannel(file)) {
             ByteBuffer bbuf = ByteBuffer.wrap(array);
+            return writeData(fc, offset, bbuf);
+         }
+    }
+
+    public static long writeData(File file, long offset, int value) throws Exception {
+        try (FileChannel fc = getFileChannel(file)) {
+            ByteBuffer bbuf = ByteBuffer.allocate(4).putInt(value).position(0);
             return writeData(fc, offset, bbuf);
          }
     }


### PR DESCRIPTION
Please review the simple fix to simplify the test case appcds/dynamicArchive/ArchiveConsistency.java to use CDSArchiveUtils, which was added in JDK-8271419.

Tests: mach5 tier1,tier4

Thanks
Yumin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273240](https://bugs.openjdk.java.net/browse/JDK-8273240): Dynamic test ArchiveConsistency.java should use CDSArchiveUtils


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5344/head:pull/5344` \
`$ git checkout pull/5344`

Update a local copy of the PR: \
`$ git checkout pull/5344` \
`$ git pull https://git.openjdk.java.net/jdk pull/5344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5344`

View PR using the GUI difftool: \
`$ git pr show -t 5344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5344.diff">https://git.openjdk.java.net/jdk/pull/5344.diff</a>

</details>
