### PR TITLE
8273315: Parallelize and increase timeouts for java/foreign/TestMatrix.java test

### DIFF
--- a/test/jdk/java/foreign/TestMatrix.java
+++ b/test/jdk/java/foreign/TestMatrix.java
@@ -1,10 +1,20 @@
 /*
+ * Note: to run this test manually, you need to build the tests first to get native
+ * libraries compiled, and then execute it with plain jtreg, like:
+ *
+ *  $ bin/jtreg -jdk:<path-to-tested-jdk> \
+ *              -nativepath:<path-to-build-dir>/support/test/jdk/jtreg/native/lib/ \
+ *              -concurrency:auto \
+ *              ./test/jdk/java/foreign/TestMatrix.java
+ */
+
+/*
  * @test id=UpcallHighArity-FFTT
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
- * @run testng/othervm/native
+ * @run testng/othervm/native/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
@@ -18,7 +28,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
- * @run testng/othervm/native
+ * @run testng/othervm/native/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
@@ -32,7 +42,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
- * @run testng/othervm/native
+ * @run testng/othervm/native/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
@@ -46,7 +56,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
- * @run testng/othervm/native
+ * @run testng/othervm/native/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
@@ -60,7 +70,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
- * @run testng/othervm/native
+ * @run testng/othervm/native/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
@@ -74,7 +84,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
- * @run testng/othervm/native
+ * @run testng/othervm/native/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
@@ -88,7 +98,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
- * @run testng/othervm/native
+ * @run testng/othervm/native/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
@@ -102,7 +112,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
- * @run testng/othervm/native
+ * @run testng/othervm/native/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
@@ -116,7 +126,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
- * @run testng/othervm/native
+ * @run testng/othervm/native/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
@@ -130,7 +140,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
- * @run testng/othervm/native
+ * @run testng/othervm/native/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
@@ -144,7 +154,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
- * @run testng/othervm/native
+ * @run testng/othervm/native/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
@@ -158,7 +168,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
- * @run testng/othervm/native
+ * @run testng/othervm/native/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
@@ -172,7 +182,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
- * @run testng/othervm/native
+ * @run testng/othervm/native/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
@@ -186,7 +196,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
- * @run testng/othervm/native
+ * @run testng/othervm/native/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
@@ -200,7 +210,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
- * @run testng/othervm/native
+ * @run testng/othervm/native/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
@@ -214,7 +224,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
- * @run testng/othervm/native
+ * @run testng/othervm/native/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
@@ -228,7 +238,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestDowncall
  *
- * @run testng/othervm
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
@@ -240,7 +250,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestDowncall
  *
- * @run testng/othervm
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
@@ -252,7 +262,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestDowncall
  *
- * @run testng/othervm
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
@@ -264,7 +274,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestDowncall
  *
- * @run testng/othervm
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
@@ -276,7 +286,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm/timeout=480
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
@@ -290,7 +300,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm/timeout=480
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
@@ -304,7 +314,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm/timeout=480
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
@@ -318,7 +328,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm/timeout=480
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
@@ -332,7 +342,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm/timeout=480
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
@@ -346,7 +356,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm/timeout=480
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
@@ -360,7 +370,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm/timeout=480
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
@@ -374,7 +384,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm/timeout=480
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
@@ -388,7 +398,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm/timeout=480
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
@@ -402,7 +412,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm/timeout=480
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
@@ -416,7 +426,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm/timeout=480
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
@@ -430,7 +440,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm/timeout=480
+ * @run testng/othervm/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true

--- a/test/jdk/java/foreign/TestMatrix.java
+++ b/test/jdk/java/foreign/TestMatrix.java
@@ -2,7 +2,7 @@
  * @test id=UpcallHighArity-FFTT
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
@@ -16,7 +16,7 @@
 /* @test id=UpcallHighArity-TFTT
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
@@ -30,7 +30,7 @@
 /* @test id=UpcallHighArity-FTTT
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
@@ -44,7 +44,7 @@
 /* @test id=UpcallHighArity-TTTT
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
@@ -53,13 +53,12 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcallHighArity
- *
  */
 
 /* @test id=UpcallHighArity-FFTF
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
@@ -73,7 +72,7 @@
 /* @test id=UpcallHighArity-TFTF
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
@@ -87,7 +86,7 @@
 /* @test id=UpcallHighArity-FTTF
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
@@ -101,7 +100,7 @@
 /* @test id=UpcallHighArity-TTTF
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
@@ -110,13 +109,12 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
  *   TestUpcallHighArity
- *
  */
 
 /* @test id=UpcallHighArity-FFFT
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
@@ -130,7 +128,7 @@
 /* @test id=UpcallHighArity-TFFT
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
@@ -144,7 +142,7 @@
 /* @test id=UpcallHighArity-FTFT
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
@@ -158,7 +156,7 @@
 /* @test id=UpcallHighArity-TTFT
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
@@ -167,13 +165,12 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcallHighArity
- *
  */
 
 /* @test id=UpcallHighArity-FFFF
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
@@ -187,7 +184,7 @@
 /* @test id=UpcallHighArity-TFFF
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
@@ -201,7 +198,7 @@
 /* @test id=UpcallHighArity-FTFF
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
@@ -215,7 +212,7 @@
 /* @test id=UpcallHighArity-TTFF
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
@@ -229,7 +226,7 @@
 /* @test id=Downcall-FF
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestDowncall
  *
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED
@@ -241,7 +238,7 @@
 /* @test id=Downcall-TF
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestDowncall
  *
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED
@@ -253,7 +250,7 @@
 /* @test id=Downcall-FT
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestDowncall
  *
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED
@@ -265,7 +262,7 @@
 /* @test id=Downcall-TT
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestDowncall
  *
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED
@@ -277,9 +274,9 @@
 /* @test id=Upcall-TFTT
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm
+ * @run testng/othervm/timeout=480
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
@@ -291,9 +288,9 @@
 /* @test id=Upcall-FTTT
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm
+ * @run testng/othervm/timeout=480
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
@@ -305,24 +302,23 @@
 /* @test id=Upcall-TTTT
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm
+ * @run testng/othervm/timeout=480
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcall
- *
  */
 
 /* @test id=Upcall-TFTF
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm
+ * @run testng/othervm/timeout=480
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
@@ -334,9 +330,9 @@
 /* @test id=Upcall-FTTF
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm
+ * @run testng/othervm/timeout=480
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
@@ -348,24 +344,23 @@
 /* @test id=Upcall-TTTF
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm
+ * @run testng/othervm/timeout=480
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
  *   TestUpcall
- *
  */
 
 /* @test id=Upcall-TFFT
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm
+ * @run testng/othervm/timeout=480
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
@@ -377,9 +372,9 @@
 /* @test id=Upcall-FTFT
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm
+ * @run testng/othervm/timeout=480
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
@@ -391,9 +386,9 @@
 /* @test id=Upcall-TTFT
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm
+ * @run testng/othervm/timeout=480
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
@@ -405,9 +400,9 @@
 /* @test id=Upcall-TFFF
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm
+ * @run testng/othervm/timeout=480
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
@@ -419,9 +414,9 @@
 /* @test id=Upcall-FTFF
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm
+ * @run testng/othervm/timeout=480
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
@@ -433,9 +428,9 @@
 /* @test id=Upcall-TTFF
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
- * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm
+ * @run testng/othervm/timeout=480
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true

--- a/test/jdk/java/foreign/TestMatrix.java
+++ b/test/jdk/java/foreign/TestMatrix.java
@@ -1,5 +1,5 @@
 /*
- * @test
+ * @test id=UpcallHighArity-FFTT
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
@@ -11,6 +11,13 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-TFTT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
@@ -18,6 +25,13 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-FTTT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
@@ -25,6 +39,13 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-TTTT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
@@ -33,13 +54,27 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcallHighArity
  *
-  * @run testng/othervm/native
+ */
+
+/* @test id=UpcallHighArity-FFTF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
+ * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
  *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-TFTF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
@@ -47,6 +82,13 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
  *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-FTTF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
@@ -54,6 +96,13 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
  *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-TTTF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
@@ -62,6 +111,13 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
  *   TestUpcallHighArity
  *
+ */
+
+/* @test id=UpcallHighArity-FFFT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
@@ -69,6 +125,13 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-TFFT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
@@ -76,6 +139,13 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-FTFT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
@@ -83,6 +153,13 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-TTFT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
@@ -91,6 +168,13 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcallHighArity
  *
+ */
+
+/* @test id=UpcallHighArity-FFFF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
@@ -98,6 +182,13 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
  *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-TFFF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
@@ -105,6 +196,13 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
  *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-FTFF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
@@ -112,6 +210,13 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
  *   TestUpcallHighArity
+ */
+
+/* @test id=UpcallHighArity-TTFF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
@@ -119,27 +224,60 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
  *   TestUpcallHighArity
+ */
+
+/* @test id=Downcall-FF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
  *
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
  *   TestDowncall
+ */
+
+/* @test id=Downcall-TF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
  *   TestDowncall
+ */
+
+/* @test id=Downcall-FT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
  *   TestDowncall
+ */
+
+/* @test id=Downcall-TT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
  *   TestDowncall
+ */
+
+/* @test id=Upcall-TFTT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
  *
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED
@@ -148,13 +286,13 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcall
- * @run testng/othervm
- *   --enable-native-access=ALL-UNNAMED
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
- *   TestUpcall
+ */
+
+/* @test id=Upcall-FTTT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
@@ -162,6 +300,13 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcall
+ */
+
+/* @test id=Upcall-TTTT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
@@ -170,6 +315,13 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcall
  *
+ */
+
+/* @test id=Upcall-TFTF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
@@ -177,13 +329,13 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
  *   TestUpcall
- * @run testng/othervm
- *   --enable-native-access=ALL-UNNAMED
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
- *   TestUpcall
+ */
+
+/* @test id=Upcall-FTTF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
@@ -191,6 +343,13 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
  *   TestUpcall
+ */
+
+/* @test id=Upcall-TTTF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
@@ -199,6 +358,13 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
  *   TestUpcall
  *
+ */
+
+/* @test id=Upcall-TFFT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
@@ -206,13 +372,13 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcall
- * @run testng/othervm
- *   --enable-native-access=ALL-UNNAMED
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
- *   TestUpcall
+ */
+
+/* @test id=Upcall-FTFT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
@@ -220,6 +386,13 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcall
+ */
+
+/* @test id=Upcall-TTFT
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
@@ -227,6 +400,12 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
  *   TestUpcall
+ */
+
+/* @test id=Upcall-TFFF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
  *
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED
@@ -235,13 +414,13 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
  *   TestUpcall
- * @run testng/othervm
- *   --enable-native-access=ALL-UNNAMED
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
- *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
- *   TestUpcall
+ */
+
+/* @test id=Upcall-FTFF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
@@ -249,6 +428,13 @@
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
  *   TestUpcall
+ */
+
+/* @test id=Upcall-TTFF
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true


### PR DESCRIPTION
This test runs a lot of configurations, and spends a lot of time serially. This is especially pronounced when run in prospective tier4 runs (JDK-8273314). There are reports of multi-hour runs (see JDK-8271613). We can parallelize the test configurations for this test to make it hurt less. Also, timeouts need to be increased for `TestUpcall` test configs, because some of them are very slow in fastdebug mode. 

Sample run:

```
$ time CONF=linux-x86_64-server-fastdebug make run-test TEST=java/foreign/TestMatrix.java | ts -s
00:00:00 Building target 'run-test' in configuration 'linux-x86_64-server-fastdebug'
00:00:03 Test selection 'java/foreign/TestMatrix.java', will run:
00:00:03 * jtreg:test/jdk/java/foreign/TestMatrix.java
00:00:03 
00:00:03 Running test 'jtreg:test/jdk/java/foreign/TestMatrix.java'
00:00:31 Passed: java/foreign/TestMatrix.java#UpcallHighArity-TTFT
00:00:31 Passed: java/foreign/TestMatrix.java#UpcallHighArity-FFFF
00:00:31 Passed: java/foreign/TestMatrix.java#UpcallHighArity-FFTF
00:00:31 Passed: java/foreign/TestMatrix.java#UpcallHighArity-TTTT
00:00:31 Passed: java/foreign/TestMatrix.java#UpcallHighArity-FTTT
00:00:31 Passed: java/foreign/TestMatrix.java#UpcallHighArity-FFTT
00:00:31 Passed: java/foreign/TestMatrix.java#UpcallHighArity-FFFT
00:00:31 Passed: java/foreign/TestMatrix.java#UpcallHighArity-TTTF
00:00:31 Passed: java/foreign/TestMatrix.java#UpcallHighArity-FTTF
00:00:31 Passed: java/foreign/TestMatrix.java#UpcallHighArity-TFFT
00:00:31 Passed: java/foreign/TestMatrix.java#UpcallHighArity-TFTF
00:00:32 Passed: java/foreign/TestMatrix.java#UpcallHighArity-TFFF
00:00:32 Passed: java/foreign/TestMatrix.java#UpcallHighArity-FTFF
00:00:35 Passed: java/foreign/TestMatrix.java#UpcallHighArity-TFTT
00:00:35 Passed: java/foreign/TestMatrix.java#UpcallHighArity-TTFF
00:00:38 Passed: java/foreign/TestMatrix.java#UpcallHighArity-FTFT
00:01:50 Passed: java/foreign/TestMatrix.java#Downcall-FF
00:02:27 Passed: java/foreign/TestMatrix.java#Downcall-TF
00:03:03 Passed: java/foreign/TestMatrix.java#Downcall-FT
00:03:47 Passed: java/foreign/TestMatrix.java#Downcall-TT
00:04:17 Passed: java/foreign/TestMatrix.java#Upcall-FTFF
00:04:23 Passed: java/foreign/TestMatrix.java#Upcall-TFFF
00:05:46 Passed: java/foreign/TestMatrix.java#Upcall-TTFF
00:06:03 Passed: java/foreign/TestMatrix.java#Upcall-TFFT
00:06:44 Passed: java/foreign/TestMatrix.java#Upcall-FTFT
00:08:24 Passed: java/foreign/TestMatrix.java#Upcall-TFTF
00:08:39 Passed: java/foreign/TestMatrix.java#Upcall-TTFT
00:09:16 Passed: java/foreign/TestMatrix.java#Upcall-FTTF
00:09:19 Passed: java/foreign/TestMatrix.java#Upcall-TFTT
00:10:01 Passed: java/foreign/TestMatrix.java#Upcall-FTTT
00:10:37 Passed: java/foreign/TestMatrix.java#Upcall-TTTF
00:12:16 Passed: java/foreign/TestMatrix.java#Upcall-TTTT
00:12:17 Test results: passed: 32
00:12:21 
00:12:21 ==============================
00:12:21 Test summary
00:12:21 ==============================
00:12:21    TEST                                              TOTAL  PASS  FAIL ERROR   
00:12:21    jtreg:test/jdk/java/foreign/TestMatrix.java          32    32     0     0   
00:12:21 ==============================

real	12m20.538s
user	131m54.043s
sys	0m59.944s
```

If we don't parallelize, then those 130 minutes are spent serially.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273315](https://bugs.openjdk.java.net/browse/JDK-8273315): Parallelize and increase timeouts for java/foreign/TestMatrix.java test


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5358/head:pull/5358` \
`$ git checkout pull/5358`

Update a local copy of the PR: \
`$ git checkout pull/5358` \
`$ git pull https://git.openjdk.java.net/jdk pull/5358/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5358`

View PR using the GUI difftool: \
`$ git pr show -t 5358`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5358.diff">https://git.openjdk.java.net/jdk/pull/5358.diff</a>

</details>
