### PR TITLE
8273610: LogTestFixture::restore_config() should not restore options

### DIFF
--- a/test/hotspot/gtest/logging/logTestFixture.cpp
+++ b/test/hotspot/gtest/logging/logTestFixture.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,14 +97,15 @@ void LogTestFixture::restore_config() {
 
     char* decorators = str;
 
-    char* options = NULL;
     str = strchr(str, ' ');
     if (str != NULL) {
+      // This output has options. However, UL doesn't allow the options of any
+      // output to be changed, so they cannot be modified by the tests,
+      // and also we cannot change them here. So just mark the end of the
+      // decorators.
       *str++ = '\0';
-      options = str;
     }
-
-    set_log_config(name, selection, decorators, options != NULL ? options : "");
+    set_log_config(name, selection, decorators, /* options = */ NULL);
   }
 }
 


### PR DESCRIPTION
This is a prerequisite of https://github.com/openjdk/jdk/pull/5407

LogTestFixture::restore_config() should not restore the options because it's neither necessary nor allowed. Please see the RFE description for details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273610](https://bugs.openjdk.java.net/browse/JDK-8273610): LogTestFixture::restore_config() should not restore options


### Reviewers
 * [Yasumasa Suenaga](https://openjdk.java.net/census#ysuenaga) (@YaSuenag - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5472/head:pull/5472` \
`$ git checkout pull/5472`

Update a local copy of the PR: \
`$ git checkout pull/5472` \
`$ git pull https://git.openjdk.java.net/jdk pull/5472/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5472`

View PR using the GUI difftool: \
`$ git pr show -t 5472`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5472.diff">https://git.openjdk.java.net/jdk/pull/5472.diff</a>

</details>
