### PR TITLE
8268558: [TESTBUG] Case 2 in TestP11KeyFactoryGetRSAKeySpec is skipped

### DIFF
--- a/test/jdk/sun/security/pkcs11/rsa/TestP11KeyFactoryGetRSAKeySpec.java
+++ b/test/jdk/sun/security/pkcs11/rsa/TestP11KeyFactoryGetRSAKeySpec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Amazon.com, Inc. or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -21,7 +22,6 @@
  * questions.
  */
 
-import java.math.BigInteger;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -86,7 +86,7 @@ public class TestP11KeyFactoryGetRSAKeySpec extends PKCS11Test {
 
     private static void testKeySpec(KeyFactory factory, PrivateKey key, Class<? extends KeySpec> specClass) throws Exception {
         try {
-            KeySpec spec = factory.getKeySpec(key, RSAPrivateKeySpec.class);
+            KeySpec spec = factory.getKeySpec(key, specClass);
             if (testingSensitiveKeys) {
                 throw new Exception("Able to retrieve spec from sensitive key");
             }


### PR DESCRIPTION
This trivial change fixes the case 2 in test sun/security/pkcs11/rsa/TestP11KeyFactoryGetRSAKeySpec, the method testKeySpec is expecting a class object of type KeySpec as second argument in order to be reusable for multiple test scenarios, but then instead of using that argument the RSAPrivateKeySpec.class is hardcoded:

```
private static void testKeySpec(KeyFactory factory, PrivateKey key, Class<? extends KeySpec> specClass) throws Exception {
        try {
            KeySpec spec = factory.getKeySpec(key, RSAPrivateKeySpec.class);
```

it should be:

`KeySpec spec = factory.getKeySpec(key, specClass);
`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268558](https://bugs.openjdk.java.net/browse/JDK-8268558): [TESTBUG] Case 2 in TestP11KeyFactoryGetRSAKeySpec is skipped


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)
 * [Rajan Halade](https://openjdk.java.net/census#rhalade) (@rhalade - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5351/head:pull/5351` \
`$ git checkout pull/5351`

Update a local copy of the PR: \
`$ git checkout pull/5351` \
`$ git pull https://git.openjdk.java.net/jdk pull/5351/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5351`

View PR using the GUI difftool: \
`$ git pr show -t 5351`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5351.diff">https://git.openjdk.java.net/jdk/pull/5351.diff</a>

</details>
