### PR TITLE
8273263: Incorrect recovery attribution of record component type when j.l.Record is unavailable

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
@@ -552,6 +552,16 @@ public class TypeEnter implements Completer {
             return result;
         }
 
+        /** Generate a base clause for a record type.
+         *  @param pos              The position for trees and diagnostics, if any
+         *  @param c                The class symbol of the record
+         */
+        protected  JCExpression recordBase(int pos, ClassSymbol c) {
+            JCExpression result = make.at(pos).
+                QualIdent(syms.recordType.tsym);
+            return result;
+        }
+
         protected Type modelMissingTypes(Env<AttrContext> env, Type t, final JCExpression tree, final boolean interfaceExpected) {
             if (!t.hasTag(ERROR))
                 return t;
@@ -694,7 +704,10 @@ public class TypeEnter implements Completer {
                                   true, false, false)
                 : (sym.fullname == names.java_lang_Object)
                 ? Type.noType
-                : sym.isRecord() ? syms.recordType : syms.objectType;
+                : sym.isRecord()
+                ? attr.attribBase(recordBase(tree.pos, sym), baseEnv,
+                                  true, false, false)
+                : syms.objectType;
             }
             ct.supertype_field = modelMissingTypes(baseEnv, supertype, extending, false);
 

--- a/test/langtools/tools/javac/api/TestGetElementReference.java
+++ b/test/langtools/tools/javac/api/TestGetElementReference.java
@@ -58,9 +58,14 @@ public class TestGetElementReference {
         analyze(false, "TestGetElementReferenceData.java");
         analyze(false, "mod/module-info.java", "mod/api/pkg/Api.java");
         analyze(true, "TestGetElementReferenceDataWithErrors.java");
+        analyze(true, new String[] {"--release", "8", "-XDshould-stop.at=FLOW"}, "TestGetElementReferenceDataWithRecord.java");
     }
 
     private static void analyze(boolean allowErrors, String... fileNames) throws IOException {
+        analyze(allowErrors, new String[0], fileNames);
+    }
+
+    private static void analyze(boolean allowErrors, String[] extraParams, String... fileNames) throws IOException {
         try (StandardJavaFileManager fm = ToolProvider.getSystemJavaCompiler().getStandardFileManager(null, null, null)) {
             List<JavaFileObject> files = new ArrayList<>();
             for (String fileName : fileNames) {
@@ -70,7 +75,9 @@ public class TestGetElementReference {
                 }
             }
             DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-            List<String> options = List.of("-Xjcov");
+            List<String> options = new ArrayList<>();
+            options.add("-Xjcov");
+            options.addAll(List.of(extraParams));
             JavacTask ct = (JavacTask) ToolProvider.getSystemJavaCompiler().getTask(null, null, diagnostics, options, null, files);
             Trees trees = Trees.instance(ct);
             CompilationUnitTree cut = ct.parse().iterator().next();

--- a/test/langtools/tools/javac/api/TestGetElementReferenceDataWithRecord.java
+++ b/test/langtools/tools/javac/api/TestGetElementReferenceDataWithRecord.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test;
+
+public record TestGetElementReferenceDataWithRecord(String/*getElement:CLASS:java.lang.String*/ s1,
+                                                    String/*getElement:CLASS:java.lang.String*/ s2) implements I {}
+
+interface I {}


### PR DESCRIPTION
This is a little obscure case where `j.l.Record` is not available, yet the source code contains a record, the AST model is slightly broken - the first record's component has an erroneous type. The reason is that `syms.recordType` is used directly, and when it is completed (for the first time), the `CompletionFailure` thrown will break the component's type. It would be better to report the error on the proper place at a proper place. This is already done for enums, where the supertype is attributed from an AST, which reports any errors at an appropriate place. The proposal in this patch is to also create a temporary AST for `j.l.Record` and attribute it, so that the errors are reported at an appropriate time and place.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273263](https://bugs.openjdk.java.net/browse/JDK-8273263): Incorrect recovery attribution of record component type when j.l.Record is unavailable


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5349/head:pull/5349` \
`$ git checkout pull/5349`

Update a local copy of the PR: \
`$ git checkout pull/5349` \
`$ git pull https://git.openjdk.java.net/jdk pull/5349/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5349`

View PR using the GUI difftool: \
`$ git pr show -t 5349`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5349.diff">https://git.openjdk.java.net/jdk/pull/5349.diff</a>

</details>
