### PR TITLE
8273439: Fix G1CollectedHeap includes and forward declarations

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -51,9 +51,10 @@
 #include "gc/shared/plab.hpp"
 #include "gc/shared/softRefPolicy.hpp"
 #include "gc/shared/taskqueue.hpp"
+#include "memory/allocation.hpp"
+#include "memory/iterator.hpp"
 #include "memory/memRegion.hpp"
 #include "utilities/bitMap.hpp"
-#include "utilities/stack.hpp"
 
 // A "G1CollectedHeap" is an implementation of a java heap for HotSpot.
 // It uses the "Garbage First" heap organization and algorithm, which
@@ -61,45 +62,28 @@
 // heap subsets that will yield large amounts of garbage.
 
 // Forward declarations
-class HeapRegion;
-class GenerationSpec;
-class G1CardSetFreeMemoryTask;
-class G1ParScanThreadState;
-class G1ParScanThreadStateSet;
-class G1ParScanThreadState;
-class MemoryPool;
-class MemoryManager;
-class ObjectClosure;
-class SpaceClosure;
-class CompactibleSpaceClosure;
-class Space;
+class G1Allocator;
+class G1ArchiveAllocator;
 class G1BatchedGangTask;
 class G1CardTableEntryClosure;
-class G1CollectionSet;
-class G1GCCounters;
-class G1Policy;
-class G1HotCardCache;
-class G1RemSet;
-class G1ServiceTask;
-class G1ServiceThread;
 class G1ConcurrentMark;
 class G1ConcurrentMarkThread;
 class G1ConcurrentRefine;
-class GenerationCounters;
-class STWGCTimer;
-class G1NewTracer;
-class nmethod;
-class WorkGang;
-class G1Allocator;
-class G1ArchiveAllocator;
-class G1FullGCScope;
-class G1HeapVerifier;
-class G1HeapSizingPolicy;
-class G1HeapSummary;
-class G1EvacSummary;
+class G1GCCounters;
 class G1GCPhaseTimes;
+class G1HeapSizingPolicy;
+class G1HotCardCache;
+class G1NewTracer;
+class G1RemSet;
+class G1ServiceTask;
+class G1ServiceThread;
+class GCMemoryManager;
+class HeapRegion;
+class MemoryPool;
+class nmethod;
 class ReferenceProcessor;
-class G1BatchedGangTask;
+class STWGCTimer;
+class WorkGang;
 
 typedef OverflowTaskQueue<ScannerTask, mtGC>           G1ScannerTasksQueue;
 typedef GenericTaskQueueSet<G1ScannerTasksQueue, mtGC> G1ScannerTasksQueueSet;


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that
  * removes unnecessary includes (just one actually)
  * removes unnecessary forwards (either not used, or already covered by the #include declaration)
  * sorts the forward declarations
  * adds necessary forwards that were not directly included

Testing: building on various platforms

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273439](https://bugs.openjdk.java.net/browse/JDK-8273439): Fix G1CollectedHeap includes and forward declarations


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5393/head:pull/5393` \
`$ git checkout pull/5393`

Update a local copy of the PR: \
`$ git checkout pull/5393` \
`$ git pull https://git.openjdk.java.net/jdk pull/5393/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5393`

View PR using the GUI difftool: \
`$ git pr show -t 5393`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5393.diff">https://git.openjdk.java.net/jdk/pull/5393.diff</a>

</details>
