### PR TITLE
8273639: tests fail with "assert(_handle_mark_nesting > 1) failed: memory leak: allocating handle outside HandleMark"

### DIFF
--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -1862,7 +1862,10 @@ void VM_HeapDumper::dump_stack_traces() {
     oop threadObj = thread->threadObj();
     if (threadObj != NULL && !thread->is_exiting() && !thread->is_hidden_from_external_view()) {
       // dump thread stack trace
-      ResourceMark rm;
+      Thread* current_thread = Thread::current();
+      ResourceMark rm(current_thread);
+      HandleMark hm(current_thread);
+
       ThreadStackTrace* stack_trace = new ThreadStackTrace(thread, false);
       stack_trace->dump_stack_at_safepoint(-1);
       _stack_traces[_num_threads++] = stack_trace;


### PR DESCRIPTION
This is a fix for an unintended side-effect of JDK-8273482. The problem is that we need to have a HandleMark on the stack before calling ThreadStackTrace::dump_stack_at_safepoint(). Before JDK-8273482, calls to ThreadStackTrace::dump_stack_at_safepoint()  were always done from the VMThread, which always has a HandleMark on the stack before evaluating a VM operation. After JDK-8273482, calls to this function can be made from WorkerThreads, which doesn't always have a HandleMark on its stack. The fix is simple, make sure we have a HandleMark on the stack before calling ThreadStackTrace::dump_stack_at_safepoint().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273639](https://bugs.openjdk.java.net/browse/JDK-8273639): tests fail with "assert(_handle_mark_nesting > 1) failed: memory leak: allocating handle outside HandleMark"


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5492/head:pull/5492` \
`$ git checkout pull/5492`

Update a local copy of the PR: \
`$ git checkout pull/5492` \
`$ git pull https://git.openjdk.java.net/jdk pull/5492/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5492`

View PR using the GUI difftool: \
`$ git pr show -t 5492`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5492.diff">https://git.openjdk.java.net/jdk/pull/5492.diff</a>

</details>
