### PR TITLE
8273804: Platform.isTieredSupported should handle the no-compiler case

### DIFF
--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -79,7 +79,7 @@ public class Platform {
     }
 
     public static boolean isTieredSupported() {
-        return compiler.contains("Tiered Compilers");
+        return (compiler != null) && compiler.contains("Tiered Compilers");
     }
 
     public static boolean isInt() {


### PR DESCRIPTION
Happens with Zero tests:

```
$ CONF=linux-x86_64-zero-fastdebug make exploded-test TEST=compiler/codecache/CheckSegmentedCodeCache.java
...

java.lang.NullPointerException: Cannot invoke "String.contains(java.lang.CharSequence)" because "jdk.test.lib.Platform.compiler" is null
at jdk.test.lib.Platform.isTieredSupported(Platform.java:82)
at compiler.codecache.CheckSegmentedCodeCache.verifySegmentedCodeCache(CheckSegmentedCodeCache.java:61)
at compiler.codecache.CheckSegmentedCodeCache.main(CheckSegmentedCodeCache.java:108)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.base/java.lang.reflect.Method.invoke(Method.java:568)
at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
at java.base/java.lang.Thread.run(Thread.java:833) 
```

Additional testing:
 - [x] Linux x86_64 Zero, `compiler/codecache/CheckSegmentedCodeCache.java` now properly fails with "no compilers" error

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273804](https://bugs.openjdk.java.net/browse/JDK-8273804): Platform.isTieredSupported should handle the no-compiler case


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5528/head:pull/5528` \
`$ git checkout pull/5528`

Update a local copy of the PR: \
`$ git checkout pull/5528` \
`$ git pull https://git.openjdk.java.net/jdk pull/5528/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5528`

View PR using the GUI difftool: \
`$ git pr show -t 5528`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5528.diff">https://git.openjdk.java.net/jdk/pull/5528.diff</a>

</details>
