### PR TITLE
8273638: javax/swing/JTable/4235420/bug4235420.java fails in GTK L&F

### DIFF
--- a/test/jdk/javax/swing/JTable/4235420/bug4235420.java
+++ b/test/jdk/javax/swing/JTable/4235420/bug4235420.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public class bug4235420 {
             System.out.println("Testing L&F: " + LF.getClassName());
 
             if ("Nimbus".equals(UIManager.getLookAndFeel().getName()) ||
-                "GTK".equals(UIManager.getLookAndFeel().getName())) {
+                "GTK".equals(UIManager.getLookAndFeel().getID())) {
                 System.out.println("The test is skipped for Nimbus and GTK");
 
                 continue;


### PR DESCRIPTION
As discussed here https://github.com/openjdk/jdk/pull/1813 the test should skip the GTK L&F unfortunately the name of the GTK L&F is "GTK look and feel" not "GTK". The ID="GTK" can be used instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273638](https://bugs.openjdk.java.net/browse/JDK-8273638): javax/swing/JTable/4235420/bug4235420.java fails in GTK L&F


### Reviewers
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5485/head:pull/5485` \
`$ git checkout pull/5485`

Update a local copy of the PR: \
`$ git checkout pull/5485` \
`$ git pull https://git.openjdk.java.net/jdk pull/5485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5485`

View PR using the GUI difftool: \
`$ git pr show -t 5485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5485.diff">https://git.openjdk.java.net/jdk/pull/5485.diff</a>

</details>
