### PR TITLE
8273656: Improve java.lang.invoke.MethodType.parameterList() and its usage

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -5882,8 +5882,8 @@ System.out.println((int) f0.invokeExact("x", "y")); // 2
         BoundMethodHandle result = target.rebind();
         LambdaForm lform = result.editor().collectReturnValueForm(filterType.basicType());
         MethodType newType = targetType.changeReturnType(filterType.returnType());
-        if (filterType.parameterList().size() > 1) {
-            for (int i = 0 ; i < filterType.parameterList().size() - 1 ; i++) {
+        if (filterType.parameterCount() > 1) {
+            for (int i = 0 ; i < filterType.parameterCount() - 1 ; i++) {
                 newType = newType.appendParameterTypes(filterType.parameterType(i));
             }
         }
@@ -6735,7 +6735,7 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
                         filter(t -> t.parameterCount() > skipSize).
                         map(MethodType::parameterList).
                         reduce((p, q) -> p.size() >= q.size() ? p : q).orElse(empty);
-        return longest.size() == 0 ? empty : longest.subList(skipSize, longest.size());
+        return longest.isEmpty() ? empty : longest.subList(skipSize, longest.size());
     }
 
     private static List<Class<?>> longestParameterList(List<List<Class<?>>> lists) {
@@ -7019,7 +7019,7 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
         List<Class<?>> outerList = innerList;
         if (returnType == void.class) {
             // OK
-        } else if (innerList.size() == 0 || innerList.get(0) != returnType) {
+        } else if (innerList.isEmpty() || innerList.get(0) != returnType) {
             // leading V argument missing => error
             MethodType expected = bodyType.insertParameterTypes(0, returnType);
             throw misMatchedTypes("body function", bodyType, expected);
@@ -7349,7 +7349,7 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
         List<Class<?>> innerList = bodyType.parameterList();
         // strip leading V value if present
         int vsize = (returnType == void.class ? 0 : 1);
-        if (vsize != 0 && (innerList.size() == 0 || innerList.get(0) != returnType)) {
+        if (vsize != 0 && (innerList.isEmpty() || innerList.get(0) != returnType)) {
             // argument list has no "V" => error
             MethodType expected = bodyType.insertParameterTypes(0, returnType);
             throw misMatchedTypes("body function", bodyType, expected);
@@ -7573,7 +7573,7 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
         List<Class<?>> internalParamList = bodyType.parameterList();
         // strip leading V value if present
         int vsize = (returnType == void.class ? 0 : 1);
-        if (vsize != 0 && (internalParamList.size() == 0 || internalParamList.get(0) != returnType)) {
+        if (vsize != 0 && (internalParamList.isEmpty() || internalParamList.get(0) != returnType)) {
             // argument list has no "V" => error
             MethodType expected = bodyType.insertParameterTypes(0, returnType);
             throw misMatchedTypes("body function", bodyType, expected);

--- a/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -792,7 +792,7 @@ class MethodType
      * @return the parameter types (as an immutable list)
      */
     public List<Class<?>> parameterList() {
-        return Collections.unmodifiableList(Arrays.asList(ptypes.clone()));
+        return List.of(ptypes);
     }
 
     /**


### PR DESCRIPTION
Currently the method is implemented like
```java
public List<Class<?>> parameterList() {
  return Collections.unmodifiableList(Arrays.asList(ptypes.clone()));
}
```
This seems to be excessive, as three objects are allocated here. Instead we can use `List.of(ptypes)` which doesn't allocate anything for empty array and for one of length 1 and 2 it allocates lightweight objects with 2 fields, still copying longer arrays. This is likely to be fruitful as most of methods have 0-2 parameters.

Also there is a couple of cases when `MethodType.parameterLis()` is called to get its size, which is excessive either as we can use `MethodType.parameterCount()` instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273656](https://bugs.openjdk.java.net/browse/JDK-8273656): Improve java.lang.invoke.MethodType.parameterList() and its usage


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5489/head:pull/5489` \
`$ git checkout pull/5489`

Update a local copy of the PR: \
`$ git checkout pull/5489` \
`$ git pull https://git.openjdk.java.net/jdk pull/5489/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5489`

View PR using the GUI difftool: \
`$ git pr show -t 5489`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5489.diff">https://git.openjdk.java.net/jdk/pull/5489.diff</a>

</details>
