### PR TITLE
8273832: gc/shenandoah/TestJcmdHeapDump.java does not have a @requires vm.gc.shenandoah

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/TestJcmdHeapDump.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestJcmdHeapDump.java
@@ -26,7 +26,7 @@
  * @test id=passive
  * @library /test/lib
  * @modules jdk.attach/com.sun.tools.attach
-
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive
@@ -43,6 +43,7 @@
  * @test id=aggressive
  * @library /test/lib
  * @modules jdk.attach/com.sun.tools.attach
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
@@ -63,6 +64,7 @@
  * @test id=adaptive
  * @library /test/lib
  * @modules jdk.attach/com.sun.tools.attach
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=adaptive
@@ -74,6 +76,7 @@
  * @test id=static
  * @library /test/lib
  * @modules jdk.attach/com.sun.tools.attach
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=static
@@ -84,6 +87,7 @@
  * @test id=compact
  * @library /test/lib
  * @modules jdk.attach/com.sun.tools.attach
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact
@@ -94,6 +98,7 @@
  * @test id=iu-aggressive
  * @library /test/lib
  * @modules jdk.attach/com.sun.tools.attach
+ * @requires vm.gc.Shenandoah
  *
  * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive


### PR DESCRIPTION
Hi all,

  can I get quick reviews for this change adding necessary @requires labels for builds without Shenandoah?

Currently testing tier2 with this change, but I expect this to work.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273832](https://bugs.openjdk.java.net/browse/JDK-8273832): gc/shenandoah/TestJcmdHeapDump.java does not have a @requires vm.gc.shenandoah


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5535/head:pull/5535` \
`$ git checkout pull/5535`

Update a local copy of the PR: \
`$ git checkout pull/5535` \
`$ git pull https://git.openjdk.java.net/jdk pull/5535/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5535`

View PR using the GUI difftool: \
`$ git pr show -t 5535`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5535.diff">https://git.openjdk.java.net/jdk/pull/5535.diff</a>

</details>
