### PR TITLE
8271834: TestStringDeduplicationAgeThreshold intermittent failures on Shenandoah

### DIFF
--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
@@ -27,8 +27,12 @@ package gc.stringdedup;
  * Common code for string deduplication tests
  */
 
+import com.sun.management.GarbageCollectionNotificationInfo;
 import java.lang.reflect.*;
+import java.lang.management.*;
 import java.util.*;
+import javax.management.*;
+import javax.management.openmbean.*;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import sun.misc.*;
@@ -89,21 +93,58 @@ class TestStringDeduplicationTools {
         }
     }
 
+    private static volatile int gcCount;
+    private static NotificationListener listener = new NotificationListener() {
+        @Override
+        public void handleNotification(Notification n, Object o) {
+            if (n.getType().equals(GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION)) {
+                GarbageCollectionNotificationInfo info = GarbageCollectionNotificationInfo.from((CompositeData) n.getUserData());
+                // Shenandoah GC also report GC pauses, skip them
+                if (info.getGcName().startsWith("Shenandoah")) {
+                    if ("end of GC cycle".equals(info.getGcAction())) {
+                        gcCount ++;
+                    }
+                } else {
+                    gcCount ++;
+                }
+            }
+        }
+    };
+
+    private static void registerGCListener() {
+        for (GarbageCollectorMXBean bean : ManagementFactory.getGarbageCollectorMXBeans()) {
+            ((NotificationEmitter)bean).addNotificationListener(listener, null, null);
+        }
+    }
+
+    private static void unregisterGCListener() {
+        for (GarbageCollectorMXBean bean : ManagementFactory.getGarbageCollectorMXBeans()) {
+            try {
+                ((NotificationEmitter) bean).removeNotificationListener(listener, null, null);
+            } catch (Exception e) {
+            }
+        }
+    }
+
     private static void doYoungGc(int numberOfTimes) {
-        // Provoke at least numberOfTimes young GCs
         final int objectSize = 128;
-        final int maxObjectInYoung = (Xmn * MB) / objectSize;
         List<List<String>> newStrings = new ArrayList<List<String>>();
-        for (int i = 0; i < numberOfTimes; i++) {
+
+        // Provoke at least numberOfTimes young GCs
+        gcCount = 0;
+        registerGCListener();
+        while (gcCount < numberOfTimes) {
+            int currentCount = gcCount;
             // Create some more strings for every collection, to ensure
             // there will be deduplication work that will be reported.
             newStrings.add(createStrings(SmallNumberOfStrings, SmallNumberOfStrings));
-            System.out.println("Begin: Young GC " + (i + 1) + "/" + numberOfTimes);
-            for (int j = 0; j < maxObjectInYoung + 1; j++) {
+            System.out.println("Begin: Young GC " + (currentCount + 1) + "/" + numberOfTimes);
+            while (currentCount == gcCount) {
                 dummy = new byte[objectSize];
             }
-            System.out.println("End: Young GC " + (i + 1) + "/" + numberOfTimes);
+            System.out.println("End: Young GC " + (currentCount + 1) + "/" + numberOfTimes);
         }
+        unregisterGCListener();
     }
 
     private static void forceDeduplication(int ageThreshold, String gcType) {

--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
@@ -99,13 +99,13 @@ class TestStringDeduplicationTools {
         public void handleNotification(Notification n, Object o) {
             if (n.getType().equals(GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION)) {
                 GarbageCollectionNotificationInfo info = GarbageCollectionNotificationInfo.from((CompositeData) n.getUserData());
-                // Shenandoah GC also report GC pauses, skip them
+                // Shenandoah GC also reports GC pauses, skip them
                 if (info.getGcName().startsWith("Shenandoah")) {
                     if ("end of GC cycle".equals(info.getGcAction())) {
-                        gcCount ++;
+                        gcCount++;
                     }
                 } else {
-                    gcCount ++;
+                    gcCount++;
                 }
             }
         }

--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
@@ -99,8 +99,8 @@ class TestStringDeduplicationTools {
         public void handleNotification(Notification n, Object o) {
             if (n.getType().equals(GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION)) {
                 GarbageCollectionNotificationInfo info = GarbageCollectionNotificationInfo.from((CompositeData) n.getUserData());
-                // Shenandoah GC also reports GC pauses, skip them
-                if (info.getGcName().startsWith("Shenandoah")) {
+                // Shenandoah and Z GC also report GC pauses, skip them
+                if (info.getGcName().startsWith("Shenandoah") || info.getGcName().startsWith("ZGC")) {
                     if ("end of GC cycle".equals(info.getGcAction())) {
                         gcCount++;
                     }


### PR DESCRIPTION
To trigger young GC, the test fills heap with -Xmn amount of garbage. However, -Xmn does not apply to non-generational GC, such as Shenandoah, and -Xmn amount of garbage, sometimes, it not enough to trigger GC, therefore, there is no guarantee that strings can reach deduplication age threshold.

I purpose to use MXBean to get exact gc count to ensure expected gc cycles actually performed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271834](https://bugs.openjdk.java.net/browse/JDK-8271834): TestStringDeduplicationAgeThreshold intermittent failures on Shenandoah


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5428/head:pull/5428` \
`$ git checkout pull/5428`

Update a local copy of the PR: \
`$ git checkout pull/5428` \
`$ git pull https://git.openjdk.java.net/jdk pull/5428/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5428`

View PR using the GUI difftool: \
`$ git pr show -t 5428`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5428.diff">https://git.openjdk.java.net/jdk/pull/5428.diff</a>

</details>
