### PR TITLE
JDK-8273162 AbstractSplittableWithBrineGenerator does not create a random salt

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
@@ -2380,7 +2380,7 @@ public class RandomSupport {
             long bits = nextLong();
             long multiplier = (1L << SALT_SHIFT) - 1;
             long salt = multiplier << (64 - SALT_SHIFT);
-            while ((salt & multiplier) != 0) {
+            while ((salt & multiplier) == 0) {
                 long digit = Math.multiplyHigh(bits, multiplier);
                 salt = (salt >>> SALT_SHIFT) | (digit << (64 - SALT_SHIFT));
                 bits *= multiplier;


### PR DESCRIPTION
RandomSupport.AbstractSplittableWithBrineGenerator. makeSplitsSpliterator is intending to create a salt from a random long. The salt should have random letters of size 4 for each consecutive 4 bits and then the last 4 bits as ff, i.e. all bits set. 

However the loop is never executed, the random bits are not used and the salt is always the same. 

This condition is false on the first execution: 

  long multiplier = (1L << SALT_SHIFT) - 1; 
  long salt = multiplier << (64 - SALT_SHIFT); 
  while ((salt & multiplier) != 0) { 


This can be corrected by changing: 

  while ((salt & multiplier) != 0) { 

to 

  while ((salt & multiplier) == 0) {

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273162](https://bugs.openjdk.java.net/browse/JDK-8273162): AbstractSplittableWithBrineGenerator does not create a random salt


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5449/head:pull/5449` \
`$ git checkout pull/5449`

Update a local copy of the PR: \
`$ git checkout pull/5449` \
`$ git pull https://git.openjdk.java.net/jdk pull/5449/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5449`

View PR using the GUI difftool: \
`$ git pr show -t 5449`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5449.diff">https://git.openjdk.java.net/jdk/pull/5449.diff</a>

</details>
