### PR TITLE
8273433: Enable parallelism in vmTestbase_nsk_sysdict tests

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree001/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree001/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree002/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree002/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree003/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree003/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree004/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree004/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree005/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree005/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree006/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree006/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree007/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree007/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree008/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree008/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree009/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree009/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree010/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree010/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree011/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree011/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree012/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree012/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain001/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain001/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain002/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain002/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain003/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain003/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain004/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain004/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain005/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain005/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain006/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain006/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain007/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain007/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain008/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain008/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.


### PR DESCRIPTION
Current `vmTestbase_nsk_sysdict` suite contains about 20 tests, each running exclusively. There seem to be no reason to run them exclusively, though: they complete in reasonable time, are single-threaded, and consume the usual amount of memory.

We should consider enabling parallelism for them and get improved test performance. Currently it is blocked by `TEST.properties` with `exclusiveAccess.dirs` directives in them.

Motivational performance improvements below.

Before:

```
$ time CONF=linux-x86_64-server-fastdebug make run-test TEST=vmTestbase_nsk_sysdict | ts -s
...
00:45:14 ==============================
00:45:14 Test summary
00:45:14 ==============================
00:45:14    TEST                                              TOTAL  PASS  FAIL ERROR   
00:45:14    jtreg:test/hotspot/jtreg:vmTestbase_nsk_sysdict      20    20     0     0   
00:45:14 ==============================
00:45:14 TEST SUCCESS
00:45:14 
00:45:15 Finished building target 'run-test' in configuration 'linux-x86_64-server-fastdebug'

real	45m14.839s
user	149m49.850s
sys	13m25.849s
```

After:

```
$ time CONF=linux-x86_64-server-fastdebug make run-test TEST=vmTestbase_nsk_sysdict | ts -s
...
00:03:25 ==============================
00:03:25 Test summary
00:03:25 ==============================
00:03:25    TEST                                              TOTAL  PASS  FAIL ERROR   
00:03:25    jtreg:test/hotspot/jtreg:vmTestbase_nsk_sysdict      20    20     0     0   
00:03:25 ==============================
00:03:25 TEST SUCCESS
00:03:25 
00:03:25 Finished building target 'run-test' in configuration 'linux-x86_64-server-fastdebug'

real	3m24.702s
user	119m7.488s
sys	8m11.716s
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273433](https://bugs.openjdk.java.net/browse/JDK-8273433): Enable parallelism in vmTestbase_nsk_sysdict tests


### Reviewers
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5389/head:pull/5389` \
`$ git checkout pull/5389`

Update a local copy of the PR: \
`$ git checkout pull/5389` \
`$ git pull https://git.openjdk.java.net/jdk pull/5389/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5389`

View PR using the GUI difftool: \
`$ git pr show -t 5389`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5389.diff">https://git.openjdk.java.net/jdk/pull/5389.diff</a>

</details>
