### PR TITLE
8273528: Avoid ByteArrayOutputStream.toByteArray when converting stream to String

### DIFF
--- a/src/java.base/share/classes/sun/security/util/BitArray.java
+++ b/src/java.base/share/classes/sun/security/util/BitArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -261,7 +261,7 @@ public class BitArray {
             out.write(get(i) ? '1' : '0');
         }
 
-        return new String(out.toByteArray());
+        return out.toString();
 
     }
 

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/png/PNGImageReader.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/png/PNGImageReader.java
@@ -227,7 +227,7 @@ public class PNGImageReader extends ImageReader {
         if (b != 0) {
             throw new IIOException("Found non null terminated string");
         }
-        return new String(baos.toByteArray(), charset);
+        return baos.toString(charset);
     }
 
     private void readHeader() throws IIOException {

--- a/src/java.desktop/share/classes/sun/awt/DebugSettings.java
+++ b/src/java.desktop/share/classes/sun/awt/DebugSettings.java
@@ -134,7 +134,7 @@ public final class DebugSettings {
             String value = props.getProperty(key, "");
             pout.println(key + " = " + value);
         }
-        return new String(bout.toByteArray());
+        return bout.toString();
     }
 
     /*

--- a/src/java.desktop/share/classes/sun/awt/datatransfer/DataTransferer.java
+++ b/src/java.desktop/share/classes/sun/awt/datatransfer/DataTransferer.java
@@ -945,10 +945,9 @@ search:
                 }
 
                 if (DataFlavorUtil.isFlavorCharsetTextType(flavor) && isTextFormat(format)) {
-                    byte[] bytes = bos.toByteArray();
                     String sourceEncoding = DataFlavorUtil.getTextCharset(flavor);
                     return translateTransferableString(
-                               new String(bytes, sourceEncoding),
+                               bos.toString(sourceEncoding),
                                format);
                 }
                 theByteArray = bos.toByteArray();


### PR DESCRIPTION
Using `ByteArrayOutputStream.toString` to convert it's content to a String is cleaner than `new String(out.toByteArray())`. Also it's a bit faster because of one less array copy.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273528](https://bugs.openjdk.java.net/browse/JDK-8273528): Avoid ByteArrayOutputStream.toByteArray when converting stream to String


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * @stsypanov (no known github.com user name / role)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5355/head:pull/5355` \
`$ git checkout pull/5355`

Update a local copy of the PR: \
`$ git checkout pull/5355` \
`$ git pull https://git.openjdk.java.net/jdk pull/5355/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5355`

View PR using the GUI difftool: \
`$ git pr show -t 5355`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5355.diff">https://git.openjdk.java.net/jdk/pull/5355.diff</a>

</details>
