### PR TITLE
8273803: Zero: Handle "zero" variant in CommandLineOptionTest.java

### DIFF
--- a/test/lib/jdk/test/lib/cli/CommandLineOptionTest.java
+++ b/test/lib/jdk/test/lib/cli/CommandLineOptionTest.java
@@ -500,6 +500,8 @@ public abstract class CommandLineOptionTest {
             return "-client";
         } else if (Platform.isMinimal()) {
             return "-minimal";
+        } else if (Platform.isZero()) {
+            return "-zero";
         }
         throw new RuntimeException("Unknown VM mode.");
     }


### PR DESCRIPTION
This currently manifests if you run Zero with compiler/codecache/cli tests (part of tier1):

```
$ CONF=linux-x86_64-zero-fastdebug make exploded-test TEST=compiler/codecache/cli/

STDERR:
java.lang.RuntimeException: Unknown VM mode.
at jdk.test.lib.cli.CommandLineOptionTest.getVMTypeOption(CommandLineOptionTest.java:504)
at jdk.test.lib.cli.CommandLineOptionTest.verifyOptionValueForSameVM(CommandLineOptionTest.java:397)
at compiler.codecache.cli.codeheapsize.GenericCodeHeapSizeRunner.run(GenericCodeHeapSizeRunner.java:42)
at compiler.codecache.cli.common.CodeCacheCLITestCase.run(CodeCacheCLITestCase.java:62)
at compiler.codecache.cli.common.CodeCacheCLITestBase.runTestCases(CodeCacheCLITestBase.java:58)
at compiler.codecache.cli.codeheapsize.TestCodeHeapSizeOptions.main(TestCodeHeapSizeOptions.java:86)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.base/java.lang.reflect.Method.invoke(Method.java:568)
at com.sun.javatest.regtest.agent.MainActionHelper$AgentVMRunnable.run(MainActionHelper.java:312)
at java.base/java.lang.Thread.run(Thread.java:833)
```

While these tests are compiler tests, and they should arguably never run with Zero, the problem is in shared code, which can be used in future by other non-compiler tests. 

Additional testing:
 - [x] Affected compiler tests now "properly" fail with "no compilers" errors

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273803](https://bugs.openjdk.java.net/browse/JDK-8273803): Zero: Handle "zero" variant in CommandLineOptionTest.java


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5527/head:pull/5527` \
`$ git checkout pull/5527`

Update a local copy of the PR: \
`$ git checkout pull/5527` \
`$ git pull https://git.openjdk.java.net/jdk pull/5527/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5527`

View PR using the GUI difftool: \
`$ git pr show -t 5527`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5527.diff">https://git.openjdk.java.net/jdk/pull/5527.diff</a>

</details>
