### PR TITLE
8273651: JFR: onMetadata(), setStartTime(), setEndTime() lacks test coverage

### DIFF
--- a/test/jdk/jdk/jfr/jmx/streaming/TestDelegated.java
+++ b/test/jdk/jdk/jfr/jmx/streaming/TestDelegated.java
@@ -175,7 +175,6 @@ public class TestDelegated {
             latch.await();
         }
     }
-    
 
     private static void testonMetadata() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);

--- a/test/jdk/jdk/jfr/jmx/streaming/TestDelegated.java
+++ b/test/jdk/jdk/jfr/jmx/streaming/TestDelegated.java
@@ -27,14 +27,10 @@ import java.lang.management.ManagementFactory;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicReference;
 
 import javax.management.MBeanServerConnection;
 
 import jdk.jfr.Event;
-import jdk.jfr.EventType;
-import jdk.jfr.FlightRecorder;
-import jdk.jfr.consumer.MetadataEvent;
 import jdk.management.jfr.RemoteRecordingStream;
 
 /**

--- a/test/jdk/jdk/jfr/jmx/streaming/TestDelegated.java
+++ b/test/jdk/jdk/jfr/jmx/streaming/TestDelegated.java
@@ -62,7 +62,6 @@ public class TestDelegated {
         testOrdered();
         testOnEvent();
         testOnEventName();
-        testonMetadata();
         testOnFlush();
         testOnError();
         testOnClose();
@@ -175,30 +174,6 @@ public class TestDelegated {
             latch.await();
         }
     }
-
-    private static void testonMetadata() throws Exception {
-        CountDownLatch latch = new CountDownLatch(1);
-        var holder  = new AtomicReference<MetadataEvent>();
-        try (RemoteRecordingStream rs = new RemoteRecordingStream(CONNECTION)) {
-            FlightRecorder.register(TestDelegatedEvent.class);
-            rs.onMetadata(e -> {
-                holder.set(e);
-                latch.countDown();
-            });
-            rs.startAsync();
-            TestDelegatedEvent e = new TestDelegatedEvent();
-            e.commit();
-            latch.await();
-            MetadataEvent event = holder.get();
-            for (EventType t : event.getEventTypes()) {
-                if (t.getName().equals(TestDelegatedEvent.class.getName())) {
-                    return; // OK
-                }
-            }
-            throw new Exception("Could not find metadata for event " + TestDelegatedEvent.class.getName());
-        }
-    }
-
 
     private static void testOrdered() throws Exception {
         try (RemoteRecordingStream rs = new RemoteRecordingStream(CONNECTION)) {

--- a/test/jdk/jdk/jfr/jmx/streaming/TestMetadataEvent.java
+++ b/test/jdk/jdk/jfr/jmx/streaming/TestMetadataEvent.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.jfr.jmx.streaming;
+
+import java.lang.management.ManagementFactory;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.function.Function;
+
+import jdk.jfr.Configuration;
+import jdk.jfr.EventType;
+import jdk.jfr.FlightRecorder;
+import jdk.jfr.consumer.MetadataEvent;
+import jdk.management.jfr.RemoteRecordingStream;
+
+/**
+ * @test
+ * @key jfr
+ * @summary Sanity tests RemoteRecordingStream::onMetadata
+ * @requires vm.hasJFR
+ * @library /test/lib /test/jdk
+ * @run main/othervm jdk.jfr.jmx.streaming.TestMetadataEvent
+ */
+public class TestMetadataEvent {
+
+    public static void main(String... args) throws Exception {
+        var conn = ManagementFactory.getPlatformMBeanServer();
+        var q = new ArrayBlockingQueue<MetadataEvent>(1);
+        try (RemoteRecordingStream e = new RemoteRecordingStream(conn)) {
+            e.onMetadata(q::offer);
+            e.startAsync();
+            MetadataEvent event = q.take();
+            assertEventTypes(FlightRecorder.getFlightRecorder().getEventTypes(), event.getEventTypes());
+            assertConfigurations(Configuration.getConfigurations(), event.getConfigurations());
+        }
+    }
+
+    private static void assertEventTypes(List<EventType> expected, List<EventType> eventTypes) throws Exception {
+        assertListProperty(expected, eventTypes, EventType::getName);
+    }
+
+    private static void assertConfigurations(List<Configuration> expected, List<Configuration> configurations) throws Exception {
+        assertListProperty(expected, configurations, Configuration::getName);
+    }
+
+    private static <T, R> void assertListProperty(List<T> expected, List<T> result, Function<T, R> mapper) throws Exception {
+        var a1 = new HashSet<R>();
+        a1.addAll(expected.stream().map(mapper).toList());
+        var a2 = new HashSet<R>();
+        a2.addAll(result.stream().map(mapper).toList());
+        if (!a1.equals(a2)) {
+            throw new Exception("Result not as expected!\nexpected = " + a1 + "\nresult= " + a2);
+        }
+    }
+}


### PR DESCRIPTION
Hi,

Could I have review of a test fix that increases the code coverage for methods in the jdk.management.jfr.RemoteRecordingStream class.

Testing: jdk/jdk/jfr/jmx/streaming/

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273651](https://bugs.openjdk.java.net/browse/JDK-8273651): JFR: onMetadata(), setStartTime(), setEndTime() lacks test coverage


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5477/head:pull/5477` \
`$ git checkout pull/5477`

Update a local copy of the PR: \
`$ git checkout pull/5477` \
`$ git pull https://git.openjdk.java.net/jdk pull/5477/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5477`

View PR using the GUI difftool: \
`$ git pr show -t 5477`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5477.diff">https://git.openjdk.java.net/jdk/pull/5477.diff</a>

</details>
