### PR TITLE
8273539: [PPC64] gtest build error after JDK-8264207

### DIFF
--- a/test/hotspot/gtest/code/test_codestrings.cpp
+++ b/test/hotspot/gtest/code/test_codestrings.cpp
@@ -26,7 +26,7 @@
 #ifndef PRODUCT
 #ifndef ZERO
 
-#include "asm/macroAssembler.hpp"
+#include "asm/macroAssembler.inline.hpp"
 #include "compiler/disassembler.hpp"
 #include "memory/resourceArea.hpp"
 #include "unittest.hpp"


### PR DESCRIPTION
`macroAssembler.inline.hpp` needs to be included to fix the build. Definition of e.g. `nop()` is not visible otherwise. See JBS bug for build error message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273539](https://bugs.openjdk.java.net/browse/JDK-8273539): [PPC64] gtest build error after JDK-8264207


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5438/head:pull/5438` \
`$ git checkout pull/5438`

Update a local copy of the PR: \
`$ git checkout pull/5438` \
`$ git pull https://git.openjdk.java.net/jdk pull/5438/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5438`

View PR using the GUI difftool: \
`$ git pr show -t 5438`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5438.diff">https://git.openjdk.java.net/jdk/pull/5438.diff</a>

</details>
