### PR TITLE
JDK-8273229: Update OS detection code to recognize Windows Server 2022

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1866,9 +1866,12 @@ void os::win32::print_windows_version(outputStream* st) {
     if (is_workstation) {
       st->print("10");
     } else {
-      // distinguish Windows Server 2016 and 2019 by build number
+      // distinguish Windows Server 2016, 2019 and 2022 by build number
       // Windows server 2019 GA 10/2018 build number is 17763
-      if (build_number > 17762) {
+      // Windows server 2022 build number is 20348
+      if (build_number > 20347) {
+        st->print("Server 2022");
+      } else if (build_number > 17762) {
         st->print("Server 2019");
       } else {
         st->print("Server 2016");

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1866,9 +1866,10 @@ void os::win32::print_windows_version(outputStream* st) {
     if (is_workstation) {
       st->print("10");
     } else {
-      // distinguish Windows Server 2016, 2019 and 2022 by build number
-      // Windows server 2019 GA 10/2018 build number is 17763
-      // Windows server 2022 build number is 20348
+      // distinguish Windows Server by build number
+      // - 2016 GA 10/2016 build: 14393
+      // - 2019 GA 11/2018 build: 17763
+      // - 2022 GA 08/2021 build: 20348
       if (build_number > 20347) {
         st->print("Server 2022");
       } else if (build_number > 17762) {

--- a/src/java.base/windows/native/libjava/java_props_md.c
+++ b/src/java.base/windows/native/libjava/java_props_md.c
@@ -389,7 +389,7 @@ GetJavaProperties(JNIEnv* env)
             GetVersionEx((OSVERSIONINFO *) &ver);
             majorVersion = ver.dwMajorVersion;
             minorVersion = ver.dwMinorVersion;
-            /* distinguish Windows Server 2016 and 2019 by build number */
+            /* distinguish Windows Server 2016+ by build number */
             buildNumber = ver.dwBuildNumber;
             is_workstation = (ver.wProductType == VER_NT_WORKSTATION);
             platformId = ver.dwPlatformId;

--- a/src/java.base/windows/native/libjava/java_props_md.c
+++ b/src/java.base/windows/native/libjava/java_props_md.c
@@ -474,6 +474,8 @@ GetJavaProperties(JNIEnv* env)
          * Windows Server 2016          10              0  (!VER_NT_WORKSTATION)
          * Windows Server 2019          10              0  (!VER_NT_WORKSTATION)
          *       where (buildNumber > 17762)
+         * Windows Server 2022          10              0  (!VER_NT_WORKSTATION)
+         *       where (buildNumber > 20347)
          *
          * This mapping will presumably be augmented as new Windows
          * versions are released.
@@ -549,7 +551,10 @@ GetJavaProperties(JNIEnv* env)
                     switch (minorVersion) {
                     case  0:
                         /* Windows server 2019 GA 10/2018 build number is 17763 */
-                        if (buildNumber > 17762) {
+                        /* Windows server 2022 build number is 20348 */
+                        if (buildNumber > 20347) {
+                            sprops.os_name = "Windows Server 2022";
+                        } else if (buildNumber > 17676) {
                             sprops.os_name = "Windows Server 2019";
                         } else {
                             sprops.os_name = "Windows Server 2016";


### PR DESCRIPTION
Hello, please review this small change.
The OS detection code of the JDK/JVM should recognize the new Windows server 2022 :

https://docs.microsoft.com/en-us/lifecycle/products/windows-server-2022
https://docs.microsoft.com/en-us/windows-server/get-started/windows-server-release-info

The build number of Windows server 2022 according to the documentation in the second link is 20348 .
Thanks, Matthias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273229](https://bugs.openjdk.java.net/browse/JDK-8273229): Update OS detection code to recognize Windows Server 2022


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to c7ce4abc33191a0dcc9aaaa353edee20380c8a44
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5347/head:pull/5347` \
`$ git checkout pull/5347`

Update a local copy of the PR: \
`$ git checkout pull/5347` \
`$ git pull https://git.openjdk.java.net/jdk pull/5347/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5347`

View PR using the GUI difftool: \
`$ git pr show -t 5347`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5347.diff">https://git.openjdk.java.net/jdk/pull/5347.diff</a>

</details>
