### PR TITLE
8273516: ProblemList compiler/c2/Test7179138_1.java in -Xcomp mode on win-X64

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -36,3 +36,5 @@ vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java 8265295 lin
 vmTestbase/nsk/jvmti/scenarios/sampling/SP07/sp07t002/TestDescription.java 8245680 windows-x64
 
 vmTestbase/vm/mlvm/anonloader/stress/oome/heap/Test.java 8273095 generic-all
+
+compiler/c2/Test7179138_1.java 8273498 windows-x64


### PR DESCRIPTION
A trivial fix to ProblemList compiler/c2/Test7179138_1.java in -Xcomp mode on win-X64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273516](https://bugs.openjdk.java.net/browse/JDK-8273516): ProblemList compiler/c2/Test7179138_1.java in -Xcomp mode on win-X64


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5429/head:pull/5429` \
`$ git checkout pull/5429`

Update a local copy of the PR: \
`$ git checkout pull/5429` \
`$ git pull https://git.openjdk.java.net/jdk pull/5429/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5429`

View PR using the GUI difftool: \
`$ git pr show -t 5429`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5429.diff">https://git.openjdk.java.net/jdk/pull/5429.diff</a>

</details>
