### PR TITLE
8274757: Cleanup unnecessary calls to Throwable.initCause() in java.management module

### DIFF
--- a/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java
+++ b/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java
@@ -1648,8 +1648,7 @@ public class RMIConnectionImpl implements RMIConnection, Unreferenced {
      */
     private static IOException newIOException(String message,
                                               Throwable cause) {
-        final IOException x = new IOException(message);
-        return EnvHelp.initCause(x,cause);
+        return new IOException(message, cause);
     }
 
     /**

--- a/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnector.java
+++ b/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnector.java
@@ -367,7 +367,7 @@ public class RMIConnector implements JMXConnector, Serializable, JMXAddressable 
         } catch (NamingException e) {
             final String msg = "Failed to retrieve RMIServer stub: " + e;
             if (tracing) logger.trace("connect",idstr + " " + msg);
-            throw EnvHelp.initCause(new IOException(msg),e);
+            throw new IOException(msg, e);
         }
     }
 
@@ -543,9 +543,7 @@ public class RMIConnector implements JMXConnector, Serializable, JMXAddressable 
                 throw (IOException) closeException;
             if (closeException instanceof RuntimeException)
                 throw (RuntimeException) closeException;
-            final IOException x =
-                    new IOException("Failed to close: " + closeException);
-            throw EnvHelp.initCause(x,closeException);
+            throw new IOException("Failed to close: " + closeException, closeException);
         }
     }
 

--- a/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectorServer.java
+++ b/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectorServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -420,8 +420,7 @@ public class RMIConnectorServer extends JMXConnectorServer {
                 try {
                     mbsf = new MBeanServerFileAccessController(accessFile);
                 } catch (IOException e) {
-                    throw EnvHelp.initCause(
-                        new IllegalArgumentException(e.getMessage()), e);
+                    throw new IllegalArgumentException(e.getMessage(), e);
                 }
                 // Set the MBeanServerForwarder
                 //
@@ -434,9 +433,7 @@ public class RMIConnectorServer extends JMXConnectorServer {
             defaultClassLoader = EnvHelp.resolveServerClassLoader(
                     attributes, getMBeanServer());
         } catch (InstanceNotFoundException infc) {
-            IllegalArgumentException x = new
-                IllegalArgumentException("ClassLoader not found: "+infc);
-            throw EnvHelp.initCause(x,infc);
+            throw new IllegalArgumentException("ClassLoader not found: "+infc, infc);
         }
 
         if (tracing) logger.trace("start", "setting RMIServer object");
@@ -831,8 +828,7 @@ public class RMIConnectorServer extends JMXConnectorServer {
      */
     private static IOException newIOException(String message,
                                               Throwable cause) {
-        final IOException x = new IOException(message);
-        return EnvHelp.initCause(x,cause);
+        return new IOException(message, cause);
     }
 
 

--- a/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectorServer.java
+++ b/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectorServer.java
@@ -433,7 +433,7 @@ public class RMIConnectorServer extends JMXConnectorServer {
             defaultClassLoader = EnvHelp.resolveServerClassLoader(
                     attributes, getMBeanServer());
         } catch (InstanceNotFoundException infc) {
-            throw new IllegalArgumentException("ClassLoader not found: "+infc, infc);
+            throw new IllegalArgumentException("ClassLoader not found: " + infc, infc);
         }
 
         if (tracing) logger.trace("start", "setting RMIServer object");

--- a/src/java.management/share/classes/com/sun/jmx/interceptor/DefaultMBeanServerInterceptor.java
+++ b/src/java.management/share/classes/com/sun/jmx/interceptor/DefaultMBeanServerInterceptor.java
@@ -38,7 +38,6 @@ import com.sun.jmx.mbeanserver.Repository.RegistrationContext;
 import com.sun.jmx.mbeanserver.Util;
 import com.sun.jmx.remote.util.EnvHelp;
 
-import java.io.ObjectInputStream;
 import java.lang.ref.WeakReference;
 import java.security.AccessControlContext;
 import java.security.AccessController;
@@ -80,7 +79,6 @@ import javax.management.NotificationFilter;
 import javax.management.NotificationListener;
 import javax.management.ObjectInstance;
 import javax.management.ObjectName;
-import javax.management.OperationsException;
 import javax.management.QueryEval;
 import javax.management.QueryExp;
 import javax.management.ReflectionException;
@@ -208,8 +206,7 @@ public class DefaultMBeanServerInterceptor implements MBeanServerInterceptor {
         } catch (InstanceNotFoundException e) {
             /* Can only happen if loaderName doesn't exist, but we just
                passed null, so we shouldn't get this exception.  */
-            throw EnvHelp.initCause(
-                new IllegalArgumentException("Unexpected exception: " + e), e);
+            throw new IllegalArgumentException("Unexpected exception: " + e, e);
         }
     }
 

