### PR TITLE
8273483: Zero: Clear pending JNI exception check in native method handler

### DIFF
--- a/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
+++ b/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
@@ -562,6 +562,12 @@ int ZeroInterpreter::native_entry(Method* method, intptr_t UNUSED, TRAPS) {
     }
   }
 
+  // Already did every pending exception check here.
+  // If HAS_PENDING_EXCEPTION is true, the interpreter would handle the rest.
+  if (CheckJNICalls) {
+    THREAD->clear_pending_jni_exception_check();
+  }
+
   // No deoptimized frames on the stack
   return 0;
 }


### PR DESCRIPTION
If you run Zero with existing tier1 test, then it would fail like this:

```
$ CONF=linux-x86_64-zero-fastdebug make exploded-test TEST=runtime/jni/checked/TestCheckedJniExceptionCheck.java

 stdout: [TEST STARTED
testSingleCallNoCheck start
WARNING in native method: JNI call made without checking exceptions when required to from CallVoidMethod
at java.lang.Object.getClass(java.base/Native Method)
at java.io.PrintStream.println(java.base/PrintStream.java:1035)
at TestCheckedJniExceptionCheck.testSingleCallNoCheck(TestCheckedJniExceptionCheck.java:82)
at TestCheckedJniExceptionCheck.test(TestCheckedJniExceptionCheck.java:66)
at TestCheckedJniExceptionCheck.main(TestCheckedJniExceptionCheck.java:203)
testSingleCallNoCheck end
```

In other words, there is a warning from the native call to Object.getClass from the test println itself, which it does not expect. This is because Zero does not clear the pending JNI exception check flag. All other (template) interpreter implementation do clear it in native call handlers. So the test rightfully reports the excess warning. 

Additional testing:
 - [x] Linux x86_64 Zero, `runtime/jni` tests now pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273483](https://bugs.openjdk.java.net/browse/JDK-8273483): Zero: Clear pending JNI exception check in native method handler


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5411/head:pull/5411` \
`$ git checkout pull/5411`

Update a local copy of the PR: \
`$ git checkout pull/5411` \
`$ git pull https://git.openjdk.java.net/jdk pull/5411/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5411`

View PR using the GUI difftool: \
`$ git pr show -t 5411`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5411.diff">https://git.openjdk.java.net/jdk/pull/5411.diff</a>

</details>
