### PR TITLE
8258734: jdk/jfr/event/oldobject/TestClassLoaderLeak.java failed with "RuntimeException: Could not find class leak"

### DIFF
--- a/test/jdk/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
@@ -49,7 +49,6 @@ import jdk.test.lib.jfr.Events;
 public class TestClassLoaderLeak {
 
     public static List<Object> classObjects = new ArrayList<>(OldObjects.MIN_SIZE);
-    public static Random random = new Random();
 
     public static void main(String[] args) throws Exception {
         WhiteBox.setWriteAllObjectSamples(true);
@@ -60,7 +59,6 @@ public class TestClassLoaderLeak {
             TestClassLoader testClassLoader = new TestClassLoader();
             for (Class<?> clazz : testClassLoader.loadClasses(OldObjects.MIN_SIZE / 200)) {
                 // Allocate array to trigger sampling code path for interpreter / c1
-                int count = 20 + random.nextInt(5);
                 for (int i = 0; i < 200; i++) {
                     Object classArray = Array.newInstance(clazz, 200);
                     Array.set(classArray, i, clazz.newInstance());

--- a/test/jdk/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
@@ -59,8 +59,11 @@ public class TestClassLoaderLeak {
             for (Class<?> clazz : testClassLoader.loadClasses(OldObjects.MIN_SIZE / 200)) {
                 // Allocate array to trigger sampling code path for interpreter / c1
                 for (int i = 0; i < 200; i++) {
-                    Object classArray = Array.newInstance(clazz, 200);
-                    Array.set(classArray, i, clazz.newInstance());
+                    Object classArray = Array.newInstance(clazz, 20);
+                    // No need to fill whole array
+                    for (int j = 0; j < 5; j++) {
+                        Array.set(classArray, j, clazz.getConstructors()[0].newInstance());
+                    }
                     classObjects.add(classArray);
                 }
             }

--- a/test/jdk/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
@@ -58,10 +58,10 @@ public class TestClassLoaderLeak {
             r.enable(EventNames.OldObjectSample).withStackTrace().with("cutoff", "infinity");
             r.start();
             TestClassLoader testClassLoader = new TestClassLoader();
-            for (Class<?> clazz : testClassLoader.loadClasses(OldObjects.MIN_SIZE / 20)) {
+            for (Class<?> clazz : testClassLoader.loadClasses(OldObjects.MIN_SIZE / 200)) {
                 // Allocate array to trigger sampling code path for interpreter / c1
                 int count = 20 + random.nextInt(5);
-                for (int i = 0; i < 20; i++) {
+                for (int i = 0; i < 200; i++) {
                     Object classArray = Array.newInstance(clazz, 20);
                     Array.set(classArray, i, clazz.newInstance());
                     classObjects.add(classArray);

--- a/test/jdk/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
@@ -62,7 +62,7 @@ public class TestClassLoaderLeak {
                 // Allocate array to trigger sampling code path for interpreter / c1
                 int count = 20 + random.nextInt(5);
                 for (int i = 0; i < 200; i++) {
-                    Object classArray = Array.newInstance(clazz, 20);
+                    Object classArray = Array.newInstance(clazz, 200);
                     Array.set(classArray, i, clazz.newInstance());
                     classObjects.add(classArray);
                 }

--- a/test/jdk/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
@@ -26,7 +26,6 @@ package jdk.jfr.event.oldobject;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedClass;


### PR DESCRIPTION
Hi,

Could I have a review of a test fix that prints all old objects events to simplify analysis. I also changed the ratio between loaded classes and instances to increase the likelihood that an object is sampled.

Testing: Running jdk/jfr/event/oldobject/TestClassLoaderLeak.java 100 times

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258734](https://bugs.openjdk.java.net/browse/JDK-8258734): jdk/jfr/event/oldobject/TestClassLoaderLeak.java failed with "RuntimeException: Could not find class leak"


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5513/head:pull/5513` \
`$ git checkout pull/5513`

Update a local copy of the PR: \
`$ git checkout pull/5513` \
`$ git pull https://git.openjdk.java.net/jdk pull/5513/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5513`

View PR using the GUI difftool: \
`$ git pr show -t 5513`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5513.diff">https://git.openjdk.java.net/jdk/pull/5513.diff</a>

</details>
