### PR TITLE
8273606: Zero: SPARC64 build fails with si_band type mismatch

### DIFF
--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -1145,6 +1145,10 @@ void os::print_siginfo(outputStream* os, const void* si0) {
     os->print(", si_addr: " PTR_FORMAT, p2i(si->si_addr));
 #ifdef SIGPOLL
   } else if (sig == SIGPOLL) {
+    // siginfo_t.si_band is defined as "long", and it is so in most
+    // implementations. But SPARC64 glibc has a bug: si_band is "int".
+    // Cast si_band to "long" to prevent format specifier mismatch.
+    // See: https://sourceware.org/bugzilla/show_bug.cgi?id=23821
     os->print(", si_band: %ld", (long) si->si_band);
 #endif
   }

--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -1145,7 +1145,7 @@ void os::print_siginfo(outputStream* os, const void* si0) {
     os->print(", si_addr: " PTR_FORMAT, p2i(si->si_addr));
 #ifdef SIGPOLL
   } else if (sig == SIGPOLL) {
-    os->print(", si_band: %ld", si->si_band);
+    os->print(", si_band: %ld", (long) si->si_band);
 #endif
   }
 }


### PR DESCRIPTION
This is actually caught by `-Werror=format` that is enabled by default.

```
$  sh ./configure --with-debug-level=slowdebug --with-boot-jdk=/home/shade/Install/jdk16-16.0.2-ea/ --openjdk-target=sparc64-linux-gnu --with-sysroot=/chroots/sparc64/ --with-jvm-variants=zero
$ make images

/home/shade/trunks/jdk/src/hotspot/os/posix/signals_posix.cpp: In static member function 'static void os::print_siginfo(outputStream*, const void*)':
/home/shade/trunks/jdk/src/hotspot/os/posix/signals_posix.cpp:1148:29: error: format '%ld' expects argument of type 'long int', but argument 3 has type 'int' [-Werror=format=]
 1148 |     os->print(", si_band: %ld", si->si_band);
      |                           ~~^
      |                             |
      |                             long int
      |                           %d

man sigaction says:

siginfo_t {
    ...
               long     si_band;      /* Band event (was int in
                                         glibc 2.3.2 and earlier) */
    ...
}
```

I see that was already reported as [glibc bug #23821](https://sourceware.org/bugzilla/show_bug.cgi?id=23821), and glibc maintainers decided not to fix it. So, we can still make a defensive cast to (long), which would be no-op if the type is in fact long.

I looked at how Debian folks avoid this problem, and I think there is Debian patch that just disables `-Werror` wholesale. Right, @glaubitz? :)

Additional testing: 
 - [x] Linux sparc64 Zero cross-compilation now passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273606](https://bugs.openjdk.java.net/browse/JDK-8273606): Zero: SPARC64 build fails with si_band type mismatch


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to b1c72819dffca2c6ed809fe8959cdebcd713a93a


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5470/head:pull/5470` \
`$ git checkout pull/5470`

Update a local copy of the PR: \
`$ git checkout pull/5470` \
`$ git pull https://git.openjdk.java.net/jdk pull/5470/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5470`

View PR using the GUI difftool: \
`$ git pr show -t 5470`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5470.diff">https://git.openjdk.java.net/jdk/pull/5470.diff</a>

</details>
