### PR TITLE
JDK-8273815: move have_special_privileges to os_posix for POSIX platforms

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -267,18 +267,6 @@ julong os::physical_memory() {
   return Aix::physical_memory();
 }
 
-// Return true if user is running as root.
-
-bool os::have_special_privileges() {
-  static bool init = false;
-  static bool privileges = false;
-  if (!init) {
-    privileges = (getuid() != geteuid()) || (getgid() != getegid());
-    init = true;
-  }
-  return privileges;
-}
-
 // Helper function, emulates disclaim64 using multiple 32bit disclaims
 // because we cannot use disclaim64() on AS/400 and old AIX releases.
 static bool my_disclaim64(char* addr, size_t size) {

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -179,20 +179,6 @@ julong os::physical_memory() {
   return Bsd::physical_memory();
 }
 
-// Return true if user is running as root.
-
-bool os::have_special_privileges() {
-  static bool init = false;
-  static bool privileges = false;
-  if (!init) {
-    privileges = (getuid() != geteuid()) || (getgid() != getegid());
-    init = true;
-  }
-  return privileges;
-}
-
-
-
 // Cpu architecture string
 #if   defined(ZERO)
 static char cpu_arch[] = ZERO_LIBARCH;

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -308,19 +308,6 @@ bool os::Linux::get_tick_information(CPUPerfTicks* pticks, int which_logical_cpu
   return true;
 }
 
-// Return true if user is running as root.
-
-bool os::have_special_privileges() {
-  static bool init = false;
-  static bool privileges = false;
-  if (!init) {
-    privileges = (getuid() != geteuid()) || (getgid() != getegid());
-    init = true;
-  }
-  return privileges;
-}
-
-
 #ifndef SYS_gettid
 // i386: 224, ia64: 1105, amd64: 186, sparc: 143
   #ifdef __ia64__

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -185,12 +185,7 @@ size_t os::lasterror(char *buf, size_t len) {
 
 // Return true if user is running as root.
 bool os::have_special_privileges() {
-  static bool init = false;
-  static bool privileges = false;
-  if (!init) {
-    privileges = (getuid() != geteuid()) || (getgid() != getegid());
-    init = true;
-  }
+  static bool privileges = (getuid() != geteuid()) || (getgid() != getegid());
   return privileges;
 }
 

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -183,6 +183,17 @@ size_t os::lasterror(char *buf, size_t len) {
   return n;
 }
 
+// Return true if user is running as root.
+bool os::have_special_privileges() {
+  static bool init = false;
+  static bool privileges = false;
+  if (!init) {
+    privileges = (getuid() != geteuid()) || (getgid() != getegid());
+    init = true;
+  }
+  return privileges;
+}
+
 void os::wait_for_keypress_at_exit(void) {
   // don't do anything on posix platforms
   return;


### PR DESCRIPTION
We have identical have_special_privileges() for Linux/AIX/BSD so the function is a good candidate to be moved to os_posix.

Thanks, Matthias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273815](https://bugs.openjdk.java.net/browse/JDK-8273815): move have_special_privileges to os_posix for POSIX platforms


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to 3e48d8cf6bab6b9213aa9b506ebcab7ae38d9edc
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5540/head:pull/5540` \
`$ git checkout pull/5540`

Update a local copy of the PR: \
`$ git checkout pull/5540` \
`$ git pull https://git.openjdk.java.net/jdk pull/5540/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5540`

View PR using the GUI difftool: \
`$ git pr show -t 5540`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5540.diff">https://git.openjdk.java.net/jdk/pull/5540.diff</a>

</details>
