### PR TITLE
8273369: Computing micros between two instants unexpectedly overflows for some cases

### DIFF
--- a/src/java.base/share/classes/java/time/Instant.java
+++ b/src/java.base/share/classes/java/time/Instant.java
@@ -243,9 +243,9 @@ public final class Instant
      */
     public static final Instant MAX = Instant.ofEpochSecond(MAX_SECOND, 999_999_999);
     /**
-     * Nanos per micro.
+     * Micros per second
      */
-    private static final long NANOS_PER_MICRO =  1_000L;
+    private static final long MICROS_PER_SECOND =  1_000_000L;
 
     /**
      * Serialization version.
@@ -1170,7 +1170,7 @@ public final class Instant
 
     private long microsUntil(Instant end) {
         long secsDiff = Math.subtractExact(end.seconds, seconds);
-        long totalMicros = Math.multiplyExact(secsDiff, NANOS_PER_MICRO);
+        long totalMicros = Math.multiplyExact(secsDiff, MICROS_PER_SECOND);
         return Math.addExact(totalMicros, (end.nanos - nanos) / 1000);
     }
 

--- a/src/java.base/share/classes/java/time/Instant.java
+++ b/src/java.base/share/classes/java/time/Instant.java
@@ -61,6 +61,7 @@
  */
 package java.time;
 
+import static java.time.LocalTime.MICROS_PER_SECOND;
 import static java.time.LocalTime.NANOS_PER_SECOND;
 import static java.time.LocalTime.SECONDS_PER_DAY;
 import static java.time.LocalTime.SECONDS_PER_HOUR;
@@ -242,10 +243,6 @@ public final class Instant
      * an {@code int}.
      */
     public static final Instant MAX = Instant.ofEpochSecond(MAX_SECOND, 999_999_999);
-    /**
-     * Micros per second
-     */
-    private static final long MICROS_PER_SECOND =  1_000_000L;
 
     /**
      * Serialization version.

--- a/src/java.base/share/classes/java/time/Instant.java
+++ b/src/java.base/share/classes/java/time/Instant.java
@@ -62,6 +62,7 @@
 package java.time;
 
 import static java.time.LocalTime.MICROS_PER_SECOND;
+import static java.time.LocalTime.MILLIS_PER_SECOND;
 import static java.time.LocalTime.NANOS_PER_SECOND;
 import static java.time.LocalTime.SECONDS_PER_DAY;
 import static java.time.LocalTime.SECONDS_PER_HOUR;
@@ -1147,7 +1148,7 @@ public final class Instant
             return switch (chronoUnit) {
                 case NANOS     -> nanosUntil(end);
                 case MICROS    -> microsUntil(end);
-                case MILLIS    -> Math.subtractExact(end.toEpochMilli(), toEpochMilli());
+                case MILLIS    -> millisUntil(end);
                 case SECONDS   -> secondsUntil(end);
                 case MINUTES   -> secondsUntil(end) / SECONDS_PER_MINUTE;
                 case HOURS     -> secondsUntil(end) / SECONDS_PER_HOUR;
@@ -1169,6 +1170,12 @@ public final class Instant
         long secsDiff = Math.subtractExact(end.seconds, seconds);
         long totalMicros = Math.multiplyExact(secsDiff, MICROS_PER_SECOND);
         return Math.addExact(totalMicros, (end.nanos - nanos) / 1000);
+    }
+
+    private long millisUntil(Instant end) {
+        long secsDiff = Math.subtractExact(end.seconds, seconds);
+        long totalMillis = Math.multiplyExact(secsDiff, MILLIS_PER_SECOND);
+        return Math.addExact(totalMillis, (end.nanos - nanos) / 1000_000);
     }
 
     private long secondsUntil(Instant end) {

--- a/src/java.base/share/classes/java/time/Instant.java
+++ b/src/java.base/share/classes/java/time/Instant.java
@@ -242,6 +242,10 @@ public final class Instant
      * an {@code int}.
      */
     public static final Instant MAX = Instant.ofEpochSecond(MAX_SECOND, 999_999_999);
+    /**
+     * Nanos per micro.
+     */
+    private static final long NANOS_PER_MICRO =  1_000L;
 
     /**
      * Serialization version.
@@ -1166,7 +1170,7 @@ public final class Instant
 
     private long microsUntil(Instant end) {
         long secsDiff = Math.subtractExact(end.seconds, seconds);
-        long totalMicros = Math.multiplyExact(secsDiff, NANOS_PER_SECOND / 1000);
+        long totalMicros = Math.multiplyExact(secsDiff, NANOS_PER_MICRO);
         return Math.addExact(totalMicros, (end.nanos - nanos) / 1000);
     }
 

--- a/src/java.base/share/classes/java/time/Instant.java
+++ b/src/java.base/share/classes/java/time/Instant.java
@@ -1145,7 +1145,7 @@ public final class Instant
         if (unit instanceof ChronoUnit chronoUnit) {
             return switch (chronoUnit) {
                 case NANOS     -> nanosUntil(end);
-                case MICROS    -> nanosUntil(end) / 1000;
+                case MICROS    -> microsUntil(end);
                 case MILLIS    -> Math.subtractExact(end.toEpochMilli(), toEpochMilli());
                 case SECONDS   -> secondsUntil(end);
                 case MINUTES   -> secondsUntil(end) / SECONDS_PER_MINUTE;
@@ -1162,6 +1162,12 @@ public final class Instant
         long secsDiff = Math.subtractExact(end.seconds, seconds);
         long totalNanos = Math.multiplyExact(secsDiff, NANOS_PER_SECOND);
         return Math.addExact(totalNanos, end.nanos - nanos);
+    }
+
+    private long microsUntil(Instant end) {
+        long secsDiff = Math.subtractExact(end.seconds, seconds);
+        long totalMicros = Math.multiplyExact(secsDiff, NANOS_PER_SECOND / 1000);
+        return Math.addExact(totalMicros, (end.nanos - nanos) / 1000);
     }
 
     private long secondsUntil(Instant end) {

--- a/src/java.base/share/classes/java/time/LocalTime.java
+++ b/src/java.base/share/classes/java/time/LocalTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -183,9 +183,13 @@ public final class LocalTime
      */
     static final int SECONDS_PER_DAY = SECONDS_PER_HOUR * HOURS_PER_DAY;
     /**
+     * Milliseconds per second.
+     */
+    static final long MILLIS_PER_SECOND = 1000L;
+    /**
      * Milliseconds per day.
      */
