### PR TITLE
8272815: jpackage --type rpm produces an error: Invalid or unsupported type: [null]

### DIFF
--- a/test/jdk/tools/jpackage/share/jdk/jpackage/tests/ErrorTest.java
+++ b/test/jdk/tools/jpackage/share/jdk/jpackage/tests/ErrorTest.java
@@ -32,7 +32,7 @@ import jdk.jpackage.test.TKit;
 
 /*
  * @test
- * @summary jpackage application version testing
+ * @summary Test jpackage output for erroneous input
  * @library ../../../../helpers
  * @build jdk.jpackage.test.*
  * @modules jdk.jpackage/jdk.jpackage.internal
@@ -44,7 +44,7 @@ import jdk.jpackage.test.TKit;
 
 /*
  * @test
- * @summary jpackage application version testing
+ * @summary Test jpackage output for erroneous input
  * @library ../../../../helpers
  * @build jdk.jpackage.test.*
  * @modules jdk.jpackage/jdk.jpackage.internal
@@ -96,7 +96,7 @@ public final class ErrorTest {
             {"Hello",
                     new String[]{"--type", "invalid-type"},
                     null,
-                    "Invalid or unsupported type:"},
+                    "Invalid or unsupported type: [invalid-type]"},
             // no --input
             {"Hello",
                     null,


### PR DESCRIPTION
Fix jpackage error output when "--type" CLI option is missing and jpackage detects that it can't build native packages in the environment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272815](https://bugs.openjdk.java.net/browse/JDK-8272815): jpackage --type rpm produces an error: Invalid or unsupported type: [null]


### Reviewers
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**) ⚠️ Review applies to caac338f2310c83fd5d32fd9e8f73e88507bd89c
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5512/head:pull/5512` \
`$ git checkout pull/5512`

Update a local copy of the PR: \
`$ git checkout pull/5512` \
`$ git pull https://git.openjdk.java.net/jdk pull/5512/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5512`

View PR using the GUI difftool: \
`$ git pr show -t 5512`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5512.diff">https://git.openjdk.java.net/jdk/pull/5512.diff</a>

</details>
