### PR TITLE
8273438: Enable parallelism in vmTestbase/metaspace/stressHierarchy tests

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy001/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy001/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy002/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy002/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy003/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy003/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy004/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy004/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy005/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy005/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy006/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy006/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy007/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy007/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy008/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy008/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy009/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy009/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy010/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy010/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy011/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy011/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy012/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy012/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy013/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy013/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy014/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy014/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy015/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy015/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.


### PR DESCRIPTION
Current `vmTestbase/metaspace/stressHierarchy` tests (part of vmTestbase_vm_metaspace suite) contains about 15 tests, each running exclusively. There seem to be no reason to run them exclusively, though: they complete in reasonable time, are single-threaded, and consume the usual amount of memory. There is no evidence in JBS that they ever timed out without a reason, and their history unfortunately predates OpenJDK to see why they were not concurrent from day one.

We should consider enabling parallelism for `vmTestbase/metaspace/stressHierarchy` and get improved test performance. Currently it is blocked by `TEST.properties` with `exclusiveAccess.dirs` directives in them. 

Note there are other exclusive tests in `vmTestbase_vm_metaspace`, but those seem to be the hard stress tests: pushing GC to the limits, or doing many threads, etc.

Motivational test time improvements below.

Before:

```
$ time CONF=linux-x86_64-server-fastdebug make run-test TEST=vmTestbase_vm_metaspace | ts -s
...
00:24:53 ==============================
00:24:53 Test summary
00:24:53 ==============================
00:24:53    TEST                                              TOTAL  PASS  FAIL ERROR   
00:24:53    jtreg:test/hotspot/jtreg:vmTestbase_vm_metaspace     25    25     0     0   
00:24:53 ==============================
00:24:53 TEST SUCCESS
00:24:53 
00:24:53 Finished building target 'run-test' in configuration 'linux-x86_64-server-fastdebug'

real	24m53.389s
user	53m2.029s
sys	1m1.849s
```

After:

```
$ time CONF=linux-x86_64-server-fastdebug make run-test TEST=vmTestbase_vm_metaspace | ts -s
...
00:04:04 ==============================
00:04:04 Test summary
00:04:04 ==============================
00:04:04    TEST                                              TOTAL  PASS  FAIL ERROR   
00:04:04    jtreg:test/hotspot/jtreg:vmTestbase_vm_metaspace     25    25     0     0   
00:04:04 ==============================
00:04:04 TEST SUCCESS
00:04:04 
00:04:04 Finished building target 'run-test' in configuration 'linux-x86_64-server-fastdebug'

real	4m4.574s
user	56m10.582s
sys	1m4.725s
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273438](https://bugs.openjdk.java.net/browse/JDK-8273438): Enable parallelism in vmTestbase/metaspace/stressHierarchy tests


### Reviewers
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5391/head:pull/5391` \
`$ git checkout pull/5391`

Update a local copy of the PR: \
`$ git checkout pull/5391` \
`$ git pull https://git.openjdk.java.net/jdk pull/5391/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5391`

View PR using the GUI difftool: \
`$ git pr show -t 5391`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5391.diff">https://git.openjdk.java.net/jdk/pull/5391.diff</a>

</details>
