### PR TITLE
8273635: Attempting to acquire lock StackWatermark_lock/9 out of order with lock tty_lock/3

### DIFF
--- a/src/hotspot/share/runtime/mutex.hpp
+++ b/src/hotspot/share/runtime/mutex.hpp
@@ -45,10 +45,10 @@ class Mutex : public CHeapObj<mtSynchronizer> {
   // Special low level locks are given names and ranges avoid overlap.
   enum lock_types {
        event,
-       tty            = event          +   3,
-       service        = tty            +   3,
+       service        = event          +   3,
        stackwatermark = service        +   3,
-       special        = stackwatermark +   3,
+       tty            = stackwatermark +   3,
+       special        = tty            +   3,
        oopstorage     = special        +   3,
        leaf           = oopstorage     +   2,
        safepoint      = leaf           +  10,

--- a/test/hotspot/jtreg/compiler/uncommontrap/TestDeoptOOM.java
+++ b/test/hotspot/jtreg/compiler/uncommontrap/TestDeoptOOM.java
@@ -36,7 +36,7 @@
 /*
  * @test
  * @bug 8273456
- * @summary Test that ttyLock isn't held when taking StackWatermark_lock
+ * @summary Test that ttyLock is ranked about StackWatermark_lock
  * @requires !vm.graal.enabled & vm.gc.Z
  * @run main/othervm -XX:-BackgroundCompilation -Xmx128M -XX:+IgnoreUnrecognizedVMOptions -XX:+VerifyStack
  *      -XX:CompileCommand=exclude,compiler.uncommontrap.TestDeoptOOM::main

--- a/test/hotspot/jtreg/compiler/uncommontrap/TestDeoptOOM.java
+++ b/test/hotspot/jtreg/compiler/uncommontrap/TestDeoptOOM.java
@@ -36,7 +36,7 @@
 /*
  * @test
  * @bug 8273456
- * @summary Test that ttyLock is ranked about StackWatermark_lock
+ * @summary Test that ttyLock is ranked above StackWatermark_lock
  * @requires !vm.graal.enabled & vm.gc.Z
  * @run main/othervm -XX:-BackgroundCompilation -Xmx128M -XX:+IgnoreUnrecognizedVMOptions -XX:+VerifyStack
  *      -XX:CompileCommand=exclude,compiler.uncommontrap.TestDeoptOOM::main


### PR DESCRIPTION
This change reverts the rank ordering of ttyLock and StackWatermark_lock because the latter is held through a very large region and printing all of this to a buffer with xmlstream is non-trivial.
With this change, if tty->print_cr() is done while holding the stackwatermark lock or lower (which is service ranking, etc), a lock inversion will happen with ttyLock.  This doesn't happen now because all the code in GC and much of the rest of the runtime use UL and not tty->print().
Tested with tier1-6.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273635](https://bugs.openjdk.java.net/browse/JDK-8273635): Attempting to acquire lock StackWatermark_lock/9 out of order with lock tty_lock/3


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 53dd04d23b3fdedf04be2071c4a35bfb0943d9c8
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5499/head:pull/5499` \
`$ git checkout pull/5499`

Update a local copy of the PR: \
`$ git checkout pull/5499` \
`$ git pull https://git.openjdk.java.net/jdk pull/5499/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5499`

View PR using the GUI difftool: \
`$ git pr show -t 5499`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5499.diff">https://git.openjdk.java.net/jdk/pull/5499.diff</a>

</details>
