### PR TITLE
8256735: JFR: 'jfr' tool displays incorrect timestamps

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
@@ -59,7 +59,7 @@ import jdk.jfr.internal.Utils;
  */
 public final class PrettyWriter extends EventPrintWriter {
     private static final String TYPE_OLD_OBJECT = Type.TYPES_PREFIX + "OldObject";
-    private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
+    private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss.SSS (YYYY-MM-dd)");
     private static final Long ZERO = 0L;
     private boolean showIds;
     private RecordedEvent currentEvent;


### PR DESCRIPTION
Hi,

Could I have a review that adds the date to jfr tool output. 

Testing: jdk/jdk/jfr + manual inspection

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256735](https://bugs.openjdk.java.net/browse/JDK-8256735): JFR: 'jfr' tool displays incorrect timestamps


### Reviewers
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5494/head:pull/5494` \
`$ git checkout pull/5494`

Update a local copy of the PR: \
`$ git checkout pull/5494` \
`$ git pull https://git.openjdk.java.net/jdk pull/5494/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5494`

View PR using the GUI difftool: \
`$ git pr show -t 5494`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5494.diff">https://git.openjdk.java.net/jdk/pull/5494.diff</a>

</details>
