### PR TITLE
8273629: compiler/uncommontrap/TestDeoptOOM.java fails with release VMs

### DIFF
--- a/test/hotspot/jtreg/compiler/uncommontrap/TestDeoptOOM.java
+++ b/test/hotspot/jtreg/compiler/uncommontrap/TestDeoptOOM.java
@@ -41,6 +41,7 @@
  * @run main/othervm -XX:-BackgroundCompilation -Xmx128M -XX:+IgnoreUnrecognizedVMOptions -XX:+VerifyStack
  *      -XX:CompileCommand=exclude,compiler.uncommontrap.TestDeoptOOM::main
  *      -XX:CompileCommand=exclude,compiler.uncommontrap.TestDeoptOOM::m9_1
+ *      -XX:+UnlockDiagnosticVMOptions
  *      -XX:+UseZGC -XX:+LogCompilation -XX:+PrintDeoptimizationDetails -XX:+TraceDeoptimization -XX:+Verbose
  *      compiler.uncommontrap.TestDeoptOOM
  */


### PR DESCRIPTION
Hi all,

The test fails since VM option 'LogCompilation' is diagnostic and must be enabled via -XX:+UnlockDiagnosticVMOptions.
So only `-XX:+UnlockDiagnosticVMOptions` is added to fix it.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273629](https://bugs.openjdk.java.net/browse/JDK-8273629): compiler/uncommontrap/TestDeoptOOM.java fails with release VMs


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5479/head:pull/5479` \
`$ git checkout pull/5479`

Update a local copy of the PR: \
`$ git checkout pull/5479` \
`$ git pull https://git.openjdk.java.net/jdk pull/5479/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5479`

View PR using the GUI difftool: \
`$ git pr show -t 5479`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5479.diff">https://git.openjdk.java.net/jdk/pull/5479.diff</a>

</details>
