### PR TITLE
8273361: InfoOptsTest is failing in tier1

### DIFF
--- a/test/langtools/tools/javac/options/modes/InfoOptsTest.java
+++ b/test/langtools/tools/javac/options/modes/InfoOptsTest.java
@@ -69,18 +69,23 @@ public class InfoOptsTest extends OptionModesTester {
 
     @Test
     void testUniqueInfoOpts() throws IOException {
-        testUniqueInfoOpt(new String[] {"--help", "--help"}, "where possible options");
-        testUniqueInfoOpt(new String[] {"-X", "-X"}, "These extra options");
-        testUniqueInfoOpt(new String[] {"--help-lint", "--help-lint"}, "The supported keys");
+        testUniqueInfoOpt(new String[] {"--help"},       new String[] {"--help", "--help"});
+        testUniqueInfoOpt(new String[] {"-X"},           new String[] {"-X", "-X"});
+        testUniqueInfoOpt(new String[] {"--help-lint"},  new String[] {"--help-lint", "--help-lint"});
 
-        testUniqueInfoOpt(new String[] {"-version", "-version"}, "javac");
-        testUniqueInfoOpt(new String[] {"-fullversion", "-fullversion"}, "javac full version");
+        testUniqueInfoOpt(new String[] {"-version"},     new String[] {"-version", "-version"});
+        testUniqueInfoOpt(new String[] {"-fullversion"}, new String[] {"-fullversion", "-fullversion"});
     }
 
-    void testUniqueInfoOpt(String[] opts, String... expect) {
+    void testUniqueInfoOpt(String[] baseOpts, String[] testOpts) {
         String[] files = { };
-        runMain(opts, files)
-                .checkOK()
-                .checkUniqueStartLog(expect);
+
+        TestResult base = runMain(baseOpts, files)
+                                 .checkOK();
+
+        TestResult test = runMain(testOpts, files)
+                                 .checkOK();
+
+        base.checkSameLog(test);
     }
 }

--- a/test/langtools/tools/javac/options/modes/InfoOptsTest.java
+++ b/test/langtools/tools/javac/options/modes/InfoOptsTest.java
@@ -73,9 +73,8 @@ public class InfoOptsTest extends OptionModesTester {
         testUniqueInfoOpt(new String[] {"-X", "-X"}, "extra options");
         testUniqueInfoOpt(new String[] {"--help-lint", "--help-lint"}, "supported keys");
 
-        String specVersion = System.getProperty("java.specification.version");
-        testUniqueInfoOpt(new String[] {"-version", "-version"}, "javac", specVersion);
-        testUniqueInfoOpt(new String[] {"-fullversion", "-fullversion"}, "javac", specVersion);
+        testUniqueInfoOpt(new String[] {"-version", "-version"}, "javac");
+        testUniqueInfoOpt(new String[] {"-fullversion", "-fullversion"}, "javac full version");
     }
 
     void testUniqueInfoOpt(String[] opts, String... expect) {

--- a/test/langtools/tools/javac/options/modes/InfoOptsTest.java
+++ b/test/langtools/tools/javac/options/modes/InfoOptsTest.java
@@ -69,9 +69,9 @@ public class InfoOptsTest extends OptionModesTester {
 
     @Test
     void testUniqueInfoOpts() throws IOException {
-        testUniqueInfoOpt(new String[] {"--help", "--help"}, "possible options");
-        testUniqueInfoOpt(new String[] {"-X", "-X"}, "extra options");
-        testUniqueInfoOpt(new String[] {"--help-lint", "--help-lint"}, "supported keys");
+        testUniqueInfoOpt(new String[] {"--help", "--help"}, "where possible options");
+        testUniqueInfoOpt(new String[] {"-X", "-X"}, "These extra options");
+        testUniqueInfoOpt(new String[] {"--help-lint", "--help-lint"}, "The supported keys");
 
         testUniqueInfoOpt(new String[] {"-version", "-version"}, "javac");
         testUniqueInfoOpt(new String[] {"-fullversion", "-fullversion"}, "javac full version");
@@ -81,6 +81,6 @@ public class InfoOptsTest extends OptionModesTester {
         String[] files = { };
         runMain(opts, files)
                 .checkOK()
-                .checkUniqueLog(expect);
+                .checkUniqueStartLog(expect);
     }
 }

--- a/test/langtools/tools/javac/options/modes/OptionModesTester.java
+++ b/test/langtools/tools/javac/options/modes/OptionModesTester.java
@@ -270,25 +270,15 @@ public class OptionModesTester {
             return this;
         }
 
-        TestResult checkUniqueStartLog(String... uniqueExpects) {
-            return checkUniqueStartLog(Log.DIRECT, uniqueExpects);
+        TestResult checkSameLog(TestResult other) {
+            return checkSameLog(Log.DIRECT, other);
         }
 
-        TestResult checkUniqueStartLog(Log l, String... uniqueExpects) {
-            String log = logs.get(l);
-            for (String e : uniqueExpects) {
-                Scanner scanner = new Scanner(log);
-                int num = 0;
-                while (scanner.hasNextLine()) {
-                    if (scanner.nextLine().startsWith(e)) {
-                        num++;
-                    }
-                }
-                if (num == 0) {
-                    error("Expected string not found: " + e);
-                } else if (num > 1) {
-                    error("Expected string appears more than once: " + e);
-                }
+        TestResult checkSameLog(Log l, TestResult other) {
+            String thisLog = logs.get(l);
+            String otherLog = other.logs.get(l);
+            if (!thisLog.equals(otherLog)) {
+                error("Logs are not the same.\nThis:\n" + thisLog + "\nOther:\n" + otherLog);
             }
             return this;
         }

--- a/test/langtools/tools/javac/options/modes/OptionModesTester.java
+++ b/test/langtools/tools/javac/options/modes/OptionModesTester.java
@@ -45,7 +45,6 @@ import java.util.EnumMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Scanner;
 import java.util.stream.Collectors;
 import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;

--- a/test/langtools/tools/javac/options/modes/OptionModesTester.java
+++ b/test/langtools/tools/javac/options/modes/OptionModesTester.java
@@ -45,6 +45,7 @@ import java.util.EnumMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Scanner;
 import java.util.stream.Collectors;
 import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
@@ -269,16 +270,23 @@ public class OptionModesTester {
             return this;
         }
 
-        TestResult checkUniqueLog(String... uniqueExpects) {
-            return checkUniqueLog(Log.DIRECT, uniqueExpects);
+        TestResult checkUniqueStartLog(String... uniqueExpects) {
+            return checkUniqueStartLog(Log.DIRECT, uniqueExpects);
         }
 
-        TestResult checkUniqueLog(Log l, String... uniqueExpects) {
+        TestResult checkUniqueStartLog(Log l, String... uniqueExpects) {
             String log = logs.get(l);
             for (String e : uniqueExpects) {
-                if (!log.contains(e)) {
+                Scanner scanner = new Scanner(log);
+                int num = 0;
+                while (scanner.hasNextLine()) {
+                    if (scanner.nextLine().startsWith(e)) {
+                        num++;
+                    }
+                }
+                if (num == 0) {
                     error("Expected string not found: " + e);
-                } else if (log.indexOf(e) != log.lastIndexOf(e)) {
+                } else if (num > 1) {
                     error("Expected string appears more than once: " + e);
                 }
             }


### PR DESCRIPTION
Current test checks that informational messages are not printed twice. The failing tests verifies that by checking `java.specification.version` is not present twice in the version string. Effectively, it searches for `18`. But a second `18` could get to version string from anywhere: the Git hash, the user name, etc. It is failing in current GHA due to Git hash containing `18`.

I believe the test should be more conservative: look for more unique strings, and check that the lines start with it. "javac" and "javac full version" seem unique enough. Checking that lines start with "javac" handles the case of accidental version strings that includes that string (think username that includes "javac" for some reason, who are we to judge...).

Additional testing:
 - [x] Affected test passes with default version string
 - [x] Affected test fails with JDK-8266239 reverted
 - [x] Affected test passes with `--with-version-opt=javac`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273361](https://bugs.openjdk.java.net/browse/JDK-8273361): InfoOptsTest is failing in tier1


### Reviewers
 * [Jaikiran Pai](https://openjdk.java.net/census#jpai) (@jaikiran - Committer) ⚠️ Review applies to a3558a440cd59e2fe4810089eba588475c475c75
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5381/head:pull/5381` \
`$ git checkout pull/5381`

Update a local copy of the PR: \
`$ git checkout pull/5381` \
`$ git pull https://git.openjdk.java.net/jdk pull/5381/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5381`

View PR using the GUI difftool: \
`$ git pr show -t 5381`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5381.diff">https://git.openjdk.java.net/jdk/pull/5381.diff</a>

</details>
