### PR TITLE
8273927: Enable hsdis for riscv64

### DIFF
--- a/src/utils/hsdis/hsdis.c
+++ b/src/utils/hsdis/hsdis.c
@@ -496,6 +496,9 @@ static const char* native_arch_name() {
 #ifdef LIBARCH_s390x
   res = "s390:64-bit";
 #endif
+#ifdef LIBARCH_riscv64
+  res = "riscv:rv64";
+#endif
   if (res == NULL)
     res = "architecture not set in Makefile!";
   return res;


### PR DESCRIPTION
Currently compiled `hsdis-riscv64.so` binary complains:

```
hsdis: bad native mach=architecture not set in Makefile!; please port hsdis to this platform
```

It seems to be as simple as point to the right BFD arch.

Additional testing:
 - [x] Linux RISC-V port, `-XX:+PrintAssembly` works

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273927](https://bugs.openjdk.java.net/browse/JDK-8273927): Enable hsdis for riscv64


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5558/head:pull/5558` \
`$ git checkout pull/5558`

Update a local copy of the PR: \
`$ git checkout pull/5558` \
`$ git pull https://git.openjdk.java.net/jdk pull/5558/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5558`

View PR using the GUI difftool: \
`$ git pr show -t 5558`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5558.diff">https://git.openjdk.java.net/jdk/pull/5558.diff</a>

</details>
