### PR TITLE
8273375: Remove redundant 'new String' calls after concatenation in java.desktop

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTabbedPaneCopyFromBasicUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTabbedPaneCopyFromBasicUI.java
@@ -3206,7 +3206,10 @@ public class AquaTabbedPaneCopyFromBasicUI extends TabbedPaneUI implements Swing
         }
 
         public String toString() {
-            return "viewport.viewSize=" + viewport.getViewSize() + "\n" + "viewport.viewRectangle=" + viewport.getViewRect() + "\n" + "leadingTabIndex=" + leadingTabIndex + "\n" + "tabViewPosition=" + tabViewPosition;
+            return "viewport.viewSize=" + viewport.getViewSize() + "\n"
+                    + "viewport.viewRectangle=" + viewport.getViewRect() + "\n"
+                    + "leadingTabIndex=" + leadingTabIndex + "\n"
+                    + "tabViewPosition=" + tabViewPosition;
         }
 
     }

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTabbedPaneCopyFromBasicUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTabbedPaneCopyFromBasicUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3206,7 +3206,7 @@ public class AquaTabbedPaneCopyFromBasicUI extends TabbedPaneUI implements Swing
         }
 
         public String toString() {
-            return new String("viewport.viewSize=" + viewport.getViewSize() + "\n" + "viewport.viewRectangle=" + viewport.getViewRect() + "\n" + "leadingTabIndex=" + leadingTabIndex + "\n" + "tabViewPosition=" + tabViewPosition);
+            return "viewport.viewSize=" + viewport.getViewSize() + "\n" + "viewport.viewRectangle=" + viewport.getViewRect() + "\n" + "leadingTabIndex=" + leadingTabIndex + "\n" + "tabViewPosition=" + tabViewPosition;
         }
 
     }

--- a/src/java.desktop/macosx/classes/sun/java2d/IntegerNIORaster.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/IntegerNIORaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,10 +87,10 @@ public class IntegerNIORaster extends SunWritableRaster {
     }
 
     public String toString() {
-        return new String ("IntegerNIORaster: width = "+width
-                           +" height = " + height
-                           +" #Bands = " + numBands
-                           +" xOff = "+sampleModelTranslateX
-                           +" yOff = "+sampleModelTranslateY);
+        return "IntegerNIORaster: width = " + width
+                + " height = " + height
+                + " #Bands = " + numBands
+                + " xOff = " + sampleModelTranslateX
+                + " yOff = " + sampleModelTranslateY;
     }
 }

