### PR TITLE
JDK-8273541: Cleaner Thread creates with normal priority instead of MAX_PRIORITY - 2

### DIFF
--- a/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
+++ b/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
@@ -214,7 +214,7 @@ public final class CleanerImpl implements Runnable {
 
         public Thread newThread(Runnable r) {
             return InnocuousThread.newThread("Cleaner-" + cleanerThreadNumber.getAndIncrement(),
-                r, Thread.MIN_PRIORITY - 2);
+                r, Thread.MAX_PRIORITY - 2);
         }
     }
 


### PR DESCRIPTION
Hi all!

Please review this fix for JDK-8273541. It seems that change [1] accidentally modified Thread.MAX_PRIORITY to Thread.MIN_PRIORITY.  As Thread.MIN_PRIORITY - 2 is negative and because of the check [2], the thread priority is not set. Changing this back to Thread.MAX_PRIORITY should fix the problem. I tried this patch locally and it seems to fix the issue for me. 

[1]: https://github.com/openjdk/jdk/pull/2380/files#diff-d62f4055445b40f5d9862e02f8be6da2d547ac77ffae362d7034595d58c7389aL220-R217
[2]: https://github.com/openjdk/jdk/pull/2380/files#diff-9f140a5980d51de2a5f392a6ffb91f51d2303760b699d5366125fb66f55b70f0R120-R122
Regards,
Kartik
