### PR TITLE
8273797: Stop impersonating "server" VM in all VM variants

### DIFF
--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -32,16 +32,10 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS],
 
   # Setup the target toolchain
 
+  # The target dir matches the name of VM variant
+  TARGET_JVM_VARIANT_PATH=$JVM_VARIANT_MAIN
+
   # On some platforms (mac) the linker warns about non existing -L dirs.
-  # For any of the variants server, client, minimal or zero, the dir matches the
-  # variant name. The "main" variant should be used for linking. For the
-  # rest, the dir is just server.
-  if HOTSPOT_CHECK_JVM_VARIANT(server) || HOTSPOT_CHECK_JVM_VARIANT(client) \
-      || HOTSPOT_CHECK_JVM_VARIANT(minimal) || HOTSPOT_CHECK_JVM_VARIANT(zero); then
-    TARGET_JVM_VARIANT_PATH=$JVM_VARIANT_MAIN
-  else
-    TARGET_JVM_VARIANT_PATH=server
-  fi
   FLAGS_SETUP_LDFLAGS_CPU_DEP([TARGET])
 
   # Setup the build toolchain

--- a/make/autoconf/hotspot.m4
+++ b/make/autoconf/hotspot.m4
@@ -83,15 +83,6 @@ AC_DEFUN_ONCE([HOTSPOT_SETUP_JVM_VARIANTS],
     AC_MSG_ERROR([Cannot continue])
   fi
 
-  # All "special" variants share the same output directory ("server")
-  VALID_MULTIPLE_JVM_VARIANTS="server client minimal zero"
-  UTIL_GET_NON_MATCHING_VALUES(INVALID_MULTIPLE_VARIANTS, $JVM_VARIANTS, \
-      $VALID_MULTIPLE_JVM_VARIANTS)
-  if  test "x$INVALID_MULTIPLE_VARIANTS" != x && \
-      test "x$BUILDING_MULTIPLE_JVM_VARIANTS" = xtrue; then
-    AC_MSG_ERROR([You can only build multiple variants using these variants: '$VALID_MULTIPLE_JVM_VARIANTS'])
-  fi
-
   # The "main" variant is the one used by other libs to link against during the
   # build.
   if test "x$BUILDING_MULTIPLE_JVM_VARIANTS" = "xtrue"; then

--- a/make/hotspot/HotspotCommon.gmk
+++ b/make/hotspot/HotspotCommon.gmk
@@ -34,13 +34,7 @@ JVM_SUPPORT_DIR := $(JVM_VARIANT_OUTPUTDIR)/support
 DTRACE_SUPPORT_DIR := $(JVM_SUPPORT_DIR)/dtrace
 
 LIB_OUTPUTDIR := $(call FindLibDirForModule, java.base)
-ifneq ($(filter client minimal zero, $(JVM_VARIANT)), )
-  JVM_VARIANT_SUBDIR := $(JVM_VARIANT)
-else
-  # Use 'server' as default target directory name for all other variants.
-  JVM_VARIANT_SUBDIR := server
-endif
-JVM_LIB_OUTPUTDIR := $(LIB_OUTPUTDIR)/$(JVM_VARIANT_SUBDIR)
+JVM_LIB_OUTPUTDIR := $(LIB_OUTPUTDIR)/$(JVM_VARIANT)
 
 ################################################################################
 

--- a/make/modules/java.base/Copy.gmk
+++ b/make/modules/java.base/Copy.gmk
@@ -95,16 +95,10 @@ ifeq ($(call And, $(call isTargetOs, windows) $(call isTargetCpu, x86)), true)
 endif
 DEFAULT_CFG_VARIANT ?= server
 
-# Any variant other than server, client, minimal, or zero is represented as server in
-# the cfg file.
-VALID_CFG_VARIANTS := server client minimal zero
-CFG_VARIANTS := $(filter $(VALID_CFG_VARIANTS), $(JVM_VARIANTS)) \
-    $(if $(filter-out $(VALID_CFG_VARIANTS), $(JVM_VARIANTS)), server)
-
 # Change the order to put the default variant first if present.
 ORDERED_CFG_VARIANTS := \
-    $(if $(filter $(DEFAULT_CFG_VARIANT), $(CFG_VARIANTS)), $(DEFAULT_CFG_VARIANT)) \
-    $(filter-out $(DEFAULT_CFG_VARIANT), $(CFG_VARIANTS))
+    $(if $(filter $(DEFAULT_CFG_VARIANT), $(JVM_VARIANTS)), $(DEFAULT_CFG_VARIANT)) \
+    $(filter-out $(DEFAULT_CFG_VARIANT), $(JVM_VARIANTS))
 
 JVMCFG := $(LIB_DST_DIR)/jvm.cfg
 

--- a/make/modules/java.base/Lib.gmk
+++ b/make/modules/java.base/Lib.gmk
@@ -156,11 +156,8 @@ ifeq ($(call isTargetOsType, unix), true)
         TARGETS += $(LIB_OUTPUTDIR)/$1/$(call SHARED_LIBRARY,jsig)
       endef
 
-      # The subdir is the same as the variant for client, minimal or zero, for all
-      # others it's server.
-      VARIANT_SUBDIRS := $(filter client minimal zero, $(JVM_VARIANTS)) \
-          $(if $(filter-out client minimal zero, $(JVM_VARIANTS)), server)
-      $(foreach v, $(VARIANT_SUBDIRS), $(eval $(call CreateSymlinks,$v)))
+      # The subdir is the same as the variant
+      $(foreach v, $(JVM_VARIANTS), $(eval $(call CreateSymlinks,$v)))
     endif
     ############################################################################
 


### PR DESCRIPTION
As the follow-up for Zero-specific JDK-8273494, we might want to clean up build system logic for all VM variants: stop impersonating "server" VMs for all of them. This basically leaves "core" and "custom" variants to be handled with this patch.

Additional testing:
 - [x] Linux x86_64 `core` build passes, `libjvm.so` now in `core`, `jvm.cfg` mentions `-core KNOWN`
 - [x] Linux x86_64 `custom` (+serialgc,+compiler2) build passes, `libjvm.so` now in `custom`, `jvm.cfg` mentions `-custom KNOWN`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273797](https://bugs.openjdk.java.net/browse/JDK-8273797): Stop impersonating "server" VM in all VM variants


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5526/head:pull/5526` \
`$ git checkout pull/5526`

Update a local copy of the PR: \
`$ git checkout pull/5526` \
`$ git pull https://git.openjdk.java.net/jdk pull/5526/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5526`

View PR using the GUI difftool: \
`$ git pr show -t 5526`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5526.diff">https://git.openjdk.java.net/jdk/pull/5526.diff</a>

</details>
