### PR TITLE
8273605: VM Exit does not abort concurrent mark 

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -2040,9 +2040,8 @@ void G1ConcurrentMark::concurrent_cycle_abort() {
   for (uint i = 0; i < _max_num_tasks; ++i) {
     _tasks[i]->clear_region_fields();
   }
-  _first_overflow_barrier_sync.abort();
-  _second_overflow_barrier_sync.abort();
-  _has_aborted = true;
+
+  abort_marking_threads();
 
   SATBMarkQueueSet& satb_mq_set = G1BarrierSet::satb_mark_queue_set();
   satb_mq_set.abandon_partial_marking();
@@ -2051,6 +2050,12 @@ void G1ConcurrentMark::concurrent_cycle_abort() {
   satb_mq_set.set_active_all_threads(
                                  false, /* new active value */
                                  satb_mq_set.is_active() /* expected_active */);
+}
+
+void G1ConcurrentMark::abort_marking_threads() {
+  _has_aborted = true;
+  _first_overflow_barrier_sync.abort();
+  _second_overflow_barrier_sync.abort();
 }
 
 static void print_ms_time_info(const char* prefix, const char* name,

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -495,6 +495,10 @@ public:
   void concurrent_cycle_abort();
   void concurrent_cycle_end();
 
+  // Notifies marking threads to abort. This is a best-effort notification. Does not
+  // guarantee or update any state after the call.
+  void abort_marking_threads();
+
   void update_accum_task_vtime(int i, double vtime) {
     _accum_task_vtime[i] += vtime;
   }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
@@ -159,6 +159,8 @@ void G1ConcurrentMarkThread::run_service() {
 }
 
 void G1ConcurrentMarkThread::stop_service() {
+  _cm->abort_marking_threads();
+
   MutexLocker ml(CGC_lock, Mutex::_no_safepoint_check_flag);
   CGC_lock->notify_all();
 }


### PR DESCRIPTION
Hi,

  can I have reviews for this change that adds (best-effort) notification of the concurrent mark thread about that the VM is exiting. In particular, the change reuses the existing abort mechanism.

Best-effort because the change just flips a global flag that is periodically polled by all threads (particularly the concurrent mark thread) to see whether we should abort.

In that test case it reduces shutdown time from a wait until the whole marking cycle finished to "immediate".

There is no test case because I could not think of anything that's reproducable: after all to have a very long delay for shutdown we need to have a *huge* heap (tested on a 50gb heap with 25gb live data), and additionally measuring shutdown time in CI is just asking for spurious errors when that process does not get enough cpu time for any reason.

Testing: test case that found that issue; tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273605](https://bugs.openjdk.java.net/browse/JDK-8273605): VM Exit does not abort concurrent mark


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5493/head:pull/5493` \
`$ git checkout pull/5493`

Update a local copy of the PR: \
`$ git checkout pull/5493` \
`$ git pull https://git.openjdk.java.net/jdk pull/5493/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5493`

View PR using the GUI difftool: \
`$ git pr show -t 5493`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5493.diff">https://git.openjdk.java.net/jdk/pull/5493.diff</a>

</details>
