### PR TITLE
8273659: Replay compilation crashes with SIGSEGV since 8271911

### DIFF
--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -370,6 +370,9 @@ class CompileReplay : public StackObj {
     char* ref = parse_string();
     if (strcmp(ref, "bci") == 0) {
       Method* m = parse_method(CHECK_NULL);
+      if (m == NULL) {
+        return NULL;
+      }
 
       InstanceKlass* ik = m->method_holder();
       const constantPoolHandle cp(Thread::current(), ik->constants());
@@ -437,6 +440,9 @@ class CompileReplay : public StackObj {
       }
 
       Klass* k = parse_klass(CHECK_NULL);
+      if (k == NULL) {
+        return NULL;
+      }
       InstanceKlass* ik = InstanceKlass::cast(k);
       const constantPoolHandle cp(Thread::current(), ik->constants());
 


### PR DESCRIPTION
I noticed replay fails when it encounters classes that it can't
resolve (when running with -XX:+ReplayIgnoreInitErrors).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273659](https://bugs.openjdk.java.net/browse/JDK-8273659): Replay compilation crashes with SIGSEGV since 8271911


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5490/head:pull/5490` \
`$ git checkout pull/5490`

Update a local copy of the PR: \
`$ git checkout pull/5490` \
`$ git pull https://git.openjdk.java.net/jdk pull/5490/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5490`

View PR using the GUI difftool: \
`$ git pr show -t 5490`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5490.diff">https://git.openjdk.java.net/jdk/pull/5490.diff</a>

</details>
