### PR TITLE
8273376: Zero: Disable vtable/itableStub gtests

### DIFF
--- a/test/hotspot/gtest/code/test_vtableStub.cpp
+++ b/test/hotspot/gtest/code/test_vtableStub.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/gtest/code/test_vtableStub.cpp
+++ b/test/hotspot/gtest/code/test_vtableStub.cpp
@@ -27,6 +27,8 @@
 #include "runtime/interfaceSupport.inline.hpp"
 #include "unittest.hpp"
 
+#ifndef ZERO
+
 TEST_VM(code, vtableStubs) {
   // Should be in VM to use locks
   ThreadInVMfromNative ThreadInVMfromNative(JavaThread::current());
@@ -50,3 +52,5 @@ TEST_VM(code, itableStubs) {
   }
   VtableStubs::find_itable_stub((1 << 15) - 1); // max itable index
 }
+
+#endif


### PR DESCRIPTION
Simple test bug fix.

Additional testing:
 - [x] Linux x86_64 Server still runs the test
 - [x] Linux x86_64 Zero now skips the test

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273376](https://bugs.openjdk.java.net/browse/JDK-8273376): Zero: Disable vtable/itableStub gtests


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5377/head:pull/5377` \
`$ git checkout pull/5377`

Update a local copy of the PR: \
`$ git checkout pull/5377` \
`$ git pull https://git.openjdk.java.net/jdk pull/5377/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5377`

View PR using the GUI difftool: \
`$ git pr show -t 5377`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5377.diff">https://git.openjdk.java.net/jdk/pull/5377.diff</a>

</details>
