### PR TITLE
JDK-8273902: Memory leak in OopStorage due to bug in OopHandle::release()

### DIFF
--- a/src/hotspot/share/oops/oopHandle.inline.hpp
+++ b/src/hotspot/share/oops/oopHandle.inline.hpp
@@ -48,7 +48,7 @@ inline OopHandle::OopHandle(OopStorage* storage, oop obj) :
 }
 
 inline void OopHandle::release(OopStorage* storage) {
-  if (peek() != NULL) {
+  if (_obj != NULL) {
     // Clear the OopHandle first
     NativeAccess<>::oop_store(_obj, (oop)NULL);
     storage->release(_obj);

--- a/src/hotspot/share/prims/jvmtiImpl.cpp
+++ b/src/hotspot/share/prims/jvmtiImpl.cpp
@@ -206,9 +206,7 @@ JvmtiBreakpoint::JvmtiBreakpoint(Method* m_method, jlocation location)
 }
 
 JvmtiBreakpoint::~JvmtiBreakpoint() {
-  if (_class_holder.peek() != NULL) {
-    _class_holder.release(JvmtiExport::jvmti_oop_storage());
-  }
+  _class_holder.release(JvmtiExport::jvmti_oop_storage());
 }
 
 void JvmtiBreakpoint::copy(JvmtiBreakpoint& bp) {


### PR DESCRIPTION
Currently, `OopHandle::release()` is implemented as follows:
```
inline void OopHandle::release(OopStorage* storage) {
  if (peek() != NULL) {
    // Clear the OopHandle first
    NativeAccess<>::oop_store(_obj, (oop)NULL);
    storage->release(_obj);
  }
}
```
However, peek() returns NULL not only if the oop* `_obj` is NULL, but also when `_obj` points to a zero oop. In the latter case, the oop* `_obj` will not be released from the corresponding OopStorage and the slot it occupies will remain alive forever.

This behavior can be easily triggered with the `LeakTestMinimal.java` test which is attached to the [JBS issue](https://bugs.openjdk.java.net/browse/JDK-8273902)(thanks to Oli Gillespie from the Amazon Profiler team for detecting the issue and providing a reproducer).

This fix should probably also be downported to jdk17 as quickly as possible.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273902](https://bugs.openjdk.java.net/browse/JDK-8273902): Memory leak in OopStorage due to bug in OopHandle::release()


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5549/head:pull/5549` \
`$ git checkout pull/5549`

Update a local copy of the PR: \
`$ git checkout pull/5549` \
`$ git pull https://git.openjdk.java.net/jdk pull/5549/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5549`

View PR using the GUI difftool: \
`$ git pr show -t 5549`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5549.diff">https://git.openjdk.java.net/jdk/pull/5549.diff</a>

</details>
