### PR TITLE
8273599: Remove cross_threshold method usage around GC

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
@@ -405,9 +405,8 @@ void G1BlockOffsetTablePart::zero_bottom_entry_raw() {
   _bot->set_offset_array_raw(bottom_index, 0);
 }
 
-HeapWord* G1BlockOffsetTablePart::initialize_threshold() {
+void G1BlockOffsetTablePart::initialize_threshold() {
   _next_offset_threshold = _hr->bottom() + BOTConstants::N_words;
-  return _next_offset_threshold;
 }
 
 void G1BlockOffsetTablePart::set_for_starts_humongous(HeapWord* obj_top, size_t fill_size) {

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -193,7 +193,7 @@ public:
 
   // Initialize the threshold to reflect the first boundary after the
   // bottom of the covered region.
-  HeapWord* initialize_threshold();
+  void initialize_threshold();
 
   void reset_bot() {
     zero_bottom_entry_raw();

--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -154,7 +154,7 @@ public:
 
     HeapWord* obj_end = obj_addr + obj_size;
     _last_forwarded_object_end = obj_end;
-    _hr->cross_threshold(obj_addr, obj_end);
+    _hr->alloc_block_in_bot(obj_addr, obj_end);
   }
 
   // Fill the memory area from start to end with filler objects, and update the BOT
@@ -170,13 +170,13 @@ public:
       CollectedHeap::fill_with_objects(start, gap_size);
 
       HeapWord* end_first_obj = start + cast_to_oop(start)->size();
-      _hr->cross_threshold(start, end_first_obj);
+      _hr->alloc_block_in_bot(start, end_first_obj);
       // Fill_with_objects() may have created multiple (i.e. two)
       // objects, as the max_fill_size() is half a region.
       // After updating the BOT for the first object, also update the
       // BOT for the second object to make the BOT complete.
       if (end_first_obj != end) {
-        _hr->cross_threshold(end_first_obj, end);
+        _hr->alloc_block_in_bot(end_first_obj, end);
 #ifdef ASSERT
         size_t size_second_obj = cast_to_oop(end_first_obj)->size();
         HeapWord* end_of_second_obj = end_first_obj + size_second_obj;

--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -115,47 +115,46 @@ public:
     HeapWord* obj_addr = cast_from_oop<HeapWord*>(obj);
     assert(_hr->is_in(obj_addr), "sanity");
 
-    if (obj->is_forwarded() && obj->forwardee() == obj) {
-      // The object failed to move.
+    // The object failed to move.
+    assert(obj->is_forwarded() && obj->forwardee() == obj, "sanity");
 
-      zap_dead_objects(_last_forwarded_object_end, obj_addr);
-      // We consider all objects that we find self-forwarded to be
-      // live. What we'll do is that we'll update the prev marking
-      // info so that they are all under PTAMS and explicitly marked.
-      if (!_cm->is_marked_in_prev_bitmap(obj)) {
-        _cm->mark_in_prev_bitmap(obj);
-      }
-      if (_during_concurrent_start) {
-        // For the next marking info we'll only mark the
-        // self-forwarded objects explicitly if we are during
-        // concurrent start (since, normally, we only mark objects pointed
-        // to by roots if we succeed in copying them). By marking all
-        // self-forwarded objects we ensure that we mark any that are
-        // still pointed to be roots. During concurrent marking, and
-        // after concurrent start, we don't need to mark any objects
-        // explicitly and all objects in the CSet are considered
-        // (implicitly) live. So, we won't mark them explicitly and
-        // we'll leave them over NTAMS.
-        _cm->mark_in_next_bitmap(_worker_id, _hr, obj);
-      }
-      size_t obj_size = obj->size();
-
-      _marked_bytes += (obj_size * HeapWordSize);
-      PreservedMarks::init_forwarded_mark(obj);
-
-      // During evacuation failure we do not record inter-region
-      // references referencing regions that need a remembered set
-      // update originating from young regions (including eden) that
-      // failed evacuation. Make up for that omission now by rescanning
-      // these failed objects.
-      if (_is_young) {
-        obj->oop_iterate(_log_buffer_cl);
-      }
-
-      HeapWord* obj_end = obj_addr + obj_size;
-      _last_forwarded_object_end = obj_end;
-      _hr->cross_threshold(obj_addr, obj_end);
+    zap_dead_objects(_last_forwarded_object_end, obj_addr);
+    // We consider all objects that we find self-forwarded to be
+    // live. What we'll do is that we'll update the prev marking
+    // info so that they are all under PTAMS and explicitly marked.
+    if (!_cm->is_marked_in_prev_bitmap(obj)) {
+      _cm->mark_in_prev_bitmap(obj);
     }
+    if (_during_concurrent_start) {
+      // For the next marking info we'll only mark the
+      // self-forwarded objects explicitly if we are during
+      // concurrent start (since, normally, we only mark objects pointed
+      // to by roots if we succeed in copying them). By marking all
+      // self-forwarded objects we ensure that we mark any that are
+      // still pointed to be roots. During concurrent marking, and
+      // after concurrent start, we don't need to mark any objects
+      // explicitly and all objects in the CSet are considered
+      // (implicitly) live. So, we won't mark them explicitly and
+      // we'll leave them over NTAMS.
+      _cm->mark_in_next_bitmap(_worker_id, _hr, obj);
+    }
+    size_t obj_size = obj->size();
+
+    _marked_bytes += (obj_size * HeapWordSize);
+    PreservedMarks::init_forwarded_mark(obj);
+
+    // During evacuation failure we do not record inter-region
+    // references referencing regions that need a remembered set
+    // update originating from young regions (including eden) that
+    // failed evacuation. Make up for that omission now by rescanning
+    // these failed objects.
+    if (_is_young) {
+      obj->oop_iterate(_log_buffer_cl);
+    }
+
+    HeapWord* obj_end = obj_addr + obj_size;
+    _last_forwarded_object_end = obj_end;
+    _hr->cross_threshold(obj_addr, obj_end);
   }
 
   // Fill the memory area from start to end with filler objects, and update the BOT
@@ -229,7 +228,8 @@ public:
                                         &_log_buffer_cl,
                                         during_concurrent_start,
                                         _worker_id);
-    hr->object_iterate(&rspc);
+    // Iterates evac failure objs which are recorded during evacuation.
+    hr->iterate_evac_failure_objs(&rspc);
     // Need to zap the remainder area of the processed region.
     rspc.zap_remainder();
 

--- a/src/hotspot/share/gc/g1/g1EvacuationFailureObjsInHR.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacuationFailureObjsInHR.cpp
@@ -80,17 +80,17 @@ void G1EvacuationFailureObjsInHR::iterate_internal(ObjectClosure* closure) {
 }
 
 G1EvacuationFailureObjsInHR::G1EvacuationFailureObjsInHR(uint region_idx, HeapWord* bottom) :
-  _max_offset(1u << HeapRegion::LogOfHRGrainBytes-LogHeapWordSize),
+  _max_offset(1u << (HeapRegion::LogOfHRGrainBytes-LogHeapWordSize)),
   _region_idx(region_idx),
   _bottom(bottom),
-  _nodes_array(HeapRegion::GrainWords / NODE_LENGTH + 1),
-  _offset_array(NULL),
-  _objs_num(0u) {
+  _nodes_array(HeapRegion::GrainWords / NODE_LENGTH + 2),
+  _offset_array(NULL) {
+  _objs_num = 0;
   assert(HeapRegion::LogOfHRGrainBytes < 32, "must be");
 }
 
 G1EvacuationFailureObjsInHR::~G1EvacuationFailureObjsInHR() {
-  clear_array();
+  assert(_offset_array == NULL, "must be");
 }
 
 void G1EvacuationFailureObjsInHR::record(oop obj) {

--- a/src/hotspot/share/gc/g1/g1EvacuationFailureObjsInHR.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacuationFailureObjsInHR.cpp
@@ -24,98 +24,85 @@
 
 #include "precompiled.hpp"
 #include "g1EvacuationFailureObjsInHR.hpp"
+#include "gc/g1/g1CollectedHeap.hpp"
+#include "gc/g1/heapRegion.hpp"
+#include "gc/g1/heapRegion.inline.hpp"
 #include "utilities/quickSort.hpp"
 
 
-static intptr_t order_oop(oop a, oop b) {
-  return static_cast<intptr_t>(a-b);
+
+// === G1EvacuationFailureObjsInHR ===
+
+void G1EvacuationFailureObjsInHR::visit(Elem elem) {
+  uint32_t offset = elem;
+  _offset_array[_objs_num++] = offset;
+}
+
+void G1EvacuationFailureObjsInHR::visit(Array<NODE_LENGTH, Elem>::NODE_XXX* node, uint32_t limit) {
+  ::memcpy(&_offset_array[_objs_num], node->_oop_offsets, limit * sizeof(Elem));
+  _objs_num += limit;
 }
 
 void G1EvacuationFailureObjsInHR::compact() {
-  assert(_oop_array == NULL, "Must be");
-  _oop_array = NEW_C_HEAP_ARRAY(oop, _objs_num, mtGC);
-  Node* cur = _head._next;
-  uint i = 0;
-  while (cur != NULL) {
-    assert(cur->_obj != NULL, "Must be");
-    _oop_array[i++] = cur->_obj;
-    cur = cur->_next;
-  }
-  clear_list();
+  assert(_offset_array == NULL, "must be");
+  _offset_array = NEW_C_HEAP_ARRAY(Elem, _nodes_array.objs_num(), mtGC);
+  // _nodes_array.iterate_elements(this);
+  _nodes_array.iterate_nodes(this);
+  uint expected = _nodes_array.objs_num();
+  assert(_objs_num == expected, "must be %u, %u", _objs_num, expected);
+  _nodes_array.reset();
+}
+
+static int32_t order_oop(G1EvacuationFailureObjsInHR::Elem a,
+                         G1EvacuationFailureObjsInHR::Elem b) {
+  // assert(a != b, "must be");
+  int r = a-b;
+  return r;
 }
 
 void G1EvacuationFailureObjsInHR::sort() {
-  QuickSort::sort(_oop_array, _objs_num, order_oop, true);
+  QuickSort::sort(_offset_array, _objs_num, order_oop, true);
+}
+
+void G1EvacuationFailureObjsInHR::clear_array() {
+  FREE_C_HEAP_ARRAY(oop, _offset_array);
+  _offset_array = NULL;
+  _objs_num = 0;
 }
 
 void G1EvacuationFailureObjsInHR::iterate_internal(ObjectClosure* closure) {
-  oop prev = NULL;
+  Elem prev = 0;
   for (uint i = 0; i < _objs_num; i++) {
-    assert(prev < _oop_array[i], "sanity");
-    closure->do_object(prev = _oop_array[i]);
+    assert(prev < _offset_array[i], "must be");
+    closure->do_object(cast_from_offset(prev = _offset_array[i]));
   }
   clear_array();
 }
 
-void G1EvacuationFailureObjsInHR::clear_list() {
-  DEBUG_ONLY(uint i = _objs_num);
-  Node* cur = _head._next;
-  _head._next = NULL;
-
-  while (cur != NULL) {
-    Node* next = cur->_next;
-    cur->_next = NULL;
-    delete cur;
-    cur = next;
-    DEBUG_ONLY(i--);
-  }
-  assert(i == 0, "Must be, %u", i);
-}
-
-void G1EvacuationFailureObjsInHR::clear_array() {
-  FREE_C_HEAP_ARRAY(oop, _oop_array);
-  _oop_array = NULL;
-  _objs_num = 0;
-}
-
-void G1EvacuationFailureObjsInHR::reset() {
-  Atomic::store(&_tail, &_head);
-}
-
-G1EvacuationFailureObjsInHR::G1EvacuationFailureObjsInHR(uint region_idx) :
+G1EvacuationFailureObjsInHR::G1EvacuationFailureObjsInHR(uint region_idx, HeapWord* bottom) :
+  offset_mask((1l << HeapRegion::LogOfHRGrainBytes) - 1),
   _region_idx(region_idx),
-  _objs_num(0),
-  _oop_array(NULL) {
-  reset();
+  _bottom(bottom),
+  _nodes_array(HeapRegion::GrainWords / NODE_LENGTH + 1),
+  _offset_array(NULL),
+  _objs_num(0) {
 }
 
 G1EvacuationFailureObjsInHR::~G1EvacuationFailureObjsInHR() {
-  clear_list();
   clear_array();
 }
 
 void G1EvacuationFailureObjsInHR::record(oop obj) {
-  assert(obj != NULL, "Must be");
-  Node* new_one = new Node(obj);
-  while (true) {
-    Node* t = Atomic::load(&_tail);
-    Node* next = Atomic::load(&t->_next);
-    while (next != NULL) {
-      t = next;
-      next = Atomic::load(&next->_next);
-    }
-    Node* old_one = Atomic::cmpxchg(&t->_next, (Node*)NULL, new_one);
-    if (old_one == NULL) {
-      Atomic::store(&_tail, new_one);
-      Atomic::inc(&_objs_num);
-      break;
-    }
-  }
+  assert(obj != NULL, "must be");
+  assert(G1CollectedHeap::heap()->heap_region_containing(obj)->hrm_index() == _region_idx, "must be");
+  Elem offset = cast_from_oop_addr(obj);
+  assert(obj == cast_from_offset(offset), "must be");
+  assert(offset < (1<<25), "must be");
+  _nodes_array.add(offset);
 }
 
 void G1EvacuationFailureObjsInHR::iterate(ObjectClosure* closure) {
   compact();
   sort();
   iterate_internal(closure);
-  reset();
 }

--- a/src/hotspot/share/gc/g1/g1EvacuationFailureObjsInHR.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacuationFailureObjsInHR.cpp
@@ -69,7 +69,7 @@ void G1EvacuationFailureObjsInHR::clear_list() {
     cur = next;
     DEBUG_ONLY(i--);
   }
-  assert(i == 0, "Must be");
+  assert(i == 0, "Must be, %u", i);
 }
 
 void G1EvacuationFailureObjsInHR::clear_array() {
@@ -78,11 +78,15 @@ void G1EvacuationFailureObjsInHR::clear_array() {
   _objs_num = 0;
 }
 
+void G1EvacuationFailureObjsInHR::reset() {
+  Atomic::store(&_tail, &_head);
+}
+
 G1EvacuationFailureObjsInHR::G1EvacuationFailureObjsInHR(uint region_idx) :
   _region_idx(region_idx),
   _objs_num(0),
   _oop_array(NULL) {
-  Atomic::store(&_tail, &_head);
+  reset();
 }
 
 G1EvacuationFailureObjsInHR::~G1EvacuationFailureObjsInHR() {
@@ -113,4 +117,5 @@ void G1EvacuationFailureObjsInHR::iterate(ObjectClosure* closure) {
   compact();
   sort();
   iterate_internal(closure);
+  reset();
 }

--- a/src/hotspot/share/gc/g1/g1EvacuationFailureObjsInHR.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacuationFailureObjsInHR.cpp
@@ -80,12 +80,13 @@ void G1EvacuationFailureObjsInHR::iterate_internal(ObjectClosure* closure) {
 }
 
 G1EvacuationFailureObjsInHR::G1EvacuationFailureObjsInHR(uint region_idx, HeapWord* bottom) :
-  _max_offset(1u << (HeapRegion::LogOfHRGrainBytes-LogHeapWordSize)),
+  _max_offset(static_cast<Elem>(1u << (HeapRegion::LogOfHRGrainBytes-LogHeapWordSize))),
   _region_idx(region_idx),
   _bottom(bottom),
   _nodes_array(HeapRegion::GrainWords / NODE_LENGTH + 2),
-  _offset_array(NULL) {
-  _objs_num = 0;
+  _offset_array(NULL),
+  _objs_num(0)
+  {
   assert(HeapRegion::LogOfHRGrainBytes < 32, "must be");
 }
 

--- a/src/hotspot/share/gc/g1/g1EvacuationFailureObjsInHR.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacuationFailureObjsInHR.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2021, Huawei and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "g1EvacuationFailureObjsInHR.hpp"
+#include "utilities/quickSort.hpp"
+
+
+static intptr_t order_oop(oop a, oop b) {
+  return static_cast<intptr_t>(a-b);
+}
+
+void G1EvacuationFailureObjsInHR::compact() {
+  assert(_oop_array == NULL, "Must be");
+  _oop_array = NEW_C_HEAP_ARRAY(oop, _objs_num, mtGC);
+  Node* cur = _head._next;
+  uint i = 0;
+  while (cur != NULL) {
+    assert(cur->_obj != NULL, "Must be");
+    _oop_array[i++] = cur->_obj;
+    cur = cur->_next;
+  }
+  clear_list();
+}
+
+void G1EvacuationFailureObjsInHR::sort() {
+  QuickSort::sort(_oop_array, _objs_num, order_oop, true);
+}
+
+void G1EvacuationFailureObjsInHR::iterate_internal(ObjectClosure* closure) {
+  oop prev = NULL;
+  for (uint i = 0; i < _objs_num; i++) {
+    assert(prev < _oop_array[i], "sanity");
+    closure->do_object(prev = _oop_array[i]);
+  }
+  clear_array();
+}
+
+void G1EvacuationFailureObjsInHR::clear_list() {
+  DEBUG_ONLY(uint i = _objs_num);
+  Node* cur = _head._next;
+  _head._next = NULL;
+
+  while (cur != NULL) {
+    Node* next = cur->_next;
+    cur->_next = NULL;
+    delete cur;
+    cur = next;
+    DEBUG_ONLY(i--);
+  }
+  assert(i == 0, "Must be");
+}
+
+void G1EvacuationFailureObjsInHR::clear_array() {
+  FREE_C_HEAP_ARRAY(oop, _oop_array);
+  _oop_array = NULL;
+  _objs_num = 0;
+}
+
+G1EvacuationFailureObjsInHR::G1EvacuationFailureObjsInHR(uint region_idx) :
+  _region_idx(region_idx),
+  _objs_num(0),
+  _oop_array(NULL) {
+  Atomic::store(&_tail, &_head);
+}
+
+G1EvacuationFailureObjsInHR::~G1EvacuationFailureObjsInHR() {
+  clear_list();
+  clear_array();
+}
+
+void G1EvacuationFailureObjsInHR::record(oop obj) {
+  assert(obj != NULL, "Must be");
+  Node* new_one = new Node(obj);
+  while (true) {
+    Node* t = Atomic::load(&_tail);
+    Node* next = Atomic::load(&t->_next);
+    while (next != NULL) {
+      t = next;
+      next = Atomic::load(&next->_next);
+    }
+    Node* old_one = Atomic::cmpxchg(&t->_next, (Node*)NULL, new_one);
+    if (old_one == NULL) {
+      Atomic::store(&_tail, new_one);
+      Atomic::inc(&_objs_num);
+      break;
+    }
+  }
+}
+
+void G1EvacuationFailureObjsInHR::iterate(ObjectClosure* closure) {
+  compact();
+  sort();
+  iterate_internal(closure);
+}

--- a/src/hotspot/share/gc/g1/g1EvacuationFailureObjsInHR.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacuationFailureObjsInHR.cpp
@@ -53,11 +53,9 @@ void G1EvacuationFailureObjsInHR::compact() {
   _nodes_array.reset();
 }
 
-static int32_t order_oop(G1EvacuationFailureObjsInHR::Elem a,
-                         G1EvacuationFailureObjsInHR::Elem b) {
-  // assert(a != b, "must be");
-  int r = a-b;
-  return r;
+static int order_oop(G1EvacuationFailureObjsInHR::Elem a,
+                     G1EvacuationFailureObjsInHR::Elem b) {
+  return static_cast<int>(a-b);
 }
 
 void G1EvacuationFailureObjsInHR::sort() {
@@ -80,12 +78,12 @@ void G1EvacuationFailureObjsInHR::iterate_internal(ObjectClosure* closure) {
 }
 
 G1EvacuationFailureObjsInHR::G1EvacuationFailureObjsInHR(uint region_idx, HeapWord* bottom) :
-  offset_mask((1l << HeapRegion::LogOfHRGrainBytes) - 1),
   _region_idx(region_idx),
   _bottom(bottom),
   _nodes_array(HeapRegion::GrainWords / NODE_LENGTH + 1),
   _offset_array(NULL),
   _objs_num(0) {
+  assert(HeapRegion::LogOfHRGrainBytes < 32, "must be");
 }
 
 G1EvacuationFailureObjsInHR::~G1EvacuationFailureObjsInHR() {

--- a/src/hotspot/share/gc/g1/g1EvacuationFailureObjsInHR.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacuationFailureObjsInHR.cpp
@@ -83,10 +83,9 @@ G1EvacuationFailureObjsInHR::G1EvacuationFailureObjsInHR(uint region_idx, HeapWo
   _max_offset(static_cast<Elem>(1u << (HeapRegion::LogOfHRGrainBytes-LogHeapWordSize))),
   _region_idx(region_idx),
   _bottom(bottom),
-  _nodes_array(HeapRegion::GrainWords / NODE_LENGTH + 2),
+  _nodes_array(static_cast<uint32_t>(HeapRegion::GrainWords) / NODE_LENGTH + 2u),
   _offset_array(NULL),
-  _objs_num(0)
-  {
+  _objs_num(0) {
   assert(HeapRegion::LogOfHRGrainBytes < 32, "must be");
 }
 

--- a/src/hotspot/share/gc/g1/g1EvacuationFailureObjsInHR.hpp
+++ b/src/hotspot/share/gc/g1/g1EvacuationFailureObjsInHR.hpp
@@ -36,6 +36,9 @@ class G1EvacuationFailureObjsInHR {
   template<uint32_t LEN, typename Elem>
   class Array;
 
+
+  // === Node ===
+
   template<uint32_t LEN, typename Elem>
   class Node : public CHeapObj<mtGC>{
     friend G1EvacuationFailureObjsInHR;
@@ -61,6 +64,9 @@ class G1EvacuationFailureObjsInHR {
       delete(node);
     }
   };
+
+
+  // === Array ===
 
   template<uint32_t NODE_SIZE, typename Elem>
   class Array : public CHeapObj<mtGC> {
@@ -191,11 +197,15 @@ class G1EvacuationFailureObjsInHR {
     }
   };
 
+
+  // === G1EvacuationFailureObjsInHR ===
+
 public:
   typedef uint32_t Elem;
 
 private:
   static const uint32_t NODE_LENGTH = 256;
+  const Elem _max_offset;
   const uint _region_idx;
   const HeapWord* _bottom;
   Array<NODE_LENGTH, Elem> _nodes_array;

--- a/src/hotspot/share/gc/g1/g1EvacuationFailureObjsInHR.hpp
+++ b/src/hotspot/share/gc/g1/g1EvacuationFailureObjsInHR.hpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021, Huawei and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_GC_G1_G1EVACUATIONFAILUREOBJSINHR_HPP
+#define SHARE_GC_G1_G1EVACUATIONFAILUREOBJSINHR_HPP
+
+#include "memory/iterator.hpp"
+#include "oops/oop.hpp"
+
+// This class
+//   1. records the objects per region which have failed to evacuate.
+//   2. speeds up removing self forwarded ptrs in post evacuation phase.
+//
+class G1EvacuationFailureObjsInHR {
+  class Node : public CHeapObj<mtGC>{
+    friend G1EvacuationFailureObjsInHR;
+  private:
+    Node* volatile _next;
+    oop _obj;
+  public:
+    Node(oop obj = NULL) : _next(NULL), _obj(obj) {}
+  };
+
+private:
+  uint _region_idx;
+  Node  _head;
+  Node* volatile _tail;
+  uint _objs_num;
+  oop* _oop_array;
+
+private:
+  void compact();
+  void sort();
+  void iterate_internal(ObjectClosure* closure);
+  void clear_list();
+  void clear_array();
+
+public:
+  G1EvacuationFailureObjsInHR(uint region_idx);
+  ~G1EvacuationFailureObjsInHR();
+
+  void record(oop obj);
+  void iterate(ObjectClosure* closure);
+};
+
+
+#endif //SHARE_GC_G1_G1EVACUATIONFAILUREOBJSINHR_HPP

--- a/src/hotspot/share/gc/g1/g1EvacuationFailureObjsInHR.hpp
+++ b/src/hotspot/share/gc/g1/g1EvacuationFailureObjsInHR.hpp
@@ -43,7 +43,7 @@ class G1EvacuationFailureObjsInHR {
   };
 
 private:
-  uint _region_idx;
+  const uint _region_idx;
   Node  _head;
   Node* volatile _tail;
   uint _objs_num;
@@ -55,6 +55,7 @@ private:
   void iterate_internal(ObjectClosure* closure);
   void clear_list();
   void clear_array();
+  void reset();
 
 public:
   G1EvacuationFailureObjsInHR(uint region_idx);

--- a/src/hotspot/share/gc/g1/g1EvacuationFailureObjsInHR.hpp
+++ b/src/hotspot/share/gc/g1/g1EvacuationFailureObjsInHR.hpp
@@ -33,32 +33,192 @@
 //   2. speeds up removing self forwarded ptrs in post evacuation phase.
 //
 class G1EvacuationFailureObjsInHR {
+  template<uint32_t LEN, typename Elem>
+  class Array;
+
+  template<uint32_t LEN, typename Elem>
   class Node : public CHeapObj<mtGC>{
     friend G1EvacuationFailureObjsInHR;
+    friend Array<LEN, Elem>;
+
   private:
-    Node* volatile _next;
-    oop _obj;
+    static const uint32_t LENGTH = LEN;
+    static const size_t SIZE = LENGTH * sizeof(Elem);
+    Elem* _oop_offsets;
+
   public:
-    Node(oop obj = NULL) : _next(NULL), _obj(obj) {}
+    Node() {
+      _oop_offsets = (Elem*)AllocateHeap(SIZE, mtGC);
+    }
+    Elem& operator[] (size_t idx) {
+      return _oop_offsets[idx];
+    }
+    static Node<LEN, Elem>* create_node() {
+      return new Node<LEN, Elem>();
+    }
+    static void free_node(Node<LEN, Elem>* node) {
+      FreeHeap(node->_oop_offsets);
+      delete(node);
+    }
   };
 
-private:
-  const uint _region_idx;
-  Node  _head;
-  Node* volatile _tail;
-  uint _objs_num;
-  oop* _oop_array;
+  template<uint32_t NODE_SIZE, typename Elem>
+  class Array : public CHeapObj<mtGC> {
+  public:
+    typedef Node<NODE_SIZE, Elem> NODE_XXX;
 
-private:
-  void compact();
-  void sort();
-  void iterate_internal(ObjectClosure* closure);
-  void clear_list();
-  void clear_array();
-  void reset();
+  private:
+    static const uint64_t TMP = 1l << 32;
+    static const uint64_t LOW_MASK = TMP - 1;
+    static const uint64_t HIGH_MASK = LOW_MASK << 32;
+    const uint32_t _max_nodes_length;
+
+    volatile uint64_t _cur_pos;
+    NODE_XXX* volatile * _nodes;
+    volatile uint _elements_num;
+
+  private:
+    uint64_t low(uint64_t n) {
+      return (n & LOW_MASK);
+    }
+    uint64_t high(uint64_t n) {
+      return (n & HIGH_MASK);
+    }
+    uint32_t elem_index(uint64_t n) {
+      assert(low(n) < NODE_XXX::LENGTH, "must be");
+      return low(n);
+    }
+    uint32_t node_index(uint64_t n) {
+      return high(n) >> 32;
+    }
+
+    uint64_t next(uint64_t n) {
+      uint64_t lo = low(n);
+      uint64_t hi = high(n);
+      assert((lo < NODE_XXX::LENGTH) && (NODE_XXX::LENGTH <= LOW_MASK), "must be");
+      assert(hi < HIGH_MASK, "must be");
+      if ((lo+1) == NODE_XXX::LENGTH) {
+        lo = 0;
+        hi += (1l << 32);
+      } else {
+        lo++;
+      }
+      assert(hi <= HIGH_MASK, "must be");
+      return hi | lo;
+    }
+
+  public:
+    Array(uint32_t max_nodes_length) : _max_nodes_length(max_nodes_length) {
+      _nodes = (NODE_XXX**)AllocateHeap(_max_nodes_length * sizeof(NODE_XXX*), mtGC);
+      for (uint32_t i = 0; i < _max_nodes_length; i++) {
+        Atomic::store(&_nodes[i], (NODE_XXX *)NULL);
+      }
+
+      Atomic::store(&_elements_num, 0u);
+      Atomic::store(&_cur_pos, (uint64_t)0);
+    }
+
+    ~Array() {
+      reset();
+      FreeHeap((NODE_XXX**)_nodes);
+    }
+
+    uint objs_num() {
+      return Atomic::load(&_elements_num);
+    }
+
+    void add(Elem elem) {
+      while (true) {
+        uint64_t pos = Atomic::load(&_cur_pos);
+        uint64_t next_pos = next(pos);
+        uint64_t res = Atomic::cmpxchg(&_cur_pos, pos, next_pos);
+        if (res == pos) {
+          uint32_t hi = node_index(pos);
+          uint32_t lo = elem_index(pos);
+          if (lo == 0) {
+            Atomic::store(&_nodes[hi], NODE_XXX::create_node());
+          }
+          NODE_XXX* node = NULL;
+          while ((node = Atomic::load(&_nodes[hi])) == NULL);
+
+          node->operator[](lo) = elem;
+          Atomic::inc(&_elements_num);
+          break;
+        }
+      }
+    }
+
+    template<typename VISITOR>
+    void iterate_elements(VISITOR v) {
+      int64_t pos = Atomic::load(&_cur_pos);
+      DEBUG_ONLY(uint total = 0);
+      uint32_t hi = node_index(pos);
+      uint32_t lo = elem_index(pos);
+      for (uint32_t i = 0; i <= hi; i++) {
+        uint32_t limit = (i == hi) ? lo : NODE_XXX::LENGTH;
+        NODE_XXX* node = Atomic::load(&_nodes[i]);
+        for (uint32_t j = 0; j < limit; j++) {
+          v->visit(node->operator[](j));
+          DEBUG_ONLY(total++);
+        }
+      }
+      assert(total == Atomic::load(&_elements_num), "must be");
+    }
+
+    template<typename VISITOR>
+    void iterate_nodes(VISITOR v) {
+      int64_t pos = Atomic::load(&_cur_pos);
+      uint32_t hi = node_index(pos);
+      uint32_t lo = elem_index(pos);
+      for (uint32_t i = 0; i <= hi; i++) {
+        NODE_XXX* node = Atomic::load(&_nodes[i]);
+        uint32_t limit = (i == hi) ? lo : NODE_XXX::LENGTH;
+        v->visit(node, limit);
+      }
+    }
+
+    void reset() {
+      int64_t pos = Atomic::load(&_cur_pos);
+      for (uint32_t hi = 0; hi <= node_index(pos); hi++) {
+        NODE_XXX::free_node(_nodes[hi]);
+        Atomic::store(&_nodes[hi], (NODE_XXX *)NULL);
+      }
+      Atomic::store(&_elements_num, 0u);
+      Atomic::store(&_cur_pos, (uint64_t)0);
+    }
+  };
 
 public:
-  G1EvacuationFailureObjsInHR(uint region_idx);
+  typedef uint32_t Elem;
+
+private:
+  static const uint32_t NODE_LENGTH = 256;
+  const uint64_t offset_mask;
+  const uint _region_idx;
+  const HeapWord* _bottom;
+  Array<NODE_LENGTH, Elem> _nodes_array;
+  Elem* _offset_array;
+  uint _objs_num;
+
+private:
+  oop cast_from_offset(Elem offset) {
+    return oop(_bottom + offset);
+  }
+  Elem cast_from_oop_addr(oop obj) {
+    const HeapWord* o = cast_from_oop<const HeapWord*>(obj);
+    size_t offset = pointer_delta(o, _bottom);
+    assert(offset_mask >= offset, "must be");
+    return offset & offset_mask;
+  }
+  void visit(Elem);
+  void visit(Array<NODE_LENGTH, Elem>::NODE_XXX* node, uint32_t limit);
+  void compact();
+  void sort();
+  void clear_array();
+  void iterate_internal(ObjectClosure* closure);
+
+public:
+  G1EvacuationFailureObjsInHR(uint region_idx, HeapWord* bottom);
   ~G1EvacuationFailureObjsInHR();
 
   void record(oop obj);

--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
@@ -30,7 +30,6 @@
 
 G1FullGCCompactionPoint::G1FullGCCompactionPoint() :
     _current_region(NULL),
-    _threshold(NULL),
     _compaction_top(NULL) {
   _compaction_regions = new (ResourceObj::C_HEAP, mtGC) GrowableArray<HeapRegion*>(32, mtGC);
   _compaction_region_iterator = _compaction_regions->begin();
@@ -49,7 +48,7 @@ void G1FullGCCompactionPoint::update() {
 void G1FullGCCompactionPoint::initialize_values(bool init_threshold) {
   _compaction_top = _current_region->compaction_top();
   if (init_threshold) {
-    _threshold = _current_region->initialize_threshold();
+    _current_region->initialize_bot_threshold();
   }
 }
 
@@ -123,9 +122,7 @@ void G1FullGCCompactionPoint::forward(oop object, size_t size) {
 
   // Update compaction values.
   _compaction_top += size;
-  if (_compaction_top > _threshold) {
-    _threshold = _current_region->cross_threshold(_compaction_top - size, _compaction_top);
-  }
+  _current_region->alloc_block_in_bot(_compaction_top - size, _compaction_top);
 }
 
 void G1FullGCCompactionPoint::add(HeapRegion* hr) {

--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.hpp
@@ -33,7 +33,6 @@ class HeapRegion;
 
 class G1FullGCCompactionPoint : public CHeapObj<mtGC> {
   HeapRegion* _current_region;
-  HeapWord*   _threshold;
   HeapWord*   _compaction_top;
   GrowableArray<HeapRegion*>* _compaction_regions;
   GrowableArrayIterator<HeapRegion*> _compaction_region_iterator;

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -598,6 +598,9 @@ oop G1ParScanThreadState::handle_evacuation_failure_par(oop old, markWord m, siz
   if (forward_ptr == NULL) {
     // Forward-to-self succeeded. We are the "owner" of the object.
     HeapRegion* r = _g1h->heap_region_containing(old);
+    // Records evac failure objs, this will help speed up iteration
+    // of these objs later in *remove self forward* phase of post evacuation.
+    r->record_evac_failure_obj(old);
 
     if (_evac_failure_regions->record(r->hrm_index())) {
       _g1h->hr_printer()->evac_failure(r);

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -257,7 +257,7 @@ HeapRegion::HeapRegion(uint hrm_index,
   _young_index_in_cset(-1),
   _surv_rate_group(NULL), _age_index(G1SurvRateGroup::InvalidAgeIndex), _gc_efficiency(-1.0),
   _node_index(G1NUMA::UnknownNodeIndex),
-  _evac_failure_objs(hrm_index)
+  _evac_failure_objs(hrm_index, _bottom)
 {
   assert(Universe::on_page_boundary(mr.start()) && Universe::on_page_boundary(mr.end()),
          "invalid space boundaries");

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -808,13 +808,12 @@ void HeapRegion::mangle_unused_area() {
 }
 #endif
 
-HeapWord* HeapRegion::initialize_threshold() {
-  return _bot_part.initialize_threshold();
+void HeapRegion::initialize_bot_threshold() {
+  _bot_part.initialize_threshold();
 }
 
-HeapWord* HeapRegion::cross_threshold(HeapWord* start, HeapWord* end) {
+void HeapRegion::alloc_block_in_bot(HeapWord* start, HeapWord* end) {
   _bot_part.alloc_block(start, end);
-  return _bot_part.threshold();
 }
 
 void HeapRegion::object_iterate(ObjectClosure* blk) {

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -108,6 +108,14 @@ void HeapRegion::handle_evacuation_failure() {
   _next_marked_bytes = 0;
 }
 
+void HeapRegion::record_evac_failure_obj(oop obj) {
+  _evac_failure_objs.record(obj);
+}
+
+void HeapRegion::iterate_evac_failure_objs(ObjectClosure* closure) {
+  _evac_failure_objs.iterate(closure);
+}
+
 void HeapRegion::unlink_from_list() {
   set_next(NULL);
   set_prev(NULL);
@@ -248,7 +256,8 @@ HeapRegion::HeapRegion(uint hrm_index,
   _prev_marked_bytes(0), _next_marked_bytes(0),
   _young_index_in_cset(-1),
   _surv_rate_group(NULL), _age_index(G1SurvRateGroup::InvalidAgeIndex), _gc_efficiency(-1.0),
-  _node_index(G1NUMA::UnknownNodeIndex)
+  _node_index(G1NUMA::UnknownNodeIndex),
+  _evac_failure_objs(hrm_index)
 {
   assert(Universe::on_page_boundary(mr.start()) && Universe::on_page_boundary(mr.end()),
          "invalid space boundaries");

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -26,6 +26,7 @@
 #define SHARE_GC_G1_HEAPREGION_HPP
 
 #include "gc/g1/g1BlockOffsetTable.hpp"
+#include "gc/g1/g1EvacuationFailureObjsInHR.hpp"
 #include "gc/g1/g1HeapRegionTraceType.hpp"
 #include "gc/g1/g1SurvRateGroup.hpp"
 #include "gc/g1/heapRegionTracer.hpp"
@@ -257,6 +258,8 @@ private:
   double _gc_efficiency;
 
   uint _node_index;
+
+  G1EvacuationFailureObjsInHR _evac_failure_objs;
 
   void report_region_type_change(G1HeapRegionTraceType::Type to);
 
@@ -554,6 +557,11 @@ public:
 
   // Update the region state after a failed evacuation.
   void handle_evacuation_failure();
+  // Records evac failure objs during evaucation, this will help speed up iteration
+  // of these objs later in *remove self forward* phase of post evacuation.
+  void record_evac_failure_obj(oop obj);
+  // Iterates evac failure objs which are recorded during evcauation.
+  void iterate_evac_failure_objs(ObjectClosure* closure);
 
   // Iterate over the objects overlapping the given memory region, applying cl
   // to all references in the region.  This is a helper for

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -168,8 +168,8 @@ public:
 
   // Full GC support methods.
 
-  HeapWord* initialize_threshold();
-  HeapWord* cross_threshold(HeapWord* start, HeapWord* end);
+  void initialize_bot_threshold();
+  void alloc_block_in_bot(HeapWord* start, HeapWord* end);
 
   // Update heap region that has been compacted to be consistent after Full GC.
   void reset_compacted_after_full_gc();

--- a/src/hotspot/share/gc/shared/blockOffsetTable.cpp
+++ b/src/hotspot/share/gc/shared/blockOffsetTable.cpp
@@ -474,12 +474,11 @@ void BlockOffsetArrayContigSpace::alloc_block_work(HeapWord* blk_start,
 #endif
 }
 
-HeapWord* BlockOffsetArrayContigSpace::initialize_threshold() {
+void BlockOffsetArrayContigSpace::initialize_threshold() {
   _next_offset_index = _array->index_for(_bottom);
   _next_offset_index++;
   _next_offset_threshold =
     _array->address_for_index(_next_offset_index);
-  return _next_offset_threshold;
 }
 
 void BlockOffsetArrayContigSpace::zero_bottom_entry() {

--- a/src/hotspot/share/gc/shared/blockOffsetTable.hpp
+++ b/src/hotspot/share/gc/shared/blockOffsetTable.hpp
@@ -406,9 +406,9 @@ class BlockOffsetArrayContigSpace: public BlockOffsetArray {
   void set_contig_space(ContiguousSpace* sp) { set_space((Space*)sp); }
 
   // Initialize the threshold for an empty heap.
-  HeapWord* initialize_threshold();
+  void initialize_threshold();
   // Zero out the entry for _bottom (offset will be zero)
-  void      zero_bottom_entry();
+  void zero_bottom_entry();
 
   // Return the next threshold, the point at which the table should be
   // updated.

--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -364,7 +364,7 @@ HeapWord* CompactibleSpace::forward(oop q, size_t size,
     }
     compact_top = cp->space->bottom();
     cp->space->set_compaction_top(compact_top);
-    cp->threshold = cp->space->initialize_threshold();
+    cp->space->initialize_threshold();
     compaction_max_size = pointer_delta(cp->space->end(), compact_top);
   }
 
@@ -381,12 +381,10 @@ HeapWord* CompactibleSpace::forward(oop q, size_t size,
 
   compact_top += size;
 
-  // we need to update the offset table so that the beginnings of objects can be
+  // We need to update the offset table so that the beginnings of objects can be
   // found during scavenge.  Note that we are updating the offset table based on
   // where the object will be once the compaction phase finishes.
-  if (compact_top > cp->threshold)
-    cp->threshold =
-      cp->space->cross_threshold(compact_top - size, compact_top);
+  cp->space->alloc_block(compact_top - size, compact_top);
   return compact_top;
 }
 
@@ -402,10 +400,9 @@ void ContiguousSpace::prepare_for_compaction(CompactPoint* cp) {
 
   if (cp->space == NULL) {
     assert(cp->gen != NULL, "need a generation");
-    assert(cp->threshold == NULL, "just checking");
     assert(cp->gen->first_compaction_space() == this, "just checking");
     cp->space = cp->gen->first_compaction_space();
-    cp->threshold = cp->space->initialize_threshold();
+    cp->space->initialize_threshold();
     cp->space->set_compaction_top(cp->space->bottom());
   }
 
@@ -765,13 +762,12 @@ void ContiguousSpace::allocate_temporary_filler(int factor) {
   }
 }
 
-HeapWord* OffsetTableContigSpace::initialize_threshold() {
-  return _offsets.initialize_threshold();
+void OffsetTableContigSpace::initialize_threshold() {
+  _offsets.initialize_threshold();
 }
 
-HeapWord* OffsetTableContigSpace::cross_threshold(HeapWord* start, HeapWord* end) {
+void OffsetTableContigSpace::alloc_block(HeapWord* start, HeapWord* end) {
   _offsets.alloc_block(start, end);
-  return _offsets.threshold();
 }
 
 OffsetTableContigSpace::OffsetTableContigSpace(BlockOffsetSharedArray* sharedOffsetArray,


### PR DESCRIPTION
Hi all,

  can I get reviews for this change that removes an unnecessary indirection, saving one check during GC (per object)?

In particular `cross_threshold()` method is used in a few places to update the BOT after major changes to object locations (typically full gc compaction).

It has the following signature:

    HeapWord* HeapRegion::cross_threshold(HeapWord* start, HeapWord* end);

to update the BOT for an object from start to end, returning the next (higher) address where there is need to call it again if advancing forward in the heap (i.e. basically after the last BOT entry that has just been written).

So it can be used in a loop to be only called in that case like this:

    _compaction_top += size;
    if (_compaction_top > _threshold) {
      _threshold = _current_region->cross_threshold(_compaction_top - size, _compaction_top);
    }

However the method it calls, `alloc_block()` does that check to shortcut unnecessary calls to some `alloc_block_work()` method already:

    if (blk_end > _next_offset_threshold) {
      alloc_block_work(&_next_offset_threshold, blk_start, blk_end);
    }

as `cross_threshold()` always returns `_next_offset_threshold`.

So the `cross_threshold()` method and all the machinery to avoid unnecessary calls is... unnecessary. 

Performance checking did not see any particular impact either way - it's just not called that often after all.

Testing: tier1-3, local jtreg gc/g1

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8273599](https://bugs.openjdk.java.net/browse/JDK-8273599): Remove cross_threshold method usage around GC


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5468/head:pull/5468` \
`$ git checkout pull/5468`

Update a local copy of the PR: \
`$ git checkout pull/5468` \
`$ git pull https://git.openjdk.java.net/jdk pull/5468/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5468`

View PR using the GUI difftool: \
`$ git pr show -t 5468`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5468.diff">https://git.openjdk.java.net/jdk/pull/5468.diff</a>

</details>
