### PR TITLE
[PATCH] Remove redundant String.toString calls in jdk.deps and jdk.hotspot.agent

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/classbrowser/HTMLGenerator.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/classbrowser/HTMLGenerator.java
@@ -1007,7 +1007,7 @@ public class HTMLGenerator implements /* imports */ ClassConstants {
          Formatter tmpBuf = new Formatter(genHTML);
          long startPc = addressToLong(addr);
          tmpBuf.append("0x");
-         tmpBuf.append(Long.toHexString(startPc + visitor.getInstructionSize()).toString());
+         tmpBuf.append(Long.toHexString(startPc + visitor.getInstructionSize()));
          tmpBuf.append(",0x");
          tmpBuf.append(Long.toHexString(startPc));
          if (prevPCs != null) {

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/TypeAnnotation.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/TypeAnnotation.java
@@ -62,7 +62,7 @@ public class TypeAnnotation {
     @Override
     public String toString() {
         try {
-            return "@" + constant_pool.getUTF8Value(annotation.type_index).toString().substring(1) +
+            return "@" + constant_pool.getUTF8Value(annotation.type_index).substring(1) +
                     " pos: " + position.toString();
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/LocalVariableTypeTableWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/LocalVariableTypeTableWriter.java
@@ -125,7 +125,7 @@ public class LocalVariableTypeTableWriter extends  InstructionDetailWriter {
                     print(" // ");
                     Descriptor d = new Signature(entry.signature_index);
                     try {
-                        print(d.getFieldType(constant_pool).toString().replace("/", "."));
+                        print(d.getFieldType(constant_pool).replace("/", "."));
                     } catch (InvalidDescriptor e) {
                         print(report(e));
                     } catch (ConstantPoolException e) {


### PR DESCRIPTION
Method `String.toString()` does just return the same String. One possible case, when it's needed - for `null` check. I found 3 places, where it's definitely redundant - either String is guarantee to be non-null (like in `Long.toHexString` case) or if null check is still be there.