### PR TITLE
8271254: javac generates unreachable code when using empty semicolon statement

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -1471,7 +1471,7 @@ public class Gen extends JCTree.Visitor {
             }
         };
         syncEnv.info.gaps = new ListBuffer<>();
-        genTry(tree.body, List.nil(), syncEnv, false);
+        genTry(tree.body, List.nil(), syncEnv);
         code.endScopes(limit);
     }
 
@@ -1505,16 +1505,15 @@ public class Gen extends JCTree.Visitor {
 
         };
         tryEnv.info.gaps = new ListBuffer<>();
-        genTry(tree.body, tree.catchers, tryEnv, true);
+        genTry(tree.body, tree.catchers, tryEnv);
     }
     //where
         /** Generate code for a try or synchronized statement
          *  @param body      The body of the try or synchronized statement.
          *  @param catchers  The list of catch clauses.
          *  @param env       The current environment of the body.
-         *  @param actualTry Identify try or synchronized statement, true for try and false for synchronized.
          */
-        void genTry(JCTree body, List<JCCatch> catchers, Env<GenContext> env, boolean actualTry) {
+        void genTry(JCTree body, List<JCCatch> catchers, Env<GenContext> env) {
             int limit = code.nextreg;
             int startpc = code.curCP();
             Code.State stateTry = code.state.dup();
@@ -1525,6 +1524,7 @@ public class Gen extends JCTree.Visitor {
             genFinalizer(env);
             code.statBegin(TreeInfo.endPos(env.tree));
             Chain exitChain;
+            boolean actualTry = env.tree.hasTag(TRY);
             if (startpc == endpc && actualTry) {
                 exitChain = code.branch(dontgoto);
             } else {

--- a/test/langtools/tools/javac/T8022186/DeadCodeGeneratedForEmptyTryTest.java
+++ b/test/langtools/tools/javac/T8022186/DeadCodeGeneratedForEmptyTryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/T8022186/DeadCodeGeneratedForEmptyTryTest.java
+++ b/test/langtools/tools/javac/T8022186/DeadCodeGeneratedForEmptyTryTest.java
@@ -217,7 +217,7 @@ public class DeadCodeGeneratedForEmptyTryTest {
         void methodToLookFor() {
             try {
                 // empty try statement
-                try { } finally { }
+                try { } catch (Exception e) { } finally { }
             } catch (Exception e) {
                 System.out.println("EXCEPTION");
             } finally {
@@ -229,7 +229,7 @@ public class DeadCodeGeneratedForEmptyTryTest {
     public class Test7 {
         void methodToLookFor() {
             try {
-                // empty try statement
+                // empty try statement with skip statement
                 try { ; } finally { }
             } finally {
                 System.out.println("STR_TO_LOOK_FOR");
@@ -240,8 +240,8 @@ public class DeadCodeGeneratedForEmptyTryTest {
     public class Test8 {
         void methodToLookFor() {
             try {
-                // empty try statement
-                try { ; } finally { }
+                // empty try statement with skip statement
+                try { ; } catch (Exception e) { } finally { }
             } catch (Exception e) {
                 System.out.println("EXCEPTION");
             } finally {

--- a/test/langtools/tools/javac/T8022186/DeadCodeGeneratedForEmptyTryTest.java
+++ b/test/langtools/tools/javac/T8022186/DeadCodeGeneratedForEmptyTryTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8022186
+ * @bug 8022186 8271254
  * @summary javac generates dead code if a try with an empty body has a finalizer
  * @modules jdk.jdeps/com.sun.tools.classfile
  *          jdk.compiler/com.sun.tools.javac.util
@@ -53,8 +53,10 @@ public class DeadCodeGeneratedForEmptyTryTest {
     }
 
     void run() throws Exception {
-        checkClassFile(Paths.get(System.getProperty("test.classes"),
-                this.getClass().getName() + "$Test.class"));
+        for (int i = 1; i <= 8; i++) {
+            checkClassFile(Paths.get(System.getProperty("test.classes"),
+                    this.getClass().getName() + "$Test" + i + ".class"));
+        }
     }
 
     int utf8Index;
@@ -62,6 +64,7 @@ public class DeadCodeGeneratedForEmptyTryTest {
     ConstantPool constantPool;
 
     void checkClassFile(final Path path) throws Exception {
+        numberOfRefToStr = 0;
         ClassFile classFile = ClassFile.read(
                 new BufferedInputStream(Files.newInputStream(path)));
         constantPool = classFile.constant_pool;
@@ -155,9 +158,92 @@ public class DeadCodeGeneratedForEmptyTryTest {
 
     }
 
-    public class Test {
+    public class Test1 {
         void methodToLookFor() {
             try {
+                // empty intentionally
+            } finally {
+                System.out.println("STR_TO_LOOK_FOR");
+            }
+        }
+    }
+
+    public class Test2 {
+        void methodToLookFor() {
+            try {
+                // empty intentionally
+            } catch (Exception e) {
+                System.out.println("EXCEPTION");
+            } finally {
+                System.out.println("STR_TO_LOOK_FOR");
+            }
+        }
+    }
+
+    public class Test3 {
+        void methodToLookFor() {
+            try {
+                ;  // skip statement intentionally
+            } finally {
+                System.out.println("STR_TO_LOOK_FOR");
+            }
+        }
+    }
+
+    public class Test4 {
+        void methodToLookFor() {
+            try {
+                ;  // skip statement intentionally
+            } catch (Exception e) {
+                System.out.println("EXCEPTION");
+            } finally {
+                System.out.println("STR_TO_LOOK_FOR");
+            }
+        }
+    }
+
+    public class Test5 {
+        void methodToLookFor() {
+            try {
+                // empty try statement
+                try { } finally { }
+            } finally {
+                System.out.println("STR_TO_LOOK_FOR");
+            }
+        }
+    }
+
+    public class Test6 {
+        void methodToLookFor() {
+            try {
+                // empty try statement
+                try { } finally { }
+            } catch (Exception e) {
+                System.out.println("EXCEPTION");
+            } finally {
+                System.out.println("STR_TO_LOOK_FOR");
+            }
+        }
+    }
+
+    public class Test7 {
+        void methodToLookFor() {
+            try {
+                // empty try statement
+                try { ; } finally { }
+            } finally {
+                System.out.println("STR_TO_LOOK_FOR");
+            }
+        }
+    }
+
+    public class Test8 {
+        void methodToLookFor() {
+            try {
+                // empty try statement
+                try { ; } finally { }
+            } catch (Exception e) {
+                System.out.println("EXCEPTION");
             } finally {
                 System.out.println("STR_TO_LOOK_FOR");
             }


### PR DESCRIPTION
Hi all,

The method `Gen#genTry` is used by `visitTry` and `visitSynchronized`, but `genTry` can't identify who is invoking it so that it can't solve the concrete issues about try statement or synchronized statement separately. This patch adds a new parameter `actualTry` to identify the concrete situation( try or synchronized) and fixes this issue about using empty skip statement in the try statement body. And some related test cases are added.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271254](https://bugs.openjdk.java.net/browse/JDK-8271254): javac generates unreachable code when using empty semicolon statement


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5495/head:pull/5495` \
`$ git checkout pull/5495`

Update a local copy of the PR: \
`$ git checkout pull/5495` \
`$ git pull https://git.openjdk.java.net/jdk pull/5495/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5495`

View PR using the GUI difftool: \
`$ git pr show -t 5495`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5495.diff">https://git.openjdk.java.net/jdk/pull/5495.diff</a>

</details>
