### PR TITLE
8273486: Zero: Handle DiagnoseSyncOnValueBasedClasses VM option

### DIFF
--- a/src/hotspot/cpu/zero/vm_version_zero.cpp
+++ b/src/hotspot/cpu/zero/vm_version_zero.cpp
@@ -45,6 +45,11 @@ void VM_Version::initialize() {
   }
   FLAG_SET_DEFAULT(AllocatePrefetchDistance, 0);
 
+  // If lock diagnostics is needed, always call to runtime
+  if (DiagnoseSyncOnValueBasedClasses != 0) {
+    FLAG_SET_DEFAULT(UseHeavyMonitors, true);
+  }
+
   // Not implemented
   UNSUPPORTED_OPTION(CriticalJNINatives);
 }


### PR DESCRIPTION
JDK-8257027 added a diagnostic option to check for synchronization on value-based classes. Zero does not support it, so it would fail the relevant test:

```
$ CONF=linux-x86_64-zero-fastdebug make exploded-test TEST=runtime/Monitor/SyncOnValueBasedClassTest.java

STDERR:
 stdout: [];
 stderr: [Exception in thread "main" java.lang.RuntimeException: synchronization on value based class did not fail
	at SyncOnValueBasedClassTest$FatalTest.main(SyncOnValueBasedClassTest.java:128)
]
 exitValue = 1

java.lang.RuntimeException: 'fatal error: Synchronizing on object' missing from stdout/stderr 
```

Template interpreters implement this check by going to to slowpath that calls `InterpreterRuntime::monitorenter`. Zero already goes to that path when `UseHeavyMonitors` is enabled, so we might just enable it when lock diagnostics is requested. This would cost us zero (pun intended) when diagnostic option is disabled.

Additional testing:
 - [x] Linux x86_64 Zero, affected test now passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273486](https://bugs.openjdk.java.net/browse/JDK-8273486): Zero: Handle DiagnoseSyncOnValueBasedClasses VM option


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5412/head:pull/5412` \
`$ git checkout pull/5412`

Update a local copy of the PR: \
`$ git checkout pull/5412` \
`$ git pull https://git.openjdk.java.net/jdk pull/5412/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5412`

View PR using the GUI difftool: \
`$ git pr show -t 5412`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5412.diff">https://git.openjdk.java.net/jdk/pull/5412.diff</a>

</details>
