### PR TITLE
8273805: gc/g1/TestGCLogMessages.java test should handle non-JFR configs

### DIFF
--- a/test/hotspot/jtreg/gc/g1/TestGCLogMessages.java
+++ b/test/hotspot/jtreg/gc/g1/TestGCLogMessages.java
@@ -90,6 +90,17 @@ public class TestGCLogMessages {
         }
     }
 
+    private class LogMessageWithJFROnly extends LogMessageWithLevel {
+        public LogMessageWithJFROnly(String message, Level level) {
+            super(message, level);
+        }
+
+        public boolean isAvailable() {
+            sun.hotspot.WhiteBox WB = sun.hotspot.WhiteBox.getWhiteBox();
+            return WB.isJFRIncluded();
+        }
+    }
+
     private LogMessageWithLevel allLogMessages[] = new LogMessageWithLevel[] {
         new LogMessageWithLevel("Pre Evacuate Collection Set", Level.INFO),
         new LogMessageWithLevel("Evacuate Collection Set", Level.INFO),
@@ -153,7 +164,7 @@ public class TestGCLogMessages {
         new LogMessageWithLevel("JVMTI Tag Weak OopStorage", Level.DEBUG),
         new LogMessageWithLevel("StringTable Weak", Level.DEBUG),
         new LogMessageWithLevel("ResolvedMethodTable Weak", Level.DEBUG),
-        new LogMessageWithLevel("Weak JFR Old Object Samples", Level.DEBUG),
+        new LogMessageWithJFROnly("Weak JFR Old Object Samples", Level.DEBUG),
         new LogMessageWithLevel("JNI Weak", Level.DEBUG),
 
         // Post Evacuate Cleanup 1


### PR DESCRIPTION
JDK-8273147 introduced a more thorough GC messages test, which includes JFR. But it is not guaranteed that JFR is actually in the build, like in the case of Zero:

```
$ CONF=linux-x86_64-zero-fastdebug make exploded-test TEST=gc/g1/TestGCLogMessages.java

java.lang.RuntimeException: '\[debug.*Weak JFR Old Object Samples' missing from stdout/stderr

at jdk.test.lib.process.OutputAnalyzer.shouldMatch(OutputAnalyzer.java:340)
at gc.g1.TestGCLogMessages.checkMessagesAtLevel(TestGCLogMessages.java:193)
at gc.g1.TestGCLogMessages.testNormalLogs(TestGCLogMessages.java:224)
at gc.g1.TestGCLogMessages.main(TestGCLogMessages.java:199)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.base/java.lang.reflect.Method.invoke(Method.java:568)
at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
at java.base/java.lang.Thread.run(Thread.java:833) 
```

Luckily, the test already uses `WhiteBox`, so we can just ask if JFR is in the build or not.

Additional testing:
 - [x] Linux x86_64 Zero, affected test now passes
 - [x] Linux x86_64 Server, affected test still passes
 - [x]  Linux x86_64 Server, verified the JFR test path is taken

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273805](https://bugs.openjdk.java.net/browse/JDK-8273805): gc/g1/TestGCLogMessages.java test should handle non-JFR configs


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5529/head:pull/5529` \
`$ git checkout pull/5529`

Update a local copy of the PR: \
`$ git checkout pull/5529` \
`$ git pull https://git.openjdk.java.net/jdk pull/5529/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5529`

View PR using the GUI difftool: \
`$ git pr show -t 5529`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5529.diff">https://git.openjdk.java.net/jdk/pull/5529.diff</a>

</details>
