### PR TITLE
8273522: Rename test property vm.cds.archived.java.heap to vm.cds.write.archived.java.heap

### DIFF
--- a/src/hotspot/share/cds/heapShared.hpp
+++ b/src/hotspot/share/cds/heapShared.hpp
@@ -155,7 +155,6 @@ public:
 
   // Can this VM write heap regions into the CDS archive? Currently only G1+compressed{oops,cp}
   static bool can_write() {
-    assert(DumpSharedSpaces, "only when writing static archive");
     CDS_JAVA_HEAP_ONLY(return (UseG1GC && UseCompressedOops && UseCompressedClassPointers);)
     NOT_CDS_JAVA_HEAP(return false;)
   }

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -2001,8 +2001,8 @@ WB_ENTRY(jboolean, WB_IsJVMCISupportedByGC(JNIEnv* env))
 #endif
 WB_END
 
-WB_ENTRY(jboolean, WB_IsJavaHeapArchiveSupported(JNIEnv* env))
-  return HeapShared::can_use();
+WB_ENTRY(jboolean, WB_CanWriteJavaHeapArchive(JNIEnv* env))
+  return HeapShared::can_write();
 WB_END
 
 
@@ -2643,7 +2643,7 @@ static JNINativeMethod methods[] = {
   {CC"isJFRIncluded",                     CC"()Z",    (void*)&WB_IsJFRIncluded },
   {CC"isC2OrJVMCIIncluded",               CC"()Z",    (void*)&WB_isC2OrJVMCIIncluded },
   {CC"isJVMCISupportedByGC",              CC"()Z",    (void*)&WB_IsJVMCISupportedByGC},
-  {CC"isJavaHeapArchiveSupported",        CC"()Z",    (void*)&WB_IsJavaHeapArchiveSupported },
+  {CC"canWriteJavaHeapArchive",           CC"()Z",    (void*)&WB_CanWriteJavaHeapArchive },
   {CC"cdsMemoryMappingFailed",            CC"()Z",    (void*)&WB_CDSMemoryMappingFailed },
 
   {CC"clearInlineCaches0",  CC"(Z)V",                 (void*)&WB_ClearInlineCaches },

--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -67,7 +67,7 @@ requires.properties= \
     vm.rtm.compiler \
     vm.cds \
     vm.cds.custom.loaders \
-    vm.cds.archived.java.heap \
+    vm.cds.write.archived.java.heap \
     vm.jvmti \
     vm.graal.enabled \
     vm.compiler1.enabled \

--- a/test/hotspot/jtreg/runtime/cds/SharedStrings.java
+++ b/test/hotspot/jtreg/runtime/cds/SharedStrings.java
@@ -25,7 +25,7 @@
  * @test
  * @summary Check to make sure that shared strings in the bootstrap CDS archive
  *          are actually shared
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @requires vm.flagless
  * @library /test/lib
  * @build SharedStringsWb sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/SharedStringsDedup.java
+++ b/test/hotspot/jtreg/runtime/cds/SharedStringsDedup.java
@@ -24,7 +24,7 @@
 /**
  * @test SharedStringsDedup
  * @summary Test -Xshare:auto with shared strings and -XX:+UseStringDeduplication
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/lib
  * @run driver SharedStringsDedup
  */

--- a/test/hotspot/jtreg/runtime/cds/SharedStringsRunAuto.java
+++ b/test/hotspot/jtreg/runtime/cds/SharedStringsRunAuto.java
@@ -24,7 +24,7 @@
 /**
  * @test SharedStringsAuto
  * @summary Test -Xshare:auto with shared strings.
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/lib
  * @run driver SharedStringsRunAuto
  */

--- a/test/hotspot/jtreg/runtime/cds/appcds/CommandLineFlagCombo.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/CommandLineFlagCombo.java
@@ -24,7 +24,7 @@
 
 /*
  * @test CommandLineFlagCombo
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @comment This test explicitly chooses the type of GC to be used by sub-processes. It may conflict with the GC type set
  * via the -vmoptions command line option of JTREG. vm.gc==null will help the test case to discard the explicitly passed
  * vm options.

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedIntegerCacheTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedIntegerCacheTest.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Test primitive box caches integrity in various scenarios (IntegerCache etc)
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/jdk/lib/testlibrary /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build sun.hotspot.WhiteBox
  * @compile CheckIntegerCacheApp.java

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleComboTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleComboTest.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Test archived system module sub-graph and verify objects are archived.
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/jdk/lib/testlibrary /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build sun.hotspot.WhiteBox
  * @compile CheckArchivedModuleApp.java

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleCompareTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleCompareTest.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Compare archived system modules with non-archived.
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/jdk/lib/testlibrary /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @compile PrintSystemModulesApp.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar PrintSystemModulesApp

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleWithCustomImageTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleWithCustomImageTest.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @summary Test archived module graph with custom runtime image
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @requires vm.flagless
  * @library /test/jdk/lib/testlibrary /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/CheckCachedMirrorTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/CheckCachedMirrorTest.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Test archived mirror
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @requires vm.cds.custom.loaders
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/DifferentHeapSizes.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/DifferentHeapSizes.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Test automatic relocation of archive heap regions dur to heap size changes.
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @compile ../test-classes/Hello.java
  * @build sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/DumpTimeVerifyFailure.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/DumpTimeVerifyFailure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @test
  * @summary Dump time should not crash if any class with shared strings fails verification due to missing dependencies.
  * @bug 8186789
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @compile MyOuter.java MyException.java
  * @run driver DumpTimeVerifyFailure

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/GCStressTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/GCStressTest.java
@@ -26,7 +26,7 @@
  * @test
  * @key randomness
  * @summary
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build sun.hotspot.WhiteBox jdk.test.lib.Utils
  * @compile GCStressApp.java

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/HeapFragmentationTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/HeapFragmentationTest.java
@@ -26,7 +26,7 @@
  * @test
  * @summary Relocate CDS archived regions to the top of the G1 heap
  * @bug 8214455
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @requires (sun.arch.data.model == "64" & os.maxMemory > 4g)
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build HeapFragmentationApp

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/MirrorWithReferenceFieldsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/MirrorWithReferenceFieldsTest.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Test archived mirror with reference fields
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build sun.hotspot.WhiteBox
  * @compile MirrorWithReferenceFieldsApp.java

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/OpenArchiveRegion.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/OpenArchiveRegion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Test open archive heap regions
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @comment This test explicitly chooses the type of GC to be used by sub-processes. It may conflict with the GC type set
  * via the -vmoptions command line option of JTREG. vm.gc==null will help the test case to discard the explicitly passed
  * vm options.

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/PrimitiveTypesTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/PrimitiveTypesTest.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Test archived primitive type mirrors
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build sun.hotspot.WhiteBox
  * @compile PrimitiveTypesApp.java

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/RedefineClassTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/RedefineClassTest.java
@@ -26,7 +26,7 @@
  * @test
  * @summary Redefine shared class. GC should not cause crash with cached resolved_references.
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes /test/hotspot/jtreg/runtime/cds/appcds/jvmti
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @requires vm.jvmti
  * @build sun.hotspot.WhiteBox
  *        RedefineClassApp

--- a/test/hotspot/jtreg/runtime/cds/appcds/javaldr/ExceptionDuringDumpAtObjectsInitPhase.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/javaldr/ExceptionDuringDumpAtObjectsInitPhase.java
@@ -26,7 +26,7 @@
  * @test
  * @summary Out of memory When dumping the CDS archive
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @requires vm.jvmti
  * @run driver ExceptionDuringDumpAtObjectsInitPhase
  */

--- a/test/hotspot/jtreg/runtime/cds/appcds/javaldr/GCSharedStringsDuringDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/javaldr/GCSharedStringsDuringDump.java
@@ -27,7 +27,7 @@
  * @summary Similar to GCDuringDumping.java, this test adds the -XX:SharedArchiveConfigFile
  *          option for testing the interaction with GC and shared strings.
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @requires vm.jvmti
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/appcds/javaldr/HumongousDuringDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/javaldr/HumongousDuringDump.java
@@ -26,7 +26,7 @@
  * @test
  * @summary Test how CDS dumping handles the existence of humongous G1 regions.
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @requires vm.jvmti
  * @run driver/timeout=240 HumongousDuringDump
  */

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/ExerciseGC.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/ExerciseGC.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Exercise GC with shared strings
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @requires vm.gc == null
  * @library /test/hotspot/jtreg/runtime/cds/appcds /test/lib
  * @build HelloStringGC sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/FlagCombo.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/FlagCombo.java
@@ -25,7 +25,7 @@
 /**
  * @test
  * @summary Test relevant combinations of command line flags with shared strings
- * @requires vm.cds.archived.java.heap & vm.hasJFR
+ * @requires vm.cds.write.archived.java.heap & vm.hasJFR
  * @requires vm.gc == null
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build HelloString
@@ -36,7 +36,7 @@
  * @test
  * @summary Test relevant combinations of command line flags with shared strings
  * @comment A special test excluding the case that requires JFR
- * @requires vm.cds.archived.java.heap & !vm.hasJFR
+ * @requires vm.cds.write.archived.java.heap & !vm.hasJFR
  * @requires vm.gc == null
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build HelloString

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/IncompatibleOptions.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/IncompatibleOptions.java
@@ -31,7 +31,7 @@
  * @test
  * @summary Test options that are incompatible with use of shared strings
  *          Also test mismatch in oops encoding between dump time and run time
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @comment This test explicitly chooses the type of GC to be used by sub-processes. It may conflict with the GC type set
  * via the -vmoptions command line option of JTREG. vm.gc==null will help the test case to discard the explicitly passed
  * vm options.
@@ -46,7 +46,7 @@
 
 /*
  * @test
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @requires (vm.gc=="null")
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build sun.hotspot.WhiteBox
@@ -57,7 +57,7 @@
 
 /*
  * @test
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @requires (vm.gc=="null")
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/InternSharedString.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/InternSharedString.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Test shared strings together with string intern operation
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @requires vm.gc == null
  * @library /test/hotspot/jtreg/runtime/cds/appcds /test/lib
  * @compile InternStringTest.java

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/InvalidFileFormat.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/InvalidFileFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Check most common errors in file format
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build HelloString
  * @run driver InvalidFileFormat

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/LargePages.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/LargePages.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Basic shared string test with large pages
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @requires vm.gc == null
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build HelloString

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/LockSharedStrings.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/LockSharedStrings.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Test locking on shared strings
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @requires vm.gc == null
  * @library /test/hotspot/jtreg/runtime/cds/appcds /test/lib
  * @compile LockStringTest.java LockStringValueTest.java

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsBasic.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsBasic.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Basic test for shared strings
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/hotspot/jtreg/runtime/cds/appcds /test/lib
  * @build HelloString
  * @run driver SharedStringsBasic

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsBasicPlus.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsBasicPlus.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Basic plus test for shared strings
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @requires vm.gc == null
  * @library /test/hotspot/jtreg/runtime/cds/appcds /test/lib
  * @build HelloStringPlus sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsHumongous.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsHumongous.java
@@ -26,7 +26,7 @@
  * @test
  * @summary Use a shared string allocated in a humongous G1 region.
  * @comment -- the following implies that G1 is used (by command-line or by default)
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  *
  * @library /test/hotspot/jtreg/runtime/cds/appcds /test/lib
  * @build HelloString

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsStress.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsStress.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Write a lots of shared strings.
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/hotspot/jtreg/runtime/cds/appcds /test/lib
  * @build HelloString
  * @run driver/timeout=500 SharedStringsStress

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsWbTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsWbTest.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary White box test for shared strings
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @requires vm.gc == null
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build sun.hotspot.WhiteBox SharedStringsWb

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SysDictCrash.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SysDictCrash.java
@@ -26,7 +26,7 @@
  * @test
  * @summary Regression test for JDK-8098821
  * @bug 8098821
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @requires vm.gc == null
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @run driver SysDictCrash

--- a/test/hotspot/jtreg/runtime/cds/serviceability/ReplaceCriticalClassesForSubgraphs.java
+++ b/test/hotspot/jtreg/runtime/cds/serviceability/ReplaceCriticalClassesForSubgraphs.java
@@ -26,7 +26,7 @@
  * @test
  * @summary Tests how CDS works when critical library classes are replaced with JVMTI ClassFileLoadHook
  * @library /test/lib
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar whitebox.jar sun.hotspot.WhiteBox
  * @run main/othervm/native ReplaceCriticalClassesForSubgraphs

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -110,7 +110,7 @@ public class VMProps implements Callable<Map<String, String>> {
         // vm.cds is true if the VM is compiled with cds support.
         map.put("vm.cds", this::vmCDS);
         map.put("vm.cds.custom.loaders", this::vmCDSForCustomLoaders);
-        map.put("vm.cds.archived.java.heap", this::vmCDSForArchivedJavaHeap);
+        map.put("vm.cds.write.archived.java.heap", this::vmCDSCanWriteArchivedJavaHeap);
         // vm.graal.enabled is true if Graal is used as JIT
         map.put("vm.graal.enabled", this::isGraalEnabled);
         map.put("vm.compiler1.enabled", this::isCompiler1Enabled);
@@ -407,12 +407,10 @@ public class VMProps implements Callable<Map<String, String>> {
     }
 
     /**
-     * Check for CDS support for archived Java heap regions.
-     *
-     * @return true if CDS provides support for archive Java heap regions in the VM to be tested.
+     * @return true if this VM can write Java heap objects into the CDS archive
      */
-    protected String vmCDSForArchivedJavaHeap() {
-        return "" + ("true".equals(vmCDS()) && WB.isJavaHeapArchiveSupported());
+    protected String vmCDSCanWriteArchivedJavaHeap() {
+        return "" + ("true".equals(vmCDS()) && WB.canWriteJavaHeapArchive());
     }
 
     /**

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -595,7 +595,7 @@ public class WhiteBox {
   public native boolean isSharedInternedString(String s);
   public native boolean isCDSIncluded();
   public native boolean isJFRIncluded();
-  public native boolean isJavaHeapArchiveSupported();
+  public native boolean canWriteJavaHeapArchive();
   public native Object  getResolvedReferences(Class<?> c);
   public native void    linkClass(Class<?> c);
   public native boolean areOpenArchiveHeapObjectsMapped();

--- a/test/lib/sun/hotspot/WhiteBox.java
+++ b/test/lib/sun/hotspot/WhiteBox.java
@@ -596,7 +596,7 @@ public class WhiteBox {
   public native boolean isSharedInternedString(String s);
   public native boolean isCDSIncluded();
   public native boolean isJFRIncluded();
-  public native boolean isJavaHeapArchiveSupported();
+  public native boolean canWriteJavaHeapArchive();
   public native Object  getResolvedReferences(Class<?> c);
   public native void    linkClass(Class<?> c);
   public native boolean areOpenArchiveHeapObjectsMapped();


### PR DESCRIPTION
The vm.cds.archived.java.heap test property (see test/jtreg-ext/requires/VMProps.java) is ambiguous -- after JDK-8270489, there are now two distinct capabilities:

- HeapShared::can_write() -- G1 only
- HeapShared::can_read() -- G1, Epsilon

A few CDS tests are marked with

```
@requires vm.cds.archived.java.heap
```

These tests actually require the VM to be able to write Java objects into the CDS archive. Therefore, for clarify, they should be changed to use

```
@requires vm.cds.write.archived.java.heap
```

*****
This fix is required for JDK-8273508 - "Support archived heap objects in SerialGC".

Without this fix, tests marked with `@requires vm.cds.archived.java.heap` would be executed even if SerialGC is selected, but this will dump CDS archives without archived heap objects, causing the tests to fail.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273522](https://bugs.openjdk.java.net/browse/JDK-8273522): Rename test property vm.cds.archived.java.heap to vm.cds.write.archived.java.heap


### Reviewers
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5455/head:pull/5455` \
`$ git checkout pull/5455`

Update a local copy of the PR: \
`$ git checkout pull/5455` \
`$ git pull https://git.openjdk.java.net/jdk pull/5455/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5455`

View PR using the GUI difftool: \
`$ git pr show -t 5455`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5455.diff">https://git.openjdk.java.net/jdk/pull/5455.diff</a>

</details>
