### PR TITLE
8273482: Remove "foreground work" concept from WorkGang

### DIFF
--- a/src/hotspot/share/gc/shared/workgroup.hpp
+++ b/src/hotspot/share/gc/shared/workgroup.hpp
@@ -169,9 +169,8 @@ class WorkGang : public CHeapObj<mtInternal> {
   // Run a task with the given number of workers, returns
   // when the task is done. The number of workers must be at most the number of
   // active workers.  Additional workers may be created if an insufficient
-  // number currently exists. If the add_foreground_work flag is true, the current thread
-  // is used to run the task too.
-  void run_task(AbstractGangTask* task, uint num_workers, bool add_foreground_work = false);
+  // number currently exists.
+  void run_task(AbstractGangTask* task, uint num_workers);
 };
 
 // Temporarily try to set the number of active workers.

--- a/src/hotspot/share/gc/shenandoah/shenandoahCodeRoots.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCodeRoots.cpp
@@ -355,7 +355,6 @@ ShenandoahCodeRootsIterator::ShenandoahCodeRootsIterator() :
         _par_iterator(CodeCache::heaps()),
         _table_snapshot(NULL) {
   assert(SafepointSynchronize::is_at_safepoint(), "Must be at safepoint");
-  assert(!Thread::current()->is_Worker_thread(), "Should not be acquired by workers");
   CodeCache_lock->lock_without_safepoint_check();
   _table_snapshot = ShenandoahCodeRoots::table()->snapshot_for_iteration();
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.cpp
@@ -258,7 +258,6 @@ ShenandoahHeapIterationRootScanner::ShenandoahHeapIterationRootScanner() :
  }
 
  void ShenandoahHeapIterationRootScanner::roots_do(OopClosure* oops) {
-   assert(Thread::current()->is_VM_thread(), "Only by VM thread");
    // Must use _claim_none to avoid interfering with concurrent CLDG iteration
    CLDToOopClosure clds(oops, ClassLoaderData::_claim_none);
    MarkingCodeBlobClosure code(oops, !CodeBlobToOopClosure::FixRelocations);

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.inline.hpp
@@ -86,9 +86,8 @@ ShenandoahClassLoaderDataRoots<CONCURRENT, SINGLE_THREADED>::ShenandoahClassLoad
     ClassLoaderDataGraph_lock->lock();
   }
 
-  // Non-concurrent mode only runs at safepoints by VM thread
+  // Non-concurrent mode only runs at safepoints
   assert(CONCURRENT || SafepointSynchronize::is_at_safepoint(), "Must be at a safepoint");
-  assert(CONCURRENT || Thread::current()->is_VM_thread(), "Can only be done by VM thread");
 }
 
 template <bool CONCURRENT, bool SINGLE_THREADED>

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -1771,7 +1771,7 @@ void VM_HeapDumper::doit() {
   if (gang == NULL) {
     work(0);
   } else {
-    gang->run_task(this, gang->active_workers(), true);
+    gang->run_task(this);
   }
 
   // Now we clear the global variables, so that a future dumper can run.
@@ -1780,7 +1780,7 @@ void VM_HeapDumper::doit() {
 }
 
 void VM_HeapDumper::work(uint worker_id) {
-  if (!Thread::current()->is_VM_thread()) {
+  if (worker_id != 0) {
     writer()->writer_loop();
     return;
   }


### PR DESCRIPTION
JDK-8237354 introduced the concept of "foreground work" in WorkGang, as a special case for use by the HeapDumper. I propose that we remove this code, since this special use case can be solved without the need for the concept of "foreground work" in WorkGang.

As far as I can tell, there's no reason why it must be the VM thread that takes on the task of writing the header, iterating over roots, etc. So, in VM_HeapDumper::work(), instead of checking if the current thread is the VM thread we can just check if the worker_id is non-zero. That way, a single worker thread will take on the task of writing the header, iterating over roots, etc, and all other worker threads will continue to call worker_loop().

Testing:
 - Passed Tier1-3
 - Passed multiple runs of test/hotspot/jtreg/serviceability/dcmd/gc/
 - Manually ran jcmd GC.heap_dump with various GCs enabled

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273482](https://bugs.openjdk.java.net/browse/JDK-8273482): Remove "foreground work" concept from WorkGang


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 74ab4a073a81f008e54c74c6dd735f5b075c6be4
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to 74ab4a073a81f008e54c74c6dd735f5b075c6be4


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5410/head:pull/5410` \
`$ git checkout pull/5410`

Update a local copy of the PR: \
`$ git checkout pull/5410` \
`$ git pull https://git.openjdk.java.net/jdk pull/5410/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5410`

View PR using the GUI difftool: \
`$ git pr show -t 5410`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5410.diff">https://git.openjdk.java.net/jdk/pull/5410.diff</a>

</details>
