### PR TITLE
8273257: jshell doesn't compile a sealed hierarchy with a sealed interface and a non-sealed leaf

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5303,9 +5303,16 @@ public class Attr extends JCTree.Visitor {
 
             if (sealedSupers.isEmpty()) {
                 if ((c.flags_field & Flags.NON_SEALED) != 0) {
-                    boolean hasErrorSuper = types.directSupertypes(c.type)
-                                                 .stream()
-                                                 .anyMatch(s -> s.tsym.kind == Kind.ERR);
+                    boolean hasErrorSuper = false;
+
+                    hasErrorSuper |= types.directSupertypes(c.type)
+                                          .stream()
+                                          .anyMatch(s -> s.tsym.kind == Kind.ERR);
+
+                    ClassType ct = (ClassType) c.type;
+
+                    hasErrorSuper |= !ct.isCompound() && ct.interfaces_field != ct.all_interfaces_field;
+
                     if (!hasErrorSuper) {
                         log.error(TreeInfo.diagnosticPositionFor(c, env.tree), Errors.NonSealedWithNoSealedSupertype(c));
                     }

--- a/test/langtools/jdk/jshell/SealedClassesTest.java
+++ b/test/langtools/jdk/jshell/SealedClassesTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8246353
+ * @bug 8246353 8273257
  * @summary Test sealed class in jshell
  * @modules jdk.jshell
  * @build KullaTesting TestingInputStream ExpectedDiagnostic
@@ -53,6 +53,16 @@ public class SealedClassesTest extends KullaTesting {
         assertEval("new I()");
     }
 
+    public void testInterface() {
+        TypeDeclSnippet base = classKey(
+                assertEval("sealed interface I permits C {}",
+                           ste(MAIN_SNIPPET, Status.NONEXISTENT, Status.RECOVERABLE_NOT_DEFINED, false, null)));
+        assertEval("final class C implements I {}",
+                   added(VALID),
+                   ste(base, Status.RECOVERABLE_NOT_DEFINED, Status.VALID, true, null));
+        assertEval("new C()");
+    }
+
     public void testNonSealed() {
         TypeDeclSnippet base = classKey(
                 assertEval("sealed class B permits I {}",
@@ -62,5 +72,16 @@ public class SealedClassesTest extends KullaTesting {
                    ste(base, Status.RECOVERABLE_NOT_DEFINED, Status.VALID, true, null));
         assertEval("class I2 extends I {}");
         assertEval("new I2()");
+    }
+
+    public void testNonSealedInterface() {
+        TypeDeclSnippet base = classKey(
+                assertEval("sealed interface B permits C {}",
+                           ste(MAIN_SNIPPET, Status.NONEXISTENT, Status.RECOVERABLE_NOT_DEFINED, false, null)));
+        assertEval("non-sealed class C implements B {}",
+                   added(VALID),
+                   ste(base, Status.RECOVERABLE_NOT_DEFINED, Status.VALID, true, null));
+        assertEval("class C2 extends C {}");
+        assertEval("new C2()");
     }
 }

--- a/test/langtools/tools/javac/sealed/SealedCompilationTests.java
+++ b/test/langtools/tools/javac/sealed/SealedCompilationTests.java
@@ -25,7 +25,7 @@
  * SealedCompilationTests
  *
  * @test
- * @bug 8246353
+ * @bug 8246353 8273257
  * @summary Negative compilation tests, and positive compilation (smoke) tests for sealed classes
  * @library /lib/combo /tools/lib
  * @modules
@@ -724,6 +724,18 @@ public class SealedCompilationTests extends CompilationTestCase {
                    },
                    """
                    non-sealed class C extends Undefined {}
+                   """);
+    }
+
+    public void testNonSealedErroneousSuperInterface() {
+        assertFail("compiler.err.cant.resolve",
+                   d -> {
+                       if (diags.keys().size() != 1) {
+                           fail("Unexpected errors: " + diags.toString());
+                       }
+                   },
+                   """
+                   non-sealed class C implements Undefined {}
                    """);
     }
 


### PR DESCRIPTION
Considering code like:
```
non-sealed class C implements Undefined {}
```

javac will currently produce these compile-time errors:

```
/tmp/C.java:1: error: cannot find symbol
non-sealed class C implements Undefined {}
                              ^
  symbol: class Undefined
/tmp/C.java:1: error: non-sealed modifier not allowed here
non-sealed class C implements Undefined {}
           ^
  (class C does not have any sealed supertypes)
2 errors
```

The second error confuses JShell in cases like:
```
sealed interface I permits C {}
non-sealed class C implements I {}
```

Because when compiling the second snippet, JShell needs to analyze both these snippets together, but the second error seems unrepairable to JShell, so it does not try to include the first snippet in the compilation.

While JShell could be changed to consider the second error repairable, it seems better to tweak the error recovery to skip the second error, as javac does not know whether the `Undefined` interface is or is not sealed.

There is already code attempting to skip the error for erroneous supertypes, but erroneous superinterfaces are not returned by `Types.directSupertypes`, so attempting to detect cases where superinterfaces are erroneous.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273257](https://bugs.openjdk.java.net/browse/JDK-8273257): jshell doesn't compile a sealed hierarchy with a sealed interface and a non-sealed leaf


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5348/head:pull/5348` \
`$ git checkout pull/5348`

Update a local copy of the PR: \
`$ git checkout pull/5348` \
`$ git pull https://git.openjdk.java.net/jdk pull/5348/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5348`

View PR using the GUI difftool: \
`$ git pr show -t 5348`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5348.diff">https://git.openjdk.java.net/jdk/pull/5348.diff</a>

</details>
