### PR TITLE
8273806: compiler/cpuflags/TestSSE4Disabled.java should test for CPU feature explicitly

### DIFF
--- a/test/hotspot/jtreg/compiler/cpuflags/TestSSE4Disabled.java
+++ b/test/hotspot/jtreg/compiler/cpuflags/TestSSE4Disabled.java
@@ -24,7 +24,7 @@
 /*
  * @test TestSSE4Disabled
  * @bug 8158214
- * @requires (vm.simpleArch == "x64")
+ * @requires vm.cpu.features ~= ".*sse4.*"
  * @summary Test correct execution without SSE 4.
  *
  * @run main/othervm -Xcomp -XX:UseSSE=3 compiler.cpuflags.TestSSE4Disabled


### PR DESCRIPTION
JDK-8158214 added a test that verifies that machines with SSE4 support do not crash when lower SSE level is required. But it tests for CPU capabilities weirdly.

This _tangentially_ manifests when running the test with Zero:

```
$ CONF=linux-x86_64-zero-fastdebug make exploded-test TEST=compiler/cpuflags/TestSSE4Disabled.java
...
STDERR:
Unrecognized VM option 'UseSSE=3'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

I think we can test that target CPU supports SSE4, and only run the test then. It would implicitly fix Zero test failure too, as Zero impersonates a "generic" featureless CPU. Plus, it would stop running the -Xcomp test on arches that do not actually need this test to run.

Additional testing:
 - [x] Linux x86_64 Server, TR 3970X, affected test still runs
 - [x] Linux x86_64 Zero, TR 3970X, affected test is now skipped

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273806](https://bugs.openjdk.java.net/browse/JDK-8273806): compiler/cpuflags/TestSSE4Disabled.java should test for CPU feature explicitly


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5530/head:pull/5530` \
`$ git checkout pull/5530`

Update a local copy of the PR: \
`$ git checkout pull/5530` \
`$ git pull https://git.openjdk.java.net/jdk pull/5530/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5530`

View PR using the GUI difftool: \
`$ git pr show -t 5530`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5530.diff">https://git.openjdk.java.net/jdk/pull/5530.diff</a>

</details>
