### PR TITLE
8273821: Limit parallelism for sanity/client/SwingSet tests

### DIFF
--- a/test/jdk/sanity/client/TEST.properties
+++ b/test/jdk/sanity/client/TEST.properties
@@ -28,3 +28,6 @@
 
 # The list of keywords supported in this part of the test suite
 keys=screenshots
+
+# These are GUI tests, they cannot run in parallel with other tests
+exclusiveAccess.dirs=SwingSet/src


### PR DESCRIPTION
If you run them today on a parallel machine with the usual invocation:

$ CONF=linux-x86_64-server-fastdebug make run-test TEST=sanity/client/SwingSet/

...then a whole lot of these tests would fail. It seems to be caused by the overlapping GUI windows that robots fail to reach properly then. It seems these tests need to be run exclusively. 

@mrserb, maybe I am missing something? How do you run these tests? 

Additional testing:
 - [x] `sanity/client/SwingSet/` tests now pass on TR 3970X

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8273821](https://bugs.openjdk.java.net/browse/JDK-8273821): Limit parallelism for sanity/client/SwingSet tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5533/head:pull/5533` \
`$ git checkout pull/5533`

Update a local copy of the PR: \
`$ git checkout pull/5533` \
`$ git pull https://git.openjdk.java.net/jdk pull/5533/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5533`

View PR using the GUI difftool: \
`$ git pr show -t 5533`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5533.diff">https://git.openjdk.java.net/jdk/pull/5533.diff</a>

</details>
