### PR TITLE
8273359: CI: ciInstanceKlass::get_canonical_holder() doesn't respect instance size

### DIFF
--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -647,7 +647,7 @@ void LIRGenerator::new_instance(LIR_Opr dst, ciInstanceKlass* klass, bool is_unr
 
     assert(klass->is_loaded(), "must be loaded");
     // allocate space for instance
-    assert(klass->size_helper() >= 0, "illegal instance size");
+    assert(klass->size_helper() > 0, "illegal instance size");
     const int instance_size = align_object_size(klass->size_helper());
     __ allocate_object(dst, scratch1, scratch2, scratch3, scratch4,
                        oopDesc::header_size(), instance_size, klass_reg, !klass->is_initialized(), slow_path);

--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -205,12 +205,12 @@ ciConstantPoolCache* ciInstanceKlass::field_cache() {
 //
 ciInstanceKlass* ciInstanceKlass::get_canonical_holder(int offset) {
   #ifdef ASSERT
-  if (!(offset >= 0 && offset < layout_helper())) {
+  if (!(offset >= 0 && offset < layout_helper_size_in_bytes())) {
     tty->print("*** get_canonical_holder(%d) on ", offset);
     this->print();
     tty->print_cr(" ***");
   };
-  assert(offset >= 0 && offset < layout_helper(), "offset must be tame");
+  assert(offset >= 0 && offset < layout_helper_size_in_bytes(), "offset must be tame");
   #endif
 
   if (offset < instanceOopDesc::base_offset_in_bytes()) {
@@ -227,7 +227,9 @@ ciInstanceKlass* ciInstanceKlass::get_canonical_holder(int offset) {
     for (;;) {
       assert(self->is_loaded(), "must be loaded to have size");
       ciInstanceKlass* super = self->super();
-      if (super == NULL || super->nof_nonstatic_fields() == 0) {
+      if (super == NULL ||
+          super->nof_nonstatic_fields() == 0 ||
+          super->layout_helper_size_in_bytes() <= offset) {
         return self;
       } else {
         self = super;  // return super->get_canonical_holder(offset)

--- a/src/hotspot/share/ci/ciInstanceKlass.hpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.hpp
@@ -165,6 +165,9 @@ public:
     return compute_shared_has_subklass();
   }
 
+  jint                   layout_helper_size_in_bytes()  {
+    return Klass::layout_helper_size_in_bytes(layout_helper());
+  }
   jint                   size_helper()  {
     return (Klass::layout_helper_size_in_bytes(layout_helper())
             >> LogHeapWordSize);

--- a/test/hotspot/jtreg/compiler/unsafe/AlignmentGapAccess.java
+++ b/test/hotspot/jtreg/compiler/unsafe/AlignmentGapAccess.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8273359
+ *
+ * @modules java.base/jdk.internal.misc:+open
+ * @run main/othervm -Xbatch compiler.unsafe.AlignmentGapAccess
+ */
+
+package compiler.unsafe;
+
+import jdk.internal.misc.Unsafe;
+
+public class AlignmentGapAccess {
+    private static final Unsafe UNSAFE = Unsafe.getUnsafe();
+
+    static class A           { int  fa; }
+    static class B extends A { byte fb; }
+
+    static final long FA_OFFSET = UNSAFE.objectFieldOffset(A.class, "fa");
+    static final long FB_OFFSET = UNSAFE.objectFieldOffset(B.class, "fb");
+
+    static int test(B obj) {
+        return UNSAFE.getInt(obj, FB_OFFSET + 1);
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            test(new B());
+        }
+        System.out.println("TEST PASSED");
+    }
+}


### PR DESCRIPTION
`Compile::flatten_alias_type()` relies on `ciInstanceKlass::get_canonical_holder()` to canonicalise holder class.
When a declared field is not found for a fixed offset (it can happen for unsafe accesses), the next thing `ciInstanceKlass::get_canonical_holder()` does it ascends class hierarchy looking for a most specific class without instance fields declared. But it completely ignores the instance size, so it can report a class as canonical while its size is smaller than the offset. It makes the address looks out-of-bounds which breaks idempotence property of address type flattening, because out-of-bounds field address types are flattened to `TypeOopPtr::BOTTOM`.

Proposed fix stops the ascend when superclass size shrinks below `offset`.

Testing: hs-tier1 - hs-tier4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273359](https://bugs.openjdk.java.net/browse/JDK-8273359): CI: ciInstanceKlass::get_canonical_holder() doesn't respect instance size


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5395/head:pull/5395` \
`$ git checkout pull/5395`

Update a local copy of the PR: \
`$ git checkout pull/5395` \
`$ git pull https://git.openjdk.java.net/jdk pull/5395/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5395`

View PR using the GUI difftool: \
`$ git pr show -t 5395`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5395.diff">https://git.openjdk.java.net/jdk/pull/5395.diff</a>

</details>
