### PR TITLE
8270434: JDI+UT: Unexpected event in JDI tests

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventIterator/nextEvent/nextevent001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventIterator/nextEvent/nextevent001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -320,6 +320,8 @@ public class nextevent001 extends JDIBase {
         log1("     TESTING BEGINS");
 
         {
+            final String testThreadName = "thread2";
+
             log2("......setting up ThreadStartRequest");
             ThreadStartRequest tsr = eventRManager.createThreadStartRequest();
             tsr.addCountFilter(1);
@@ -342,7 +344,7 @@ public class nextevent001 extends JDIBase {
             vm.resume();
 
             log2("......waiting for ThreadStartEvent");
-            getEventSet();
+            getEventSetForThreadStartDeath(testThreadName);
             eventSets[10] = eventSet;
 
             Event receivedEvent = eventIterator.nextEvent();
@@ -357,7 +359,7 @@ public class nextevent001 extends JDIBase {
             vm.resume();
 
             log2("......waiting for ThreadDeathEvent");
-            getEventSet();
+            getEventSetForThreadStartDeath(testThreadName);
             eventSets[9] = eventSet;
             receivedEvent = eventIterator.nextEvent();
             if ( !(receivedEvent instanceof ThreadDeathEvent) ) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/methodEntryRequests/methentreq002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/methodEntryRequests/methentreq002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -266,7 +266,7 @@ public class methentreq002 extends JDIBase {
         for (int i = 0; ; i++) {
 
             vm.resume();
-            breakpointForCommunication();
+            breakpointForCommunication(debuggeeName);
 
             int instruction = ((IntegerValue)
                                (debuggeeClass.getValue(debuggeeClass.fieldByName("instruction")))).value();

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/JDIBase.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/JDIBase.java
@@ -197,4 +197,25 @@ public class JDIBase {
         throw new JDITestRuntimeException("** event '" + event + "' IS NOT a breakpoint **");
     }
 
+    // Similar to breakpointForCommunication, but skips Locatable events from unexpected locations.
+    // It's useful for cases when enabled event requests can cause notifications from system threads
+    // (like MethodEntryRequest, MethodExitRequest).
+    protected void breakpointForCommunication(String debuggeeName) throws JDITestRuntimeException {
+        log2("breakpointForCommunication");
+        while (true) {
+            getEventSet();
+
+            Event event = eventIterator.nextEvent();
+            if (event instanceof BreakpointEvent) {
+                return;
+            }
+            if (EventFilters.filtered(event, debuggeeName)) {
+                log2("  got unexpected event: " + event + ", skipping");
+                eventSet.resume();
+            } else {
+                throw new JDITestRuntimeException("** event '" + event + "' IS NOT a breakpoint **");
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Updated the tests to skip events from unexpected threads.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270434](https://bugs.openjdk.java.net/browse/JDK-8270434): JDI+UT: Unexpected event in JDI tests


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5538/head:pull/5538` \
`$ git checkout pull/5538`

Update a local copy of the PR: \
`$ git checkout pull/5538` \
`$ git pull https://git.openjdk.java.net/jdk pull/5538/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5538`

View PR using the GUI difftool: \
`$ git pr show -t 5538`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5538.diff">https://git.openjdk.java.net/jdk/pull/5538.diff</a>

</details>
