### PR TITLE
JDK-8273526: Extend the OSContainer API pids controller with pids.current

### DIFF
--- a/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
@@ -245,6 +245,7 @@ class CgroupSubsystem: public CHeapObj<mtInternal> {
     virtual int cpu_period() = 0;
     virtual int cpu_shares() = 0;
     virtual jlong pids_max() = 0;
+    virtual jlong pids_current() = 0;
     virtual jlong memory_usage_in_bytes() = 0;
     virtual jlong memory_and_swap_limit_in_bytes() = 0;
     virtual jlong memory_soft_limit_in_bytes() = 0;

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
@@ -252,6 +252,15 @@ char* CgroupV1Subsystem::pids_max_val() {
   return os::strdup(pidsmax);
 }
 
+char* CgroupV1Subsystem::pids_current_val() {
+  GET_CONTAINER_INFO_CPTR(cptr, _pids, "/pids.current",
+                     "Current number of tasks is: %s", "%s %*d", pids_current, 1024);
+  if (pids_current == NULL) {
+    return NULL;
+  }
+  return os::strdup(pids_current);
+}
+
 /* pids_max
  *
  * Return the maximum number of tasks available to the process
@@ -265,4 +274,18 @@ jlong CgroupV1Subsystem::pids_max() {
   if (_pids == NULL) return OSCONTAINER_ERROR;
   char * pidsmax_str = pids_max_val();
   return limit_from_str(pidsmax_str);
+}
+
+/* pids_current
+ *
+ * The number of tasks currently in the cgroup (and its descendants) of the process
+ *
+ * return:
+ *    current number of tasks
+ *    OSCONTAINER_ERROR for not supported
+ */
+jlong CgroupV1Subsystem::pids_current() {
+  if (_pids == NULL) return OSCONTAINER_ERROR;
+  char * pidscurrent_str = pids_current_val();
+  return limit_from_str(pidscurrent_str);
 }

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
@@ -252,15 +252,6 @@ char* CgroupV1Subsystem::pids_max_val() {
   return os::strdup(pidsmax);
 }
 
-char* CgroupV1Subsystem::pids_current_val() {
-  GET_CONTAINER_INFO_CPTR(cptr, _pids, "/pids.current",
-                     "Current number of tasks is: %s", "%s %*d", pids_current, 1024);
-  if (pids_current == NULL) {
-    return NULL;
-  }
-  return os::strdup(pids_current);
-}
-
 /* pids_max
  *
  * Return the maximum number of tasks available to the process

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
@@ -286,6 +286,7 @@ jlong CgroupV1Subsystem::pids_max() {
  */
 jlong CgroupV1Subsystem::pids_current() {
   if (_pids == NULL) return OSCONTAINER_ERROR;
-  char * pidscurrent_str = pids_current_val();
-  return limit_from_str(pidscurrent_str);
+  GET_CONTAINER_INFO(jlong, _pids, "/pids.current",
+                     "Current number of tasks is: " JLONG_FORMAT, JLONG_FORMAT, pids_current);
+  return pids_current;
 }

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
@@ -107,7 +107,6 @@ class CgroupV1Subsystem: public CgroupSubsystem {
     CgroupV1Controller* _pids = NULL;
 
     char * pids_max_val();
-    char * pids_current_val();
 
   public:
     CgroupV1Subsystem(CgroupV1Controller* cpuset,

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
@@ -88,6 +88,7 @@ class CgroupV1Subsystem: public CgroupSubsystem {
     int cpu_shares();
 
     jlong pids_max();
+    jlong pids_current();
 
     const char * container_type() {
       return "cgroupv1";
@@ -106,6 +107,7 @@ class CgroupV1Subsystem: public CgroupSubsystem {
     CgroupV1Controller* _pids = NULL;
 
     char * pids_max_val();
+    char * pids_current_val();
 
   public:
     CgroupV1Subsystem(CgroupV1Controller* cpuset,

--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
@@ -235,6 +235,16 @@ char* CgroupV2Subsystem::pids_max_val() {
   return os::strdup(pidsmax);
 }
 
+char* CgroupV2Subsystem::pids_current_val() {
+  GET_CONTAINER_INFO_CPTR(cptr, _unified, "/pids.current",
+                     "Current number of tasks is: %s", "%s %*d", pids_current, 1024);
+  if (pids_current == NULL) {
+    return NULL;
+  }
+  return os::strdup(pids_current);
+}
+
+
 /* pids_max
  *
  * Return the maximum number of tasks available to the process
@@ -249,3 +259,15 @@ jlong CgroupV2Subsystem::pids_max() {
   return limit_from_str(pidsmax_str);
 }
 
+/* pids_current
+ *
+ * The number of tasks currently in the cgroup (and its descendants) of the process
+ *
+ * return:
+ *    current number of tasks
+ *    OSCONTAINER_ERROR for not supported
+ */
+jlong CgroupV2Subsystem::pids_current() {
+  char * pidscurrent_str = pids_current_val();
+  return limit_from_str(pidscurrent_str);
+}

--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
@@ -235,16 +235,6 @@ char* CgroupV2Subsystem::pids_max_val() {
   return os::strdup(pidsmax);
 }
 
-char* CgroupV2Subsystem::pids_current_val() {
-  GET_CONTAINER_INFO_CPTR(cptr, _unified, "/pids.current",
-                     "Current number of tasks is: %s", "%s %*d", pids_current, 1024);
-  if (pids_current == NULL) {
-    return NULL;
-  }
-  return os::strdup(pids_current);
-}
-
-
 /* pids_max
  *
  * Return the maximum number of tasks available to the process
@@ -268,6 +258,7 @@ jlong CgroupV2Subsystem::pids_max() {
  *    OSCONTAINER_ERROR for not supported
  */
 jlong CgroupV2Subsystem::pids_current() {
-  char * pidscurrent_str = pids_current_val();
-  return limit_from_str(pidscurrent_str);
+  GET_CONTAINER_INFO(jlong, _unified, "/pids.current",
+                     "Current number of tasks is: " JLONG_FORMAT, JLONG_FORMAT, pids_current);
+  return pids_current;
 }

--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.hpp
@@ -61,6 +61,7 @@ class CgroupV2Subsystem: public CgroupSubsystem {
     char *mem_soft_limit_val();
     char *cpu_quota_val();
     char *pids_max_val();
+    char *pids_current_val();
 
   public:
     CgroupV2Subsystem(CgroupController * unified) {
@@ -80,6 +81,7 @@ class CgroupV2Subsystem: public CgroupSubsystem {
     char * cpu_cpuset_cpus();
     char * cpu_cpuset_memory_nodes();
     jlong pids_max();
+    jlong pids_current();
 
     const char * container_type() {
       return "cgroupv2";

--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.hpp
@@ -61,7 +61,6 @@ class CgroupV2Subsystem: public CgroupSubsystem {
     char *mem_soft_limit_val();
     char *cpu_quota_val();
     char *pids_max_val();
-    char *pids_current_val();
 
   public:
     CgroupV2Subsystem(CgroupController * unified) {

--- a/src/hotspot/os/linux/osContainer_linux.cpp
+++ b/src/hotspot/os/linux/osContainer_linux.cpp
@@ -134,3 +134,8 @@ jlong OSContainer::pids_max() {
   assert(cgroup_subsystem != NULL, "cgroup subsystem not available");
   return cgroup_subsystem->pids_max();
 }
+
+jlong OSContainer::pids_current() {
+  assert(cgroup_subsystem != NULL, "cgroup subsystem not available");
+  return cgroup_subsystem->pids_current();
+}

--- a/src/hotspot/os/linux/osContainer_linux.hpp
+++ b/src/hotspot/os/linux/osContainer_linux.hpp
@@ -63,6 +63,7 @@ class OSContainer: AllStatic {
   static int cpu_shares();
 
   static jlong pids_max();
+  static jlong pids_current();
 };
 
 inline bool OSContainer::is_containerized() {

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2327,6 +2327,16 @@ bool os::Linux::print_container_info(outputStream* st) {
     st->print_cr("%s", j == OSCONTAINER_ERROR ? "not supported" : "unlimited");
   }
 
+  j = OSContainer::OSContainer::pids_current();
+  st->print("current number of tasks: ");
+  if (j > 0) {
+    st->print_cr(JLONG_FORMAT, j);
+  } else {
+    if (j == OSCONTAINER_ERROR) {
+      st->print_cr("not supported");
+    }
+  }
+
   return true;
 }
 

--- a/src/java.base/linux/classes/jdk/internal/platform/CgroupMetrics.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/CgroupMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Red Hat Inc.
+ * Copyright (c) 2020, 2021, Red Hat Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -152,6 +152,11 @@ public class CgroupMetrics implements Metrics {
     @Override
     public long getPidsMax() {
         return subsystem.getPidsMax();
+    }
+
+    @Override
+    public long getPidsCurrent() {
+        return subsystem.getPidsCurrent();
     }
 
     @Override

--- a/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1Subsystem.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1Subsystem.java
@@ -417,8 +417,7 @@ public class CgroupV1Subsystem implements CgroupSubsystem, CgroupV1Metrics {
     }
 
     public long getPidsCurrent() {
-        String pidsCurrentStr = CgroupSubsystemController.getStringValue(pids, "pids.current");
-        return CgroupSubsystem.limitFromString(pidsCurrentStr);
+        return getLongValue(pids, "pids.current");
     }
 
     /*****************************************************************

--- a/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1Subsystem.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1Subsystem.java
@@ -416,6 +416,11 @@ public class CgroupV1Subsystem implements CgroupSubsystem, CgroupV1Metrics {
         return CgroupSubsystem.limitFromString(pidsMaxStr);
     }
 
+    public long getPidsCurrent() {
+        String pidsCurrentStr = CgroupSubsystemController.getStringValue(pids, "pids.current");
+        return CgroupSubsystem.limitFromString(pidsCurrentStr);
+    }
+
     /*****************************************************************
      * BlKIO Subsystem
      ****************************************************************/

--- a/src/java.base/linux/classes/jdk/internal/platform/cgroupv2/CgroupV2Subsystem.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/cgroupv2/CgroupV2Subsystem.java
@@ -313,8 +313,7 @@ public class CgroupV2Subsystem implements CgroupSubsystem {
 
     @Override
     public long getPidsCurrent() {
-        String pidsCurrentStr = CgroupSubsystemController.getStringValue(unified, "pids.current");
-        return CgroupSubsystem.limitFromString(pidsCurrentStr);
+        return getLongVal("pids.current");
     }
 
     @Override

--- a/src/java.base/linux/classes/jdk/internal/platform/cgroupv2/CgroupV2Subsystem.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/cgroupv2/CgroupV2Subsystem.java
@@ -312,6 +312,12 @@ public class CgroupV2Subsystem implements CgroupSubsystem {
     }
 
     @Override
+    public long getPidsCurrent() {
+        String pidsCurrentStr = CgroupSubsystemController.getStringValue(unified, "pids.current");
+        return CgroupSubsystem.limitFromString(pidsCurrentStr);
+    }
+
+    @Override
     public long getBlkIOServiceCount() {
         return sumTokensIOStat(CgroupV2Subsystem::lineToRandWIOs);
     }

--- a/src/java.base/share/classes/jdk/internal/platform/Metrics.java
+++ b/src/java.base/share/classes/jdk/internal/platform/Metrics.java
@@ -365,6 +365,14 @@ public interface Metrics {
      */
     public long getPidsMax();
 
+    /**
+     * Returns the current number of tasks in the Isolation Group.
+     *
+     * @return The current number of tasks or -2 if not supported
+     *
+     */
+    public long getPidsCurrent();
+
     /*****************************************************************
      * BlKIO Subsystem
      ****************************************************************/

--- a/src/java.base/share/classes/sun/launcher/LauncherHelper.java
+++ b/src/java.base/share/classes/sun/launcher/LauncherHelper.java
@@ -408,6 +408,11 @@ public final class LauncherHelper {
         limit = c.getPidsMax();
         ostream.println(formatLimitString(limit, INDENT + "Maximum Processes Limit: ",
                                           longRetvalNotSupported, false));
+
+        long val = c.getPidsCurrent();
+        ostream.println(formatLimitString(val, INDENT + "Current number of processes: ",
+                                          longRetvalNotSupported, false));
+
         ostream.println("");
     }
 

--- a/src/java.base/share/classes/sun/launcher/LauncherHelper.java
+++ b/src/java.base/share/classes/sun/launcher/LauncherHelper.java
@@ -408,11 +408,6 @@ public final class LauncherHelper {
         limit = c.getPidsMax();
         ostream.println(formatLimitString(limit, INDENT + "Maximum Processes Limit: ",
                                           longRetvalNotSupported, false));
-
-        long val = c.getPidsCurrent();
-        ostream.println(formatLimitString(val, INDENT + "Current number of processes: ",
-                                          longRetvalNotSupported, false));
-
         ostream.println("");
     }
 

--- a/test/hotspot/jtreg/containers/docker/TestMisc.java
+++ b/test/hotspot/jtreg/containers/docker/TestMisc.java
@@ -106,7 +106,8 @@ public class TestMisc {
             "Memory Usage",
             "Maximum Memory Usage",
             "memory_max_usage_in_bytes",
-            "maximum number of tasks"
+            "maximum number of tasks",
+            "current number of tasks"
         };
 
         for (String s : expectedToContain) {

--- a/test/hotspot/jtreg/containers/docker/TestPids.java
+++ b/test/hotspot/jtreg/containers/docker/TestPids.java
@@ -46,6 +46,8 @@ import jdk.test.lib.Utils;
 public class TestPids {
     private static final String imageName = Common.imageName("pids");
 
+    static final String warning_kernel_no_pids_support = "WARNING: Your kernel does not support pids limit capabilities";
+
     public static void main(String[] args) throws Exception {
         if (!DockerTestUtils.canTestDocker()) {
             return;
@@ -83,7 +85,7 @@ public class TestPids {
         boolean lineMarkerFound = false;
 
         for (String line : lines) {
-            if (line.contains("WARNING: Your kernel does not support pids limit capabilities")) {
+            if (line.contains(warning_kernel_no_pids_support)) {
                 System.out.println("Docker pids limitation seems not to work, avoiding check");
                 return;
             }
@@ -93,12 +95,12 @@ public class TestPids {
                 String[] parts = line.split(":");
                 System.out.println("DEBUG: line = " + line);
                 System.out.println("DEBUG: parts.length = " + parts.length);
-                if (expectedValue.equals("no_value_expected")) {
+                if (expectedValue.equals("any_integer")) {
                     Asserts.assertEquals(parts.length, 2);
                     String ivalue = parts[1].replaceAll("\\s","");
-                    System.out.println("Found " + lineMarker + " with value: " + ivalue);
                     try {
                         int ai = Integer.parseInt(ivalue);
+                        System.out.println("Found " + lineMarker + " with value: " + ai + ". PASS.");
                     } catch (NumberFormatException ex) {
                         throw new RuntimeException("Could not convert " + ivalue + " to an integer, log line was " + line);
                     }
@@ -149,7 +151,7 @@ public class TestPids {
             checkResult(lines, "Maximum number of tasks is: ", value);
         }
         // current number of tasks value is hard to predict, so better expect no value
-        checkResult(lines, "Current number of tasks is: ", "no_value_expected");
+        checkResult(lines, "Current number of tasks is: ", "any_integer");
     }
 
 }

--- a/test/hotspot/jtreg/containers/docker/TestPids.java
+++ b/test/hotspot/jtreg/containers/docker/TestPids.java
@@ -94,7 +94,14 @@ public class TestPids {
                 System.out.println("DEBUG: line = " + line);
                 System.out.println("DEBUG: parts.length = " + parts.length);
                 if (expectedValue.equals("no_value_expected")) {
-                    System.out.println("No value expected for " + lineMarker);
+                    Asserts.assertEquals(parts.length, 2);
+                    String ivalue = parts[1].replaceAll("\\s","");
+                    System.out.println("Found " + lineMarker + " with value: " + ivalue);
+                    try {
+                        int ai = Integer.parseInt(ivalue);
+                    } catch (NumberFormatException ex) {
+                        throw new RuntimeException("Could not convert " + ivalue + " to an integer, log line was " + line);
+                    }
                     break;
                 }
 

--- a/test/hotspot/jtreg/containers/docker/TestPids.java
+++ b/test/hotspot/jtreg/containers/docker/TestPids.java
@@ -93,6 +93,10 @@ public class TestPids {
                 String[] parts = line.split(":");
                 System.out.println("DEBUG: line = " + line);
                 System.out.println("DEBUG: parts.length = " + parts.length);
+                if (expectedValue.equals("no_value_expected")) {
+                    System.out.println("No value expected for " + lineMarker);
+                    break;
+                }
 
                 Asserts.assertEquals(parts.length, 2);
                 String actual = parts[1].replaceAll("\\s","");
@@ -137,6 +141,8 @@ public class TestPids {
         } else {
             checkResult(lines, "Maximum number of tasks is: ", value);
         }
+        // current number of tasks value is hard to predict, so better expect no value
+        checkResult(lines, "Current number of tasks is: ", "no_value_expected");
     }
 
 }


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8266490
extended the OSContainer API in order to also support the pids controller of cgroups. However only pids.max output was added with 8266490.
There is a second parameter pids.current , see https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html#pid
that would be helpful too and can be added to the OSContainer API .
pids.current :
A read-only single value file which exists on all cgroups.
The number of processes currently in the cgroup and its descendants.

Best regards, Matthias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273526](https://bugs.openjdk.java.net/browse/JDK-8273526): Extend the OSContainer API  pids controller with pids.current


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5437/head:pull/5437` \
`$ git checkout pull/5437`

Update a local copy of the PR: \
`$ git checkout pull/5437` \
`$ git pull https://git.openjdk.java.net/jdk pull/5437/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5437`

View PR using the GUI difftool: \
`$ git pr show -t 5437`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5437.diff">https://git.openjdk.java.net/jdk/pull/5437.diff</a>

</details>
