### PR TITLE
8273774: CDSPluginTest should only expect classes_nocoops.jsa exists on supported 64-bit platforms

### DIFF
--- a/test/jdk/tools/jlink/plugins/CDSPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/CDSPluginTest.java
@@ -29,6 +29,8 @@ import jdk.test.lib.process.*;
 
 import tests.Helper;
 
+import jtreg.SkippedException;
+
 /* @test
  * @bug 8264322
  * @summary Test the --generate-cds-archive plugin
@@ -48,6 +50,9 @@ import tests.Helper;
 public class CDSPluginTest {
 
     public static void main(String[] args) throws Throwable {
+
+        if (!Platform.isDefaultCDSArchiveSupported())
+            throw new SkippedException("not a supported platform");
 
         Helper helper = Helper.newHelper();
         if (helper == null) {
@@ -69,8 +74,14 @@ public class CDSPluginTest {
             subDir = "lib" + sep;
         }
         subDir += "server" + sep;
-        helper.checkImage(image, module, null, null,
-                          new String[] { subDir + "classes.jsa", subDir + "classes_nocoops.jsa" });
+
+        if (Platform.isAArch64() || Platform.isX64()) {
+            helper.checkImage(image, module, null, null,
+                      new String[] { subDir + "classes.jsa", subDir + "classes_nocoops.jsa" });
+        } else {
+            helper.checkImage(image, module, null, null,
+                      new String[] { subDir + "classes.jsa" });
+        }
 
        // Simulate different platforms between current runtime and target image.
        if (Platform.isLinux()) {


### PR DESCRIPTION
The test assumes that it always runs on 64-bit platform and classes_nocoops.jsa is always created.
It's a test bug. The test should only expect classes_nocoops.jsa exists if it's running on a supported 64-bit platform.
However, for unknown target platform, it's unknown if it's 64-bit or not.

This patch fix the test to check if classes_nocoops.jsa exists only on one of the JDK supported platforms (x64 or aarch64) via the sun.arch.data.model system property.

Please review this change. Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273774](https://bugs.openjdk.java.net/browse/JDK-8273774): CDSPluginTest should only expect classes_nocoops.jsa exists on supported 64-bit platforms


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5519/head:pull/5519` \
`$ git checkout pull/5519`

Update a local copy of the PR: \
`$ git checkout pull/5519` \
`$ git pull https://git.openjdk.java.net/jdk pull/5519/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5519`

View PR using the GUI difftool: \
`$ git pr show -t 5519`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5519.diff">https://git.openjdk.java.net/jdk/pull/5519.diff</a>

</details>
