### PR TITLE
8272867: JFR: ManagementSupport.removeBefore() lost coverage

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/management/ManagementSupport.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/management/ManagementSupport.java
@@ -136,12 +136,6 @@ public final class ManagementSupport {
         return PrivateAccess.getInstance().newEventSettings(esm);
     }
 
-    // When streaming an ongoing recording, consumed chunks should be removed
-    public static void removeBefore(Recording recording, Instant timestamp) {
-        PlatformRecording pr = PrivateAccess.getInstance().getPlatformRecording(recording);
-        pr.removeBefore(timestamp);
-    }
-
     // Needed callback to detect when a chunk has been parsed.
     public static void removePath(Recording recording, Path path) {
         PlatformRecording pr = PrivateAccess.getInstance().getPlatformRecording(recording);


### PR DESCRIPTION
Hi,

Could I have a review of a fix that removes an unused method

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * ⚠️ Failed to retrieve information on issue `8272867`.


### Reviewers
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5453/head:pull/5453` \
`$ git checkout pull/5453`

Update a local copy of the PR: \
`$ git checkout pull/5453` \
`$ git pull https://git.openjdk.java.net/jdk pull/5453/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5453`

View PR using the GUI difftool: \
`$ git pr show -t 5453`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5453.diff">https://git.openjdk.java.net/jdk/pull/5453.diff</a>

</details>
