### PR TITLE
8273711: Remove redundant stream() call before forEach in jdk.jlink

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImageFileCreator.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImageFileCreator.java
@@ -109,7 +109,7 @@ public final class ImageFileCreator {
     }
 
     private void readAllEntries(Set<Archive> archives) {
-        archives.stream().forEach((archive) -> {
+        archives.forEach((archive) -> {
             Map<Boolean, List<Entry>> es;
             try (Stream<Entry> entries = archive.entries()) {
                 es = entries.collect(Collectors.partitioningBy(n -> n.type()
@@ -237,7 +237,7 @@ public final class ImageFileCreator {
         out.write(bytes, 0, bytes.length);
 
         // write module content
-        content.stream().forEach((res) -> {
+        content.forEach((res) -> {
             res.write(out);
         });
 

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImagePluginConfiguration.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImagePluginConfiguration.java
@@ -94,7 +94,7 @@ public final class ImagePluginConfiguration {
         }
 
         List<Plugin> orderedPlugins = new ArrayList<>();
-        plugins.entrySet().stream().forEach((entry) -> {
+        plugins.entrySet().forEach((entry) -> {
             orderedPlugins.addAll(entry.getValue());
         });
         Plugin lastSorter = null;

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImagePluginStack.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImagePluginStack.java
@@ -181,7 +181,7 @@ public final class ImagePluginStack {
         this.imageBuilder = Objects.requireNonNull(imageBuilder);
         this.lastSorter = lastSorter;
         this.plugins.addAll(Objects.requireNonNull(plugins));
-        plugins.stream().forEach((p) -> {
+        plugins.forEach((p) -> {
             Objects.requireNonNull(p);
             if (p instanceof ResourcePrevisitor) {
                 resourcePrevisitors.add((ResourcePrevisitor) p);
@@ -227,13 +227,13 @@ public final class ImagePluginStack {
                     resources.getStringTable()).resourcePool();
         }
         PreVisitStrings previsit = new PreVisitStrings();
-        resourcePrevisitors.stream().forEach((p) -> {
+        resourcePrevisitors.forEach((p) -> {
             p.previsit(resources.resourcePool(), previsit);
         });
 
         // Store the strings resulting from the previsit.
         List<String> sorted = previsit.getSortedStrings();
-        sorted.stream().forEach((s) -> {
+        sorted.forEach((s) -> {
             resources.getStringTable().addString(s);
         });
 

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/PerfectHashBuilder.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/PerfectHashBuilder.java
@@ -283,7 +283,7 @@ public class PerfectHashBuilder<E> {
         // Build bucket chains based on key hash.  Collisions end up in same chain.
         Bucket<E>[] buckets = (Bucket<E>[])Array.newInstance(bucketComponent, count);
 
-        map.values().stream().forEach((entry) -> {
+        map.values().forEach((entry) -> {
             int index = (entry.hashCode() & 0x7FFFFFFF) % count;
             Bucket<E> bucket = buckets[index];
 
@@ -327,7 +327,7 @@ public class PerfectHashBuilder<E> {
                     }
 
                     // Undo the attempted packing.
-                    undo.stream().forEach((i) -> {
+                    undo.forEach((i) -> {
                         order[i] = null;
                     });
 

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/PluginRepository.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/PluginRepository.java
@@ -143,7 +143,7 @@ public final class PluginRepository {
             while (providers.hasNext()) {
                 factories.add(providers.next());
             }
-            registeredPlugins.values().stream().forEach((fact) -> {
+            registeredPlugins.values().forEach((fact) -> {
                 if (clazz.isInstance(fact)) {
                     @SuppressWarnings("unchecked")
                     T trans = (T) fact;

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ResourcePoolConfiguration.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ResourcePoolConfiguration.java
@@ -47,15 +47,15 @@ final class ResourcePoolConfiguration {
 
         // drop hashes
         ModuleDescriptor.Builder builder = ModuleDescriptor.newModule(md.name());
-        md.requires().stream()
+        md.requires()
           .forEach(builder::requires);
-        md.exports().stream()
+        md.exports()
           .forEach(builder::exports);
-        md.opens().stream()
+        md.opens()
           .forEach(builder::opens);
-        md.uses().stream()
+        md.uses()
           .forEach(builder::uses);
-        md.provides().stream()
+        md.provides()
           .forEach(builder::provides);
         builder.packages(md.packages());
 

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ReleaseInfoPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ReleaseInfoPlugin.java
@@ -99,9 +99,8 @@ public final class ReleaseInfoPlugin extends AbstractPlugin {
                 if (keys == null || keys.isEmpty()) {
                     throw new IllegalArgumentException("No key specified for delete");
                 }
-                Utils.parseList(keys).forEach((k) -> {
-                    release.remove(k);
-                });
+                Utils.parseList(keys)
+                        .forEach(release::remove);
             }
             break;
 

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ReleaseInfoPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ReleaseInfoPlugin.java
@@ -99,7 +99,7 @@ public final class ReleaseInfoPlugin extends AbstractPlugin {
                 if (keys == null || keys.isEmpty()) {
                     throw new IllegalArgumentException("No key specified for delete");
                 }
-                Utils.parseList(keys).stream().forEach((k) -> {
+                Utils.parseList(keys).forEach((k) -> {
                     release.remove(k);
                 });
             }

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ResourceFilter.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ResourceFilter.java
@@ -65,7 +65,7 @@ public class ResourceFilter implements Predicate<String> {
                         throw new UncheckedIOException(ex);
                     }
 
-                    lines.stream().forEach((line) -> {
+                    lines.forEach((line) -> {
                         matchers.add(Utils.getJRTFSPathMatcher(line.trim()));
                     });
                 } else {

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/StringSharingPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/StringSharingPlugin.java
@@ -311,7 +311,7 @@ public class StringSharingPlugin extends AbstractPlugin implements ResourcePrevi
                 buffers.add(buffer);
             }
             ByteBuffer bb = ByteBuffer.allocate(l);
-            buffers.stream().forEach((buf) -> {
+            buffers.forEach((buf) -> {
                 bb.put(buf);
             });
             byte[] compressed_indices = bb.array();

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/StringSharingPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/StringSharingPlugin.java
@@ -311,9 +311,7 @@ public class StringSharingPlugin extends AbstractPlugin implements ResourcePrevi
                 buffers.add(buffer);
             }
             ByteBuffer bb = ByteBuffer.allocate(l);
-            buffers.forEach((buf) -> {
-                bb.put(buf);
-            });
+            buffers.forEach(bb::put);
             byte[] compressed_indices = bb.array();
             byte[] compressed_size = CompressIndexes.
                     compress(compressed_indices.length);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273711](https://bugs.openjdk.java.net/browse/JDK-8273711): Remove redundant stream() call before forEach in jdk.jlink


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to 153a9ea18bc47d7b4890bec7a5632887ec4336af
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to 153a9ea18bc47d7b4890bec7a5632887ec4336af
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5500/head:pull/5500` \
`$ git checkout pull/5500`

Update a local copy of the PR: \
`$ git checkout pull/5500` \
`$ git pull https://git.openjdk.java.net/jdk pull/5500/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5500`

View PR using the GUI difftool: \
`$ git pr show -t 5500`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5500.diff">https://git.openjdk.java.net/jdk/pull/5500.diff</a>

</details>
