### PR TITLE
8273872: ZGC: Explicitly use 2M large pages

### DIFF
--- a/src/hotspot/os/linux/gc/z/zPhysicalMemoryBacking_linux.cpp
+++ b/src/hotspot/os/linux/gc/z/zPhysicalMemoryBacking_linux.cpp
@@ -196,6 +196,8 @@ ZPhysicalMemoryBacking::ZPhysicalMemoryBacking(size_t max_capacity) :
 }
 
 int ZPhysicalMemoryBacking::create_mem_fd(const char* name) const {
+  assert(ZGranuleSize == 2 * M, "Granule size must match MFD_HUGE_2MB");
+
   // Create file name
   char filename[PATH_MAX];
   snprintf(filename, sizeof(filename), "%s%s", name, ZLargePages::is_explicit() ? ".hugetlb" : "");

--- a/src/hotspot/share/gc/z/zArguments.cpp
+++ b/src/hotspot/share/gc/z/zArguments.cpp
@@ -72,9 +72,9 @@ void ZArguments::initialize() {
     vm_exit_during_initialization("The flag -XX:+UseZGC can not be combined with -XX:ConcGCThreads=0");
   }
 
-  // Only 2M large pages is supported
+  // Only 2M large pages are supported
   if (!FLAG_IS_DEFAULT(LargePageSizeInBytes) && LargePageSizeInBytes != 2 * M) {
-    vm_exit_during_initialization("Invalid -XX:LargePageSizeInBytes (only 2M large pages is supported)");
+    vm_exit_during_initialization("Incompatible -XX:LargePageSizeInBytes, only 2M large pages are supported by ZGC");
   }
 
   // The heuristics used when UseDynamicNumberOfGCThreads is

--- a/src/hotspot/share/gc/z/zArguments.cpp
+++ b/src/hotspot/share/gc/z/zArguments.cpp
@@ -74,7 +74,8 @@ void ZArguments::initialize() {
 
   // Only 2M large pages are supported
   if (!FLAG_IS_DEFAULT(LargePageSizeInBytes) && LargePageSizeInBytes != ZGranuleSize) {
-    vm_exit_during_initialization(err_msg("Incompatible -XX:LargePageSizeInBytes, only " SIZE_FORMAT "M large pages are supported by ZGC",
+    vm_exit_during_initialization(err_msg("Incompatible -XX:LargePageSizeInBytes, only "
+                                          SIZE_FORMAT "M large pages are supported by ZGC",
                                           ZGranuleSize / M));
   }
 

--- a/src/hotspot/share/gc/z/zArguments.cpp
+++ b/src/hotspot/share/gc/z/zArguments.cpp
@@ -72,7 +72,7 @@ void ZArguments::initialize() {
     vm_exit_during_initialization("The flag -XX:+UseZGC can not be combined with -XX:ConcGCThreads=0");
   }
 
-  // Only 2M large pages are supported
+  // Large page size must match granule size
   if (!FLAG_IS_DEFAULT(LargePageSizeInBytes) && LargePageSizeInBytes != ZGranuleSize) {
     vm_exit_during_initialization(err_msg("Incompatible -XX:LargePageSizeInBytes, only "
                                           SIZE_FORMAT "M large pages are supported by ZGC",

--- a/src/hotspot/share/gc/z/zArguments.cpp
+++ b/src/hotspot/share/gc/z/zArguments.cpp
@@ -72,6 +72,11 @@ void ZArguments::initialize() {
     vm_exit_during_initialization("The flag -XX:+UseZGC can not be combined with -XX:ConcGCThreads=0");
   }
 
+  // Only 2M large pages is supported
+  if (!FLAG_IS_DEFAULT(LargePageSizeInBytes) && LargePageSizeInBytes != 2 * M) {
+    vm_exit_during_initialization("Invalid -XX:LargePageSizeInBytes (only 2M large pages is supported)");
+  }
+
   // The heuristics used when UseDynamicNumberOfGCThreads is
   // enabled defaults to using a ZAllocationSpikeTolerance of 1.
   if (UseDynamicNumberOfGCThreads && FLAG_IS_DEFAULT(ZAllocationSpikeTolerance)) {

--- a/src/hotspot/share/gc/z/zArguments.cpp
+++ b/src/hotspot/share/gc/z/zArguments.cpp
@@ -73,8 +73,9 @@ void ZArguments::initialize() {
   }
 
   // Only 2M large pages are supported
-  if (!FLAG_IS_DEFAULT(LargePageSizeInBytes) && LargePageSizeInBytes != 2 * M) {
-    vm_exit_during_initialization("Incompatible -XX:LargePageSizeInBytes, only 2M large pages are supported by ZGC");
+  if (!FLAG_IS_DEFAULT(LargePageSizeInBytes) && LargePageSizeInBytes != ZGranuleSize) {
+    vm_exit_during_initialization(err_msg("Incompatible -XX:LargePageSizeInBytes, only " SIZE_FORMAT "M large pages are supported by ZGC",
+                                          ZGranuleSize / M));
   }
 
   // The heuristics used when UseDynamicNumberOfGCThreads is


### PR DESCRIPTION
ZGC requires large pages to be 2M. However, ZGC doesn't explicitly asks for this page size and instead relies on the default large pages size for the system to be 2M. On systems where this is not true, ZGC will fails with an error message. To avoid this, ZGC should explicitly ask for 2M large pages and not rely on the system default. Furthermore, ZGC currently ignores `-XX:LargePageSizeInBytes`. ZGC should fails with an error message if it's specified to something other than 2M.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273872](https://bugs.openjdk.java.net/browse/JDK-8273872): ZGC: Explicitly use 2M large pages


### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to 7228007a3b08b92a1dc28dc138d8296ee3d00461
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 910ef308deff7f6af462c48141a9db5873db2827
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5541/head:pull/5541` \
`$ git checkout pull/5541`

Update a local copy of the PR: \
`$ git checkout pull/5541` \
`$ git pull https://git.openjdk.java.net/jdk pull/5541/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5541`

View PR using the GUI difftool: \
`$ git pr show -t 5541`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5541.diff">https://git.openjdk.java.net/jdk/pull/5541.diff</a>

</details>
