### PR TITLE
8274949: Use String.contains() instead of String.indexOf() in java.base

### DIFF
--- a/src/java.base/share/classes/java/net/HttpCookie.java
+++ b/src/java.base/share/classes/java/net/HttpCookie.java
@@ -1078,13 +1078,13 @@ public final class HttpCookie implements Cloneable {
         int version = 0;
 
         header = header.toLowerCase();
-        if (header.indexOf("expires=") != -1) {
+        if (header.contains("expires=")) {
             // only netscape cookie using 'expires'
             version = 0;
-        } else if (header.indexOf("version=") != -1) {
+        } else if (header.contains("version=")) {
             // version is mandatory for rfc 2965/2109 cookie
             version = 1;
-        } else if (header.indexOf("max-age") != -1) {
+        } else if (header.contains("max-age")) {
             // rfc 2965/2109 use 'max-age'
             version = 1;
         } else if (startsWithIgnoreCase(header, SET_COOKIE2)) {

--- a/src/java.base/share/classes/java/net/HttpURLConnection.java
+++ b/src/java.base/share/classes/java/net/HttpURLConnection.java
@@ -600,7 +600,7 @@ public abstract class HttpURLConnection extends URLConnection {
     public long getHeaderFieldDate(String name, long Default) {
         String dateString = getHeaderField(name);
         try {
-            if (dateString.indexOf("GMT") == -1) {
+            if (!dateString.contains("GMT")) {
                 dateString = dateString+" GMT";
             }
             return Date.parse(dateString);

--- a/src/java.base/share/classes/java/net/SocketPermission.java
+++ b/src/java.base/share/classes/java/net/SocketPermission.java
@@ -30,12 +30,10 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamField;
 import java.io.Serializable;
-import java.net.InetAddress;
 import java.security.AccessController;
 import java.security.Permission;
 import java.security.PermissionCollection;
 import java.security.PrivilegedAction;
-import java.security.Security;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Map;
@@ -333,7 +331,7 @@ public final class SocketPermission extends Permission
                         ind = host.lastIndexOf(':');
                         host = "[" + host.substring(0, ind) + "]" +
                             host.substring(ind);
-                    } else if (tokens == 8 && host.indexOf("::") == -1) {
+                    } else if (tokens == 8 && !host.contains("::")) {
                         // IPv6 address only, not followed by port
                         host = "[" + host + "]";
                     } else {

--- a/src/java.base/share/classes/jdk/internal/jrtfs/JrtPath.java
+++ b/src/java.base/share/classes/jdk/internal/jrtfs/JrtPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -485,7 +485,7 @@ final class JrtPath implements Path {
     // Remove DotSlash(./) and resolve DotDot (..) components
     private String getResolved() {
         int length = path.length();
-        if (length == 0 || (path.indexOf("./") == -1 && path.charAt(length - 1) != '.')) {
+        if (length == 0 || (!path.contains("./") && path.charAt(length - 1) != '.')) {
             return path;
         } else {
             return resolvePath();

--- a/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
+++ b/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
@@ -556,11 +556,11 @@ public class URLClassPath {
                     // fallback to checkRead/checkConnect for pre 1.2
                     // security managers
                     if ((perm instanceof java.io.FilePermission) &&
-                        perm.getActions().indexOf("read") != -1) {
+                        perm.getActions().contains("read")) {
                         security.checkRead(perm.getName());
                     } else if ((perm instanceof
                         java.net.SocketPermission) &&
-                        perm.getActions().indexOf("connect") != -1) {
+                        perm.getActions().contains("connect")) {
                         URL locUrl = url;
                         if (urlConnection instanceof JarURLConnection) {
                             locUrl = ((JarURLConnection)urlConnection).getJarFileURL();
@@ -1233,7 +1233,7 @@ public class URLClassPath {
                     URLClassPath.check(url);
 
                 final File file;
-                if (name.indexOf("..") != -1) {
+                if (name.contains("..")) {
                     file = (new File(dir, name.replace('/', File.separatorChar)))
                           .getCanonicalFile();
                     if ( !((file.getPath()).startsWith(dir.getPath())) ) {

--- a/src/java.base/share/classes/sun/net/www/http/HttpCapture.java
+++ b/src/java.base/share/classes/sun/net/www/http/HttpCapture.java
@@ -157,7 +157,7 @@ public class HttpCapture {
             if (p.matcher(s).find()) {
                 String f = capFiles.get(i);
                 File fi;
-                if (f.indexOf("%d") >= 0) {
+                if (f.contains("%d")) {
                     java.util.Random rand = new java.util.Random();
                     do {
                         String f2 = f.replace("%d", Integer.toString(rand.nextInt()));

--- a/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
@@ -645,7 +645,7 @@ final class HttpsClient extends HttpClient
             // ignore
         }
 
-        if ((cipher != null) && (cipher.indexOf("_anon_") != -1)) {
+        if ((cipher != null) && (cipher.contains("_anon_"))) {
             return;
         } else if ((hostnameVerifier != null) &&
                    (hostnameVerifier.verify(host, session))) {

--- a/src/java.base/share/classes/sun/security/provider/PolicyFile.java
+++ b/src/java.base/share/classes/sun/security/provider/PolicyFile.java
@@ -723,7 +723,7 @@ public class PolicyFile extends java.security.Policy {
                                 + SELF;
                     }
                     // check for self
-                    if (pe.name != null && pe.name.indexOf(SELF) != -1) {
+                    if (pe.name != null && pe.name.contains(SELF)) {
                         // Create a "SelfPermission" , it could be an
                         // an unresolved permission which will be resolved
                         // when implies is called

--- a/src/java.base/share/classes/sun/security/rsa/RSAPSSSignature.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAPSSSignature.java
@@ -59,7 +59,7 @@ public class RSAPSSSignature extends SignatureSpi {
     private boolean isDigestEqual(String stdAlg, String givenAlg) {
         if (stdAlg == null || givenAlg == null) return false;
 
-        if (givenAlg.indexOf("-") != -1) {
+        if (givenAlg.contains("-")) {
             return stdAlg.equalsIgnoreCase(givenAlg);
         } else {
             if (stdAlg.equals("SHA-1")) {

--- a/src/java.base/share/classes/sun/security/rsa/RSAUtil.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 
 package sun.security.rsa;
 
-import java.io.IOException;
 import java.security.*;
 import java.security.spec.*;
 import sun.security.util.ObjectIdentifier;
@@ -61,9 +60,9 @@ public class RSAUtil {
 
             // match loosely in order to work with 3rd party providers which
             // may not follow the standard names
-            if (name.indexOf("PSS") != -1) {
+            if (name.contains("PSS")) {
                 return PSS;
-            } else if (name.indexOf("RSA") != -1) {
+            } else if (name.contains("RSA")) {
                 return RSA;
             } else { // no match
                 throw new ProviderException("Unsupported algorithm " + name);
@@ -151,7 +150,7 @@ public class RSAUtil {
         } catch (ProviderException pe) {
             // accommodate RSA keys encoded with various RSA signature oids
             // for backward compatibility
-            if (algName.indexOf("RSA") != -1) {
+            if (algName.contains("RSA")) {
                 result[0] = KeyType.RSA;
             } else {
                 // pass it up

--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -1471,10 +1471,10 @@ public final class Main {
             if (s == null) break;
             // OpenSSL does not use NEW
             //if (s.startsWith("-----BEGIN NEW CERTIFICATE REQUEST-----")) {
-            if (s.startsWith("-----BEGIN") && s.indexOf("REQUEST") >= 0) {
+            if (s.startsWith("-----BEGIN") && s.contains("REQUEST")) {
                 canRead = true;
             //} else if (s.startsWith("-----END NEW CERTIFICATE REQUEST-----")) {
-            } else if (s.startsWith("-----END") && s.indexOf("REQUEST") >= 0) {
+            } else if (s.startsWith("-----END") && s.contains("REQUEST")) {
                 break;
             } else if (canRead) {
                 sb.append(s);

--- a/src/java.base/share/classes/sun/security/util/Debug.java
+++ b/src/java.base/share/classes/sun/security/util/Debug.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -161,10 +161,10 @@ public class Debug {
         if (args == null)
             return false;
         else {
-            if (args.indexOf("all") != -1)
+            if (args.contains("all"))
                 return true;
             else
-                return (args.indexOf(option) != -1);
+                return (args.contains(option));
         }
     }
 

--- a/src/java.base/share/classes/sun/security/util/SignatureUtil.java
+++ b/src/java.base/share/classes/sun/security/util/SignatureUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@ public class SignatureUtil {
      *      form of an OID, or the OID value if no match is found.
      */
     private static String checkName(String algName) {
-        if (algName.indexOf(".") == -1) {
+        if (!algName.contains(".")) {
             return algName;
         } else {
             // convert oid to String
@@ -100,7 +100,7 @@ public class SignatureUtil {
             // AlgorithmParameters.getAlgorithm() may returns oid if it's
             // created during DER decoding. Convert to use the standard name
             // before passing it to RSAUtil
-            if (params.getAlgorithm().indexOf(".") != -1) {
+            if (params.getAlgorithm().contains(".")) {
                 try {
                     params = createAlgorithmParameters(sigName,
                         params.getEncoded());
@@ -109,9 +109,9 @@ public class SignatureUtil {
                 }
             }
 
-            if (sigName.indexOf("RSA") != -1) {
+            if (sigName.contains("RSA")) {
                 paramSpec = RSAUtil.getParamSpec(params);
-            } else if (sigName.indexOf("ECDSA") != -1) {
+            } else if (sigName.contains("ECDSA")) {
                 try {
                     paramSpec = params.getParameterSpec(ECParameterSpec.class);
                 } catch (Exception e) {
@@ -141,11 +141,11 @@ public class SignatureUtil {
 
         if (paramBytes != null) {
             sigName = checkName(sigName).toUpperCase(Locale.ENGLISH);
-            if (sigName.indexOf("RSA") != -1) {
+            if (sigName.contains("RSA")) {
                 AlgorithmParameters params =
                     createAlgorithmParameters(sigName, paramBytes);
                 paramSpec = RSAUtil.getParamSpec(params);
-            } else if (sigName.indexOf("ECDSA") != -1) {
+            } else if (sigName.contains("ECDSA")) {
                 try {
                     Provider p = Signature.getInstance(sigName).getProvider();
                     paramSpec = ECUtil.getECParameterSpec(p, paramBytes);

--- a/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
+++ b/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
@@ -520,7 +520,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
         }
 
         // unknown algorithm oids
-        if (name.indexOf(".") == -1) {
+        if (!name.contains(".")) {
             // see if there is a matching oid string alias mapping from
             // 3rd party providers
             name = name.toUpperCase(Locale.ENGLISH);

--- a/src/java.base/share/classes/sun/util/locale/LocaleMatcher.java
+++ b/src/java.base/share/classes/sun/util/locale/LocaleMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,7 +83,7 @@ public final class LocaleMatcher {
             for (LanguageRange lr : priorityList) {
                 String range = lr.getRange();
                 if (range.startsWith("*-")
-                    || range.indexOf("-*") != -1) { // Extended range
+                    || range.contains("-*")) { // Extended range
                     if (mode == AUTOSELECT_FILTERING) {
                         return filterExtended(priorityList, tags);
                     } else if (mode == MAP_EXTENDED_RANGES) {

--- a/src/java.base/unix/classes/sun/net/www/protocol/jar/JarFileFactory.java
+++ b/src/java.base/unix/classes/sun/net/www/protocol/jar/JarFileFactory.java
@@ -203,11 +203,11 @@ class JarFileFactory implements URLJarFile.URLJarFileCloseController {
                         // fallback to checkRead/checkConnect for pre 1.2
                         // security managers
                         if ((perm instanceof java.io.FilePermission) &&
-                            perm.getActions().indexOf("read") != -1) {
+                            perm.getActions().contains("read")) {
                             sm.checkRead(perm.getName());
                         } else if ((perm instanceof
                             java.net.SocketPermission) &&
-                            perm.getActions().indexOf("connect") != -1) {
+                            perm.getActions().contains("connect")) {
                             sm.checkConnect(url.getHost(), url.getPort());
                         } else {
                             throw se;

--- a/src/java.base/windows/classes/sun/net/www/protocol/jar/JarFileFactory.java
+++ b/src/java.base/windows/classes/sun/net/www/protocol/jar/JarFileFactory.java
@@ -226,11 +226,11 @@ class JarFileFactory implements URLJarFile.URLJarFileCloseController {
                         // fallback to checkRead/checkConnect for pre 1.2
                         // security managers
                         if ((perm instanceof java.io.FilePermission) &&
-                            perm.getActions().indexOf("read") != -1) {
+                            perm.getActions().contains("read")) {
                             sm.checkRead(perm.getName());
                         } else if ((perm instanceof
                             java.net.SocketPermission) &&
-                            perm.getActions().indexOf("connect") != -1) {
+                            perm.getActions().contains("connect")) {
                             sm.checkConnect(url.getHost(), url.getPort());
                         } else {
                             throw se;


### PR DESCRIPTION
String.contains was introduced in Java 5.
Some code in java.base still uses old approach with `String.indexOf` to check if String contains specified substring.
I propose to migrate such usages. Makes code shorter and easier to read.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274949](https://bugs.openjdk.java.net/browse/JDK-8274949): Use String.contains() instead of String.indexOf() in java.base


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Vyom Tewari](https://openjdk.java.net/census#vtewari) (@vyommani - Committer)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5559/head:pull/5559` \
`$ git checkout pull/5559`

Update a local copy of the PR: \
`$ git checkout pull/5559` \
`$ git pull https://git.openjdk.java.net/jdk pull/5559/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5559`

View PR using the GUI difftool: \
`$ git pr show -t 5559`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5559.diff">https://git.openjdk.java.net/jdk/pull/5559.diff</a>

</details>
