### PR TITLE
8273595: tools/jpackage tests do not work on apt-based Linux distros like Debian

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageType.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageType.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageType.java
@@ -119,6 +119,6 @@ public enum PackageType {
     private final static class Inner {
         private final static Set<String> DISABLED_PACKAGERS = Optional.ofNullable(
                 TKit.tokenizeConfigProperty("disabledPackagers")).orElse(
-                TKit.isUbuntu() ? Set.of("rpm") : Collections.emptySet());
+                TKit.isLinuxAPT() ? Set.of("rpm") : Collections.emptySet());
     }
 }

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
@@ -184,25 +184,12 @@ final public class TKit {
         return ((OS.contains("nix") || OS.contains("nux")));
     }
 
-    public static boolean isUbuntu() {
+    public static boolean isLinuxAPT() {
         if (!isLinux()) {
             return false;
         }
-        File releaseFile = new File("/etc/os-release");
-        if (releaseFile.exists()) {
-            try (BufferedReader lineReader = new BufferedReader(new FileReader(releaseFile))) {
-                String lineText = null;
-                while ((lineText = lineReader.readLine()) != null) {
-                    if (lineText.indexOf("NAME=\"Ubuntu") != -1) {
-                        lineReader.close();
-                        return true;
-                    }
-                }
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }
-        return false;
+        File aptFile = new File("/usr/bin/apt-get");
+        return aptFile.exists();
     }
 
     private static String addTimestamp(String msg) {

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
@@ -22,10 +22,8 @@
  */
 package jdk.jpackage.test;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.reflect.InvocationTargetException;


### PR DESCRIPTION
A similar issue on Ubuntu has been fixed by [JDK-8238953](https://bugs.openjdk.java.net/browse/JDK-8238953). However, tools/jpackage tests do not work on Debian Linux or other apt-based Linux, when rpm package is installed. This issue proposes a general fix for apt-based Linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273595](https://bugs.openjdk.java.net/browse/JDK-8273595): tools/jpackage tests do not work on apt-based Linux distros like Debian


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)


### Contributors
 * Sun Xu `<sunxu01@loongson.cn>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5462/head:pull/5462` \
`$ git checkout pull/5462`

Update a local copy of the PR: \
`$ git checkout pull/5462` \
`$ git pull https://git.openjdk.java.net/jdk pull/5462/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5462`

View PR using the GUI difftool: \
`$ git pr show -t 5462`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5462.diff">https://git.openjdk.java.net/jdk/pull/5462.diff</a>

</details>
