### PR TITLE
8273414: ResourceObj::operator delete should handle nullptr in debug builds

### DIFF
--- a/src/hotspot/share/memory/allocation.cpp
+++ b/src/hotspot/share/memory/allocation.cpp
@@ -147,6 +147,9 @@ void* ResourceObj::operator new(size_t size, const std::nothrow_t&  nothrow_cons
 }
 
 void ResourceObj::operator delete(void* p) {
+  if (p == nullptr) {
+    return;
+  }
   assert(((ResourceObj *)p)->allocated_on_C_heap(),
          "delete only allowed for C_HEAP objects");
   DEBUG_ONLY(((ResourceObj *)p)->_allocation_t[0] = (uintptr_t)badHeapOopVal;)


### PR DESCRIPTION
This is how delete usually works, This is also how FreeHeap and CHeapObj::operator delete works. Delete does handle nullptr in release builds, it is the assert that may crash. Also, as a user it is nice to call delete without first checking the argument for nullptr.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273414](https://bugs.openjdk.java.net/browse/JDK-8273414): ResourceObj::operator delete should handle nullptr in debug builds


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5385/head:pull/5385` \
`$ git checkout pull/5385`

Update a local copy of the PR: \
`$ git checkout pull/5385` \
`$ git pull https://git.openjdk.java.net/jdk pull/5385/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5385`

View PR using the GUI difftool: \
`$ git pr show -t 5385`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5385.diff">https://git.openjdk.java.net/jdk/pull/5385.diff</a>

</details>
