### PR TITLE
JDK-8273387: remove some unreferenced gtk-related functions

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk2_interface.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk2_interface.c
@@ -595,7 +595,6 @@ GtkApi* gtk2_load(JNIEnv *env, const char* lib_name)
         fp_gtk_paint_vline = dl_symbol("gtk_paint_vline");
         fp_gtk_paint_shadow = dl_symbol("gtk_paint_shadow");
         fp_gtk_paint_arrow = dl_symbol("gtk_paint_arrow");
-        fp_gtk_paint_diamond = dl_symbol("gtk_paint_diamond");
         fp_gtk_paint_box = dl_symbol("gtk_paint_box");
         fp_gtk_paint_flat_box = dl_symbol("gtk_paint_flat_box");
         fp_gtk_paint_check = dl_symbol("gtk_paint_check");

--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk2_interface.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk2_interface.c
@@ -147,10 +147,6 @@ static void (*fp_gtk_paint_arrow)(GtkStyle* style, GdkWindow* window,
         GdkRectangle* area, GtkWidget* widget, const gchar* detail,
         GtkArrowType arrow_type, gboolean fill, gint x, gint y,
         gint width, gint height);
-static void (*fp_gtk_paint_diamond)(GtkStyle* style, GdkWindow* window,
-        GtkStateType state_type, GtkShadowType shadow_type,
-        GdkRectangle* area, GtkWidget* widget, const gchar* detail,
-        gint x, gint y, gint width, gint height);
 static void (*fp_gtk_paint_box)(GtkStyle* style, GdkWindow* window,
         GtkStateType state_type, GtkShadowType shadow_type,
         GdkRectangle* area, GtkWidget* widget, const gchar* detail,

--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk2_interface.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk2_interface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1846,19 +1846,6 @@ static void gtk2_paint_check(WidgetType widget_type, gint synth_state,
             shadow_type, NULL, gtk2_widget, detail,
             x, y, width, height);
     (*fp_gtk_paint_check)(gtk2_widget->style, gtk2_black_pixmap, state_type,
-            shadow_type, NULL, gtk2_widget, detail,
-            x, y, width, height);
-}
-
-static void gtk2_paint_diamond(WidgetType widget_type, GtkStateType state_type,
-        GtkShadowType shadow_type, const gchar *detail,
-        gint x, gint y, gint width, gint height)
-{
-    gtk2_widget = gtk2_get_widget(widget_type);
-    (*fp_gtk_paint_diamond)(gtk2_widget->style, gtk2_white_pixmap, state_type,
-            shadow_type, NULL, gtk2_widget, detail,
-            x, y, width, height);
-    (*fp_gtk_paint_diamond)(gtk2_widget->style, gtk2_black_pixmap, state_type,
             shadow_type, NULL, gtk2_widget, detail,
             x, y, width, height);
 }

--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,26 +57,6 @@ static cairo_t *cr = NULL;
 static const char ENV_PREFIX[] = "GTK_MODULES=";
 
 static GtkWidget *gtk3_widgets[_GTK_WIDGET_TYPE_SIZE];
-
-static void throw_exception(JNIEnv *env, const char* name, const char* message)
-{
-    jclass class = (*env)->FindClass(env, name);
-
-    if (class != NULL)
-        (*env)->ThrowNew(env, class, message);
-
-    (*env)->DeleteLocalRef(env, class);
-}
-
-static void gtk3_add_state(GtkWidget *widget, GtkStateType state) {
-    GtkStateType old_state = fp_gtk_widget_get_state(widget);
-    fp_gtk_widget_set_state(widget, old_state | state);
-}
-
-static void gtk3_remove_state(GtkWidget *widget, GtkStateType state) {
-    GtkStateType old_state = fp_gtk_widget_get_state(widget);
-    fp_gtk_widget_set_state(widget, old_state & ~state);
-}
 
 /* This is a workaround for the bug:
  * http://sourceware.org/bugzilla/show_bug.cgi?id=1814
@@ -838,21 +818,6 @@ static void gtk3_set_direction(GtkWidget *widget, GtkTextDirection dir)
     }
 }
 
-/* GTK state_type filter */
-static GtkStateType get_gtk_state_type(WidgetType widget_type, gint synth_state)
-{
-    GtkStateType result = GTK_STATE_NORMAL;
-
-    if ((synth_state & DISABLED) != 0) {
-        result = GTK_STATE_INSENSITIVE;
-    } else if ((synth_state & PRESSED) != 0) {
-        result = GTK_STATE_ACTIVE;
-    } else if ((synth_state & MOUSE_OVER) != 0) {
-        result = GTK_STATE_PRELIGHT;
-    }
-    return result;
-}
-
 static GtkStateFlags get_gtk_state_flags(gint synth_state)
 {
     GtkStateFlags flags = 0;
@@ -896,19 +861,6 @@ static GtkStateFlags get_gtk_flags(GtkStateType state_type) {
     }
     return flags;
 }
-
-/* GTK shadow_type filter */
-static GtkShadowType get_gtk_shadow_type(WidgetType widget_type,
-                                                               gint synth_state)
-{
-    GtkShadowType result = GTK_SHADOW_OUT;
-
-    if ((synth_state & SELECTED) != 0) {
-        result = GTK_SHADOW_IN;
-    }
-    return result;
-}
-
 
 static GtkWidget* gtk3_get_arrow(GtkArrowType arrow_type,
                                                       GtkShadowType shadow_type)


### PR DESCRIPTION
Please review this small change.
Looks like there are a few functions, like gtk2_paint_diamond, that are unreferenced and can be removed.

Thanks, Matthias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273387](https://bugs.openjdk.java.net/browse/JDK-8273387): remove some unreferenced gtk-related functions


### Reviewers
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5384/head:pull/5384` \
`$ git checkout pull/5384`

Update a local copy of the PR: \
`$ git checkout pull/5384` \
`$ git pull https://git.openjdk.java.net/jdk pull/5384/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5384`

View PR using the GUI difftool: \
`$ git pr show -t 5384`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5384.diff">https://git.openjdk.java.net/jdk/pull/5384.diff</a>

</details>
