### PR TITLE
8273514: java/util/DoubleStreamSums/CompensatedSums.java failure

### DIFF
--- a/test/jdk/java/util/DoubleStreamSums/CompensatedSums.java
+++ b/test/jdk/java/util/DoubleStreamSums/CompensatedSums.java
@@ -32,10 +32,7 @@ import java.util.Random;
 import java.util.function.BiConsumer;
 import java.util.function.ObjDoubleConsumer;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
-
-import static org.testng.Assert.assertTrue;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -68,21 +65,21 @@ public class CompensatedSums {
             // Older less accurate implementations included here as the baseline.
 
             // squared error of naive sum by reduction - should be large
-            naive += Math.pow(DoubleStream.of(rand).reduce((x, y) -> x+y).getAsDouble() - sum[0], 2);
+            naive += square(DoubleStream.of(rand).reduce((x, y) -> x+y).getAsDouble() - sum[0]);
 
             // squared error of sequential sum - should be 0
-            jdkSequentialStreamError += Math.pow(DoubleStream.of(rand).sum() - sum[0], 2);
+            jdkSequentialStreamError += square(DoubleStream.of(rand).sum() - sum[0]);
 
-            goodSequentialStreamError += Math.pow(computeFinalSum(DoubleStream.of(rand).collect(doubleSupplier,objDoubleConsumer,goodCollectorConsumer)) - sum[0], 2);
+            goodSequentialStreamError += square(computeFinalSum(DoubleStream.of(rand).collect(doubleSupplier,objDoubleConsumer,goodCollectorConsumer)) - sum[0]);
 
             // squared error of parallel sum from the JDK
-            jdkParallelStreamError += Math.pow(DoubleStream.of(rand).parallel().sum() - sum[0], 2);
+            jdkParallelStreamError += square(DoubleStream.of(rand).parallel().sum() - sum[0]);
 
             // squared error of parallel sum
-            goodParallelStreamError += Math.pow(computeFinalSum(DoubleStream.of(rand).parallel().collect(doubleSupplier,objDoubleConsumer,goodCollectorConsumer)) - sum[0], 2);
+            goodParallelStreamError += square(computeFinalSum(DoubleStream.of(rand).parallel().collect(doubleSupplier,objDoubleConsumer,goodCollectorConsumer)) - sum[0]);
 
             // the bad parallel stream
-            badParallelStreamError += Math.pow(computeFinalSum(DoubleStream.of(rand).parallel().collect(doubleSupplier,objDoubleConsumer,badCollectorConsumer)) - sum[0], 2);
+            badParallelStreamError += square(computeFinalSum(DoubleStream.of(rand).parallel().collect(doubleSupplier,objDoubleConsumer,badCollectorConsumer)) - sum[0]);
 
 
         }
@@ -94,6 +91,10 @@ public class CompensatedSums {
         Assert.assertTrue(naive > jdkSequentialStreamError);
         Assert.assertTrue(naive > jdkParallelStreamError);
 
+    }
+
+    private static double square(double arg) {
+        return arg * arg;
     }
 
     // from OpenJDK8 Collectors, unmodified

--- a/test/jdk/java/util/DoubleStreamSums/CompensatedSums.java
+++ b/test/jdk/java/util/DoubleStreamSums/CompensatedSums.java
@@ -88,8 +88,9 @@ public class CompensatedSums {
         }
 
         Assert.assertTrue(jdkParallelStreamError <= goodParallelStreamError);
-        Assert.assertTrue(badParallelStreamError > goodParallelStreamError);
+        Assert.assertTrue(badParallelStreamError > jdkParallelStreamError);
 
+        Assert.assertTrue(goodSequentialStreamError >= jdkSequentialStreamError);
         Assert.assertTrue(naive > jdkSequentialStreamError);
         Assert.assertTrue(naive > jdkParallelStreamError);
 

--- a/test/jdk/java/util/DoubleStreamSums/CompensatedSums.java
+++ b/test/jdk/java/util/DoubleStreamSums/CompensatedSums.java
@@ -87,8 +87,6 @@ public class CompensatedSums {
 
         }
 
-        Assert.assertEquals(goodSequentialStreamError, jdkSequentialStreamError);
-
         Assert.assertTrue(jdkParallelStreamError <= goodParallelStreamError);
         Assert.assertTrue(badParallelStreamError > goodParallelStreamError);
 

--- a/test/jdk/java/util/DoubleStreamSums/CompensatedSums.java
+++ b/test/jdk/java/util/DoubleStreamSums/CompensatedSums.java
@@ -87,7 +87,6 @@ public class CompensatedSums {
 
         }
 
-        Assert.assertEquals(goodSequentialStreamError, 0.0);
         Assert.assertEquals(goodSequentialStreamError, jdkSequentialStreamError);
 
         Assert.assertTrue(jdkParallelStreamError <= goodParallelStreamError);


### PR DESCRIPTION
Relaxing some assertion bounds to allow for small error values that still show improvement over previous summation method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273514](https://bugs.openjdk.java.net/browse/JDK-8273514): java/util/DoubleStreamSums/CompensatedSums.java failure


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to 8f77f3d374df8d36278c613269a1439c2392b807
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to 8f77f3d374df8d36278c613269a1439c2392b807


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5430/head:pull/5430` \
`$ git checkout pull/5430`

Update a local copy of the PR: \
`$ git checkout pull/5430` \
`$ git pull https://git.openjdk.java.net/jdk pull/5430/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5430`

View PR using the GUI difftool: \
`$ git pr show -t 5430`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5430.diff">https://git.openjdk.java.net/jdk/pull/5430.diff</a>

</details>
