### PR TITLE
8274640: Cleanup unnecessary null comparison before instanceof check in java.desktop

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaBorder.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaBorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -128,7 +128,7 @@ public abstract class AquaBorder implements Border, UIResource {
             if (!((javax.swing.text.JTextComponent)focusable).isEditable()) return false;
         }
 
-        return (focusable != null && focusable instanceof JComponent && ((JComponent)focusable).hasFocus());
+        return (focusable instanceof JComponent jComponent) && jComponent.hasFocus();
     }
 
     @Override

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaButtonBorder.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaButtonBorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -145,9 +145,9 @@ public abstract class AquaButtonBorder extends AquaBorder implements Border, UIR
      * @param c the component for which this border insets value applies
      */
     public Insets getBorderInsets(final Component c) {
-        if (c == null || !(c instanceof AbstractButton)) return new Insets(0, 0, 0, 0);
+        if (!(c instanceof AbstractButton button)) return new Insets(0, 0, 0, 0);
 
-        Insets margin = ((AbstractButton)c).getMargin();
+        Insets margin = button.getMargin();
         margin = (margin == null) ? new InsetsUIResource(0, 0, 0, 0) : (Insets)margin.clone();
 
         margin.top += sizeVariant.margins.top;

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaComboBoxUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaComboBoxUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -598,8 +598,7 @@ public class AquaComboBoxUI extends BasicComboBoxUI implements Sizeable {
         final boolean editable = comboBox.isEditable();
 
         final Dimension size;
-        if (!editable && arrowButton != null && arrowButton instanceof AquaComboBoxButton) {
-            final AquaComboBoxButton button = (AquaComboBoxButton)arrowButton;
+        if (!editable && arrowButton instanceof final AquaComboBoxButton button) {
             final Insets buttonInsets = button.getInsets();
             //  Insets insets = comboBox.getInsets();
             final Insets insets = new Insets(0, 5, 0, 25);//comboBox.getInsets();

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaFileChooserUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaFileChooserUI.java
@@ -519,14 +519,14 @@ public class AquaFileChooserUI extends FileChooserUI {
 
     void setPackageIsTraversable(final Object o) {
         int newProp = -1;
-        if (o != null && o instanceof String) newProp = parseTraversableProperty((String)o);
+        if (o instanceof String s) newProp = parseTraversableProperty(s);
         if (newProp != -1) fPackageIsTraversable = newProp;
         else fPackageIsTraversable = sGlobalPackageIsTraversable;
     }
 
     void setApplicationIsTraversable(final Object o) {
         int newProp = -1;
-        if (o != null && o instanceof String) newProp = parseTraversableProperty((String)o);
+        if (o instanceof String s) newProp = parseTraversableProperty(s);
         if (newProp != -1) fApplicationIsTraversable = newProp;
         else fApplicationIsTraversable = sGlobalApplicationIsTraversable;
     }
@@ -1985,11 +1985,11 @@ public class AquaFileChooserUI extends FileChooserUI {
 
     static {
         Object o = UIManager.get(PACKAGE_TRAVERSABLE_PROPERTY);
-        if (o != null && o instanceof String) sGlobalPackageIsTraversable = parseTraversableProperty((String)o);
+        if (o instanceof String s) sGlobalPackageIsTraversable = parseTraversableProperty(s);
         else sGlobalPackageIsTraversable = kOpenConditional;
 
         o = UIManager.get(APPLICATION_TRAVERSABLE_PROPERTY);
-        if (o != null && o instanceof String) sGlobalApplicationIsTraversable = parseTraversableProperty((String)o);
+        if (o instanceof String s) sGlobalApplicationIsTraversable = parseTraversableProperty(s);
         else sGlobalApplicationIsTraversable = kOpenConditional;
     }
     static final String sDataPrefix = "FileChooser.";

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaLookAndFeel.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaLookAndFeel.java
@@ -188,8 +188,8 @@ public class AquaLookAndFeel extends BasicLookAndFeel {
         KeyboardFocusManager.getCurrentKeyboardFocusManager().removeKeyEventPostProcessor(AquaMnemonicHandler.getInstance());
 
         final PopupFactory popupFactory = PopupFactory.getSharedInstance();
-        if (popupFactory != null && popupFactory instanceof ScreenPopupFactory) {
-            ((ScreenPopupFactory)popupFactory).setActive(false);
+        if (popupFactory instanceof ScreenPopupFactory spf) {
+            spf.setActive(false);
         }
 
         super.uninitialize();

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaRootPaneUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaRootPaneUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,8 +75,7 @@ public class AquaRootPaneUI extends BasicRootPaneUI implements AncestorListener,
         // it is not since we are going to grab the one that was set on the JFrame. :(
         final Component parent = c.getParent();
 
-        if (parent != null && parent instanceof JFrame) {
-            final JFrame frameParent = (JFrame)parent;
+        if (parent instanceof JFrame frameParent) {
             final Color bg = frameParent.getBackground();
             if (bg == null || bg instanceof UIResource) {
                 frameParent.setBackground(UIManager.getColor("Panel.background"));
@@ -126,8 +125,8 @@ public class AquaRootPaneUI extends BasicRootPaneUI implements AncestorListener,
                     final Window owningWindow = SwingUtilities.getWindowAncestor(jmb);
 
                     // Could be a JDialog, and may have been added to a JRootPane not yet in a window.
-                    if (owningWindow != null && owningWindow instanceof JFrame) {
-                        ((AquaMenuBarUI)mbui).setScreenMenuBar((JFrame)owningWindow);
+                    if (owningWindow instanceof JFrame frame) {
+                        ((AquaMenuBarUI)mbui).setScreenMenuBar(frame);
                     }
                 }
             }
@@ -154,8 +153,8 @@ public class AquaRootPaneUI extends BasicRootPaneUI implements AncestorListener,
                     final Window owningWindow = SwingUtilities.getWindowAncestor(jmb);
 
                     // Could be a JDialog, and may have been added to a JRootPane not yet in a window.
-                    if (owningWindow != null && owningWindow instanceof JFrame) {
-                        ((AquaMenuBarUI)mbui).clearScreenMenuBar((JFrame)owningWindow);
+                    if (owningWindow instanceof JFrame frame) {
+                        ((AquaMenuBarUI)mbui).clearScreenMenuBar(frame);
                     }
                 }
             }

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaSliderUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaSliderUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -266,8 +266,8 @@ public class AquaSliderUI extends BasicSliderUI implements Sizeable {
         if (slider.getPaintTicks() || slider.getPaintLabels()) return true;
 
         final Object shouldPaintArrowThumbProperty = slider.getClientProperty("Slider.paintThumbArrowShape");
-        if (shouldPaintArrowThumbProperty != null && shouldPaintArrowThumbProperty instanceof Boolean) {
-            return ((Boolean)shouldPaintArrowThumbProperty).booleanValue();
+        if (shouldPaintArrowThumbProperty instanceof Boolean b) {
+            return b;
         }
 
         return false;

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTableHeaderUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTableHeaderUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,9 +103,8 @@ public class AquaTableHeaderUI extends BasicTableHeaderUI {
         }
 
         final TableHeaderUI headerUI = target.getUI();
-        if (headerUI == null || !(headerUI instanceof AquaTableHeaderUI)) return;
+        if (!(headerUI instanceof AquaTableHeaderUI aquaHeaderUI)) return;
 
-        final AquaTableHeaderUI aquaHeaderUI = (AquaTableHeaderUI)headerUI;
         aquaHeaderUI.sortColumn = tableColumn.getModelIndex();
         aquaHeaderUI.sortOrder = sortDirection;
         final AquaTableCellRenderer renderer = aquaHeaderUI.new AquaTableCellRenderer();
@@ -145,8 +144,8 @@ public class AquaTableHeaderUI extends BasicTableHeaderUI {
     }
 
     protected static TableColumn getTableColumn(final JTableHeader target, final Object value) {
-        if (value == null || !(value instanceof Integer)) return null;
-        final int columnIndex = ((Integer)value).intValue();
+        if (!(value instanceof Integer idx)) return null;
+        final int columnIndex = idx;
 
         final TableColumnModel columnModel = target.getColumnModel();
         if (columnIndex < 0 || columnIndex >= columnModel.getColumnCount()) return null;

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaTableHeaderUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaTableHeaderUI.java
@@ -144,8 +144,7 @@ public class AquaTableHeaderUI extends BasicTableHeaderUI {
     }
 
     protected static TableColumn getTableColumn(final JTableHeader target, final Object value) {
-        if (!(value instanceof Integer idx)) return null;
-        final int columnIndex = idx;
+        if (!(value instanceof Integer columnIndex)) return null;
 
         final TableColumnModel columnModel = target.getColumnModel();
         if (columnIndex < 0 || columnIndex >= columnModel.getColumnCount()) return null;

--- a/src/java.desktop/macosx/classes/com/apple/laf/ScreenMenu.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/ScreenMenu.java
@@ -351,11 +351,8 @@ final class ScreenMenu extends Menu
         // Tell our parent to add/remove us
         final MenuContainer parent = getParent();
 
-        if (parent != null) {
-            if (parent instanceof ScreenMenu) {
-                final ScreenMenu sm = (ScreenMenu)parent;
-                sm.setChildVisible(fInvoker, b);
-            }
+        if (parent instanceof ScreenMenu sm) {
+            sm.setChildVisible(fInvoker, b);
         }
     }
 

--- a/src/java.desktop/macosx/classes/sun/font/CFontManager.java
+++ b/src/java.desktop/macosx/classes/sun/font/CFontManager.java
@@ -283,9 +283,9 @@ public final class CFontManager extends SunFontManager {
         if (realFamily == null) return false;
 
         Font2D realFont = realFamily.getFontWithExactStyleMatch(style);
-        if (realFont == null || !(realFont instanceof CFont)) return false;
+        if (!(realFont instanceof CFont cFont)) return false;
 
-        CFont newFont = new CFont((CFont)realFont, logicalFamilyName);
+        CFont newFont = new CFont(cFont, logicalFamilyName);
         registerGenericFont(newFont, true);
 
         return true;

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
@@ -626,8 +626,8 @@ class CAccessibility implements PropertyChangeListener {
         return invokeAndWait(new Callable<Accessible>() {
             public Accessible call() throws Exception {
                 Component c = KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner();
-                if (c == null || !(c instanceof Accessible)) return null;
-                return CAccessible.getCAccessible((Accessible)c);
+                if (!(c instanceof Accessible accessible)) return null;
+                return CAccessible.getCAccessible(accessible);
             }
         }, c);
     }

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
@@ -244,12 +244,12 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
             c.execute(ptr -> nativeRevalidateNSWindowShadow(ptr));
         }},
         new Property<CPlatformWindow>(WINDOW_DOCUMENT_FILE) { public void applyProperty(final CPlatformWindow c, final Object value) {
-            if (value == null || !(value instanceof java.io.File)) {
+            if (!(value instanceof java.io.File f)) {
                 c.execute(ptr->nativeSetNSWindowRepresentedFilename(ptr, null));
                 return;
             }
 
-            final String filename = ((java.io.File)value).getAbsolutePath();
+            final String filename = f.getAbsolutePath();
             c.execute(ptr->nativeSetNSWindowRepresentedFilename(ptr, filename));
         }},
         new Property<CPlatformWindow>(WINDOW_FULL_CONTENT) {

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
@@ -244,12 +244,12 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
             c.execute(ptr -> nativeRevalidateNSWindowShadow(ptr));
         }},
         new Property<CPlatformWindow>(WINDOW_DOCUMENT_FILE) { public void applyProperty(final CPlatformWindow c, final Object value) {
-            if (!(value instanceof java.io.File f)) {
+            if (!(value instanceof java.io.File file)) {
                 c.execute(ptr->nativeSetNSWindowRepresentedFilename(ptr, null));
                 return;
             }
 
-            final String filename = f.getAbsolutePath();
+            final String filename = file.getAbsolutePath();
             c.execute(ptr->nativeSetNSWindowRepresentedFilename(ptr, filename));
         }},
         new Property<CPlatformWindow>(WINDOW_FULL_CONTENT) {

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
@@ -845,10 +845,10 @@ public final class CPrinterJob extends RasterPrinterJob {
     @Override
     protected MediaSize getMediaSize(Media media, PrintService service,
             PageFormat page) {
-        if (media == null || !(media instanceof MediaSizeName)) {
+        if (!(media instanceof MediaSizeName msn)) {
             return getDefaultMediaSize(page);
         }
-        MediaSize size = MediaSize.getMediaSizeForName((MediaSizeName) media);
+        MediaSize size = MediaSize.getMediaSizeForName(msn);
         return size != null ? size : getDefaultMediaSize(page);
     }
 

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/bmp/BMPImageWriter.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/bmp/BMPImageWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -210,10 +210,8 @@ public class BMPImageWriter extends ImageWriter implements BMPConstants {
 
         IIOMetadata imageMetadata = image.getMetadata();
         BMPMetadata bmpImageMetadata = null;
-        if (imageMetadata != null
-            && imageMetadata instanceof BMPMetadata)
-        {
-            bmpImageMetadata = (BMPMetadata)imageMetadata;
+        if (imageMetadata instanceof BMPMetadata bmp) {
+            bmpImageMetadata = bmp;
         } else {
             ImageTypeSpecifier imageType =
                 new ImageTypeSpecifier(colorModel, sampleModel);

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/common/SimpleCMYKColorSpace.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/common/SimpleCMYKColorSpace.java
@@ -59,7 +59,7 @@ public final class SimpleCMYKColorSpace extends ColorSpace {
     }
 
     public boolean equals(Object o) {
-        return o != null && o instanceof SimpleCMYKColorSpace;
+        return o instanceof SimpleCMYKColorSpace;
     }
 
     public int hashCode() {

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/gif/GIFWritableImageMetadata.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/gif/GIFWritableImageMetadata.java
@@ -248,8 +248,7 @@ class GIFWritableImageMetadata extends GIFImageMetadata {
 
                 Object applicationExtensionData =
                     applicationExtension.getUserObject();
-                if (applicationExtensionData == null ||
-                    !(applicationExtensionData instanceof byte[])) {
+                if (!(applicationExtensionData instanceof byte[])) {
                     fatal(applicationExtension,
                           "Bad user object in ApplicationExtension!");
                 }

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JPEGMetadata.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JPEGMetadata.java
@@ -371,8 +371,8 @@ public class JPEGMetadata extends IIOMetadata implements Cloneable {
 
         JPEGImageWriteParam jparam = null;
 
-        if ((param != null) && (param instanceof JPEGImageWriteParam)) {
-            jparam = (JPEGImageWriteParam) param;
+        if (param instanceof JPEGImageWriteParam p) {
+            jparam = p;
             if (!jparam.areTablesSet()) {
                 jparam = null;
             }

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFBaseJPEGCompressor.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFBaseJPEGCompressor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -274,8 +274,8 @@ public abstract class TIFFBaseJPEGCompressor extends TIFFCompressor {
 
         // Initialize the ImageWriteParam.
         if(this.JPEGParam == null) {
-            if(param != null && param instanceof JPEGImageWriteParam) {
-                JPEGParam = (JPEGImageWriteParam)param;
+            if (param instanceof JPEGImageWriteParam p) {
+                JPEGParam = p;
             } else {
                 JPEGParam =
                     new JPEGImageWriteParam(writer != null ?

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFImageWriter.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFImageWriter.java
@@ -2895,7 +2895,7 @@ public class TIFFImageWriter extends ImageWriter {
             int numThumbs = thumbnails.size();
             for(int i = 0; i < numThumbs; i++) {
                 Object thumb = thumbnails.get(i);
-                if(thumb == null || !(thumb instanceof BufferedImage)) {
+                if(!(thumb instanceof BufferedImage)) {
                     throw new IllegalArgumentException
                         ("thumbnails contains null references or objects other than BufferedImages!");
                 }

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFImageWriter.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFImageWriter.java
@@ -2895,7 +2895,7 @@ public class TIFFImageWriter extends ImageWriter {
             int numThumbs = thumbnails.size();
             for(int i = 0; i < numThumbs; i++) {
                 Object thumb = thumbnails.get(i);
-                if(!(thumb instanceof BufferedImage)) {
+                if (!(thumb instanceof BufferedImage)) {
                     throw new IllegalArgumentException
                         ("thumbnails contains null references or objects other than BufferedImages!");
                 }

--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/motif/MotifFileChooserUI.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/motif/MotifFileChooserUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -787,8 +787,8 @@ public class MotifFileChooserUI extends BasicFileChooserUI {
 
             super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
 
-            if (value != null && value instanceof FileFilter) {
-                setText(((FileFilter)value).getDescription());
+            if (value instanceof FileFilter fileFilter) {
+                setText(fileFilter.getDescription());
             }
 
             return this;

--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/motif/MotifMenuUI.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/motif/MotifMenuUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,10 +110,10 @@ public class MotifMenuUI extends BasicMenuUI
                         manager.clearSelectedPath();
                     } else {
                         Container cnt = menu.getParent();
-                        if(cnt != null && cnt instanceof JMenuBar) {
+                        if (cnt instanceof JMenuBar menuBar) {
                             MenuElement[] me = new MenuElement[2];
-                            me[0]=(MenuElement)cnt;
-                            me[1]=menu;
+                            me[0] = menuBar;
+                            me[1] = menu;
                             manager.setSelectedPath(me);
                         }
                     }

--- a/src/java.desktop/share/classes/com/sun/media/sound/AbstractMidiDevice.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/AbstractMidiDevice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -576,11 +576,9 @@ abstract class AbstractMidiDevice implements MidiDevice, ReferenceCountingDevice
                 if (midiOutReceiver == oldR) {
                     midiOutReceiver = null;
                 }
-                if (newR != null) {
-                    if ((newR instanceof MidiOutDevice.MidiOutReceiver)
+                if ((newR instanceof MidiOutDevice.MidiOutReceiver newReceiver)
                         && (midiOutReceiver == null)) {
-                        midiOutReceiver = ((MidiOutDevice.MidiOutReceiver) newR);
-                    }
+                    midiOutReceiver = newReceiver;
                 }
                 optimizedReceiverCount =
                       ((midiOutReceiver!=null)?1:0);

--- a/src/java.desktop/share/classes/com/sun/media/sound/AudioFloatFormatConverter.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/AudioFloatFormatConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -293,8 +293,7 @@ public final class AudioFloatFormatConverter extends FormatConversionProvider {
                     format.getSampleRate(), sourceFormat.isBigEndian());
             nrofchannels = targetFormat.getChannels();
             Object interpolation = format.getProperty("interpolation");
-            if (interpolation != null && (interpolation instanceof String)) {
-                String resamplerType = (String) interpolation;
+            if (interpolation instanceof String resamplerType) {
                 if (resamplerType.equalsIgnoreCase("point"))
                     this.resampler = new SoftPointResampler();
                 if (resamplerType.equalsIgnoreCase("linear"))

--- a/src/java.desktop/share/classes/com/sun/media/sound/PortMixer.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/PortMixer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,7 +115,7 @@ final class PortMixer extends AbstractMixer {
     public Line getLine(Line.Info info) throws LineUnavailableException {
         Line.Info fullInfo = getLineInfo(info);
 
-        if ((fullInfo != null) && (fullInfo instanceof Port.Info)) {
+        if (fullInfo instanceof Port.Info) {
             for (int i = 0; i < portInfos.length; i++) {
                 if (fullInfo.equals(portInfos[i])) {
                     return getPort(i);

--- a/src/java.desktop/share/classes/com/sun/media/sound/SoftMixingDataLine.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/SoftMixingDataLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,8 +102,7 @@ public abstract class SoftMixingDataLine implements DataLine {
                     format.getSampleRate(), sourceFormat.isBigEndian());
             nrofchannels = targetFormat.getChannels();
             Object interpolation = format.getProperty("interpolation");
-            if (interpolation != null && (interpolation instanceof String)) {
-                String resamplerType = (String) interpolation;
+            if (interpolation instanceof String resamplerType) {
                 if (resamplerType.equalsIgnoreCase("point"))
                     this.resampler = new SoftPointResampler();
                 if (resamplerType.equalsIgnoreCase("linear"))

--- a/src/java.desktop/share/classes/com/sun/media/sound/SoftSynthesizer.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/SoftSynthesizer.java
@@ -575,25 +575,25 @@ public final class SoftSynthesizer implements AudioSynthesizer,
 
     @Override
     public boolean loadInstrument(Instrument instrument) {
-        if (instrument == null || (!(instrument instanceof ModelInstrument))) {
+        if (!(instrument instanceof ModelInstrument modelInstrument)) {
             throw new IllegalArgumentException("Unsupported instrument: " +
                     instrument);
         }
         List<ModelInstrument> instruments = new ArrayList<>();
-        instruments.add((ModelInstrument)instrument);
+        instruments.add(modelInstrument);
         return loadInstruments(instruments);
     }
 
     @Override
     public void unloadInstrument(Instrument instrument) {
-        if (instrument == null || (!(instrument instanceof ModelInstrument))) {
+        if (!(instrument instanceof ModelInstrument modelInstrument)) {
             throw new IllegalArgumentException("Unsupported instrument: " +
                     instrument);
         }
         if (!isOpen())
             return;
 
-        String pat = patchToString(instrument.getPatch());
+        String pat = patchToString(modelInstrument.getPatch());
         synchronized (control_mutex) {
             for (SoftChannel c: channels)
                 c.current_instrument = null;
@@ -842,11 +842,11 @@ public final class SoftSynthesizer implements AudioSynthesizer,
     public boolean loadAllInstruments(Soundbank soundbank) {
         List<ModelInstrument> instruments = new ArrayList<>();
         for (Instrument ins: soundbank.getInstruments()) {
-            if (ins == null || !(ins instanceof ModelInstrument)) {
+            if (!(ins instanceof ModelInstrument modelInstrument)) {
                 throw new IllegalArgumentException(
                         "Unsupported instrument: " + ins);
             }
-            instruments.add((ModelInstrument)ins);
+            instruments.add(modelInstrument);
         }
         return loadInstruments(instruments);
     }
@@ -871,11 +871,11 @@ public final class SoftSynthesizer implements AudioSynthesizer,
         List<ModelInstrument> instruments = new ArrayList<>();
         for (Patch patch: patchList) {
             Instrument ins = soundbank.getInstrument(patch);
-            if (ins == null || !(ins instanceof ModelInstrument)) {
+            if (!(ins instanceof ModelInstrument modelInstrument)) {
                 throw new IllegalArgumentException(
                         "Unsupported instrument: " + ins);
             }
-            instruments.add((ModelInstrument)ins);
+            instruments.add(modelInstrument);
         }
         return loadInstruments(instruments);
     }

--- a/src/java.desktop/share/classes/java/awt/AWTEvent.java
+++ b/src/java.desktop/share/classes/java/awt/AWTEvent.java
@@ -355,8 +355,7 @@ public abstract class AWTEvent extends EventObject {
         Component comp = null;
         if (newSource instanceof Component) {
             comp = (Component)newSource;
-            while (comp != null && comp.peer != null &&
-                   (comp.peer instanceof LightweightPeer)) {
+            while (comp != null && (comp.peer instanceof LightweightPeer)) {
                 comp = comp.parent;
             }
         }

--- a/src/java.desktop/share/classes/java/awt/Component.java
+++ b/src/java.desktop/share/classes/java/awt/Component.java
@@ -4955,8 +4955,8 @@ public abstract class Component implements ImageObserver, MenuContainer,
             // the active/passive/peered clients loose focus.
             if (id == FocusEvent.FOCUS_GAINED) {
                 InputContext inputContext = getInputContext();
-                if (inputContext != null && inputContext instanceof sun.awt.im.InputContext) {
-                    ((sun.awt.im.InputContext)inputContext).disableNativeIM();
+                if (inputContext instanceof sun.awt.im.InputContext ctx) {
+                    ctx.disableNativeIM();
                 }
             }
         }

--- a/src/java.desktop/share/classes/java/awt/Container.java
+++ b/src/java.desktop/share/classes/java/awt/Container.java
@@ -3891,18 +3891,18 @@ public class Container extends Component {
 
             public void componentAdded(ContainerEvent e) {
                 Component c = e.getChild();
-                if (c != null && c instanceof Accessible) {
+                if (c instanceof Accessible accessible) {
                     AccessibleAWTContainer.this.firePropertyChange(
                         AccessibleContext.ACCESSIBLE_CHILD_PROPERTY,
-                        null, ((Accessible) c).getAccessibleContext());
+                        null, accessible.getAccessibleContext());
                 }
             }
             public void componentRemoved(ContainerEvent e) {
                 Component c = e.getChild();
-                if (c != null && c instanceof Accessible) {
+                if (c instanceof Accessible accessible) {
                     AccessibleAWTContainer.this.firePropertyChange(
                         AccessibleContext.ACCESSIBLE_CHILD_PROPERTY,
-                        ((Accessible) c).getAccessibleContext(), null);
+                        accessible.getAccessibleContext(), null);
                 }
             }
         }

--- a/src/java.desktop/share/classes/java/awt/MenuComponent.java
+++ b/src/java.desktop/share/classes/java/awt/MenuComponent.java
@@ -373,8 +373,7 @@ public abstract class MenuComponent implements java.io.Serializable {
         Toolkit.getDefaultToolkit().notifyAWTEventListeners(e);
 
         if (newEventsOnly ||
-            (parent != null && parent instanceof MenuComponent &&
-             ((MenuComponent)parent).newEventsOnly)) {
+            (parent instanceof MenuComponent mc && mc.newEventsOnly)) {
             if (eventEnabled(e)) {
                 processEvent(e);
             } else if (e instanceof ActionEvent && parent != null) {

--- a/src/java.desktop/share/classes/java/awt/dnd/DropTarget.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DropTarget.java
@@ -793,7 +793,7 @@ public class DropTarget implements DropTargetListener, Serializable {
      */
 
     protected void initializeAutoscrolling(Point p) {
-        if (component == null || !(component instanceof Autoscroll)) return;
+        if (!(component instanceof Autoscroll)) return;
 
         autoScroller = createDropTargetAutoScroller(component, p);
     }

--- a/src/java.desktop/share/classes/java/awt/image/AreaAveragingScaleFilter.java
+++ b/src/java.desktop/share/classes/java/awt/image/AreaAveragingScaleFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,7 +105,7 @@ public class AreaAveragingScaleFilter extends ReplicateScaleFilter {
 
     private int[] calcRow() {
         float origmult = ((float) srcWidth) * srcHeight;
-        if (outpixbuf == null || !(outpixbuf instanceof int[])) {
+        if (!(outpixbuf instanceof int[])) {
             outpixbuf = new int[destWidth];
         }
         int[] outpix = (int[]) outpixbuf;

--- a/src/java.desktop/share/classes/java/awt/image/ComponentSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/ComponentSampleModel.java
@@ -1185,11 +1185,10 @@ public class ComponentSampleModel extends SampleModel
     }
 
     public boolean equals(Object o) {
-        if ((o == null) || !(o instanceof ComponentSampleModel)) {
+        if (!(o instanceof ComponentSampleModel that)) {
             return false;
         }
 
-        ComponentSampleModel that = (ComponentSampleModel)o;
         return this.width == that.width &&
             this.height == that.height &&
             this.numBands == that.numBands &&

--- a/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -655,11 +655,10 @@ public class MultiPixelPackedSampleModel extends SampleModel
     }
 
     public boolean equals(Object o) {
-        if ((o == null) || !(o instanceof MultiPixelPackedSampleModel)) {
+        if (!(o instanceof MultiPixelPackedSampleModel that)) {
             return false;
         }
 
-        MultiPixelPackedSampleModel that = (MultiPixelPackedSampleModel)o;
         return this.width == that.width &&
             this.height == that.height &&
             this.numBands == that.numBands &&

--- a/src/java.desktop/share/classes/java/awt/image/ReplicateScaleFilter.java
+++ b/src/java.desktop/share/classes/java/awt/image/ReplicateScaleFilter.java
@@ -194,8 +194,8 @@ public class ReplicateScaleFilter extends ImageFilter {
         int dx1 = (2 * x * destWidth + srcWidth - 1) / (2 * srcWidth);
         int dy1 = (2 * y * destHeight + srcHeight - 1) / (2 * srcHeight);
         byte[] outpix;
-        if (outpixbuf != null && outpixbuf instanceof byte[]) {
-            outpix = (byte[]) outpixbuf;
+        if (outpixbuf instanceof byte[] outbytes) {
+            outpix = outbytes;
         } else {
             outpix = new byte[destWidth];
             outpixbuf = outpix;
@@ -235,8 +235,8 @@ public class ReplicateScaleFilter extends ImageFilter {
         int dx1 = (2 * x * destWidth + srcWidth - 1) / (2 * srcWidth);
         int dy1 = (2 * y * destHeight + srcHeight - 1) / (2 * srcHeight);
         int[] outpix;
-        if (outpixbuf != null && outpixbuf instanceof int[]) {
-            outpix = (int[]) outpixbuf;
+        if (outpixbuf instanceof int[] outints) {
+            outpix = outints;
         } else {
             outpix = new int[destWidth];
             outpixbuf = outpix;

--- a/src/java.desktop/share/classes/java/awt/image/ReplicateScaleFilter.java
+++ b/src/java.desktop/share/classes/java/awt/image/ReplicateScaleFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,8 +126,8 @@ public class ReplicateScaleFilter extends ImageFilter {
         String key = "rescale";
         String val = destWidth + "x" + destHeight;
         Object o = p.get(key);
-        if (o != null && o instanceof String) {
-            val = ((String) o) + ", " + val;
+        if (o instanceof String s) {
+            val = s + ", " + val;
         }
         p.put(key, val);
         super.setProperties(p);

--- a/src/java.desktop/share/classes/java/awt/image/SinglePixelPackedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/SinglePixelPackedSampleModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -754,11 +754,10 @@ public class SinglePixelPackedSampleModel extends SampleModel
     }
 
     public boolean equals(Object o) {
-        if ((o == null) || !(o instanceof SinglePixelPackedSampleModel)) {
+        if (!(o instanceof SinglePixelPackedSampleModel that)) {
             return false;
         }
 
-        SinglePixelPackedSampleModel that = (SinglePixelPackedSampleModel)o;
         return this.width == that.width &&
             this.height == that.height &&
             this.numBands == that.numBands &&

--- a/src/java.desktop/share/classes/java/beans/IndexedPropertyDescriptor.java
+++ b/src/java.desktop/share/classes/java/beans/IndexedPropertyDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -407,8 +407,7 @@ public class IndexedPropertyDescriptor extends PropertyDescriptor {
             return true;
         }
 
-        if (obj != null && obj instanceof IndexedPropertyDescriptor) {
-            IndexedPropertyDescriptor other = (IndexedPropertyDescriptor)obj;
+        if (obj instanceof IndexedPropertyDescriptor other) {
             Method otherIndexedReadMethod = other.getIndexedReadMethod();
             Method otherIndexedWriteMethod = other.getIndexedWriteMethod();
 

--- a/src/java.desktop/share/classes/java/beans/PropertyDescriptor.java
+++ b/src/java.desktop/share/classes/java/beans/PropertyDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -503,8 +503,7 @@ public class PropertyDescriptor extends FeatureDescriptor {
         if (this == obj) {
             return true;
         }
-        if (obj != null && obj instanceof PropertyDescriptor) {
-            PropertyDescriptor other = (PropertyDescriptor)obj;
+        if (obj instanceof PropertyDescriptor other) {
             Method otherReadMethod = other.getReadMethod();
             Method otherWriteMethod = other.getWriteMethod();
 

--- a/src/java.desktop/share/classes/javax/imageio/ImageTypeSpecifier.java
+++ b/src/java.desktop/share/classes/javax/imageio/ImageTypeSpecifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -328,13 +328,9 @@ public class ImageTypeSpecifier {
         }
 
         public boolean equals(Object o) {
-            if ((o == null) ||
-                !(o instanceof ImageTypeSpecifier.Interleaved)) {
+            if (!(o instanceof Interleaved that)) {
                 return false;
             }
-
-            ImageTypeSpecifier.Interleaved that =
-                (ImageTypeSpecifier.Interleaved)o;
 
             if ((!(this.colorSpace.equals(that.colorSpace))) ||
                 (this.dataType != that.dataType) ||
@@ -472,13 +468,9 @@ public class ImageTypeSpecifier {
         }
 
         public boolean equals(Object o) {
-            if ((o == null) ||
-                !(o instanceof ImageTypeSpecifier.Banded)) {
+            if (!(o instanceof Banded that)) {
                 return false;
             }
-
-            ImageTypeSpecifier.Banded that =
-                (ImageTypeSpecifier.Banded)o;
 
             if ((!(this.colorSpace.equals(that.colorSpace))) ||
                 (this.dataType != that.dataType) ||
@@ -1095,11 +1087,10 @@ public class ImageTypeSpecifier {
      * {@code ImageTypeSpecifier}.
      */
     public boolean equals(Object o) {
-        if ((o == null) || !(o instanceof ImageTypeSpecifier)) {
+        if (!(o instanceof ImageTypeSpecifier that)) {
             return false;
         }
 
-        ImageTypeSpecifier that = (ImageTypeSpecifier)o;
         return (colorModel.equals(that.colorModel)) &&
             (sampleModel.equals(that.sampleModel));
     }

--- a/src/java.desktop/share/classes/javax/print/DocFlavor.java
+++ b/src/java.desktop/share/classes/javax/print/DocFlavor.java
@@ -537,10 +537,8 @@ public class DocFlavor implements Serializable, Cloneable {
      *         {@code false} otherwise
      */
     public boolean equals(Object obj) {
-        return
-            obj != null &&
-            obj instanceof DocFlavor &&
-            getStringValue().equals (((DocFlavor) obj).getStringValue());
+        return obj instanceof DocFlavor other &&
+                getStringValue().equals(other.getStringValue());
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/print/MimeType.java
+++ b/src/java.desktop/share/classes/javax/print/MimeType.java
@@ -141,10 +141,9 @@ class MimeType implements Serializable, Cloneable {
             throw new UnsupportedOperationException();
         }
         public boolean equals(Object o) {
-            return (o != null &&
-                    o instanceof Map.Entry &&
-                    getKey().equals (((Map.Entry) o).getKey()) &&
-                    getValue().equals(((Map.Entry) o).getValue()));
+            return o instanceof Map.Entry entry &&
+                    getKey().equals(entry.getKey()) &&
+                    getValue().equals(entry.getValue());
         }
         public int hashCode() {
             return getKey().hashCode() ^ getValue().hashCode();
@@ -290,9 +289,8 @@ class MimeType implements Serializable, Cloneable {
      *         {@code false} otherwise
      */
     public boolean equals (Object obj) {
-        return(obj != null &&
-               obj instanceof MimeType &&
-               getStringValue().equals(((MimeType) obj).getStringValue()));
+        return obj instanceof MimeType mimeType &&
+                getStringValue().equals(mimeType.getStringValue());
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/print/MimeType.java
+++ b/src/java.desktop/share/classes/javax/print/MimeType.java
@@ -141,7 +141,7 @@ class MimeType implements Serializable, Cloneable {
             throw new UnsupportedOperationException();
         }
         public boolean equals(Object o) {
-            return o instanceof Map.Entry entry &&
+            return o instanceof Map.Entry<?, ?> entry &&
                     getKey().equals(entry.getKey()) &&
                     getValue().equals(entry.getValue());
         }

--- a/src/java.desktop/share/classes/javax/print/attribute/DateTimeSyntax.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/DateTimeSyntax.java
@@ -115,9 +115,8 @@ public abstract class DateTimeSyntax implements Serializable, Cloneable {
      *         attribute, {@code false} otherwise
      */
     public boolean equals(Object object) {
-        return (object != null &&
-                object instanceof DateTimeSyntax &&
-                value.equals(((DateTimeSyntax) object).value));
+        return object instanceof DateTimeSyntax other &&
+                value.equals(other.value);
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/HashAttributeSet.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/HashAttributeSet.java
@@ -345,10 +345,8 @@ public class HashAttributeSet implements AttributeSet, Serializable {
      *         value
      */
     public boolean containsValue(Attribute attribute) {
-        return
-           attribute != null &&
-           attribute instanceof Attribute &&
-           attribute.equals(attrMap.get(attribute.getCategory()));
+        return attribute != null &&
+                attribute.equals(attrMap.get(attribute.getCategory()));
     }
 
     /**
@@ -441,11 +439,10 @@ public class HashAttributeSet implements AttributeSet, Serializable {
      *         set
      */
     public boolean equals(Object object) {
-        if (object == null || !(object instanceof AttributeSet)) {
+        if (!(object instanceof AttributeSet aset)) {
             return false;
         }
 
-        AttributeSet aset = (AttributeSet)object;
         if (aset.size() != size()) {
             return false;
         }

--- a/src/java.desktop/share/classes/javax/print/attribute/IntegerSyntax.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/IntegerSyntax.java
@@ -108,9 +108,8 @@ public abstract class IntegerSyntax implements Serializable, Cloneable {
      *         attribute, {@code false} otherwise
      */
     public boolean equals(Object object) {
-
-        return (object != null && object instanceof IntegerSyntax &&
-                value == ((IntegerSyntax) object).value);
+        return object instanceof IntegerSyntax other &&
+                value == other.value;
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/ResolutionSyntax.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/ResolutionSyntax.java
@@ -267,13 +267,9 @@ public abstract class ResolutionSyntax implements Serializable, Cloneable {
      *         attribute, {@code false} otherwise
      */
     public boolean equals(Object object) {
-
-        return(object != null &&
-               object instanceof ResolutionSyntax &&
-               this.crossFeedResolution ==
-               ((ResolutionSyntax) object).crossFeedResolution &&
-               this.feedResolution ==
-               ((ResolutionSyntax) object).feedResolution);
+        return object instanceof ResolutionSyntax other &&
+                this.crossFeedResolution == other.crossFeedResolution &&
+                this.feedResolution == other.feedResolution;
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/SetOfIntegerSyntax.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/SetOfIntegerSyntax.java
@@ -483,9 +483,9 @@ public abstract class SetOfIntegerSyntax implements Serializable, Cloneable {
      *         set-of-integer attribute, {@code false} otherwise
      */
     public boolean equals(Object object) {
-        if (object != null && object instanceof SetOfIntegerSyntax) {
+        if (object instanceof SetOfIntegerSyntax other) {
             int[][] myMembers = this.members;
-            int[][] otherMembers = ((SetOfIntegerSyntax) object).members;
+            int[][] otherMembers = other.members;
             int m = myMembers.length;
             int n = otherMembers.length;
             if (m == n) {

--- a/src/java.desktop/share/classes/javax/print/attribute/Size2DSyntax.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/Size2DSyntax.java
@@ -264,10 +264,9 @@ public abstract class Size2DSyntax implements Serializable, Cloneable {
      *         two-dimensional size attribute, {@code false} otherwise
      */
     public boolean equals(Object object) {
-        return(object != null &&
-               object instanceof Size2DSyntax &&
-               this.x == ((Size2DSyntax) object).x &&
-               this.y == ((Size2DSyntax) object).y);
+        return object instanceof Size2DSyntax size2DSyntax &&
+                this.x == size2DSyntax.x &&
+                this.y == size2DSyntax.y;
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/TextSyntax.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/TextSyntax.java
@@ -132,10 +132,9 @@ public abstract class TextSyntax implements Serializable, Cloneable {
      *         attribute, {@code false} otherwise
      */
     public boolean equals(Object object) {
-        return(object != null &&
-               object instanceof TextSyntax &&
-               this.value.equals (((TextSyntax) object).value) &&
-               this.locale.equals (((TextSyntax) object).locale));
+        return object instanceof TextSyntax other &&
+                this.value.equals(other.value) &&
+                this.locale.equals(other.locale);
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/URISyntax.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/URISyntax.java
@@ -101,9 +101,8 @@ public abstract class URISyntax implements Serializable, Cloneable {
      *         attribute, {@code false} otherwise
      */
     public boolean equals(Object object) {
-        return(object != null &&
-               object instanceof URISyntax &&
-               this.uri.equals (((URISyntax) object).uri));
+        return object instanceof URISyntax other &&
+                this.uri.equals(other.uri);
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/Media.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/Media.java
@@ -90,9 +90,9 @@ public abstract class Media extends EnumSyntax
      *         attribute, {@code false} otherwise
      */
     public boolean equals(Object object) {
-        return(object != null && object instanceof Media &&
-               object.getClass() == this.getClass() &&
-               ((Media)object).getValue() == this.getValue());
+        return object instanceof Media other &&
+                object.getClass() == this.getClass() &&
+                other.getValue() == this.getValue();
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/AbstractAction.java
+++ b/src/java.desktop/share/classes/javax/swing/AbstractAction.java
@@ -193,7 +193,7 @@ public abstract class AbstractAction implements Action, Cloneable, Serializable
             // to change enabled, it would be possible for stack
             // overflow in the case where a developer implemented setEnabled
             // in terms of putValue.
-            if (newValue == null || !(newValue instanceof Boolean)) {
+            if (!(newValue instanceof Boolean)) {
                 newValue = false;
             }
             oldValue = enabled;

--- a/src/java.desktop/share/classes/javax/swing/AbstractButton.java
+++ b/src/java.desktop/share/classes/javax/swing/AbstractButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2394,8 +2394,8 @@ public abstract class AbstractButton extends JComponent implements ItemSelectabl
             if (defaultIcon instanceof Accessible) {
                 AccessibleContext ac =
                     ((Accessible)defaultIcon).getAccessibleContext();
-                if (ac != null && ac instanceof AccessibleIcon) {
-                    return new AccessibleIcon[] { (AccessibleIcon)ac };
+                if (ac instanceof AccessibleIcon ai) {
+                    return new AccessibleIcon[] { ai };
                 }
             }
             return null;
@@ -2441,8 +2441,8 @@ public abstract class AbstractButton extends JComponent implements ItemSelectabl
             if (!relationSet.contains(AccessibleRelation.MEMBER_OF)) {
                 // get the members of the button group if one exists
                 ButtonModel model = getModel();
-                if (model != null && model instanceof DefaultButtonModel) {
-                    ButtonGroup group = ((DefaultButtonModel)model).getGroup();
+                if (model instanceof DefaultButtonModel defaultModel) {
+                    ButtonGroup group = defaultModel.getGroup();
                     if (group != null) {
                         // set the target of the MEMBER_OF relation to be
                         // the members of the button group.

--- a/src/java.desktop/share/classes/javax/swing/DebugGraphics.java
+++ b/src/java.desktop/share/classes/javax/swing/DebugGraphics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1417,8 +1417,8 @@ public class DebugGraphics extends Graphics {
             Container container = (Container)component;
             int debugOptions = 0;
 
-            while (container != null && (container instanceof JComponent)) {
-                debugOptions |= info.getDebugOptions((JComponent)container);
+            while (container instanceof JComponent jc) {
+                debugOptions |= info.getDebugOptions(jc);
                 container = container.getParent();
             }
 

--- a/src/java.desktop/share/classes/javax/swing/JComboBox.java
+++ b/src/java.desktop/share/classes/javax/swing/JComboBox.java
@@ -2000,11 +2000,10 @@ implements ItemSelectable,ListDataListener,ActionListener, Accessible {
             // Get the popup
             Accessible a =
                 JComboBox.this.getUI().getAccessibleChild(JComboBox.this, 0);
-            if (a != null &&
-                a instanceof javax.swing.plaf.basic.ComboPopup) {
+            if (a instanceof javax.swing.plaf.basic.ComboPopup popup) {
 
                 // get the popup list
-                JList<?> list = ((javax.swing.plaf.basic.ComboPopup)a).getList();
+                JList<?> list = popup.getList();
 
                 // return the i-th selection in the popup list
                 AccessibleContext ac = list.getAccessibleContext();

--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -878,8 +878,7 @@ public abstract class JComponent extends Container implements Serializable,
             }
             // If we are only to paint to a specific child, determine
             // its index.
-            if (paintingChild != null &&
-                (paintingChild instanceof JComponent) &&
+            if ((paintingChild instanceof JComponent) &&
                 paintingChild.isOpaque()) {
                 for (; i >= 0; i--) {
                     if (getComponent(i) == paintingChild){

--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -3636,20 +3636,18 @@ public abstract class JComponent extends Container implements Serializable,
                                               boolean temporary, boolean focusedWindowChangeAllowed,
                                               FocusEvent.Cause cause)
             {
-                if ((to == null) || !(to instanceof JComponent)) {
+                if (!(to instanceof JComponent target)) {
                     return true;
                 }
 
-                if ((from == null) || !(from instanceof JComponent)) {
+                if (!(from instanceof JComponent jFocusOwner)) {
                     return true;
                 }
 
-                JComponent target = (JComponent) to;
                 if (!target.getVerifyInputWhenFocusTarget()) {
                     return true;
                 }
 
-                JComponent jFocusOwner = (JComponent)from;
                 InputVerifier iv = jFocusOwner.getInputVerifier();
 
                 if (iv == null) {
@@ -3774,7 +3772,7 @@ public abstract class JComponent extends Container implements Serializable,
             protected AccessibleContainerHandler() {}
             public void componentAdded(ContainerEvent e) {
                 Component c = e.getChild();
-                if (c != null && c instanceof Accessible) {
+                if (c instanceof Accessible) {
                     AccessibleJComponent.this.firePropertyChange(
                         AccessibleContext.ACCESSIBLE_CHILD_PROPERTY,
                         null, c.getAccessibleContext());
@@ -3782,7 +3780,7 @@ public abstract class JComponent extends Container implements Serializable,
             }
             public void componentRemoved(ContainerEvent e) {
                 Component c = e.getChild();
-                if (c != null && c instanceof Accessible) {
+                if (c instanceof Accessible) {
                     AccessibleJComponent.this.firePropertyChange(
                         AccessibleContext.ACCESSIBLE_CHILD_PROPERTY,
                         c.getAccessibleContext(), null);

--- a/src/java.desktop/share/classes/javax/swing/JInternalFrame.java
+++ b/src/java.desktop/share/classes/javax/swing/JInternalFrame.java
@@ -1233,10 +1233,9 @@ public class JInternalFrame extends JComponent implements
     @BeanProperty(bound = false, expert = true, description
             = "Specifies what desktop layer is used.")
     public void setLayer(Integer layer) {
-        if(getParent() != null && getParent() instanceof JLayeredPane) {
+        if (getParent() instanceof JLayeredPane p) {
             // Normally we want to do this, as it causes the LayeredPane
             // to draw properly.
-            JLayeredPane p = (JLayeredPane)getParent();
             p.setLayer(this, layer.intValue(), p.getPosition(this));
         } else {
              // Try to do the right thing

--- a/src/java.desktop/share/classes/javax/swing/JLabel.java
+++ b/src/java.desktop/share/classes/javax/swing/JLabel.java
@@ -1110,8 +1110,8 @@ public class JLabel extends JComponent implements SwingConstants, Accessible
             if (icon instanceof Accessible) {
                 AccessibleContext ac =
                 ((Accessible)icon).getAccessibleContext();
-                if (ac != null && ac instanceof AccessibleIcon) {
-                    return new AccessibleIcon[] { (AccessibleIcon)ac };
+                if (ac instanceof AccessibleIcon ai) {
+                    return new AccessibleIcon[] { ai };
                 }
             }
             return null;

--- a/src/java.desktop/share/classes/javax/swing/JList.java
+++ b/src/java.desktop/share/classes/javax/swing/JList.java
@@ -2949,10 +2949,10 @@ public class JList<E> extends JComponent implements Scrollable, Accessible
                 // re-set listData listeners
             if (name.compareTo("model") == 0) {
 
-                if (oldValue instanceof ListModel oldModel) {
+                if (oldValue instanceof ListModel<?> oldModel) {
                     oldModel.removeListDataListener(this);
                 }
-                if (newValue instanceof ListModel newModel) {
+                if (newValue instanceof ListModel<?> newModel) {
                     newModel.addListDataListener(this);
                 }
 

--- a/src/java.desktop/share/classes/javax/swing/JList.java
+++ b/src/java.desktop/share/classes/javax/swing/JList.java
@@ -2949,21 +2949,21 @@ public class JList<E> extends JComponent implements Scrollable, Accessible
                 // re-set listData listeners
             if (name.compareTo("model") == 0) {
 
-                if (oldValue != null && oldValue instanceof ListModel) {
-                    ((ListModel) oldValue).removeListDataListener(this);
+                if (oldValue instanceof ListModel oldModel) {
+                    oldModel.removeListDataListener(this);
                 }
-                if (newValue != null && newValue instanceof ListModel) {
-                    ((ListModel) newValue).addListDataListener(this);
+                if (newValue instanceof ListModel newModel) {
+                    newModel.addListDataListener(this);
                 }
 
                 // re-set listSelectionModel listeners
             } else if (name.compareTo("selectionModel") == 0) {
 
-                if (oldValue != null && oldValue instanceof ListSelectionModel) {
-                    ((ListSelectionModel) oldValue).removeListSelectionListener(this);
+                if (oldValue instanceof ListSelectionModel oldModel) {
+                    oldModel.removeListSelectionListener(this);
                 }
-                if (newValue != null && newValue instanceof ListSelectionModel) {
-                    ((ListSelectionModel) newValue).addListSelectionListener(this);
+                if (newValue instanceof ListSelectionModel newModel) {
+                    newModel.addListSelectionListener(this);
                 }
 
                 firePropertyChange(

--- a/src/java.desktop/share/classes/javax/swing/JMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JMenu.java
@@ -1598,7 +1598,7 @@ public class JMenu extends JMenuItem implements Accessible,MenuElement
                 return;
             }
             JMenuItem mi = getItem(i);
-            if (mi != null && mi instanceof JMenu) {
+            if (mi instanceof JMenu) {
                 if (mi.isSelected()) {
                     MenuElement[] old =
                         MenuSelectionManager.defaultManager().getSelectedPath();

--- a/src/java.desktop/share/classes/javax/swing/JMenuBar.java
+++ b/src/java.desktop/share/classes/javax/swing/JMenuBar.java
@@ -706,9 +706,7 @@ public class JMenuBar extends JComponent implements Accessible,MenuElement
             return false;
         }
 
-        if (c != null && c instanceof JComponent &&
-            ((JComponent)c).processKeyBinding(ks, e, condition, pressed)) {
-
+        if (c instanceof JComponent jc && jc.processKeyBinding(ks, e, condition, pressed)) {
             return true;
         }
 

--- a/src/java.desktop/share/classes/javax/swing/JOptionPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JOptionPane.java
@@ -2330,17 +2330,17 @@ public class JOptionPane extends JComponent implements Accessible
         Vector<Object> values = new Vector<Object>();
 
         s.defaultWriteObject();
-        // Save the icon, if its Serializable.
-        if(icon != null && icon instanceof Serializable) {
+        // Save the icon, if it's Serializable.
+        if (icon instanceof Serializable ser) {
             values.addElement("icon");
-            values.addElement(icon);
+            values.addElement(ser);
         }
-        // Save the message, if its Serializable.
-        if(message != null && message instanceof Serializable) {
+        // Save the message, if it's Serializable.
+        if (message instanceof Serializable ser) {
             values.addElement("message");
-            values.addElement(message);
+            values.addElement(ser);
         }
-        // Save the treeModel, if its Serializable.
+        // Save the treeModel, if it's Serializable.
         if(options != null) {
             ArrayList<Object> serOptions = new ArrayList<Object>();
 
@@ -2354,17 +2354,17 @@ public class JOptionPane extends JComponent implements Accessible
                 values.addElement(arrayOptions);
             }
         }
-        // Save the initialValue, if its Serializable.
-        if(initialValue != null && initialValue instanceof Serializable) {
+        // Save the initialValue, if it's Serializable.
+        if (initialValue instanceof Serializable ser) {
             values.addElement("initialValue");
-            values.addElement(initialValue);
+            values.addElement(ser);
         }
-        // Save the value, if its Serializable.
-        if(value != null && value instanceof Serializable) {
+        // Save the value, if it's Serializable.
+        if (value instanceof Serializable ser) {
             values.addElement("value");
-            values.addElement(value);
+            values.addElement(ser);
         }
-        // Save the selectionValues, if its Serializable.
+        // Save the selectionValues, if it's Serializable.
         if(selectionValues != null) {
             boolean            serialize = true;
 
@@ -2381,16 +2381,15 @@ public class JOptionPane extends JComponent implements Accessible
                 values.addElement(selectionValues);
             }
         }
-        // Save the inputValue, if its Serializable.
-        if(inputValue != null && inputValue instanceof Serializable) {
+        // Save the inputValue, if it's Serializable.
+        if (inputValue instanceof Serializable ser) {
             values.addElement("inputValue");
-            values.addElement(inputValue);
+            values.addElement(ser);
         }
-        // Save the initialSelectionValue, if its Serializable.
-        if(initialSelectionValue != null &&
-           initialSelectionValue instanceof Serializable) {
+        // Save the initialSelectionValue, if it's Serializable.
+        if (initialSelectionValue instanceof Serializable ser) {
             values.addElement("initialSelectionValue");
-            values.addElement(initialSelectionValue);
+            values.addElement(ser);
         }
         s.writeObject(values);
     }

--- a/src/java.desktop/share/classes/javax/swing/JOptionPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JOptionPane.java
@@ -2331,14 +2331,14 @@ public class JOptionPane extends JComponent implements Accessible
 
         s.defaultWriteObject();
         // Save the icon, if it's Serializable.
-        if (icon instanceof Serializable ser) {
+        if (icon instanceof Serializable) {
             values.addElement("icon");
-            values.addElement(ser);
+            values.addElement(icon);
         }
         // Save the message, if it's Serializable.
-        if (message instanceof Serializable ser) {
+        if (message instanceof Serializable) {
             values.addElement("message");
-            values.addElement(ser);
+            values.addElement(message);
         }
         // Save the treeModel, if it's Serializable.
         if(options != null) {
@@ -2355,14 +2355,14 @@ public class JOptionPane extends JComponent implements Accessible
             }
         }
         // Save the initialValue, if it's Serializable.
-        if (initialValue instanceof Serializable ser) {
+        if (initialValue instanceof Serializable) {
             values.addElement("initialValue");
-            values.addElement(ser);
+            values.addElement(initialValue);
         }
         // Save the value, if it's Serializable.
-        if (value instanceof Serializable ser) {
+        if (value instanceof Serializable) {
             values.addElement("value");
-            values.addElement(ser);
+            values.addElement(value);
         }
         // Save the selectionValues, if it's Serializable.
         if(selectionValues != null) {
@@ -2382,14 +2382,14 @@ public class JOptionPane extends JComponent implements Accessible
             }
         }
         // Save the inputValue, if it's Serializable.
-        if (inputValue instanceof Serializable ser) {
+        if (inputValue instanceof Serializable) {
             values.addElement("inputValue");
-            values.addElement(ser);
+            values.addElement(inputValue);
         }
         // Save the initialSelectionValue, if it's Serializable.
-        if (initialSelectionValue instanceof Serializable ser) {
+        if (initialSelectionValue instanceof Serializable) {
             values.addElement("initialSelectionValue");
-            values.addElement(ser);
+            values.addElement(initialSelectionValue);
         }
         s.writeObject(values);
     }

--- a/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
@@ -1330,15 +1330,15 @@ public class JPopupMenu extends JComponent implements Accessible,MenuElement {
         Vector<Object> values = new Vector<Object>();
 
         s.defaultWriteObject();
-        // Save the invoker, if its Serializable.
-        if(invoker != null && invoker instanceof Serializable) {
+        // Save the invoker if != null, (Component implements Serializable)
+        if (invoker != null) {
             values.addElement("invoker");
             values.addElement(invoker);
         }
-        // Save the popup, if its Serializable.
-        if(popup != null && popup instanceof Serializable) {
+        // Save the popup, if it's Serializable.
+        if (popup instanceof Serializable ser) {
             values.addElement("popup");
-            values.addElement(popup);
+            values.addElement(ser);
         }
         s.writeObject(values);
 

--- a/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
@@ -988,10 +988,9 @@ public class JPopupMenu extends JComponent implements Accessible,MenuElement {
         JPopupMenu mp = this;
         while((mp!=null) && (mp.isPopupMenu()!=true) &&
               (mp.getInvoker() != null) &&
-              (mp.getInvoker().getParent() != null) &&
-              (mp.getInvoker().getParent() instanceof JPopupMenu)
+              (mp.getInvoker().getParent() instanceof JPopupMenu popupMenu)
               ) {
-            mp = (JPopupMenu) mp.getInvoker().getParent();
+            mp = popupMenu;
         }
         return mp;
     }

--- a/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
@@ -1335,9 +1335,9 @@ public class JPopupMenu extends JComponent implements Accessible,MenuElement {
             values.addElement(invoker);
         }
         // Save the popup, if it's Serializable.
-        if (popup instanceof Serializable ser) {
+        if (popup instanceof Serializable) {
             values.addElement("popup");
-            values.addElement(ser);
+            values.addElement(popup);
         }
         s.writeObject(values);
 

--- a/src/java.desktop/share/classes/javax/swing/JSlider.java
+++ b/src/java.desktop/share/classes/javax/swing/JSlider.java
@@ -1018,8 +1018,8 @@ public class JSlider extends JComponent implements SwingConstants, Accessible {
         @SuppressWarnings("rawtypes")
         Dictionary labelTable = getLabelTable();
 
-        if (labelTable != null && (labelTable instanceof PropertyChangeListener)) {
-            removePropertyChangeListener((PropertyChangeListener) labelTable);
+        if (labelTable instanceof PropertyChangeListener listener) {
+            removePropertyChangeListener(listener);
         }
 
         addPropertyChangeListener( table );

--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -6758,11 +6758,11 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
                 // re-set tableModel listeners
             if (name.compareTo("model") == 0) {
 
-                if (oldValue != null && oldValue instanceof TableModel) {
-                    ((TableModel) oldValue).removeTableModelListener(this);
+                if (oldValue instanceof TableModel oldModel) {
+                    oldModel.removeTableModelListener(this);
                 }
-                if (newValue != null && newValue instanceof TableModel) {
-                    ((TableModel) newValue).addTableModelListener(this);
+                if (newValue instanceof TableModel newModel) {
+                    newModel.addTableModelListener(this);
                 }
 
                 // re-set selectionModel listeners
@@ -6771,24 +6771,20 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
                 Object source = e.getSource();
                 if (source == JTable.this) {    // row selection model
 
-                    if (oldValue != null &&
-                        oldValue instanceof ListSelectionModel) {
-                        ((ListSelectionModel) oldValue).removeListSelectionListener(this);
+                    if (oldValue instanceof ListSelectionModel oldModel) {
+                        oldModel.removeListSelectionListener(this);
                     }
-                    if (newValue != null &&
-                        newValue instanceof ListSelectionModel) {
-                        ((ListSelectionModel) newValue).addListSelectionListener(this);
+                    if (newValue instanceof ListSelectionModel newModel) {
+                        newModel.addListSelectionListener(this);
                     }
 
                 } else if (source == JTable.this.getColumnModel()) {
 
-                    if (oldValue != null &&
-                        oldValue instanceof ListSelectionModel) {
-                        ((ListSelectionModel) oldValue).removeListSelectionListener(this);
+                    if (oldValue instanceof ListSelectionModel oldModel) {
+                        oldModel.removeListSelectionListener(this);
                     }
-                    if (newValue != null &&
-                        newValue instanceof ListSelectionModel) {
-                        ((ListSelectionModel) newValue).addListSelectionListener(this);
+                    if (newValue instanceof ListSelectionModel newModel) {
+                        newModel.addListSelectionListener(this);
                     }
 
                 } else {
@@ -6799,13 +6795,11 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
                 // and column's selection property listener as well
             } else if (name.compareTo("columnModel") == 0) {
 
-                if (oldValue != null && oldValue instanceof TableColumnModel) {
-                    TableColumnModel tcm = (TableColumnModel) oldValue;
+                if (oldValue instanceof TableColumnModel tcm) {
                     tcm.removeColumnModelListener(this);
                     tcm.getSelectionModel().removeListSelectionListener(this);
                 }
-                if (newValue != null && newValue instanceof TableColumnModel) {
-                    TableColumnModel tcm = (TableColumnModel) newValue;
+                if (newValue instanceof TableColumnModel tcm) {
                     tcm.addColumnModelListener(this);
                     tcm.getSelectionModel().addListSelectionListener(this);
                 }
@@ -6813,11 +6807,11 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
                 // re-se cellEditor listeners
             } else if (name.compareTo("tableCellEditor") == 0) {
 
-                if (oldValue != null && oldValue instanceof TableCellEditor) {
-                    ((TableCellEditor) oldValue).removeCellEditorListener(this);
+                if (oldValue instanceof TableCellEditor oldEditor) {
+                    oldEditor.removeCellEditorListener(this);
                 }
-                if (newValue != null && newValue instanceof TableCellEditor) {
-                    ((TableCellEditor) newValue).addCellEditorListener(this);
+                if (newValue instanceof TableCellEditor newEditor) {
+                    newEditor.addCellEditorListener(this);
                 }
             }
         }

--- a/src/java.desktop/share/classes/javax/swing/JTree.java
+++ b/src/java.desktop/share/classes/javax/swing/JTree.java
@@ -5415,14 +5415,12 @@ public class JTree extends JComponent implements Scrollable, Accessible
             public Rectangle getBounds() {
                 Rectangle r = tree.getPathBounds(path);
                 Accessible parent = getAccessibleParent();
-                if (parent != null) {
-                    if (parent instanceof AccessibleJTreeNode) {
-                        Point parentLoc = ((AccessibleJTreeNode) parent).getLocationInJTree();
-                        if (parentLoc != null && r != null) {
-                            r.translate(-parentLoc.x, -parentLoc.y);
-                        } else {
-                            return null;        // not visible!
-                        }
+                if (parent instanceof AccessibleJTreeNode treeNode) {
+                    Point parentLoc = treeNode.getLocationInJTree();
+                    if (parentLoc != null && r != null) {
+                        r.translate(-parentLoc.x, -parentLoc.y);
+                    } else {
+                        return null;        // not visible!
                     }
                 }
                 return r;

--- a/src/java.desktop/share/classes/javax/swing/JTree.java
+++ b/src/java.desktop/share/classes/javax/swing/JTree.java
@@ -3128,25 +3128,25 @@ public class JTree extends JComponent implements Scrollable, Accessible
         Vector<Object> values = new Vector<Object>();
 
         s.defaultWriteObject();
-        // Save the cellRenderer, if its Serializable.
-        if(cellRenderer != null && cellRenderer instanceof Serializable) {
+        // Save the cellRenderer, if it's Serializable.
+        if (cellRenderer instanceof Serializable ser) {
             values.addElement("cellRenderer");
-            values.addElement(cellRenderer);
+            values.addElement(ser);
         }
-        // Save the cellEditor, if its Serializable.
-        if(cellEditor != null && cellEditor instanceof Serializable) {
+        // Save the cellEditor, if it's Serializable.
+        if (cellEditor instanceof Serializable ser) {
             values.addElement("cellEditor");
-            values.addElement(cellEditor);
+            values.addElement(ser);
         }
-        // Save the treeModel, if its Serializable.
-        if(treeModel != null && treeModel instanceof Serializable) {
+        // Save the treeModel, if it's Serializable.
+        if (treeModel instanceof Serializable ser) {
             values.addElement("treeModel");
-            values.addElement(treeModel);
+            values.addElement(ser);
         }
-        // Save the selectionModel, if its Serializable.
-        if(selectionModel != null && selectionModel instanceof Serializable) {
+        // Save the selectionModel, if it's Serializable.
+        if (selectionModel instanceof Serializable ser) {
             values.addElement("selectionModel");
-            values.addElement(selectionModel);
+            values.addElement(ser);
         }
 
         Object      expandedData = getArchivableExpandedState();

--- a/src/java.desktop/share/classes/javax/swing/JTree.java
+++ b/src/java.desktop/share/classes/javax/swing/JTree.java
@@ -3129,24 +3129,24 @@ public class JTree extends JComponent implements Scrollable, Accessible
 
         s.defaultWriteObject();
         // Save the cellRenderer, if it's Serializable.
-        if (cellRenderer instanceof Serializable ser) {
+        if (cellRenderer instanceof Serializable) {
             values.addElement("cellRenderer");
-            values.addElement(ser);
+            values.addElement(cellRenderer);
         }
         // Save the cellEditor, if it's Serializable.
-        if (cellEditor instanceof Serializable ser) {
+        if (cellEditor instanceof Serializable) {
             values.addElement("cellEditor");
-            values.addElement(ser);
+            values.addElement(cellEditor);
         }
         // Save the treeModel, if it's Serializable.
-        if (treeModel instanceof Serializable ser) {
+        if (treeModel instanceof Serializable) {
             values.addElement("treeModel");
-            values.addElement(ser);
+            values.addElement(treeModel);
         }
         // Save the selectionModel, if it's Serializable.
-        if (selectionModel instanceof Serializable ser) {
+        if (selectionModel instanceof Serializable) {
             values.addElement("selectionModel");
-            values.addElement(ser);
+            values.addElement(selectionModel);
         }
 
         Object      expandedData = getArchivableExpandedState();

--- a/src/java.desktop/share/classes/javax/swing/MenuSelectionManager.java
+++ b/src/java.desktop/share/classes/javax/swing/MenuSelectionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,8 +72,8 @@ public class MenuSelectionManager {
 
                 // installing additional listener if found in the AppContext
                 Object o = context.get(SwingUtilities2.MENU_SELECTION_MANAGER_LISTENER_KEY);
-                if (o != null && o instanceof ChangeListener) {
-                    msm.addChangeListener((ChangeListener) o);
+                if (o instanceof ChangeListener listener) {
+                    msm.addChangeListener(listener);
                 }
             }
 

--- a/src/java.desktop/share/classes/javax/swing/RepaintManager.java
+++ b/src/java.desktop/share/classes/javax/swing/RepaintManager.java
@@ -929,7 +929,7 @@ public class RepaintManager
         for (int i = roots.size() - 1; i >= index; i--) {
             Component c = roots.get(i);
             for(;;) {
-                if (c == root || c == null || !(c instanceof JComponent)) {
+                if (c == root || !(c instanceof JComponent)) {
                     break;
                 }
                 c = c.getParent();

--- a/src/java.desktop/share/classes/javax/swing/SpinnerDateModel.java
+++ b/src/java.desktop/share/classes/javax/swing/SpinnerDateModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -454,11 +454,11 @@ public class SpinnerDateModel extends AbstractSpinnerModel implements Serializab
      * @see #addChangeListener
      */
     public void setValue(Object value) {
-        if ((value == null) || !(value instanceof Date)) {
+        if (!(value instanceof Date date)) {
             throw new IllegalArgumentException("illegal value");
         }
-        if (!value.equals(this.value.getTime())) {
-            this.value.setTime((Date)value);
+        if (!date.equals(this.value.getTime())) {
+            this.value.setTime(date);
             fireStateChanged();
         }
     }

--- a/src/java.desktop/share/classes/javax/swing/SpinnerNumberModel.java
+++ b/src/java.desktop/share/classes/javax/swing/SpinnerNumberModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -452,11 +452,11 @@ public class SpinnerNumberModel extends AbstractSpinnerModel implements Serializ
      * @see SpinnerModel#addChangeListener
      */
     public void setValue(Object value) {
-        if ((value == null) || !(value instanceof Number)) {
+        if (!(value instanceof Number number)) {
             throw new IllegalArgumentException("illegal value");
         }
-        if (!value.equals(this.value)) {
-            this.value = (Number)value;
+        if (!number.equals(this.value)) {
+            this.value = number;
             fireStateChanged();
         }
     }

--- a/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
+++ b/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
@@ -2054,8 +2054,8 @@ public class SwingUtilities implements SwingConstants
      * ImageIcon, and the image it contains is the same as <code>image</code>.
      */
     static boolean doesIconReferenceImage(Icon icon, Image image) {
-        Image iconImage = (icon != null && (icon instanceof ImageIcon)) ?
-                           ((ImageIcon)icon).getImage() : null;
+        Image iconImage = (icon instanceof ImageIcon i) ?
+                           i.getImage() : null;
         return (iconImage == image);
     }
 

--- a/src/java.desktop/share/classes/javax/swing/TransferHandler.java
+++ b/src/java.desktop/share/classes/javax/swing/TransferHandler.java
@@ -1272,9 +1272,9 @@ public class TransferHandler implements Serializable {
                 // If the Drop target is inactive the dragExit will not be dispatched to the dtListener,
                 // so make sure that we clean up the dtListener anyway.
                 DropTargetListener dtListener = getDropTargetListener();
-                    if (dtListener != null && dtListener instanceof DropHandler) {
-                        ((DropHandler)dtListener).cleanup(false);
-                    }
+                if (dtListener instanceof DropHandler dropHandler) {
+                    dropHandler.cleanup(false);
+                }
             }
         }
 

--- a/src/java.desktop/share/classes/javax/swing/event/EventListenerList.java
+++ b/src/java.desktop/share/classes/javax/swing/event/EventListenerList.java
@@ -283,7 +283,7 @@ public class EventListenerList implements Serializable {
         for (int i = 0; i < lList.length; i+=2) {
             Class<?> t = (Class)lList[i];
             EventListener l = (EventListener)lList[i+1];
-            if ((l!=null) && (l instanceof Serializable)) {
+            if (l instanceof Serializable) {
                 s.writeObject(t.getName());
                 s.writeObject(l);
             }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDesktopPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDesktopPaneUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -566,10 +566,7 @@ public class BasicDesktopPaneUI extends DesktopPaneUI {
                 if (cycleRoot != null) {
                     FocusTraversalPolicy policy =
                         cycleRoot.getFocusTraversalPolicy();
-                    if (policy != null && policy instanceof
-                            SortingFocusTraversalPolicy) {
-                        SortingFocusTraversalPolicy sPolicy =
-                            (SortingFocusTraversalPolicy)policy;
+                    if (policy instanceof SortingFocusTraversalPolicy sPolicy) {
                         boolean idc = sPolicy.getImplicitDownCycleTraversal();
                         try {
                             sPolicy.setImplicitDownCycleTraversal(false);

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicInternalFrameUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicInternalFrameUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -578,9 +578,8 @@ public class BasicInternalFrameUI extends InternalFrameUI
      * @param c the new north pane
      */
     public void setNorthPane(JComponent c) {
-        if (northPane != null &&
-                northPane instanceof BasicInternalFrameTitlePane) {
-            ((BasicInternalFrameTitlePane)northPane).uninstallListeners();
+        if (northPane instanceof BasicInternalFrameTitlePane tp) {
+            tp.uninstallListeners();
         }
         replacePane(northPane, c);
         northPane = c;
@@ -1614,9 +1613,8 @@ public class BasicInternalFrameUI extends InternalFrameUI
             // account the title pane since you are allowed to resize
             // the frames to the point where just the title pane is visible.
             Dimension result = new Dimension();
-            if (getNorthPane() != null &&
-                getNorthPane() instanceof BasicInternalFrameTitlePane) {
-                  result = new Dimension(getNorthPane().getMinimumSize());
+            if (getNorthPane() instanceof BasicInternalFrameTitlePane tp) {
+                  result = new Dimension(tp.getMinimumSize());
             }
             Insets i = frame.getInsets();
             result.width += i.left + i.right;

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -297,20 +297,20 @@ public class BasicMenuUI extends BasicMenuItemUI
             final MenuSelectionManager defaultManager = MenuSelectionManager.defaultManager();
             if(force) {
                 Container cnt = menu.getParent();
-                if(cnt != null && cnt instanceof JMenuBar) {
+                if (cnt instanceof JMenuBar menuBar) {
                     MenuElement[] me;
                     MenuElement[] subElements;
 
                     subElements = menu.getPopupMenu().getSubElements();
                     if(subElements.length > 0) {
                         me = new MenuElement[4];
-                        me[0] = (MenuElement) cnt;
+                        me[0] = menuBar;
                         me[1] = menu;
                         me[2] = menu.getPopupMenu();
                         me[3] = subElements[0];
                     } else {
                         me = new MenuElement[3];
-                        me[0] = (MenuElement)cnt;
+                        me[0] = menuBar;
                         me[1] = menu;
                         me[2] = menu.getPopupMenu();
                     }
@@ -512,10 +512,10 @@ public class BasicMenuUI extends BasicMenuItemUI
                     manager.clearSelectedPath();
                 } else {
                     Container cnt = menu.getParent();
-                    if(cnt != null && cnt instanceof JMenuBar) {
+                    if (cnt instanceof JMenuBar menuBar) {
                         MenuElement[] me = new MenuElement[2];
-                        me[0]=(MenuElement)cnt;
-                        me[1]=menu;
+                        me[0] = menuBar;
+                        me[1] = menu;
                         manager.setSelectedPath(me);
                     }
                 }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
@@ -966,7 +966,7 @@ public class BasicOptionPaneUI extends OptionPaneUI {
     protected void resetInputValue() {
         if (inputComponent instanceof JTextField textField) {
             optionPane.setInputValue(textField.getText());
-        } else if (inputComponent instanceof JComboBox comboBox) {
+        } else if (inputComponent instanceof JComboBox<?> comboBox) {
             optionPane.setInputValue(comboBox.getSelectedItem());
         } else if(inputComponent != null) {
             optionPane.setInputValue(((JList)inputComponent)

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -964,13 +964,10 @@ public class BasicOptionPaneUI extends OptionPaneUI {
      * the look and feel for based on the value in the inputComponent.
      */
     protected void resetInputValue() {
-        if(inputComponent != null && (inputComponent instanceof JTextField)) {
-            optionPane.setInputValue(((JTextField)inputComponent).getText());
-
-        } else if(inputComponent != null &&
-                  (inputComponent instanceof JComboBox)) {
-            optionPane.setInputValue(((JComboBox)inputComponent)
-                                     .getSelectedItem());
+        if (inputComponent instanceof JTextField textField) {
+            optionPane.setInputValue(textField.getText());
+        } else if (inputComponent instanceof JComboBox comboBox) {
+            optionPane.setInputValue(comboBox.getSelectedItem());
         } else if(inputComponent != null) {
             optionPane.setInputValue(((JList)inputComponent)
                                      .getSelectedValue());

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSpinnerUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSpinnerUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -197,8 +197,8 @@ public class BasicSpinnerUI extends SpinnerUI
             spinner.addChangeListener(getHandler());
         }
         JComponent editor = spinner.getEditor();
-        if (editor != null && editor instanceof JSpinner.DefaultEditor) {
-            JTextField tf = ((JSpinner.DefaultEditor)editor).getTextField();
+        if (editor instanceof JSpinner.DefaultEditor defaultEditor) {
+            JTextField tf = defaultEditor.getTextField();
             if (tf != null) {
                 tf.addFocusListener(nextButtonHandler);
                 tf.addFocusListener(previousButtonHandler);

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -344,7 +344,7 @@ public class BasicSplitPaneUI extends SplitPaneUI
 
         Border    b = divider.getBorder();
 
-        if (b == null || !(b instanceof UIResource)) {
+        if (!(b instanceof UIResource)) {
             divider.setBorder(UIManager.getBorder("SplitPaneDivider.border"));
         }
 
@@ -2359,8 +2359,7 @@ public class BasicSplitPaneUI extends SplitPaneUI
         }
 
         private Component getFirstAvailableComponent(Component c) {
-            if (c!=null && c instanceof JSplitPane) {
-                JSplitPane sp = (JSplitPane)c;
+            if (c instanceof JSplitPane sp) {
                 Component left = getFirstAvailableComponent(sp.getLeftComponent());
                 if (left != null) {
                     c = left;

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableHeaderUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableHeaderUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -535,13 +535,11 @@ public class BasicTableHeaderUI extends TableHeaderUI {
      * to ensure that the newly selected column is visible.
      */
     private void scrollToColumn(int col) {
-        Container container;
         JTable table;
 
         //Test whether the header is in a scroll pane and has a table.
         if ((header.getParent() == null) ||
-            ((container = header.getParent().getParent()) == null) ||
-            !(container instanceof JScrollPane) ||
+            !(header.getParent().getParent() instanceof JScrollPane) ||
             ((table = header.getTable()) == null)) {
             return;
         }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableUI.java
@@ -933,24 +933,21 @@ public class BasicTableUI extends TableUI
             // the table, seems to have no effect.
 
             Component editorComp = table.getEditorComponent();
-            if (table.isEditing() && editorComp != null) {
-                if (editorComp instanceof JComponent) {
-                    JComponent component = (JComponent)editorComp;
-                    map = component.getInputMap(JComponent.WHEN_FOCUSED);
-                    Object binding = (map != null) ? map.get(keyStroke) : null;
-                    if (binding == null) {
-                        map = component.getInputMap(JComponent.
-                                         WHEN_ANCESTOR_OF_FOCUSED_COMPONENT);
-                        binding = (map != null) ? map.get(keyStroke) : null;
-                    }
-                    if (binding != null) {
-                        ActionMap am = component.getActionMap();
-                        Action action = (am != null) ? am.get(binding) : null;
-                        if (action != null && SwingUtilities.
+            if (table.isEditing() && editorComp instanceof JComponent component) {
+                map = component.getInputMap(JComponent.WHEN_FOCUSED);
+                Object binding = (map != null) ? map.get(keyStroke) : null;
+                if (binding == null) {
+                    map = component.getInputMap(JComponent.
+                            WHEN_ANCESTOR_OF_FOCUSED_COMPONENT);
+                    binding = (map != null) ? map.get(keyStroke) : null;
+                }
+                if (binding != null) {
+                    ActionMap am = component.getActionMap();
+                    Action action = (am != null) ? am.get(binding) : null;
+                    if (action != null && SwingUtilities.
                             notifyAction(action, keyStroke, e, component,
-                                         e.getModifiers())) {
-                            e.consume();
-                        }
+                                    e.getModifiers())) {
+                        e.consume();
                     }
                 }
             }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1485,8 +1485,8 @@ public class BasicTableUI extends TableUI
         Container parent = SwingUtilities.getUnwrappedParent(table);  // should be viewport
         if (parent != null) {
             parent = parent.getParent();  // should be the scrollpane
-            if (parent != null && parent instanceof JScrollPane) {
-                LookAndFeel.installBorder((JScrollPane)parent, "Table.scrollPaneBorder");
+            if (parent instanceof JScrollPane scrollPane) {
+                LookAndFeel.installBorder(scrollPane, "Table.scrollPaneBorder");
             }
         }
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
@@ -182,8 +182,7 @@ public abstract class BasicTextUI extends TextUI implements ViewFactory {
             String prefix = getPropertyPrefix();
             Object o = DefaultLookup.get(editor, this,
                 prefix + ".keyBindings");
-            if ((o != null) && (o instanceof JTextComponent.KeyBinding[])) {
-                JTextComponent.KeyBinding[] bindings = (JTextComponent.KeyBinding[]) o;
+            if (o instanceof JTextComponent.KeyBinding[] bindings) {
                 JTextComponent.loadKeymap(map, bindings, getComponent().getActions());
             }
         }
@@ -536,8 +535,7 @@ public abstract class BasicTextUI extends TextUI implements ViewFactory {
          * should allow Tab to keyboard - accessibility
          */
         EditorKit editorKit = getEditorKit(editor);
-        if ( editorKit != null
-             && editorKit instanceof DefaultEditorKit) {
+        if (editorKit instanceof DefaultEditorKit) {
             Set<AWTKeyStroke> storedForwardTraversalKeys = editor.
                 getFocusTraversalKeys(KeyboardFocusManager.
                                       FORWARD_TRAVERSAL_KEYS);
@@ -617,9 +615,8 @@ public abstract class BasicTextUI extends TextUI implements ViewFactory {
         if (getEditorKit(editor) instanceof DefaultEditorKit) {
             if (map != null) {
                 Object obj = map.get(DefaultEditorKit.insertBreakAction);
-                if (obj != null
-                    && obj instanceof DefaultEditorKit.InsertBreakAction) {
-                    Action action =  new TextActionWrapper((TextAction)obj);
+                if (obj instanceof DefaultEditorKit.InsertBreakAction breakAction) {
+                    Action action =  new TextActionWrapper(breakAction);
                     componentMap.put(action.getValue(Action.NAME),action);
                 }
             }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
@@ -616,7 +616,7 @@ public abstract class BasicTextUI extends TextUI implements ViewFactory {
             if (map != null) {
                 Object obj = map.get(DefaultEditorKit.insertBreakAction);
                 if (obj instanceof DefaultEditorKit.InsertBreakAction breakAction) {
-                    Action action =  new TextActionWrapper(breakAction);
+                    Action action = new TextActionWrapper(breakAction);
                     componentMap.put(action.getValue(Action.NAME),action);
                 }
             }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicToolBarUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicToolBarUI.java
@@ -654,8 +654,8 @@ public class BasicToolBarUI extends ToolBarUI implements SwingConstants
             Container p;
             for(p = toolBar.getParent() ; p != null && !(p instanceof Window) ;
                 p = p.getParent());
-            if(p != null && p instanceof Window)
-                frame = (Window) p;
+            if (p instanceof Window window)
+                frame = window;
         }
         if(floatingToolBar == null) {
             floatingToolBar = createFloatingWindow(toolBar);

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTreeUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTreeUI.java
@@ -1131,10 +1131,8 @@ public class BasicTreeUI extends TreeUI
      * @return a default cell editor
      */
     protected TreeCellEditor createDefaultCellEditor() {
-        if(currentCellRenderer != null &&
-           (currentCellRenderer instanceof DefaultTreeCellRenderer)) {
-            DefaultTreeCellEditor editor = new DefaultTreeCellEditor
-                        (tree, (DefaultTreeCellRenderer)currentCellRenderer);
+        if (currentCellRenderer instanceof DefaultTreeCellRenderer defaultRenderer) {
+            DefaultTreeCellEditor editor = new DefaultTreeCellEditor(tree, defaultRenderer);
 
             return editor;
         }

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalFileChooserUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalFileChooserUI.java
@@ -1144,8 +1144,8 @@ public class MetalFileChooserUI extends BasicFileChooserUI {
 
             super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
 
-            if (value != null && value instanceof FileFilter) {
-                setText(((FileFilter)value).getDescription());
+            if (value instanceof FileFilter fileFilter) {
+                setText(fileFilter.getDescription());
             }
 
             return this;

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTextFieldUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTextFieldUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -147,8 +147,7 @@ public class SynthTextFieldUI extends BasicTextFieldUI implements SynthUI {
         Caret caret = comp.getCaret();
         if (caret instanceof UIResource) {
             Object o = style.get(context, prefix + ".caretBlinkRate");
-            if (o != null && o instanceof Integer) {
-                Integer rate = (Integer)o;
+            if (o instanceof Integer rate) {
                 caret.setBlinkRate(rate.intValue());
             }
         }

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTreeUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTreeUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -203,9 +203,8 @@ public class SynthTreeUI extends BasicTreeUI
         TreeCellRenderer renderer = tree.getCellRenderer();
         DefaultTreeCellEditor editor;
 
-        if(renderer != null && (renderer instanceof DefaultTreeCellRenderer)) {
-            editor = new SynthTreeCellEditor(tree, (DefaultTreeCellRenderer)
-                                             renderer);
+        if (renderer instanceof DefaultTreeCellRenderer defaultRenderer) {
+            editor = new SynthTreeCellEditor(tree, defaultRenderer);
         }
         else {
             editor = new SynthTreeCellEditor(tree, null);

--- a/src/java.desktop/share/classes/javax/swing/text/BoxView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/BoxView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1150,9 +1150,9 @@ public class BoxView extends CompositeView {
             int index = getViewIndexAtPosition(testPos);
             if(index != -1) {
                 View v = getView(index);
-                if(v != null && v instanceof CompositeView) {
-                    return ((CompositeView)v).flipEastAndWestAtEnds(position,
-                                                                    bias);
+                if (v instanceof CompositeView compositeView) {
+                    return compositeView.flipEastAndWestAtEnds(position,
+                                                               bias);
                 }
             }
         }

--- a/src/java.desktop/share/classes/javax/swing/text/DefaultStyledDocument.java
+++ b/src/java.desktop/share/classes/javax/swing/text/DefaultStyledDocument.java
@@ -438,11 +438,11 @@ public class DefaultStyledDocument extends AbstractDocument implements StyledDoc
      */
     public void setLogicalStyle(int pos, Style s) {
         Element paragraph = getParagraphElement(pos);
-        if ((paragraph != null) && (paragraph instanceof AbstractElement)) {
+        if (paragraph instanceof AbstractElement abstractElement) {
             try {
                 writeLock();
-                StyleChangeUndoableEdit edit = new StyleChangeUndoableEdit((AbstractElement)paragraph, s);
-                ((AbstractElement)paragraph).setResolveParent(s);
+                StyleChangeUndoableEdit edit = new StyleChangeUndoableEdit(abstractElement, s);
+                abstractElement.setResolveParent(s);
                 int p0 = paragraph.getStartOffset();
                 int p1 = paragraph.getEndOffset();
                 DefaultDocumentEvent e =

--- a/src/java.desktop/share/classes/javax/swing/text/JTextComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/text/JTextComponent.java
@@ -3306,8 +3306,7 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
 
             // Fixes bug 4487492
             Document doc = JTextComponent.this.getDocument();
-            if (doc != null && doc instanceof StyledDocument) {
-                StyledDocument sDoc = (StyledDocument)doc;
+            if (doc instanceof StyledDocument sDoc) {
                 int offset = startIndex;
                 int length = endIndex - startIndex;
                 sDoc.setCharacterAttributes(offset, length, as, true);

--- a/src/java.desktop/share/classes/javax/swing/text/html/AccessibleHTML.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/AccessibleHTML.java
@@ -1216,9 +1216,8 @@ class AccessibleHTML implements Accessible {
             private String getText(int offset, int length)
                 throws BadLocationException {
 
-                if (model != null && model instanceof StyledDocument) {
-                    StyledDocument doc = (StyledDocument)model;
-                    return model.getText(offset, length);
+                if (model instanceof StyledDocument doc) {
+                    return doc.getText(offset, length);
                 } else {
                     return null;
                 }

--- a/src/java.desktop/share/classes/javax/swing/text/html/AccessibleHTML.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/AccessibleHTML.java
@@ -372,8 +372,8 @@ class AccessibleHTML implements Accessible {
          */
         public Accessible getAccessibleChild(int i) {
             ElementInfo childInfo = elementInfo.getChild(i);
-            if (childInfo != null && childInfo instanceof Accessible) {
-                return (Accessible)childInfo;
+            if (childInfo instanceof Accessible accessibleChild) {
+                return accessibleChild;
             } else {
                 return null;
             }

--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -1609,8 +1609,8 @@ public class CSS implements Serializable {
             if (key instanceof HTML.Tag) {
                 HTML.Tag tag = (HTML.Tag)key;
                 Object o = htmlAttrSet.getAttribute(tag);
-                if (o != null && o instanceof AttributeSet) {
-                    translateAttributes(tag, (AttributeSet)o, cssAttrSet);
+                if (o instanceof AttributeSet attributeSet) {
+                    translateAttributes(tag, attributeSet, cssAttrSet);
                 }
             } else if (key instanceof CSS.Attribute) {
                 cssAttrSet.addAttribute(key, htmlAttrSet.getAttribute(key));

--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -1609,8 +1609,8 @@ public class CSS implements Serializable {
             if (key instanceof HTML.Tag) {
                 HTML.Tag tag = (HTML.Tag)key;
                 Object o = htmlAttrSet.getAttribute(tag);
-                if (o instanceof AttributeSet attributeSet) {
-                    translateAttributes(tag, attributeSet, cssAttrSet);
+                if (o instanceof AttributeSet as) {
+                    translateAttributes(tag, as, cssAttrSet);
                 }
             } else if (key instanceof CSS.Attribute) {
                 cssAttrSet.addAttribute(key, htmlAttrSet.getAttribute(key));

--- a/src/java.desktop/share/classes/javax/swing/text/html/HRuleView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HRuleView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,16 +72,16 @@ class HRuleView extends View  {
 
             noshade = (String)eAttr.getAttribute(HTML.Attribute.NOSHADE);
             Object value = eAttr.getAttribute(HTML.Attribute.SIZE);
-            if (value != null && (value instanceof String)) {
+            if (value instanceof String s) {
                 try {
-                    size = Integer.parseInt((String)value);
+                    size = Integer.parseInt(s);
                 } catch (NumberFormatException e) {
                     size = 1;
                 }
             }
             value = attr.getAttribute(CSS.Attribute.WIDTH);
-            if (value != null && (value instanceof CSS.LengthValue)) {
-                widthValue = (CSS.LengthValue)value;
+            if (value instanceof CSS.LengthValue lv) {
+                widthValue = lv;
             }
             topMargin = getLength(CSS.Attribute.MARGIN_TOP, attr);
             bottomMargin = getLength(CSS.Attribute.MARGIN_BOTTOM, attr);

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -901,8 +901,8 @@ public class HTMLDocument extends DefaultStyledDocument {
         if (name != null) {
             Object     maps = getProperty(MAP_PROPERTY);
 
-            if (maps != null && (maps instanceof Hashtable)) {
-                return (Map)((Hashtable)maps).get(name);
+            if (maps instanceof Hashtable hashtable) {
+                return (Map) hashtable.get(name);
             }
         }
         return null;

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
@@ -901,7 +901,7 @@ public class HTMLDocument extends DefaultStyledDocument {
         if (name != null) {
             Object     maps = getProperty(MAP_PROPERTY);
 
-            if (maps instanceof Hashtable hashtable) {
+            if (maps instanceof Hashtable<?, ?> hashtable) {
                 return (Map) hashtable.get(name);
             }
         }

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLEditorKit.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLEditorKit.java
@@ -1473,10 +1473,8 @@ public class HTMLEditorKit extends StyledEditorKit implements Accessible {
 
             protected void layoutMinorAxis(int targetSpan, int axis, int[] offsets, int[] spans) {
                 Container container = getContainer();
-                Container parentContainer;
                 if ((container instanceof JEditorPane)
-                        && (parentContainer = container.getParent()) != null
-                        && (parentContainer instanceof JViewport viewPort)) {
+                        && (container.getParent() instanceof JViewport viewPort)) {
                     if (cachedViewPort != null) {
                         JViewport cachedObject = cachedViewPort.get();
                         if (cachedObject != null) {

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLEditorKit.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLEditorKit.java
@@ -842,8 +842,8 @@ public class HTMLEditorKit extends StyledEditorKit implements Accessible {
                                   Element elem, AttributeSet attr, int offset,
                                   int x, int y) {
             Object useMap = attr.getAttribute(HTML.Attribute.USEMAP);
-            if (useMap != null && (useMap instanceof String)) {
-                Map m = hdoc.getMap((String)useMap);
+            if (useMap instanceof String s) {
+                Map m = hdoc.getMap(s);
                 if (m != null && offset < hdoc.getLength()) {
                     Rectangle bounds;
                     TextUI ui = html.getUI();
@@ -1474,11 +1474,9 @@ public class HTMLEditorKit extends StyledEditorKit implements Accessible {
             protected void layoutMinorAxis(int targetSpan, int axis, int[] offsets, int[] spans) {
                 Container container = getContainer();
                 Container parentContainer;
-                if (container != null
-                    && (container instanceof javax.swing.JEditorPane)
-                    && (parentContainer = container.getParent()) != null
-                    && (parentContainer instanceof javax.swing.JViewport)) {
-                    JViewport viewPort = (JViewport)parentContainer;
+                if ((container instanceof JEditorPane)
+                        && (parentContainer = container.getParent()) != null
+                        && (parentContainer instanceof JViewport viewPort)) {
                     if (cachedViewPort != null) {
                         JViewport cachedObject = cachedViewPort.get();
                         if (cachedObject != null) {
@@ -2393,9 +2391,9 @@ public class HTMLEditorKit extends StyledEditorKit implements Accessible {
          */
         private void doObjectAction(JEditorPane editor, Element elem) {
             View view = getView(editor, elem);
-            if (view != null && view instanceof ObjectView) {
-                Component comp = ((ObjectView)view).getComponent();
-                if (comp != null && comp instanceof Accessible) {
+            if (view instanceof ObjectView objectView) {
+                Component comp = objectView.getComponent();
+                if (comp instanceof Accessible) {
                     AccessibleContext ac = comp.getAccessibleContext();
                     if (ac != null) {
                         AccessibleAction aa = ac.getAccessibleAction();
@@ -2479,10 +2477,9 @@ public class HTMLEditorKit extends StyledEditorKit implements Accessible {
             JEditorPane editor = (JEditorPane)c;
 
             Document d = editor.getDocument();
-            if (d == null || !(d instanceof HTMLDocument)) {
+            if (!(d instanceof HTMLDocument doc)) {
                 return;
             }
-            HTMLDocument doc = (HTMLDocument)d;
 
             ElementIterator ei = new ElementIterator(doc);
             int currentOffset = editor.getCaretPosition();

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLWriter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -308,9 +308,7 @@ public class HTMLWriter extends AbstractWriter {
             // If an instance of an UNKNOWN Tag, or an instance of a
             // tag that is only visible during editing
             //
-            if (nameTag != null && endTag != null &&
-                (endTag instanceof String) &&
-                endTag.equals("true")) {
+            if (nameTag != null && "true".equals(endTag)) {
                 outputEndTag = true;
             }
 
@@ -732,8 +730,8 @@ public class HTMLWriter extends AbstractWriter {
                 write('<');
                 write(tag.toString());
                 Object o = attr.getAttribute(tag);
-                if (o != null && o instanceof AttributeSet) {
-                    writeAttributes((AttributeSet)o);
+                if (o instanceof AttributeSet as) {
+                    writeAttributes(as);
                 }
                 write('>');
                 tags.addElement(tag);
@@ -813,8 +811,8 @@ public class HTMLWriter extends AbstractWriter {
                 write('<');
                 write(t.toString());
                 Object o = tagValues.elementAt(i);
-                if (o != null && o instanceof AttributeSet) {
-                    writeAttributes((AttributeSet)o);
+                if (o instanceof AttributeSet as) {
+                    writeAttributes(as);
                 }
                 write('>');
             }

--- a/src/java.desktop/share/classes/javax/swing/text/html/HiddenTagView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HiddenTagView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -271,8 +271,7 @@ class HiddenTagView extends EditableView implements DocumentListener {
         AttributeSet as = getElement().getAttributes();
         if (as != null) {
             Object end = as.getAttribute(HTML.Attribute.ENDTAG);
-            if (end != null && (end instanceof String) &&
-                ((String)end).equals("true")) {
+            if ("true".equals(end)) {
                 return true;
             }
         }

--- a/src/java.desktop/share/classes/javax/swing/text/html/Map.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/Map.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -181,12 +181,11 @@ class Map implements Serializable {
      * from trying to parse one of the numbers null is returned.
      */
     protected static int[] extractCoords(Object stringCoords) {
-        if (stringCoords == null || !(stringCoords instanceof String)) {
+        if (!(stringCoords instanceof String s)) {
             return null;
         }
 
-        StringTokenizer    st = new StringTokenizer((String)stringCoords,
-                                                    ", \t\n\r");
+        StringTokenizer    st = new StringTokenizer(s, ", \t\n\r");
         int[]              retValue = null;
         int                numCoords = 0;
 

--- a/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
@@ -2211,10 +2211,9 @@ public class StyleSheet extends StyleContext {
                     retIndex--;
                 } else if (as.isDefined(HTML.Attribute.VALUE)) {
                     Object value = as.getAttribute(HTML.Attribute.VALUE);
-                    if (value != null &&
-                        (value instanceof String)) {
+                    if (value instanceof String s) {
                         try {
-                            int iValue = Integer.parseInt((String)value);
+                            int iValue = Integer.parseInt(s);
                             return retIndex - counter + iValue;
                         }
                         catch (NumberFormatException nfe) {}
@@ -2744,8 +2743,7 @@ public class StyleSheet extends StyleContext {
                                    kind of conditional behaviour in the
                                    stylesheet.
                                  **/
-                                    if (o != null && o instanceof AttributeSet) {
-                                        AttributeSet attr = (AttributeSet)o;
+                                    if (o instanceof AttributeSet attr) {
                                         if (attr.getAttribute(HTML.Attribute.HREF) == null) {
                                             continue;
                                         }

--- a/src/java.desktop/share/classes/javax/swing/text/rtf/RTFGenerator.java
+++ b/src/java.desktop/share/classes/javax/swing/text/rtf/RTFGenerator.java
@@ -392,7 +392,7 @@ public void writeRTFHeader()
             updateCharacterAttributes(goat, style, false);
 
             basis = style.getResolveParent();
-            if (basis != null && basis instanceof Style) {
+            if (basis instanceof Style) {
                 Integer basedOn = styleTable.get(basis);
                 if (basedOn != null) {
                     writeControlWord("sbasedon", basedOn.intValue());

--- a/src/java.desktop/share/classes/javax/swing/tree/DefaultMutableTreeNode.java
+++ b/src/java.desktop/share/classes/javax/swing/tree/DefaultMutableTreeNode.java
@@ -1297,11 +1297,11 @@ public class DefaultMutableTreeNode implements Cloneable,
         Object[]             tValues;
 
         s.defaultWriteObject();
-        // Save the userObject, if its Serializable.
-        if(userObject != null && userObject instanceof Serializable) {
+        // Save the userObject, if it's Serializable.
+        if (userObject instanceof Serializable ser) {
             tValues = new Object[2];
             tValues[0] = "userObject";
-            tValues[1] = userObject;
+            tValues[1] = ser;
         }
         else
             tValues = new Object[0];

--- a/src/java.desktop/share/classes/javax/swing/tree/DefaultMutableTreeNode.java
+++ b/src/java.desktop/share/classes/javax/swing/tree/DefaultMutableTreeNode.java
@@ -1298,10 +1298,10 @@ public class DefaultMutableTreeNode implements Cloneable,
 
         s.defaultWriteObject();
         // Save the userObject, if it's Serializable.
-        if (userObject instanceof Serializable ser) {
+        if (userObject instanceof Serializable) {
             tValues = new Object[2];
             tValues[0] = "userObject";
-            tValues[1] = ser;
+            tValues[1] = userObject;
         }
         else
             tValues = new Object[0];

--- a/src/java.desktop/share/classes/javax/swing/tree/DefaultTreeModel.java
+++ b/src/java.desktop/share/classes/javax/swing/tree/DefaultTreeModel.java
@@ -690,10 +690,10 @@ public class DefaultTreeModel implements Serializable, TreeModel {
         Vector<Object> values = new Vector<Object>();
 
         s.defaultWriteObject();
-        // Save the root, if its Serializable.
-        if(root != null && root instanceof Serializable) {
+        // Save the root, if it's Serializable.
+        if (root instanceof Serializable ser) {
             values.addElement("root");
-            values.addElement(root);
+            values.addElement(ser);
         }
         s.writeObject(values);
     }

--- a/src/java.desktop/share/classes/javax/swing/tree/DefaultTreeModel.java
+++ b/src/java.desktop/share/classes/javax/swing/tree/DefaultTreeModel.java
@@ -691,9 +691,9 @@ public class DefaultTreeModel implements Serializable, TreeModel {
 
         s.defaultWriteObject();
         // Save the root, if it's Serializable.
-        if (root instanceof Serializable ser) {
+        if (root instanceof Serializable) {
             values.addElement("root");
-            values.addElement(ser);
+            values.addElement(root);
         }
         s.writeObject(values);
     }

--- a/src/java.desktop/share/classes/javax/swing/tree/DefaultTreeSelectionModel.java
+++ b/src/java.desktop/share/classes/javax/swing/tree/DefaultTreeSelectionModel.java
@@ -1218,10 +1218,10 @@ public class DefaultTreeSelectionModel implements Cloneable, Serializable, TreeS
 
         s.defaultWriteObject();
         // Save the rowMapper, if it implements Serializable
-        if(rowMapper != null && rowMapper instanceof Serializable) {
+        if (rowMapper instanceof Serializable ser) {
             tValues = new Object[2];
             tValues[0] = "rowMapper";
-            tValues[1] = rowMapper;
+            tValues[1] = ser;
         }
         else
             tValues = new Object[0];

--- a/src/java.desktop/share/classes/javax/swing/tree/DefaultTreeSelectionModel.java
+++ b/src/java.desktop/share/classes/javax/swing/tree/DefaultTreeSelectionModel.java
@@ -1218,10 +1218,10 @@ public class DefaultTreeSelectionModel implements Cloneable, Serializable, TreeS
 
         s.defaultWriteObject();
         // Save the rowMapper, if it implements Serializable
-        if (rowMapper instanceof Serializable ser) {
+        if (rowMapper instanceof Serializable) {
             tValues = new Object[2];
             tValues[0] = "rowMapper";
-            tValues[1] = ser;
+            tValues[1] = rowMapper;
         }
         else
             tValues = new Object[0];

--- a/src/java.desktop/share/classes/sun/awt/im/InputContext.java
+++ b/src/java.desktop/share/classes/sun/awt/im/InputContext.java
@@ -790,8 +790,8 @@ public class InputContext extends java.awt.im.InputContext
      */
     public void disableNativeIM() {
         InputMethod inputMethod = getInputMethod();
-        if (inputMethod != null && inputMethod instanceof InputMethodAdapter) {
-            ((InputMethodAdapter)inputMethod).stopListening();
+        if (inputMethod instanceof InputMethodAdapter adapter) {
+            adapter.stopListening();
         }
     }
 

--- a/src/java.desktop/share/classes/sun/awt/shell/ShellFolder.java
+++ b/src/java.desktop/share/classes/sun/awt/shell/ShellFolder.java
@@ -181,9 +181,7 @@ public abstract class ShellFolder extends File {
      * @see #compareTo(Object)
      */
     public int compareTo(File file2) {
-        if (file2 == null || !(file2 instanceof ShellFolder)
-            || ((file2 instanceof ShellFolder) && ((ShellFolder)file2).isFileSystem())) {
-
+        if (!(file2 instanceof ShellFolder sf) || sf.isFileSystem()) {
             if (isFileSystem()) {
                 return super.compareTo(file2);
             } else {

--- a/src/java.desktop/share/classes/sun/font/AttributeValues.java
+++ b/src/java.desktop/share/classes/sun/font/AttributeValues.java
@@ -764,8 +764,8 @@ public final class AttributeValues implements Cloneable {
                 return ((AttributeMap)map).getValues().justification;
             }
             Object obj = map.get(TextAttribute.JUSTIFICATION);
-            if (obj != null && obj instanceof Number) {
-                return max(0, min(1, ((Number)obj).floatValue()));
+            if (obj instanceof Number number) {
+                return max(0, min(1, number.floatValue()));
             }
         }
         return DEFAULT.justification;
@@ -778,8 +778,8 @@ public final class AttributeValues implements Cloneable {
                 return ((AttributeMap)map).getValues().numericShaping;
             }
             Object obj = map.get(TextAttribute.NUMERIC_SHAPING);
-            if (obj != null && obj instanceof NumericShaper) {
-                return (NumericShaper)obj;
+            if (obj instanceof NumericShaper shaper) {
+                return shaper;
             }
         }
         return DEFAULT.numericShaping;

--- a/src/java.desktop/share/classes/sun/font/FontUtilities.java
+++ b/src/java.desktop/share/classes/sun/font/FontUtilities.java
@@ -413,10 +413,9 @@ public final class FontUtilities {
         FontManager fm = FontManagerFactory.getInstance();
         Font2D dialog = fm.findFont2D("dialog", font.getStyle(), FontManager.NO_FALLBACK);
         // Should never be null, but MACOSX fonts are not CompositeFonts
-        if (dialog == null || !(dialog instanceof CompositeFont)) {
+        if (!(dialog instanceof CompositeFont dialog2D)) {
             return fuir;
         }
-        CompositeFont dialog2D = (CompositeFont)dialog;
         PhysicalFont physicalFont = (PhysicalFont)font2D;
         ConcurrentHashMap<PhysicalFont, CompositeFont> compMap = compMapRef.get();
         if (compMap == null) { // Its been collected.

--- a/src/java.desktop/share/classes/sun/print/PSStreamPrintService.java
+++ b/src/java.desktop/share/classes/sun/print/PSStreamPrintService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -320,8 +320,7 @@ public class PSStreamPrintService extends StreamPrintService
             MediaSize mediaSize = (MediaSize)attributes.get(MediaSize.class);
             if (mediaSize == null) {
                 Media media = (Media)attributes.get(Media.class);
-                if (media != null && media instanceof MediaSizeName) {
-                    MediaSizeName msn = (MediaSizeName)media;
+                if (media instanceof MediaSizeName msn) {
                     mediaSize = MediaSize.getMediaSizeForName(msn);
                 }
             }

--- a/src/java.desktop/share/classes/sun/print/PathGraphics.java
+++ b/src/java.desktop/share/classes/sun/print/PathGraphics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -895,8 +895,8 @@ public abstract class PathGraphics extends ProxyGraphics2D {
              */
             Map<TextAttribute, ?> map = font.getAttributes();
             Object o = map.get(TextAttribute.TRACKING);
-            boolean tracking = o != null && (o instanceof Number) &&
-                (((Number)o).floatValue() != 0f);
+            boolean tracking = (o instanceof Number n) &&
+                (n.floatValue() != 0f);
 
             if (tracking) {
                 noPositionAdjustments = false;

--- a/src/java.desktop/share/classes/sun/print/PrintJob2D.java
+++ b/src/java.desktop/share/classes/sun/print/PrintJob2D.java
@@ -454,8 +454,8 @@ public class PrintJob2D extends PrintJob implements Printable, Runnable {
 
             Media media = (Media)attributes.get(Media.class);
             MediaSize mediaSize =  null;
-            if (media != null  && media instanceof MediaSizeName) {
-                mediaSize = MediaSize.getMediaSizeForName((MediaSizeName)media);
+            if (media instanceof MediaSizeName msn) {
+                mediaSize = MediaSize.getMediaSizeForName(msn);
             }
 
             Paper p = pageFormat.getPaper();
@@ -594,9 +594,9 @@ public class PrintJob2D extends PrintJob implements Printable, Runnable {
             pageAttributes.setPrintQuality(PrintQualityType.NORMAL);
         }
 
-        Media msn = (Media)attributes.get(Media.class);
-        if (msn != null && msn instanceof MediaSizeName) {
-            MediaType mType = unMapMedia((MediaSizeName)msn);
+        Media media = (Media)attributes.get(Media.class);
+        if (media instanceof MediaSizeName msn) {
+            MediaType mType = unMapMedia(msn);
 
             if (mType != null) {
                 pageAttributes.setMedia(mType);

--- a/src/java.desktop/share/classes/sun/print/ServiceDialog.java
+++ b/src/java.desktop/share/classes/sun/print/ServiceDialog.java
@@ -1620,11 +1620,10 @@ public class ServiceDialog extends JDialog implements ActionListener {
             MediaSize mediaSize = null;
 
             Media media = (Media)asCurrent.get(Media.class);
-            if (media == null || !(media instanceof MediaSizeName)) {
+            if (!(media instanceof MediaSizeName)) {
                 media = (Media)psCurrent.getDefaultAttributeValue(Media.class);
             }
-            if (media != null && (media instanceof MediaSizeName)) {
-                MediaSizeName msn = (MediaSizeName)media;
+            if (media instanceof MediaSizeName msn) {
                 mediaSize = MediaSize.getMediaSizeForName(msn);
             }
             if (mediaSize == null) {
@@ -1706,11 +1705,10 @@ public class ServiceDialog extends JDialog implements ActionListener {
             MediaSize mediaSize = null;
 
             Media media = (Media)asCurrent.get(Media.class);
-            if (media == null || !(media instanceof MediaSizeName)) {
+            if (!(media instanceof MediaSizeName)) {
                 media = (Media)psCurrent.getDefaultAttributeValue(Media.class);
             }
-            if (media != null && (media instanceof MediaSizeName)) {
-                MediaSizeName msn = (MediaSizeName)media;
+            if (media instanceof MediaSizeName msn) {
                 mediaSize = MediaSize.getMediaSizeForName(msn);
             }
             if (mediaSize == null) {

--- a/src/java.desktop/share/classes/sun/swing/DefaultLookup.java
+++ b/src/java.desktop/share/classes/sun/swing/DefaultLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -132,10 +132,10 @@ public class DefaultLookup {
                              int defaultValue) {
         Object iValue = get(c, ui, key);
 
-        if (iValue == null || !(iValue instanceof Number)) {
-            return defaultValue;
+        if (iValue instanceof Number number) {
+            return number.intValue();
         }
-        return ((Number)iValue).intValue();
+        return defaultValue;
     }
 
     public static int getInt(JComponent c, ComponentUI ui, String key) {
@@ -146,10 +146,10 @@ public class DefaultLookup {
                                    Insets defaultValue) {
         Object iValue = get(c, ui, key);
 
-        if (iValue == null || !(iValue instanceof Insets)) {
-            return defaultValue;
+        if (iValue instanceof Insets insets) {
+            return insets;
         }
-        return (Insets)iValue;
+        return defaultValue;
     }
 
     public static Insets getInsets(JComponent c, ComponentUI ui, String key) {
@@ -160,10 +160,10 @@ public class DefaultLookup {
                                      boolean defaultValue) {
         Object iValue = get(c, ui, key);
 
-        if (iValue == null || !(iValue instanceof Boolean)) {
-            return defaultValue;
+        if (iValue instanceof Boolean b) {
+            return b;
         }
-        return ((Boolean)iValue).booleanValue();
+        return defaultValue;
     }
 
     public static boolean getBoolean(JComponent c, ComponentUI ui, String key) {
@@ -174,10 +174,10 @@ public class DefaultLookup {
                                  Color defaultValue) {
         Object iValue = get(c, ui, key);
 
-        if (iValue == null || !(iValue instanceof Color)) {
-            return defaultValue;
+        if (iValue instanceof Color color) {
+            return color;
         }
-        return (Color)iValue;
+        return defaultValue;
     }
 
     public static Color getColor(JComponent c, ComponentUI ui, String key) {
@@ -187,10 +187,10 @@ public class DefaultLookup {
     public static Icon getIcon(JComponent c, ComponentUI ui, String key,
             Icon defaultValue) {
         Object iValue = get(c, ui, key);
-        if (iValue == null || !(iValue instanceof Icon)) {
-            return defaultValue;
+        if (iValue instanceof Icon icon) {
+            return icon;
         }
-        return (Icon)iValue;
+        return defaultValue;
     }
 
     public static Icon getIcon(JComponent c, ComponentUI ui, String key) {
@@ -200,10 +200,10 @@ public class DefaultLookup {
     public static Border getBorder(JComponent c, ComponentUI ui, String key,
             Border defaultValue) {
         Object iValue = get(c, ui, key);
-        if (iValue == null || !(iValue instanceof Border)) {
-            return defaultValue;
+        if (iValue instanceof Border border) {
+            return border;
         }
-        return (Border)iValue;
+        return defaultValue;
     }
 
     public static Border getBorder(JComponent c, ComponentUI ui, String key) {

--- a/src/java.desktop/share/classes/sun/swing/MenuItemLayoutHelper.java
+++ b/src/java.desktop/share/classes/sun/swing/MenuItemLayoutHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -378,10 +378,10 @@ public class MenuItemLayoutHelper {
         if (miParent != null) {
             value = miParent.getClientProperty(propertyName);
         }
-        if ((value == null) || !(value instanceof Integer)) {
-            value = 0;
+        if (value instanceof Integer intValue) {
+            return intValue;
         }
-        return (Integer) value;
+        return 0;
     }
 
     public static boolean isColumnLayout(boolean isLeftToRight,

--- a/src/java.desktop/unix/classes/sun/awt/X11/XComponentPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XComponentPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1365,8 +1365,8 @@ public class XComponentPeer extends XWindow implements ComponentPeer, DropTarget
         if (graphicsConfig != null) {
             oldVisual = graphicsConfig.getVisual();
         }
-        if (gc != null && gc instanceof X11GraphicsConfig) {
-            newVisual = ((X11GraphicsConfig)gc).getVisual();
+        if (gc instanceof X11GraphicsConfig x11Config) {
+            newVisual = x11Config.getVisual();
         }
 
         // If the new visual differs from the old one, the peer must be

--- a/src/java.desktop/unix/classes/sun/awt/X11/XEmbedCanvasPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XEmbedCanvasPeer.java
@@ -567,8 +567,7 @@ public class XEmbedCanvasPeer extends XCanvasPeer implements WindowFocusListener
         // Find the top-level and see if it is XEmbed client. If so, ask him to
         // register the accelerator
         XWindowPeer parent = getToplevelXWindow();
-        if (parent != null && parent instanceof XEmbeddedFramePeer) {
-            XEmbeddedFramePeer embedded = (XEmbeddedFramePeer)parent;
+        if (parent instanceof XEmbeddedFramePeer embedded) {
             embedded.registerAccelerator(stroke);
         }
     }
@@ -577,8 +576,7 @@ public class XEmbedCanvasPeer extends XCanvasPeer implements WindowFocusListener
         // Find the top-level and see if it is XEmbed client. If so, ask him to
         // register the accelerator
         XWindowPeer parent = getToplevelXWindow();
-        if (parent != null && parent instanceof XEmbeddedFramePeer) {
-            XEmbeddedFramePeer embedded = (XEmbeddedFramePeer)parent;
+        if (parent instanceof XEmbeddedFramePeer embedded) {
             embedded.unregisterAccelerator(stroke);
         }
     }

--- a/src/java.desktop/unix/classes/sun/awt/X11/XWindow.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XWindow.java
@@ -303,15 +303,13 @@ class XWindow extends XBaseWindow implements X11ComponentPeer {
         Component temp = target.getParent();
         final ComponentAccessor acc = AWTAccessor.getComponentAccessor();
         ComponentPeer peer = acc.getPeer(temp);
-        while (!(peer instanceof XWindow))
+        while (!(peer instanceof XWindow window))
         {
             temp = temp.getParent();
             peer = acc.getPeer(temp);
         }
 
-        if (peer != null && peer instanceof XWindow)
-            return ((XWindow)peer).getContentWindow();
-        else return 0;
+        return window.getContentWindow();
     }
 
 

--- a/src/java.desktop/unix/classes/sun/awt/X11/XWindow.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -327,8 +327,8 @@ class XWindow extends XBaseWindow implements X11ComponentPeer {
             temp = temp.getParent();
             peer = acc.getPeer(temp);
         }
-        if (peer != null && peer instanceof XWindow)
-            return (XWindow) peer;
+        if (peer instanceof XWindow xWindow)
+            return xWindow;
         else return null;
     }
 
@@ -927,9 +927,7 @@ class XWindow extends XBaseWindow implements X11ComponentPeer {
         long childWnd = xce.get_subwindow();
         if (childWnd != XConstants.None) {
             XBaseWindow child = XToolkit.windowToXWindow(childWnd);
-            if (child != null && child instanceof XWindow &&
-                !child.isEventDisabled(xev))
-            {
+            if (child instanceof XWindow && !child.isEventDisabled(xev)) {
                 return;
             }
         }
@@ -1438,20 +1436,19 @@ class XWindow extends XBaseWindow implements X11ComponentPeer {
             XToolkit.awtLock();
             try {
                 Object wpeer = XToolkit.targetToPeer(comp);
-                if (wpeer == null
-                    || !(wpeer instanceof XDecoratedPeer)
-                    || ((XDecoratedPeer)wpeer).configure_seen)
+                if (!(wpeer instanceof XDecoratedPeer xDecoratedPeer)
+                        || xDecoratedPeer.configure_seen)
                 {
                     return toGlobal(0, 0);
                 }
 
                 // wpeer is an XDecoratedPeer not yet fully adopted by WM
                 Point pt = toOtherWindow(getContentWindow(),
-                                         ((XDecoratedPeer)wpeer).getContentWindow(),
+                                         xDecoratedPeer.getContentWindow(),
                                          0, 0);
 
                 if (pt == null) {
-                    pt = new Point(((XBaseWindow)wpeer).getAbsoluteX(), ((XBaseWindow)wpeer).getAbsoluteY());
+                    pt = new Point(xDecoratedPeer.getAbsoluteX(), xDecoratedPeer.getAbsoluteY());
                 }
                 pt.x += comp.getX();
                 pt.y += comp.getY();

--- a/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
@@ -418,10 +418,10 @@ class XWindowPeer extends XPanelPeer implements WindowPeer,
         final ComponentAccessor acc = AWTAccessor.getComponentAccessor();
         for (int i = 0; i < cnt; i++) {
             final ComponentPeer childPeer = acc.getPeer(children[i]);
-            if (childPeer != null && childPeer instanceof XWindowPeer) {
-                if (((XWindowPeer)childPeer).winAttr.iconsInherited) {
-                    ((XWindowPeer)childPeer).winAttr.icons = icons;
-                    ((XWindowPeer)childPeer).recursivelySetIcon(icons);
+            if (childPeer instanceof XWindowPeer xWindowPeer) {
+                if (xWindowPeer.winAttr.iconsInherited) {
+                    xWindowPeer.winAttr.icons = icons;
+                    xWindowPeer.recursivelySetIcon(icons);
                 }
             }
         }

--- a/src/java.desktop/unix/classes/sun/java2d/xr/XRSurfaceData.java
+++ b/src/java.desktop/unix/classes/sun/java2d/xr/XRSurfaceData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -207,9 +207,8 @@ public abstract class XRSurfaceData extends XSurfaceData {
 
     protected MaskFill getMaskFill(SunGraphics2D sg2d) {
         AlphaComposite aComp = null;
-        if(sg2d.composite != null
-                && sg2d.composite instanceof AlphaComposite) {
-            aComp = (AlphaComposite) sg2d.composite;
+        if (sg2d.composite instanceof AlphaComposite alphaComposite) {
+            aComp = alphaComposite;
         }
 
         boolean supportedPaint = sg2d.paintState <= SunGraphics2D.PAINT_ALPHACOLOR

--- a/src/java.desktop/unix/classes/sun/print/IPPPrintService.java
+++ b/src/java.desktop/unix/classes/sun/print/IPPPrintService.java
@@ -671,8 +671,7 @@ public class IPPPrintService implements PrintService, SunPrinterJobService {
 
             int match = -1;
             Media media = (Media)attributes.get(Media.class);
-            if (media != null && media instanceof MediaSizeName) {
-                MediaSizeName msn = (MediaSizeName)media;
+            if (media instanceof MediaSizeName msn) {
 
                 // case when no supported mediasizenames are reported
                 // check given media against the default

--- a/src/java.desktop/unix/classes/sun/print/UnixPrintJob.java
+++ b/src/java.desktop/unix/classes/sun/print/UnixPrintJob.java
@@ -366,8 +366,7 @@ public class UnixPrintJob implements CancelablePrintJob {
                  }
              }
 
-             if (customTray != null &&
-                 customTray instanceof CustomMediaTray) {
+             if (customTray != null) {
                  String choice = customTray.getChoiceName();
                  if (choice != null) {
                      mOptions += " InputSlot="+choice;

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsFileChooserUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsFileChooserUI.java
@@ -1221,8 +1221,8 @@ public class WindowsFileChooserUI extends BasicFileChooserUI {
 
             super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
 
-            if (value != null && value instanceof FileFilter) {
-                setText(((FileFilter)value).getDescription());
+            if (value instanceof FileFilter fileFilter) {
+                setText(fileFilter.getDescription());
             }
 
             return this;

--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
@@ -540,14 +540,13 @@ final class Win32ShellFolder2 extends ShellFolder {
      * Check to see if two ShellFolder objects are the same
      */
     public boolean equals(Object o) {
-        if (o == null || !(o instanceof Win32ShellFolder2)) {
+        if (!(o instanceof Win32ShellFolder2 rhs)) {
             // Short-circuit circuitous delegation path
             if (!(o instanceof File)) {
                 return super.equals(o);
             }
             return pathsEqual(getPath(), ((File) o).getPath());
         }
-        Win32ShellFolder2 rhs = (Win32ShellFolder2) o;
         if ((parent == null && rhs.parent != null) ||
             (parent != null && rhs.parent == null)) {
             return false;

--- a/src/java.desktop/windows/classes/sun/awt/windows/WPrinterJob.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WPrinterJob.java
@@ -731,8 +731,7 @@ public final class WPrinterJob extends RasterPrinterJob
                      */
                     if (attr.getCategory() == SunAlternateMedia.class) {
                         Media media = (Media)attributes.get(Media.class);
-                        if (media == null ||
-                            !(media instanceof MediaTray)) {
+                        if (!(media instanceof MediaTray)) {
                             attr = ((SunAlternateMedia)attr).getMedia();
                         }
                     }


### PR DESCRIPTION
Updated code checks both non-null and instance of a class in java.desktop module classes.
The checks and explicit casts could also be replaced with pattern matching for the instanceof operator. 
Similar cleanups
1. [JDK-8273484](https://bugs.openjdk.java.net/browse/JDK-8273484) java.naming
2. [JDK-8258422](https://bugs.openjdk.java.net/browse/JDK-8258422) java.base

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274640](https://bugs.openjdk.java.net/browse/JDK-8274640): Cleanup unnecessary null comparison before instanceof check in java.desktop


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5482/head:pull/5482` \
`$ git checkout pull/5482`

Update a local copy of the PR: \
`$ git checkout pull/5482` \
`$ git pull https://git.openjdk.java.net/jdk pull/5482/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5482`

View PR using the GUI difftool: \
`$ git pr show -t 5482`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5482.diff">https://git.openjdk.java.net/jdk/pull/5482.diff</a>

</details>
