### PR TITLE
8273386: Remove duplicated code in G1DCQS::abandon_completed_buffers

### DIFF
--- a/src/hotspot/share/gc/g1/g1DirtyCardQueue.cpp
+++ b/src/hotspot/share/gc/g1/g1DirtyCardQueue.cpp
@@ -307,8 +307,6 @@ void G1DirtyCardQueueSet::enqueue_all_paused_buffers() {
 }
 
 void G1DirtyCardQueueSet::abandon_completed_buffers() {
-  enqueue_all_paused_buffers();
-  verify_num_cards();
   G1BufferNodeList list = take_all_completed_buffers();
   BufferNode* buffers_to_delete = list._head;
   while (buffers_to_delete != NULL) {


### PR DESCRIPTION
Please review this small change to remove some redundant code in
G1DirtyCardQueueSet::abandon_completed_buffers.  After the two removed lines
it calls take_all_completed_buffers, which begins with those same two lines.

Testing:
Local (linux-x64) hotspot:tier1 with -XX:+UseG1GC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273386](https://bugs.openjdk.java.net/browse/JDK-8273386): Remove duplicated code in G1DCQS::abandon_completed_buffers


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5382/head:pull/5382` \
`$ git checkout pull/5382`

Update a local copy of the PR: \
`$ git checkout pull/5382` \
`$ git pull https://git.openjdk.java.net/jdk pull/5382/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5382`

View PR using the GUI difftool: \
`$ git pr show -t 5382`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5382.diff">https://git.openjdk.java.net/jdk/pull/5382.diff</a>

</details>
