### PR TITLE
8273685 : Remove jtreg tag manual=yesno for java/awt/Graphics/LCDTextAndGraphicsState.java & show test instruction

### DIFF
--- a/test/jdk/java/awt/Graphics/LCDTextAndGraphicsState.java
+++ b/test/jdk/java/awt/Graphics/LCDTextAndGraphicsState.java
@@ -36,37 +36,29 @@ import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
-import java.awt.GridBagLayout;
-import java.awt.GridBagConstraints;
+import java.awt.GridLayout;
 import java.awt.RenderingHints;
 import java.awt.AlphaComposite;
 import java.awt.GradientPaint;
-import java.awt.TextArea;
 import java.awt.Shape;
 import java.awt.Panel;
-import java.awt.Insets;
 
 import java.awt.event.ActionEvent;
 import java.awt.geom.RoundRectangle2D;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 public class LCDTextAndGraphicsState extends Component {
 
-    private static final Frame instructionFrame = new Frame();
-    private static volatile boolean testResult = false;
+    private static final Frame testFrame = new Frame("Composite and Text Test");
+    private static final String text = "This test passes only if this text appears SIX TIMES else fail";
+    private static volatile boolean testResult;
     private static volatile CountDownLatch countDownLatch;
-    private static String text = "This test passes only if this text appears SIX TIMES";
-    private static final String INSTRUCTIONS = "INSTRUCTIONS:\n\n" +
-            "You should see the text \' " + text + " \' on the frame. \n" +
-            "If you see the same then test pass else test fail.";
 
     public void paint(Graphics g) {
-        Graphics2D g2d = (Graphics2D) g.create();
+        Graphics2D g2d = (Graphics2D)g.create();
         g2d.setColor(Color.white);
-        g2d.fillRect(0, 0, getSize().width, getSize().height);
+        g2d.fillRect(0,0,getSize().width, getSize().height);
 
         test1(g.create(0, 0, 500, 200));
         test2(g.create(0, 200, 500, 200));
@@ -74,31 +66,31 @@ public class LCDTextAndGraphicsState extends Component {
     }
 
     public void test1(Graphics g) {
-        Graphics2D g2d = (Graphics2D) g;
+        Graphics2D g2d = (Graphics2D)g;
         g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
-                RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
+                             RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
         g2d.setColor(Color.black);
         g2d.drawString(text, 10, 50);
         g2d.setComposite(AlphaComposite.getInstance(
-                AlphaComposite.SRC_OVER, 0.9f));
+                         AlphaComposite.SRC_OVER, 0.9f));
         g2d.drawString(text, 10, 80);
     }
 
     public void test2(Graphics g) {
-        Graphics2D g2d = (Graphics2D) g;
+        Graphics2D g2d = (Graphics2D)g;
         g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
-                RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
+                             RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
         g2d.setColor(Color.black);
         g2d.drawString(text, 10, 50);
         g2d.setPaint(new GradientPaint(
-                0f, 0f, Color.BLACK, 100f, 100f, Color.GRAY));
+                     0f, 0f, Color.BLACK, 100f, 100f, Color.GRAY));
         g2d.drawString(text, 10, 80);
     }
 
     public void test3(Graphics g) {
-        Graphics2D g2d = (Graphics2D) g;
+        Graphics2D g2d = (Graphics2D)g;
         g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
-                RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
+                             RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
         g2d.setColor(Color.black);
         g2d.drawString(text, 10, 50);
         Shape s = new RoundRectangle2D.Double(0, 60, 400, 50, 5, 5);
@@ -107,77 +99,40 @@ public class LCDTextAndGraphicsState extends Component {
     }
 
     public Dimension getPreferredSize() {
-        return new Dimension(500, 600);
+        return new Dimension(500,600);
     }
 
-    private static void createInstructionUI() {
-        GridBagLayout layout = new GridBagLayout();
-        Panel mainControlPanel = new Panel(layout);
-        Panel resultButtonPanel = new Panel(layout);
-        GridBagConstraints gbc = new GridBagConstraints();
-        gbc.gridx = 0;
-        gbc.gridy = 0;
-        gbc.insets = new Insets(5, 15, 5, 15);
-        gbc.fill = GridBagConstraints.HORIZONTAL;
+    public static void disposeUI() {
+        countDownLatch.countDown();
+        testFrame.dispose();
+    }
 
-        TextArea instructionTextArea = new TextArea();
-        instructionTextArea.setText(INSTRUCTIONS);
-        instructionTextArea.setEditable(false);
-        instructionTextArea.setBackground(Color.white);
-        mainControlPanel.add(instructionTextArea, gbc);
-
+    public static void createTestUI() {
+        testFrame.add(new LCDTextAndGraphicsState(), BorderLayout.NORTH);
+        Panel resultButtonPanel = new Panel(new GridLayout(1, 2));
         Button passButton = new Button("Pass");
-        passButton.setActionCommand("Pass");
         passButton.addActionListener((ActionEvent e) -> {
             testResult = true;
-            countDownLatch.countDown();
+            disposeUI();
         });
 
         Button failButton = new Button("Fail");
-        failButton.setActionCommand("Fail");
         failButton.addActionListener(e -> {
-            countDownLatch.countDown();
+            testResult = false;
+            disposeUI();
         });
-
-        gbc.gridx = 0;
-        gbc.gridy = 0;
-
-        resultButtonPanel.add(passButton, gbc);
-
-        gbc.gridx = 1;
-        gbc.gridy = 0;
-        resultButtonPanel.add(failButton, gbc);
-
-        gbc.gridx = 0;
-        gbc.gridy = 2;
-        mainControlPanel.add(resultButtonPanel, gbc);
-
-        instructionFrame.addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent e) {
-                super.windowClosing(e);
-                countDownLatch.countDown();
-            }
-        });
-        instructionFrame.pack();
-        instructionFrame.add(mainControlPanel);
-        instructionFrame.pack();
-        instructionFrame.setVisible(true);
-    }
-
-    public static void createUI() {
-        Frame f = new Frame("Composite and Text Test");
-        f.add(new LCDTextAndGraphicsState(), BorderLayout.CENTER);
-        f.pack();
-        f.setLocationRelativeTo(null);
-        f.setVisible(true);
+        resultButtonPanel.add(passButton);
+        resultButtonPanel.add(failButton);
+        testFrame.add(resultButtonPanel, BorderLayout.SOUTH);
+        testFrame.pack();
+        testFrame.setLocationRelativeTo(null);
+        testFrame.setVisible(true);
     }
 
     public static void main(String[] args) throws InterruptedException {
         countDownLatch = new CountDownLatch(1);
-        createInstructionUI();
-        createUI();
-        if (!countDownLatch.await(15, TimeUnit.MINUTES)) {
+        createTestUI();
+        if (!countDownLatch.await(10, TimeUnit.MINUTES)) {
             throw new RuntimeException("Timeout : No action was performed on the test UI.");
         }
         if (!testResult) {

--- a/test/jdk/java/awt/Graphics/LCDTextAndGraphicsState.java
+++ b/test/jdk/java/awt/Graphics/LCDTextAndGraphicsState.java
@@ -28,21 +28,21 @@
  * @run main/manual LCDTextAndGraphicsState
  */
 
+import java.awt.AlphaComposite;
 import java.awt.BorderLayout;
 import java.awt.Button;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Frame;
+import java.awt.GradientPaint;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.GridLayout;
-import java.awt.RenderingHints;
-import java.awt.AlphaComposite;
-import java.awt.GradientPaint;
-import java.awt.Shape;
 import java.awt.Panel;
-
+import java.awt.RenderingHints;
+import java.awt.Shape;
+import java.awt.TextArea;
 import java.awt.event.ActionEvent;
 import java.awt.geom.RoundRectangle2D;
 import java.util.concurrent.CountDownLatch;
@@ -59,10 +59,9 @@ public class LCDTextAndGraphicsState extends Component {
         Graphics2D g2d = (Graphics2D)g.create();
         g2d.setColor(Color.white);
         g2d.fillRect(0,0,getSize().width, getSize().height);
-
-        test1(g.create(0, 0, 500, 200));
-        test2(g.create(0, 200, 500, 200));
-        test3(g.create(0, 400, 500, 200));
+        test1(g.create(0, 0, 500, 100));
+        test2(g.create(0, 100, 500, 100));
+        test3(g.create(0, 200, 500, 100));
     }
 
     public void test1(Graphics g) {
@@ -70,10 +69,10 @@ public class LCDTextAndGraphicsState extends Component {
         g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
                              RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
         g2d.setColor(Color.black);
-        g2d.drawString(text, 10, 50);
+        g2d.drawString(text, 10, 20);
         g2d.setComposite(AlphaComposite.getInstance(
                          AlphaComposite.SRC_OVER, 0.9f));
-        g2d.drawString(text, 10, 80);
+        g2d.drawString(text, 10, 50);
     }
 
     public void test2(Graphics g) {
@@ -81,10 +80,10 @@ public class LCDTextAndGraphicsState extends Component {
         g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
                              RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
         g2d.setColor(Color.black);
-        g2d.drawString(text, 10, 50);
+        g2d.drawString(text, 10, 20);
         g2d.setPaint(new GradientPaint(
                      0f, 0f, Color.BLACK, 100f, 100f, Color.GRAY));
-        g2d.drawString(text, 10, 80);
+        g2d.drawString(text, 10, 50);
     }
 
     public void test3(Graphics g) {
@@ -92,14 +91,14 @@ public class LCDTextAndGraphicsState extends Component {
         g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
                              RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
         g2d.setColor(Color.black);
-        g2d.drawString(text, 10, 50);
-        Shape s = new RoundRectangle2D.Double(0, 60, 400, 50, 5, 5);
+        g2d.drawString(text, 10, 20);
+        Shape s = new RoundRectangle2D.Double(0, 30, 400, 50, 5, 5);
         g2d.clip(s);
-        g2d.drawString(text, 10, 80);
+        g2d.drawString(text, 10, 50);
     }
 
     public Dimension getPreferredSize() {
-        return new Dimension(500,600);
+        return new Dimension(500,300);
     }
 
     public static void disposeUI() {
@@ -115,7 +114,6 @@ public class LCDTextAndGraphicsState extends Component {
             testResult = true;
             disposeUI();
         });
-
         Button failButton = new Button("Fail");
         failButton.addActionListener(e -> {
             testResult = false;
@@ -123,7 +121,21 @@ public class LCDTextAndGraphicsState extends Component {
         });
         resultButtonPanel.add(passButton);
         resultButtonPanel.add(failButton);
-        testFrame.add(resultButtonPanel, BorderLayout.SOUTH);
+
+        Panel controlUI = new Panel(new BorderLayout());
+        TextArea instructions = new TextArea(
+                "Instructions:\n" +
+                "If you see the text six times above, press Pass.\n" +
+                "If not, press Fail.",
+                3,
+                50,
+                TextArea.SCROLLBARS_NONE
+        );
+        instructions.setEditable(false);
+        controlUI.add(instructions, BorderLayout.CENTER);
+        controlUI.add(resultButtonPanel, BorderLayout.SOUTH);
+
+        testFrame.add(controlUI, BorderLayout.SOUTH);
         testFrame.pack();
         testFrame.setLocationRelativeTo(null);
         testFrame.setVisible(true);

--- a/test/jdk/java/awt/Graphics/LCDTextAndGraphicsState.java
+++ b/test/jdk/java/awt/Graphics/LCDTextAndGraphicsState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,52 +25,80 @@
  * @test
  * @bug 6576507
  * @summary Both lines of text should be readable
- * @run main/manual=yesno LCDTextAndGraphicsState
+ * @run main/manual LCDTextAndGraphicsState
  */
-import java.awt.*;
-import java.awt.geom.*;
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.GridBagLayout;
+import java.awt.GridBagConstraints;
+import java.awt.RenderingHints;
+import java.awt.AlphaComposite;
+import java.awt.GradientPaint;
+import java.awt.TextArea;
+import java.awt.Shape;
+import java.awt.Panel;
+import java.awt.Insets;
+
+import java.awt.event.ActionEvent;
+import java.awt.geom.RoundRectangle2D;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public class LCDTextAndGraphicsState extends Component {
 
-    String text = "This test passes only if this text appears SIX TIMES";
+    private static final Frame instructionFrame = new Frame();
+    private static volatile boolean testResult = false;
+    private static volatile CountDownLatch countDownLatch;
+    private static String text = "This test passes only if this text appears SIX TIMES";
+    private static final String INSTRUCTIONS = "INSTRUCTIONS:\n\n" +
+            "You should see the text \' " + text + " \' on the frame. \n" +
+            "If you see the same then test pass else test fail.";
 
     public void paint(Graphics g) {
-
-        Graphics2D g2d = (Graphics2D)g.create();
+        Graphics2D g2d = (Graphics2D) g.create();
         g2d.setColor(Color.white);
-        g2d.fillRect(0,0,getSize().width, getSize().height);
+        g2d.fillRect(0, 0, getSize().width, getSize().height);
 
-        test1(g.create(0,   0, 500, 200));
+        test1(g.create(0, 0, 500, 200));
         test2(g.create(0, 200, 500, 200));
         test3(g.create(0, 400, 500, 200));
     }
 
     public void test1(Graphics g) {
-        Graphics2D g2d = (Graphics2D)g;
+        Graphics2D g2d = (Graphics2D) g;
         g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
-                             RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
+                RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
         g2d.setColor(Color.black);
         g2d.drawString(text, 10, 50);
         g2d.setComposite(AlphaComposite.getInstance(
-                         AlphaComposite.SRC_OVER, 0.9f));
+                AlphaComposite.SRC_OVER, 0.9f));
         g2d.drawString(text, 10, 80);
     }
 
     public void test2(Graphics g) {
-        Graphics2D g2d = (Graphics2D)g;
+        Graphics2D g2d = (Graphics2D) g;
         g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
-                             RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
+                RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
         g2d.setColor(Color.black);
         g2d.drawString(text, 10, 50);
         g2d.setPaint(new GradientPaint(
-                     0f, 0f, Color.BLACK, 100f, 100f, Color.GRAY));
+                0f, 0f, Color.BLACK, 100f, 100f, Color.GRAY));
         g2d.drawString(text, 10, 80);
     }
 
     public void test3(Graphics g) {
-        Graphics2D g2d = (Graphics2D)g;
+        Graphics2D g2d = (Graphics2D) g;
         g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
-                             RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
+                RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
         g2d.setColor(Color.black);
         g2d.drawString(text, 10, 50);
         Shape s = new RoundRectangle2D.Double(0, 60, 400, 50, 5, 5);
@@ -79,14 +107,81 @@ public class LCDTextAndGraphicsState extends Component {
     }
 
     public Dimension getPreferredSize() {
-        return new Dimension(500,600);
+        return new Dimension(500, 600);
     }
 
-    public static void main(String[] args) throws Exception {
+    private static void createInstructionUI() {
+        GridBagLayout layout = new GridBagLayout();
+        Panel mainControlPanel = new Panel(layout);
+        Panel resultButtonPanel = new Panel(layout);
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        gbc.insets = new Insets(5, 15, 5, 15);
+        gbc.fill = GridBagConstraints.HORIZONTAL;
 
+        TextArea instructionTextArea = new TextArea();
+        instructionTextArea.setText(INSTRUCTIONS);
+        instructionTextArea.setEditable(false);
+        instructionTextArea.setBackground(Color.white);
+        mainControlPanel.add(instructionTextArea, gbc);
+
+        Button passButton = new Button("Pass");
+        passButton.setActionCommand("Pass");
+        passButton.addActionListener((ActionEvent e) -> {
+            testResult = true;
+            countDownLatch.countDown();
+        });
+
+        Button failButton = new Button("Fail");
+        failButton.setActionCommand("Fail");
+        failButton.addActionListener(e -> {
+            countDownLatch.countDown();
+        });
+
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+
+        resultButtonPanel.add(passButton, gbc);
+
+        gbc.gridx = 1;
+        gbc.gridy = 0;
+        resultButtonPanel.add(failButton, gbc);
+
+        gbc.gridx = 0;
+        gbc.gridy = 2;
+        mainControlPanel.add(resultButtonPanel, gbc);
+
+        instructionFrame.addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent e) {
+                super.windowClosing(e);
+                countDownLatch.countDown();
+            }
+        });
+        instructionFrame.pack();
+        instructionFrame.add(mainControlPanel);
+        instructionFrame.pack();
+        instructionFrame.setVisible(true);
+    }
+
+    public static void creatUI() {
         Frame f = new Frame("Composite and Text Test");
         f.add(new LCDTextAndGraphicsState(), BorderLayout.CENTER);
         f.pack();
+        f.setLocationRelativeTo(null);
         f.setVisible(true);
+    }
+
+    public static void main(String[] args) throws InterruptedException {
+        countDownLatch = new CountDownLatch(1);
+        createInstructionUI();
+        creatUI();
+        if (!countDownLatch.await(15, TimeUnit.MINUTES)) {
+            throw new RuntimeException("Timeout : No action was performed on the test UI.");
+        }
+        if (!testResult) {
+            throw new RuntimeException("Test failed!");
+        }
     }
 }

--- a/test/jdk/java/awt/Graphics/LCDTextAndGraphicsState.java
+++ b/test/jdk/java/awt/Graphics/LCDTextAndGraphicsState.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 6576507
  * @summary Both lines of text should be readable
@@ -165,7 +165,7 @@ public class LCDTextAndGraphicsState extends Component {
         instructionFrame.setVisible(true);
     }
 
-    public static void creatUI() {
+    public static void createUI() {
         Frame f = new Frame("Composite and Text Test");
         f.add(new LCDTextAndGraphicsState(), BorderLayout.CENTER);
         f.pack();
@@ -176,7 +176,7 @@ public class LCDTextAndGraphicsState extends Component {
     public static void main(String[] args) throws InterruptedException {
         countDownLatch = new CountDownLatch(1);
         createInstructionUI();
-        creatUI();
+        createUI();
         if (!countDownLatch.await(15, TimeUnit.MINUTES)) {
             throw new RuntimeException("Timeout : No action was performed on the test UI.");
         }


### PR DESCRIPTION
Problem : 
1) Test case was failing with following exception
test result: Error. Parse Exception: Arguments to `manual' option not supported: yes 
2) After removing =yes/no Parser exception is not seen but test UI will show and closes immediately  where the user cannot see what is on the frame. 

Fix : 
1) Add frame to show the test instructions.
2) Added timeout for the test case.
3) Show the test UI until either test case gets timeout or user press pass or fail button.

@shurymury

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273685](https://bugs.openjdk.java.net/browse/JDK-8273685): Remove jtreg tag manual=yesno for  java/awt/Graphics/LCDTextAndGraphicsState.java & show test instruction


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5503/head:pull/5503` \
`$ git checkout pull/5503`

Update a local copy of the PR: \
`$ git checkout pull/5503` \
`$ git pull https://git.openjdk.java.net/jdk pull/5503/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5503`

View PR using the GUI difftool: \
`$ git pr show -t 5503`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5503.diff">https://git.openjdk.java.net/jdk/pull/5503.diff</a>

</details>
