### PR TITLE
8273478: [macos11] JTabbedPane selected and pressed tab is not legible

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaLookAndFeel.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaLookAndFeel.java
@@ -869,7 +869,7 @@ public class AquaLookAndFeel extends BasicLookAndFeel {
             //"TabbedPane.selectedTabPadInsets", new InsetsUIResource(0, 0, 1, 0), // Really outsets, this is where we allow for overlap
             "TabbedPane.selectedTabPadInsets", new InsetsUIResource(0, 0, 0, 0), // Really outsets, this is where we allow for overlap
             "TabbedPane.tabsOverlapBorder", Boolean.TRUE,
-            "TabbedPane.selectedTabTitlePressedColor", selectedTabTitlePressedColor,
+            "TabbedPane.selectedTabTitlePressedColor", JRSUIUtils.isMacOSXBigSurOrAbove() ? selectedControlTextColor : selectedTabTitlePressedColor,
             "TabbedPane.selectedTabTitleDisabledColor", selectedTabTitleDisabledColor,
             "TabbedPane.selectedTabTitleNormalColor", JRSUIUtils.isMacOSXBigSurOrAbove() ? selectedControlTextColor : selectedTabTitleNormalColor,
             "TabbedPane.selectedTabTitleShadowDisabledColor", selectedTabTitleShadowDisabledColor,


### PR DESCRIPTION
On macOS 11 (bigsur), using the Swing Aqua Look and Feel,
the text of the selected and "pressed" JTabbedPane tab title text is just a light gray outline of white text on a white background which is not readable. 
Fix is to use selectedControlTextColor for TabbedPane.selectedTabTitlePressedColor same as what we use for TabbedPane.selectedTabTitleNormalColor. Result is black over white text same as what is seen for native app pressed tabbedpane.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273478](https://bugs.openjdk.java.net/browse/JDK-8273478): [macos11] JTabbedPane selected and pressed tab is not legible


### Reviewers
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5409/head:pull/5409` \
`$ git checkout pull/5409`

Update a local copy of the PR: \
`$ git checkout pull/5409` \
`$ git pull https://git.openjdk.java.net/jdk pull/5409/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5409`

View PR using the GUI difftool: \
`$ git pr show -t 5409`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5409.diff">https://git.openjdk.java.net/jdk/pull/5409.diff</a>

</details>
