### PR TITLE
8273563: Improve performance of implicit exceptions with -XX:-OmitStackTraceInFastThrow

### DIFF
--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -372,7 +372,7 @@ void ciEnv::cache_dtrace_flags() {
 
 // ------------------------------------------------------------------
 // helper for -XX:+OptimizeImplicitExceptions
-ciInstanceKlass* ciEnv::exception_instanceKlass_for_reason(Deoptimization::DeoptReason reason, bool aastore) {
+ciInstanceKlass* ciEnv::exception_instanceKlass_for_reason(Deoptimization::DeoptReason reason, bool is_aastore) {
   Symbol* ex_symbol = NULL;
   switch (reason) {
   case Deoptimization::Reason_null_check:
@@ -385,7 +385,7 @@ ciInstanceKlass* ciEnv::exception_instanceKlass_for_reason(Deoptimization::Deopt
     ex_symbol = vmSymbols::java_lang_ArrayIndexOutOfBoundsException();
     break;
   case Deoptimization::Reason_class_check:
-    if (aastore) {
+    if (is_aastore) {
       ex_symbol = vmSymbols::java_lang_ArrayStoreException();
     } else {
       ex_symbol = vmSymbols::java_lang_ClassCastException();

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -372,7 +372,7 @@ void ciEnv::cache_dtrace_flags() {
 
 // ------------------------------------------------------------------
 // helper for -XX:+OptimizeImplicitExceptions
-ciInstanceKlass* ciEnv::exception_instanceKlass_for_reason(Deoptimization::DeoptReason reason, bool is_aastore) {
+ciInstanceKlass* ciEnv::exception_instanceKlass_for_reason(Deoptimization::DeoptReason reason) {
   Symbol* ex_symbol = NULL;
   switch (reason) {
   case Deoptimization::Reason_null_check:
@@ -385,11 +385,10 @@ ciInstanceKlass* ciEnv::exception_instanceKlass_for_reason(Deoptimization::Deopt
     ex_symbol = vmSymbols::java_lang_ArrayIndexOutOfBoundsException();
     break;
   case Deoptimization::Reason_class_check:
-    if (is_aastore) {
-      ex_symbol = vmSymbols::java_lang_ArrayStoreException();
-    } else {
-      ex_symbol = vmSymbols::java_lang_ClassCastException();
-    }
+    ex_symbol = vmSymbols::java_lang_ClassCastException();
+    break;
+  case Deoptimization::Reason_array_check:
+    ex_symbol = vmSymbols::java_lang_ArrayStoreException();
     break;
   default:
     break;

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -402,7 +402,7 @@ public:
   VM_CLASSES_DO(VM_CLASS_FUNC)
 #undef VM_CLASS_FUNC
 
-  ciInstanceKlass* exception_instanceKlass_for_reason(Deoptimization::DeoptReason reason, bool is_aastore);
+  ciInstanceKlass* exception_instanceKlass_for_reason(Deoptimization::DeoptReason reason);
 
   ciInstance* NullPointerException_instance() {
     assert(_NullPointerException_instance != NULL, "initialization problem");

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -402,7 +402,7 @@ public:
   VM_CLASSES_DO(VM_CLASS_FUNC)
 #undef VM_CLASS_FUNC
 
-  ciInstanceKlass* exception_instanceKlass_for_reason(Deoptimization::DeoptReason reason, bool aastore);
+  ciInstanceKlass* exception_instanceKlass_for_reason(Deoptimization::DeoptReason reason, bool is_aastore);
 
   ciInstance* NullPointerException_instance() {
     assert(_NullPointerException_instance != NULL, "initialization problem");

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -34,6 +34,7 @@
 #include "code/exceptionHandlerTable.hpp"
 #include "compiler/compilerThread.hpp"
 #include "oops/methodData.hpp"
+#include "runtime/deoptimization.hpp"
 #include "runtime/thread.hpp"
 
 class CompileTask;
@@ -400,6 +401,8 @@ public:
   }
   VM_CLASSES_DO(VM_CLASS_FUNC)
 #undef VM_CLASS_FUNC
+
+  ciInstanceKlass* exception_instanceKlass_for_reason(Deoptimization::DeoptReason reason, bool aastore);
 
   ciInstance* NullPointerException_instance() {
     assert(_NullPointerException_instance != NULL, "initialization problem");

--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -1032,8 +1032,8 @@ void CallJavaNode::copy_call_debug_info(PhaseIterGVN* phase, SafePointNode* sfpt
 
 #ifdef ASSERT
 bool CallJavaNode::validate_symbolic_info() const {
-  if (method() == NULL) {
-    return true; // call into runtime or uncommon trap
+  if (method() == NULL || _implicit_exception_init) {
+    return true; // call into runtime or uncommon trap or implicit exception <init>
   }
   ciMethod* symbolic_info = jvms()->method()->get_method_at_bci(jvms()->bci());
   ciMethod* callee = method();

--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -677,6 +677,9 @@ protected:
   bool    _optimized_virtual;
   bool    _method_handle_invoke;
   bool    _override_symbolic_info; // Override symbolic call site info from bytecode
+  bool    _implicit_exception_init;// <init> call for an implicitly created exception
+                                   // if -XX:+OptimizeImplicitExceptions. This also
+                                   // overrides the symbolic call site info from bytecode.
   ciMethod* _method;               // Method being direct called
   bool    _arg_escape;             // ArgEscape in parameter list
 public:
@@ -685,6 +688,7 @@ public:
       _optimized_virtual(false),
       _method_handle_invoke(false),
       _override_symbolic_info(false),
+      _implicit_exception_init(false),
       _method(method),
       _arg_escape(false)
   {
@@ -700,6 +704,8 @@ public:
   bool  is_method_handle_invoke() const    { return _method_handle_invoke; }
   void  set_override_symbolic_info(bool f) { _override_symbolic_info = f; }
   bool  override_symbolic_info() const     { return _override_symbolic_info; }
+  void  set_implicit_exception_init(bool f){ _implicit_exception_init = f; }
+  bool  implicit_exception_init() const    { return _implicit_exception_init; }
   void  set_arg_escape(bool f)             { _arg_escape = f; }
   bool  arg_escape() const                 { return _arg_escape; }
   void copy_call_debug_info(PhaseIterGVN* phase, SafePointNode *sfpt);

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -620,8 +620,7 @@ void GraphKit::builtin_throw(Deoptimization::DeoptReason reason, Node* arg) {
   }
 
   if (treat_throw_as_hot && OptimizeImplicitExceptions) {
-    ciInstanceKlass* ex_ciInstKlass =
-      env()->exception_instanceKlass_for_reason(reason, java_bc() == Bytecodes::_aastore);
+    ciInstanceKlass* ex_ciInstKlass = env()->exception_instanceKlass_for_reason(reason);
     if (ex_ciInstKlass != NULL) {
       const TypeKlassPtr *ex_type = TypeKlassPtr::make(ex_ciInstKlass);
       kill_dead_locals();

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -627,7 +627,7 @@ void GraphKit::builtin_throw(Deoptimization::DeoptReason reason, Node* arg) {
       kill_dead_locals();
       Node* ex_node = new_instance(makecon(ex_type), NULL, NULL, true);
       set_argument(0, ex_node);
-      ciMethod* init =  ex_ciInstKlass->find_method(ciSymbol::make("<init>"), ciSymbol::make("()V"));
+      ciMethod* init = ex_ciInstKlass->find_method(ciSymbol::make("<init>"), ciSymbol::make("()V"));
 
       // The following code is modeled after:
       // DirectCallGenerator* cg = CallGenerator::for_direct_call(init);

--- a/src/hotspot/share/opto/machnode.hpp
+++ b/src/hotspot/share/opto/machnode.hpp
@@ -934,17 +934,20 @@ protected:
 public:
   ciMethod* _method;                 // Method being direct called
   bool      _override_symbolic_info; // Override symbolic call site info from bytecode
+  bool      _implicit_exception_init;// <init> call for an implicitly created exception
+                                     // if -XX:+OptimizeImplicitExceptions. This also
+                                     // overrides the symbolic call site info from bytecode.
   bool      _optimized_virtual;      // Tells if node is a static call or an optimized virtual
   bool      _method_handle_invoke;   // Tells if the call has to preserve SP
   bool      _arg_escape;             // ArgEscape in parameter list
-  MachCallJavaNode() : MachCallNode(), _override_symbolic_info(false) {
+  MachCallJavaNode() : MachCallNode(), _override_symbolic_info(false), _implicit_exception_init(false) {
     init_class_id(Class_MachCallJava);
   }
 
   virtual const RegMask &in_RegMask(uint) const;
 
   int resolved_method_index(CodeBuffer &cbuf) const {
-    if (_override_symbolic_info) {
+    if (_override_symbolic_info || _implicit_exception_init) {
       // Attach corresponding Method* to the call site, so VM can use it during resolution
       // instead of querying symbolic info from bytecode.
       assert(_method != NULL, "method should be set");

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -1290,6 +1290,7 @@ MachNode *Matcher::match_sfpt( SafePointNode *sfpt ) {
       is_method_handle_invoke = call_java->is_method_handle_invoke();
       mcall_java->_method_handle_invoke = is_method_handle_invoke;
       mcall_java->_override_symbolic_info = call_java->override_symbolic_info();
+      mcall_java->_implicit_exception_init = call_java->implicit_exception_init();
       mcall_java->_arg_escape = call_java->arg_escape();
       if (is_method_handle_invoke) {
         C->set_has_method_handle_invokes(true);

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -639,7 +639,7 @@ const intx ObjectAlignmentInBytes = 8;
   product(bool, OmitStackTraceInFastThrow, true,                            \
           "Omit backtraces for some 'hot' exceptions in optimized code")    \
                                                                             \
-  product(bool, OptimizeImplicitExceptions, true,                           \
+  product(bool, OptimizeImplicitExceptions, true, DIAGNOSTIC,               \
           "Create implicit, 'non-hot' exceptions right in compiled code "   \
           "rather than deoptimizing and resorting back to the interpreter") \
                                                                             \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -639,6 +639,10 @@ const intx ObjectAlignmentInBytes = 8;
   product(bool, OmitStackTraceInFastThrow, true,                            \
           "Omit backtraces for some 'hot' exceptions in optimized code")    \
                                                                             \
+  product(bool, OptimizeImplicitExceptions, true,                           \
+          "Create implicit, 'non-hot' exceptions right in compiled code "   \
+          "rather than deoptimizing and resorting back to the interpreter") \
+                                                                            \
   product(bool, ShowCodeDetailsInExceptionMessages, true, MANAGEABLE,       \
           "Show exception messages from RuntimeExceptions that contain "    \
           "snippets of the failing code. Disable this to improve privacy.") \

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1096,8 +1096,7 @@ Handle SharedRuntime::find_callee_info_helper(vframeStream& vfst, Bytecodes::Cod
     // This is the normal case for invoke* bytecodes
     bytecode_index = bytecode.index();
     bc = bytecode.invoke_code();
-  }
-  else {
+  } else {
     // This is for implicit exceptions with -XX:+OptimizeImplicitExceptions
     // where we create an artificial call to *Exception::<init>()
     bc = Bytecodes::_invokespecial;

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1143,7 +1143,7 @@ Handle SharedRuntime::find_callee_info_helper(vframeStream& vfst, Bytecodes::Cod
     // If we've created an implicit NPE for an invoke* bytecode due to
     // -XX:+OptimizeImplicitExceptions we have to adjust the bytecode to
     // invokespecial here because we're actually invoking the exceptions
-    // constructor here.
+    // constructor.
     bc = Bytecodes::_invokespecial;
   }
 

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestIRMatching.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestIRMatching.java
@@ -188,7 +188,7 @@ public class TestIRMatching {
                  BadFailOnConstraint.create(Traps.class, "unstableIf(boolean)",  2, "CallStaticJava", "uncommon_trap", "unstable_if"),
                  GoodRuleConstraint.create(Traps.class, "unstableIf(boolean)", 3),
                  BadFailOnConstraint.create(Traps.class, "classCheck()", 1, "CallStaticJava", "uncommon_trap"),
-                 BadFailOnConstraint.create(Traps.class, "classCheck()", 2, "CallStaticJava", "uncommon_trap", "class_check"),
+                 BadFailOnConstraint.create(Traps.class, "classCheck()", 2, "CallStaticJava", "uncommon_trap", "unhandled"),
                  BadFailOnConstraint.create(Traps.class, "classCheck()", 3, "CallStaticJava", "uncommon_trap", "null_check"),
                  GoodRuleConstraint.create(Traps.class, "classCheck()", 4),
                  BadFailOnConstraint.create(Traps.class, "rangeCheck()", 1, "CallStaticJava", "uncommon_trap"),
@@ -1119,7 +1119,7 @@ class Traps {
 
     @Test
     @IR(failOn = IRNode.TRAP) // fails
-    @IR(failOn = IRNode.CLASS_CHECK_TRAP) // fails
+    @IR(failOn = IRNode.UNHANDLED_TRAP) // fails (slow-path allocation of implicit ClassCastException)
     @IR(failOn = IRNode.NULL_CHECK_TRAP) // fails
     @IR(failOn = {IRNode.PREDICATE_TRAP,
                   IRNode.UNSTABLE_IF_TRAP,
@@ -1127,7 +1127,7 @@ class Traps {
                   IRNode.RANGE_CHECK_TRAP,
                   IRNode.INTRINSIC_TRAP,
                   IRNode.INTRINSIC_OR_TYPE_CHECKED_INLINING_TRAP,
-                  IRNode.UNHANDLED_TRAP})
+                  IRNode.CLASS_CHECK_TRAP})
     public void classCheck() {
         try {
             myClassSub = (MyClassSub) myClass;

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t105/t105.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t105/t105.java
@@ -30,11 +30,12 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -XX:-OmitStackTraceInFastThrow jit.t.t105.t105
- * @run main/othervm -XX:-OmitStackTraceInFastThrow -Xbatch -XX:Tier0BackedgeNotifyFreqLog=0 -XX:Tier2BackedgeNotifyFreqLog=0 -XX:Tier3BackedgeNotifyFreqLog=0 -XX:Tier2BackEdgeThreshold=1 -XX:Tier3BackEdgeThreshold=1 -XX:Tier4BackEdgeThreshold=1 jit.t.t105.t105
+ * @run main/othervm -XX:-OmitStackTraceInFastThrow -XX:-OptimizeImplicitExceptions jit.t.t105.t105
+ * @run main/othervm -XX:-OmitStackTraceInFastThrow -XX:-OptimizeImplicitExceptions -Xbatch -XX:Tier0BackedgeNotifyFreqLog=0 -XX:Tier2BackedgeNotifyFreqLog=0 -XX:Tier3BackedgeNotifyFreqLog=0 -XX:Tier2BackEdgeThreshold=1 -XX:Tier3BackEdgeThreshold=1 -XX:Tier4BackEdgeThreshold=1 jit.t.t105.t105
  *
- * This test must be run with OmitStackTraceInFastThrow disabled to avoid preallocated
- * exceptions. They don't have the detailed message that this test relies on.
+ * This test must be run with OmitStackTraceInFastThrow and OptimizeImplicitExceptions
+ * disabled to avoid preallocated exceptions. They don't have the detailed message
+ * that this test relies on.
  */
 
 package jit.t.t105;

--- a/test/micro/org/openjdk/bench/vm/lang/ImplicitExceptions.java
+++ b/test/micro/org/openjdk/bench/vm/lang/ImplicitExceptions.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.vm.lang;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@State(Scope.Benchmark)
+public class ImplicitExceptions {
+    static final int ASCII_SIZE = 128;
+    static final boolean[] ASCII_ALPHA = new boolean[ASCII_SIZE];
+    static final int testStringLengthLog = 7;
+    static final int TestStringLenghtMask = (1 << testStringLengthLog) - 1;
+    static final char[] testString = new char[1 << testStringLengthLog];
+    int iterator = 0;
+
+    @Param({"0.0", "0.33", "0.66", "1.00"})
+    public double exceptionProbability;
+
+    @Setup
+    public void init() {
+        for (int i = 0; i < ASCII_SIZE; i++) {
+            if (i >= 'a' && i <= 'z' || i >= 'A' && i <= 'Z') {
+              ASCII_ALPHA[i] = true;
+            }
+        }
+        Random rnd = new Random();
+        rnd.setSeed(Long.getLong("random.seed", 42L));
+        for (int i = 0; i < testString.length; i++) {
+            if (rnd.nextDouble() < exceptionProbability) {
+              testString[i] = 0xbad; // Something bigger than ASCII_SIZE
+            }
+            else {
+              testString[i] = (char)rnd.nextInt(ASCII_SIZE);
+            }
+        }
+    }
+
+    public boolean isAlphaWithExceptions(int c) {
+        try {
+            return ASCII_ALPHA[c];
+        } catch (ArrayIndexOutOfBoundsException ex) {
+            return false;
+        }
+    }
+
+    @Benchmark
+    public void bench() {
+        isAlphaWithExceptions(testString[iterator++ & TestStringLenghtMask]);
+        //if (++iterator == Long.MAX_VALUE) {
+        //    iterator = 0;
+        //}
+    }
+}


### PR DESCRIPTION
Currently, if running with `-XX:-OmitStackTraceInFastThrow`, C2 has no possibility to create implicit exceptions like AIOOBE, NullPointerExceptions, etc. in compiled code. This means that such methods will always be deoptimized and re-executed in the interpreter if such exceptions are happening.

If implicit exceptions are used for normal control flow, that can have a dramatic impact on performance. A prominent example for such code is [Tomcat's `HttpParser::isAlpha()` method](https://github.com/apache/tomcat/blob/26ba86cdbd40ca718e43b82e62b3eb49d004c3d6/java/org/apache/tomcat/util/http/parser/HttpParser.java#L266-L274):
```
    public static boolean isAlpha(int c) {
        try {
            return IS_ALPHA[c];
        } catch (ArrayIndexOutOfBoundsException ex) {
            return false;
        }
    }
```

### Solution

Instead of deoptimizing and resorting to the interpreter, we can generate code which allocates and initializes the corresponding exceptions right in compiled code. This results in a ten-times performance improvement for the above code:
```
-XX:-OmitStackTraceInFastThrow -XX:-OptimizeImplicitExceptions
Benchmark                 (exceptionProbability)  Mode  Cnt      Score      Error  Units
ImplicitExceptions.bench                     0.0  avgt    5      1.430 ±    0.353  ns/op
ImplicitExceptions.bench                    0.33  avgt    5   3563.038 ±   77.358  ns/op
ImplicitExceptions.bench                    0.66  avgt    5   8609.693 ± 1205.104  ns/op
ImplicitExceptions.bench                    1.00  avgt    5  12842.401 ± 1022.728  ns/op

-XX:-OmitStackTraceInFastThrow -XX:+OptimizeImplicitExceptions
Benchmark                 (exceptionProbability)  Mode  Cnt      Score      Error  Units
ImplicitExceptions.bench                     0.0  avgt    5     1.432  ±    0.352  ns/op
ImplicitExceptions.bench                    0.33  avgt    5   355.723  ±   16.641  ns/op
ImplicitExceptions.bench                    0.66  avgt    5   887.068  ±  166.728  ns/op
ImplicitExceptions.bench                    1.00  avgt    5  1274.418  ±   88.235  ns/op
```

### Implementation details

- The new optimization is guarded by the option `OptimizeImplicitExceptions` which is on by default.
- In `GraphKit::builtin_throw()` we can't simply use `CallGenerator::for_direct_call()` to create a `DirectCallGenerator` for the call to the exception's `<init>` function because `DirectCallGenerator` assumes in various places that calls are only issued at `invoke*` bytecodes. This is is not true in genral for bytecode which can cause an implicit exception. 
- Instead, we manually wire up the call based on the code in `DirectCallGenerator::generate()`.
- We use a similar trick like for method handle intrinsics where the callee from the bytecode is replaced by a direct call and this fact is recorded in the call's `_override_symbolic_info` field. For calling constructors of implicit exceptions I've introduced the new field `_implicit_exception_init`. This field is also used in various assertions to prevent queries for the bytecode's symbolic method information which doesn't exist because we're not at an `invoke*` bytecode at the place where we generate the call.
- The PR contains a micro-benchmark which compares the old and the new implementation for [Tomcat's `HttpParser::isAlpha()` method](https://github.com/apache/tomcat/blob/26ba86cdbd40ca718e43b82e62b3eb49d004c3d6/java/org/apache/tomcat/util/http/parser/HttpParser.java#L266-L274). Except for the trivial case where the exception probability is 0 (i.e. no exceptions are happening at all) the new implementation is about 10 times faster.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273563](https://bugs.openjdk.java.net/browse/JDK-8273563): Improve performance of implicit exceptions with -XX:-OmitStackTraceInFastThrow


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to 625da2f99af6214a21a650e0e3fab710c7358276


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5488/head:pull/5488` \
`$ git checkout pull/5488`

Update a local copy of the PR: \
`$ git checkout pull/5488` \
`$ git pull https://git.openjdk.java.net/jdk pull/5488/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5488`

View PR using the GUI difftool: \
`$ git pr show -t 5488`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5488.diff">https://git.openjdk.java.net/jdk/pull/5488.diff</a>

</details>
