### PR TITLE
8273487: Zero: Handle "zero" variant in runtime tests

### DIFF
--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -364,6 +364,8 @@ public class Platform {
             return "client";
         } else if (Platform.isMinimal()) {
             return "minimal";
+        } else if (Platform.isZero()) {
+            return "zero";
         } else {
             throw new Error("TESTBUG: unsupported vm variant");
         }

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -365,7 +365,10 @@ public class Platform {
         } else if (Platform.isMinimal()) {
             return "minimal";
         } else if (Platform.isZero()) {
-            return "zero";
+            // This name is used to search for libjvm.so. Weirdly, current
+            // build system puts libjvm.so into default location, which is
+            // "server". See JDK-8273494.
+            return "server";
         } else {
             throw new Error("TESTBUG: unsupported vm variant");
         }


### PR DESCRIPTION
JDK-8179317 rewritten runtime shell tests to Java. There is a little omission in VM variant selection, which makes Zero fail some of the tier1 tests, like:

```
$ CONF=linux-x86_64-zero-fastdebug make exploded-test TEST=runtime/StackGap/TestStackGap.java

STDERR:
java.lang.Error: TESTBUG: unsupported vm variant
at jdk.test.lib.Platform.variant(Platform.java:368)
at jdk.test.lib.Platform.jvmLibDir(Platform.java:357)
at jdk.test.lib.process.ProcessTools.addJvmLib(ProcessTools.java:585)
at jdk.test.lib.process.ProcessTools.createNativeTestProcessBuilder(ProcessTools.java:575) 
```

Additional testing:
 - [x] Linux x86_64 Zero affected tests (StackGap, StackGuardPages, TestTLS) now run

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273487](https://bugs.openjdk.java.net/browse/JDK-8273487): Zero: Handle "zero" variant in runtime tests


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to 141d8184ed761066edba4354ce71d4c8c5c6d2b1
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5413/head:pull/5413` \
`$ git checkout pull/5413`

Update a local copy of the PR: \
`$ git checkout pull/5413` \
`$ git pull https://git.openjdk.java.net/jdk pull/5413/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5413`

View PR using the GUI difftool: \
`$ git pr show -t 5413`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5413.diff">https://git.openjdk.java.net/jdk/pull/5413.diff</a>

</details>
