### PR TITLE
8273335: compiler/blackhole tests should not run with interpreter-only VMs

### DIFF
--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeExistingIntrinsicWarningTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeExistingIntrinsicWarningTest.java
@@ -25,6 +25,7 @@
  * @test
  * @library /test/lib /
  * @requires vm.flagless
+ * @requires vm.compMode != "Xint"
  * @run driver compiler.blackhole.BlackholeExistingIntrinsicWarningTest
  */
 

--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeExperimentalUnlockTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeExperimentalUnlockTest.java
@@ -25,6 +25,7 @@
  * @test
  * @library /test/lib /
  * @requires vm.flagless
+ * @requires vm.compMode != "Xint"
  * @run driver compiler.blackhole.BlackholeExperimentalUnlockTest
  */
 

--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeIntrinsicTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeIntrinsicTest.java
@@ -25,6 +25,7 @@
  * @test
  * @library /test/lib /
  * @requires vm.flagless
+ * @requires vm.compMode != "Xint"
  * @run driver compiler.blackhole.BlackholeIntrinsicTest
  */
 

--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeNonEmptyWarningTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeNonEmptyWarningTest.java
@@ -25,6 +25,7 @@
  * @test
  * @library /test/lib /
  * @requires vm.flagless
+ * @requires vm.compMode != "Xint"
  * @run driver compiler.blackhole.BlackholeNonEmptyWarningTest
  */
 

--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeNonStaticWarningTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeNonStaticWarningTest.java
@@ -25,6 +25,7 @@
  * @test
  * @library /test/lib /
  * @requires vm.flagless
+ * @requires vm.compMode != "Xint"
  * @run driver compiler.blackhole.BlackholeNonStaticWarningTest
  */
 

--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeNonVoidWarningTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeNonVoidWarningTest.java
@@ -25,6 +25,7 @@
  * @test
  * @library /test/lib /
  * @requires vm.flagless
+ * @requires vm.compMode != "Xint"
  * @run driver compiler.blackhole.BlackholeNonVoidWarningTest
  */
 


### PR DESCRIPTION
This affects Zero, as it runs these tests expecting `CompilerCommand`s to work. Which are obviously missing since there are no compilers configured. Since [JDK-8255718](https://bugs.openjdk.java.net/browse/JDK-8255718), Zero knows it runs in interpreter-only mode, so we can just leverage that. 

Additional testing: 
  - [x] `compiler/blackhole` tests are skipped with Zero
  - [x] `compiler/blackhole` tests still run with Server

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273335](https://bugs.openjdk.java.net/browse/JDK-8273335): compiler/blackhole tests should not run with interpreter-only VMs


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5365/head:pull/5365` \
`$ git checkout pull/5365`

Update a local copy of the PR: \
`$ git checkout pull/5365` \
`$ git pull https://git.openjdk.java.net/jdk pull/5365/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5365`

View PR using the GUI difftool: \
`$ git pr show -t 5365`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5365.diff">https://git.openjdk.java.net/jdk/pull/5365.diff</a>

</details>
