### PR TITLE
8273901: Fix scale() link in BigDecimal.scale comment

### DIFF
--- a/src/java.base/share/classes/java/math/BigDecimal.java
+++ b/src/java.base/share/classes/java/math/BigDecimal.java
@@ -310,10 +310,10 @@ public class BigDecimal extends Number implements Comparable<BigDecimal> {
     private final BigInteger intVal;
 
     /**
-     * The scale of this BigDecimal, as returned by {@link #scale}.
+     * The scale of this BigDecimal, as returned by {@link #scale()}.
      *
      * @serial
-     * @see #scale
+     * @see #scale()
      */
     private final int scale;  // Note: this may have any value, so
                               // calculations must be done in longs


### PR DESCRIPTION
Looks like the link is pointing itself

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8273901](https://bugs.openjdk.java.net/browse/JDK-8273901): Fix scale() link in BigDecimal.scale comment


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5483/head:pull/5483` \
`$ git checkout pull/5483`

Update a local copy of the PR: \
`$ git checkout pull/5483` \
`$ git pull https://git.openjdk.java.net/jdk pull/5483/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5483`

View PR using the GUI difftool: \
`$ git pr show -t 5483`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5483.diff">https://git.openjdk.java.net/jdk/pull/5483.diff</a>

</details>
