### PR TITLE
8273317: crash in cmovP_cmpP_zero_zeroNode::bottom_type()

### DIFF
--- a/src/hotspot/share/adlc/output_h.cpp
+++ b/src/hotspot/share/adlc/output_h.cpp
@@ -1944,27 +1944,29 @@ void ArchDesc::declareClasses(FILE *fp) {
       int offset = 1;
       // Special special hack to see if the Cmp? has been incorporated in the conditional move
       MatchNode *rl = instr->_matrule->_rChild->_lChild;
-      if( rl && !strcmp(rl->_opType, "Binary") ) {
-          MatchNode *rlr = rl->_rChild;
-          if (rlr && strncmp(rlr->_opType, "Cmp", 3) == 0)
-            offset = 2;
-      }
-      // Special hack for ideal CMoveP; ideal type depends on inputs
-      fprintf(fp,"  const Type            *bottom_type() const { const Type *t = in(oper_input_base()+%d)->bottom_type(); return (req() <= oper_input_base()+%d) ? t : t->meet(in(oper_input_base()+%d)->bottom_type()); } // CMoveP\n",
+      if( rl && !strcmp(rl->_opType, "Binary") && rl->_rChild && strncmp(rl->_rChild->_opType, "Cmp", 3) == 0) {
+        offset = 2;
+        fprintf(fp,"  const Type            *bottom_type() const { if (req() == 3) return in(2)->bottom_type();\n\tconst Type *t = in(oper_input_base()+%d)->bottom_type(); return (req() <= oper_input_base()+%d) ? t : t->meet(in(oper_input_base()+%d)->bottom_type()); } // CMoveP\n",
         offset, offset+1, offset+1);
+      } else {
+        // Special hack for ideal CMoveP; ideal type depends on inputs
+        fprintf(fp,"  const Type            *bottom_type() const { const Type *t = in(oper_input_base()+%d)->bottom_type(); return (req() <= oper_input_base()+%d) ? t : t->meet(in(oper_input_base()+%d)->bottom_type()); } // CMoveP\n",
+        offset, offset+1, offset+1);
+      }
     }
     else if( instr->_matrule && instr->_matrule->_rChild && !strcmp(instr->_matrule->_rChild->_opType,"CMoveN") ) {
       int offset = 1;
       // Special special hack to see if the Cmp? has been incorporated in the conditional move
       MatchNode *rl = instr->_matrule->_rChild->_lChild;
-      if( rl && !strcmp(rl->_opType, "Binary") ) {
-          MatchNode *rlr = rl->_rChild;
-          if (rlr && strncmp(rlr->_opType, "Cmp", 3) == 0)
-            offset = 2;
-      }
-      // Special hack for ideal CMoveN; ideal type depends on inputs
-      fprintf(fp,"  const Type            *bottom_type() const { const Type *t = in(oper_input_base()+%d)->bottom_type(); return (req() <= oper_input_base()+%d) ? t : t->meet(in(oper_input_base()+%d)->bottom_type()); } // CMoveN\n",
+      if( rl && !strcmp(rl->_opType, "Binary") && rl->_rChild && strncmp(rl->_rChild->_opType, "Cmp", 3) == 0) {
+        offset = 2;
+        fprintf(fp,"  const Type            *bottom_type() const { if (req() == 3) return in(2)->bottom_type();\n\tconst Type *t = in(oper_input_base()+%d)->bottom_type(); return (req() <= oper_input_base()+%d) ? t : t->meet(in(oper_input_base()+%d)->bottom_type()); } // CMoveN\n",
         offset, offset+1, offset+1);
+      } else {
+        // Special hack for ideal CMoveN; ideal type depends on inputs
+        fprintf(fp,"  const Type            *bottom_type() const { const Type *t = in(oper_input_base()+%d)->bottom_type(); return (req() <= oper_input_base()+%d) ? t : t->meet(in(oper_input_base()+%d)->bottom_type()); } // CMoveN\n",
+        offset, offset+1, offset+1);
+      }
     }
     else if (instr->is_tls_instruction()) {
       // Special hack for tlsLoadP


### PR DESCRIPTION
Hi all,

When I implement a new instrict in adfile for match CMoveP with Cmp node,like this:

match(Set dst (CMoveP (Binary cop (CmpP op1 zero)) (Binary dst zero)));

this means right child of CmpP is immediate zero and right child of CmovP also is immediate zero, then an exception will occur:

#
# A fatal error has been detected by the Java Runtime Environment:
#
# SIGSEGV (0xb) at pc=0x000000fff410fcc4, pid=11130, tid=11146
#
# JRE version: OpenJDK Runtime Environment (17.0) (build 17-internal+0-jenkins-slave-20210821140615-jdk-ls-a526852e137)
# Java VM: OpenJDK 64-Bit Server VM (17-internal+0-jenkins-slave-20210821140615-jdk-ls-a526852e137, compiled mode, compressed oops, compressed class ptrs, g1 gc, linux-loongarch64)
# Problematic frame:
# V [libjvm.so+0x21fcc4] cmovP_cmpP_zero_zeroNode::bottom_type() const+0x44
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# If you would like to submit a bug report, please visit:
# https://bugreport.java.com/bugreport/crash.jsp
#

In this case, cmovp_ cmpP_ zero_ Zeronode has three input nodes, so an exception is triggered. This is a patch to fix this problem. Please help review it 

Thanks,
Sun Guoyun