### PR TITLE
8273599: Remove cross_threshold method usage around GC

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
@@ -405,9 +405,8 @@ void G1BlockOffsetTablePart::zero_bottom_entry_raw() {
   _bot->set_offset_array_raw(bottom_index, 0);
 }
 
-HeapWord* G1BlockOffsetTablePart::initialize_threshold() {
+void G1BlockOffsetTablePart::initialize_threshold() {
   _next_offset_threshold = _hr->bottom() + BOTConstants::N_words;
-  return _next_offset_threshold;
 }
 
 void G1BlockOffsetTablePart::set_for_starts_humongous(HeapWord* obj_top, size_t fill_size) {

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -193,7 +193,7 @@ public:
 
   // Initialize the threshold to reflect the first boundary after the
   // bottom of the covered region.
-  HeapWord* initialize_threshold();
+  void initialize_threshold();
 
   void reset_bot() {
     zero_bottom_entry_raw();

--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -154,7 +154,7 @@ public:
 
       HeapWord* obj_end = obj_addr + obj_size;
       _last_forwarded_object_end = obj_end;
-      _hr->cross_threshold(obj_addr, obj_end);
+      _hr->alloc_block_in_bot(obj_addr, obj_end);
     }
   }
 
@@ -171,13 +171,13 @@ public:
       CollectedHeap::fill_with_objects(start, gap_size);
 
       HeapWord* end_first_obj = start + cast_to_oop(start)->size();
-      _hr->cross_threshold(start, end_first_obj);
+      _hr->alloc_block_in_bot(start, end_first_obj);
       // Fill_with_objects() may have created multiple (i.e. two)
       // objects, as the max_fill_size() is half a region.
       // After updating the BOT for the first object, also update the
       // BOT for the second object to make the BOT complete.
       if (end_first_obj != end) {
-        _hr->cross_threshold(end_first_obj, end);
+        _hr->alloc_block_in_bot(end_first_obj, end);
 #ifdef ASSERT
         size_t size_second_obj = cast_to_oop(end_first_obj)->size();
         HeapWord* end_of_second_obj = end_first_obj + size_second_obj;

--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
@@ -30,7 +30,6 @@
 
 G1FullGCCompactionPoint::G1FullGCCompactionPoint() :
     _current_region(NULL),
-    _threshold(NULL),
     _compaction_top(NULL) {
   _compaction_regions = new (ResourceObj::C_HEAP, mtGC) GrowableArray<HeapRegion*>(32, mtGC);
   _compaction_region_iterator = _compaction_regions->begin();
@@ -49,7 +48,7 @@ void G1FullGCCompactionPoint::update() {
 void G1FullGCCompactionPoint::initialize_values(bool init_threshold) {
   _compaction_top = _current_region->compaction_top();
   if (init_threshold) {
-    _threshold = _current_region->initialize_threshold();
+    _current_region->initialize_bot_threshold();
   }
 }
 
@@ -123,9 +122,7 @@ void G1FullGCCompactionPoint::forward(oop object, size_t size) {
 
   // Update compaction values.
   _compaction_top += size;
-  if (_compaction_top > _threshold) {
-    _threshold = _current_region->cross_threshold(_compaction_top - size, _compaction_top);
-  }
+  _current_region->alloc_block_in_bot(_compaction_top - size, _compaction_top);
 }
 
 void G1FullGCCompactionPoint::add(HeapRegion* hr) {

--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.hpp
@@ -33,7 +33,6 @@ class HeapRegion;
 
 class G1FullGCCompactionPoint : public CHeapObj<mtGC> {
   HeapRegion* _current_region;
-  HeapWord*   _threshold;
   HeapWord*   _compaction_top;
   GrowableArray<HeapRegion*>* _compaction_regions;
   GrowableArrayIterator<HeapRegion*> _compaction_region_iterator;

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -799,13 +799,12 @@ void HeapRegion::mangle_unused_area() {
 }
 #endif
 
-HeapWord* HeapRegion::initialize_threshold() {
-  return _bot_part.initialize_threshold();
+void HeapRegion::initialize_bot_threshold() {
+  _bot_part.initialize_threshold();
 }
 
-HeapWord* HeapRegion::cross_threshold(HeapWord* start, HeapWord* end) {
+void HeapRegion::alloc_block_in_bot(HeapWord* start, HeapWord* end) {
   _bot_part.alloc_block(start, end);
-  return _bot_part.threshold();
 }
 
 void HeapRegion::object_iterate(ObjectClosure* blk) {

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -167,8 +167,8 @@ public:
 
   // Full GC support methods.
 
-  HeapWord* initialize_threshold();
-  HeapWord* cross_threshold(HeapWord* start, HeapWord* end);
+  void initialize_bot_threshold();
+  void alloc_block_in_bot(HeapWord* start, HeapWord* end);
 
   // Update heap region that has been compacted to be consistent after Full GC.
   void reset_compacted_after_full_gc();

--- a/src/hotspot/share/gc/shared/blockOffsetTable.cpp
+++ b/src/hotspot/share/gc/shared/blockOffsetTable.cpp
@@ -474,12 +474,11 @@ void BlockOffsetArrayContigSpace::alloc_block_work(HeapWord* blk_start,
 #endif
 }
 
-HeapWord* BlockOffsetArrayContigSpace::initialize_threshold() {
+void BlockOffsetArrayContigSpace::initialize_threshold() {
   _next_offset_index = _array->index_for(_bottom);
   _next_offset_index++;
   _next_offset_threshold =
     _array->address_for_index(_next_offset_index);
-  return _next_offset_threshold;
 }
 
 void BlockOffsetArrayContigSpace::zero_bottom_entry() {

--- a/src/hotspot/share/gc/shared/blockOffsetTable.hpp
+++ b/src/hotspot/share/gc/shared/blockOffsetTable.hpp
@@ -406,9 +406,9 @@ class BlockOffsetArrayContigSpace: public BlockOffsetArray {
   void set_contig_space(ContiguousSpace* sp) { set_space((Space*)sp); }
 
   // Initialize the threshold for an empty heap.
-  HeapWord* initialize_threshold();
+  void initialize_threshold();
   // Zero out the entry for _bottom (offset will be zero)
-  void      zero_bottom_entry();
+  void zero_bottom_entry();
 
   // Return the next threshold, the point at which the table should be
   // updated.

--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -364,7 +364,7 @@ HeapWord* CompactibleSpace::forward(oop q, size_t size,
     }
     compact_top = cp->space->bottom();
     cp->space->set_compaction_top(compact_top);
-    cp->threshold = cp->space->initialize_threshold();
+    cp->space->initialize_threshold();
     compaction_max_size = pointer_delta(cp->space->end(), compact_top);
   }
 
@@ -381,12 +381,10 @@ HeapWord* CompactibleSpace::forward(oop q, size_t size,
 
   compact_top += size;
 
-  // we need to update the offset table so that the beginnings of objects can be
+  // We need to update the offset table so that the beginnings of objects can be
   // found during scavenge.  Note that we are updating the offset table based on
   // where the object will be once the compaction phase finishes.
-  if (compact_top > cp->threshold)
-    cp->threshold =
-      cp->space->cross_threshold(compact_top - size, compact_top);
+  cp->space->alloc_block(compact_top - size, compact_top);
   return compact_top;
 }
 
@@ -402,10 +400,9 @@ void ContiguousSpace::prepare_for_compaction(CompactPoint* cp) {
 
   if (cp->space == NULL) {
     assert(cp->gen != NULL, "need a generation");
-    assert(cp->threshold == NULL, "just checking");
     assert(cp->gen->first_compaction_space() == this, "just checking");
     cp->space = cp->gen->first_compaction_space();
-    cp->threshold = cp->space->initialize_threshold();
+    cp->space->initialize_threshold();
     cp->space->set_compaction_top(cp->space->bottom());
   }
 
@@ -765,13 +762,12 @@ void ContiguousSpace::allocate_temporary_filler(int factor) {
   }
 }
 
-HeapWord* OffsetTableContigSpace::initialize_threshold() {
-  return _offsets.initialize_threshold();
+void OffsetTableContigSpace::initialize_threshold() {
+  _offsets.initialize_threshold();
 }
 
-HeapWord* OffsetTableContigSpace::cross_threshold(HeapWord* start, HeapWord* end) {
+void OffsetTableContigSpace::alloc_block(HeapWord* start, HeapWord* end) {
   _offsets.alloc_block(start, end);
-  return _offsets.threshold();
 }
 
 OffsetTableContigSpace::OffsetTableContigSpace(BlockOffsetSharedArray* sharedOffsetArray,


### PR DESCRIPTION
HI all,

 the cross_threshold() method is used in a few places to update the BOT after major changes to object locations (typically full gc compaction).

It has the following signature:

HeapWord* HeapRegion::cross_threshold(HeapWord* start, HeapWord* end);

to update the BOT for an object from start to end, returning the next (higher) address where there is need to call it again if advancing forward in the heap (i.e. basically after the last BOT entry that has just been written).

So it can be used in a loop to be only called in that case like this:

  _compaction_top += size;
  if (_compaction_top > _threshold) {
    _threshold = _current_region->cross_threshold(_compaction_top - size, _compaction_top);
  }

However the method it calls, alloc_block() does that check to shortcut unnecessary calls to some alloc_block_work() method already:

    if (blk_end > _next_offset_threshold) {
      alloc_block_work(&_next_offset_threshold, blk_start, blk_end);
    }

as cross_threshold() always returns _next_offset_threshold.

So the cross_threshold method and all the machinery to avoid unnecessary calls is... unnecessary. 

No particular performance implications either way.

Testing: tier1-3, gc/g1

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273599](https://bugs.openjdk.java.net/browse/JDK-8273599): Remove cross_threshold method usage around GC


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5469/head:pull/5469` \
`$ git checkout pull/5469`

Update a local copy of the PR: \
`$ git checkout pull/5469` \
`$ git pull https://git.openjdk.java.net/jdk pull/5469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5469`

View PR using the GUI difftool: \
`$ git pr show -t 5469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5469.diff">https://git.openjdk.java.net/jdk/pull/5469.diff</a>

</details>
