### PR TITLE
8274079: Cleanup unnecessary calls to Throwable.initCause() in java.base module

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/AESCipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/AESCipher.java
@@ -72,9 +72,7 @@ abstract class AESCipher extends CipherSpi {
                 engineSetPadding(padding);
             } catch (GeneralSecurityException gse) {
                 // internal error; re-throw as provider exception
-                ProviderException pe =new ProviderException("Internal Error");
-                pe.initCause(gse);
-                throw pe;
+                throw new ProviderException("Internal Error", gse);
             }
         }
     }

--- a/src/java.base/share/classes/com/sun/crypto/provider/ConstructKeys.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/ConstructKeys.java
@@ -76,16 +76,10 @@ final class ConstructKeys {
                                                    encodedKeyAlgorithm +
                                                    "algorithm");
             } catch (InvalidKeySpecException ikse2) {
-                InvalidKeyException ike =
-                    new InvalidKeyException("Cannot construct public key");
-                ike.initCause(ikse2);
-                throw ike;
+                throw new InvalidKeyException("Cannot construct public key", ikse2);
             }
         } catch (InvalidKeySpecException ikse) {
-            InvalidKeyException ike =
-                new InvalidKeyException("Cannot construct public key");
-            ike.initCause(ikse);
-            throw ike;
+            throw new InvalidKeyException("Cannot construct public key", ikse);
         }
 
         return key;
@@ -116,16 +110,10 @@ final class ConstructKeys {
                                                    encodedKeyAlgorithm +
                                                    "algorithm");
             } catch (InvalidKeySpecException ikse2) {
-                InvalidKeyException ike =
-                    new InvalidKeyException("Cannot construct private key");
-                ike.initCause(ikse2);
-                throw ike;
+                throw new InvalidKeyException("Cannot construct private key", ikse2);
             }
         } catch (InvalidKeySpecException ikse) {
-            InvalidKeyException ike =
-                new InvalidKeyException("Cannot construct private key");
-            ike.initCause(ikse);
-            throw ike;
+            throw new InvalidKeyException("Cannot construct private key", ikse);
         } finally {
             SharedSecrets.getJavaSecuritySpecAccess().clearEncodedKeySpec(keySpec);
             if (keyBytes != encodedKey) {

--- a/src/java.base/share/classes/com/sun/crypto/provider/DESedeWrapCipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DESedeWrapCipher.java
@@ -181,10 +181,7 @@ public final class DESedeWrapCipher extends CipherSpi {
             engineInit(opmode, key, (AlgorithmParameterSpec) null, random);
         } catch (InvalidAlgorithmParameterException iape) {
             // should never happen
-            InvalidKeyException ike =
-                new InvalidKeyException("Parameters required");
-            ike.initCause(iape);
-            throw ike;
+            throw new InvalidKeyException("Parameters required", iape);
         }
     }
 
@@ -285,11 +282,8 @@ public final class DESedeWrapCipher extends CipherSpi {
                 paramsEng.engineInit(params.getEncoded());
                 ivSpec = paramsEng.engineGetParameterSpec(IvParameterSpec.class);
             } catch (Exception ex) {
-                InvalidAlgorithmParameterException iape =
-                    new InvalidAlgorithmParameterException
-                        ("Wrong parameter type: IV expected");
-                iape.initCause(ex);
-                throw iape;
+                throw new InvalidAlgorithmParameterException
+                    ("Wrong parameter type: IV expected", ex);
             }
         }
         engineInit(opmode, key, ivSpec, random);

