### PR TITLE
8273933: [TESTBUG] Test must run without preallocated exceptions

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/jit/t/t105/t105.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t105/t105.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t105/t105.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t105/t105.java
@@ -29,7 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -XX:-ProfileTraps jit.t.t105.t105
+ * @run main/othervm -XX:-OmitStackTraceInFastThrow jit.t.t105.t105
  *
  * This test must be run with ProfileTraps disabled to avoid preallocated
  * exceptions. They don't have the detailed message that this test relies on.

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t105/t105.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t105/t105.java
@@ -29,7 +29,10 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm jit.t.t105.t105
+ * @run main/othervm -XX:-ProfileTraps jit.t.t105.t105
+ *
+ * This test must be run with ProfileTraps disabled to avoid preallocated
+ * exceptions. They don't have the detailed message that this test relies on.
  */
 
 package jit.t.t105;


### PR DESCRIPTION
Executing vmTestbase/jit/t/t105/t105.java with the fix for (JDK-8273277) makes the test fail when run with the following arguments:

-XX:+TieredCompilation
-XX:Tier0BackedgeNotifyFreqLog=0
-XX:Tier2BackedgeNotifyFreqLog=0
-XX:Tier3BackedgeNotifyFreqLog=0
-XX:Tier2BackEdgeThreshold=1
-XX:Tier3BackEdgeThreshold=1
-XX:Tier4BackEdgeThreshold=1
-Xbatch

The problem is that the tests expects a detailed message from ArrayIndexOutOfBoundsException, but this test will trigger the optimization that reuses preallocated exceptions that have an empty detailed exceptions.

It is wrong for the test to assume exceptions messages.

Solution disable preallocated exceptions with the flag -XX:-ProfileTraps.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273933](https://bugs.openjdk.java.net/browse/JDK-8273933): [TESTBUG] Test must run without preallocated exceptions


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5560/head:pull/5560` \
`$ git checkout pull/5560`

Update a local copy of the PR: \
`$ git checkout pull/5560` \
`$ git pull https://git.openjdk.java.net/jdk pull/5560/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5560`

View PR using the GUI difftool: \
`$ git pr show -t 5560`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5560.diff">https://git.openjdk.java.net/jdk/pull/5560.diff</a>

</details>
