### PR TITLE
8273801: Handle VMTYPE for "core" VM variant

### DIFF
--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -58,6 +58,10 @@ else
   JVM_EXCLUDE_PATTERNS += /zero/
 endif
 
+ifeq ($(JVM_VARIANT), core)
+  JVM_CFLAGS_FEATURES += -DVMTYPE=\"Core\"
+endif
+
 ifeq ($(JVM_VARIANT), custom)
   JVM_CFLAGS_FEATURES += -DVMTYPE=\"Custom\"
 endif


### PR DESCRIPTION
Building with --with-jvm-variants=core currently produces a binary that replies an odd version:

```
$ build/linux-x86_64-core-fastdebug/images/jdk/bin/java -version
openjdk version "18-internal" 2022-03-15
OpenJDK Runtime Environment (fastdebug build 18-internal+0-adhoc.shade.jdk)
OpenJDK 64-Bit  VM (fastdebug build 18-internal+0-adhoc.shade.jdk, interpreted mode)
```

It should actually say "OpenJDK 64-Bit Core VM", I think. Build just misses a simple definition of `VMTYPE` for core variant. 

After the patch:

```
$ build/linux-x86_64-core-fastdebug/images/jdk/bin/java -client -version
openjdk version "18-internal" 2022-03-15
OpenJDK Runtime Environment (fastdebug build 18-internal+0-adhoc.shade.jdk)
OpenJDK 64-Bit Core VM (fastdebug build 18-internal+0-adhoc.shade.jdk, interpreted mode)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273801](https://bugs.openjdk.java.net/browse/JDK-8273801): Handle VMTYPE for "core" VM variant


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5525/head:pull/5525` \
`$ git checkout pull/5525`

Update a local copy of the PR: \
`$ git checkout pull/5525` \
`$ git pull https://git.openjdk.java.net/jdk pull/5525/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5525`

View PR using the GUI difftool: \
`$ git pr show -t 5525`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5525.diff">https://git.openjdk.java.net/jdk/pull/5525.diff</a>

</details>
