### PR TITLE
[PATCH] Use shorter String.join method instead of Stream.collect(joining())

### DIFF
--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -2257,7 +2257,7 @@ public final class Locale implements Cloneable, Serializable {
         // If we have no list patterns, compose the list in a simple,
         // non-localized way.
         if (pattern == null) {
-            return Arrays.stream(stringList).collect(Collectors.joining(","));
+            return String.join(",", stringList);
         }
 
         return switch (stringList.length) {

--- a/src/java.base/share/classes/sun/launcher/LauncherHelper.java
+++ b/src/java.base/share/classes/sun/launcher/LauncherHelper.java
@@ -1153,7 +1153,7 @@ public final class LauncherHelper {
             ostream.format("uses %s%n", s);
         }
         for (Provides ps : md.provides()) {
-            String names = ps.providers().stream().collect(Collectors.joining(" "));
+            String names = String.join(" ", ps.providers());
             ostream.format("provides %s with %s%n", ps.service(), names);
 
         }
@@ -1161,7 +1161,7 @@ public final class LauncherHelper {
         // qualified exports
         for (Exports e : md.exports()) {
             if (e.isQualified()) {
-                String who = e.targets().stream().collect(Collectors.joining(" "));
+                String who = String.join(" ", e.targets());
                 ostream.format("qualified exports %s to %s%n", e.source(), who);
             }
         }
@@ -1175,7 +1175,7 @@ public final class LauncherHelper {
                     .collect(Collectors.joining(" "));
             ostream.format("opens %s", sourceAndMods);
             if (opens.isQualified()) {
-                String who = opens.targets().stream().collect(Collectors.joining(" "));
+                String who = String.join(" ", opens.targets());
                 ostream.format(" to %s", who);
             }
             ostream.println();

--- a/src/java.net.http/share/classes/jdk/internal/net/http/hpack/HPACK.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/hpack/HPACK.java
@@ -65,7 +65,7 @@ public final class HPACK {
                 LOGGER = new RootLogger(NONE);
                 LOGGER.log(System.Logger.Level.INFO,
                         () -> format("%s value '%s' not recognized (use %s); logging disabled",
-                                     PROPERTY, value, logLevels.keySet().stream().collect(joining(", "))));
+                                     PROPERTY, value, String.join(", ", logLevels.keySet())));
             } else {
                 LOGGER = new RootLogger(l);
                 LOGGER.log(System.Logger.Level.DEBUG,

--- a/src/jdk.compiler/share/classes/jdk/internal/shellsupport/doc/JavadocHelper.java
+++ b/src/jdk.compiler/share/classes/jdk/internal/shellsupport/doc/JavadocHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -564,7 +564,7 @@ public abstract class JavadocHelper implements AutoCloseable {
             for (Entry<int[], List<String>> e : replace.entrySet()) {
                 replacedInheritDoc.delete(e.getKey()[0] - offset, e.getKey()[1] - offset);
                 replacedInheritDoc.insert(e.getKey()[0] - offset,
-                                          e.getValue().stream().collect(Collectors.joining("")));
+                                          String.join("", e.getValue()));
             }
 
             return replacedInheritDoc.toString();

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -562,7 +562,7 @@ class JdepsTask {
                       .sorted(Map.Entry.comparingByKey())
                       .forEach(e -> warning("warn.split.package",
                                             e.getKey(),
-                                            e.getValue().stream().collect(joining(" "))));
+                                            String.join(" ", e.getValue())));
             }
 
             // check if any module specified in --add-modules, --require, and -m is missing

--- a/src/jdk.jlink/share/classes/jdk/tools/jimage/JImageTask.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jimage/JImageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -222,7 +222,7 @@ class JImageTask {
             if (options.version || options.fullVersion) {
                 if (options.task == null && !unhandled.isEmpty()) {
                     throw TASK_HELPER.newBadArgs("err.not.a.task",
-                        Stream.of(args).collect(Collectors.joining(" ")));
+                        String.join(" ", args));
                 }
 
                 TASK_HELPER.showVersion(options.fullVersion);

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JlinkTask.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JlinkTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -233,7 +233,7 @@ public class JlinkTask {
             List<String> remaining = optionsHelper.handleOptions(this, args);
             if (remaining.size() > 0 && !options.suggestProviders) {
                 throw taskHelper.newBadArgs("err.orphan.arguments",
-                                                 remaining.stream().collect(Collectors.joining(" ")))
+                                            String.join(" ", remaining))
                                 .showUsage(true);
             }
             if (options.help) {
@@ -713,7 +713,7 @@ public class JlinkTask {
                                         : args.subList(1, args.size());
             throw taskHelper.newBadArgs("err.invalid.arg.for.option",
                                         "--suggest-providers",
-                                        arguments.stream().collect(Collectors.joining(" ")));
+                                        String.join(" ", arguments));
         }
 
         if (options.bindServices) {

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/JLinkBundlerHelper.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/JLinkBundlerHelper.java
@@ -208,8 +208,7 @@ final class JLinkBundlerHelper {
     }
 
     private static String getStringList(Set<String> strings) {
-        return Matcher.quoteReplacement(strings.stream().collect(
-                Collectors.joining(",")));
+        return Matcher.quoteReplacement(String.join(",", strings));
     }
 
     // The token for "all modules on the module path".

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/ConsoleIOContext.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/ConsoleIOContext.java
@@ -788,7 +788,7 @@ class ConsoleIOContext extends IOContext {
         public Result perform(String text, int cursor) throws IOException {
             in.getTerminal().writer().println();
             in.getTerminal().writer().println(repl.getResourceString("jshell.console.completion.current.signatures"));
-            in.getTerminal().writer().println(doc.stream().collect(Collectors.joining(LINE_SEPARATOR)));
+            in.getTerminal().writer().println(String.join(LINE_SEPARATOR, doc));
             return Result.FINISH;
         }
 

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -384,15 +384,13 @@ public class JShellTool implements MessageHandler {
                 return parse(oset);
             } catch (OptionException ex) {
                 if (ex.options().isEmpty()) {
-                    msg("jshell.err.opt.invalid", stream(args).collect(joining(", ")));
+                    msg("jshell.err.opt.invalid", String.join(", ", args));
                 } else {
                     boolean isKnown = parser.recognizedOptions().containsKey(ex.options().iterator().next());
                     msg(isKnown
                             ? "jshell.err.opt.arg"
                             : "jshell.err.opt.unknown",
-                            ex.options()
-                            .stream()
-                            .collect(joining(", ")));
+                            String.join(", ", ex.options()));
                 }
                 exitCode = 1;
                 return null;
@@ -2062,16 +2060,14 @@ public class JShellTool implements MessageHandler {
         if (matches.length == 0) {
             // There are no matching sub-commands
             errormsg("jshell.err.arg", cmd, sub);
-            fluffmsg("jshell.msg.use.one.of", Arrays.stream(subs)
-                    .collect(Collectors.joining(", "))
+            fluffmsg("jshell.msg.use.one.of", String.join(", ", subs)
             );
             return null;
         }
         if (matches.length > 1) {
             // More than one sub-command matches the initial characters provided
             errormsg("jshell.err.sub.ambiguous", cmd, sub);
-            fluffmsg("jshell.msg.use.one.of", Arrays.stream(matches)
-                    .collect(Collectors.joining(", "))
+            fluffmsg("jshell.msg.use.one.of", String.join(", ", matches)
             );
             return null;
         }


### PR DESCRIPTION
String.join is shorter and easier to read.
It's also more performant, as it was heavily optimized recently in [JDK-8265237](https://bugs.openjdk.java.net/browse/JDK-8265237)
Found by IntelliJ IDEA inspection `Stream API call chain can be simplified`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5537/head:pull/5537` \
`$ git checkout pull/5537`

Update a local copy of the PR: \
`$ git checkout pull/5537` \
`$ git pull https://git.openjdk.java.net/jdk pull/5537/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5537`

View PR using the GUI difftool: \
`$ git pr show -t 5537`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5537.diff">https://git.openjdk.java.net/jdk/pull/5537.diff</a>

</details>
