### PR TITLE
8273378: Shenandoah: Remove the remaining uses of os::is_MP

### DIFF
--- a/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
@@ -682,13 +682,14 @@ void ShenandoahBarrierSetAssembler::cmpxchg_oop(MacroAssembler* masm,
   //
   // Try to CAS with given arguments. If successful, then we are done.
 
-  if (os::is_MP()) __ lock();
 #ifdef _LP64
   if (UseCompressedOops) {
+    __ lock();
     __ cmpxchgl(newval, addr);
   } else
 #endif
   {
+    __ lock();
     __ cmpxchgptr(newval, addr);
   }
   __ jcc(Assembler::equal, L_success);
@@ -765,13 +766,14 @@ void ShenandoahBarrierSetAssembler::cmpxchg_oop(MacroAssembler* masm,
   }
 #endif
 
-  if (os::is_MP()) __ lock();
 #ifdef _LP64
   if (UseCompressedOops) {
+    __ lock();
     __ cmpxchgl(tmp2, addr);
   } else
 #endif
   {
+    __ lock();
     __ cmpxchgptr(tmp2, addr);
   }
 
@@ -791,13 +793,14 @@ void ShenandoahBarrierSetAssembler::cmpxchg_oop(MacroAssembler* masm,
     __ movptr(oldval, tmp2);
   }
 
-  if (os::is_MP()) __ lock();
 #ifdef _LP64
   if (UseCompressedOops) {
+    __ lock();
     __ cmpxchgl(newval, addr);
   } else
 #endif
   {
+    __ lock();
     __ cmpxchgptr(newval, addr);
   }
   if (!exchange) {


### PR DESCRIPTION
JDK-8188764 removed many uses of `os::is_MP`, effectively defaulting it to `true`, but some Shenandoah code still has it. This is a simple omission. All current uses on x86 already imply lock prefix, so this is a cleanup, and not a functional change.

Additional testing:
 - [x] Linux x86_64 `hotspot_gc_shenandoah`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273378](https://bugs.openjdk.java.net/browse/JDK-8273378): Shenandoah: Remove the remaining uses of os::is_MP


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5378/head:pull/5378` \
`$ git checkout pull/5378`

Update a local copy of the PR: \
`$ git checkout pull/5378` \
`$ git pull https://git.openjdk.java.net/jdk pull/5378/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5378`

View PR using the GUI difftool: \
`$ git pr show -t 5378`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5378.diff">https://git.openjdk.java.net/jdk/pull/5378.diff</a>

</details>
