### PR TITLE
8273392: Improve usability of stack-less exceptions due to -XX:+OmitStackTraceInFastThrow

### DIFF
--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -404,7 +404,7 @@ ciInstance* ciEnv::create_implicit_exception(Symbol* name, GraphKit* gk) {
     oop obj = ik->allocate_instance(THREAD);
     if (!HAS_PENDING_EXCEPTION) {
       Handle handle = Handle(THREAD, obj);
-      java_lang_Throwable::fill_in_stack_trace_of_implicit_exception(handle, gk);
+      java_lang_Throwable::allocate_fill_stack_trace_of_implicit_exception(handle, gk);
       // nmethods are no strong roots so we have to create a global JNI handle
       // for the created exception in order to keep it alive accross GCs.
       objh = JNIHandles::make_global(handle);

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -37,6 +37,7 @@
 
 class CompileTask;
 class OopMapSet;
+class GraphKit;
 
 // ciEnv
 //
@@ -228,6 +229,8 @@ private:
 
   ciInstance* get_or_create_exception(jobject& handle, Symbol* name);
 
+  ciInstance* create_implicit_exception(Symbol* name, GraphKit* gk) NOT_COMPILER2({ return NULL;});
+
   // Get a ciMethod representing either an unfound method or
   // a method with an unloaded holder.  Ensures uniqueness of
   // the result.
@@ -380,7 +383,8 @@ public:
                        bool                      has_unsafe_access,
                        bool                      has_wide_vectors,
                        RTMState                  rtm_state = NoRTM,
-                       const GrowableArrayView<RuntimeStub*>& native_invokers = GrowableArrayView<RuntimeStub*>::EMPTY);
+                       const GrowableArrayView<RuntimeStub*>& native_invokers = GrowableArrayView<RuntimeStub*>::EMPTY,
+                       const GrowableArrayView<jobject>& implicit_exceptions = GrowableArrayView<jobject>::EMPTY);
 
 
   // Access to certain well known ciObjects.
@@ -391,19 +395,13 @@ public:
   VM_CLASSES_DO(VM_CLASS_FUNC)
 #undef VM_CLASS_FUNC
 
-  ciInstance* NullPointerException_instance() {
-    assert(_NullPointerException_instance != NULL, "initialization problem");
-    return _NullPointerException_instance;
-  }
-  ciInstance* ArithmeticException_instance() {
-    assert(_ArithmeticException_instance != NULL, "initialization problem");
-    return _ArithmeticException_instance;
-  }
+  ciInstance* NullPointerException_instance(GraphKit* gk);
+  ciInstance* ArithmeticException_instance(GraphKit* gk);
 
   // Lazy constructors:
