### PR TITLE
8273584: TypeElement.getSuperclass crashes for a record TypeElement when j.l.Record is not available

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
@@ -700,12 +700,12 @@ public class TypeEnter implements Completer {
             } else {
                 extending = null;
                 supertype = ((tree.mods.flags & Flags.ENUM) != 0)
-                ? attr.attribBase(enumBase(tree.pos, sym), baseEnv,
+                ? attr.attribBase(extending = enumBase(tree.pos, sym), baseEnv,
                                   true, false, false)
                 : (sym.fullname == names.java_lang_Object)
                 ? Type.noType
                 : sym.isRecord()
-                ? attr.attribBase(recordBase(tree.pos, sym), baseEnv,
+                ? attr.attribBase(extending = recordBase(tree.pos, sym), baseEnv,
                                   true, false, false)
                 : syms.objectType;
             }

--- a/test/langtools/tools/javac/records/RecordsErrorRecovery.java
+++ b/test/langtools/tools/javac/records/RecordsErrorRecovery.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8273584
+ * @summary Verify TypeElement.getSuperclass works for records when j.l.Record is unavailable
+ * @modules jdk.compiler
+ */
+
+import com.sun.source.tree.CompilationUnitTree;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.StreamSupport;
+import javax.lang.model.element.TypeElement;
+import javax.tools.JavaCompiler;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.ToolProvider;
+
+import com.sun.source.util.JavacTask;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.Trees;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.tools.ForwardingJavaFileManager;
+import javax.tools.JavaFileManager;
+import javax.tools.JavaFileObject;
+
+import static javax.tools.JavaFileObject.Kind.CLASS;
+import static javax.tools.JavaFileObject.Kind.SOURCE;
+
+public class RecordsErrorRecovery {
+    public static void main(String... args) throws IOException {
+        new RecordsErrorRecovery().getSuperclass();
+    }
+
+    public void getSuperclass() throws IOException {
+        JavaCompiler c = ToolProvider.getSystemJavaCompiler();
+        try (JavaFileManager fm = c.getStandardFileManager(null, null, null);
+             JavaFileManager filtering = new FilteringJavaFileManager(fm)) {
+            for (String code : new String[] {"record R(String s) {}", "enum E {A}"}) {
+                JavacTask t = (JavacTask) c.getTask(null, filtering, null, null, null,
+                        List.of(new MyFileObject(code)));
+                CompilationUnitTree cut = t.parse().iterator().next();
+
+                t.analyze();
+
+                Trees trees = Trees.instance(t);
+                TreePath tp = new TreePath(new TreePath(cut), cut.getTypeDecls().get(0));
+                TypeElement record = (TypeElement) trees.getElement(tp);
+                TypeMirror superclass = record.getSuperclass();
+
+                if (superclass.getKind() != TypeKind.ERROR) {
+                    throw new AssertionError("Unexpected superclass!");
+                }
+            }
+        }
+    }
+
+    class MyFileObject extends SimpleJavaFileObject {
+        private final String code;
+
+        MyFileObject(String code) {
+            super(URI.create("myfo:///Test.java"), SOURCE);
+            this.code = code;
+        }
+
+        @Override
+        public String getCharContent(boolean ignoreEncodingErrors) {
+            return code;
+        }
+
+    }
+
+    private static final class FilteringJavaFileManager extends ForwardingJavaFileManager<JavaFileManager> {
+
+        public FilteringJavaFileManager(JavaFileManager fileManager) {
+            super(fileManager);
+        }
+
+        @Override
+        public Iterable<JavaFileObject> list(JavaFileManager.Location location,
+                                             String packageName,
+                                             Set<JavaFileObject.Kind> kinds,
+                                             boolean recurse) throws IOException {
+            Iterable<JavaFileObject> files = super.list(location, packageName, kinds, recurse);
+
+            if ("java.lang".equals(packageName)) {
+                files = StreamSupport.stream(files.spliterator(), false)
+                                     .filter(fo -> !fo.isNameCompatible("Record", CLASS))
+                                     .filter(fo -> !fo.isNameCompatible("Enum", CLASS))
+                                     .toList();
+            }
+            return files;
+        }
+
+    }
+}


### PR DESCRIPTION
After JDK-8273263, calling TypeElement.getSuperclass may fail on a record when j.l.Record is not available, because the method will try to synthesize the type based on treee, but the tree is not filled. The proposal is to fill in the tree.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273584](https://bugs.openjdk.java.net/browse/JDK-8273584): TypeElement.getSuperclass crashes for a record TypeElement when j.l.Record is not available


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5465/head:pull/5465` \
`$ git checkout pull/5465`

Update a local copy of the PR: \
`$ git checkout pull/5465` \
`$ git pull https://git.openjdk.java.net/jdk pull/5465/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5465`

View PR using the GUI difftool: \
`$ git pr show -t 5465`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5465.diff">https://git.openjdk.java.net/jdk/pull/5465.diff</a>

</details>
