### PR TITLE
8273372: Remove scavenge trace message in psPromotionManager

### DIFF
--- a/src/hotspot/share/gc/parallel/psPromotionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.cpp
@@ -369,7 +369,10 @@ oop PSPromotionManager::oop_promotion_failed(oop obj, markWord obj_mark) {
     obj = obj->forwardee();
   }
 
-  log_develop_trace(gc, scavenge)("{promotion-failure %s " PTR_FORMAT " (%d)}", obj->klass()->internal_name(), p2i(obj), obj->size());
-
+  if (log_develop_is_enabled(Trace, gc, scavenge)) {
+    ResourceMark rm; // required by internal_name()
+    log_develop_trace(gc, scavenge)("{promotion-failure %s " PTR_FORMAT " (%d)}",
+            obj->klass()->internal_name(), p2i(obj), obj->size());
+  }
   return obj;
 }

--- a/src/hotspot/share/gc/parallel/psPromotionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.cpp
@@ -369,10 +369,5 @@ oop PSPromotionManager::oop_promotion_failed(oop obj, markWord obj_mark) {
     obj = obj->forwardee();
   }
 
-  if (log_develop_is_enabled(Trace, gc, scavenge)) {
-    ResourceMark rm; // required by internal_name()
-    log_develop_trace(gc, scavenge)("{promotion-failure %s " PTR_FORMAT " (%d)}",
-            obj->klass()->internal_name(), p2i(obj), obj->size());
-  }
   return obj;
 }

--- a/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
@@ -267,11 +267,13 @@ inline oop PSPromotionManager::copy_unmarked_to_survivor_space(oop o,
       assert(young_space()->contains(new_obj), "Attempt to push non-promoted obj");
     }
 
-    log_develop_trace(gc, scavenge)("{%s %s " PTR_FORMAT " -> " PTR_FORMAT " (%d)}",
-                                    new_obj_is_tenured ? "copying" : "tenuring",
-                                    new_obj->klass()->internal_name(),
-                                    p2i((void *)o), p2i((void *)new_obj), new_obj->size());
-
+    if (log_develop_is_enabled(Trace, gc, scavenge)) {
+      ResourceMark rm; // required by internal_name()
+      log_develop_trace(gc, scavenge)("{%s %s " PTR_FORMAT " -> " PTR_FORMAT " (%d)}",
+                                      new_obj_is_tenured ? "copying" : "tenuring",
+                                      new_obj->klass()->internal_name(),
+                                      p2i((void*) o), p2i((void*) new_obj), new_obj->size());
+    }
     // Do the size comparison first with new_obj_size, which we
     // already have. Hopefully, only a few objects are larger than
     // _min_array_size_for_chunking, and most of them will be arrays.

--- a/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
@@ -267,13 +267,6 @@ inline oop PSPromotionManager::copy_unmarked_to_survivor_space(oop o,
       assert(young_space()->contains(new_obj), "Attempt to push non-promoted obj");
     }
 
-    if (log_develop_is_enabled(Trace, gc, scavenge)) {
-      ResourceMark rm; // required by internal_name()
-      log_develop_trace(gc, scavenge)("{%s %s " PTR_FORMAT " -> " PTR_FORMAT " (%d)}",
-                                      new_obj_is_tenured ? "copying" : "tenuring",
-                                      new_obj->klass()->internal_name(),
-                                      p2i((void*) o), p2i((void*) new_obj), new_obj->size());
-    }
     // Do the size comparison first with new_obj_size, which we
     // already have. Hopefully, only a few objects are larger than
     // _min_array_size_for_chunking, and most of them will be arrays.

--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -469,7 +469,6 @@ public:
                BoolObjectClosure* is_alive,
                OopClosure* keep_alive,
                VoidClosure* complete_gc) override {
-    ResourceMark rm;
     RefProcWorkerTimeTracker t(_phase_times->soft_weak_final_refs_phase_worker_time_sec(), tracker_id(worker_id));
 
     process_discovered_list(worker_id, REF_SOFT, is_alive, keep_alive);
@@ -495,7 +494,6 @@ public:
                BoolObjectClosure* is_alive,
                OopClosure* keep_alive,
                VoidClosure* complete_gc) override {
-    ResourceMark rm;
     RefProcSubPhasesWorkerTimeTracker tt(ReferenceProcessor::KeepAliveFinalRefsSubPhase, _phase_times, tracker_id(worker_id));
     _ref_processor.process_final_keep_alive_work(_ref_processor._discoveredFinalRefs[worker_id], keep_alive);
     // Close the reachable set
@@ -514,7 +512,6 @@ public:
                BoolObjectClosure* is_alive,
                OopClosure* keep_alive,
                VoidClosure* complete_gc) override {
-    ResourceMark rm;
     process_discovered_list(worker_id, REF_PHANTOM, is_alive, keep_alive);
 
     // Close the reachable set; needed for collectors which keep_alive_closure do


### PR DESCRIPTION
Simple change of moving `ResourceMark` closer to where it is actually required.

Test: tier1-6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273372](https://bugs.openjdk.java.net/browse/JDK-8273372): Remove scavenge trace message in psPromotionManager


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Leo Korinth](https://openjdk.java.net/census#lkorinth) (@lkorinth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5375/head:pull/5375` \
`$ git checkout pull/5375`

Update a local copy of the PR: \
`$ git checkout pull/5375` \
`$ git pull https://git.openjdk.java.net/jdk pull/5375/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5375`

View PR using the GUI difftool: \
`$ git pr show -t 5375`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5375.diff">https://git.openjdk.java.net/jdk/pull/5375.diff</a>

</details>
