### PR TITLE
8273416: C2: assert(false) failed: bad AD file after JDK-8252372 with UseSSE={0,1}

### DIFF
--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -7202,7 +7202,8 @@ instruct castLL( eRegL dst ) %{
   ins_pipe( empty );
 %}
 
-instruct castFF( regFPR dst ) %{
+instruct castFF( regF dst ) %{
+  predicate(UseSSE >= 2);
   match(Set dst (CastFF dst));
   format %{ "#castFF of $dst" %}
   ins_encode( /*empty encoding*/ );
@@ -7210,7 +7211,26 @@ instruct castFF( regFPR dst ) %{
   ins_pipe( empty );
 %}
 
-instruct castDD( regDPR dst ) %{
+instruct castDD( regD dst ) %{
+  predicate(UseSSE >= 2);
+  match(Set dst (CastDD dst));
+  format %{ "#castDD of $dst" %}
+  ins_encode( /*empty encoding*/ );
+  ins_cost(0);
+  ins_pipe( empty );
+%}
+
+instruct castFF_PR( regFPR dst ) %{
+  predicate(UseSSE < 2);
+  match(Set dst (CastFF dst));
+  format %{ "#castFF of $dst" %}
+  ins_encode( /*empty encoding*/ );
+  ins_cost(0);
+  ins_pipe( empty );
+%}
+
+instruct castDD_PR( regDPR dst ) %{
+  predicate(UseSSE < 2);
   match(Set dst (CastDD dst));
   format %{ "#castDD of $dst" %}
   ins_encode( /*empty encoding*/ );

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -7202,7 +7202,7 @@ instruct castLL( eRegL dst ) %{
   ins_pipe( empty );
 %}
 
-instruct castFF( regF dst ) %{
+instruct castFF( regFPR dst ) %{
   match(Set dst (CastFF dst));
   format %{ "#castFF of $dst" %}
   ins_encode( /*empty encoding*/ );
@@ -7210,7 +7210,7 @@ instruct castFF( regF dst ) %{
   ins_pipe( empty );
 %}
 
-instruct castDD( regD dst ) %{
+instruct castDD( regDPR dst ) %{
   match(Set dst (CastDD dst));
   format %{ "#castDD of $dst" %}
   ins_encode( /*empty encoding*/ );

--- a/src/hotspot/share/opto/castnode.hpp
+++ b/src/hotspot/share/opto/castnode.hpp
@@ -140,7 +140,7 @@ public:
     init_class_id(Class_CastFF);
   }
   virtual int Opcode() const;
-  virtual uint ideal_reg() const { return Op_RegF; }
+  virtual uint ideal_reg() const { return in(1)->ideal_reg(); }
 };
 
 class CastDDNode: public ConstraintCastNode {
@@ -150,7 +150,7 @@ public:
     init_class_id(Class_CastDD);
   }
   virtual int Opcode() const;
-  virtual uint ideal_reg() const { return Op_RegD; }
+  virtual uint ideal_reg() const { return in(1)->ideal_reg(); }
 };
 
 class CastVVNode: public ConstraintCastNode {


### PR DESCRIPTION
See the bug report for reproducer and failure message. I think the newly added `CastDD`/`CastFF` nodes should handle the extended `regDPR`/`regFPR` (which includes FPU "registers") instead of just `regD`/`regF` to avoid this mismatch error when `UseSSE < 2`.

Unfortunately, we cannot just use `reg*PR` operands in existing match rules, because those operands are defined as `UseSSE < 2`, and using them as operands and `ideal_regs()` would break the matching on `UseSSE >= 2`. Therefore I had to add another pair of matches.

Additonal testing:
 - [x] Linux x86_32 `tier1` `-XX:UseAVX=0 -XX:UseSSE=0`
 - [x] Linux x86_32 `tier1` default
 - [x] Linux x86_64 `tier1` default

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273416](https://bugs.openjdk.java.net/browse/JDK-8273416): C2: assert(false) failed: bad AD file after JDK-8252372 with UseSSE={0,1}


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5386/head:pull/5386` \
`$ git checkout pull/5386`

Update a local copy of the PR: \
`$ git checkout pull/5386` \
`$ git pull https://git.openjdk.java.net/jdk pull/5386/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5386`

View PR using the GUI difftool: \
`$ git pr show -t 5386`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5386.diff">https://git.openjdk.java.net/jdk/pull/5386.diff</a>

</details>