--- a/src/java.desktop/share/classes/java/awt/image/ColorModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/ColorModel.java
@@ -1673,13 +1673,12 @@ public abstract class ColorModel implements Transparency{
      * {@code ColorModel} object.
      */
     public String toString() {
-       return new String("ColorModel: #pixelBits = "+pixel_bits
-                         + " numComponents = "+numComponents
-                         + " color space = "+colorSpace
-                         + " transparency = "+transparency
-                         + " has alpha = "+supportsAlpha
-                         + " isAlphaPre = "+isAlphaPremultiplied
-                         );
+       return "ColorModel: #pixelBits = " + pixel_bits
+               + " numComponents = " + numComponents
+               + " color space = " + colorSpace
+               + " transparency = " + transparency
+               + " has alpha = " + supportsAlpha
+               + " isAlphaPre = " + isAlphaPremultiplied;
     }
 
     static int getDefaultTransferType(int pixel_bits) {

--- a/src/java.desktop/share/classes/java/awt/image/DirectColorModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/DirectColorModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1407,10 +1407,10 @@ public class DirectColorModel extends PackedColorModel {
      * {@code DirectColorModel}.
      */
     public String toString() {
-        return new String("DirectColorModel: rmask="
-                          +Integer.toHexString(red_mask)+" gmask="
-                          +Integer.toHexString(green_mask)+" bmask="
-                          +Integer.toHexString(blue_mask)+" amask="
-                          +Integer.toHexString(alpha_mask));
+        return "DirectColorModel: rmask="
+                + Integer.toHexString(red_mask) + " gmask="
+                + Integer.toHexString(green_mask) + " bmask="
+                + Integer.toHexString(blue_mask) + " amask="
+                + Integer.toHexString(alpha_mask);
     }
 }

--- a/src/java.desktop/share/classes/java/awt/image/DirectColorModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/DirectColorModel.java
@@ -1407,10 +1407,9 @@ public class DirectColorModel extends PackedColorModel {
      * {@code DirectColorModel}.
      */
     public String toString() {
-        return "DirectColorModel: rmask="
-                + Integer.toHexString(red_mask) + " gmask="
-                + Integer.toHexString(green_mask) + " bmask="
-                + Integer.toHexString(blue_mask) + " amask="
-                + Integer.toHexString(alpha_mask);
+        return "DirectColorModel: rmask=" + Integer.toHexString(red_mask)
+                + " gmask=" + Integer.toHexString(green_mask)
+                + " bmask=" + Integer.toHexString(blue_mask)
+                + " amask=" + Integer.toHexString(alpha_mask);
     }
 }

--- a/src/java.desktop/share/classes/java/awt/image/IndexColorModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/IndexColorModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1536,14 +1536,13 @@ public class IndexColorModel extends ColorModel {
      * {@code ColorModel} object.
      */
     public String toString() {
-       return new String("IndexColorModel: #pixelBits = "+pixel_bits
-                         + " numComponents = "+numComponents
-                         + " color space = "+colorSpace
-                         + " transparency = "+transparency
-                         + " transIndex   = "+transparent_index
-                         + " has alpha = "+supportsAlpha
-                         + " isAlphaPre = "+isAlphaPremultiplied
-                         );
+       return "IndexColorModel: #pixelBits = " + pixel_bits
+               + " numComponents = " + numComponents
+               + " color space = " + colorSpace
+               + " transparency = " + transparency
+               + " transIndex   = " + transparent_index
+               + " has alpha = " + supportsAlpha
+               + " isAlphaPre = " + isAlphaPremultiplied;
     }
 
     /**

--- a/src/java.desktop/share/classes/sun/awt/image/ByteBandedRaster.java
+++ b/src/java.desktop/share/classes/sun/awt/image/ByteBandedRaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
  */
 
 package sun.awt.image;
+
 import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
 import java.awt.image.RasterFormatException;
@@ -818,10 +819,10 @@ public class ByteBandedRaster extends SunWritableRaster {
     }
 
     public String toString() {
-        return new String ("ByteBandedRaster: width = "+width+" height = "
-                           + height
-                           +" #bands "+numDataElements
-                           +" minX = "+minX+" minY = "+minY);
+        return "ByteBandedRaster: width = " + width + " height = "
+                + height
+                + " #bands " + numDataElements
+                + " minX = " + minX + " minY = " + minY;
     }
 
 }

--- a/src/java.desktop/share/classes/sun/awt/image/ByteBandedRaster.java
+++ b/src/java.desktop/share/classes/sun/awt/image/ByteBandedRaster.java
@@ -819,10 +819,11 @@ public class ByteBandedRaster extends SunWritableRaster {
     }
 
     public String toString() {
-        return "ByteBandedRaster: width = " + width + " height = "
-                + height
+        return "ByteBandedRaster: width = " + width
+                + " height = " + height
                 + " #bands " + numDataElements
-                + " minX = " + minX + " minY = " + minY;
+                + " minX = " + minX
+                + " minY = " + minY;
     }
 
 }

--- a/src/java.desktop/share/classes/sun/awt/image/ByteComponentRaster.java
+++ b/src/java.desktop/share/classes/sun/awt/image/ByteComponentRaster.java
@@ -946,8 +946,8 @@ public class ByteComponentRaster extends SunWritableRaster {
     }
 
     public String toString() {
-        return "ByteComponentRaster: width = " + width + " height = "
-                + height
+        return "ByteComponentRaster: width = " + width
+                + " height = " + height
                 + " #numDataElements " + numDataElements
                 //  +" xOff = "+xOffset+" yOff = "+yOffset
                 + " dataOff[0] = " + dataOffsets[0];

--- a/src/java.desktop/share/classes/sun/awt/image/ByteComponentRaster.java
+++ b/src/java.desktop/share/classes/sun/awt/image/ByteComponentRaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
  */
 
 package sun.awt.image;
+
 import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
 import java.awt.image.RasterFormatException;
@@ -945,11 +946,11 @@ public class ByteComponentRaster extends SunWritableRaster {
     }
 
     public String toString() {
-        return new String ("ByteComponentRaster: width = "+width+" height = "
-                           + height
-                           +" #numDataElements "+numDataElements
-                           //  +" xOff = "+xOffset+" yOff = "+yOffset
-                           +" dataOff[0] = "+dataOffsets[0]);
+        return "ByteComponentRaster: width = " + width + " height = "
+                + height
+                + " #numDataElements " + numDataElements
+                //  +" xOff = "+xOffset+" yOff = "+yOffset
+                + " dataOff[0] = " + dataOffsets[0];
     }
 
 //    /**

--- a/src/java.desktop/share/classes/sun/awt/image/ByteInterleavedRaster.java
+++ b/src/java.desktop/share/classes/sun/awt/image/ByteInterleavedRaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
  */
 
 package sun.awt.image;
+
 import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
 import java.awt.image.RasterFormatException;
@@ -1288,11 +1289,11 @@ public class ByteInterleavedRaster extends ByteComponentRaster {
     }
 
     public String toString() {
-        return new String ("ByteInterleavedRaster: width = "+width+" height = "
-                           + height
-                           +" #numDataElements "+numDataElements
-                           //  +" xOff = "+xOffset+" yOff = "+yOffset
-                           +" dataOff[0] = "+dataOffsets[0]);
+        return "ByteInterleavedRaster: width = " + width + " height = "
+                + height
+                + " #numDataElements " + numDataElements
+                //  +" xOff = "+xOffset+" yOff = "+yOffset
+                + " dataOff[0] = " + dataOffsets[0];
     }
 
 //    /**

--- a/src/java.desktop/share/classes/sun/awt/image/ByteInterleavedRaster.java
+++ b/src/java.desktop/share/classes/sun/awt/image/ByteInterleavedRaster.java
@@ -1289,8 +1289,8 @@ public class ByteInterleavedRaster extends ByteComponentRaster {
     }
 
     public String toString() {
-        return "ByteInterleavedRaster: width = " + width + " height = "
-                + height
+        return "ByteInterleavedRaster: width = " + width
+                + " height = " + height
                 + " #numDataElements " + numDataElements
                 //  +" xOff = "+xOffset+" yOff = "+yOffset
                 + " dataOff[0] = " + dataOffsets[0];

--- a/src/java.desktop/share/classes/sun/awt/image/BytePackedRaster.java
+++ b/src/java.desktop/share/classes/sun/awt/image/BytePackedRaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1425,9 +1425,9 @@ public class BytePackedRaster extends SunWritableRaster {
     }
 
     public String toString() {
-        return new String ("BytePackedRaster: width = "+width+" height = "+height
-                           +" #channels "+numBands
-                           +" xOff = "+sampleModelTranslateX
-                           +" yOff = "+sampleModelTranslateY);
+        return "BytePackedRaster: width = " + width + " height = " + height
+                + " #channels " + numBands
+                + " xOff = " + sampleModelTranslateX
+                + " yOff = " + sampleModelTranslateY;
     }
 }

--- a/src/java.desktop/share/classes/sun/awt/image/BytePackedRaster.java
+++ b/src/java.desktop/share/classes/sun/awt/image/BytePackedRaster.java
@@ -1425,7 +1425,8 @@ public class BytePackedRaster extends SunWritableRaster {
     }
 
     public String toString() {
-        return "BytePackedRaster: width = " + width + " height = " + height
+        return "BytePackedRaster: width = " + width
+                + " height = " + height
                 + " #channels " + numBands
                 + " xOff = " + sampleModelTranslateX
                 + " yOff = " + sampleModelTranslateY;

--- a/src/java.desktop/share/classes/sun/awt/image/IntegerComponentRaster.java
+++ b/src/java.desktop/share/classes/sun/awt/image/IntegerComponentRaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
  */
 
 package sun.awt.image;
+
 import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
 import java.awt.image.RasterFormatException;
@@ -714,13 +715,13 @@ public class IntegerComponentRaster extends SunWritableRaster {
     }
 
     public String toString() {
-        return new String ("IntegerComponentRaster: width = "+width
-                           +" height = " + height
-                           +" #Bands = " + numBands
-                           +" #DataElements "+numDataElements
-                           +" xOff = "+sampleModelTranslateX
-                           +" yOff = "+sampleModelTranslateY
-                           +" dataOffset[0] "+dataOffsets[0]);
+        return "IntegerComponentRaster: width = " + width
+                + " height = " + height
+                + " #Bands = " + numBands
+                + " #DataElements " + numDataElements
+                + " xOff = " + sampleModelTranslateX
+                + " yOff = " + sampleModelTranslateY
+                + " dataOffset[0] " + dataOffsets[0];
     }
 
 //    /**

--- a/src/java.desktop/share/classes/sun/awt/image/IntegerInterleavedRaster.java
+++ b/src/java.desktop/share/classes/sun/awt/image/IntegerInterleavedRaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
  */
 
 package sun.awt.image;
+
 import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
 import java.awt.image.RasterFormatException;
@@ -537,12 +538,12 @@ public class IntegerInterleavedRaster extends IntegerComponentRaster {
     }
 
     public String toString() {
-        return new String ("IntegerInterleavedRaster: width = "+width
-                           +" height = " + height
-                           +" #Bands = " + numBands
-                           +" xOff = "+sampleModelTranslateX
-                           +" yOff = "+sampleModelTranslateY
-                           +" dataOffset[0] "+dataOffsets[0]);
+        return "IntegerInterleavedRaster: width = " + width
+                + " height = " + height
+                + " #Bands = " + numBands
+                + " xOff = " + sampleModelTranslateX
+                + " yOff = " + sampleModelTranslateY
+                + " dataOffset[0] " + dataOffsets[0];
     }
 
 //    /**

--- a/src/java.desktop/share/classes/sun/awt/image/ShortBandedRaster.java
+++ b/src/java.desktop/share/classes/sun/awt/image/ShortBandedRaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
  */
 
 package sun.awt.image;
+
 import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
 import java.awt.image.RasterFormatException;
@@ -802,10 +803,10 @@ public class ShortBandedRaster extends SunWritableRaster {
     }
 
     public String toString() {
-        return new String ("ShortBandedRaster: width = "+width+" height = "
-                           + height
-                           +" #numBands " + numBands
-                           +" #dataElements "+numDataElements);
+        return "ShortBandedRaster: width = " + width + " height = "
+                + height
+                + " #numBands " + numBands
+                + " #dataElements " + numDataElements;
 
     }
 

--- a/src/java.desktop/share/classes/sun/awt/image/ShortBandedRaster.java
+++ b/src/java.desktop/share/classes/sun/awt/image/ShortBandedRaster.java
@@ -803,8 +803,8 @@ public class ShortBandedRaster extends SunWritableRaster {
     }
 
     public String toString() {
-        return "ShortBandedRaster: width = " + width + " height = "
-                + height
+        return "ShortBandedRaster: width = " + width
+                + " height = " + height
                 + " #numBands " + numBands
                 + " #dataElements " + numDataElements;
 

--- a/src/java.desktop/share/classes/sun/awt/image/ShortComponentRaster.java
+++ b/src/java.desktop/share/classes/sun/awt/image/ShortComponentRaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
  */
 
 package sun.awt.image;
+
 import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
 import java.awt.image.RasterFormatException;
@@ -877,10 +878,10 @@ public class ShortComponentRaster extends SunWritableRaster {
     }
 
     public String toString() {
-        return new String ("ShortComponentRaster: width = "+width
-                           +" height = " + height
-                           +" #numDataElements "+numDataElements);
-                           // +" xOff = "+xOffset+" yOff = "+yOffset);
+        return "ShortComponentRaster: width = " + width
+                + " height = " + height
+                + " #numDataElements " + numDataElements;
+                // +" xOff = "+xOffset+" yOff = "+yOffset);
     }
 
 }

--- a/src/java.desktop/share/classes/sun/awt/image/ShortInterleavedRaster.java
+++ b/src/java.desktop/share/classes/sun/awt/image/ShortInterleavedRaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
  */
 
 package sun.awt.image;
+
 import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
 import java.awt.image.RasterFormatException;
@@ -758,10 +759,10 @@ public class ShortInterleavedRaster extends ShortComponentRaster {
     }
 
     public String toString() {
-        return new String ("ShortInterleavedRaster: width = "+width
-                           +" height = " + height
-                           +" #numDataElements "+numDataElements);
-                           // +" xOff = "+xOffset+" yOff = "+yOffset);
+        return "ShortInterleavedRaster: width = " + width
+                + " height = " + height
+                + " #numDataElements " + numDataElements;
+                // +" xOff = "+xOffset+" yOff = "+yOffset);
     }
 
 }

--- a/src/java.desktop/unix/classes/sun/awt/X11/InfoWindow.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/InfoWindow.java
@@ -389,7 +389,7 @@ public abstract class InfoWindow extends Window {
                     if (nLines == BALLOON_WORD_LINE_MAX_COUNT) {
                         if (end != BreakIterator.DONE) {
                             lineLabels[nLines - 1].setText(
-                                new String(lineLabels[nLines - 1].getText() + " ..."));
+                                lineLabels[nLines - 1].getText() + " ...");
                         }
                         break;
                     }


### PR DESCRIPTION
Result of string concatenation is a newly created `String` object. There is no need it wrap it in another `new String` call.
Such calls are confusing and produce warnings in IDE. Without them code is easier to read.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273375](https://bugs.openjdk.java.net/browse/JDK-8273375): Remove redundant 'new String' calls after concatenation in java.desktop


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5356/head:pull/5356` \
`$ git checkout pull/5356`

Update a local copy of the PR: \
`$ git checkout pull/5356` \
`$ git pull https://git.openjdk.java.net/jdk pull/5356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5356`

View PR using the GUI difftool: \
`$ git pr show -t 5356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5356.diff">https://git.openjdk.java.net/jdk/pull/5356.diff</a>

</details>
