### PR TITLE
8273256: runtime/cds/appcds/TestEpsilonGCWithCDS.java fails due to Unrecognized VM option 'ObjectAlignmentInBytes=64' on x86_32

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/TestEpsilonGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestEpsilonGCWithCDS.java
@@ -54,7 +54,7 @@ public class TestEpsilonGCWithCDS {
 
         // We usually have 2 heap regions. To increase test coverage, we can have 3 heap regions
         // by using "-Xmx256m -XX:ObjectAlignmentInBytes=64"
-        test(false, true, true);
+        if (Platform.is64bit()) test(false, true, true);
     }
 
     final static String G1 = "-XX:+UseG1GC";


### PR DESCRIPTION
Hi all,

It fails on x86_32 since `ObjectAlignmentInBytes` is not a VM option.
Let's fix it.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273256](https://bugs.openjdk.java.net/browse/JDK-8273256): runtime/cds/appcds/TestEpsilonGCWithCDS.java fails due to Unrecognized VM option 'ObjectAlignmentInBytes=64' on x86_32


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5345/head:pull/5345` \
`$ git checkout pull/5345`

Update a local copy of the PR: \
`$ git checkout pull/5345` \
`$ git pull https://git.openjdk.java.net/jdk pull/5345/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5345`

View PR using the GUI difftool: \
`$ git pr show -t 5345`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5345.diff">https://git.openjdk.java.net/jdk/pull/5345.diff</a>

</details>
