### PR TITLE
8273654: JFR: Remove unused SecuritySupport.setAccessible(Field)

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/SecuritySupport.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/SecuritySupport.java
@@ -431,10 +431,6 @@ public final class SecuritySupport {
         doPrivileged(() -> method.setAccessible(true), new ReflectPermission("suppressAccessChecks"));
     }
 
-    static void setAccessible(Field field) {
-        doPrivileged(() -> field.setAccessible(true), new ReflectPermission("suppressAccessChecks"));
-    }
-
     static void setAccessible(Constructor<?> constructor) {
         doPrivileged(() -> constructor.setAccessible(true), new ReflectPermission("suppressAccessChecks"));
     }


### PR DESCRIPTION
Hi,

Could I have a review of a fix that removes an unused method.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273654](https://bugs.openjdk.java.net/browse/JDK-8273654): JFR: Remove unused SecuritySupport.setAccessible(Field)


### Reviewers
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5484/head:pull/5484` \
`$ git checkout pull/5484`

Update a local copy of the PR: \
`$ git checkout pull/5484` \
`$ git pull https://git.openjdk.java.net/jdk pull/5484/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5484`

View PR using the GUI difftool: \
`$ git pr show -t 5484`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5484.diff">https://git.openjdk.java.net/jdk/pull/5484.diff</a>

</details>
