### PR TITLE
8273401: Disable JarIndex support in URLClassPath

### DIFF
--- a/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
+++ b/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
@@ -946,7 +946,7 @@ public class URLClassPath {
             if (entry != null)
                 return checkResource(name, check, entry);
 
-            if (index == null || !ENABLE_JAR_INDEX)
+            if (index == null)
                 return null;
 
             HashSet<String> visited = new HashSet<>();

--- a/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
+++ b/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
@@ -90,6 +90,7 @@ public class URLClassPath {
     private static final boolean DISABLE_ACC_CHECKING;
     private static final boolean DISABLE_CP_URL_CHECK;
     private static final boolean DEBUG_CP_URL_CHECK;
+    private static final boolean ENABLE_JAR_INDEX;
 
     static {
         Properties props = GetPropertyAction.privilegedGetProperties();
@@ -109,6 +110,9 @@ public class URLClassPath {
         // the check is not disabled).
         p = props.getProperty("jdk.net.URLClassPath.showIgnoredClassPathEntries");
         DEBUG_CP_URL_CHECK = p != null ? p.equals("true") || p.isEmpty() : false;
+
+        p = props.getProperty("jdk.net.URLClassPath.enableJarIndex");
+        ENABLE_JAR_INDEX = p != null ? p.equals("true") : false;
     }
 
     /* The original search path of URLs. */
@@ -763,8 +767,10 @@ public class URLClassPath {
                                     System.err.println("Opening " + csu);
                                     Thread.dumpStack();
                                 }
-
                                 jar = getJarFile(csu);
+                                if (!ENABLE_JAR_INDEX) {
+                                    return null;
+                                }
                                 index = JarIndex.getJarIndex(jar);
                                 if (index != null) {
                                     String[] jarfiles = index.getJarFiles();
@@ -940,7 +946,7 @@ public class URLClassPath {
             if (entry != null)
                 return checkResource(name, check, entry);
 
-            if (index == null)
+            if (index == null || !ENABLE_JAR_INDEX)
                 return null;
 
             HashSet<String> visited = new HashSet<>();

--- a/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
+++ b/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
@@ -112,7 +112,7 @@ public class URLClassPath {
         DEBUG_CP_URL_CHECK = p != null ? p.equals("true") || p.isEmpty() : false;
 
         p = props.getProperty("jdk.net.URLClassPath.enableJarIndex");
-        ENABLE_JAR_INDEX = p != null ? p.equals("true") : false;
+        ENABLE_JAR_INDEX = p != null ? p.equals("true") || p.isEmpty() : false;
     }
 
     /* The original search path of URLs. */

--- a/test/jdk/sun/misc/JarIndex/JarIndexMergeForClassLoaderTest.java
+++ b/test/jdk/sun/misc/JarIndex/JarIndexMergeForClassLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  * @summary InvalidJarIndexException due to bug in sun.misc.JarIndex.merge()
  *          Test URLClassLoader usage of the merge method when using indexes
  * @author  Diego Belfer
+ * @run main/othervm -Djdk.net.URLClassPath.enableJarIndex=true JarIndexMergeForClassLoaderTest
  */
 import java.io.BufferedReader;
 import java.io.File;

--- a/test/jdk/sun/misc/JarIndex/metaInfFilenames/Basic.java
+++ b/test/jdk/sun/misc/JarIndex/metaInfFilenames/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@
  *          jdk.httpserver
  *          jdk.compiler
  *          jdk.zipfs
- * @run main/othervm Basic
+ * @run main/othervm -Djdk.net.URLClassPath.enableJarIndex=true Basic
  */
 
 import java.io.IOException;


### PR DESCRIPTION
There is a bug for URLClassPath.findResources with JarIndex.
Currently, there was agreement on dropping the support from the URLClassLoader implementation but it was suggested that it should be disabled for a release or two before the code is removed. 
A system property can be used to re-enable JarIndex support in URLClassPath.

The PR includes:
Disable JarIndex support in URLClassPath by default.
Add system property jdk.net.URLClassPath.enableJarIndex to re-enable JarIndex support.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273401](https://bugs.openjdk.java.net/browse/JDK-8273401): Disable JarIndex Support In URLClassPath


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to 8dd17484ac66e21a113da4356e750a1d2543ca3f
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to 8dd17484ac66e21a113da4356e750a1d2543ca3f
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5524/head:pull/5524` \
`$ git checkout pull/5524`

Update a local copy of the PR: \
`$ git checkout pull/5524` \
`$ git pull https://git.openjdk.java.net/jdk pull/5524/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5524`

View PR using the GUI difftool: \
`$ git pr show -t 5524`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5524.diff">https://git.openjdk.java.net/jdk/pull/5524.diff</a>

</details>
