### PR TITLE
8271073: Improve testing with VM option VerifyArchivedFields

### DIFF
--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -674,7 +674,7 @@ void HeapShared::serialize_subgraph_info_table_header(SerializeClosure* soc) {
 }
 
 static void verify_the_heap(Klass* k, const char* which) {
-  if (VerifyArchivedFields) {
+  if (VerifyArchivedFields > 0) {
     ResourceMark rm;
     log_info(cds, heap)("Verify heap %s initializing static field(s) in %s",
                         which, k->external_name());
@@ -682,15 +682,20 @@ static void verify_the_heap(Klass* k, const char* which) {
     VM_Verify verify_op;
     VMThread::execute(&verify_op);
 
-    if (!FLAG_IS_DEFAULT(VerifyArchivedFields)) {
-      // If VerifyArchivedFields has a non-default value (e.g., specified on the command-line), do
-      // more expensive checks.
-      if (is_init_completed()) {
-        FlagSetting fs1(VerifyBeforeGC, true);
-        FlagSetting fs2(VerifyDuringGC, true);
-        FlagSetting fs3(VerifyAfterGC,  true);
-        Universe::heap()->collect(GCCause::_java_lang_system_gc);
-      }
+    if (VerifyArchivedFields > 1 && is_init_completed()) {
+      // At this time, the oop->klass() of some archived objects in the heap may not
+      // have been loaded into the system dictionary yet. Nevertheless, oop->klass() should
+      // have enough information (object size, oop maps, etc) so that a GC can be safely
+      // performed.
+      //
+      // -XX:VerifyArchivedFields=2 force a GC to happen in such an early stage
+      // to check for GC safety.
+      log_info(cds, heap)("Trigger GC %s initializing static field(s) in %s",
+                          which, k->external_name());
+      FlagSetting fs1(VerifyBeforeGC, true);
+      FlagSetting fs2(VerifyDuringGC, true);
+      FlagSetting fs3(VerifyAfterGC,  true);
+      Universe::heap()->collect(GCCause::_java_lang_system_gc);
     }
   }
 }
@@ -1707,9 +1712,11 @@ class VerifyLoadedHeapEmbeddedPointers: public BasicOopIterateClosure {
 };
 
 void HeapShared::verify_loaded_heap() {
-  if (!VerifyArchivedFields || !is_loaded()) {
+  if (VerifyArchivedFields <= 0 || !is_loaded()) {
     return;
   }
+
+  log_info(cds, heap)("Verify all oops and pointers in loaded heap");
 
   ResourceMark rm;
   ResourceHashtable<uintptr_t, bool> table;

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -523,8 +523,11 @@
   product(bool, VerifyDuringGC, false, DIAGNOSTIC,                          \
           "Verify memory system during GC (between phases)")                \
                                                                             \
-  product(bool, VerifyArchivedFields, trueInDebug, DIAGNOSTIC,              \
-          "Verify memory when archived oop fields are loaded from CDS)")    \
+  product(int, VerifyArchivedFields, 0, DIAGNOSTIC,                         \
+          "Verify memory when archived oop fields are loaded from CDS; "    \
+          "0: No check; "                                                   \
+          "1: Basic verification with VM_Verify (no side effects); "        \
+          "2: Detailed verification by forcing a GC (with side effects)")   \
                                                                             \
   product(ccstrlist, VerifyGCType, "", DIAGNOSTIC,                          \
              "GC type(s) to verify when Verify*GC is enabled."              \

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -528,6 +528,7 @@
           "0: No check; "                                                   \
           "1: Basic verification with VM_Verify (no side effects); "        \
           "2: Detailed verification by forcing a GC (with side effects)")   \
+          range(0, 2)                                                       \
                                                                             \
   product(ccstrlist, VerifyGCType, "", DIAGNOSTIC,                          \
              "GC type(s) to verify when Verify*GC is enabled."              \

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
@@ -409,6 +409,8 @@ public class TestCommon extends CDSTestUtils {
             cmd.add(opts.appJar);
         }
 
+        CDSTestUtils.addVerifyArchivedFields(cmd);
+
         for (String s : opts.suffix) cmd.add(s);
 
         if (RUN_WITH_JFR) {

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/VerifyArchivedFields.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/VerifyArchivedFields.java
@@ -26,7 +26,7 @@
  * @test
  * @summary run with -XX:VerifyArchivedFields=2 for more expensive verification
  *          of the archived heap objects.
- * @requires vm.cds
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @build Hello
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar Hello.jar Hello

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/VerifyArchivedFields.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/VerifyArchivedFields.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @summary run with -XX:VerifyArchivedFields=2 for more expensive verification
+ *          of the archived heap objects.
+ * @requires vm.cds
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
+ * @build Hello
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar Hello.jar Hello
+ * @run driver VerifyArchivedFields
+ */
+
+import jdk.test.lib.helpers.ClassFileInstaller;
+
+public class VerifyArchivedFields {
+    // Note: -XX:VerifyArchivedFields=2 will force a GC every time when
+    // HeapShared::initialize_from_archived_subgraph(Klass* k, ...) is called. This ensures
+    // that it's safe to do a GC even when the oop->klass() of some archived heap objects
+    // are not yet loaded into the system dictionary.
+    public static void main(String[] args) throws Exception {
+        TestCommon.test(ClassFileInstaller.getJarPath("Hello.jar"),
+                        TestCommon.list("Hello"),
+                        "-XX:+UnlockDiagnosticVMOptions",
+                        "-XX:VerifyArchivedFields=2",
+                        "-Xlog:cds=debug",
+                        "-Xlog:cds+heap=debug",
+                        "-Xlog:gc*=debug",
+                        "Hello");
+  }
+}

--- a/test/lib/jdk/test/lib/cds/CDSTestUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSTestUtils.java
@@ -399,6 +399,12 @@ public class CDSTestUtils {
                                .addPrefix(cliPrefix) );
     }
 
+    // Enable basic verification (VerifyArchivedFields=1, no side effects) for all CDS
+    // tests to make sure the archived heap objects are mapped/loaded properly.
+    public static void addVerifyArchivedFields(ArrayList<String> cmd) {
+        cmd.add("-XX:+UnlockDiagnosticVMOptions");
+        cmd.add("-XX:VerifyArchivedFields=1");
+    }
 
     // Execute JVM with CDS archive, specify CDSOptions
     public static OutputAnalyzer runWithArchive(CDSOptions opts)
@@ -413,6 +419,7 @@ public class CDSTestUtils {
                 opts.archiveName = getDefaultArchiveName();
             cmd.add("-XX:SharedArchiveFile=" + opts.archiveName);
         }
+        addVerifyArchivedFields(cmd);
 
         if (opts.useVersion)
             cmd.add("-version");


### PR DESCRIPTION
- Changed the definition of `VerifyArchivedFields` from a whacky use of `bool` to an `int` and properly define its three levels:
  - 0: No verification 
  - 1: Basic verification with VM_Verify (no side effects)
  - 2: Detailed verification by forcing a GC (with side effects)
- Changed the default value to 0. The functionality checked by this flag has been very stable so there's no need to verify it in every single test case.
- Enabled `-XX:VerifyArchivedFields=1` for all CDS test cases.
- Added a new test case for `-XX:VerifyArchivedFields=2` .
- Also added comments about that this flag is suppose to check for.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271073](https://bugs.openjdk.java.net/browse/JDK-8271073): Improve testing with VM option VerifyArchivedFields


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5514/head:pull/5514` \
`$ git checkout pull/5514`

Update a local copy of the PR: \
`$ git checkout pull/5514` \
`$ git pull https://git.openjdk.java.net/jdk pull/5514/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5514`

View PR using the GUI difftool: \
`$ git pr show -t 5514`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5514.diff">https://git.openjdk.java.net/jdk/pull/5514.diff</a>

</details>
