### PR TITLE
8273109: runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest times out

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java
@@ -33,7 +33,7 @@
  *          jdk.httpserver
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. DynamicLoaderConstraintsTest
+ * @run main/othervm/timeout=180 -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. DynamicLoaderConstraintsTest
  */
 
 /**
@@ -49,7 +49,7 @@
  *          jdk.httpserver
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. DynamicLoaderConstraintsTest custom
+ * @run main/othervm/timeout=180 -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. DynamicLoaderConstraintsTest custom
  */
 
 import com.sun.net.httpserver.HttpExchange;


### PR DESCRIPTION
A trivial fix to increase the timeouts for the two sub-tests in
runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273109](https://bugs.openjdk.java.net/browse/JDK-8273109): runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest times out


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5422/head:pull/5422` \
`$ git checkout pull/5422`

Update a local copy of the PR: \
`$ git checkout pull/5422` \
`$ git pull https://git.openjdk.java.net/jdk pull/5422/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5422`

View PR using the GUI difftool: \
`$ git pr show -t 5422`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5422.diff">https://git.openjdk.java.net/jdk/pull/5422.diff</a>

</details>
