### PR TITLE
8273730: WorkGangBarrierSync constructor unused

### DIFF
--- a/src/hotspot/share/gc/shared/workgroup.cpp
+++ b/src/hotspot/share/gc/shared/workgroup.cpp
@@ -250,11 +250,6 @@ WorkGangBarrierSync::WorkGangBarrierSync()
     _n_workers(0), _n_completed(0), _should_reset(false), _aborted(false) {
 }
 
-WorkGangBarrierSync::WorkGangBarrierSync(uint n_workers, const char* name)
-  : _monitor(Mutex::safepoint, name, Monitor::_safepoint_check_never),
-    _n_workers(n_workers), _n_completed(0), _should_reset(false), _aborted(false) {
-}
-
 void WorkGangBarrierSync::set_n_workers(uint n_workers) {
   _n_workers    = n_workers;
   _n_completed  = 0;

--- a/src/hotspot/share/gc/shared/workgroup.hpp
+++ b/src/hotspot/share/gc/shared/workgroup.hpp
@@ -237,7 +237,6 @@ protected:
 
 public:
   WorkGangBarrierSync();
-  WorkGangBarrierSync(uint n_workers, const char* name);
 
   // Set the number of workers that will use the barrier.
   // Must be called before any of the workers start running.


### PR DESCRIPTION
Please review this trivial change.  This constructor is unused and uses a lock rank that doesn't really mean anything in the jvm.  Built vm with shenandoah and testing with tier1 on Oracle platforms.  Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273730](https://bugs.openjdk.java.net/browse/JDK-8273730): WorkGangBarrierSync constructor unused


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5508/head:pull/5508` \
`$ git checkout pull/5508`

Update a local copy of the PR: \
`$ git checkout pull/5508` \
`$ git pull https://git.openjdk.java.net/jdk pull/5508/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5508`

View PR using the GUI difftool: \
`$ git pr show -t 5508`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5508.diff">https://git.openjdk.java.net/jdk/pull/5508.diff</a>

</details>
