### PR TITLE
8273823: Problemlist gc/stringdedup tests timing out on ZGC

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -85,6 +85,11 @@ gc/stress/gclocker/TestGCLockerWithParallel.java 8180622 generic-all
 gc/stress/gclocker/TestGCLockerWithG1.java 8180622 generic-all
 gc/stress/TestJNIBlockFullGC/TestJNIBlockFullGC.java 8192647 generic-all
 gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java 8241293 macosx-x64
+gc/stringdedup/TestStringDeduplicationAgeThreshold.java#id4 8273695 generic-all
+gc/stringdedup/TestStringDeduplicationPrintOptions.java#id4 8273695 generic-all
+gc/stringdedup/TestStringDeduplicationInterned.java#id4 8273695 generic-all
+gc/stringdedup/TestStringDeduplicationTableResize.java#id4 8273695 generic-all
+gc/stringdedup/TestStringDeduplicationYoungGC.java#id4 8273695 generic-all
 
 #############################################################################
 


### PR DESCRIPTION
Hi all,

  can I have reviews for problemlist the gc/stringdedup tests for ZGC? They time out a lot in CI currently, and generate a lot of noise.

Testing: CI run with this change does not run the #id4 tests any more

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273823](https://bugs.openjdk.java.net/browse/JDK-8273823): Problemlist gc/stringdedup tests timing out on ZGC


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Leo Korinth](https://openjdk.java.net/census#lkorinth) (@lkorinth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5534/head:pull/5534` \
`$ git checkout pull/5534`

Update a local copy of the PR: \
`$ git checkout pull/5534` \
`$ git pull https://git.openjdk.java.net/jdk pull/5534/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5534`

View PR using the GUI difftool: \
`$ git pr show -t 5534`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5534.diff">https://git.openjdk.java.net/jdk/pull/5534.diff</a>

</details>
