### PR TITLE
8273498: compiler/c2/Test7179138_1.java timed out

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -36,5 +36,3 @@ vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java 8265295 lin
 vmTestbase/nsk/jvmti/scenarios/sampling/SP07/sp07t002/TestDescription.java 8245680 windows-x64
 
 vmTestbase/vm/mlvm/anonloader/stress/oome/heap/Test.java 8273095 generic-all
-
-compiler/c2/Test7179138_1.java 8273498 windows-x64

--- a/test/hotspot/jtreg/compiler/c2/Test7179138_1.java
+++ b/test/hotspot/jtreg/compiler/c2/Test7179138_1.java
@@ -29,7 +29,7 @@
  * @run main/othervm -Xbatch -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation
  *      compiler.c2.Test7179138_1
  * @run main/othervm -Xbatch -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation
- *      -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:RepeatCompilation=100 compiler.c2.Test7179138_1
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN compiler.c2.Test7179138_1
  *
  * @author Skip Balk
  */


### PR DESCRIPTION
The test times out with `-Xcomp` because it sets `-XX:RepeatCompilation=100` to give `-XX:+StressIGVN` a chance to reproduce the issue. I propose to simply remove the `RepeatCompilation`flag, given that tests are usually executed many times. That's also consistent with how we do it with other tests that use stress flags (for example, `TestDeadLoopSplitIfLoop.java`).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273498](https://bugs.openjdk.java.net/browse/JDK-8273498): compiler/c2/Test7179138_1.java timed out


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5431/head:pull/5431` \
`$ git checkout pull/5431`

Update a local copy of the PR: \
`$ git checkout pull/5431` \
`$ git pull https://git.openjdk.java.net/jdk pull/5431/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5431`

View PR using the GUI difftool: \
`$ git pr show -t 5431`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5431.diff">https://git.openjdk.java.net/jdk/pull/5431.diff</a>

</details>
