### PR TITLE
8274464: Remove redundant stream() call before forEach in java.* modules

### DIFF
--- a/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIJRMPServerImpl.java
+++ b/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIJRMPServerImpl.java
@@ -119,7 +119,7 @@ public class RMIJRMPServerImpl extends RMIServerImpl {
         else if (credentialsTypes != null) {
             allowedTypes = Arrays.stream(credentialsTypes).filter(
                     s -> s!= null).collect(Collectors.toSet());
-            allowedTypes.stream().forEach(ReflectUtil::checkPackageAccess);
+            allowedTypes.forEach(ReflectUtil::checkPackageAccess);
             cFilter = this::newClientCheckInput;
         } else {
             allowedTypes = null;

--- a/src/java.management/share/classes/java/lang/management/DefaultPlatformMBeanProvider.java
+++ b/src/java.management/share/classes/java/lang/management/DefaultPlatformMBeanProvider.java
@@ -416,8 +416,7 @@ class DefaultPlatformMBeanProvider extends PlatformMBeanProvider {
                     map = Collections.<String, BufferPoolMXBean>emptyMap();
                 } else {
                     map = new HashMap<>(list.size());
-                    list.stream()
-                        .forEach(mbean -> map.put(mbean.getObjectName().getCanonicalName(),mbean));
+                    list.forEach(mbean -> map.put(mbean.getObjectName().getCanonicalName(),mbean));
                 }
                 return map;
             }

--- a/src/java.xml/share/classes/javax/xml/catalog/CatalogFeatures.java
+++ b/src/java.xml/share/classes/javax/xml/catalog/CatalogFeatures.java
@@ -576,9 +576,7 @@ public class CatalogFeatures {
      * @param builder the CatalogFeatures builder
      */
     private void setProperties(Builder builder) {
-        builder.values.entrySet().stream().forEach((entry) -> {
-            setProperty(entry.getKey(), State.APIPROPERTY, entry.getValue());
-        });
+        builder.values.forEach((feature, value) -> setProperty(feature, State.APIPROPERTY, value));
     }
     /**
      * Sets the value of a property, updates only if it shall override.

--- a/src/java.xml/share/classes/javax/xml/catalog/CatalogImpl.java
+++ b/src/java.xml/share/classes/javax/xml/catalog/CatalogImpl.java
@@ -413,14 +413,14 @@ class CatalogImpl extends GroupEntry implements Catalog {
     void loadNextCatalogs() {
         //loads catalogs specified in nextCatalogs
         if (nextCatalogs != null) {
-            nextCatalogs.stream().forEach((next) -> {
+            nextCatalogs.forEach((next) -> {
                 getCatalog(this, next.getCatalogURI());
             });
         }
 
         //loads catalogs from the input list
         if (inputFiles != null) {
-            inputFiles.stream().forEach((uri) -> {
+            inputFiles.forEach((uri) -> {
                 getCatalog(null, URI.create(uri));
             });
         }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274464](https://bugs.openjdk.java.net/browse/JDK-8274464): Remove redundant stream() call before forEach in java.* modules


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Vyom Tewari](https://openjdk.java.net/census#vtewari) (@vyommani - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5520/head:pull/5520` \
`$ git checkout pull/5520`

Update a local copy of the PR: \
`$ git checkout pull/5520` \
`$ git pull https://git.openjdk.java.net/jdk pull/5520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5520`

View PR using the GUI difftool: \
`$ git pr show -t 5520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5520.diff">https://git.openjdk.java.net/jdk/pull/5520.diff</a>

</details>
