### PR TITLE
8273476: G1: refine G1CollectedHeap::par_iterate_regions_array_part_from

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2329,7 +2329,6 @@ void G1CollectedHeap::collection_set_iterate_increment_from(HeapRegionClosure *c
 void G1CollectedHeap::par_iterate_regions_array_part_from(HeapRegionClosure* cl,
                                                           HeapRegionClaimer* hr_claimer,
                                                           const uint* regions,
-                                                          size_t offset,
                                                           size_t length,
                                                           uint worker_id) const {
   assert_at_safepoint();
@@ -2342,7 +2341,7 @@ void G1CollectedHeap::par_iterate_regions_array_part_from(HeapRegionClosure* cl,
   size_t cur_pos = start_pos;
 
   do {
-    uint region_idx = regions[cur_pos + offset];
+    uint region_idx = regions[cur_pos];
     if (hr_claimer == NULL || hr_claimer->claim_region(region_idx)) {
       HeapRegion* r = region_at(region_idx);
       bool result = cl->do_heap_region(r);

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2326,11 +2326,11 @@ void G1CollectedHeap::collection_set_iterate_increment_from(HeapRegionClosure *c
   _collection_set.iterate_incremental_part_from(cl, hr_claimer, worker_id);
 }
 
-void G1CollectedHeap::par_iterate_regions_array_part_from(HeapRegionClosure* cl,
-                                                          HeapRegionClaimer* hr_claimer,
-                                                          const uint* regions,
-                                                          size_t length,
-                                                          uint worker_id) const {
+void G1CollectedHeap::par_iterate_regions_array(HeapRegionClosure* cl,
+                                                HeapRegionClaimer* hr_claimer,
+                                                const uint regions[],
+                                                size_t length,
+                                                uint worker_id) const {
   assert_at_safepoint();
   if (length == 0) {
     return;

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1155,7 +1155,7 @@ public:
     collection_set_iterate_increment_from(blk, NULL, worker_id);
   }
   void collection_set_iterate_increment_from(HeapRegionClosure *blk, HeapRegionClaimer* hr_claimer, uint worker_id);
-  // Iterate an array of region indexes given by offset and length, applying
+  // Iterate over the array of region indexes, uint regions[length], applying
   // the given HeapRegionClosure on each region. The worker_id will determine where
   // to start the iteration to allow for more efficient parallel iteration.
   void par_iterate_regions_array(HeapRegionClosure* cl,

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1161,7 +1161,6 @@ public:
   void par_iterate_regions_array_part_from(HeapRegionClosure* cl,
                                            HeapRegionClaimer* hr_claimer,
                                            const uint* regions,
-                                           size_t offset,
                                            size_t length,
                                            uint worker_id) const;
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1155,14 +1155,14 @@ public:
     collection_set_iterate_increment_from(blk, NULL, worker_id);
   }
   void collection_set_iterate_increment_from(HeapRegionClosure *blk, HeapRegionClaimer* hr_claimer, uint worker_id);
-  // Iterate part of an array of region indexes given by offset and length, applying
+  // Iterate an array of region indexes given by offset and length, applying
   // the given HeapRegionClosure on each region. The worker_id will determine where
-  // in the part to start the iteration to allow for more efficient parallel iteration.
-  void par_iterate_regions_array_part_from(HeapRegionClosure* cl,
-                                           HeapRegionClaimer* hr_claimer,
-                                           const uint* regions,
-                                           size_t length,
-                                           uint worker_id) const;
+  // to start the iteration to allow for more efficient parallel iteration.
+  void par_iterate_regions_array(HeapRegionClosure* cl,
+                                 HeapRegionClaimer* hr_claimer,
+                                 const uint regions[],
+                                 size_t length,
+                                 uint worker_id) const;
 
   // Returns the HeapRegion that contains addr. addr must not be NULL.
   template <class T>

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -232,11 +232,10 @@ void G1CollectionSet::iterate_part_from(HeapRegionClosure* cl,
                                         size_t offset,
                                         size_t length,
                                         uint worker_id) const {
-  assert((length > offset) || (length == offset && length == 0), "Must be");
   _g1h->par_iterate_regions_array(cl,
                                   hr_claimer,
                                   &_collection_set_regions[offset],
-                                  length - offset,
+                                  length,
                                   worker_id);
 }
 

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -232,7 +232,12 @@ void G1CollectionSet::iterate_part_from(HeapRegionClosure* cl,
                                         size_t offset,
                                         size_t length,
                                         uint worker_id) const {
-  _g1h->par_iterate_regions_array_part_from(cl, hr_claimer, _collection_set_regions, offset, length, worker_id);
+  assert(length >= offset, "Must be");
+  _g1h->par_iterate_regions_array_part_from(cl,
+                                            hr_claimer,
+                                            &_collection_set_regions[offset],
+                                            length-offset,
+                                            worker_id);
 }
 
 void G1CollectionSet::update_young_region_prediction(HeapRegion* hr,

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -232,12 +232,12 @@ void G1CollectionSet::iterate_part_from(HeapRegionClosure* cl,
                                         size_t offset,
                                         size_t length,
                                         uint worker_id) const {
-  assert(length >= offset, "Must be");
-  _g1h->par_iterate_regions_array_part_from(cl,
-                                            hr_claimer,
-                                            &_collection_set_regions[offset],
-                                            length-offset,
-                                            worker_id);
+  assert(length > offset, "Must be");
+  _g1h->par_iterate_regions_array(cl,
+                                  hr_claimer,
+                                  &_collection_set_regions[offset],
+                                  length - offset,
+                                  worker_id);
 }
 
 void G1CollectionSet::update_young_region_prediction(HeapRegion* hr,

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -232,7 +232,7 @@ void G1CollectionSet::iterate_part_from(HeapRegionClosure* cl,
                                         size_t offset,
                                         size_t length,
                                         uint worker_id) const {
-  assert(length > offset, "Must be");
+  assert((length > offset) || (length == offset && length == 0), "Must be");
   _g1h->par_iterate_regions_array(cl,
                                   hr_claimer,
                                   &_collection_set_regions[offset],

--- a/src/hotspot/share/gc/g1/g1EvacFailureRegions.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailureRegions.cpp
@@ -49,11 +49,11 @@ void G1EvacFailureRegions::initialize(uint max_regions) {
 void G1EvacFailureRegions::par_iterate(HeapRegionClosure* closure,
                                        HeapRegionClaimer* _hrclaimer,
                                        uint worker_id) {
-  G1CollectedHeap::heap()->par_iterate_regions_array_part_from(closure,
-                                                               _hrclaimer,
-                                                               _evac_failure_regions,
-                                                               Atomic::load(&_evac_failure_regions_cur_length),
-                                                               worker_id);
+  G1CollectedHeap::heap()->par_iterate_regions_array(closure,
+                                                     _hrclaimer,
+                                                     _evac_failure_regions,
+                                                     Atomic::load(&_evac_failure_regions_cur_length),
+                                                     worker_id);
 }
 
 void G1EvacFailureRegions::reset() {

--- a/src/hotspot/share/gc/g1/g1EvacFailureRegions.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailureRegions.cpp
@@ -52,7 +52,6 @@ void G1EvacFailureRegions::par_iterate(HeapRegionClosure* closure,
   G1CollectedHeap::heap()->par_iterate_regions_array_part_from(closure,
                                                                _hrclaimer,
                                                                _evac_failure_regions,
-                                                               0,
                                                                Atomic::load(&_evac_failure_regions_cur_length),
                                                                worker_id);
 }


### PR DESCRIPTION
G1CollectedHeap::par_iterate_regions_array_part_from is moved from G1CollectionSet::iterate_part_from in JDK-8254167.
The parameters and logic of this method could be refined a bit to make it more straight.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273476](https://bugs.openjdk.java.net/browse/JDK-8273476): G1: refine G1CollectedHeap::par_iterate_regions_array_part_from


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 46d5a3ccae541281e2bac2d7256fc6a6a0757b6a


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5414/head:pull/5414` \
`$ git checkout pull/5414`

Update a local copy of the PR: \
`$ git checkout pull/5414` \
`$ git pull https://git.openjdk.java.net/jdk pull/5414/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5414`

View PR using the GUI difftool: \
`$ git pr show -t 5414`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5414.diff">https://git.openjdk.java.net/jdk/pull/5414.diff</a>

</details>
