### PR TITLE
8273646: Add openssl from path variable also in to Default System Openssl Path in OpensslArtifactFetcher

### DIFF
--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -82,7 +82,9 @@ public class OpensslArtifactFetcher {
     }
 
     private static String getDefaultSystemOpensslPath(String version) {
-        if (verifyOpensslVersion("/usr/bin/openssl", version)) {
+        if (verifyOpensslVersion("openssl", version)) {
+            return "openssl";
+        } else if (verifyOpensslVersion("/usr/bin/openssl", version)) {
             return "/usr/bin/openssl";
         } else if (verifyOpensslVersion("/usr/local/bin/openssl", version)) {
             return "/usr/local/bin/openssl";

--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -84,8 +84,6 @@ public class OpensslArtifactFetcher {
     private static String getDefaultSystemOpensslPath(String version) {
         if (verifyOpensslVersion("openssl", version)) {
             return "openssl";
-        } else if (verifyOpensslVersion("/usr/bin/openssl", version)) {
-            return "/usr/bin/openssl";
         } else if (verifyOpensslVersion("/usr/local/bin/openssl", version)) {
             return "/usr/local/bin/openssl";
         }


### PR DESCRIPTION
The test "sun/security/pkcs12/KeytoolOpensslInteropTest.java" performs interoperability checks between JDK and openssl with respect to certain keystore operations. The test requires a suitable version of openssl to be available on the machine it runs. Some mechanisms are used to discover openssl, among which searching through a predefined set of paths is also one. The test at present looks only at the following absolute paths (in that order):

/usr/bin/openssl
/usr/local/bin/openssl


On some systems, especially Cygwin-windows, etc..., the openssl may not be available in the above mentioned locations. This causes the test to skip some part of the execution.

This change lets the test consider the default openssl from the system path before referring the above mentioned locations.

The patch has been tested on all supported platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273646](https://bugs.openjdk.java.net/browse/JDK-8273646): Add openssl from path variable also in to Default System Openssl Path in OpensslArtifactFetcher


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**) ⚠️ Review applies to b176776791adb7f397d18d7e10c5c98d1823ae5b


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5523/head:pull/5523` \
`$ git checkout pull/5523`

Update a local copy of the PR: \
`$ git checkout pull/5523` \
`$ git pull https://git.openjdk.java.net/jdk pull/5523/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5523`

View PR using the GUI difftool: \
`$ git pr show -t 5523`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5523.diff">https://git.openjdk.java.net/jdk/pull/5523.diff</a>

</details>
