### PR TITLE
8269418: jdk/jfr/event/oldobject/TestObjectSize.java failed with "RuntimeException: No events: expected false, was true"

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -832,7 +832,6 @@ jdk/jfr/event/os/TestThreadContextSwitches.java                 8247776 windows-
 jdk/jfr/startupargs/TestStartName.java                          8214685 windows-x64
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
 jdk/jfr/api/consumer/streaming/TestLatestEvent.java             8268297 windows-x64
-jdk/jfr/event/oldobject/TestObjectSize.java                     8269418 macosx-x64
 
 ############################################################################
 

--- a/test/jdk/jdk/jfr/event/oldobject/TestObjectSize.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestObjectSize.java
@@ -79,10 +79,16 @@ public class TestObjectSize {
                 recording.start();
 
                 for (int i = 0; i < 1000; i++) {
-                    switch (rand.nextInt(3)) {
-                    case 0: leak.add(new Leak1()); break;
-                    case 1: leak.add(new Leak2()); break;
-                    case 2: leak.add(new Leak3()); break;
+                    if (sizeLeak1 == -1) {
+                        leak.add(new Leak1());
+                        continue;
+                    }
+                    if (sizeLeak2 == -1) {
+                        leak.add(new Leak2());
+                        continue;
+                    }
+                    if (sizeLeak3 == -1) {
+                        leak.add(new Leak3());
                     }
                 }
 

--- a/test/jdk/jdk/jfr/event/oldobject/TestObjectSize.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestObjectSize.java
@@ -68,13 +68,11 @@ public class TestObjectSize {
 
         final Random rand = new Random(1L);
 
-        long sizeLeak1, sizeLeak2, sizeLeak3;
+        long sizeLeak1 = -1;
+        long sizeLeak2 = -1;
+        long sizeLeak3 = -1;
 
         do {
-            sizeLeak1 = -1;
-            sizeLeak2 = -1;
-            sizeLeak3 = -1;
-
             try (Recording recording = new Recording()) {
                 leak.clear();
                 recording.enable(EventNames.OldObjectSample).withStackTrace().with("cutoff", "infinity");
@@ -91,7 +89,6 @@ public class TestObjectSize {
                 recording.stop();
 
                 List<RecordedEvent> events = Events.fromRecording(recording);
-                Events.hasEvents(events);
                 for (RecordedEvent e : events) {
                     RecordedObject object = e.getValue("object");
                     RecordedClass type = object.getValue("type");
@@ -100,13 +97,13 @@ public class TestObjectSize {
                     if (objectSize <= 0) {
                         throw new Exception("Object size for " + type.getName() + " is lower or equal to 0");
                     }
-                    if (type.getName().equals(Leak1.class.getName())) {
+                    if (type.getName().equals(Leak1.class.getName()) && sizeLeak1 == -1) {
                         sizeLeak1 = objectSize;
                     }
-                    if (type.getName().equals(Leak2.class.getName())) {
+                    if (type.getName().equals(Leak2.class.getName()) && sizeLeak2 == -1) {
                         sizeLeak2 = objectSize;
                     }
-                    if (type.getName().equals(Leak3.class.getName())) {
+                    if (type.getName().equals(Leak3.class.getName()) && sizeLeak3 == -1) {
                         sizeLeak3 = objectSize;
                     }
                 }


### PR DESCRIPTION
Greetings,

please help review these adjustments to make the test more robust, i.e. neither trap on an invalid assertion nor timeout because of too many retries.

Testing: jdk_jfr (300 times)

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269418](https://bugs.openjdk.java.net/browse/JDK-8269418): jdk/jfr/event/oldobject/TestObjectSize.java failed with "RuntimeException: No events: expected false, was true"


### Reviewers
 * [Jaroslav Bachorik](https://openjdk.java.net/census#jbachorik) (@jbachorik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5350/head:pull/5350` \
`$ git checkout pull/5350`

Update a local copy of the PR: \
`$ git checkout pull/5350` \
`$ git pull https://git.openjdk.java.net/jdk pull/5350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5350`

View PR using the GUI difftool: \
`$ git pr show -t 5350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5350.diff">https://git.openjdk.java.net/jdk/pull/5350.diff</a>

</details>