--- a/src/java.base/share/classes/com/sun/crypto/provider/DHPrivateKey.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DHPrivateKey.java
@@ -291,10 +291,8 @@ final class DHPrivateKey implements PrivateKey,
             DerInputStream in = new DerInputStream(this.key);
             this.x = in.getBigInteger();
         } catch (IOException e) {
-            InvalidKeyException ike = new InvalidKeyException(
-                "Error parsing key encoding: " + e.getMessage());
-            ike.initCause(e);
-            throw ike;
+            throw new InvalidKeyException(
+                "Error parsing key encoding: " + e.getMessage(), e);
         }
     }
 

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBES2Core.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBES2Core.java
@@ -162,10 +162,7 @@ abstract class PBES2Core extends CipherSpi {
         try {
             engineInit(opmode, key, (AlgorithmParameterSpec) null, random);
         } catch (InvalidAlgorithmParameterException ie) {
-            InvalidKeyException ike =
-                new InvalidKeyException("requires PBE parameters");
-            ike.initCause(ie);
-            throw ike;
+            throw new InvalidKeyException("requires PBE parameters", ie);
         }
     }
 
@@ -279,10 +276,7 @@ abstract class PBES2Core extends CipherSpi {
         try {
             s = (PBKDF2KeyImpl)kdf.engineGenerateSecret(pbeSpec);
         } catch (InvalidKeySpecException ikse) {
-            InvalidKeyException ike =
-                new InvalidKeyException("Cannot construct PBE key");
-            ike.initCause(ikse);
-            throw ike;
+            throw new InvalidKeyException("Cannot construct PBE key", ikse);
         } finally {
             pbeSpec.clearPassword();
         }

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBEWithMD5AndDESCipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBEWithMD5AndDESCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package com.sun.crypto.provider;
 import java.security.*;
 import java.security.spec.*;
 import javax.crypto.*;
-import javax.crypto.spec.*;
 
 /**
  * This class represents password-based encryption as defined by the PKCS #5
@@ -183,10 +182,7 @@ public final class PBEWithMD5AndDESCipher extends CipherSpi {
         try {
             engineInit(opmode, key, (AlgorithmParameterSpec) null, random);
         } catch (InvalidAlgorithmParameterException ie) {
-            InvalidKeyException ike =
-                new InvalidKeyException("requires PBE parameters");
-            ike.initCause(ie);
-            throw ike;
+            throw new InvalidKeyException("requires PBE parameters", ie);
         }
     }
 

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBEWithMD5AndTripleDESCipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBEWithMD5AndTripleDESCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package com.sun.crypto.provider;
 import java.security.*;
 import java.security.spec.*;
 import javax.crypto.*;
-import javax.crypto.spec.*;
 
 /**
  * This class implements a proprietary password-based encryption algorithm.
@@ -195,10 +194,7 @@ public final class PBEWithMD5AndTripleDESCipher extends CipherSpi {
         try {
             core.init(opmode, key, (AlgorithmParameterSpec) null, random);
         } catch (InvalidAlgorithmParameterException ie) {
-            InvalidKeyException ike =
-                new InvalidKeyException("requires PBE parameters");
-            ike.initCause(ie);
-            throw ike;
+            throw new InvalidKeyException("requires PBE parameters", ie);
         }
     }
 

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2Core.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2Core.java
@@ -151,10 +151,8 @@ abstract class PBKDF2Core extends SecretKeyFactorySpi {
                 try {
                     return new PBKDF2KeyImpl(spec, prfAlgo);
                 } catch (InvalidKeySpecException re) {
-                    InvalidKeyException ike = new InvalidKeyException
-                        ("Invalid key component(s)");
-                    ike.initCause(re);
-                    throw ike;
+                    throw new InvalidKeyException
+                        ("Invalid key component(s)", re);
                 } finally {
                     if (password != null) {
                         Arrays.fill(password, (char) 0);

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2HmacSHA1Factory.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2HmacSHA1Factory.java
@@ -151,10 +151,8 @@ public final class PBKDF2HmacSHA1Factory extends SecretKeyFactorySpi {
                 try {
                     return new PBKDF2KeyImpl(spec, "HmacSHA1");
                 } catch (InvalidKeySpecException re) {
-                    InvalidKeyException ike = new InvalidKeyException
-                        ("Invalid key component(s)");
-                    ike.initCause(re);
-                    throw ike;
+                    throw new InvalidKeyException
+                        ("Invalid key component(s)", re);
                 } finally {
                     if (password != null) {
                         Arrays.fill(password, (char) 0);

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
@@ -119,9 +119,7 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
             this.key = deriveKey(prf, passwdBytes, salt, iterCount, keyLength);
         } catch (NoSuchAlgorithmException nsae) {
             // not gonna happen; re-throw just in case
-            InvalidKeySpecException ike = new InvalidKeySpecException();
-            ike.initCause(nsae);
-            throw ike;
+            throw new InvalidKeySpecException(nsae);
         } finally {
             Arrays.fill(passwdBytes, (byte) 0x00);
 

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBMAC1Core.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBMAC1Core.java
@@ -26,9 +26,7 @@
 package com.sun.crypto.provider;
 
 import java.util.Arrays;
-import java.nio.ByteBuffer;
 
-import javax.crypto.MacSpi;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import javax.crypto.spec.PBEKeySpec;
@@ -181,10 +179,7 @@ abstract class PBMAC1Core extends HmacCore {
             s = (PBKDF2KeyImpl)kdf.engineGenerateSecret(pbeSpec);
             derivedKey = s.getEncoded();
         } catch (InvalidKeySpecException ikse) {
-            InvalidKeyException ike =
-                new InvalidKeyException("Cannot construct PBE key");
-            ike.initCause(ikse);
-            throw ike;
+            throw new InvalidKeyException("Cannot construct PBE key", ikse);
         } finally {
             pbeSpec.clearPassword();
             if (s != null) {

--- a/src/java.base/share/classes/com/sun/crypto/provider/RSACipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/RSACipher.java
@@ -211,10 +211,7 @@ public final class RSACipher extends CipherSpi {
         } catch (InvalidAlgorithmParameterException iape) {
             // never thrown when null parameters are used;
             // but re-throw it just in case
-            InvalidKeyException ike =
-                new InvalidKeyException("Wrong parameters");
-            ike.initCause(iape);
-            throw ike;
+            throw new InvalidKeyException("Wrong parameters", iape);
         }
     }
 
@@ -237,10 +234,7 @@ public final class RSACipher extends CipherSpi {
                         params.getParameterSpec(OAEPParameterSpec.class);
                 init(opmode, key, random, spec);
             } catch (InvalidParameterSpecException ipse) {
-                InvalidAlgorithmParameterException iape =
-                    new InvalidAlgorithmParameterException("Wrong parameter");
-                iape.initCause(ipse);
-                throw iape;
+                throw new InvalidAlgorithmParameterException("Wrong parameter", ipse);
             }
         }
     }

--- a/src/java.base/share/classes/java/io/ObjectStreamClass.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamClass.java
@@ -1712,9 +1712,7 @@ public class ObjectStreamClass implements Serializable {
         } else if (th instanceof Error) {
             throw (Error) th;
         } else {
-            IOException ex = new IOException("unexpected exception type");
-            ex.initCause(th);
-            throw ex;
+            throw new IOException("unexpected exception type", th);
         }
     }
 

--- a/src/java.base/share/classes/java/security/cert/TrustAnchor.java
+++ b/src/java.base/share/classes/java/security/cert/TrustAnchor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@ import javax.security.auth.x500.X500Principal;
 
 import sun.security.util.AnchorCertificates;
 import sun.security.x509.NameConstraintsExtension;
-import sun.security.x509.X500Name;
 
 /**
  * A trust anchor or most-trusted Certification Authority (CA).
@@ -286,10 +285,7 @@ public class TrustAnchor {
             try {
                 nc = new NameConstraintsExtension(Boolean.FALSE, bytes);
             } catch (IOException ioe) {
-                IllegalArgumentException iae =
-                    new IllegalArgumentException(ioe.getMessage());
-                iae.initCause(ioe);
-                throw iae;
+                throw new IllegalArgumentException(ioe.getMessage(), ioe);
             }
         }
     }

--- a/src/java.base/share/classes/java/security/cert/X509CRLSelector.java
+++ b/src/java.base/share/classes/java/security/cert/X509CRLSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -374,7 +374,7 @@ public class X509CRLSelector implements CRLSelector {
                 try {
                     x500Principals.add(new X500Principal((byte[])nameObject));
                 } catch (IllegalArgumentException e) {
-                    throw (IOException)new IOException("Invalid name").initCause(e);
+                    throw new IOException("Invalid name", e);
                 }
             }
         }

--- a/src/java.base/share/classes/java/time/Duration.java
+++ b/src/java.base/share/classes/java/time/Duration.java
@@ -411,7 +411,7 @@ public final class Duration
                     try {
                         return create(negate, daysAsSecs, hoursAsSecs, minsAsSecs, seconds, nanos);
                     } catch (ArithmeticException ex) {
-                        throw (DateTimeParseException) new DateTimeParseException("Text cannot be parsed to a Duration: overflow", text, 0).initCause(ex);
+                        throw new DateTimeParseException("Text cannot be parsed to a Duration: overflow", text, 0, ex);
                     }
                 }
             }
@@ -432,7 +432,7 @@ public final class Duration
             long val = Long.parseLong(text, start, end, 10);
             return Math.multiplyExact(val, multiplier);
         } catch (NumberFormatException | ArithmeticException ex) {
-            throw (DateTimeParseException) new DateTimeParseException("Text cannot be parsed to a Duration: " + errorText, text, 0).initCause(ex);
+            throw new DateTimeParseException("Text cannot be parsed to a Duration: " + errorText, text, 0, ex);
         }
     }
 
@@ -451,7 +451,7 @@ public final class Duration
             }
             return fraction * negate;
         } catch (NumberFormatException | ArithmeticException ex) {
-            throw (DateTimeParseException) new DateTimeParseException("Text cannot be parsed to a Duration: fraction", text, 0).initCause(ex);
+            throw new DateTimeParseException("Text cannot be parsed to a Duration: fraction", text, 0, ex);
         }
     }
 

--- a/src/java.base/share/classes/javax/net/ssl/SSLContext.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLContext.java
@@ -372,12 +372,9 @@ public class SSLContext {
         try {
             return contextSpi.engineCreateSSLEngine();
         } catch (AbstractMethodError e) {
-            UnsupportedOperationException unsup =
-                new UnsupportedOperationException(
-                    "Provider: " + getProvider() +
-                    " doesn't support this operation");
-            unsup.initCause(e);
-            throw unsup;
+            throw new UnsupportedOperationException(
+                "Provider: " + getProvider() +
+                " doesn't support this operation", e);
         }
     }
 
@@ -412,12 +409,9 @@ public class SSLContext {
         try {
             return contextSpi.engineCreateSSLEngine(peerHost, peerPort);
         } catch (AbstractMethodError e) {
-            UnsupportedOperationException unsup =
-                new UnsupportedOperationException(
-                    "Provider: " + getProvider() +
-                    " does not support this operation");
-            unsup.initCause(e);
-            throw unsup;
+            throw new UnsupportedOperationException(
+                "Provider: " + getProvider() +
+                " does not support this operation", e);
         }
     }
 

--- a/src/java.base/share/classes/javax/security/auth/login/Configuration.java
+++ b/src/java.base/share/classes/javax/security/auth/login/Configuration.java
@@ -270,17 +270,15 @@ public abstract class Configuration {
                 } catch (PrivilegedActionException e) {
                     Exception ee = e.getException();
                     if (ee instanceof InstantiationException) {
-                        throw (SecurityException) new
-                            SecurityException
+                        throw new SecurityException
                                     ("Configuration error:" +
                                      ee.getCause().getMessage() +
-                                     "\n").initCause(ee.getCause());
+                                     "\n", ee.getCause());
                     } else {
-                        throw (SecurityException) new
-                            SecurityException
+                        throw new SecurityException
                                     ("Configuration error: " +
                                      ee.toString() +
-                                     "\n").initCause(ee);
+                                     "\n", ee);
                     }
                 }
             }

--- a/src/java.base/share/classes/javax/security/auth/x500/X500Principal.java
+++ b/src/java.base/share/classes/javax/security/auth/x500/X500Principal.java
@@ -181,10 +181,8 @@ public final class X500Principal implements Principal, java.io.Serializable {
         try {
             thisX500Name = new X500Name(name, keywordMap);
         } catch (Exception e) {
-            IllegalArgumentException iae = new IllegalArgumentException
-                        ("improperly specified input name: " + name);
-            iae.initCause(e);
-            throw iae;
+            throw new IllegalArgumentException
+                        ("improperly specified input name: " + name, e);
         }
     }
 
@@ -226,10 +224,8 @@ public final class X500Principal implements Principal, java.io.Serializable {
         try {
             thisX500Name = new X500Name(name);
         } catch (Exception e) {
-            IllegalArgumentException iae = new IllegalArgumentException
-                        ("improperly specified input name");
-            iae.initCause(e);
-            throw iae;
+            throw new IllegalArgumentException
+                        ("improperly specified input name", e);
         }
     }
 
@@ -266,17 +262,13 @@ public final class X500Principal implements Principal, java.io.Serializable {
                 try {
                     is.reset();
                 } catch (IOException ioe) {
-                    IllegalArgumentException iae = new IllegalArgumentException
+                    throw new IllegalArgumentException
                         ("improperly specified input stream " +
-                        ("and unable to reset input stream"));
-                    iae.initCause(e);
-                    throw iae;
+                        ("and unable to reset input stream"), e);
                 }
             }
-            IllegalArgumentException iae = new IllegalArgumentException
-                        ("improperly specified input stream");
-            iae.initCause(e);
-            throw iae;
+            throw new IllegalArgumentException
+                        ("improperly specified input stream", e);
         }
     }
 

--- a/src/java.base/share/classes/sun/security/provider/DigestBase.java
+++ b/src/java.base/share/classes/sun/security/provider/DigestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -184,8 +184,7 @@ abstract class DigestBase extends MessageDigestSpi implements Cloneable {
         try {
             engineDigest(b, 0, b.length);
         } catch (DigestException e) {
-            throw (ProviderException)
-                new ProviderException("Internal error").initCause(e);
+            throw new ProviderException("Internal error", e);
         }
         return b;
     }

--- a/src/java.base/share/classes/sun/security/provider/JavaKeyStore.java
+++ b/src/java.base/share/classes/sun/security/provider/JavaKeyStore.java
@@ -810,9 +810,9 @@ public abstract class JavaKeyStore extends KeyStoreSpi {
                 if (!MessageDigest.isEqual(computed, actual)) {
                     Throwable t = new UnrecoverableKeyException
                             ("Password verification failed");
-                    throw (IOException) new IOException
+                    throw new IOException
                             ("Keystore was tampered with, or "
-                                    + "password was incorrect").initCause(t);
+                                    + "password was incorrect", t);
                 }
             }
         }

--- a/src/java.base/share/classes/sun/security/util/HostnameChecker.java
+++ b/src/java.base/share/classes/sun/security/util/HostnameChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -254,8 +254,7 @@ public class HostnameChecker {
                 return new X500Name(subjectX500.getEncoded());
             }
         } catch (IOException e) {
-            throw(CertificateParsingException)
-                new CertificateParsingException().initCause(e);
+            throw new CertificateParsingException(e);
         }
     }
 


### PR DESCRIPTION
Pass "cause" exception as constructor parameter is shorter and easier to read.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274079](https://bugs.openjdk.java.net/browse/JDK-8274079): Cleanup unnecessary calls to Throwable.initCause() in java.base module


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5551/head:pull/5551` \
`$ git checkout pull/5551`

Update a local copy of the PR: \
`$ git checkout pull/5551` \
`$ git pull https://git.openjdk.java.net/jdk pull/5551/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5551`

View PR using the GUI difftool: \
`$ git pr show -t 5551`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5551.diff">https://git.openjdk.java.net/jdk/pull/5551.diff</a>

</details>
