### PR TITLE
8273550: Replace os::cgc_thread/pgc_thread with os::gc_thread

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -979,8 +979,7 @@ size_t os::Posix::get_initial_stack_size(ThreadType thr_type, size_t req_stack_s
                       _compiler_thread_min_stack_allowed);
     break;
   case os::vm_thread:
-  case os::pgc_thread:
-  case os::cgc_thread:
+  case os::gc_thread:
   case os::watcher_thread:
   default:  // presume the unknown thr_type is a VM internal
     if (req_stack_size == 0 && VMThreadStackSize > 0) {

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -712,8 +712,7 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
       } // else fall through:
         // use VMThreadStackSize if CompilerThreadStackSize is not defined
     case os::vm_thread:
-    case os::pgc_thread:
-    case os::cgc_thread:
+    case os::gc_thread:
     case os::asynclog_thread:
     case os::watcher_thread:
       if (VMThreadStackSize > 0) stack_size = (size_t)(VMThreadStackSize * K);

--- a/src/hotspot/share/gc/shared/concurrentGCThread.cpp
+++ b/src/hotspot/share/gc/shared/concurrentGCThread.cpp
@@ -35,7 +35,7 @@ ConcurrentGCThread::ConcurrentGCThread() :
     _has_terminated(false) {}
 
 void ConcurrentGCThread::create_and_start(ThreadPriority prio) {
-  if (os::create_thread(this, os::cgc_thread)) {
+  if (os::create_thread(this, os::gc_thread)) {
     os::set_priority(this, prio);
     os::start_thread(this);
   }

--- a/src/hotspot/share/gc/shared/workgroup.cpp
+++ b/src/hotspot/share/gc/shared/workgroup.cpp
@@ -160,19 +160,13 @@ GangWorker* WorkGang::install_worker(uint worker_id) {
 }
 
 void WorkGang::add_workers(bool initializing) {
-  os::ThreadType worker_type;
-  if (are_ConcurrentGC_threads()) {
-    worker_type = os::cgc_thread;
-  } else {
-    worker_type = os::pgc_thread;
-  }
   uint previous_created_workers = _created_workers;
 
   _created_workers = WorkerManager::add_workers(this,
                                                 _active_workers,
                                                 _total_workers,
                                                 _created_workers,
-                                                worker_type,
+                                                os::gc_thread,
                                                 initializing);
   _active_workers = MIN2(_created_workers, _active_workers);
 

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -441,8 +441,7 @@ class os: AllStatic {
 
   enum ThreadType {
     vm_thread,
-    cgc_thread,        // Concurrent GC thread
-    pgc_thread,        // Parallel GC thread
+    gc_thread,         // GC thread
     java_thread,       // Java, CodeCacheSweeper, JVMTIAgent and Service threads.
     compiler_thread,
     watcher_thread,


### PR DESCRIPTION
The os thread types `cgc_thread` and `pgc_thread` might have been treated differently at some point in the past, but today they are not. So I suggest we replace those two types with a single `gc_thread` type.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273550](https://bugs.openjdk.java.net/browse/JDK-8273550): Replace os::cgc_thread/pgc_thread with os::gc_thread


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5444/head:pull/5444` \
`$ git checkout pull/5444`

Update a local copy of the PR: \
`$ git checkout pull/5444` \
`$ git pull https://git.openjdk.java.net/jdk pull/5444/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5444`

View PR using the GUI difftool: \
`$ git pr show -t 5444`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5444.diff">https://git.openjdk.java.net/jdk/pull/5444.diff</a>

</details>