-    static final long MILLIS_PER_DAY = SECONDS_PER_DAY * 1000L;
+    static final long MILLIS_PER_DAY = MILLIS_PER_SECOND * SECONDS_PER_DAY;
     /**
      * Microseconds per second.
      */

--- a/src/java.base/share/classes/java/time/LocalTime.java
+++ b/src/java.base/share/classes/java/time/LocalTime.java
@@ -187,9 +187,13 @@ public final class LocalTime
      */
     static final long MILLIS_PER_DAY = SECONDS_PER_DAY * 1000L;
     /**
+     * Microseconds per second.
+     */
+    static final long MICROS_PER_SECOND = 1000_000L;
+    /**
      * Microseconds per day.
      */
-    static final long MICROS_PER_DAY = SECONDS_PER_DAY * 1000_000L;
+    static final long MICROS_PER_DAY = MICROS_PER_SECOND * SECONDS_PER_DAY;
     /**
      * Nanos per millisecond.
      */

--- a/test/jdk/java/time/test/java/time/TestInstant.java
+++ b/test/jdk/java/time/test/java/time/TestInstant.java
@@ -98,6 +98,11 @@ public class TestInstant extends AbstractTest {
         assertEquals(millis, m, name);
     }
 
+    /**
+     * Checks whether Instant.until() returning microseconds does not throw
+     * an ArithmeticException for Instants apart for more than Long.MAX_VALUE
+     * nanoseconds.
+     */
     @Test
     public void test_microsUntil() {
         var nanoMax = Instant.EPOCH.plusNanos(Long.MAX_VALUE);

--- a/test/jdk/java/time/test/java/time/TestInstant.java
+++ b/test/jdk/java/time/test/java/time/TestInstant.java
@@ -110,4 +110,14 @@ public class TestInstant extends AbstractTest {
         var plusOneMicro = Instant.EPOCH.until(nanoMax.plusNanos(1000), ChronoUnit.MICROS);
         assertEquals(plusOneMicro - totalMicros, 1L);
     }
+
+    /**
+     * Checks whether Instant.until() returning milliseconds does not throw
+     * an ArithmeticException for very large/small Instants
+     */
+    @Test
+    public void test_millisUntil() {
+        assertEquals(Instant.MIN.until(Instant.MIN.plusSeconds(1), ChronoUnit.MILLIS), 1000L);
+        assertEquals(Instant.MAX.plusSeconds(-1).until(Instant.MAX, ChronoUnit.MILLIS), 1000L);
+    }
 }

--- a/test/jdk/java/time/test/java/time/TestInstant.java
+++ b/test/jdk/java/time/test/java/time/TestInstant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,6 +60,7 @@
 package test.java.time;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 import org.testng.annotations.Test;
 import org.testng.annotations.DataProvider;
@@ -67,6 +68,7 @@ import static org.testng.Assert.assertEquals;
 
 /**
  * Test Instant.
+ * @bug 8273369
  */
 @Test
 public class TestInstant extends AbstractTest {
@@ -96,4 +98,11 @@ public class TestInstant extends AbstractTest {
         assertEquals(millis, m, name);
     }
 
+    @Test
+    public void test_microsUntil() {
+        var nanoMax = Instant.EPOCH.plusNanos(Long.MAX_VALUE);
+        var totalMicros = Instant.EPOCH.until(nanoMax, ChronoUnit.MICROS);
+        var plusOneMicro = Instant.EPOCH.until(nanoMax.plusNanos(1000), ChronoUnit.MICROS);
+        assertEquals(plusOneMicro - totalMicros, 1L);
+    }
 }


### PR DESCRIPTION
Please review the fix to the issue. Avoiding overflow by not calling nanosUntil() directly, which will overflow beyond Long.MAX_VALUE difference in nano unit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273369](https://bugs.openjdk.java.net/browse/JDK-8273369): Computing micros between two instants unexpectedly overflows for some cases


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**) ⚠️ Review applies to ccf73bf7417b93aaebeab1d2f079330e2f7cbfb7


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5396/head:pull/5396` \
`$ git checkout pull/5396`

Update a local copy of the PR: \
`$ git checkout pull/5396` \
`$ git pull https://git.openjdk.java.net/jdk pull/5396/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5396`

View PR using the GUI difftool: \
`$ git pr show -t 5396`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5396.diff">https://git.openjdk.java.net/jdk/pull/5396.diff</a>

</details>
