### PR TITLE
8236505: Mark jdk/editpad/EditPadTest.java as @headful

### DIFF
--- a/test/jdk/jdk/editpad/EditPadTest.java
+++ b/test/jdk/jdk/editpad/EditPadTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8167636 8167639 8168972
  * @summary Testing built-in editor.
  * @modules java.desktop/java.awt


### PR DESCRIPTION
This is a GUI test, and it should be `@headful`.

Additional testing:
 - [x] Test still runs in default, and does not run with `!headful`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8236505](https://bugs.openjdk.java.net/browse/JDK-8236505): Mark jdk/editpad/EditPadTest.java as @headful


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5544/head:pull/5544` \
`$ git checkout pull/5544`

Update a local copy of the PR: \
`$ git checkout pull/5544` \
`$ git pull https://git.openjdk.java.net/jdk pull/5544/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5544`

View PR using the GUI difftool: \
`$ git pr show -t 5544`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5544.diff">https://git.openjdk.java.net/jdk/pull/5544.diff</a>

</details>
