### PR TITLE
8273907: Cleanup redundant Math.max/min calls in DefaultHighlighter

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/DefaultHighlighter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/DefaultHighlighter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import javax.swing.*;
 public class DefaultHighlighter extends LayeredHighlighter {
 
     /**
-     * Creates a new DefaultHighlighther object.
+     * Creates a new DefaultHighlighter object.
      */
     public DefaultHighlighter() {
         drawsLayeredHighlights = true;
@@ -244,7 +244,7 @@ public class DefaultHighlighter extends LayeredHighlighter {
             lhi.width = lhi.height = 0;
             lhi.p0 = doc.createPosition(p0);
             lhi.p1 = doc.createPosition(p1);
-            safeDamageRange(Math.min(p0, p1), Math.max(p0, p1));
+            safeDamageRange(p0, p1);
         }
         else {
             HighlightInfo info = (HighlightInfo) tag;


### PR DESCRIPTION
This calls are redundant, because order of `p0` and `p1` is checked in method pre-conditions.
Checks were added under [JDK-6771184](https://bugs.openjdk.java.net/browse/JDK-6771184) - https://github.com/openjdk/jdk/commit/79ed0e75ceeb

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273907](https://bugs.openjdk.java.net/browse/JDK-8273907): Cleanup redundant Math.max/min calls in DefaultHighlighter


### Reviewers
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5542/head:pull/5542` \
`$ git checkout pull/5542`

Update a local copy of the PR: \
`$ git checkout pull/5542` \
`$ git pull https://git.openjdk.java.net/jdk pull/5542/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5542`

View PR using the GUI difftool: \
`$ git pr show -t 5542`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5542.diff">https://git.openjdk.java.net/jdk/pull/5542.diff</a>

</details>
