### PR TITLE
8272903: Missing license header in ArenaAllocator.java

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ArenaAllocator.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ArenaAllocator.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package jdk.internal.foreign;
 
 import jdk.incubator.foreign.MemorySegment;


### PR DESCRIPTION
This small patch adds missing copyright header to a segment allocator implementation class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272903](https://bugs.openjdk.java.net/browse/JDK-8272903): Missing license header in ArenaAllocator.java


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5447/head:pull/5447` \
`$ git checkout pull/5447`

Update a local copy of the PR: \
`$ git checkout pull/5447` \
`$ git pull https://git.openjdk.java.net/jdk pull/5447/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5447`

View PR using the GUI difftool: \
`$ git pr show -t 5447`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5447.diff">https://git.openjdk.java.net/jdk/pull/5447.diff</a>

</details>
