### PR TITLE
8273329: Remove redundant null check from String.getBytes(String charsetName)

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -1752,7 +1752,6 @@ public final class String
      */
     public byte[] getBytes(String charsetName)
             throws UnsupportedEncodingException {
-        if (charsetName == null) throw new NullPointerException();
         return encode(lookupCharset(charsetName), coder(), value);
     }
 


### PR DESCRIPTION
Current implementation looks like this:
```java
public byte[] getBytes(String charsetName)
        throws UnsupportedEncodingException {
    if (charsetName == null) throw new NullPointerException();
    return encode(lookupCharset(charsetName), coder(), value);
}
```
Null check seems to be redundant here because the same check of `charsetName` is done within `String.lookupCharset(String)`:
```java
private static Charset lookupCharset(String csn) throws UnsupportedEncodingException {
    Objects.requireNonNull(csn);
    try {
        return Charset.forName(csn);
    } catch (UnsupportedCharsetException | IllegalCharsetNameException x) {
        throw new UnsupportedEncodingException(csn);
    }
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273329](https://bugs.openjdk.java.net/browse/JDK-8273329): Remove redundant null check from String.getBytes(String charsetName)


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5361/head:pull/5361` \
`$ git checkout pull/5361`

Update a local copy of the PR: \
`$ git checkout pull/5361` \
`$ git pull https://git.openjdk.java.net/jdk pull/5361/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5361`

View PR using the GUI difftool: \
`$ git pr show -t 5361`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5361.diff">https://git.openjdk.java.net/jdk/pull/5361.diff</a>

</details>
