### PR TITLE
8272164: DumpAllocStats shouldn't subclass from ResourceObj

### DIFF
--- a/src/hotspot/share/cds/dumpAllocStats.hpp
+++ b/src/hotspot/share/cds/dumpAllocStats.hpp
@@ -30,7 +30,7 @@
 
 // This is for dumping detailed statistics for the allocations
 // in the shared spaces.
-class DumpAllocStats {
+class DumpAllocStats : public StackObj {
 public:
 
   // Here's poor man's enum inheritance

--- a/src/hotspot/share/cds/dumpAllocStats.hpp
+++ b/src/hotspot/share/cds/dumpAllocStats.hpp
@@ -30,7 +30,7 @@
 
 // This is for dumping detailed statistics for the allocations
 // in the shared spaces.
-class DumpAllocStats : public ResourceObj {
+class DumpAllocStats {
 public:
 
   // Here's poor man's enum inheritance


### PR DESCRIPTION
I picked up a simple unassigned bug to work through the contribution process.

`make run-test-tier1` passes with this change.

Signed-off-by: Dan Heidinga <heidinga@redhat.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272164](https://bugs.openjdk.java.net/browse/JDK-8272164): DumpAllocStats shouldn't subclass from ResourceObj


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to e742c19c9fa431b0cc8b15708bdd46247631a631
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to 8438b691e194442acb24218999463f04861e8049
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5362/head:pull/5362` \
`$ git checkout pull/5362`

Update a local copy of the PR: \
`$ git checkout pull/5362` \
`$ git pull https://git.openjdk.java.net/jdk pull/5362/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5362`

View PR using the GUI difftool: \
`$ git pr show -t 5362`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5362.diff">https://git.openjdk.java.net/jdk/pull/5362.diff</a>

</details>
