### PR TITLE
8274898: Cleanup usages of StringBuffer in jdk tools modules

### DIFF
--- a/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
+++ b/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
@@ -813,9 +813,9 @@ public class Main {
                     }
 
                     // Only used when -verbose provided
-                    StringBuffer sb = null;
+                    StringBuilder sb = null;
                     if (verbose != null) {
-                        sb = new StringBuffer();
+                        sb = new StringBuilder();
                         boolean inManifest =
                             ((man.getAttributes(name) != null) ||
                              (man.getAttributes("./"+name) != null) ||

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Log.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Log.java
@@ -108,7 +108,7 @@ public class Log {
         public void verbose(List<String> strings,
                 List<String> output, int returnCode, long pid) {
             if (verbose) {
-                StringBuffer sb = new StringBuffer();
+                StringBuilder sb = new StringBuilder();
                 sb.append("Command [PID: ");
                 sb.append(pid);
                 sb.append("]:\n   ");
@@ -116,13 +116,13 @@ public class Log {
                 for (String s : strings) {
                     sb.append(" " + s);
                 }
-                verbose(new String(sb));
+                verbose(sb.toString());
                 if (output != null && !output.isEmpty()) {
-                    sb = new StringBuffer("Output:");
+                    sb = new StringBuilder("Output:");
                     for (String s : output) {
                         sb.append("\n    " + s);
                     }
-                    verbose(new String(sb));
+                    verbose(sb.toString());
                 }
                 verbose("Returned: " + returnCode + "\n");
             }

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/Feedback.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/Feedback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -372,7 +372,7 @@ class Feedback {
                 return "";
             }
             Matcher m = FIELD_PATTERN.matcher(format);
-            StringBuffer sb = new StringBuffer(format.length());
+            StringBuilder sb = new StringBuilder(format.length());
             while (m.find()) {
                 String fieldName = m.group(1);
                 String sub = format(fieldName, selector);


### PR DESCRIPTION
StringBuffer is a legacy synchronized class. StringBuilder is a direct replacement to StringBuffer which generally have better performance

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274898](https://bugs.openjdk.java.net/browse/JDK-8274898): Cleanup usages of StringBuffer in jdk tools modules


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * @stsypanov (no known github.com user name / role)
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5433/head:pull/5433` \
`$ git checkout pull/5433`

Update a local copy of the PR: \
`$ git checkout pull/5433` \
`$ git pull https://git.openjdk.java.net/jdk pull/5433/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5433`

View PR using the GUI difftool: \
`$ git pr show -t 5433`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5433.diff">https://git.openjdk.java.net/jdk/pull/5433.diff</a>

</details>