-  ciInstance* ArrayIndexOutOfBoundsException_instance();
-  ciInstance* ArrayStoreException_instance();
-  ciInstance* ClassCastException_instance();
+  ciInstance* ArrayIndexOutOfBoundsException_instance(GraphKit* gk);
+  ciInstance* ArrayStoreException_instance(GraphKit* gk);
+  ciInstance* ClassCastException_instance(GraphKit* gk);
 
   ciInstance* the_null_string();
   ciInstance* the_min_jint_string();

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -558,7 +558,7 @@ class java_lang_Throwable: AllStatic {
   static void allocate_backtrace(Handle throwable, TRAPS);
   #ifdef COMPILER2
   // Fill in the stack frame(s) for an implicit exception, can cause GC
-  static void fill_in_stack_trace_of_implicit_exception(Handle throwable, GraphKit* gk);
+  static void allocate_fill_stack_trace_of_implicit_exception(Handle throwable, GraphKit* gk);
   #endif
   // Fill in current stack trace for throwable with preallocated backtrace (no GC)
   static void fill_in_stack_trace_of_preallocated_backtrace(Handle throwable);

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -33,6 +33,7 @@
 #include "utilities/vmEnums.hpp"
 
 class RecordComponent;
+class GraphKit;
 
 // Interface for manipulating the basic Java classes.
 
@@ -555,6 +556,10 @@ class java_lang_Throwable: AllStatic {
 
   // Allocate space for backtrace (created but stack trace not filled in)
   static void allocate_backtrace(Handle throwable, TRAPS);
+  #ifdef COMPILER2
+  // Fill in the stack frame(s) for an implicit exception, can cause GC
+  static void fill_in_stack_trace_of_implicit_exception(Handle throwable, GraphKit* gk);
+  #endif
   // Fill in current stack trace for throwable with preallocated backtrace (no GC)
   static void fill_in_stack_trace_of_preallocated_backtrace(Handle throwable);
   // Fill in current stack trace, can cause GC

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -638,8 +638,9 @@ nmethod::nmethod(
     scopes_data_offset       = _metadata_offset     + align_up(code_buffer->total_metadata_size(), wordSize);
     _scopes_pcs_offset       = scopes_data_offset;
     _dependencies_offset     = _scopes_pcs_offset;
-    _native_invokers_offset     = _dependencies_offset;
-    _handler_table_offset    = _native_invokers_offset;
+    _native_invokers_offset  = _dependencies_offset;
+    _implicit_excepts_offset = _native_invokers_offset;
+    _handler_table_offset    = _implicit_excepts_offset;
     _nul_chk_table_offset    = _handler_table_offset;
 #if INCLUDE_JVMCI
     _speculations_offset     = _nul_chk_table_offset;

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -209,6 +209,7 @@ class nmethod : public CompiledMethod {
   int _dependencies_offset;
   int _native_invokers_offset;
   int _handler_table_offset;
+  int _implicit_excepts_offset;
   int _nul_chk_table_offset;
 #if INCLUDE_JVMCI
   int _speculations_offset;
@@ -310,7 +311,8 @@ class nmethod : public CompiledMethod {
           ImplicitExceptionTable* nul_chk_table,
           AbstractCompiler* compiler,
           int comp_level,
-          const GrowableArrayView<RuntimeStub*>& native_invokers
+          const GrowableArrayView<RuntimeStub*>& native_invokers,
+          const GrowableArrayView<jobject>& implicit_exceptions
 #if INCLUDE_JVMCI
           , char* speculations,
           int speculations_len,
@@ -359,7 +361,8 @@ class nmethod : public CompiledMethod {
                               ImplicitExceptionTable* nul_chk_table,
                               AbstractCompiler* compiler,
                               int comp_level,
-                              const GrowableArrayView<RuntimeStub*>& native_invokers = GrowableArrayView<RuntimeStub*>::EMPTY
+                              const GrowableArrayView<RuntimeStub*>& native_invokers = GrowableArrayView<RuntimeStub*>::EMPTY,
+                              const GrowableArrayView<jobject>& implicit_exceptions = GrowableArrayView<jobject>::EMPTY
 #if INCLUDE_JVMCI
                               , char* speculations = NULL,
                               int speculations_len = 0,
@@ -410,7 +413,9 @@ class nmethod : public CompiledMethod {
   address dependencies_begin    () const          { return           header_begin() + _dependencies_offset  ; }
   address dependencies_end      () const          { return           header_begin() + _native_invokers_offset ; }
   RuntimeStub** native_invokers_begin() const     { return (RuntimeStub**)(header_begin() + _native_invokers_offset) ; }
-  RuntimeStub** native_invokers_end  () const     { return (RuntimeStub**)(header_begin() + _handler_table_offset); }
+  RuntimeStub** native_invokers_end  () const     { return (RuntimeStub**)(header_begin() + _implicit_excepts_offset); }
+  jobject* implicit_exceptions_begin () const     { return (jobject*)(header_begin() + _implicit_excepts_offset) ; }
+  jobject* implicit_exceptions_end   () const     { return (jobject*)(header_begin() + _handler_table_offset); }
   address handler_table_begin   () const          { return           header_begin() + _handler_table_offset ; }
   address handler_table_end     () const          { return           header_begin() + _nul_chk_table_offset ; }
   address nul_chk_table_begin   () const          { return           header_begin() + _nul_chk_table_offset ; }
@@ -425,12 +430,14 @@ class nmethod : public CompiledMethod {
 #endif
 
   // Sizes
-  int oops_size         () const                  { return (address)  oops_end         () - (address)  oops_begin         (); }
-  int metadata_size     () const                  { return (address)  metadata_end     () - (address)  metadata_begin     (); }
-  int dependencies_size () const                  { return            dependencies_end () -            dependencies_begin (); }
+  int oops_size               () const            { return (address) oops_end               () - (address) oops_begin               (); }
+  int metadata_size           () const            { return (address) metadata_end           () - (address) metadata_begin           (); }
+  int dependencies_size       () const            { return           dependencies_end       () -           dependencies_begin       (); }
+  int native_invokers_size    () const            { return (address) native_invokers_end    () - (address) native_invokers_begin    (); }
+  int implicit_exceptions_size() const            { return (address) implicit_exceptions_end() - (address) implicit_exceptions_begin(); }
 #if INCLUDE_JVMCI
-  int speculations_size () const                  { return            speculations_end () -            speculations_begin (); }
-  int jvmci_data_size   () const                  { return            jvmci_data_end   () -            jvmci_data_begin   (); }
+  int speculations_size () const                  { return           speculations_end       () -           speculations_begin       (); }
+  int jvmci_data_size   () const                  { return           jvmci_data_end         () -           jvmci_data_begin         (); }
 #endif
 
   int     oops_count() const { assert(oops_size() % oopSize == 0, "");  return (oops_size() / oopSize) + 1; }

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -1743,7 +1743,7 @@ JVMCI::CodeInstallResult JVMCIRuntime::register_method(JVMCIEnv* JVMCIENV,
                                  frame_words, oop_map_set,
                                  handler_table, implicit_exception_table,
                                  compiler, comp_level, GrowableArrayView<RuntimeStub*>::EMPTY,
-                                 speculations, speculations_len,
+                                 GrowableArrayView<jobject>::EMPTY, speculations, speculations_len,
                                  nmethod_mirror_index, nmethod_mirror_name, failed_speculations);
 
 

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -596,6 +596,7 @@ Compile::Compile( ciEnv* ci_env, ciMethod* target, int osr_bci,
                   _late_inlines_pos(0),
                   _number_of_mh_late_inlines(0),
                   _native_invokers(comp_arena(), 1, 0, NULL),
+                  _implicit_exceptions(comp_arena(), 1, 0, NULL),
                   _print_inlining_stream(NULL),
                   _print_inlining_list(NULL),
                   _print_inlining_idx(0),
@@ -4894,4 +4895,3 @@ Node* Compile::narrow_value(BasicType bt, Node* value, const Type* type, PhaseGV
   }
   return result;
 }
-

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -392,6 +392,8 @@ class Compile : public Phase {
 
   GrowableArray<RuntimeStub*>   _native_invokers;
 
+  GrowableArray<jobject>        _implicit_exceptions;
+
   // Inlining may not happen in parse order which would make
   // PrintInlining output confusing. Keep track of PrintInlining
   // pieces in order.
@@ -961,6 +963,10 @@ class Compile : public Phase {
   void add_native_invoker(RuntimeStub* stub);
 
   const GrowableArray<RuntimeStub*> native_invokers() const { return _native_invokers; }
+
+  void add_implicit_exception(jobject except) { _implicit_exceptions.append(except); }
+
+  const GrowableArray<jobject> implicit_exceptions() const { return _implicit_exceptions; }
 
   void remove_useless_nodes       (GrowableArray<Node*>&        node_list, Unique_Node_List &useful);
 

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -571,19 +571,19 @@ void GraphKit::builtin_throw(Deoptimization::DeoptReason reason, Node* arg) {
     ciInstance* ex_obj = NULL;
     switch (reason) {
     case Deoptimization::Reason_null_check:
-      ex_obj = env()->NullPointerException_instance();
+      ex_obj = env()->NullPointerException_instance(this);
       break;
     case Deoptimization::Reason_div0_check:
-      ex_obj = env()->ArithmeticException_instance();
+      ex_obj = env()->ArithmeticException_instance(this);
       break;
     case Deoptimization::Reason_range_check:
-      ex_obj = env()->ArrayIndexOutOfBoundsException_instance();
+      ex_obj = env()->ArrayIndexOutOfBoundsException_instance(this);
       break;
     case Deoptimization::Reason_class_check:
       if (java_bc() == Bytecodes::_aastore) {
-        ex_obj = env()->ArrayStoreException_instance();
+        ex_obj = env()->ArrayStoreException_instance(this);
       } else {
-        ex_obj = env()->ClassCastException_instance();
+        ex_obj = env()->ClassCastException_instance(this);
       }
       break;
     default:

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -3394,7 +3394,8 @@ void PhaseOutput::install_code(ciMethod*         target,
                                      has_unsafe_access,
                                      SharedRuntime::is_wide_vector(C->max_vector_size()),
                                      C->rtm_state(),
-                                     C->native_invokers());
+                                     C->native_invokers(),
+                                     C->implicit_exceptions());
 
     if (C->log() != NULL) { // Print code cache state into compiler log
       C->log()->code_cache_state();

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -642,6 +642,10 @@ const intx ObjectAlignmentInBytes = 8;
   product(bool, OmitStackTraceInFastThrow, true,                            \
           "Omit backtraces for some 'hot' exceptions in optimized code")    \
                                                                             \
+  product(bool, StackFrameInFastThrow, true,                                \
+          "Create backtraces with at least the top stack frame for 'hot' "  \
+          "exceptions optimized by -XX:+OmitStackTraceInFastThrow")         \
+                                                                            \
   product(bool, ShowCodeDetailsInExceptionMessages, true, MANAGEABLE,       \
           "Show exception messages from RuntimeExceptions that contain "    \
           "snippets of the failing code. Disable this to improve privacy.") \

--- a/test/hotspot/jtreg/compiler/exceptions/StackFrameInFastThrow.java
+++ b/test/hotspot/jtreg/compiler/exceptions/StackFrameInFastThrow.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ /*
+ * @test
+ * @bug 9999999
+ * @summary Test -XX:+/-OmitStackTraceInFastThrow and -XX:+/-StackFrameInFastThrow
+ *
+ * @requires vm.compiler2.enabled
+ * @requires vm.compMode != "Xcomp"
+ *
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:+UseSerialGC -Xbatch -XX:-UseOnStackReplacement -XX:-TieredCompilation
+ *                   -XX:CompileCommand=inline,compiler.exceptions.StackFrameInFastThrow::throwImplicitException
+ *                   -XX:CompileCommand=inline,compiler.exceptions.StackFrameInFastThrow::level2
+ *                   -XX:PerMethodTrapLimit=0 compiler.exceptions.StackFrameInFastThrow
+ */
+
+package compiler.exceptions;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+
+import jdk.test.lib.Asserts;
+import jdk.test.whitebox.WhiteBox;
+
+public class StackFrameInFastThrow {
+    public enum ImplicitException {
+        NULL_POINTER_EXCEPTION,
+        ARITHMETIC_EXCEPTION,
+        ARRAY_INDEX_OUT_OF_BOUNDS_EXCEPTION,
+        ARRAY_STORE_EXCEPTION,
+        CLASS_CAST_EXCEPTION
+    }
+    public enum CompMode {
+        INTERPRETED,
+        C2,
+        C2_RECOMPILED
+    }
+    public enum TestMode {
+        STACKTRACES_IN_FASTTHROW,
+        OMIT_STACKTRACES_IN_FASTTHROW,
+        OMIT_STACKTRACES_IN_FASTTHROW_WITH_STACKFRAME
+    }
+
+    private static final WhiteBox WB = WhiteBox.getWhiteBox();
+    private static String[] string_a = new String[1];
+    private static boolean DEBUG = Boolean.getBoolean("DEBUG");
+
+    public static Object throwImplicitException(ImplicitException type, Object[] object_a) {
+        switch (type) {
+            case NULL_POINTER_EXCEPTION: {
+                return object_a.length;
+            }
+            case ARITHMETIC_EXCEPTION: {
+                return ((42 / (object_a.length - 1)) > 2) ? null : object_a[0];
+            }
+            case ARRAY_INDEX_OUT_OF_BOUNDS_EXCEPTION: {
+                return object_a[5];
+            }
+            case ARRAY_STORE_EXCEPTION: {
+                return (object_a[0] = new Object());
+            }
+            case CLASS_CAST_EXCEPTION: {
+                return (ImplicitException[])object_a;
+            }
+        }
+        return null;
+    }
+
+    public static Object level2(ImplicitException type, Object[] object_a) {
+        return throwImplicitException(type, object_a);
+    }
+
+    public static Object level1(ImplicitException type, Object[] object_a) {
+        return level2(type, object_a);
+    }
+
+    private static void compile(Method m) {
+        Asserts.assertFalse(WB.isMethodCompiled(m), "Method shouldn't be compiled.");
+        WB.enqueueMethodForCompilation(m, 4);
+        Asserts.assertEQ(WB.getMethodCompilationLevel(m), 4, "Method should be compiled at level 4.");
+    }
+
+    private static void unload(Method m) {
+        Asserts.assertEQ(WB.getMethodCompilationLevel(m), 4, "Method should be compiled at level 4.");
+        if (DEBUG) System.console().readLine();
+        WB.deoptimizeMethod(m);  // Makes the nmethod "not entrant".
+        WB.forceNMethodSweep();  // Makes all "not entrant" nmethods "zombie". This requires
+        WB.forceNMethodSweep();  // two sweeps, see 'nmethod::can_convert_to_zombie()' for why.
+        WB.forceNMethodSweep();  // Need third sweep to actually unload/free all "zombie" nmethods.
+        if (DEBUG) System.console().readLine();
+        System.gc();
+        if (DEBUG) System.console().readLine();
+    }
+
+    private static void recompile(Method m) {
+        unload(m);
+        compile(m);
+    }
+
+    private static boolean exceptionsEqual(Exception e1, Exception e2) {
+        if (e1.getClass() == e2.getClass()) {
+            if (e1.getMessage() == e2.getMessage() || e1.getMessage().equals(e2.getMessage())) {
+                StackTraceElement[] ste1 = e1.getStackTrace();
+                StackTraceElement[] ste2 = e2.getStackTrace();
+                if (ste1.length == ste2.length) {
+                    for (int i = 0; i < ste1.length; i++) {
+                        if (!ste1[i].equals(ste2[i])) {
+                            return false;
+                        }
+                    }
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static HashMap<ImplicitException, Exception> lastException = new HashMap<>();
+
+    private static void checkResult(ImplicitException implExcp, Exception catchedExcp, CompMode compMode, TestMode testMode) {
+        catchedExcp.printStackTrace(System.out);
+
+        if (compMode == CompMode.INTERPRETED) {
+            // Exception thrown by the interpreter should have the full stack trace
+            Asserts.assertTrue(catchedExcp.getStackTrace()[3].getMethodName().equals("main"),
+                               "Can't see main() in interpreter stack trace");
+            lastException.put(implExcp, catchedExcp);
+        }
+        if (compMode == CompMode.C2 || compMode == CompMode.C2_RECOMPILED) {
+            switch (testMode) {
+                case STACKTRACES_IN_FASTTHROW : {
+                    Asserts.assertTrue(catchedExcp.getStackTrace()[3].getMethodName().equals("main"),
+                                       "-XX:-OmitStackTraceInFastThrow should generate full stack trace");
+                    Asserts.assertTrue(exceptionsEqual(lastException.get(implExcp), catchedExcp),
+                                       "With -XX:-OmitStackTraceInFastThrow interpreter and C2 generated exceptions should be equal");
+                    break;
+                }
+                case OMIT_STACKTRACES_IN_FASTTHROW : {
+                    Asserts.assertEQ(catchedExcp.getStackTrace().length, 0,
+                                     "-XX:+OmitStackTraceInFastThrow should generate an emtpy stack trace");
+                    if (compMode == CompMode.C2_RECOMPILED) {
+                        Asserts.assertEQ(lastException.get(implExcp), catchedExcp,
+                                         "With -XX:+OmitStackTraceInFastThrow all exceptions should be the same singleton instance");
+                    }
+                    break;
+                }
+                case OMIT_STACKTRACES_IN_FASTTHROW_WITH_STACKFRAME : {
+                    Asserts.assertTrue(catchedExcp.getStackTrace()[2].getMethodName().equals("level1"),
+                                       "-XX:+OmitStackTraceInFastThrow -XX:+StackFrameInFastThrow should generate a minimal stack trace");
+                    if (compMode == CompMode.C2_RECOMPILED) {
+                        Asserts.assertTrue(exceptionsEqual(lastException.get(implExcp), catchedExcp),
+                                                           "With -XX:+OmitStackTraceInFastThrow -XX:+StackFrameInFastThrow C2 generated exceptions should be equal");
+                        Asserts.assertNE(lastException.get(implExcp), catchedExcp,
+                                "With -XX:+OmitStackTraceInFastThrow -XX:+StackFrameInFastThrow new exceptions should be generated for every nmethod");
+                    }
+                    break;
+                }
+            }
+            if (compMode == CompMode.C2_RECOMPILED) {
+                lastException.put(implExcp, null);
+            }
+            else {
+                lastException.put(implExcp, catchedExcp);
+            }
+        }
+    }
+
+    private static void setFlags(TestMode testMode) {
+        if (testMode == TestMode.STACKTRACES_IN_FASTTHROW) {
+            WB.setBooleanVMFlag("OmitStackTraceInFastThrow", false);
+        }
+        else {
+            WB.setBooleanVMFlag("OmitStackTraceInFastThrow", true);
+            WB.setBooleanVMFlag("StackFrameInFastThrow", false);
+        }
+        if (testMode == TestMode.OMIT_STACKTRACES_IN_FASTTHROW_WITH_STACKFRAME) {
+            WB.setBooleanVMFlag("StackFrameInFastThrow", true);
+        }
+        System.out.println("==========================================================");
+        System.out.println("testMode=" + testMode +
+                           " OmitStackTraceInFastThrow=" + WB.getBooleanVMFlag("OmitStackTraceInFastThrow") +
+                           " StackFrameInFastThrow=" + WB.getBooleanVMFlag("StackFrameInFastThrow"));
+        System.out.println("==========================================================");
+    }
+
+    private static void printCompMode(CompMode compMode) {
+        System.out.println("----------------------------------------------------------");
+        System.out.println("compMode=" + compMode);
+        System.out.println("----------------------------------------------------------");
+
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        if (!WB.getBooleanVMFlag("ProfileTraps")) {
+            // The fast-throw optimzation only works if we're running with -XX:+ProfileTraps
+            return;
+        }
+
+        Method level1_m = StackFrameInFastThrow.class.getDeclaredMethod("level1", new Class[] { ImplicitException.class, Object[].class});
+
+        for (TestMode testMode : TestMode.values()) {
+            setFlags(testMode);
+            for (CompMode compMode : CompMode.values()) {
+                printCompMode(compMode);
+                for (ImplicitException impExcp : ImplicitException.values()) {
+                    try {
+                        level1(impExcp, impExcp == ImplicitException.NULL_POINTER_EXCEPTION ? null : string_a);
+                    } catch (Exception catchedExcp) {
+                        checkResult(impExcp, catchedExcp, compMode, testMode);
+                        continue;
+                    }
+                    throw new Exception("Should not happen");
+                }
+                if (compMode == CompMode.INTERPRETED) {
+                    compile(level1_m);
+                }
+                if (compMode == CompMode.C2) {
+                    recompile(level1_m);
+                }
+            }
+            unload(level1_m);
+        }
+    }
+}


### PR DESCRIPTION
If running with `-XX:+OmitStackTraceInFastThrow` (which is the default) C2 will optimize certain "hot" implicit exceptions (i.e. AIOOBE, NullPointerExceptions,..) and replace them by a static, pre-allocated exception without any stacktrace.

However, we can actually do better. Instead of using a single, pre-allocated exception object for all methods we can let the compiler allocate specific exceptions for each compilation unit (i.e. nmethod) and fill them with at least one stack frame with the method /line-number information of the currently compiled method. If the method in question is being inlined (which often happens), we can add stackframes for all callers up to the inlining depth of the method in question.

For the attached JTreg test, we get the following exception in interpreter mode:
```
java.lang.NullPointerException: Cannot read the array length because "<parameter2>" is null
        at compiler.exceptions.StackFrameInFastThrow.throwImplicitException(StackFrameInFastThrow.java:76)
        at compiler.exceptions.StackFrameInFastThrow.level2(StackFrameInFastThrow.java:95)
        at compiler.exceptions.StackFrameInFastThrow.level1(StackFrameInFastThrow.java:99)
        at compiler.exceptions.StackFrameInFastThrow.main(StackFrameInFastThrow.java:233)
```
Once the method gets compiled with `-XX:+OmitStackTraceInFastThrow` the same exception will look as follows:
```
java.lang.NullPointerException
```
After this change, if `StackFrameInFastThrow.throwImplicitException()` will be compiled stand alone, we will get:
```
java.lang.NullPointerException
        at compiler.exceptions.StackFrameInFastThrow.throwImplicitException(StackFrameInFastThrow.java:76)
```
and if `StackFrameInFastThrow.throwImplicitException()` will be inlined into `level2()` and `level2()` into `level1()` we will get the following exception (altough we're still running with `-XX:+OmitStackTraceInFastThrow`):
```
java.lang.NullPointerException
        at compiler.exceptions.StackFrameInFastThrow.throwImplicitException(StackFrameInFastThrow.java:76)
        at compiler.exceptions.StackFrameInFastThrow.level2(StackFrameInFastThrow.java:95)
        at compiler.exceptions.StackFrameInFastThrow.level1(StackFrameInFastThrow.java:99)
```
The new functionality is guarded by `-XX:+/-StackFrameInFastThrow`, but switched on by default (I'll create a CSR for the new option once reviewers are comfortable with the change). Notice that the optimization comes at no run-time costs because all the extra work will be done at compile time.

## Implementation details

- Already the current implementation of `-XX:+OmitStackTraceInFastThrow` potentially lazy-allocates the empty singleton exceptions like AIOOBE in `ciEnv::ArrayStoreException_instance()`. With this change, if running with `-XX:+StackFrameInFastThrow` we will always allocate new exception objects and populate them with the stack frames which are statically available at compile time (see `java_lang_Throwable::fill_in_stack_trace_of_implicit_exception()`).
- Because nmethods don't act as strong GC roots, we have to create a global JNI handle for every newly generated exception to prevent GC from collecting them.
- In order to avoid a memory leak we have to release these global JNI handles once a nmethod gets unloaded. In order to achieve this, I've added a new section "implicit exceptions" to the nmethod which holds these JNI handles.
- While adding the new  "implicit exceptions" section to the corresponding stats (`print_nmethod_stats()` and printing routines (`nmethod::print()`) I realized that a previous change ([JDK-8254231: Implementation of Foreign Linker API (Incubator)](https://bugs.openjdk.java.net/browse/JDK-8254231)) had already introduced a new nmethod section ("native invokers") but missed to add it to the corresponding stats and printing routines so I've added that section as well.
- The `#ifdef COMPILER2` guards are only required to not break the `zero`/`minimal` builds.
- The JTreg test is using `-XX:PerMethodTrapLimit=0` to handle all implicit exceptions as "hot". This makes the test simpler and at the same time provokes the allocation of more implicit exceptions.
- Manually verified that the created Exception objects are freed by GC once the corresponding nmethods have been flushed.
- Manual "stress" test with a very small heap and continuous recompilation of methods with explicit exceptions to provoke GCs during compilation didn't reveal any issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8273392](https://bugs.openjdk.java.net/browse/JDK-8273392): Improve usability of stack-less exceptions due to -XX:+OmitStackTraceInFastThrow


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5392/head:pull/5392` \
`$ git checkout pull/5392`

Update a local copy of the PR: \
`$ git checkout pull/5392` \
`$ git pull https://git.openjdk.java.net/jdk pull/5392/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5392`

View PR using the GUI difftool: \
`$ git pr show -t 5392`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5392.diff">https://git.openjdk.java.net/jdk/pull/5392.diff</a>

</details>
