### PR TITLE
8273440: Zero: Disable runtime/Unsafe/InternalErrorTest.java

### DIFF
--- a/test/hotspot/jtreg/runtime/Unsafe/InternalErrorTest.java
+++ b/test/hotspot/jtreg/runtime/Unsafe/InternalErrorTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8191278
  * @requires os.family != "windows"
+ * @requires vm.flavor != "zero"
  * @summary Check that SIGBUS errors caused by memory accesses in Unsafe_CopyMemory()
  * and UnsafeCopySwapMemory() get converted to java.lang.InternalError exceptions.
  * @modules java.base/jdk.internal.misc


### PR DESCRIPTION
JDK-8191278 added a `runtime/Unsafe/InternalErrorTest.java` test to verify that `SIGBUS` during Unsafe copy is converted into the exception. Zero currently crashes this test on `ShouldNotCall()` in signal handler:

```
# Internal Error (/home/shade/trunks/jdk/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp:155), pid=2752575, tid=2752589
# Error: ShouldNotCall()
```

It is unlikely that Zero would implement this functionality, so it seems prudent to disable the test to get clean tier1 for Zero.

Additional testing:
 - [x] Linux x86_64 Zero, test is now disabled
 - [x] Linux x86_64 Server, test still runs

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273440](https://bugs.openjdk.java.net/browse/JDK-8273440): Zero: Disable runtime/Unsafe/InternalErrorTest.java


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5394/head:pull/5394` \
`$ git checkout pull/5394`

Update a local copy of the PR: \
`$ git checkout pull/5394` \
`$ git pull https://git.openjdk.java.net/jdk pull/5394/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5394`

View PR using the GUI difftool: \
`$ git pr show -t 5394`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5394.diff">https://git.openjdk.java.net/jdk/pull/5394.diff</a>

</details>
