### PR TITLE
8273402: Use derived NamingExceptions in com.sun.jndi.ldap.Connection#readReply

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
@@ -445,9 +445,6 @@ public final class Connection implements Runnable {
         } catch (InterruptedException ex) {
             throw new InterruptedNamingException(
                 "Interrupted during LDAP operation");
-        } catch (CommunicationException ce) {
-            // Re-throw
-            throw ce;
         } catch (IOException ioe) {
             // Connection is timed out OR closed/cancelled
             // getReplyBer throws IOException when the requests needs to be abandoned
@@ -460,7 +457,10 @@ public final class Connection implements Runnable {
         }
         // ioException can be not null in the following cases:
         //  a) The response is timed-out
-        //  b) LDAP request connection has been closed or cancelled
+        //  b) LDAP request connection has been closed
+        // If the request has been cancelled - CommunicationException is
+        // thrown directly from LdapRequest.getReplyBer, since there is no
+        // need to abandon request.
         // The exception message is initialized in LdapRequest::getReplyBer
         if (ioException != null) {
             // Throw CommunicationException after all cleanups are done

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapRequest.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,17 +103,17 @@ final class LdapRequest {
      * @param millis timeout, infinite if the value is negative
      * @return BerDecoder if reply was read successfully
      * @throws CommunicationException request has been canceled and request does not need to be abandoned
-     * @throws NamingException request has been closed or timed out. Request does need to be abandoned
-     * @throws InterruptedException LDAP operation has been interrupted
+     * @throws IOException            request has been closed or timed out. Request does need to be abandoned
+     * @throws InterruptedException   LDAP operation has been interrupted
      */
-    BerDecoder getReplyBer(long millis) throws NamingException,
+    BerDecoder getReplyBer(long millis) throws IOException, CommunicationException,
                                                InterruptedException {
         if (cancelled) {
             throw new CommunicationException("Request: " + msgId +
                 " cancelled");
         }
         if (isClosed()) {
-            throw new NamingException(CLOSE_MSG);
+            throw new IOException(CLOSE_MSG);
         }
 
         BerDecoder result = millis > 0 ?
@@ -126,11 +126,11 @@ final class LdapRequest {
 
         // poll from 'replies' blocking queue ended-up with timeout
         if (result == null) {
-            throw new NamingException(String.format(TIMEOUT_MSG_FMT, millis));
+            throw new IOException(String.format(TIMEOUT_MSG_FMT, millis));
         }
         // Unexpected EOF can be caused by connection closure or cancellation
         if (result == EOF) {
-            throw new NamingException(CLOSE_MSG);
+            throw new IOException(CLOSE_MSG);
         }
         return result;
     }


### PR DESCRIPTION
Hi,
The following fix changes type of exception thrown when an LDAP operation fails for reasons like read timeout or connection closure/cancellation: instead of throwing a general `NamingException`, the internal LDAP connection class will throw a [`CommunicationException`](https://github.com/openjdk/jdk/blob/master/src/java.naming/share/classes/javax/naming/CommunicationException.java#L29) that better matches the reasons described.

Testing shows no problem with the proposed fix.
