### PR TITLE
8273409: Receiver type narrowed by CCP does not always trigger post-parse call devirtualization

### DIFF
--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1967,7 +1967,9 @@ Node *PhaseCCP::transform_once( Node *n ) {
 
   // TEMPORARY fix to ensure that 2nd GVN pass eliminates NULL checks
   switch( n->Opcode() ) {
-  case Op_FastLock:      // Revisit FastLocks for lock coarsening
+  case Op_CallStaticJava:  // Give post-parse call devirtualization a chance
+  case Op_CallDynamicJava:
+  case Op_FastLock:        // Revisit FastLocks for lock coarsening
   case Op_If:
   case Op_CountedLoopEnd:
   case Op_Region:

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestPostParseCallDevirtualization.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestPostParseCallDevirtualization.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import jdk.test.lib.Asserts;
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8273409
+ * @summary Test that post-parse call devirtualization works as intended.
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.TestPostParseCallDevirtualization
+ */
+public class TestPostParseCallDevirtualization {
+
+    public static void main(String[] args) {
+        TestFramework framework = new TestFramework();
+        Scenario noOSR = new Scenario(0, "-XX:-UseOnStackReplacement");
+        Scenario alwaysIncremental = new Scenario(1, "-XX:-UseOnStackReplacement", "-XX:+AlwaysIncrementalInline");
+        framework.addScenarios(noOSR, alwaysIncremental).start();
+    }
+
+    static interface I {
+        public int method();
+    }
+
+    static final class A implements I {
+        @Override
+        public int method() { return 0; };
+    }
+
+    static final class B implements I {
+        @Override
+        public int method() { return 42; };
+    }
+
+    static final class C implements I {
+        @Override
+        public int method() { return -1; };
+    }
+
+    static final A a = new A();
+    static final B b = new B();
+    static final C c = new C();
+
+    static int callHelper(I recv) {
+        // Receiver profile is polluted
+        return recv.method();
+    }
+
+    @Test
+    @IR(failOn = {IRNode.DYNAMIC_CALL_OF_METHOD, "method"},
+        counts = {IRNode.STATIC_CALL_OF_METHOD, "method", "= 1"})
+    public int testDynamicCallWithLoop(B val) {
+        // Make sure val is non-null below
+        if (val == null) {
+          return 0;
+        }
+        // Loop that triggers loop opts
+        I recv = a;
+        for (int i = 0; i < 3; ++i) {
+            if (i > 1) {
+                recv = val;
+            }
+        }
+        // We only know after loop opts that the receiver type is non-null B.
+        // Post-parse call devirtualization should then convert the
+        // virtual call in the helper method to a static call.
+        return callHelper(recv);
+    }
+
+    @Run(test = "testDynamicCallWithLoop")
+    public void checkTestDynamicCallWithLoop() {
+        // Pollute receiver profile with three different
+        // types to prevent (bimorphic) inlining.
+        callHelper(a);
+        callHelper(b);
+        callHelper(c);
+        Asserts.assertEquals(testDynamicCallWithLoop(b), 42);
+    }
+
+    @Test
+    @IR(failOn = {IRNode.DYNAMIC_CALL_OF_METHOD, "method"},
+        counts = {IRNode.STATIC_CALL_OF_METHOD, "method", "= 1"})
+    public int testDynamicCallWithCCP(B val) {
+        // Make sure val is non-null below
+        if (val == null) {
+          return 0;
+        }
+        // Loop that triggers CCP
+        I recv = a;
+        for (int i = 0; i < 100; i++) {
+            if ((i % 2) == 0) {
+                recv = val;
+            }
+        }
+        // We only know after CCP that the receiver type is non-null B.
+        // Post-parse call devirtualization should then convert the
+        // virtual call in the helper method to a static call.
+        return callHelper(recv);
+    }
+
+    @Run(test = "testDynamicCallWithCCP")
+    public void checkTestDynamicCallWithCCP() {
+        // Pollute receiver profile with three different
+        // types to prevent (bimorphic) inlining.
+        callHelper(a);
+        callHelper(b);
+        callHelper(c);
+        Asserts.assertEquals(testDynamicCallWithCCP(b), 42);
+    }
+
+    static final MethodHandle mh1;
+    static final MethodHandle mh2;
+
+    static {
+        try {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            mh1 = lookup.findStatic(TestPostParseCallDevirtualization.class, "method1", MethodType.methodType(int.class));
+            mh2 = lookup.findStatic(TestPostParseCallDevirtualization.class, "method2", MethodType.methodType(int.class));
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            e.printStackTrace();
+            throw new RuntimeException("Method handle lookup failed");
+        }
+    }
+
+    static int method1() { return 0; }
+    static int method2() { return 42; }
+
+    @Test
+    @IR(failOn = {IRNode.STATIC_CALL_OF_METHOD, "invokeBasic"},
+        counts = {IRNode.STATIC_CALL_OF_METHOD, "invokeStatic", "= 1"})
+    public int testMethodHandleCallWithLoop() throws Throwable {
+        MethodHandle mh = mh1;
+        for (int i = 0; i < 3; ++i) {
+            if (i > 1) {
+                mh = mh2;
+            }
+        }
+        // We only know after loop opts that the receiver is mh2.
+        // Post-parse call devirtualization should then convert the
+        // virtual call to a static call.
+        return (int)mh.invokeExact();
+    }
+
+    @Run(test = "testMethodHandleCallWithLoop")
+    public void checkTestMethodHandleCallWithLoop() throws Throwable {
+        Asserts.assertEquals(testMethodHandleCallWithLoop(), 42);
+    }
+
+    @Test
+    @IR(failOn = {IRNode.STATIC_CALL_OF_METHOD, "invokeBasic"},
+        counts = {IRNode.STATIC_CALL_OF_METHOD, "invokeStatic", "= 1"})
+    public int testMethodHandleCallWithCCP() throws Throwable {
+        MethodHandle mh = mh1;
+        int limit = 0;
+        for (int i = 0; i < 100; i++) {
+            if ((i % 2) == 0) {
+                limit = 1;
+            }
+        }
+        for (int i = 0; i < limit; ++i) {
+            mh = mh2;
+        }
+        // We only know after CCP that the receiver is mh2.
+        // Post-parse call devirtualization should then convert the
+        // virtual call to a static call.
+        return (int)mh.invokeExact();
+    }
+
+    @Run(test = "testMethodHandleCallWithCCP")
+    public void checkTestMethodHandleCallWithCCP() throws Throwable {
+        Asserts.assertEquals(testMethodHandleCallWithCCP(), 42);
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestPostParseCallDevirtualization.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestPostParseCallDevirtualization.java
@@ -41,7 +41,7 @@ public class TestPostParseCallDevirtualization {
     public static void main(String[] args) {
         TestFramework framework = new TestFramework();
         Scenario noOSR = new Scenario(0, "-XX:-UseOnStackReplacement");
-        Scenario alwaysIncremental = new Scenario(1, "-XX:-UseOnStackReplacement", "-XX:+AlwaysIncrementalInline");
+        Scenario alwaysIncremental = new Scenario(1, "-XX:-UseOnStackReplacement", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:+AlwaysIncrementalInline");
         framework.addScenarios(noOSR, alwaysIncremental).start();
     }
 

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -115,6 +115,8 @@ public class IRNode {
     public static final String COUNTEDLOOP_MAIN = START + "CountedLoop\\b" + MID + "main" + END;
 
     public static final String CALL = START + "CallStaticJava" + MID + END;
+    public static final String DYNAMIC_CALL_OF_METHOD = COMPOSITE_PREFIX + START + "CallDynamicJava" + MID + IS_REPLACED + END;
+    public static final String STATIC_CALL_OF_METHOD = COMPOSITE_PREFIX + START + "CallStaticJava" + MID + IS_REPLACED + END;
     public static final String TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*reason" + END;
     public static final String PREDICATE_TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*predicate" + END;
     public static final String UNSTABLE_IF_TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*unstable_if" + END;


### PR DESCRIPTION
While working on [JDK-8273323](https://bugs.openjdk.java.net/browse/JDK-8273323), I noticed that even if CCP is able to narrow the receiver type of a virtual call to an exact type, post-parse call devirtualization is not always triggered. The problem is that CCP only adds nodes to the IGVN worklist if their types have been improved:
https://github.com/openjdk/jdk/blob/4023646ed1bcb821b1d18f7e5104f04995e8171d/src/hotspot/share/opto/phaseX.cpp#L1961-L1965

And in turn, IGVN only adds user nodes to the worklist if the type of the parent node could be further improved. As a result, a `CallNode` is not always added to the worklist if the type of its receiver node has been improved. Often, we are lucky and macro expansion or another optimization phase after CCP adds the `CallNode` to the worklist. However, as `testDynamicCallWithCCP` shows, that's not always the case.

The fix is to explicitly add `CallStaticJavaNode` and `CallDynamicJava` to the worklist after CCP to give call devirtualization a chance to run:
https://github.com/openjdk/jdk/blob/4023646ed1bcb821b1d18f7e5104f04995e8171d/src/hotspot/share/opto/callnode.cpp#L1054-L1057
https://github.com/openjdk/jdk/blob/4023646ed1bcb821b1d18f7e5104f04995e8171d/src/hotspot/share/opto/callnode.cpp#L1137-L1140

I also considered moving the optimization from `Ideal` to `Value` (which in contrast to `Ideal` is already executed **during** CCP) but we can't trust receiver types during CCP (because CCP goes from optimistic types to pessimistic ones). Also, the current implementation relies on setting the `_generator` field which is not possible from `Value` which is declared `const`:
https://github.com/openjdk/jdk/blob/4023646ed1bcb821b1d18f7e5104f04995e8171d/src/hotspot/share/opto/callnode.cpp#L1169-L1172

All the newly added tests fail IR verification if post-parse call devirtualization is disabled (`-XX:-IncrementalInlineVirtual -XX:-IncrementalInlineMH`). Without the fix, `testDynamicCallWithCCP` always fails.

I filed [JDK-8273496](https://bugs.openjdk.java.net/browse/JDK-8273496) to improve how CCP handles this.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273409](https://bugs.openjdk.java.net/browse/JDK-8273409): Receiver type narrowed by CCP does not always trigger post-parse call devirtualization


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5418/head:pull/5418` \
`$ git checkout pull/5418`

Update a local copy of the PR: \
`$ git checkout pull/5418` \
`$ git pull https://git.openjdk.java.net/jdk pull/5418/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5418`

View PR using the GUI difftool: \
`$ git pr show -t 5418`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5418.diff">https://git.openjdk.java.net/jdk/pull/5418.diff</a>

</details>
