### PR TITLE
8273613: JFR: RemoteRecordingStream::start() blocks close()

### DIFF
--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
@@ -518,50 +518,47 @@ public final class RemoteRecordingStream implements EventStream {
         this.endTime = endTime;
     }
 
-    @Override
-    public void start() {
-        synchronized (lock) { // ensure one starter
-            ensureStartable();
-            try {
-                try {
-                    mbean.startRecording(recordingId);
-                } catch (IllegalStateException ise) {
-                    throw ise;
-                }
-                startDownload();
-            } catch (Exception e) {
-                ManagementSupport.logDebug(e.getMessage());
-                close();
-                return;
-            }
-            stream.start();
-            started = true;
-        }
-    }
+	@Override
+	public void start() {
+		ensureStartable();
+		try {
+			try {
+				mbean.startRecording(recordingId);
+			} catch (IllegalStateException ise) {
+				throw ise;
+			}
+			startDownload();
+		} catch (Exception e) {
+			ManagementSupport.logDebug(e.getMessage());
+			close();
+			return;
+		}
+		stream.start();
+	}
 
-    @Override
-    public void startAsync() {
-        synchronized (lock) { // ensure one starter
-            ensureStartable();
-            stream.startAsync();
-            try {
-                mbean.startRecording(recordingId);
-                startDownload();
-            } catch (Exception e) {
-                ManagementSupport.logDebug(e.getMessage());
-                close();
-            }
-            started = true;
-        }
-    }
+	@Override
+	public void startAsync() {
+		ensureStartable();
+		stream.startAsync();
+		try {
+			mbean.startRecording(recordingId);
+			startDownload();
+		} catch (Exception e) {
+			ManagementSupport.logDebug(e.getMessage());
+			close();
+		}
+	}
 
     private void ensureStartable() {
-        if (closed) {
-            throw new IllegalStateException("Event stream is closed");
-        }
-        if (started) {
-            throw new IllegalStateException("Event stream can only be started once");
-        }
+    	synchronized (lock) {
+            if (closed) {
+                throw new IllegalStateException("Event stream is closed");
+            }
+            if (started) {
+                throw new IllegalStateException("Event stream can only be started once");
+            }
+            started = true;
+		}
     }
 
     /**

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
@@ -518,39 +518,39 @@ public final class RemoteRecordingStream implements EventStream {
         this.endTime = endTime;
     }
 
-	@Override
-	public void start() {
-		ensureStartable();
-		try {
-			try {
-				mbean.startRecording(recordingId);
-			} catch (IllegalStateException ise) {
-				throw ise;
-			}
-			startDownload();
-		} catch (Exception e) {
-			ManagementSupport.logDebug(e.getMessage());
-			close();
-			return;
-		}
-		stream.start();
-	}
+    @Override
+    public void start() {
+        ensureStartable();
+        try {
+            try {
+                mbean.startRecording(recordingId);
+            } catch (IllegalStateException ise) {
+                throw ise;
+            }
+            startDownload();
+        } catch (Exception e) {
+            ManagementSupport.logDebug(e.getMessage());
+            close();
+            return;
+        }
+        stream.start();
+    }
 
-	@Override
-	public void startAsync() {
-		ensureStartable();
-		stream.startAsync();
-		try {
-			mbean.startRecording(recordingId);
-			startDownload();
-		} catch (Exception e) {
-			ManagementSupport.logDebug(e.getMessage());
-			close();
-		}
-	}
+    @Override
+    public void startAsync() {
+        ensureStartable();
+        stream.startAsync();
+        try {
+            mbean.startRecording(recordingId);
+            startDownload();
+        } catch (Exception e) {
+            ManagementSupport.logDebug(e.getMessage());
+            close();
+        }
+    }
 
     private void ensureStartable() {
-    	synchronized (lock) {
+        synchronized (lock) {
             if (closed) {
                 throw new IllegalStateException("Event stream is closed");
             }
@@ -558,7 +558,7 @@ public final class RemoteRecordingStream implements EventStream {
                 throw new IllegalStateException("Event stream can only be started once");
             }
             started = true;
-		}
+        }
     }
 
     /**

--- a/test/jdk/jdk/jfr/jmx/streaming/TestStart.java
+++ b/test/jdk/jdk/jfr/jmx/streaming/TestStart.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.jfr.jmx.streaming;
+
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.util.concurrent.CountDownLatch;
+
+import javax.management.MBeanServerConnection;
+
+import jdk.management.jfr.RemoteRecordingStream;
+
+/**
+ * @test
+ * @key jfr
+ * @summary Sanity tests RemoteRecordingStream::start()
+ * @requires vm.hasJFR
+ * @library /test/lib /test/jdk
+ * @run main/othervm jdk.jfr.jmx.streaming.TestStart
+ */
+public class TestStart {
+    
+    private final static MBeanServerConnection CONNECTION = ManagementFactory.getPlatformMBeanServer();
+
+    public static void main(String... args) throws Exception {
+        testStart();
+        testStartTwice();
+        testStartClosed();
+    }
+
+    private static void testStart() throws IOException {
+        try (var r = new RemoteRecordingStream(CONNECTION)) {
+            r.onFlush(() -> {
+                System.out.print("Started.");
+                r.close();
+            });
+            System.out.println("About to start ...");
+            r.start();
+            System.out.println("Finished!");
+        }
+    }
+
+    private static void testStartTwice() throws Exception {
+        var latch = new CountDownLatch(1);
+        try (var r = new RemoteRecordingStream(CONNECTION)) {
+            r.onFlush(() -> latch.countDown());
+            Runnable starter = () -> {
+                r.start();
+            };
+            new Thread(starter).start();
+            latch.await();
+            try {
+                r.start();
+            } catch (IllegalStateException ise) {
+                // OK, as expected
+                return;
+            }
+            throw new Exception("Expected IllegalStateException when starting same stream twice");
+        }
+    }
+
+    private static void testStartClosed() throws Exception {
+        var latch = new CountDownLatch(1);
+        try (var r = new RemoteRecordingStream(CONNECTION)) {
+            r.onFlush(() -> latch.countDown());
+            Runnable starter = () -> {
+                r.start();
+            };
+            new Thread(starter).start();
+            latch.await();
+            r.close();
+            try {
+                r.start();
+            } catch (IllegalStateException ise) {
+                // OK, as expected
+                return;
+            }
+            throw new Exception("Expected IllegalStateException when starting closed stream");
+        }
+    }
+}

--- a/test/jdk/jdk/jfr/jmx/streaming/TestStart.java
+++ b/test/jdk/jdk/jfr/jmx/streaming/TestStart.java
@@ -39,7 +39,7 @@ import jdk.management.jfr.RemoteRecordingStream;
  * @run main/othervm jdk.jfr.jmx.streaming.TestStart
  */
 public class TestStart {
-    
+
     private final static MBeanServerConnection CONNECTION = ManagementFactory.getPlatformMBeanServer();
 
     public static void main(String... args) throws Exception {


### PR DESCRIPTION
Hi,

Could I please have a review of a bug fix of RemoteRecordingStream?

RemoteRecordingStream::start() method takes a lock, which blocks the close() method if invoked from another thread.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273613](https://bugs.openjdk.java.net/browse/JDK-8273613): JFR: RemoteRecordingStream::start() blocks close()


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5476/head:pull/5476` \
`$ git checkout pull/5476`

Update a local copy of the PR: \
`$ git checkout pull/5476` \
`$ git pull https://git.openjdk.java.net/jdk pull/5476/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5476`

View PR using the GUI difftool: \
`$ git pr show -t 5476`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5476.diff">https://git.openjdk.java.net/jdk/pull/5476.diff</a>

</details>
