### PR TITLE
8273318: Some containers/docker/TestJFREvents.java configs are running out of memory

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestJFREvents.java
+++ b/test/hotspot/jtreg/containers/docker/TestJFREvents.java
@@ -82,13 +82,14 @@ public class TestJFREvents {
     }
 
     private static void containerInfoTestCase() throws Exception {
-            // leave one CPU for system and tools, otherwise this test may be unstable
-            int maxNrOfAvailableCpus =  availableCPUs - 1;
-            for (int i=1; i < maxNrOfAvailableCpus; i = i * 2) {
-                for (int j=64; j <= 256; j *= 2) {
-                    testContainerInfo(i, j);
-                }
+        // Leave one CPU for system and tools, otherwise this test may be unstable.
+        // Try the memory sizes that were verified by testMemory tests before.
+        int maxNrOfAvailableCpus = availableCPUs - 1;
+        for (int cpus = 1; cpus < maxNrOfAvailableCpus; cpus *= 2) {
+            for (int mem : new int[]{ 200, 500, 1024 }) {
+                testContainerInfo(cpus, mem);
             }
+        }
     }
 
     private static void testContainerInfo(int expectedCPUs, int expectedMemoryMB) throws Exception {


### PR DESCRIPTION
```
$ CONF=linux-x86_64-server-fastdebug make run-test TEST=containers/docker/TestJFREvents.java

STDERR:
 stdout: [];
 stderr: [WARNING: Your kernel does not support swap limit capabilities or the cgroup is not mounted. Memory limited without swap.
]
 exitValue = 137

java.lang.RuntimeException: Expected to get exit value of [0]

at jdk.test.lib.process.OutputAnalyzer.shouldHaveExitValue(OutputAnalyzer.java:489)
at TestJFREvents.testContainerInfo(TestJFREvents.java:110)
at TestJFREvents.containerInfoTestCase(TestJFREvents.java:89)
at TestJFREvents.main(TestJFREvents.java:74)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.base/java.lang.reflect.Method.invoke(Method.java:568)
at com.sun.javatest.regtest.agent.MainActionHelper$AgentVMRunnable.run(MainActionHelper.java:312)
at java.base/java.lang.Thread.run(Thread.java:833)
```

`exitValue = 137` suggests the container was killed by OOM killer. The failing configuration is with `64m`, and it is apparently too low.

Additional testing:
 - [x] Affected test now passes (5 runs out of 5 tries)
 - [x] `containers/docker` tests pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273318](https://bugs.openjdk.java.net/browse/JDK-8273318): Some containers/docker/TestJFREvents.java configs are running out of memory


### Reviewers
 * [Nick Gasson](https://openjdk.java.net/census#ngasson) (@nick-arm - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5359/head:pull/5359` \
`$ git checkout pull/5359`

Update a local copy of the PR: \
`$ git checkout pull/5359` \
`$ git pull https://git.openjdk.java.net/jdk pull/5359/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5359`

View PR using the GUI difftool: \
`$ git pr show -t 5359`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5359.diff">https://git.openjdk.java.net/jdk/pull/5359.diff</a>

</details>
