### PR TITLE
[PATCH] Remove superfluous use of boxing in jdk.* modules

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
@@ -1138,7 +1138,7 @@ public class CommandProcessor {
                 if (t.countTokens() == 0) {
                     out.println("echo is " + doEcho);
                 } else if (t.countTokens() == 1) {
-                    doEcho = Boolean.valueOf(t.nextToken()).booleanValue();
+                    doEcho = Boolean.parseBoolean(t.nextToken());
                 } else {
                     usage();
                 }
@@ -1150,7 +1150,7 @@ public class CommandProcessor {
                     out.println("versioncheck is " +
                                 (System.getProperty("sun.jvm.hotspot.runtime.VM.disableVersionCheck") == null));
                 } else if (t.countTokens() == 1) {
-                    if (Boolean.valueOf(t.nextToken()).booleanValue()) {
+                    if (Boolean.parseBoolean(t.nextToken())) {
                         System.clearProperty("sun.jvm.hotspot.runtime.VM.disableVersionCheck");
                     } else {
                         System.setProperty("sun.jvm.hotspot.runtime.VM.disableVersionCheck", "true");
@@ -1264,7 +1264,7 @@ public class CommandProcessor {
                     // The field's Type must already be in the database -- no exceptions
                     Type fieldType = agent.getTypeDataBase().lookupType(t.nextToken());
 
-                    boolean isStatic = Boolean.valueOf(t.nextToken()).booleanValue();
+                    boolean isStatic = Boolean.parseBoolean(t.nextToken());
                     long offset = Long.parseLong(t.nextToken());
                     Address staticAddress = parseAddress(t.nextToken());
                     if (isStatic && staticAddress == null) {
@@ -1326,9 +1326,9 @@ public class CommandProcessor {
                     if (superclassName.equals("null")) {
                         superclassName = null;
                     }
-                    boolean isOop = Boolean.valueOf(t.nextToken()).booleanValue();
-                    boolean isInteger = Boolean.valueOf(t.nextToken()).booleanValue();
-                    boolean isUnsigned = Boolean.valueOf(t.nextToken()).booleanValue();
+                    boolean isOop = Boolean.parseBoolean(t.nextToken());
+                    boolean isInteger = Boolean.parseBoolean(t.nextToken());
+                    boolean isUnsigned = Boolean.parseBoolean(t.nextToken());
                     long size = Long.parseLong(t.nextToken());
 
                     BasicType type = null;
@@ -1684,7 +1684,7 @@ public class CommandProcessor {
                 if (t.countTokens() != 1) {
                     usage();
                 } else {
-                    verboseExceptions = Boolean.valueOf(t.nextToken()).booleanValue();
+                    verboseExceptions = Boolean.parseBoolean(t.nextToken());
                 }
             }
         },
@@ -1693,7 +1693,7 @@ public class CommandProcessor {
                 if (t.countTokens() != 1) {
                     usage();
                 } else {
-                    Assert.ASSERTS_ENABLED = Boolean.valueOf(t.nextToken()).booleanValue();
+                    Assert.ASSERTS_ENABLED = Boolean.parseBoolean(t.nextToken());
                 }
             }
         },

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotTypeDataBase.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotTypeDataBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -267,7 +267,7 @@ public class HotSpotTypeDataBase extends BasicTypeDataBase {
             t.nextToken();
             Type fieldType = lookupType(t.sval);
             t.nextToken();
-            boolean isStatic = Boolean.valueOf(t.sval).booleanValue();
+            boolean isStatic = Boolean.parseBoolean(t.sval);
             t.nextToken();
             long offset = Long.parseLong(t.sval);
             t.nextToken();
@@ -321,11 +321,11 @@ public class HotSpotTypeDataBase extends BasicTypeDataBase {
               superclassName = null;
             }
             t.nextToken();
-            boolean isOop = Boolean.valueOf(t.sval).booleanValue();
+            boolean isOop = Boolean.parseBoolean(t.sval);
             t.nextToken();
-            boolean isInteger = Boolean.valueOf(t.sval).booleanValue();
+            boolean isInteger = Boolean.parseBoolean(t.sval);
             t.nextToken();
-            boolean isUnsigned = Boolean.valueOf(t.sval).booleanValue();
+            boolean isUnsigned = Boolean.parseBoolean(t.sval);
             t.nextToken();
             long size = Long.parseLong(t.sval);
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/LinuxDebuggerLocal.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/linux/LinuxDebuggerLocal.java
@@ -284,11 +284,11 @@ public class LinuxDebuggerLocal extends DebuggerBase implements LinuxDebugger {
             return lines.map(s -> s.split("\\s+"))
                         .filter(a -> a.length == 3)
                         .filter(a -> a[0].equals("NSpid:"))
-                        .mapToInt(a -> Integer.valueOf(a[2]))
+                        .mapToInt(a -> Integer.parseInt(a[2]))
                         .findFirst()
                         .getAsInt();
         } catch (IOException | NoSuchElementException e) {
-            return Integer.valueOf(statusPath.getParent()
+            return Integer.parseInt(statusPath.getParent()
                                              .toFile()
                                              .getName());
         }

--- a/src/jdk.jartool/share/classes/sun/tools/jar/Main.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -631,7 +631,7 @@ public class Main {
                     } else if (args[i].startsWith("--release")) {
                         int v = BASE_VERSION;
                         try {
-                            v = Integer.valueOf(args[++i]);
+                            v = Integer.parseInt(args[++i]);
                         } catch (NumberFormatException x) {
                             error(formatMsg("error.release.value.notnumber", args[i]));
                             // this will fall into the next error, thus returning false
@@ -1851,7 +1851,7 @@ public class Main {
 
         String s = name.substring(VERSIONS_DIR_LENGTH);
         s = s.substring(0, s.indexOf('/'));
-        return Integer.valueOf(s);
+        return Integer.parseInt(s);
     }
 
     /**

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/JavapTask.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/JavapTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -294,7 +294,7 @@ public class JavapTask implements DisassemblerTool.DisassemblerTask, Messages {
             void process(JavapTask task, String opt, String arg) throws BadArgs {
                 int sep = opt.indexOf(":");
                 try {
-                    int i = Integer.valueOf(opt.substring(sep + 1));
+                    int i = Integer.parseInt(opt.substring(sep + 1));
                     if (i > 0) // silently ignore invalid values
                         task.options.indentWidth = i;
                 } catch (NumberFormatException e) {
@@ -313,7 +313,7 @@ public class JavapTask implements DisassemblerTool.DisassemblerTask, Messages {
             void process(JavapTask task, String opt, String arg) throws BadArgs {
                 int sep = opt.indexOf(":");
                 try {
-                    int i = Integer.valueOf(opt.substring(sep + 1));
+                    int i = Integer.parseInt(opt.substring(sep + 1));
                     if (i > 0) // silently ignore invalid values
                         task.options.tabColumn = i;
                 } catch (NumberFormatException e) {

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/expr/LValue.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/expr/LValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -735,11 +735,11 @@ abstract class LValue {
     }
 
     static LValue makeFloat(VirtualMachine vm, Token token) {
-        return make(vm, Float.valueOf(token.image).floatValue());
+        return make(vm, Float.parseFloat(token.image));
     }
 
     static LValue makeDouble(VirtualMachine vm, Token token) {
-        return make(vm, Double.valueOf(token.image).doubleValue());
+        return make(vm, Double.parseDouble(token.image));
     }
 
     static LValue makeInteger(VirtualMachine vm, Token token) {

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/SocketListeningConnector.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/SocketListeningConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,6 +108,6 @@ public class SocketListeningConnector extends GenericListeningConnector {
 
     private boolean isWildcardPort(Map<String, ? extends Connector.Argument> args) {
         String port = args.get(ARG_PORT).value();
-        return port.isEmpty() || Integer.valueOf(port) == 0;
+        return port.isEmpty() || Integer.parseInt(port) == 0;
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/BooleanValue.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/BooleanValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ final class BooleanValue  {
 
     public void setValue(String value) {
         this.value = value;
-        this.booleanValue = Boolean.valueOf(value);
+        this.booleanValue = Boolean.parseBoolean(value);
     }
 
     public final String getValue() {

--- a/src/jdk.management.agent/share/classes/sun/management/jmxremote/ConnectorBootstrap.java
+++ b/src/jdk.management.agent/share/classes/sun/management/jmxremote/ConnectorBootstrap.java
@@ -362,21 +362,21 @@ public final class ConnectorBootstrap {
                 props.getProperty(PropertyNames.USE_AUTHENTICATION,
                 DefaultValues.USE_AUTHENTICATION);
         final boolean useAuthentication =
-                Boolean.valueOf(useAuthenticationStr).booleanValue();
+                Boolean.parseBoolean(useAuthenticationStr);
 
         // Do we use SSL?
         final String useSslStr =
                 props.getProperty(PropertyNames.USE_SSL,
                 DefaultValues.USE_SSL);
         final boolean useSsl =
-                Boolean.valueOf(useSslStr).booleanValue();
+                Boolean.parseBoolean(useSslStr);
 
         // Do we use RMI Registry SSL?
         final String useRegistrySslStr =
                 props.getProperty(PropertyNames.USE_REGISTRY_SSL,
                 DefaultValues.USE_REGISTRY_SSL);
         final boolean useRegistrySsl =
-                Boolean.valueOf(useRegistrySslStr).booleanValue();
+                Boolean.parseBoolean(useRegistrySslStr);
 
         final String enabledCipherSuites =
                 props.getProperty(PropertyNames.SSL_ENABLED_CIPHER_SUITES);
@@ -406,7 +406,7 @@ public final class ConnectorBootstrap {
                 props.getProperty(PropertyNames.SSL_NEED_CLIENT_AUTH,
                 DefaultValues.SSL_NEED_CLIENT_AUTH);
         final boolean sslNeedClientAuth =
-                Boolean.valueOf(sslNeedClientAuthStr).booleanValue();
+                Boolean.parseBoolean(sslNeedClientAuthStr);
 
         // Read SSL config file name
         final String sslConfigFileName =
@@ -572,7 +572,7 @@ public final class ConnectorBootstrap {
             // Do we accept connections from local interfaces only?
             String useLocalOnlyStr = props.getProperty(
                     PropertyNames.USE_LOCAL_ONLY, DefaultValues.USE_LOCAL_ONLY);
-            boolean useLocalOnly = Boolean.valueOf(useLocalOnlyStr).booleanValue();
+            boolean useLocalOnly = Boolean.parseBoolean(useLocalOnlyStr);
             if (useLocalOnly) {
                 env.put(RMIConnectorServer.RMI_SERVER_SOCKET_FACTORY_ATTRIBUTE,
                         new LocalRMIServerSocketFactory());


### PR DESCRIPTION
Usages of primitive types should be preferred and makes code easier to read.

Similar cleanups in the past:
[JDK-8273168](https://bugs.openjdk.java.net/browse/JDK-8273168)
[JDK-8248318](https://bugs.openjdk.java.net/browse/JDK-8248318)
[JDK-8200364](https://bugs.openjdk.java.net/browse/JDK-8200364)

I didn't update couple of boxings in `src/jdk.internal.le/share/classes/jdk/internal/org/jline/utils/Curses.java` because it's a part of JLine library. Created PR to upstream instead  https://github.com/jline/jline3/pull/695

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5480/head:pull/5480` \
`$ git checkout pull/5480`

Update a local copy of the PR: \
`$ git checkout pull/5480` \
`$ git pull https://git.openjdk.java.net/jdk pull/5480/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5480`

View PR using the GUI difftool: \
`$ git pr show -t 5480`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5480.diff">https://git.openjdk.java.net/jdk/pull/5480.diff</a>

</details>
