### PR TITLE
8263773: Reenable German localization for builds at Oracle

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -249,7 +249,7 @@ var getJibProfilesCommon = function (input, data) {
         dependencies: ["boot_jdk", "gnumake", "jtreg", "jib", "autoconf", "jmh", "jcov"],
         default_make_targets: ["product-bundles", "test-bundles", "static-libs-bundles"],
         configure_args: concat("--enable-jtreg-failure-handler",
-            "--with-exclude-translations=de,es,fr,it,ko,pt_BR,sv,ca,tr,cs,sk,ja_JP_A,ja_JP_HA,ja_JP_HI,ja_JP_I,zh_TW,zh_HK",
+            "--with-exclude-translations=es,fr,it,ko,pt_BR,sv,ca,tr,cs,sk,ja_JP_A,ja_JP_HA,ja_JP_HI,ja_JP_I,zh_TW,zh_HK",
             "--disable-manpages",
             "--disable-jvm-feature-shenandoahgc",
             versionArgs(input, common))

--- a/test/jdk/build/translations/VerifyTranslations.java
+++ b/test/jdk/build/translations/VerifyTranslations.java
@@ -45,7 +45,7 @@ public class VerifyTranslations {
      * The set of translations we want to see in an Oracle built image
      */
     private static final Set<String> VALID_TRANSLATION_SUFFIXES = Set.of(
-            "_en", "_en_US", "_en_US_POSIX", "_ja", "_zh_CN"
+            "_en", "_en_US", "_en_US_POSIX", "_ja", "_zh_CN", "_de"
     );
 
     /**


### PR DESCRIPTION
8263773: Request for German localization

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263773](https://bugs.openjdk.java.net/browse/JDK-8263773): Reenable German localization for builds at Oracle ⚠️ Issue is not open.


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5448/head:pull/5448` \
`$ git checkout pull/5448`

Update a local copy of the PR: \
`$ git checkout pull/5448` \
`$ git pull https://git.openjdk.java.net/jdk pull/5448/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5448`

View PR using the GUI difftool: \
`$ git pr show -t 5448`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5448.diff">https://git.openjdk.java.net/jdk/pull/5448.diff</a>

</details>
