### PR TITLE
8273451: Remove unreachable return in mutexLocker::wait

### DIFF
--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -255,12 +255,8 @@ class MonitorLocker: public MutexLocker {
   }
 
   bool wait(int64_t timeout = 0) {
-    if (_flag == Mutex::_safepoint_check_flag) {
-      return as_monitor()->wait(timeout);
-    } else {
-      return as_monitor()->wait_without_safepoint_check(timeout);
-    }
-    return false;
+    return _flag == Mutex::_safepoint_check_flag ?
+      as_monitor()->wait(timeout) : as_monitor()->wait_without_safepoint_check(timeout);
   }
 
   void notify_all() {


### PR DESCRIPTION
Refactored  mutexLocker::wait to return redundant unreachable "return false;"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273451](https://bugs.openjdk.java.net/browse/JDK-8273451): Remove unreachable return in  mutexLocker::wait


### Reviewers
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5398/head:pull/5398` \
`$ git checkout pull/5398`

Update a local copy of the PR: \
`$ git checkout pull/5398` \
`$ git pull https://git.openjdk.java.net/jdk pull/5398/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5398`

View PR using the GUI difftool: \
`$ git pr show -t 5398`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5398.diff">https://git.openjdk.java.net/jdk/pull/5398.diff</a>

</details>
