### PR TITLE
8273497: Building.md should link to testing md file rather than html

### DIFF
--- a/doc/building.md
+++ b/doc/building.md
@@ -818,7 +818,7 @@ configuration, as opposed to the "configure time" configuration.
 #### Test Make Control Variables
 
 These make control variables only make sense when running tests. Please see
-[Testing the JDK](testing.html) for details.
+[Testing the JDK](testing.md) for details.
 
   * `TEST`
   * `TEST_JOBS`


### PR DESCRIPTION
Discovered while working through the building guide.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8273497](https://bugs.openjdk.java.net/browse/JDK-8273497): Building.md should link to testing md file rather than html


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5417/head:pull/5417` \
`$ git checkout pull/5417`

Update a local copy of the PR: \
`$ git checkout pull/5417` \
`$ git pull https://git.openjdk.java.net/jdk pull/5417/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5417`

View PR using the GUI difftool: \
`$ git pr show -t 5417`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5417.diff">https://git.openjdk.java.net/jdk/pull/5417.diff</a>

</details>
