### PR TITLE
8273491: java.util.spi.LocaleServiceProvider spec contains statement that is too strict

### DIFF
--- a/src/java.base/share/classes/java/util/spi/LocaleServiceProvider.java
+++ b/src/java.base/share/classes/java/util/spi/LocaleServiceProvider.java
@@ -115,9 +115,9 @@ import java.util.Locale;
  * The search order of locale sensitive services can
  * be configured by using the {@systemProperty java.locale.providers} system property.
  * This system property declares the user's preferred order for looking up
- * the locale sensitive services separated by a comma. It is only read at
- * the Java runtime startup, so the later call to System.setProperty() won't
- * affect the order.
+ * the locale sensitive services separated by a comma. It is only read and cached at
+ * the initialization of this class, so the later call to
+ * {@link System#setProperty(String, String)} may not affect the order.
  * <p>
  * Java Runtime Environment provides the following four locale providers:
  * <ul>

--- a/src/java.base/share/classes/java/util/spi/LocaleServiceProvider.java
+++ b/src/java.base/share/classes/java/util/spi/LocaleServiceProvider.java
@@ -115,9 +115,11 @@ import java.util.Locale;
  * The search order of locale sensitive services can
  * be configured by using the {@systemProperty java.locale.providers} system property.
  * This system property declares the user's preferred order for looking up
- * the locale sensitive services separated by a comma. It is only read and cached at
- * the initialization of this class, so the later call to
- * {@link System#setProperty(String, String)} may not affect the order.
+ * the locale sensitive services separated by a comma. As this property value is
+ * read and cached only at the initialization of this class, users should specify the
+ * property on the java launcher command line. Setting it at runtime with
+ * {@link System#setProperty(String, String)} is discouraged and it may not affect
+ * the order.
  * <p>
  * Java Runtime Environment provides the following four locale providers:
  * <ul>


### PR DESCRIPTION
Small spec clarification. Corresponding CSR has also been drafted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273491](https://bugs.openjdk.java.net/browse/JDK-8273491): java.util.spi.LocaleServiceProvider spec contains statement that is too strict


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5457/head:pull/5457` \
`$ git checkout pull/5457`

Update a local copy of the PR: \
`$ git checkout pull/5457` \
`$ git pull https://git.openjdk.java.net/jdk pull/5457/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5457`

View PR using the GUI difftool: \
`$ git pr show -t 5457`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5457.diff">https://git.openjdk.java.net/jdk/pull/5457.diff</a>

</details>
