### PR TITLE
JDK-8262944: Improve exception message when automatic module lists provider class not in JAR file

### DIFF
--- a/src/java.base/share/classes/jdk/internal/module/ModulePath.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModulePath.java
@@ -551,7 +551,7 @@ public class ModulePath implements ModuleFinder {
                     if (!cn.isEmpty()) {
                         String pn = packageName(cn);
                         if (!packages.contains(pn)) {
-                            String msg = "Provider class " + cn + " not in module created for " + fn;
+                            String msg = "Provider class " + cn + " not in JAR file " + fn;
                             throw new InvalidModuleDescriptorException(msg);
                         }
                         providerClasses.add(cn);

--- a/src/java.base/share/classes/jdk/internal/module/ModulePath.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModulePath.java
@@ -551,7 +551,7 @@ public class ModulePath implements ModuleFinder {
                     if (!cn.isEmpty()) {
                         String pn = packageName(cn);
                         if (!packages.contains(pn)) {
-                            String msg = "Provider class " + cn + " not in module";
+                            String msg = "Provider class " + cn + " not in module created for " + fn;
                             throw new InvalidModuleDescriptorException(msg);
                         }
                         providerClasses.add(cn);

--- a/test/jdk/java/lang/module/AutomaticModulesTest.java
+++ b/test/jdk/java/lang/module/AutomaticModulesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8142968 8253751
+ * @bug 8142968 8253751 8262944
  * @library /test/lib
  * @build AutomaticModulesTest
  *        jdk.test.lib.util.JarUtils

--- a/test/jdk/java/lang/module/AutomaticModulesTest.java
+++ b/test/jdk/java/lang/module/AutomaticModulesTest.java
@@ -35,6 +35,7 @@
 import java.io.IOException;
 import java.lang.module.Configuration;
 import java.lang.module.FindException;
+import java.lang.module.InvalidModuleDescriptorException;
 import java.lang.module.ModuleDescriptor;
 import java.lang.module.ModuleDescriptor.Requires.Modifier;
 import java.lang.module.ModuleFinder;
@@ -449,10 +450,10 @@ public class AutomaticModulesTest {
                 }
                 throw new AssertionError(
                     """
-                        Unexpected detail message in InvalidModuleDescriptorException:
-                          Expected message -> '%s'
-                            Actual message -> '%s'
-                        """.formatted(expectedMessage, actualMessage));
+                    Unexpected detail message in InvalidModuleDescriptorException:
+                      Expected message -> '%s'
+                        Actual message -> '%s'
+                    """.formatted(expectedMessage, actualMessage));
             }
             throw new AssertionError("Unexpected exception cause: " + exception.getCause());
         }

--- a/test/jdk/java/lang/module/AutomaticModulesTest.java
+++ b/test/jdk/java/lang/module/AutomaticModulesTest.java
@@ -439,7 +439,7 @@ public class AutomaticModulesTest {
         JarUtils.createJarFile(jarfile, tmpdir);
 
         // catch FindException, inspect its cause's type and details, and rethrow
-        var expectedMessage = "Provider class q.P not in module created for " + jarfile;
+        var expectedMessage = "Provider class q.P not in module created for " + jarfile.getFileName();
         try {
             ModuleFinder.of(dir).findAll();
         } catch (FindException exception) {

--- a/test/jdk/java/lang/module/AutomaticModulesTest.java
+++ b/test/jdk/java/lang/module/AutomaticModulesTest.java
@@ -439,7 +439,7 @@ public class AutomaticModulesTest {
         JarUtils.createJarFile(jarfile, tmpdir);
 
         // catch FindException, inspect its cause's type and details, and rethrow
-        var expectedMessage = "Provider class q.P not in module created for " + jarfile.getFileName();
+        var expectedMessage = "Provider class q.P not in JAR file " + jarfile.getFileName();
         try {
             ModuleFinder.of(dir).findAll();
         } catch (FindException exception) {


### PR DESCRIPTION
This commit appends the name of the JAR file to the exception message for when automatic module lists a non-existing provider class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262944](https://bugs.openjdk.java.net/browse/JDK-8262944): Improve exception message when automatic module lists provider class not in JAR file


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to bb9762b890756b140a8db4ef3feaa9cb056b1607
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - **Reviewer**) ⚠️ Review applies to bb9762b890756b140a8db4ef3feaa9cb056b1607
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5543/head:pull/5543` \
`$ git checkout pull/5543`

Update a local copy of the PR: \
`$ git checkout pull/5543` \
`$ git pull https://git.openjdk.java.net/jdk pull/5543/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5543`

View PR using the GUI difftool: \
`$ git pr show -t 5543`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5543.diff">https://git.openjdk.java.net/jdk/pull/5543.diff</a>

</details>
