### PR TITLE
8273807: Zero: Drop incorrect test block from compiler/startup/NumCompilerThreadsCheck.java

### DIFF
--- a/test/hotspot/jtreg/compiler/startup/NumCompilerThreadsCheck.java
+++ b/test/hotspot/jtreg/compiler/startup/NumCompilerThreadsCheck.java
@@ -47,11 +47,6 @@ public class NumCompilerThreadsCheck {
 
     String expectedOutput = "outside the allowed range";
     out.shouldContain(expectedOutput);
-
-    if (Platform.isZero()) {
-      String expectedLowWaterMarkText = "must be at least 0";
-      out.shouldContain(expectedLowWaterMarkText);
-    }
   }
 
 }


### PR DESCRIPTION
There is a Zero-specific test block in compiler/startup/NumCompilerThreadsCheck.java, which currently fails:

```
$ CONF=linux-x86_64-zero-fastdebug make exploded-test TEST=compiler/startup/NumCompilerThreadsCheck.java
...

STDERR:
 stdout: [];
 stderr: [intx CICompilerCount=-1 is outside the allowed range [ 0 ... 2147483647 ]
Improperly specified VM option 'CICompilerCount=-1'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
]
 exitValue = 1

java.lang.RuntimeException: 'must be at least 0' missing from stdout/stderr

at jdk.test.lib.process.OutputAnalyzer.shouldContain(OutputAnalyzer.java:221)
at compiler.startup.NumCompilerThreadsCheck.main(NumCompilerThreadsCheck.java:53)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.base/java.lang.reflect.Method.invoke(Method.java:568)
at com.sun.javatest.regtest.agent.MainActionHelper$AgentVMRunnable.run(MainActionHelper.java:312)
at java.base/java.lang.Thread.run(Thread.java:833)
```

I believe it was rendered obsolete by JDK-8122937. 

Additional testing:
 - [x] Linux x86_64 Zero, affected test now passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273807](https://bugs.openjdk.java.net/browse/JDK-8273807): Zero: Drop incorrect test block from compiler/startup/NumCompilerThreadsCheck.java


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5531/head:pull/5531` \
`$ git checkout pull/5531`

Update a local copy of the PR: \
`$ git checkout pull/5531` \
`$ git pull https://git.openjdk.java.net/jdk pull/5531/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5531`

View PR using the GUI difftool: \
`$ git pr show -t 5531`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5531.diff">https://git.openjdk.java.net/jdk/pull/5531.diff</a>

</details>
