### PR TITLE
8273494: Zero: Put libjvm.so into "zero" folder, not "server"

### DIFF
--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -33,11 +33,11 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS],
   # Setup the target toolchain
 
   # On some platforms (mac) the linker warns about non existing -L dirs.
-  # For any of the variants server, client or minimal, the dir matches the
+  # For any of the variants server, client, minimal or zero, the dir matches the
   # variant name. The "main" variant should be used for linking. For the
   # rest, the dir is just server.
   if HOTSPOT_CHECK_JVM_VARIANT(server) || HOTSPOT_CHECK_JVM_VARIANT(client) \
-      || HOTSPOT_CHECK_JVM_VARIANT(minimal); then
+      || HOTSPOT_CHECK_JVM_VARIANT(minimal) || HOTSPOT_CHECK_JVM_VARIANT(zero); then
     TARGET_JVM_VARIANT_PATH=$JVM_VARIANT_MAIN
   else
     TARGET_JVM_VARIANT_PATH=server

--- a/make/autoconf/hotspot.m4
+++ b/make/autoconf/hotspot.m4
@@ -84,7 +84,7 @@ AC_DEFUN_ONCE([HOTSPOT_SETUP_JVM_VARIANTS],
   fi
 
   # All "special" variants share the same output directory ("server")
-  VALID_MULTIPLE_JVM_VARIANTS="server client minimal"
+  VALID_MULTIPLE_JVM_VARIANTS="server client minimal zero"
   UTIL_GET_NON_MATCHING_VALUES(INVALID_MULTIPLE_VARIANTS, $JVM_VARIANTS, \
       $VALID_MULTIPLE_JVM_VARIANTS)
   if  test "x$INVALID_MULTIPLE_VARIANTS" != x && \
@@ -95,7 +95,7 @@ AC_DEFUN_ONCE([HOTSPOT_SETUP_JVM_VARIANTS],
   # The "main" variant is the one used by other libs to link against during the
   # build.
   if test "x$BUILDING_MULTIPLE_JVM_VARIANTS" = "xtrue"; then
-    MAIN_VARIANT_PRIO_ORDER="server client minimal"
+    MAIN_VARIANT_PRIO_ORDER="server client minimal zero"
     for variant in $MAIN_VARIANT_PRIO_ORDER; do
       if HOTSPOT_CHECK_JVM_VARIANT($variant); then
         JVM_VARIANT_MAIN="$variant"

--- a/make/hotspot/HotspotCommon.gmk
+++ b/make/hotspot/HotspotCommon.gmk
@@ -34,7 +34,7 @@ JVM_SUPPORT_DIR := $(JVM_VARIANT_OUTPUTDIR)/support
 DTRACE_SUPPORT_DIR := $(JVM_SUPPORT_DIR)/dtrace
 
 LIB_OUTPUTDIR := $(call FindLibDirForModule, java.base)
-ifneq ($(filter client minimal, $(JVM_VARIANT)), )
+ifneq ($(filter client minimal zero, $(JVM_VARIANT)), )
   JVM_VARIANT_SUBDIR := $(JVM_VARIANT)
 else
   # Use 'server' as default target directory name for all other variants.

--- a/make/modules/java.base/Copy.gmk
+++ b/make/modules/java.base/Copy.gmk
@@ -95,9 +95,9 @@ ifeq ($(call And, $(call isTargetOs, windows) $(call isTargetCpu, x86)), true)
 endif
 DEFAULT_CFG_VARIANT ?= server
 
-# Any variant other than server, client or minimal is represented as server in
+# Any variant other than server, client, minimal, or zero is represented as server in
 # the cfg file.
-VALID_CFG_VARIANTS := server client minimal
+VALID_CFG_VARIANTS := server client minimal zero
 CFG_VARIANTS := $(filter $(VALID_CFG_VARIANTS), $(JVM_VARIANTS)) \
     $(if $(filter-out $(VALID_CFG_VARIANTS), $(JVM_VARIANTS)), server)
 

--- a/make/modules/java.base/Lib.gmk
+++ b/make/modules/java.base/Lib.gmk
@@ -156,10 +156,10 @@ ifeq ($(call isTargetOsType, unix), true)
         TARGETS += $(LIB_OUTPUTDIR)/$1/$(call SHARED_LIBRARY,jsig)
       endef
 
-      # The subdir is the same as the variant for client and minimal, for all
+      # The subdir is the same as the variant for client, minimal or zero, for all
       # others it's server.
-      VARIANT_SUBDIRS := $(filter client minimal, $(JVM_VARIANTS)) \
-          $(if $(filter-out client minimal, $(JVM_VARIANTS)), server)
+      VARIANT_SUBDIRS := $(filter client minimal zero, $(JVM_VARIANTS)) \
+          $(if $(filter-out client minimal zero, $(JVM_VARIANTS)), server)
       $(foreach v, $(VARIANT_SUBDIRS), $(eval $(call CreateSymlinks,$v)))
     endif
     ############################################################################

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -365,10 +365,7 @@ public class Platform {
         } else if (Platform.isMinimal()) {
             return "minimal";
         } else if (Platform.isZero()) {
-            // This name is used to search for libjvm.so. Weirdly, current
-            // build system puts libjvm.so into default location, which is
-            // "server". See JDK-8273494.
-            return "server";
+            return "zero";
         } else {
             throw new Error("TESTBUG: unsupported vm variant");
         }


### PR DESCRIPTION
Currently, the build system defaults the libjvm.so location to "server".  This makes looking for `libjvm.so` awkward, see JDK-8273487 for example. We need to see if moving the libjvm.so to a proper location breaks anything. 

Additional testing:
 - [x] Linux x86_64 Zero build
 - [x] Linux x86_64 Zero bootcycle-images
 - [x] Linux x86_64 Zero `tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273494](https://bugs.openjdk.java.net/browse/JDK-8273494): Zero: Put libjvm.so into "zero" folder, not "server"


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5440/head:pull/5440` \
`$ git checkout pull/5440`

Update a local copy of the PR: \
`$ git checkout pull/5440` \
`$ git pull https://git.openjdk.java.net/jdk pull/5440/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5440`

View PR using the GUI difftool: \
`$ git pr show -t 5440`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5440.diff">https://git.openjdk.java.net/jdk/pull/5440.diff</a>

</details>
