### PR TITLE
8273355: Lanai: Flickering on tooltip appearance IntelliJ IDEA 2021.2.1

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/LWWindowPeer.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/LWWindowPeer.java
@@ -290,8 +290,14 @@ public class LWWindowPeer
         super.setVisibleImpl(visible);
         // TODO: update graphicsConfig, see 4868278
         if (visible) {
-            // Set correct background for a window before making it visible
-            platformWindow.setOpaque(!isTranslucent());
+            // Set correct background for a window before making it visible.
+            // It is necessary for some pipelines (e.g., metal) to eliminate
+            // flashing effect (when initial background color replaced with
+            // the content layer's color)
+            Color color = getBackground();
+            if (color != null) {
+                platformWindow.setBackground(color);
+            }
         }
         platformWindow.setVisible(visible);
         if (isSimpleWindow()) {

--- a/src/java.desktop/macosx/classes/sun/lwawt/LWWindowPeer.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/LWWindowPeer.java
@@ -289,6 +289,10 @@ public class LWWindowPeer
         updateFocusableWindowState();
         super.setVisibleImpl(visible);
         // TODO: update graphicsConfig, see 4868278
+        if (visible) {
+            // Set correct background for a window before making it visible
+            platformWindow.setOpaque(!isTranslucent());
+        }
         platformWindow.setVisible(visible);
         if (isSimpleWindow()) {
             KeyboardFocusManagerPeer kfmPeer = LWKeyboardFocusManagerPeer.getInstance();

--- a/src/java.desktop/macosx/classes/sun/lwawt/PlatformWindow.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/PlatformWindow.java
@@ -139,6 +139,8 @@ public interface PlatformWindow {
 
     public void setOpaque(boolean isOpaque);
 
+    public void setBackground(Color color);
+
     public void enterFullScreenMode();
 
     public void exitFullScreenMode();

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformEmbeddedFrame.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformEmbeddedFrame.java
@@ -181,6 +181,9 @@ public class CPlatformEmbeddedFrame implements PlatformWindow {
     public void setOpaque(boolean isOpaque) {}
 
     @Override
+    public void setBackground(Color color) {}
+
+    @Override
     public void enterFullScreenMode() {}
 
     @Override

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
@@ -949,6 +949,12 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
     }
 
     @Override
+    public void setBackground(Color color) {
+        int rgb = color.getRGB();
+        execute(ptr->CWrapper.NSWindow.setBackgroundColor(ptr, rgb));
+    }
+
+    @Override
     public void enterFullScreenMode() {
         isFullScreenMode = true;
         execute(CPlatformWindow::nativeEnterFullScreenMode);

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CViewPlatformEmbeddedFrame.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CViewPlatformEmbeddedFrame.java
@@ -25,6 +25,7 @@
 
 package sun.lwawt.macosx;
 
+import java.awt.Color;
 import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.GraphicsDevice;
@@ -179,6 +180,10 @@ public class CViewPlatformEmbeddedFrame implements PlatformWindow {
 
     @Override
     public void setOpaque(boolean isOpaque) {
+    }
+
+    @Override
+    public void setBackground(Color color) {
     }
 
     @Override


### PR DESCRIPTION
Used setOpaque() method to set correct background of platform window

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8273355](https://bugs.openjdk.java.net/browse/JDK-8273355): Lanai: Flickering on tooltip appearance IntelliJ IDEA 2021.2.1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5373/head:pull/5373` \
`$ git checkout pull/5373`

Update a local copy of the PR: \
`$ git checkout pull/5373` \
`$ git pull https://git.openjdk.java.net/jdk pull/5373/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5373`

View PR using the GUI difftool: \
`$ git pr show -t 5373`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5373.diff">https://git.openjdk.java.net/jdk/pull/5373.diff</a>

</details>
