### PR TITLE
JDK-8272698: LoadNode::pin is unused

### DIFF
--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -285,7 +285,6 @@ public:
   bool  has_reinterpret_variant(const Type* rt);
   Node* convert_to_reinterpret_load(PhaseGVN& gvn, const Type* rt);
 
-  void pin() { _control_dependency = Pinned; }
   bool has_unknown_control_dependency() const { return _control_dependency == UnknownControl; }
 
 #ifndef PRODUCT


### PR DESCRIPTION
Removed dead code and tested on Tier 1.

Thanks, 
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272698](https://bugs.openjdk.java.net/browse/JDK-8272698): LoadNode::pin is unused


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5408/head:pull/5408` \
`$ git checkout pull/5408`

Update a local copy of the PR: \
`$ git checkout pull/5408` \
`$ git pull https://git.openjdk.java.net/jdk pull/5408/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5408`

View PR using the GUI difftool: \
`$ git pr show -t 5408`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5408.diff">https://git.openjdk.java.net/jdk/pull/5408.diff</a>

</details>
