### PR TITLE
8273332: [Vector API] C2 fails to check whether the rotate operation is directly supported by the target ISA after JDK-8271366

### DIFF
--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -361,6 +361,11 @@ bool LibraryCallKit::inline_vector_nary_operation(int n) {
     return false; // not supported
   }
 
+  bool is_rotate = VectorNode::is_vector_rotate(sopc);
+  if (is_rotate && !Matcher::match_rule_supported_vector(sopc, num_elem, elem_bt)) {
+    return false;
+  }
+
   Node* opd1 = NULL; Node* opd2 = NULL; Node* opd3 = NULL;
   switch (n) {
     case 3: {
@@ -1585,6 +1590,11 @@ bool LibraryCallKit::inline_vector_broadcast_int() {
     }
     return false; // not supported
   }
+
+  if (is_rotate && !Matcher::match_rule_supported_vector(sopc, num_elem, elem_bt)) {
+    return false;
+  }
+
   Node* opd1 = unbox_vector(argument(4), vbox_type, elem_bt, num_elem);
   Node* opd2 = NULL;
   if (is_shift) {


### PR DESCRIPTION
Hi all,

A lot of Vector API tests from Panama's vectorIntrinsics+mask branch crash [1].

This is because `arch_supports_vector()` fails to check whether the rotate operation is directly supported by the target ISA after JDK-8271366.
It can be fixed by adding `Matcher::match_rule_supported_vector` check in `inline_vector_broadcast_int()` and `inline_vector_nary_operation()` to prevent generation of unsupported rotate operation IR patterns.

Maybe it's hard to reproduce with the jdk-repo, but the bug still be there in theory.
So it would be better to fix it in the jdk repo.

Testing:
 - jdk/incubator/vector/ with `-ea -esa -Xcomp -XX:CompileThreshold=100`, the crash reported in [1] gets fixed with Panama's vectorIntrinsics+mask branch

Thanks.
Best regards,
Jie

[1] https://bugs.openjdk.java.net/browse/JDK-8273205

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8273332](https://bugs.openjdk.java.net/browse/JDK-8273332): [Vector API] C2 fails to check whether the rotate operation is directly supported by the target ISA after JDK-8271366


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5364/head:pull/5364` \
`$ git checkout pull/5364`

Update a local copy of the PR: \
`$ git checkout pull/5364` \
`$ git pull https://git.openjdk.java.net/jdk pull/5364/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5364`

View PR using the GUI difftool: \
`$ git pr show -t 5364`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5364.diff">https://git.openjdk.java.net/jdk/pull/5364.diff</a>

</details>
