### PR TITLE
JDK-8273351 bad tag in jdk.random module-info.java

### DIFF
--- a/src/jdk.random/share/classes/module-info.java
+++ b/src/jdk.random/share/classes/module-info.java
@@ -40,8 +40,7 @@ import jdk.internal.util.random.RandomSupport;
  * @provides jdk.random.Xoroshiro128PlusPlus
  * @provides jdk.random.Xoshiro256PlusPlus
  *
- * @use java.util.random.RandomGenerator
- * @use jdk.internal.util.random.RandomSupport
+ * @uses java.util.random.RandomGenerator
  *
  * @moduleGraph
  * @since 16


### PR DESCRIPTION
Wrong tag used to identify used modules. The 's' is missing from the @use tag. Also noted is that an internal module is specified. This PR corrects spelling of tag and removes internal module reference.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273351](https://bugs.openjdk.java.net/browse/JDK-8273351): bad tag in jdk.random module-info.java


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5388/head:pull/5388` \
`$ git checkout pull/5388`

Update a local copy of the PR: \
`$ git checkout pull/5388` \
`$ git pull https://git.openjdk.java.net/jdk pull/5388/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5388`

View PR using the GUI difftool: \
`$ git pr show -t 5388`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5388.diff">https://git.openjdk.java.net/jdk/pull/5388.diff</a>

</details>
