### PR TITLE
JDK-8272771: frame::pd_ps() is not implemented on any platform

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -814,7 +814,6 @@ frame::frame(void* sp, void* fp, void* pc) {
   init((intptr_t*)sp, (intptr_t*)fp, (address)pc);
 }
 
-void frame::pd_ps() {}
 #endif
 
 void JavaFrameAnchor::make_walkable(JavaThread* thread) {

--- a/src/hotspot/cpu/arm/frame_arm.cpp
+++ b/src/hotspot/cpu/arm/frame_arm.cpp
@@ -574,7 +574,6 @@ frame::frame(void* sp, void* fp, void* pc) {
   init((intptr_t*)sp, (intptr_t*)fp, (address)pc);
 }
 
-void frame::pd_ps() {}
 #endif
 
 intptr_t *frame::initial_deoptimization_info() {

--- a/src/hotspot/cpu/ppc/frame_ppc.cpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.cpp
@@ -387,5 +387,4 @@ frame::frame(void* sp, void* fp, void* pc) : _sp((intptr_t*)sp), _unextended_sp(
   find_codeblob_and_set_pc_and_deopt_state((address)pc); // also sets _fp and adjusts _unextended_sp
 }
 
-void frame::pd_ps() {}
 #endif

--- a/src/hotspot/cpu/s390/frame_s390.cpp
+++ b/src/hotspot/cpu/s390/frame_s390.cpp
@@ -628,8 +628,6 @@ void frame::describe_pd(FrameValues& values, int frame_no) {
   }
 }
 
-
-void frame::pd_ps() {}
 #endif // !PRODUCT
 
 intptr_t *frame::initial_deoptimization_info() {

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -718,7 +718,6 @@ frame::frame(void* sp, void* fp, void* pc) {
   init((intptr_t*)sp, (intptr_t*)fp, (address)pc);
 }
 
-void frame::pd_ps() {}
 #endif
 
 void JavaFrameAnchor::make_walkable(JavaThread* thread) {

--- a/src/hotspot/cpu/zero/frame_zero.cpp
+++ b/src/hotspot/cpu/zero/frame_zero.cpp
@@ -396,5 +396,4 @@ frame::frame(void* sp, void* fp, void* pc) {
   Unimplemented();
 }
 
-void frame::pd_ps() {}
 #endif

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -400,8 +400,6 @@ class frame {
   // Usage:
   // assert(frame::verify_return_pc(return_address), "must be a return pc");
 
-  NOT_PRODUCT(void pd_ps();)  // platform dependent frame printing
-
 #include CPU_HEADER(frame)
 
 };

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -511,7 +511,7 @@ extern "C" JNIEXPORT void ps() { // print stack
     f = f.sender(&reg_map);
     tty->print("(guessing starting frame id=" PTR_FORMAT " based on current fp)\n", p2i(f.id()));
     p->trace_stack_from(vframe::new_vframe(&f, &reg_map, p));
-    f.pd_ps();
+    f.print_on(tty);
 #endif
   }
 }

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -511,7 +511,6 @@ extern "C" JNIEXPORT void ps() { // print stack
     f = f.sender(&reg_map);
     tty->print("(guessing starting frame id=" PTR_FORMAT " based on current fp)\n", p2i(f.id()));
     p->trace_stack_from(vframe::new_vframe(&f, &reg_map, p));
-    f.print_on(tty);
 #endif
   }
 }


### PR DESCRIPTION
removed frame::pd_ps() which is not implemented on any platform. Replaced the only usage of frame::pd_ps() in the debug function `ps()` with `frame::print_on`. Tested on Tier1.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272771](https://bugs.openjdk.java.net/browse/JDK-8272771): frame::pd_ps() is not implemented on any platform


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5487/head:pull/5487` \
`$ git checkout pull/5487`

Update a local copy of the PR: \
`$ git checkout pull/5487` \
`$ git pull https://git.openjdk.java.net/jdk pull/5487/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5487`

View PR using the GUI difftool: \
`$ git pr show -t 5487`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5487.diff">https://git.openjdk.java.net/jdk/pull/5487.diff</a>

</details>
