### PR TITLE
8273135: java/awt/color/ICC_ColorSpace/MTTransformReplacedProfile.java crashes in liblcms.dylib with NULLSeek+0x7

### DIFF
--- a/src/java.desktop/share/native/liblcms/cmsio0.c
+++ b/src/java.desktop/share/native/liblcms/cmsio0.c
@@ -1532,7 +1532,7 @@ cmsBool IsTypeSupported(cmsTagDescriptor* TagDescriptor, cmsTagTypeSignature Typ
 void* CMSEXPORT cmsReadTag(cmsHPROFILE hProfile, cmsTagSignature sig)
 {
     _cmsICCPROFILE* Icc = (_cmsICCPROFILE*) hProfile;
-    cmsIOHANDLER* io = Icc ->IOhandler;
+    cmsIOHANDLER* io;
     cmsTagTypeHandler* TypeHandler;
     cmsTagTypeHandler LocalTypeHandler;
     cmsTagDescriptor*  TagDescriptor;
@@ -1573,6 +1573,7 @@ void* CMSEXPORT cmsReadTag(cmsHPROFILE hProfile, cmsTagSignature sig)
 
     if (TagSize < 8) goto Error;
 
+    io = Icc ->IOhandler;
     // Seek to its location
     if (!io -> Seek(io, Offset))
         goto Error;

--- a/test/jdk/java/awt/color/ICC_ColorSpace/MTTransformReplacedProfile.java
+++ b/test/jdk/java/awt/color/ICC_ColorSpace/MTTransformReplacedProfile.java
@@ -34,7 +34,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * @test
- * @bug 8271718
+ * @bug 8271718 8273135
  * @summary Verifies MT safety of color transformation while profile is changed
  */
 public final class MTTransformReplacedProfile {


### PR DESCRIPTION
This bug was found by the test added by the https://github.com/openjdk/jdk/pull/5042. The crash is rarely reproduced, and in the default testrun, I was not able to crash it even once. But I have found that if the 1000 tests are executed in parallel a few crashes(less than 10) usually happen.

After the code inspection, I have found and report the problem to the [LCMS upstream](https://bugs.openjdk.java.net/browse/JDK-8273135?focusedCommentId=14445750&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14445750) 

In this PR, I would like to cherry-pick the fix from the upstream and apply it to the JDK. So we prevent the crash and will have an opportunity to find some other issues if any (two crashes were found by this test already).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273135](https://bugs.openjdk.java.net/browse/JDK-8273135): java/awt/color/ICC_ColorSpace/MTTransformReplacedProfile.java crashes in liblcms.dylib with NULLSeek+0x7


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5436/head:pull/5436` \
`$ git checkout pull/5436`

Update a local copy of the PR: \
`$ git checkout pull/5436` \
`$ git pull https://git.openjdk.java.net/jdk pull/5436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5436`

View PR using the GUI difftool: \
`$ git pr show -t 5436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5436.diff">https://git.openjdk.java.net/jdk/pull/5436.diff</a>

</details>
