### PR TITLE
8273626: G1: refactor G1CardSetAllocator to support element size less pointer size

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.hpp
@@ -32,7 +32,6 @@
 #include "utilities/lockFreeStack.hpp"
 
 class G1CardSetAllocOptions;
-class G1CardSetBufferList;
 class G1CardSetHashTable;
 class G1CardSetHashTableValue;
 class G1CardSetMemoryManager;

--- a/src/hotspot/share/gc/g1/g1CardSetFreeMemoryTask.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetFreeMemoryTask.hpp
@@ -31,8 +31,6 @@
 #include "utilities/growableArray.hpp"
 #include "utilities/ticks.hpp"
 
-class G1CardSetBuffer;
-
 // Task handling deallocation of free card set memory.
 class G1CardSetFreeMemoryTask : public G1ServiceTask {
 

--- a/src/hotspot/share/gc/g1/g1CardSetMemory.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.hpp
@@ -111,9 +111,6 @@ class G1CardSetAllocator : public G1SegmentedArray<Elem, mtGCCardSet> {
   volatile uint _num_pending_nodes;   // Number of nodes in the pending list.
   volatile uint _num_free_nodes;      // Number of nodes in the free list.
 
-  // volatile uint _num_allocated_nodes; // Number of total nodes allocated and in use.
-  // volatile uint _num_available_nodes; // Number of nodes available in all buffers (allocated + free + pending + not yet used).
-
   // Try to transfer nodes from _pending_nodes_list to _free_nodes_list, with a
   // synchronization delay for any in-progress pops from the _free_nodes_list
   // to solve ABA here.
@@ -139,12 +136,12 @@ public:
   size_t mem_size() const {
     return sizeof(*this) +
       G1SegmentedArray<Elem, mtGCCardSet>::num_buffers() * sizeof(G1CardSetBuffer)
-            + G1SegmentedArray<Elem, mtGCCardSet>::_num_available_nodes * G1SegmentedArray<Elem, mtGCCardSet>::elem_size();
+            + G1SegmentedArray<Elem, mtGCCardSet>::num_available_nodes() * G1SegmentedArray<Elem, mtGCCardSet>::elem_size();
   }
 
   size_t wasted_mem_size() const {
-    return (G1SegmentedArray<Elem, mtGCCardSet>::_num_available_nodes
-              - (G1SegmentedArray<Elem, mtGCCardSet>::_num_allocated_nodes - _num_pending_nodes))
+    return (G1SegmentedArray<Elem, mtGCCardSet>::num_available_nodes()
+              - (G1SegmentedArray<Elem, mtGCCardSet>::num_allocated_nodes() - _num_pending_nodes))
                 * G1SegmentedArray<Elem, mtGCCardSet>::elem_size();
   }
 

--- a/src/hotspot/share/gc/g1/g1CardSetMemory.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.hpp
@@ -27,6 +27,8 @@
 
 #include "gc/g1/g1CardSet.hpp"
 #include "gc/g1/g1CardSetContainers.hpp"
+#include "gc/g1/g1CardSetContainers.inline.hpp"
+#include "gc/g1/g1SegmentedArray.hpp"
 #include "memory/allocation.hpp"
 #include "utilities/growableArray.hpp"
 #include "utilities/lockFreeStack.hpp"
@@ -36,25 +38,14 @@ class outputStream;
 
 // Collects G1CardSetAllocator options/heuristics. Called by G1CardSetAllocator
 // to determine the next size of the allocated G1CardSetBuffer.
-class G1CardSetAllocOptions {
-  uint _elem_size;
-  uint _initial_num_elems;
-  // Defines a limit to the number of elements in the buffer
-  uint _max_num_elems;
 
-  uint exponential_expand(uint prev_num_elems) {
-    return clamp(prev_num_elems * 2, _initial_num_elems, _max_num_elems);
-  }
+class G1CardSetAllocOptions : public G1SegmentedArrayAllocOptions {
 
 public:
   static const uint BufferAlignment = 8;
-  static const uint MinimumBufferSize = 8;
-  static const uint MaximumBufferSize =  UINT_MAX / 2;
 
   G1CardSetAllocOptions(uint elem_size, uint initial_num_elems = MinimumBufferSize, uint max_num_elems = MaximumBufferSize) :
-    _elem_size(align_up(elem_size, BufferAlignment)),
-    _initial_num_elems(initial_num_elems),
-    _max_num_elems(max_num_elems) {
+    G1SegmentedArrayAllocOptions(align_up(elem_size, BufferAlignment), initial_num_elems, max_num_elems, BufferAlignment) {
   }
 
   uint next_num_elems(uint prev_num_elems) {
@@ -64,85 +55,9 @@ public:
   uint elem_size () const {return _elem_size;}
 };
 
-// A single buffer/arena containing _num_elems blocks of memory of _elem_size.
-// G1CardSetBuffers can be linked together using a singly linked list.
-class G1CardSetBuffer : public CHeapObj<mtGCCardSet> {
-  uint _elem_size;
-  uint _num_elems;
+typedef SegmentedArrayBuffer<mtGCCardSet> G1CardSetBuffer;
 
-  G1CardSetBuffer* volatile _next;
-
-  char* _buffer;  // Actual data.
-
-  // Index into the next free block to allocate into. Full if equal (or larger)
-  // to _num_elems (can be larger because we atomically increment this value and
-  // check only afterwards if the allocation has been successful).
-  uint volatile _next_allocate;
-
-public:
-  G1CardSetBuffer(uint elem_size, uint num_elems, G1CardSetBuffer* next);
-  ~G1CardSetBuffer();
-
-  G1CardSetBuffer* volatile* next_addr() { return &_next; }
-
-  void* get_new_buffer_elem();
-
-  uint num_elems() const { return _num_elems; }
-
-  G1CardSetBuffer* next() const { return _next; }
-
-  void set_next(G1CardSetBuffer* next) {
-    assert(next != this, " loop condition");
-    _next = next;
-  }
-
-  void reset(G1CardSetBuffer* next) {
-    _next_allocate = 0;
-    assert(next != this, " loop condition");
-    set_next(next);
-    memset((void*)_buffer, 0, (size_t)_num_elems * _elem_size);
-  }
-
-  uint elem_size() const { return _elem_size; }
-
-  size_t mem_size() const { return sizeof(*this) + (size_t)_num_elems * _elem_size; }
-
-  bool is_full() const { return _next_allocate >= _num_elems; }
-};
-
-// Set of (free) G1CardSetBuffers. The assumed usage is that allocation
-// to it and removal of elements is strictly separate, but every action may be
-// performed by multiple threads at the same time.
-// Counts and memory usage are current on a best-effort basis if accessed concurrently.
-class G1CardSetBufferList {
-  static G1CardSetBuffer* volatile* next_ptr(G1CardSetBuffer& node) {
-    return node.next_addr();
-  }
-  typedef LockFreeStack<G1CardSetBuffer, &next_ptr> NodeStack;
-
-  NodeStack _list;
-
-  volatile size_t _num_buffers;
-  volatile size_t _mem_size;
-
-public:
-  G1CardSetBufferList() : _list(), _num_buffers(0), _mem_size(0) { }
-  ~G1CardSetBufferList() { free_all(); }
-
-  void bulk_add(G1CardSetBuffer& first, G1CardSetBuffer& last, size_t num, size_t mem_size);
-  void add(G1CardSetBuffer& elem) { _list.prepend(elem); }
-
-  G1CardSetBuffer* get();
-  G1CardSetBuffer* get_all(size_t& num_buffers, size_t& mem_size);
-
-  // Give back all memory to the OS.
-  void free_all();
-
-  void print_on(outputStream* out, const char* prefix = "");
-
-  size_t num_buffers() const { return Atomic::load(&_num_buffers); }
-  size_t mem_size() const { return Atomic::load(&_mem_size); }
-};
+typedef SegmentedArrayBufferList<mtGCCardSet> G1CardSetBufferList;
 
 // Arena-like allocator for (card set) heap memory objects (Elem elements).
 //
@@ -181,24 +96,11 @@ public:
 // own set of allocators, there is intentionally no padding between them to save
 // memory.
 template <class Elem>
-class G1CardSetAllocator {
+class G1CardSetAllocator : public G1SegmentedArray<Elem, mtGCCardSet> {
   // G1CardSetBuffer management.
-
-  // G1CardSetAllocOptions provides parameters for allocation buffer
-  // sizing and expansion.
-  G1CardSetAllocOptions _alloc_options;
-
-  G1CardSetBuffer* volatile _first;       // The (start of the) list of all buffers.
-  G1CardSetBuffer* _last;                 // The last element of the list of all buffers.
-  volatile uint _num_buffers;             // Number of assigned buffers to this allocator.
-  volatile size_t _mem_size;              // Memory used by all buffers.
-
-  G1CardSetBufferList* _free_buffer_list; // The global free buffer list to
-                                          // preferentially get new buffers from.
 
   // G1CardSetContainer node management within the G1CardSetBuffers allocated
   // by this allocator.
-
   static G1CardSetContainer* volatile* next_ptr(G1CardSetContainer& node);
   typedef LockFreeStack<G1CardSetContainer, &G1CardSetAllocator::next_ptr> NodeStack;
 
@@ -209,8 +111,8 @@ class G1CardSetAllocator {
   volatile uint _num_pending_nodes;   // Number of nodes in the pending list.
   volatile uint _num_free_nodes;      // Number of nodes in the free list.
 
-  volatile uint _num_allocated_nodes; // Number of total nodes allocated and in use.
-  volatile uint _num_available_nodes; // Number of nodes available in all buffers (allocated + free + pending + not yet used).
+  // volatile uint _num_allocated_nodes; // Number of total nodes allocated and in use.
+  // volatile uint _num_available_nodes; // Number of nodes available in all buffers (allocated + free + pending + not yet used).
 
   // Try to transfer nodes from _pending_nodes_list to _free_nodes_list, with a
   // synchronization delay for any in-progress pops from the _free_nodes_list
@@ -218,10 +120,6 @@ class G1CardSetAllocator {
   bool try_transfer_pending();
 
   uint num_free_elems() const;
-
-  G1CardSetBuffer* create_new_buffer(G1CardSetBuffer* const prev);
-
-  uint elem_size() const { return _alloc_options.elem_size(); }
 
 public:
   G1CardSetAllocator(const char* name,
@@ -238,15 +136,16 @@ public:
   // be called in a globally synchronized area.
   void drop_all();
 
-  uint num_buffers() const;
-
   size_t mem_size() const {
     return sizeof(*this) +
-      num_buffers() * sizeof(G1CardSetBuffer) + (size_t)_num_available_nodes * elem_size();
+      G1SegmentedArray<Elem, mtGCCardSet>::num_buffers() * sizeof(G1CardSetBuffer)
+            + G1SegmentedArray<Elem, mtGCCardSet>::_num_available_nodes * G1SegmentedArray<Elem, mtGCCardSet>::elem_size();
   }
 
   size_t wasted_mem_size() const {
-    return ((size_t)_num_available_nodes - (_num_allocated_nodes - _num_pending_nodes)) * elem_size();
+    return (G1SegmentedArray<Elem, mtGCCardSet>::_num_available_nodes
+              - (G1SegmentedArray<Elem, mtGCCardSet>::_num_allocated_nodes - _num_pending_nodes))
+                * G1SegmentedArray<Elem, mtGCCardSet>::elem_size();
   }
 
   void print(outputStream* os);

--- a/src/hotspot/share/gc/g1/g1CardSetMemory.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.inline.hpp
@@ -27,6 +27,7 @@
 
 #include "gc/g1/g1CardSetMemory.hpp"
 #include "gc/g1/g1CardSetContainers.hpp"
+#include "gc/g1/g1SegmentedArray.inline.hpp"
 #include "utilities/ostream.hpp"
 
 #include "gc/g1/g1CardSetContainers.inline.hpp"
@@ -38,41 +39,8 @@ G1CardSetContainer* volatile* G1CardSetAllocator<Elem>::next_ptr(G1CardSetContai
 }
 
 template <class Elem>
-G1CardSetBuffer* G1CardSetAllocator<Elem>::create_new_buffer(G1CardSetBuffer* const prev) {
-
-  // Take an existing buffer if available.
-  G1CardSetBuffer* next = _free_buffer_list->get();
-  if (next == nullptr) {
-    uint prev_num_elems = (prev != nullptr) ? prev->num_elems() : 0;
-    uint num_elems = _alloc_options.next_num_elems(prev_num_elems);
-    next = new G1CardSetBuffer(elem_size(), num_elems, prev);
-  } else {
-    assert(elem_size() == next->elem_size() , "Mismatch %d != %d Elem %zu", elem_size(), next->elem_size(), sizeof(Elem));
-    next->reset(prev);
-  }
-
-  // Install it as current allocation buffer.
-  G1CardSetBuffer* old = Atomic::cmpxchg(&_first, prev, next);
-  if (old != prev) {
-    // Somebody else installed the buffer, use that one.
-    delete next;
-    return old;
-  } else {
-    // Did we install the first element in the list? If so, this is also the last.
-    if (prev == nullptr) {
-      _last = next;
-    }
-    // Successfully installed the buffer into the list.
-    Atomic::inc(&_num_buffers, memory_order_relaxed);
-    Atomic::add(&_mem_size, next->mem_size(), memory_order_relaxed);
-    Atomic::add(&_num_available_nodes, next->num_elems(), memory_order_relaxed);
-    return next;
-  }
-}
-
-template <class Elem>
 Elem* G1CardSetAllocator<Elem>::allocate() {
-  assert(elem_size() > 0, "instance size not set.");
+  // assert(G1SegmentedArray<Elem, mtGCCardSet>::elem_size() > 0, "instance size not set.");
 
   if (num_free_elems() > 0) {
     // Pop under critical section to deal with ABA problem
@@ -88,22 +56,9 @@ Elem* G1CardSetAllocator<Elem>::allocate() {
     }
   }
 
-  G1CardSetBuffer* cur = Atomic::load_acquire(&_first);
-  if (cur == nullptr) {
-    cur = create_new_buffer(cur);
-  }
-
-  while (true) {
-    Elem* elem = (Elem*)cur->get_new_buffer_elem();
-    if (elem != nullptr) {
-      Atomic::inc(&_num_allocated_nodes, memory_order_relaxed);
-      guarantee(is_aligned(elem, 8), "result " PTR_FORMAT " not aligned", p2i(elem));
-      return elem;
-    }
-    // The buffer is full. Next round.
-    assert(cur->is_full(), "must be");
-    cur = create_new_buffer(cur);
-  }
+  Elem* elem = G1SegmentedArray<Elem, mtGCCardSet>::allocate();
+  assert(elem != nullptr, "must be");
+  return elem;
 }
 
 inline uint8_t* G1CardSetMemoryManager::allocate(uint type) {
@@ -117,11 +72,6 @@ inline uint8_t* G1CardSetMemoryManager::allocate_node() {
 
 inline void G1CardSetMemoryManager::free_node(void* value) {
   free(0, value);
-}
-
-template <class Elem>
-inline uint G1CardSetAllocator<Elem>::num_buffers() const {
-  return Atomic::load(&_num_buffers);
 }
 
 template <class Elem>

--- a/src/hotspot/share/gc/g1/g1CardSetMemory.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.inline.hpp
@@ -40,7 +40,8 @@ G1CardSetContainer* volatile* G1CardSetAllocator<Elem>::next_ptr(G1CardSetContai
 
 template <class Elem>
 Elem* G1CardSetAllocator<Elem>::allocate() {
-  // assert(G1SegmentedArray<Elem, mtGCCardSet>::elem_size() > 0, "instance size not set.");
+  uint elem_size = G1SegmentedArray<Elem, mtGCCardSet>::elem_size();
+  assert(elem_size > 0, "instance size not set.");
 
   if (num_free_elems() > 0) {
     // Pop under critical section to deal with ABA problem

--- a/src/hotspot/share/gc/g1/g1SegmentedArray.hpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArray.hpp
@@ -124,7 +124,7 @@ public:
 };
 
 
-
+// Configuration for G1SegmentedArray, e.g element size, element number of next SegmentedArrayBuffer.
 class G1SegmentedArrayAllocOptions {
 protected:
   uint _elem_size;
@@ -154,17 +154,18 @@ public:
     return _initial_num_elems;
   }
 
-  uint elem_size () const {return _elem_size;}
+  uint elem_size() const {return _elem_size;}
 
   uint alignment() const { return _alignment; }
 };
 
 
-
+// A segmented array where SegmentedArrayBuffer is the segment, and
+// SegmentedArrayBufferList is the free list to cache SegmentedArrayBuffer,
+// and G1SegmentedArrayAllocOptions is the configuration for G1SegmentedArray
+// attributes.
 template <class Elem, MEMFLAGS flag>
 class G1SegmentedArray {
-
-protected:
   // G1CardSetAllocOptions provides parameters for allocation buffer
   // sizing and expansion.
   G1SegmentedArrayAllocOptions _alloc_options;
@@ -172,7 +173,6 @@ protected:
   volatile uint _num_available_nodes; // Number of nodes available in all buffers (allocated + free + pending + not yet used).
   volatile uint _num_allocated_nodes; // Number of total nodes allocated and in use.
 
-private:
   SegmentedArrayBuffer<flag>* volatile _first;       // The (start of the) list of all buffers.
   SegmentedArrayBuffer<flag>* _last;                 // The last element of the list of all buffers.
   volatile uint _num_buffers;             // Number of assigned buffers to this allocator.
@@ -182,10 +182,13 @@ private:
   // preferentially get new buffers from.
 
 private:
-  SegmentedArrayBuffer<flag>* create_new_buffer(SegmentedArrayBuffer<flag>* const prev);
+  inline SegmentedArrayBuffer<flag>* create_new_buffer(SegmentedArrayBuffer<flag>* const prev);
 
 protected:
-  uint elem_size() const;
+  uint num_available_nodes() const { return _num_available_nodes; }
+  uint num_allocated_nodes() const { return _num_allocated_nodes; }
+  const SegmentedArrayBuffer<flag>* first_array_buffer() const { return _first; }
+  inline uint elem_size() const;
 
 public:
   G1SegmentedArray(const char* name,
@@ -199,9 +202,9 @@ public:
   // be called in a globally synchronized area.
   void drop_all();
 
-  Elem* allocate();
+  inline Elem* allocate();
 
-  uint num_buffers() const;
+  inline uint num_buffers() const;
 
   uint length();
 

--- a/src/hotspot/share/gc/g1/g1SegmentedArray.hpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArray.hpp
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Huawei Technologies Co. Ltd. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef LINUX_X86_64_SERVER_SLOWDEBUG_G1SEGMENTEDARRAY_HPP
+#define LINUX_X86_64_SERVER_SLOWDEBUG_G1SEGMENTEDARRAY_HPP
+
+#include "memory/allocation.hpp"
+#include "utilities/lockFreeStack.hpp"
+
+
+// A single buffer/arena containing _num_elems blocks of memory of _elem_size.
+// SegmentedArrayBuffers can be linked together using a singly linked list.
+template<MEMFLAGS flag>
+class SegmentedArrayBuffer : public CHeapObj<flag> {
+  const uint _elem_size;
+  const uint _num_elems;
+
+  SegmentedArrayBuffer* volatile _next;
+
+  char* _buffer;  // Actual data.
+
+  // Index into the next free block to allocate into. Full if equal (or larger)
+  // to _num_elems (can be larger because we atomically increment this value and
+  // check only afterwards if the allocation has been successful).
+  uint volatile _next_allocate;
+
+public:
+  SegmentedArrayBuffer(uint elem_size, uint num_elems, SegmentedArrayBuffer* next);
+  ~SegmentedArrayBuffer();
+
+  SegmentedArrayBuffer* volatile* next_addr() { return &_next; }
+
+  void* get_new_buffer_elem();
+
+  uint num_elems() const { return _num_elems; }
+
+  SegmentedArrayBuffer* next() const { return _next; }
+
+  void set_next(SegmentedArrayBuffer* next) {
+    assert(next != this, " loop condition");
+    _next = next;
+  }
+
+  void reset(SegmentedArrayBuffer* next) {
+    _next_allocate = 0;
+    assert(next != this, " loop condition");
+    set_next(next);
+    memset((void*)_buffer, 0, (size_t)_num_elems * _elem_size);
+  }
+
+  uint elem_size() const { return _elem_size; }
+
+  size_t mem_size() const { return sizeof(*this) + (size_t)_num_elems * _elem_size; }
+
+  uint length() const { return _next_allocate; }
+
+  char* start() const { return _buffer; }
+
+  bool is_full() const { return _next_allocate >= _num_elems; }
+};
+
+
+
+// Set of (free) SegmentedArrayBuffers. The assumed usage is that allocation
+// to it and removal of elements is strictly separate, but every action may be
+// performed by multiple threads at the same time.
+// Counts and memory usage are current on a best-effort basis if accessed concurrently.
+template<MEMFLAGS flag>
+class SegmentedArrayBufferList {
+  static SegmentedArrayBuffer<flag>* volatile* next_ptr(SegmentedArrayBuffer<flag>& node) {
+    return node.next_addr();
+  }
+  typedef LockFreeStack<SegmentedArrayBuffer<flag>, &SegmentedArrayBufferList::next_ptr> NodeStack;
+
+  NodeStack _list;
+
+  volatile size_t _num_buffers;
+  volatile size_t _mem_size;
+
+public:
+  SegmentedArrayBufferList() : _list(), _num_buffers(0), _mem_size(0) { }
+  ~SegmentedArrayBufferList() { free_all(); }
+
+  void bulk_add(SegmentedArrayBuffer<flag>& first, SegmentedArrayBuffer<flag>& last, size_t num, size_t mem_size);
+  void add(SegmentedArrayBuffer<flag>& elem) { _list.prepend(elem); }
+
+  SegmentedArrayBuffer<flag>* get();
+  SegmentedArrayBuffer<flag>* get_all(size_t& num_buffers, size_t& mem_size);
+
+  // Give back all memory to the OS.
+  void free_all();
+
+  void print_on(outputStream* out, const char* prefix = "");
+
+  size_t num_buffers() const { return Atomic::load(&_num_buffers); }
+  size_t mem_size() const { return Atomic::load(&_mem_size); }
+};
+
+
+
+class G1SegmentedArrayAllocOptions {
+protected:
+  uint _elem_size;
+  uint _initial_num_elems;
+  // Defines a limit to the number of elements in the buffer
+  uint _max_num_elems;
+  uint _alignment;
+
+  uint exponential_expand(uint prev_num_elems) {
+    return clamp(prev_num_elems * 2, _initial_num_elems, _max_num_elems);
+  }
+
+public:
+  static const uint BufferAlignment = 4;
+  static const uint MinimumBufferSize = 8;
+  static const uint MaximumBufferSize =  UINT_MAX / 2;
+
+  G1SegmentedArrayAllocOptions(uint elem_size, uint initial_num_elems = MinimumBufferSize,
+                               uint max_num_elems = MaximumBufferSize, uint alignment = BufferAlignment) :
+    _elem_size(elem_size),
+    _initial_num_elems(initial_num_elems),
+    _max_num_elems(max_num_elems),
+    _alignment(alignment) {
+  }
+
+  uint next_num_elems(uint prev_num_elems) {
+    return _initial_num_elems;
+  }
+
+  uint elem_size () const {return _elem_size;}
+
+  uint alignment() const { return _alignment; }
+};
+
+
+
+template <class Elem, MEMFLAGS flag>
+class G1SegmentedArray {
+
+protected:
+  // G1CardSetAllocOptions provides parameters for allocation buffer
+  // sizing and expansion.
+  G1SegmentedArrayAllocOptions _alloc_options;
+
+  volatile uint _num_available_nodes; // Number of nodes available in all buffers (allocated + free + pending + not yet used).
+  volatile uint _num_allocated_nodes; // Number of total nodes allocated and in use.
+
+private:
+  SegmentedArrayBuffer<flag>* volatile _first;       // The (start of the) list of all buffers.
+  SegmentedArrayBuffer<flag>* _last;                 // The last element of the list of all buffers.
+  volatile uint _num_buffers;             // Number of assigned buffers to this allocator.
+  volatile size_t _mem_size;              // Memory used by all buffers.
+
+  SegmentedArrayBufferList<flag>* _free_buffer_list; // The global free buffer list to
+  // preferentially get new buffers from.
+
+private:
+  SegmentedArrayBuffer<flag>* create_new_buffer(SegmentedArrayBuffer<flag>* const prev);
+
+protected:
+  uint elem_size() const;
+
+public:
+  G1SegmentedArray(const char* name,
+                   const G1SegmentedArrayAllocOptions& buffer_options,
+                   SegmentedArrayBufferList<flag>* free_buffer_list);
+  ~G1SegmentedArray() {
+    drop_all();
+  }
+
+  // Deallocate all buffers to the free buffer list and reset this allocator. Must
+  // be called in a globally synchronized area.
+  void drop_all();
+
+  Elem* allocate();
+
+  uint num_buffers() const;
+
+  uint length();
+
+  template<typename Visitor>
+  void iterate_nodes(Visitor& v);
+};
+
+
+#endif //LINUX_X86_64_SERVER_SLOWDEBUG_G1SEGMENTEDARRAY_HPP

--- a/src/hotspot/share/gc/g1/g1SegmentedArray.hpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArray.hpp
@@ -74,7 +74,12 @@ public:
 
   size_t mem_size() const { return sizeof(*this) + (size_t)_num_elems * _elem_size; }
 
-  uint length() const { return _next_allocate; }
+  uint length() {
+    // _next_allocate might grow greater than _num_elems in multi-thread env,
+    // so, here we need to return the adjusted real length value.
+    _next_allocate = _next_allocate > _num_elems ? _num_elems : _next_allocate;
+    return _next_allocate;
+  }
 
   char* start() const { return _buffer; }
 

--- a/src/hotspot/share/gc/g1/g1SegmentedArray.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArray.inline.hpp
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Huawei Technologies Co. Ltd. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "gc/g1/g1SegmentedArray.hpp"
+#include "runtime/atomic.hpp"
+#include "utilities/globalCounter.hpp"
+#include "utilities/globalCounter.inline.hpp"
+
+
+// ==== SegmentedArrayBuffer ====
+
+template<MEMFLAGS flag>
+SegmentedArrayBuffer<flag>::SegmentedArrayBuffer(uint elem_size, uint num_instances, SegmentedArrayBuffer* next) :
+  _elem_size(elem_size), _num_elems(num_instances), _next(next), _next_allocate(0) {
+
+  _buffer = NEW_C_HEAP_ARRAY(char, (size_t)_num_elems * elem_size, mtGCCardSet);
+}
+
+template<MEMFLAGS flag>
+SegmentedArrayBuffer<flag>::~SegmentedArrayBuffer() {
+  FREE_C_HEAP_ARRAY(mtGCCardSet, _buffer);
+}
+
+template<MEMFLAGS flag>
+void* SegmentedArrayBuffer<flag>::get_new_buffer_elem() {
+  if (_next_allocate >= _num_elems) {
+    return nullptr;
+  }
+  uint result = Atomic::fetch_and_add(&_next_allocate, 1u, memory_order_relaxed);
+  if (result >= _num_elems) {
+    return nullptr;
+  }
+  void* r = _buffer + (uint)result * _elem_size;
+  return r;
+}
+
+
+// ==== SegmentedArrayBufferList ====
+
+template<MEMFLAGS flag>
+void SegmentedArrayBufferList<flag>::bulk_add(SegmentedArrayBuffer<flag>& first,
+                                              SegmentedArrayBuffer<flag>& last,
+                                              size_t num,
+                                              size_t mem_size) {
+  _list.prepend(first, last);
+  Atomic::add(&_num_buffers, num, memory_order_relaxed);
+  Atomic::add(&_mem_size, mem_size, memory_order_relaxed);
+}
+
+template<MEMFLAGS flag>
+void SegmentedArrayBufferList<flag>::print_on(outputStream* out, const char* prefix) {
+  out->print_cr("%s: buffers %zu size %zu",
+                prefix, Atomic::load(&_num_buffers), Atomic::load(&_mem_size));
+}
+
+template<MEMFLAGS flag>
+SegmentedArrayBuffer<flag>* SegmentedArrayBufferList<flag>::get() {
+  GlobalCounter::CriticalSection cs(Thread::current());
+
+  SegmentedArrayBuffer<flag>* result = _list.pop();
+  if (result != nullptr) {
+    Atomic::dec(&_num_buffers, memory_order_relaxed);
+    Atomic::sub(&_mem_size, result->mem_size(), memory_order_relaxed);
+  }
+  return result;
+}
+
+template<MEMFLAGS flag>
+SegmentedArrayBuffer<flag>* SegmentedArrayBufferList<flag>::get_all(size_t& num_buffers,
+                                                                    size_t& mem_size) {
+  GlobalCounter::CriticalSection cs(Thread::current());
+
+  SegmentedArrayBuffer<flag>* result = _list.pop_all();
+  num_buffers = Atomic::load(&_num_buffers);
+  mem_size = Atomic::load(&_mem_size);
+
+  if (result != nullptr) {
+    Atomic::sub(&_num_buffers, num_buffers, memory_order_relaxed);
+    Atomic::sub(&_mem_size, mem_size, memory_order_relaxed);
+  }
+  return result;
+}
+
+template<MEMFLAGS flag>
+void SegmentedArrayBufferList<flag>::free_all() {
+  size_t num_freed = 0;
+  size_t mem_size_freed = 0;
+  SegmentedArrayBuffer<flag>* cur;
+
+  while ((cur = _list.pop()) != nullptr) {
+    mem_size_freed += cur->mem_size();
+    num_freed++;
+    delete cur;
+  }
+
+  Atomic::sub(&_num_buffers, num_freed, memory_order_relaxed);
+  Atomic::sub(&_mem_size, mem_size_freed, memory_order_relaxed);
+}
+
+
+// ==== G1SegmentedArray ====
+
+template <class Elem, MEMFLAGS flag>
+SegmentedArrayBuffer<flag>* G1SegmentedArray<Elem, flag>::create_new_buffer(
+  SegmentedArrayBuffer<flag>* const prev) {
+
+  // Take an existing buffer if available.
+  SegmentedArrayBuffer<flag>* next = _free_buffer_list->get();
+  if (next == nullptr) {
+    uint prev_num_elems = (prev != nullptr) ? prev->num_elems() : 0;
+    uint num_elems = _alloc_options.next_num_elems(prev_num_elems);
+    next = new SegmentedArrayBuffer<flag>(elem_size(), num_elems, prev);
+  } else {
+    assert(elem_size() == next->elem_size() ,
+           "Mismatch %d != %d Elem %zu", elem_size(), next->elem_size(), sizeof(Elem));
+    next->reset(prev);
+  }
+
+  // Install it as current allocation buffer.
+  SegmentedArrayBuffer<flag>* old = Atomic::cmpxchg(&_first, prev, next);
+  if (old != prev) {
+    // Somebody else installed the buffer, use that one.
+    delete next;
+    return old;
+  } else {
+    // Did we install the first element in the list? If so, this is also the last.
+    if (prev == nullptr) {
+      _last = next;
+    }
+    // Successfully installed the buffer into the list.
+    Atomic::inc(&_num_buffers, memory_order_relaxed);
+    Atomic::add(&_mem_size, next->mem_size(), memory_order_relaxed);
+    Atomic::add(&_num_available_nodes, next->num_elems(), memory_order_relaxed);
+    return next;
+  }
+}
+
+template <class Elem, MEMFLAGS flag>
+uint G1SegmentedArray<Elem, flag>::elem_size() const {
+  return _alloc_options.elem_size();
+}
+
+template <class Elem, MEMFLAGS flag>
+G1SegmentedArray<Elem, flag>::G1SegmentedArray(const char* name,
+                 const G1SegmentedArrayAllocOptions& buffer_options,
+                 SegmentedArrayBufferList<flag>* free_buffer_list) :
+     _alloc_options(buffer_options),
+     _num_available_nodes(0),
+     _num_allocated_nodes(0),
+     _first(nullptr),
+     _last(nullptr),
+     _num_buffers(0),
+     _mem_size(0),
+     _free_buffer_list(free_buffer_list) {
+  assert(_free_buffer_list != nullptr, "precondition!");
+}
+
+template <class Elem, MEMFLAGS flag>
+void G1SegmentedArray<Elem, flag>::drop_all() {
+  SegmentedArrayBuffer<flag>* cur = Atomic::load_acquire(&_first);
+
+  if (cur != nullptr) {
+    assert(_last != nullptr, "If there is at least one element, there must be a last one.");
+
+    SegmentedArrayBuffer<flag>* first = cur;
+#ifdef ASSERT
+    // Check list consistency.
+    SegmentedArrayBuffer<flag>* last = cur;
+    uint num_buffers = 0;
+    size_t mem_size = 0;
+    while (cur != nullptr) {
+      mem_size += cur->mem_size();
+      num_buffers++;
+
+      SegmentedArrayBuffer<flag>* next = cur->next();
+      last = cur;
+      cur = next;
+    }
+#endif
+    assert(num_buffers == _num_buffers, "Buffer count inconsistent %u %u", num_buffers, _num_buffers);
+    assert(mem_size == _mem_size, "Memory size inconsistent");
+    assert(last == _last, "Inconsistent last element");
+
+    _free_buffer_list->bulk_add(*first, *_last, _num_buffers, _mem_size);
+  }
+
+  _first = nullptr;
+  _last = nullptr;
+  _num_buffers = 0;
+  _mem_size = 0;
+  _num_available_nodes = 0;
+  _num_allocated_nodes = 0;
+}
+
+template <class Elem, MEMFLAGS flag>
+Elem* G1SegmentedArray<Elem, flag>::allocate() {
+  SegmentedArrayBuffer<flag>* cur = Atomic::load_acquire(&_first);
+  if (cur == nullptr) {
+    cur = create_new_buffer(cur);
+  }
+
+  while (true) {
+    Elem* elem = (Elem*)cur->get_new_buffer_elem();
+    if (elem != nullptr) {
+      Atomic::inc(&_num_allocated_nodes, memory_order_relaxed);
+      guarantee(is_aligned(elem, _alloc_options.alignment()),
+                "result " PTR_FORMAT " not aligned at %u", p2i(elem), _alloc_options.alignment());
+      return elem;
+    }
+    // The buffer is full. Next round.
+    assert(cur->is_full(), "must be");
+    cur = create_new_buffer(cur);
+  }
+}
+
+template <class Elem, MEMFLAGS flag>
+inline uint G1SegmentedArray<Elem, flag>::num_buffers() const {
+  return Atomic::load(&_num_buffers);
+}
+
+class LengthVisitor {
+  uint _total;
+public:
+  LengthVisitor() : _total(0) {}
+  void visit(SegmentedArrayBuffer<mtGC>* node, uint32_t limit) {
+    _total += limit;
+  }
+  uint length() {
+    return _total;
+  }
+};
+
+template <class Elem, MEMFLAGS flag>
+uint G1SegmentedArray<Elem, flag>::length() {
+  LengthVisitor v;
+  iterate_nodes(v);
+  return v.length();
+}
+
+template <class Elem, MEMFLAGS flag>
+template <typename Visitor>
+void G1SegmentedArray<Elem, flag>::iterate_nodes(Visitor& v)  {
+  SegmentedArrayBuffer<flag>* cur = Atomic::load_acquire(&_first);
+
+  if (cur != nullptr) {
+    assert(_last != nullptr, "If there is at least one element, there must be a last one.");
+
+    while (cur != nullptr) {
+      uint limit = cur->length();
+      v.visit(cur, limit);
+
+      cur = cur->next();
+    }
+  }
+}


### PR DESCRIPTION
To finish https://bugs.openjdk.java.net/browse/JDK-8254739, we need a segmented array to store a growing regions index array, in the initial version of that patch, a newly home made segmented array was used, but the memory efficiency is not as good as expected, G1CardSetAllocator is a potential candidate to fullfill the requirement, but need some enhancement.

This is a try to enhance G1CardSetAllocator(and G1CardSetBuffer, G1CardSetBufferList) to support element size less pointer size, and strip this basic function as a more generic segmented array (G1SegmentedArray).
