### PR TITLE
[PATCH] Use handy Arrays.stream() method instead of Arrays.asList().stream()/List.of().stream()

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/sjavac/Main.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/sjavac/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,8 +49,7 @@ public class Main {
     public static int go(String[] args) {
 
         // Server or client mode?
-        boolean serverMode = Arrays.asList(args)
-                                   .stream()
+        boolean serverMode = Arrays.stream(args)
                                    .anyMatch(arg -> arg.startsWith(STARTSERVER.arg));
 
         return serverMode ? ServerMain.run(args) : ClientMain.run(args);

--- a/src/jdk.jlink/share/classes/jdk/tools/jimage/JImageTask.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jimage/JImageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -201,7 +201,7 @@ class JImageTask {
             if (options.help) {
                 if (options.task == null) {
                     log.println(TASK_HELPER.getMessage("main.usage", PROGNAME));
-                    Arrays.asList(RECOGNIZED_OPTIONS).stream()
+                    Arrays.stream(RECOGNIZED_OPTIONS)
                         .filter(option -> !option.isHidden())
                         .sorted()
                         .forEach(option -> {

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/PerfectHashBuilder.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/PerfectHashBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -295,7 +295,7 @@ public class PerfectHashBuilder<E> {
         });
 
         // Sort chains, longest first.
-        Bucket<E>[] sorted = Arrays.asList(buckets).stream()
+        Bucket<E>[] sorted = Arrays.stream(buckets)
                 .filter((bucket) -> (bucket != null))
                 .sorted()
                 .toArray((length) -> {

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/IncludeLocalesPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/IncludeLocalesPlugin.java
@@ -130,7 +130,7 @@ public final class IncludeLocalesPlugin extends AbstractPlugin implements Resour
                                 Arrays.stream(CLDR_PARENT_LOCALES.getOrDefault(
                                     Locale.forLanguageTag(child), new String[0]))
                                         .filter(grandchild -> !grandchild.isEmpty()),
-                                List.of(child).stream()))
+                                Stream.of(child)))
                         .distinct()
                         .forEach(children::add);
                     return new AbstractMap.SimpleEntry<String, List<String>>(parent, children);
@@ -404,6 +404,6 @@ public final class IncludeLocalesPlugin extends AbstractPlugin implements Resour
                 break;
         }
 
-        return tags == null ? List.of(tag).stream() : tags.stream();
+        return tags == null ? Stream.of(tag) : tags.stream();
     }
 }

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
@@ -33,6 +33,7 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -308,7 +309,7 @@ final class LauncherData {
         return getPathParam(params, paramName, () -> {
             String value = (String) params.get(paramName);
             return (value == null) ? List.of() :
-                    List.of(value.split(File.pathSeparator)).stream()
+                    Arrays.stream(value.split(File.pathSeparator))
                     .map(Path::of)
                     .collect(Collectors.toUnmodifiableList());
         });


### PR DESCRIPTION
With `Arrays.stream()` code is shorter and also it allows to avoid redundant List object creation.
Found by IntelliJ IDEA inspection `Stream API call chain can be simplified`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5536/head:pull/5536` \
`$ git checkout pull/5536`

Update a local copy of the PR: \
`$ git checkout pull/5536` \
`$ git pull https://git.openjdk.java.net/jdk pull/5536/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5536`

View PR using the GUI difftool: \
`$ git pr show -t 5536`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5536.diff">https://git.openjdk.java.net/jdk/pull/5536.diff</a>

</details>
