### PR TITLE
8273710: Remove redundant stream() call before forEach in jdk.jdeps

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/DepsAnalyzer.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/DepsAnalyzer.java
@@ -343,7 +343,7 @@ public class DepsAnalyzer {
     public Graph<Node> moduleGraph() {
         Graph.Builder<Node> builder = new Graph.Builder<>();
 
-        archives().stream()
+        archives()
             .forEach(m -> {
                 Node u = new Node(m.getName(), Info.REQUIRES);
                 builder.addNode(u);

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/Graph.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/Graph.java
@@ -72,8 +72,7 @@ public final class Graph<T> {
      */
     public Graph<T> reduce() {
         Builder<T> builder = new Builder<>();
-        nodes.stream()
-                .forEach(u -> {
+        nodes.forEach(u -> {
                     builder.addNode(u);
                     edges.get(u).stream()
                          .filter(v -> !pathExists(u, v, false))
@@ -97,8 +96,7 @@ public final class Graph<T> {
         }
 
         Builder<T> builder = new Builder<>();
-        nodes.stream()
-                .forEach(u -> {
+        nodes.forEach(u -> {
                     builder.addNode(u);
                     // filter the edge if there exists a path from u to v in the given g
                     // or there exists another path from u to v in this graph
@@ -108,7 +106,7 @@ public final class Graph<T> {
                 });
 
         // add the overlapped edges from this graph and the given g
-        g.edges().keySet().stream()
+        g.edges().keySet()
                 .forEach(u -> g.adjacentNodes(u).stream()
                                 .filter(v -> isAdjacent(u, v))
                                 .forEach(v -> builder.addEdge(u, v)));
@@ -147,7 +145,7 @@ public final class Graph<T> {
         builder.addNodes(nodes);
         // reverse edges
         edges.keySet().forEach(u -> {
-            edges.get(u).stream()
+            edges.get(u)
                 .forEach(v -> builder.addEdge(v, u));
         });
         return builder.build();
@@ -214,8 +212,7 @@ public final class Graph<T> {
 
     public void printGraph(PrintWriter out) {
         out.println("graph for " + nodes);
-        nodes.stream()
-             .forEach(u -> adjacentNodes(u).stream()
+        nodes.forEach(u -> adjacentNodes(u)
                                .forEach(v -> out.format("  %s -> %s%n", u, v)));
     }
 
@@ -322,7 +319,7 @@ public final class Graph<T> {
                 return;
             }
             visited.add(node);
-            graph.edges().get(node).stream()
+            graph.edges().get(node)
                  .forEach(x -> visit(x, visited, done));
             done.add(node);
             result.addLast(node);

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/InverseDepsAnalyzer.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/InverseDepsAnalyzer.java
@@ -141,7 +141,7 @@ public class InverseDepsAnalyzer extends DepsAnalyzer {
             targets().forEach(builder::addNode);
 
             // transpose the module graph
-            configuration.getModules().values().stream()
+            configuration.getModules().values()
                 .forEach(m -> {
                     builder.addNode(m);
                     m.descriptor().requires().stream()
@@ -152,7 +152,7 @@ public class InverseDepsAnalyzer extends DepsAnalyzer {
 
             // add the dependences from the analysis
             Map<Archive, Set<Archive>> dependences = dependencyFinder.dependences();
-            dependences.entrySet().stream()
+            dependences.entrySet()
                 .forEach(e -> {
                     Archive u = e.getKey();
                     builder.addNode(u);
@@ -215,7 +215,7 @@ public class InverseDepsAnalyzer extends DepsAnalyzer {
             }
 
             // push unvisited adjacent edges
-            unvisitedDeps.stream().forEach(deque::push);
+            unvisitedDeps.forEach(deque::push);
 
 
             // when the adjacent edges of a node are visited, pop it from the path

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsConfiguration.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsConfiguration.java
@@ -397,8 +397,8 @@ public class JdepsConfiguration implements AutoCloseable {
             md.requires().forEach(builder::requires);
             md.exports().forEach(builder::exports);
             md.opens().forEach(builder::opens);
-            md.provides().stream().forEach(builder::provides);
-            md.uses().stream().forEach(builder::uses);
+            md.provides().forEach(builder::provides);
+            md.uses().forEach(builder::uses);
             builder.packages(md.packages());
             return builder.build();
         }

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
@@ -771,7 +771,7 @@ class JdepsTask {
             if (!options.nowarning) {
                 analyzer.archives()
                     .forEach(archive -> archive.reader()
-                        .skippedEntries().stream()
+                        .skippedEntries()
                         .forEach(name -> warning("warn.skipped.entry", name)));
             }
 
@@ -796,7 +796,7 @@ class JdepsTask {
                     log.format("%-40s %s%n",
                                internalApiTitle.replaceAll(".", "-"),
                                replacementApiTitle.replaceAll(".", "-"));
-                    jdkInternals.entrySet().stream()
+                    jdkInternals.entrySet()
                         .forEach(e -> {
                             String key = e.getKey();
                             String[] lines = e.getValue().split("\\n");
@@ -1111,7 +1111,7 @@ class JdepsTask {
 
         // --require
         if (!options.requires.isEmpty()) {
-            options.requires.stream()
+            options.requires
                 .forEach(mn -> {
                     Module m = config.findModule(mn).get();
                     builder.requires(mn, m.packages());

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/Module.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/Module.java
@@ -223,10 +223,10 @@ class Module extends Archive {
                 descriptor.packages().forEach(pn -> exports.put(pn, Collections.emptySet()));
                 descriptor.packages().forEach(pn -> opens.put(pn, Collections.emptySet()));
             } else {
-                descriptor.exports().stream()
+                descriptor.exports()
                           .forEach(exp -> exports.computeIfAbsent(exp.source(), _k -> new HashSet<>())
                                                  .addAll(exp.targets()));
-                descriptor.opens().stream()
+                descriptor.opens()
                     .forEach(exp -> opens.computeIfAbsent(exp.source(), _k -> new HashSet<>())
                         .addAll(exp.targets()));
             }

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/ModuleAnalyzer.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/ModuleAnalyzer.java
@@ -174,16 +174,14 @@ public class ModuleAnalyzer {
         private Graph<Module> buildReducedGraph() {
             ModuleGraphBuilder rpBuilder = new ModuleGraphBuilder(configuration);
             rpBuilder.addModule(root);
-            requiresTransitive.stream()
-                          .forEach(m -> rpBuilder.addEdge(root, m));
+            requiresTransitive.forEach(m -> rpBuilder.addEdge(root, m));
 
             // requires transitive graph
             Graph<Module> rbg = rpBuilder.build().reduce();
 
             ModuleGraphBuilder gb = new ModuleGraphBuilder(configuration);
             gb.addModule(root);
-            requires.stream()
-                    .forEach(m -> gb.addEdge(root, m));
+            requires.forEach(m -> gb.addEdge(root, m));
 
             // transitive reduction
             Graph<Module> newGraph = gb.buildGraph().reduce(rbg);
@@ -310,7 +308,7 @@ public class ModuleAnalyzer {
             dependencyFinder.parse(mods.stream());
 
             // adds to the qualified exports map if a module references it
-            mods.stream().forEach(m ->
+            mods.forEach(m ->
                 m.getDependencies()
                     .map(Dependency.Location::getPackageName)
                     .filter(qualifiedExports::containsKey)

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/ModuleDotGraph.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/ModuleDotGraph.java
@@ -147,7 +147,7 @@ public class ModuleDotGraph {
      */
     private Graph<String> gengraph(Configuration cf) {
         Graph.Builder<String> builder = new Graph.Builder<>();
-        cf.modules().stream()
+        cf.modules()
             .forEach(rm -> {
                 String mn = rm.name();
                 builder.addNode(mn);
@@ -406,7 +406,7 @@ public class ModuleDotGraph {
                 .collect(toSet());
 
             String mn = md.name();
-            edges.stream().forEach(dn -> {
+            edges.forEach(dn -> {
                 String attr;
                 if (dn.equals("java.base")) {
                     attr = "color=\"" + attributes.requiresMandatedColor() + "\"";

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/ModuleExportsAnalyzer.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/ModuleExportsAnalyzer.java
@@ -113,7 +113,7 @@ public class ModuleExportsAnalyzer extends DepsAnalyzer {
                     .distinct()
                     .forEach(m -> {
                         if (internalPkgs.containsKey(m)) {
-                            internalPkgs.get(m).stream()
+                            internalPkgs.get(m)
                                 .forEach(pn -> writer.format("   %s/%s%s", m, pn, separator));
                         } else {
                             writer.format("   %s%s", m, separator);

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/ModuleGraphBuilder.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/ModuleGraphBuilder.java
@@ -89,10 +89,10 @@ public class ModuleGraphBuilder extends Graph.Builder<Module> {
         Graph.Builder<Module> builder = new Graph.Builder<>();
         Set<Module> visited = new HashSet<>();
         Deque<Module> deque = new LinkedList<>();
-        edges.entrySet().stream().forEach(e -> {
+        edges.entrySet().forEach(e -> {
             Module m = e.getKey();
             deque.add(m);
-            e.getValue().stream().forEach(v -> {
+            e.getValue().forEach(v -> {
                 deque.add(v);
                 builder.addEdge(m, v);
             });


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273710](https://bugs.openjdk.java.net/browse/JDK-8273710): Remove redundant stream() call before forEach in jdk.jdeps


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5498/head:pull/5498` \
`$ git checkout pull/5498`

Update a local copy of the PR: \
`$ git checkout pull/5498` \
`$ git pull https://git.openjdk.java.net/jdk pull/5498/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5498`

View PR using the GUI difftool: \
`$ git pr show -t 5498`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5498.diff">https://git.openjdk.java.net/jdk/pull/5498.diff</a>

</details>
