### PR TITLE
8273609: Fix trivial doc typos in the compiler area

### DIFF
--- a/src/java.compiler/share/classes/javax/annotation/processing/ProcessingEnvironment.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/ProcessingEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,7 +112,7 @@ public interface ProcessingEnvironment {
 
     /**
      * {@return the current locale or {@code null} if no locale is in
-     * effect}  The locale can be be used to provide localized
+     * effect}  The locale can be used to provide localized
      * {@linkplain Messager messages}.
      */
     Locale getLocale();

--- a/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
@@ -746,7 +746,7 @@ public interface Elements {
      * record component is returned, in any other case {@code null} is returned.
      *
      * @param accessor the method for which the record component should be found.
-     * @return the record component, or null if the given method is not an record
+     * @return the record component, or null if the given method is not a record
      * component accessor
      * @since 16
      */

--- a/src/java.compiler/share/classes/javax/tools/JavaFileManager.java
+++ b/src/java.compiler/share/classes/javax/tools/JavaFileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -468,7 +468,7 @@ public interface JavaFileManager extends Closeable, Flushable, OptionChecker {
      * @return the location for the named module
      *
      * @throws IOException if an I/O error occurred
-     * @throws UnsupportedOperationException if this operation if not supported by this file manager
+     * @throws UnsupportedOperationException if this operation is not supported by this file manager
      * @throws IllegalArgumentException if the location is neither an output location nor a
      * module-oriented location
      * @since 9
@@ -491,7 +491,7 @@ public interface JavaFileManager extends Closeable, Flushable, OptionChecker {
      * @return the module containing the file
      *
      * @throws IOException if an I/O error occurred
-     * @throws UnsupportedOperationException if this operation if not supported by this file manager
+     * @throws UnsupportedOperationException if this operation is not supported by this file manager
      * @throws IllegalArgumentException if the location is neither an output location nor a
      * module-oriented location
      * @since 9
@@ -516,7 +516,7 @@ public interface JavaFileManager extends Closeable, Flushable, OptionChecker {
      * @return a service loader for the given service class
      *
      * @throws IOException if an I/O error occurred
-     * @throws UnsupportedOperationException if this operation if not supported by this file manager
+     * @throws UnsupportedOperationException if this operation is not supported by this file manager
      * @since 9
      */ // TODO: describe failure modes
     default <S> ServiceLoader<S> getServiceLoader(Location location, Class<S> service) throws  IOException {
@@ -533,7 +533,7 @@ public interface JavaFileManager extends Closeable, Flushable, OptionChecker {
      * @return the name of the module
      *
      * @throws IOException if an I/O error occurred
-     * @throws UnsupportedOperationException if this operation if not supported by this file manager
+     * @throws UnsupportedOperationException if this operation is not supported by this file manager
      * @throws IllegalArgumentException if the location is not one known to this file manager
      * @since 9
      */ // TODO: describe failure modes
@@ -552,7 +552,7 @@ public interface JavaFileManager extends Closeable, Flushable, OptionChecker {
      * @return  a series of sets of locations containing modules
      *
      * @throws IOException if an I/O error occurred
-     * @throws UnsupportedOperationException if this operation if not supported by this file manager
+     * @throws UnsupportedOperationException if this operation is not supported by this file manager
      * @throws IllegalArgumentException if the location is not a module-oriented location
      * @since 9
      */ // TODO: describe failure modes

--- a/src/jdk.compiler/share/classes/com/sun/source/doctree/DocTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/doctree/DocTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -265,7 +265,7 @@ public interface DocTree {
         VERSION("version"),
 
         /**
-         * An implementation-reserved node. This is the not the node
+         * An implementation-reserved node. This is not the node
          * you are looking for.
          */
         OTHER;

--- a/src/jdk.compiler/share/classes/com/sun/source/tree/Tree.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/tree/Tree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -685,7 +685,7 @@ public interface Tree {
         USES(UsesTree.class),
 
         /**
-         * An implementation-reserved node. This is the not the node
+         * An implementation-reserved node. This is not the node
          * you are looking for.
          */
         OTHER(null),

--- a/src/jdk.compiler/share/classes/com/sun/source/tree/TreeVisitor.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/tree/TreeVisitor.java
@@ -31,7 +31,7 @@ import jdk.internal.javac.PreviewFeature;
  * A visitor of trees, in the style of the visitor design pattern.
  * Classes implementing this interface are used to operate
  * on a tree when the kind of tree is unknown at compile time.
- * When a visitor is passed to an tree's {@link Tree#accept
+ * When a visitor is passed to a tree's {@link Tree#accept
  * accept} method, the <code>visit<i>Xyz</i></code> method most applicable
  * to that tree is invoked.
  *

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/Main.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -121,7 +121,7 @@ public class Main {
      * arguments to the main method of the first class found in the file.
      *
      * <p>If any problem occurs before executing the main class, it will
-     * be reported to the standard error stream, and the the JVM will be
+     * be reported to the standard error stream, and the JVM will be
      * terminated by calling {@code System.exit} with a non-zero return code.
      *
      * @param args the arguments


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273609](https://bugs.openjdk.java.net/browse/JDK-8273609): Fix trivial doc typos in the compiler area


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5471/head:pull/5471` \
`$ git checkout pull/5471`

Update a local copy of the PR: \
`$ git checkout pull/5471` \
`$ git pull https://git.openjdk.java.net/jdk pull/5471/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5471`

View PR using the GUI difftool: \
`$ git pr show -t 5471`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5471.diff">https://git.openjdk.java.net/jdk/pull/5471.diff</a>

</details>
