### PR TITLE
8273641: (bf) Buffer subclasses documentation contains template strings

### DIFF
--- a/src/java.base/share/classes/java/nio/X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/X-Buffer.java.template
@@ -55,12 +55,12 @@ import jdk.internal.util.ArraysSupport;
  *
  *   <li><p> Absolute and relative {@link #get($type$[]) <i>bulk get</i>}
  *   methods that transfer contiguous sequences of $type$s from this buffer
- *   into an array; {#if[!byte]?and}</p></li>
+ *   into an array;</p></li>
  *
  *   <li><p> Absolute and relative {@link #put($type$[]) <i>bulk put</i>}
  *   methods that transfer contiguous sequences of $type$s from $a$
- *   $type$ array{#if[char]?,&#32;a&#32;string,} or some other $type$
- *   buffer into this buffer;{#if[!byte]?&#32;and} </p></li>
+ *   $type$ array{#if[char]?, a string,} or some other $type$
+ *   buffer into this buffer;</p></li>
  *
 #if[byte]
  *
@@ -86,12 +86,12 @@ import jdk.internal.util.ArraysSupport;
 #if[byte]
  *
  * content, or by {@link #wrap($type$[]) <i>wrapping</i>} an
- * existing $type$ array {#if[char]?or&#32;string} into a buffer.
+ * existing $type$ array into a buffer.
  *
 #else[byte]
  *
  * content, by {@link #wrap($type$[]) <i>wrapping</i>} an existing
- * $type$ array {#if[char]?or&#32;string} into a buffer, or by creating a
+ * $type$ array {#if[char]?or string} into a buffer, or by creating a
  * <a href="ByteBuffer.html#views"><i>view</i></a> of an existing byte buffer.
  *
 #end[byte]


### PR DESCRIPTION
Please consider this doc-only fix. The template processor apparently does not like the HTML space entity `&#32;`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273641](https://bugs.openjdk.java.net/browse/JDK-8273641): (bf) Buffer subclasses documentation contains template strings


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5502/head:pull/5502` \
`$ git checkout pull/5502`

Update a local copy of the PR: \
`$ git checkout pull/5502` \
`$ git pull https://git.openjdk.java.net/jdk pull/5502/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5502`

View PR using the GUI difftool: \
`$ git pr show -t 5502`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5502.diff">https://git.openjdk.java.net/jdk/pull/5502.diff</a>

</details>
