### PR TITLE
8273484: Cleanup unnecessary null comparison before instanceof check in java.naming

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapReferralContext.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapReferralContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -198,8 +198,8 @@ final class LdapReferralContext implements DirContext, LdapContext {
 
     void setHopCount(int hopCount) {
         this.hopCount = hopCount;
-        if ((refCtx != null) && (refCtx instanceof LdapCtx)) {
-            ((LdapCtx)refCtx).setHopCount(hopCount);
+        if (refCtx instanceof LdapCtx ldapCtx) {
+            ldapCtx.setHopCount(hopCount);
         }
     }
 

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/SimpleClientId.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/SimpleClientId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,11 +69,9 @@ class SimpleClientId extends ClientId {
     }
 
     public boolean equals(Object obj) {
-        if (obj == null || !(obj instanceof SimpleClientId)) {
+        if (!(obj instanceof SimpleClientId other)) {
             return false;
         }
-
-        SimpleClientId other = (SimpleClientId)obj;
 
         return super.equals(obj)
             && (username == other.username // null OK

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/pool/ConnectionDesc.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/pool/ConnectionDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,9 +65,8 @@ final class ConnectionDesc {
      * PooledConnection.
      */
     public boolean equals(Object obj) {
-        return obj != null
-            && obj instanceof ConnectionDesc
-            && ((ConnectionDesc)obj).conn == conn;
+        return (obj instanceof ConnectionDesc other)
+            && other.conn == conn;
     }
 
     /**

--- a/src/java.naming/share/classes/com/sun/jndi/toolkit/ctx/AtomicContext.java
+++ b/src/java.naming/share/classes/com/sun/jndi/toolkit/ctx/AtomicContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -256,7 +256,7 @@ public abstract class AtomicContext extends ComponentContext {
             Object ret = null;
             if (resolve_to_penultimate_context(name, cont)) {
                 ret = a_lookup(name.toString(), cont);
-                if (ret != null && ret instanceof LinkRef) {
+                if (ret instanceof LinkRef) {
                     cont.setContinue(ret, name, this);
                     ret = null;
                 }
@@ -348,7 +348,7 @@ public abstract class AtomicContext extends ComponentContext {
                 Object ret = null;
                 if (resolve_to_penultimate_context_nns(name, cont)) {
                     ret = a_resolveIntermediate_nns(name.toString(), cont);
-                    if (ret != null && ret instanceof LinkRef) {
+                    if (ret instanceof LinkRef) {
                         cont.setContinue(ret, name, this);
                         ret = null;
                     }
@@ -368,7 +368,7 @@ public abstract class AtomicContext extends ComponentContext {
                 Object ret = null;
                 if (resolve_to_penultimate_context_nns(name, cont)) {
                     ret = a_lookup_nns(name.toString(), cont);
-                    if (ret != null && ret instanceof LinkRef) {
+                    if (ret instanceof LinkRef) {
                         cont.setContinue(ret, name, this);
                         ret = null;
                     }

--- a/src/java.naming/share/classes/javax/naming/BinaryRefAddr.java
+++ b/src/java.naming/share/classes/javax/naming/BinaryRefAddr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -121,8 +121,7 @@ public class BinaryRefAddr extends RefAddr {
       * @return true if the object is equal; false otherwise.
       */
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof BinaryRefAddr)) {
-            BinaryRefAddr target = (BinaryRefAddr)obj;
+        if (obj instanceof BinaryRefAddr target) {
             if (addrType.compareTo(target.addrType) == 0) {
                 if (buf == null && target.buf == null)
                     return true;

--- a/src/java.naming/share/classes/javax/naming/CompositeName.java
+++ b/src/java.naming/share/classes/javax/naming/CompositeName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -278,9 +278,8 @@ public class CompositeName implements Name {
       * @see #hashCode
       */
     public boolean equals(Object obj) {
-        return (obj != null &&
-                obj instanceof CompositeName &&
-                impl.equals(((CompositeName)obj).impl));
+        return (obj instanceof CompositeName other) &&
+                impl.equals(other.impl);
     }
 
     /**

--- a/src/java.naming/share/classes/javax/naming/CompoundName.java
+++ b/src/java.naming/share/classes/javax/naming/CompoundName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -244,9 +244,8 @@ public class CompoundName implements Name {
       */
     public boolean equals(Object obj) {
         // %%% check syntax too?
-        return (obj != null &&
-                obj instanceof CompoundName &&
-                impl.equals(((CompoundName)obj).impl));
+        return (obj instanceof CompoundName other) &&
+                impl.equals(other.impl);
     }
 
     /**

--- a/src/java.naming/share/classes/javax/naming/LinkRef.java
+++ b/src/java.naming/share/classes/javax/naming/LinkRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,8 +103,8 @@ public class LinkRef extends Reference {
     public String getLinkName() throws NamingException {
         if (className != null && className.equals(linkClassName)) {
             RefAddr addr = get(linkAddrType);
-            if (addr != null && addr instanceof StringRefAddr) {
-                return (String)((StringRefAddr)addr).getContent();
+            if (addr instanceof StringRefAddr stringRefAddr) {
+                return (String) stringRefAddr.getContent();
             }
         }
         throw new MalformedLinkException();

--- a/src/java.naming/share/classes/javax/naming/NameImpl.java
+++ b/src/java.naming/share/classes/javax/naming/NameImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -473,8 +473,7 @@ class NameImpl {
     }
 
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof NameImpl)) {
-            NameImpl target = (NameImpl)obj;
+        if (obj instanceof NameImpl target) {
             if (target.size() ==  this.size()) {
                 Enumeration<String> mycomps = getAll();
                 Enumeration<String> comps = target.getAll();

--- a/src/java.naming/share/classes/javax/naming/RefAddr.java
+++ b/src/java.naming/share/classes/javax/naming/RefAddr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,8 +104,7 @@ public abstract class RefAddr implements java.io.Serializable {
       * @see #getType
       */
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof RefAddr)) {
-            RefAddr target = (RefAddr)obj;
+        if (obj instanceof RefAddr target) {
             if (addrType.compareTo(target.addrType) == 0) {
                 Object thisobj = this.getContent();
                 Object thatobj = target.getContent();

--- a/src/java.naming/share/classes/javax/naming/Reference.java
+++ b/src/java.naming/share/classes/javax/naming/Reference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -326,8 +326,7 @@ public class Reference implements Cloneable, java.io.Serializable {
       * @return true if obj is equal to this reference; false otherwise.
       */
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof Reference)) {
-            Reference target = (Reference)obj;
+        if (obj instanceof Reference target) {
             // ignore factory information
             if (target.className.equals(this.className) &&
                 target.size() ==  this.size()) {

--- a/src/java.naming/share/classes/javax/naming/directory/BasicAttribute.java
+++ b/src/java.naming/share/classes/javax/naming/directory/BasicAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -130,8 +130,7 @@ public class BasicAttribute implements Attribute {
       * @see #contains
       */
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof Attribute)) {
-            Attribute target = (Attribute)obj;
+        if (obj instanceof Attribute target) {
 
             // Check order first
             if (isOrdered() != target.isOrdered()) {

--- a/src/java.naming/share/classes/javax/naming/directory/BasicAttributes.java
+++ b/src/java.naming/share/classes/javax/naming/directory/BasicAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -225,8 +225,7 @@ public class BasicAttributes implements Attributes {
      * @see #hashCode
      */
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof Attributes)) {
-            Attributes target = (Attributes)obj;
+        if (obj instanceof Attributes target) {
 
             // Check case first
             if (ignoreCase != target.isCaseIgnored()) {


### PR DESCRIPTION
Update code checks both non-null and instance of a class in java.naming module classes.
The checks and explicit casts could also be replaced with pattern matching for the instanceof operator.
For example:
    The following code:

        return (obj != null &&
                obj instanceof CompoundName &&
                impl.equals(((CompoundName)obj).impl));


Can be simplified to:
    

        return (obj instanceof CompoundName other) &&
                impl.equals(other.impl);


See similar cleanup in java.base - https://bugs.openjdk.java.net/browse/JDK-8258422

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273484](https://bugs.openjdk.java.net/browse/JDK-8273484): Cleanup unnecessary null comparison before instanceof check in java.naming


### Reviewers
 * [Aleksei Efimov](https://openjdk.java.net/census#aefimov) (@AlekseiEfimov - Committer)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5374/head:pull/5374` \
`$ git checkout pull/5374`

Update a local copy of the PR: \
`$ git checkout pull/5374` \
`$ git pull https://git.openjdk.java.net/jdk pull/5374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5374`

View PR using the GUI difftool: \
`$ git pr show -t 5374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5374.diff">https://git.openjdk.java.net/jdk/pull/5374.diff</a>

</details>
