### PR TITLE
8273047: test jfr/api/consumer/TestRecordedFrame.java timing out

### DIFF
--- a/test/jdk/jdk/jfr/api/consumer/TestRecordedFrame.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestRecordedFrame.java
@@ -43,7 +43,7 @@ import jdk.test.lib.jfr.SimpleEvent;
  * @requires vm.hasJFR
  * @library /test/lib
  * @run main/othervm -Xint  -XX:+UseInterpreter -Dinterpreted=true  jdk.jfr.api.consumer.TestRecordedFrame
- * @run main/othervm -Xcomp -XX:-UseInterpreter -Dinterpreted=false jdk.jfr.api.consumer.TestRecordedFrame
+ * @run main/othervm/timeout=180 -Xcomp -XX:-UseInterpreter -Dinterpreted=false jdk.jfr.api.consumer.TestRecordedFrame
  */
 public final class TestRecordedFrame {
 


### PR DESCRIPTION
A trivial fix to bump the timeout value for the second sub-test in
jfr/api/consumer/TestRecordedFrame.java. See the bug report
for the gory details.