### PR TITLE
8273333: Zero should warn about unimplemented -XX:+LogTouchedMethods

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -4021,6 +4021,11 @@ jint Arguments::apply_ergo() {
 #ifdef ZERO
   // Clear flags not supported on zero.
   FLAG_SET_DEFAULT(ProfileInterpreter, false);
+
+  if (LogTouchedMethods) {
+    warning("LogTouchedMethods is not supported for Zero");
+    FLAG_SET_DEFAULT(LogTouchedMethods, false);
+  }
 #endif // ZERO
 
   if (PrintAssembly && FLAG_IS_DEFAULT(DebugNonSafepoints)) {

--- a/test/hotspot/jtreg/runtime/CommandLine/PrintTouchedMethods.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/PrintTouchedMethods.java
@@ -23,8 +23,8 @@
 
 /*
  * @test
- * @requires vm.flavor != "zero"
  * @bug 8025692 8273333
+ * @requires vm.flavor != "zero"
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @library /test/lib

--- a/test/hotspot/jtreg/runtime/CommandLine/PrintTouchedMethods.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/PrintTouchedMethods.java
@@ -23,7 +23,8 @@
 
 /*
  * @test
- * @bug 8025692
+ * @requires vm.flavor != "zero"
+ * @bug 8025692 8273333
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @library /test/lib


### PR DESCRIPTION
Currently Zero VM does not implement -XX:+LogTouchedMethods runtime features, which makes `runtime/CommandLine/PrintTouchedMethods.java` tier1 test fail with it.

Instead of implementing it (risking performance and rare bugs), Zero should just reject the option. 

Additional testing:
 - [x] Eyeballing failure message
 - [x] Affected test does not run with Zero anymore
 - [x] Affected test still runs with Server

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273333](https://bugs.openjdk.java.net/browse/JDK-8273333): Zero should warn about unimplemented -XX:+LogTouchedMethods


### Reviewers
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**) ⚠️ Review applies to 9e0a3218b6a3b4795aacd7b0fdf674fab08b5650
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5363/head:pull/5363` \
`$ git checkout pull/5363`

Update a local copy of the PR: \
`$ git checkout pull/5363` \
`$ git pull https://git.openjdk.java.net/jdk pull/5363/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5363`

View PR using the GUI difftool: \
`$ git pr show -t 5363`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5363.diff">https://git.openjdk.java.net/jdk/pull/5363.diff</a>

</details>
