### PR TITLE
8274835: Remove unnecessary castings in java.base

### DIFF
--- a/src/java.base/share/classes/java/io/SequenceInputStream.java
+++ b/src/java.base/share/classes/java/io/SequenceInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,7 +98,7 @@ public class SequenceInputStream extends InputStream {
 
     private void peekNextStream() {
         if (e.hasMoreElements()) {
-            in = (InputStream) e.nextElement();
+            in = e.nextElement();
             if (in == null)
                 throw new NullPointerException();
         } else {

--- a/src/java.base/share/classes/java/lang/ClassValue.java
+++ b/src/java.base/share/classes/java/lang/ClassValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -685,7 +685,7 @@ public abstract class ClassValue<T> {
             if (haveReplacement >= 0) {
                 if (cache[(replacementPos+1) & mask] != null) {
                     // Be conservative, to avoid breaking up a non-null run.
-                    cache[replacementPos & mask] = (Entry<?>) Entry.DEAD_ENTRY;
+                    cache[replacementPos & mask] = Entry.DEAD_ENTRY;
                 } else {
                     cache[replacementPos & mask] = null;
                     cacheLoad -= 1;

--- a/src/java.base/share/classes/java/lang/Enum.java
+++ b/src/java.base/share/classes/java/lang/Enum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -193,7 +193,7 @@ public abstract class Enum<E extends Enum<E>>
      * method is the order in which the constants are declared.
      */
     public final int compareTo(E o) {
-        Enum<?> other = (Enum<?>)o;
+        Enum<?> other = o;
         Enum<E> self = this;
         if (self.getClass() != other.getClass() && // optimization
             self.getDeclaringClass() != other.getDeclaringClass())

--- a/src/java.base/share/classes/java/lang/StackTraceElement.java
+++ b/src/java.base/share/classes/java/lang/StackTraceElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -443,7 +443,7 @@ public final class StackTraceElement implements java.io.Serializable {
      */
     private synchronized void computeFormat() {
         try {
-            Class<?> cls = (Class<?>) declaringClassObject;
+            Class<?> cls = declaringClassObject;
             ClassLoader loader = cls.getClassLoader0();
             Module m = cls.getModule();
             byte bits = 0;

--- a/src/java.base/share/classes/java/security/Signature.java
+++ b/src/java.base/share/classes/java/security/Signature.java
@@ -1146,9 +1146,8 @@ public abstract class Signature extends SignatureSpi {
         public Object clone() throws CloneNotSupportedException {
             chooseFirstProvider();
             if (sigSpi instanceof Cloneable) {
-                // Because 'algorithm' and 'provider' are private
-                // members of our supertype, we must perform a cast to
-                // access them.
+                // Because 'algorithm' is private member of our supertype,
+                // we must perform a cast to access it.
                 Signature that = new CloneableDelegate(
                    (SignatureSpi)sigSpi.clone(),
                    ((Signature)this).algorithm);

--- a/src/java.base/share/classes/java/security/Signature.java
+++ b/src/java.base/share/classes/java/security/Signature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1152,7 +1152,7 @@ public abstract class Signature extends SignatureSpi {
                 Signature that = new CloneableDelegate(
                    (SignatureSpi)sigSpi.clone(),
                    ((Signature)this).algorithm);
-                that.provider = ((Signature)this).provider;
+                that.provider = this.provider;
                 return that;
             } else {
                 throw new CloneNotSupportedException();

--- a/src/java.base/share/classes/java/util/GregorianCalendar.java
+++ b/src/java.base/share/classes/java/util/GregorianCalendar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -624,7 +624,7 @@ public class GregorianCalendar extends Calendar {
      */
     public GregorianCalendar(TimeZone zone, Locale aLocale) {
         super(zone, aLocale);
-        gdate = (BaseCalendar.Date) gcal.newCalendarDate(zone);
+        gdate = gcal.newCalendarDate(zone);
         setTimeInMillis(System.currentTimeMillis());
     }
 
@@ -698,7 +698,7 @@ public class GregorianCalendar extends Calendar {
     GregorianCalendar(int year, int month, int dayOfMonth,
                       int hourOfDay, int minute, int second, int millis) {
         super();
-        gdate = (BaseCalendar.Date) gcal.newCalendarDate(getZone());
+        gdate = gcal.newCalendarDate(getZone());
         this.set(YEAR, year);
         this.set(MONTH, month);
         this.set(DAY_OF_MONTH, dayOfMonth);
@@ -736,7 +736,7 @@ public class GregorianCalendar extends Calendar {
      */
     GregorianCalendar(TimeZone zone, Locale locale, boolean flag) {
         super(zone, locale);
-        gdate = (BaseCalendar.Date) gcal.newCalendarDate(getZone());
+        gdate = gcal.newCalendarDate(getZone());
     }
 
 /////////////////
@@ -2370,7 +2370,7 @@ public class GregorianCalendar extends Calendar {
         } else {
             // Handle Julian calendar dates.
             calsys = getJulianCalendarSystem();
-            cdate = (BaseCalendar.Date) jcal.newCalendarDate(getZone());
+            cdate = jcal.newCalendarDate(getZone());
             jcal.getCalendarDateFromFixedDate(cdate, fixedDate);
             Era e = cdate.getEra();
             if (e == jeras[0]) {
@@ -3109,7 +3109,7 @@ public class GregorianCalendar extends Calendar {
             return (int)(next1 - month1);
         }
         if (cdate != gdate) {
-            date = (BaseCalendar.Date) gcal.newCalendarDate(TimeZone.NO_TIMEZONE);
+            date = gcal.newCalendarDate(TimeZone.NO_TIMEZONE);
         }
         gcal.getCalendarDateFromFixedDate(date, next1);
         next1 = getFixedDateMonth1(date, next1);
@@ -3198,7 +3198,7 @@ public class GregorianCalendar extends Calendar {
             throws IOException, ClassNotFoundException {
         stream.defaultReadObject();
         if (gdate == null) {
-            gdate = (BaseCalendar.Date) gcal.newCalendarDate(getZone());
+            gdate = gcal.newCalendarDate(getZone());
             cachedFixedDate = Long.MIN_VALUE;
         }
         setGregorianChange(gregorianCutover);

--- a/src/java.base/share/classes/java/util/HashSet.java
+++ b/src/java.base/share/classes/java/util/HashSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -334,7 +334,7 @@ public class HashSet<E>
                      .checkArray(s, Map.Entry[].class, HashMap.tableSizeFor(capacity));
 
         // Create backing HashMap
-        map = (((HashSet<?>)this) instanceof LinkedHashSet ?
+        map = (this instanceof LinkedHashSet ?
                new LinkedHashMap<>(capacity, loadFactor) :
                new HashMap<>(capacity, loadFactor));
 

--- a/src/java.base/share/classes/java/util/stream/ReferencePipeline.java
+++ b/src/java.base/share/classes/java/util/stream/ReferencePipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -612,7 +612,7 @@ abstract class ReferencePipeline<P_IN, P_OUT>
         // Runtime checking will be performed when an element is stored in A[], thus if A is not a
         // super type of U an ArrayStoreException will be thrown.
         @SuppressWarnings("rawtypes")
-        IntFunction rawGenerator = (IntFunction) generator;
+        IntFunction rawGenerator = generator;
         return (A[]) Nodes.flatten(evaluateToArrayNode(rawGenerator), rawGenerator)
                               .asArray(rawGenerator);
     }

--- a/src/java.base/share/classes/sun/net/www/MimeTable.java
+++ b/src/java.base/share/classes/sun/net/www/MimeTable.java
@@ -24,6 +24,7 @@
  */
 
 package sun.net.www;
+
 import jdk.internal.util.StaticProperty;
 
 import java.io.*;
@@ -89,7 +90,7 @@ public class MimeTable implements FileNameMap {
      */
     public static FileNameMap loadTable() {
         MimeTable mt = getDefaultTable();
-        return (FileNameMap)mt;
+        return mt;
     }
 
     public synchronized int getSize() {

--- a/src/java.base/share/classes/sun/net/www/protocol/http/AuthCacheImpl.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/AuthCacheImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,7 @@ public class AuthCacheImpl implements AuthCache {
         }
         if (skey == null) {
             // list should contain only one element
-            return (AuthenticationInfo)list.get (0);
+            return list.get(0);
         }
         ListIterator<AuthCacheValue> iter = list.listIterator();
         while (iter.hasNext()) {

--- a/src/java.base/share/classes/sun/security/provider/DSAPublicKey.java
+++ b/src/java.base/share/classes/sun/security/provider/DSAPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,7 +122,7 @@ implements java.security.interfaces.DSAPublicKey, Serializable {
                     return null;
                 }
                 paramSpec = algParams.getParameterSpec(DSAParameterSpec.class);
-                return (DSAParams)paramSpec;
+                return paramSpec;
             }
         } catch (InvalidParameterSpecException e) {
             return null;

--- a/src/java.base/share/classes/sun/security/provider/certpath/PKIX.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/PKIX.java
@@ -269,7 +269,6 @@ class PKIX {
             for (CertStore store : stores) {
                 try {
                     Collection<? extends Certificate> certs =
-                        (Collection<? extends Certificate>)
                             store.getCertificates(sel);
                     if (!certs.isEmpty()) {
                         X509Certificate xc =

--- a/src/java.base/share/classes/sun/security/provider/certpath/RevocationChecker.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/RevocationChecker.java
@@ -792,8 +792,7 @@ class RevocationChecker extends PKIXRevocationChecker {
                 e, null, -1, BasicReason.UNDETERMINED_REVOCATION_STATUS);
         }
 
-        RevocationStatus rs =
-            (RevocationStatus)response.getSingleResponse(certId);
+        RevocationStatus rs = response.getSingleResponse(certId);
         RevocationStatus.CertStatus certStatus = rs.getCertStatus();
         if (certStatus == RevocationStatus.CertStatus.REVOKED) {
             Date revocationTime = rs.getRevocationTime();

--- a/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
@@ -1036,7 +1036,7 @@ final class SSLSessionImpl extends ExtendedSSLSession {
         // Certs are immutable objects, therefore we don't clone them.
         // But do need to clone the array, so that nothing is inserted
         // into peerCerts.
-        return (java.security.cert.Certificate[])peerCerts.clone();
+        return peerCerts.clone();
     }
 
     /**
@@ -1054,8 +1054,7 @@ final class SSLSessionImpl extends ExtendedSSLSession {
         // clone to preserve integrity of session ... caller can't
         // change record of peer identity even by accident, much
         // less do it intentionally.
-        return (localCerts == null ? null :
-            (java.security.cert.Certificate[])localCerts.clone());
+        return (localCerts == null ? null : localCerts.clone());
     }
 
     /**

--- a/src/java.base/share/classes/sun/util/calendar/Era.java
+++ b/src/java.base/share/classes/sun/util/calendar/Era.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,7 +80,7 @@ public final class Era {
         this.since = since;
         this.localTime = localTime;
         Gregorian gcal = CalendarSystem.getGregorianCalendar();
-        BaseCalendar.Date d = (BaseCalendar.Date) gcal.newCalendarDate(null);
+        BaseCalendar.Date d = gcal.newCalendarDate(null);
         gcal.getCalendarDate(since, d);
         sinceDate = new ImmutableGregorianDate(d);
     }


### PR DESCRIPTION
Redundant castings make code harder to read.
Found them by IntelliJ IDEA.
I tried to select only casts which are definitely safe to remove. Also didn't touch primitive types casts.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274835](https://bugs.openjdk.java.net/browse/JDK-8274835): Remove unnecessary castings in java.base


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5454/head:pull/5454` \
`$ git checkout pull/5454`

Update a local copy of the PR: \
`$ git checkout pull/5454` \
`$ git pull https://git.openjdk.java.net/jdk pull/5454/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5454`

View PR using the GUI difftool: \
`$ git pr show -t 5454`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5454.diff">https://git.openjdk.java.net/jdk/pull/5454.diff</a>

</details>
