### PR TITLE
8273912: Add threadControl_dumpThread(jthread) function

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -2586,6 +2586,17 @@ threadControl_dumpAllThreads()
     dumpThreadList(&otherThreads);
 }
 
+void
+threadControl_dumpThread(jthread thread)
+{
+    ThreadNode* node = findThread(NULL, thread);
+    if (node == NULL) {
+        tty_message("Thread not found");
+    } else {
+        dumpThread(node);
+    }
+}
+
 static void
 dumpThreadList(ThreadList *list)
 {

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.h
@@ -78,6 +78,7 @@ jlong threadControl_getFrameGeneration(jthread thread);
 
 #ifdef DEBUG
 void threadControl_dumpAllThreads();
+void threadControl_dumpThread(jthread thread);
 #endif
 
 #endif


### PR DESCRIPTION
Trivial change to add an internal API that is useful when debugging. Only included in debug builds, and has no impact on debug agent functionality.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273912](https://bugs.openjdk.java.net/browse/JDK-8273912): Add threadControl_dumpThread(jthread) function


### Reviewers
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5554/head:pull/5554` \
`$ git checkout pull/5554`

Update a local copy of the PR: \
`$ git checkout pull/5554` \
`$ git pull https://git.openjdk.java.net/jdk pull/5554/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5554`

View PR using the GUI difftool: \
`$ git pr show -t 5554`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5554.diff">https://git.openjdk.java.net/jdk/pull/5554.diff</a>

</details>
