### PR TITLE
8273675: Remove unused Universe::_verify_in_progress flag

### DIFF
--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -122,7 +122,6 @@ LatestMethodCache* Universe::_throw_illegal_access_error_cache = NULL;
 LatestMethodCache* Universe::_throw_no_such_method_error_cache = NULL;
 LatestMethodCache* Universe::_do_stack_walk_cache     = NULL;
 
-bool Universe::_verify_in_progress                    = false;
 long Universe::verify_flags                           = Universe::Verify_All;
 
 Array<int>* Universe::_the_empty_int_array            = NULL;
@@ -1077,12 +1076,6 @@ bool Universe::should_verify_subset(uint subset) {
 }
 
 void Universe::verify(VerifyOption option, const char* prefix) {
-  // The use of _verify_in_progress is a temporary work around for
-  // 6320749.  Don't bother with a creating a class to set and clear
-  // it since it is only used in this method and the control flow is
-  // straight forward.
-  _verify_in_progress = true;
-
   COMPILER2_PRESENT(
     assert(!DerivedPointerTable::is_active(),
          "DPT should not be active during verification "
@@ -1145,8 +1138,6 @@ void Universe::verify(VerifyOption option, const char* prefix) {
     log_debug(gc, verify)("String Deduplication");
     StringDedup::verify();
   }
-
-  _verify_in_progress = false;
 }
 
 

--- a/src/hotspot/share/memory/universe.hpp
+++ b/src/hotspot/share/memory/universe.hpp
@@ -184,9 +184,6 @@ class Universe: AllStatic {
 
   // Debugging
   static int _verify_count;                           // number of verifies done
-
-  // True during call to verify().  Should only be set/cleared in verify().
-  static bool _verify_in_progress;
   static long verify_flags;
 
   static uintptr_t _verify_oop_mask;
@@ -348,7 +345,6 @@ class Universe: AllStatic {
   };
   static void initialize_verify_flags();
   static bool should_verify_subset(uint subset);
-  static bool verify_in_progress() { return _verify_in_progress; }
   static void verify(VerifyOption option, const char* prefix);
   static void verify(const char* prefix) {
     verify(VerifyOption_Default, prefix);


### PR DESCRIPTION
This is a trivial change to remove an unused flag in class Universe.
Tested with tier1 on Oracle platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273675](https://bugs.openjdk.java.net/browse/JDK-8273675): Remove unused Universe::_verify_in_progress flag


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5501/head:pull/5501` \
`$ git checkout pull/5501`

Update a local copy of the PR: \
`$ git checkout pull/5501` \
`$ git pull https://git.openjdk.java.net/jdk pull/5501/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5501`

View PR using the GUI difftool: \
`$ git pr show -t 5501`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5501.diff">https://git.openjdk.java.net/jdk/pull/5501.diff</a>

</details>
