### PR TITLE
JDK-8264517: C2: make MachCallNode::return_value_is_used() only available for x86

### DIFF
--- a/src/hotspot/share/opto/machnode.cpp
+++ b/src/hotspot/share/opto/machnode.cpp
@@ -681,6 +681,7 @@ void MachCallNode::dump_spec(outputStream *st) const {
 }
 #endif
 
+#ifndef _LP64
 bool MachCallNode::return_value_is_used() const {
   if (tf()->range()->cnt() == TypeFunc::Parms) {
     // void return
@@ -697,6 +698,7 @@ bool MachCallNode::return_value_is_used() const {
   }
   return false;
 }
+#endif
 
 // Similar to cousin class CallNode::returns_pointer
 // Because this is used in deoptimization, we want the type info, not the data

--- a/src/hotspot/share/opto/machnode.hpp
+++ b/src/hotspot/share/opto/machnode.hpp
@@ -914,7 +914,9 @@ public:
   virtual int ret_addr_offset() { return 0; }
 
   bool returns_long() const { return tf()->return_type() == T_LONG; }
+#ifndef _LP64
   bool return_value_is_used() const;
+#endif
 
   // Similar to cousin class CallNode::returns_pointer
   bool returns_pointer() const;

--- a/src/hotspot/share/opto/machnode.hpp
+++ b/src/hotspot/share/opto/machnode.hpp
@@ -913,10 +913,7 @@ public:
   virtual const RegMask &in_RegMask(uint) const;
   virtual int ret_addr_offset() { return 0; }
 
-  bool returns_long() const { return tf()->return_type() == T_LONG; }
-#ifndef _LP64
-  bool return_value_is_used() const;
-#endif
+  NOT_LP64(bool return_value_is_used() const;)
 
   // Similar to cousin class CallNode::returns_pointer
   bool returns_pointer() const;


### PR DESCRIPTION
Added #ifndef _LP64 guard to the MachCallNode::return_value_is_used() method in src/hotspot/share/opto/machnode.* because it is only used for 32-bit x86.

Thanks, 
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264517](https://bugs.openjdk.java.net/browse/JDK-8264517): C2: make MachCallNode::return_value_is_used() only available for x86


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5435/head:pull/5435` \
`$ git checkout pull/5435`

Update a local copy of the PR: \
`$ git checkout pull/5435` \
`$ git pull https://git.openjdk.java.net/jdk pull/5435/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5435`

View PR using the GUI difftool: \
`$ git pr show -t 5435`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5435.diff">https://git.openjdk.java.net/jdk/pull/5435.diff</a>

</details>