--- a/src/java.management/share/classes/com/sun/jmx/remote/internal/ArrayNotificationBuffer.java
+++ b/src/java.management/share/classes/com/sun/jmx/remote/internal/ArrayNotificationBuffer.java
@@ -610,11 +610,9 @@ public class ArrayNotificationBuffer implements NotificationBuffer {
             logger.debug("createListeners", "added creationListener");
         } catch (Exception e) {
             final String msg = "Can't add listener to MBean server delegate: ";
-            RuntimeException re = new IllegalArgumentException(msg + e);
-            EnvHelp.initCause(re, e);
             logger.fine("createListeners", msg + e);
             logger.debug("createListeners", e);
-            throw re;
+            throw new IllegalArgumentException(msg + e, e);
         }
 
         /* Spec doesn't say whether Set returned by QueryNames can be modified

--- a/src/java.management/share/classes/com/sun/jmx/remote/internal/ClientNotifForwarder.java
+++ b/src/java.management/share/classes/com/sun/jmx/remote/internal/ClientNotifForwarder.java
@@ -51,7 +51,6 @@ import javax.management.remote.TargetedNotification;
 
 import com.sun.jmx.remote.util.ClassLogger;
 import com.sun.jmx.remote.util.EnvHelp;
-import java.lang.reflect.UndeclaredThrowableException;
 import java.util.concurrent.RejectedExecutionException;
 
 
@@ -340,9 +339,7 @@ public abstract class ClientNotifForwarder {
             try {
                 wait();
             } catch (InterruptedException ire) {
-                IOException ioe = new IOException(ire.toString());
-                EnvHelp.initCause(ioe, ire);
-                throw ioe;
+                throw new IOException(ire.toString(), ire);
             }
         }
 
@@ -381,9 +378,7 @@ public abstract class ClientNotifForwarder {
                   try {
                       wait();
                   } catch (InterruptedException ire) {
-                      IOException ioe = new IOException(ire.toString());
-                      EnvHelp.initCause(ioe, ire);
-                      throw ioe;
+                      throw new IOException(ire.toString(), ire);
                   }
               }
 
@@ -821,10 +816,7 @@ public abstract class ClientNotifForwarder {
                 try {
                     wait();
                 } catch (InterruptedException ire) {
-                    IOException ioe = new IOException(ire.toString());
-                    EnvHelp.initCause(ioe, ire);
-
-                    throw ioe;
+                    throw new IOException(ire.toString(), ire);
                 }
             }
 
@@ -901,10 +893,7 @@ public abstract class ClientNotifForwarder {
             try {
                 wait();
             } catch (InterruptedException ire) {
-                IOException ioe = new IOException(ire.toString());
-                EnvHelp.initCause(ioe, ire);
-
-                throw ioe;
+                throw new IOException(ire.toString(), ire);
             }
         }
 

--- a/src/java.management/share/classes/com/sun/jmx/remote/internal/ServerNotifForwarder.java
+++ b/src/java.management/share/classes/com/sun/jmx/remote/internal/ServerNotifForwarder.java
@@ -121,9 +121,7 @@ public class ServerNotifForwarder {
                                             name.getKeyPropertyList());
             } catch (MalformedObjectNameException mfoe) {
                 // impossible, but...
-                IOException ioe = new IOException(mfoe.getMessage());
-                ioe.initCause(mfoe);
-                throw ioe;
+                throw new IOException(mfoe.getMessage(), mfoe);
             }
         }
 

--- a/src/java.management/share/classes/com/sun/jmx/remote/security/JMXPluggableAuthenticator.java
+++ b/src/java.management/share/classes/com/sun/jmx/remote/security/JMXPluggableAuthenticator.java
@@ -44,7 +44,6 @@ import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
 import javax.security.auth.spi.LoginModule;
 import com.sun.jmx.remote.util.ClassLogger;
-import com.sun.jmx.remote.util.EnvHelp;
 
 /**
  * <p>This class represents a
@@ -228,9 +227,7 @@ public final class JMXPluggableAuthenticator implements JMXAuthenticator {
             se = (SecurityException) exception;
         } else {
             msg = "Authentication failed! " + exception.getMessage();
-            final SecurityException e = new SecurityException(msg);
-            EnvHelp.initCause(e, exception);
-            se = e;
+            se = new SecurityException(msg, exception);
         }
         logException(method, msg, se);
         throw se;

--- a/src/java.management/share/classes/javax/management/openmbean/OpenMBeanAttributeInfoSupport.java
+++ b/src/java.management/share/classes/javax/management/openmbean/OpenMBeanAttributeInfoSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,6 @@
 package javax.management.openmbean;
 
 
-// java import
-//
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -44,7 +42,6 @@ import javax.management.Descriptor;
 import javax.management.DescriptorRead;
 import javax.management.ImmutableDescriptor;
 import javax.management.MBeanAttributeInfo;
-import com.sun.jmx.remote.util.EnvHelp;
 import sun.reflect.misc.MethodUtil;
 import sun.reflect.misc.ReflectUtil;
 
@@ -626,7 +623,7 @@ public class OpenMBeanAttributeInfoSupport
             final String msg =
                 "Cannot convert descriptor field " + name + "  to " +
                 openType.getTypeName();
-            throw EnvHelp.initCause(new IllegalArgumentException(msg), e);
+            throw new IllegalArgumentException(msg, e);
         }
     }
 

--- a/src/java.management/share/classes/javax/management/remote/JMXConnectorFactory.java
+++ b/src/java.management/share/classes/javax/management/remote/JMXConnectorFactory.java
@@ -619,8 +619,7 @@ public class JMXConnectorFactory {
                             if (e instanceof IOException) {
                                 exception = (IOException) e;
                             } else {
-                                exception = EnvHelp.initCause(
-                                    new IOException(e.getMessage()), e);
+                                exception = new IOException(e.getMessage(), e);
                             }
                         }
                     }


### PR DESCRIPTION
Pass cause exception as constructor parameter is shorter and easier to read.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274757](https://bugs.openjdk.java.net/browse/JDK-8274757): Cleanup unnecessary calls to Throwable.initCause() in java.management module


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5552/head:pull/5552` \
`$ git checkout pull/5552`

Update a local copy of the PR: \
`$ git checkout pull/5552` \
`$ git pull https://git.openjdk.java.net/jdk pull/5552/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5552`

View PR using the GUI difftool: \
`$ git pr show -t 5552`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5552.diff">https://git.openjdk.java.net/jdk/pull/5552.diff</a>

</details>
