### PR TITLE
[PATCH] Use String.contains() instead of String.indexOf() in java.desktop

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -38,7 +38,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Hashtable;
-import java.util.Vector;
 
 import javax.swing.ImageIcon;
 import javax.swing.SizeRequirements;
@@ -891,8 +890,8 @@ public class CSS implements Serializable {
                               (CSS.Attribute.VERTICAL_ALIGN);
         if ((vAlignV != null)) {
             String vAlign = vAlignV.toString();
-            if ((vAlign.indexOf("sup") >= 0) ||
-                (vAlign.indexOf("sub") >= 0)) {
+            if ((vAlign.contains("sup")) ||
+                (vAlign.contains("sub"))) {
                 size -= 2;
             }
         }
@@ -908,7 +907,7 @@ public class CSS implements Serializable {
             style |= Font.BOLD;
         }
         Object fs = a.getAttribute(CSS.Attribute.FONT_STYLE);
-        if ((fs != null) && (fs.toString().indexOf("italic") >= 0)) {
+        if ((fs != null) && (fs.toString().contains("italic"))) {
             style |= Font.ITALIC;
         }
         if (family.equalsIgnoreCase("monospace")) {
@@ -1965,12 +1964,12 @@ public class CSS implements Serializable {
          */
         Object toStyleConstants(StyleConstants key, View v) {
             if (key == StyleConstants.Italic) {
-                if (svalue.indexOf("italic") >= 0) {
+                if (svalue.contains("italic")) {
                     return Boolean.TRUE;
                 }
                 return Boolean.FALSE;
             } else if (key == StyleConstants.Underline) {
-                if (svalue.indexOf("underline") >= 0) {
+                if (svalue.contains("underline")) {
                     return Boolean.TRUE;
                 }
                 return Boolean.FALSE;
@@ -1984,17 +1983,17 @@ public class CSS implements Serializable {
                 }
                 return StyleConstants.ALIGN_LEFT;
             } else if (key == StyleConstants.StrikeThrough) {
-                if (svalue.indexOf("line-through") >= 0) {
+                if (svalue.contains("line-through")) {
                     return Boolean.TRUE;
                 }
                 return Boolean.FALSE;
             } else if (key == StyleConstants.Superscript) {
-                if (svalue.indexOf("super") >= 0) {
+                if (svalue.contains("super")) {
                     return Boolean.TRUE;
                 }
                 return Boolean.FALSE;
             } else if (key == StyleConstants.Subscript) {
-                if (svalue.indexOf("sub") >= 0) {
+                if (svalue.contains("sub")) {
                     return Boolean.TRUE;
                 }
                 return Boolean.FALSE;
@@ -2004,23 +2003,23 @@ public class CSS implements Serializable {
 
         // Used by ViewAttributeSet
         boolean isItalic() {
-            return (svalue.indexOf("italic") != -1);
+            return (svalue.contains("italic"));
         }
 
         boolean isStrike() {
-            return (svalue.indexOf("line-through") != -1);
+            return (svalue.contains("line-through"));
         }
 
         boolean isUnderline() {
-            return (svalue.indexOf("underline") != -1);
+            return (svalue.contains("underline"));
         }
 
         boolean isSub() {
-            return (svalue.indexOf("sub") != -1);
+            return (svalue.contains("sub"));
         }
 
         boolean isSup() {
-            return (svalue.indexOf("sup") != -1);
+            return (svalue.contains("sup"));
         }
     }
 

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3253,8 +3253,8 @@ public class HTMLDocument extends DefaultStyledDocument {
                     }
                     if (rel != null) {
                         rel = rel.toLowerCase();
-                        if ((media.indexOf("all") != -1 ||
-                             media.indexOf("screen") != -1) &&
+                        if ((media.contains("all") ||
+                             media.contains("screen")) &&
                             (rel.equals("stylesheet") ||
                              (rel.equals("alternate stylesheet") &&
                               title.equals(defaultStyle)))) {

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLWriter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1074,23 +1074,23 @@ public class HTMLWriter extends AbstractWriter {
                     }
                 } else if (key == CSS.Attribute.FONT_STYLE) {
                     String s = from.getAttribute(key).toString();
-                    if (s.indexOf("italic") >= 0) {
+                    if (s.contains("italic")) {
                         addAttribute(to, HTML.Tag.I, SimpleAttributeSet.EMPTY);
                     }
                 } else if (key == CSS.Attribute.TEXT_DECORATION) {
                     String decor = from.getAttribute(key).toString();
-                    if (decor.indexOf("underline") >= 0) {
+                    if (decor.contains("underline")) {
                         addAttribute(to, HTML.Tag.U, SimpleAttributeSet.EMPTY);
                     }
-                    if (decor.indexOf("line-through") >= 0) {
+                    if (decor.contains("line-through")) {
                         addAttribute(to, HTML.Tag.STRIKE, SimpleAttributeSet.EMPTY);
                     }
                 } else if (key == CSS.Attribute.VERTICAL_ALIGN) {
                     String vAlign = from.getAttribute(key).toString();
-                    if (vAlign.indexOf("sup") >= 0) {
+                    if (vAlign.contains("sup")) {
                         addAttribute(to, HTML.Tag.SUP, SimpleAttributeSet.EMPTY);
                     }
-                    if (vAlign.indexOf("sub") >= 0) {
+                    if (vAlign.contains("sub")) {
                         addAttribute(to, HTML.Tag.SUB, SimpleAttributeSet.EMPTY);
                     }
                 } else if (key == CSS.Attribute.TEXT_ALIGN) {

--- a/src/java.desktop/share/classes/javax/swing/text/html/InlineView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/InlineView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -188,15 +188,15 @@ public class InlineView extends LabelView {
         AttributeSet a = getAttributes();
         Object decor = a.getAttribute(CSS.Attribute.TEXT_DECORATION);
         boolean u = (decor != null) ?
-          (decor.toString().indexOf("underline") >= 0) : false;
+          (decor.toString().contains("underline")) : false;
         setUnderline(u);
         boolean s = (decor != null) ?
-          (decor.toString().indexOf("line-through") >= 0) : false;
+          (decor.toString().contains("line-through")) : false;
         setStrikeThrough(s);
         Object vAlign = a.getAttribute(CSS.Attribute.VERTICAL_ALIGN);
-        s = (vAlign != null) ? (vAlign.toString().indexOf("sup") >= 0) : false;
+        s = (vAlign != null) ? (vAlign.toString().contains("sup")) : false;
         setSuperscript(s);
-        s = (vAlign != null) ? (vAlign.toString().indexOf("sub") >= 0) : false;
+        s = (vAlign != null) ? (vAlign.toString().contains("sub")) : false;
         setSubscript(s);
 
         Object whitespace = a.getAttribute(CSS.Attribute.WHITE_SPACE);

--- a/src/java.desktop/share/classes/sun/font/Font2D.java
+++ b/src/java.desktop/share/classes/sun/font/Font2D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -153,21 +153,21 @@ public abstract class Font2D {
         String fName = fullName.toLowerCase();
 
         for (int i=0; i < boldItalicNames.length; i++) {
-            if (fName.indexOf(boldItalicNames[i]) != -1) {
+            if (fName.contains(boldItalicNames[i])) {
                 style = Font.BOLD|Font.ITALIC;
                 return;
             }
         }
 
         for (int i=0; i < italicNames.length; i++) {
-            if (fName.indexOf(italicNames[i]) != -1) {
+            if (fName.contains(italicNames[i])) {
                 style = Font.ITALIC;
                 return;
             }
         }
 
         for (int i=0; i < boldNames.length; i++) {
-            if (fName.indexOf(boldNames[i]) != -1 ) {
+            if (fName.contains(boldNames[i])) {
                 style = Font.BOLD;
                 return;
             }

--- a/src/java.desktop/unix/classes/sun/awt/X11/XWM.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XWM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -252,7 +252,7 @@ final class XWM
          * Quick checks for specific servers.
          */
         String vendor_string = XlibWrapper.ServerVendor(XToolkit.getDisplay());
-        if (vendor_string.indexOf("eXcursion") != -1) {
+        if (vendor_string.contains("eXcursion")) {
             /*
              * Use NO_WM since in all other aspects eXcursion is like not
              * having a window manager running. I.e. it does not reparent

--- a/src/java.desktop/unix/classes/sun/font/NativeFont.java
+++ b/src/java.desktop/unix/classes/sun/font/NativeFont.java
@@ -133,14 +133,14 @@ public class NativeFont extends PhysicalFont {
 
             String styleStr = null;
 
-            if (tmpWeight.indexOf("bold") >= 0 ||
-                tmpWeight.indexOf("demi") >= 0) {
+            if (tmpWeight.contains("bold") ||
+                tmpWeight.contains("demi")) {
                 style |= Font.BOLD;
                 styleStr = "Bold";
             }
 
             if (tmpSlant.equals("i") ||
-                tmpSlant.indexOf("italic") >= 0) {
+                tmpSlant.contains("italic")) {
                 style |= Font.ITALIC;
 
                 if (styleStr == null) {
@@ -150,7 +150,7 @@ public class NativeFont extends PhysicalFont {
                 }
             }
             else if (tmpSlant.equals("o") ||
-                tmpSlant.indexOf("oblique") >= 0) {
+                tmpSlant.contains("oblique")) {
                 style |= Font.ITALIC;
                 if (styleStr == null) {
                     styleStr = "Oblique";
@@ -169,10 +169,10 @@ public class NativeFont extends PhysicalFont {
             if (encoding.startsWith("-")) {
                 encoding = xlfd.substring(hPos[13]+1);
             }
-            if (encoding.indexOf("fontspecific") >= 0) {
-                if (tmpFamily.indexOf("dingbats") >= 0) {
+            if (encoding.contains("fontspecific")) {
+                if (tmpFamily.contains("dingbats")) {
                     encoding = "dingbats";
-                } else if (tmpFamily.indexOf("symbol") >= 0) {
+                } else if (tmpFamily.contains("symbol")) {
                     encoding = "symbol";
                 } else {
                     encoding = "iso8859-1";

--- a/src/java.desktop/unix/classes/sun/font/XMap.java
+++ b/src/java.desktop/unix/classes/sun/font/XMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,12 +25,7 @@
 
 package sun.font;
 
-import java.awt.FontFormatException;
-import java.awt.font.FontRenderContext;
-import java.awt.geom.GeneralPath;
-import java.awt.geom.Rectangle2D;
 import java.util.HashMap;
-import java.util.Locale;
 import java.nio.charset.*;
 import java.nio.CharBuffer;
 import java.nio.ByteBuffer;
@@ -119,13 +114,13 @@ class XMap {
         } else if (encoding.equals("ksc5601.1987-0")) {
             jclass ="sun.font.X11KSC5601";
             nBytes = DOUBLE_BYTE;
-        } else if (encoding.equals( "ksc5601.1992-3")) {
+        } else if (encoding.equals("ksc5601.1992-3")) {
             jclass ="sun.font.X11Johab";
             nBytes = DOUBLE_BYTE;
-        } else if (encoding.equals( "ksc5601.1987-1")) {
+        } else if (encoding.equals("ksc5601.1987-1")) {
             jclass ="EUC_KR";
             nBytes = DOUBLE_BYTE;
-        } else if (encoding.equals( "cns11643-1")) {
+        } else if (encoding.equals("cns11643-1")) {
             jclass = "sun.font.X11CNS11643P1";
             nBytes = DOUBLE_BYTE;
         } else if (encoding.equals("cns11643-2")) {
@@ -137,7 +132,7 @@ class XMap {
         } else if (encoding.equals("gb2312.1980-0")) {
             jclass = "sun.font.X11GB2312";
             nBytes = DOUBLE_BYTE;
-        } else if (encoding.indexOf("big5") >= 0) {
+        } else if (encoding.contains("big5")) {
             jclass = "Big5";
             nBytes = DOUBLE_BYTE;
             addAscii = true;
@@ -146,16 +141,16 @@ class XMap {
         } else if (encoding.equals("gbk-0")) {
             jclass = "sun.font.X11GBK";
             nBytes = DOUBLE_BYTE;
-        } else if (encoding.indexOf("sun.unicode-0") >= 0) {
+        } else if (encoding.contains("sun.unicode-0")) {
             jclass = "sun.font.X11SunUnicode_0";
             nBytes = DOUBLE_BYTE;
-        } else if (encoding.indexOf("gb18030.2000-1") >= 0) {
+        } else if (encoding.contains("gb18030.2000-1")) {
             jclass = "sun.font.X11GB18030_1";
             nBytes = DOUBLE_BYTE;
-        } else if (encoding.indexOf( "gb18030.2000-0") >= 0) {
+        } else if (encoding.contains("gb18030.2000-0")) {
             jclass = "sun.font.X11GB18030_0";
             nBytes = DOUBLE_BYTE;
-        } else if (encoding.indexOf("hkscs") >= 0) {
+        } else if (encoding.contains("hkscs")) {
             jclass = "MS950_HKSCS_XP";
             nBytes = DOUBLE_BYTE;
         }

--- a/src/java.desktop/unix/classes/sun/print/IPPPrintService.java
+++ b/src/java.desktop/unix/classes/sun/print/IPPPrintService.java
@@ -927,7 +927,7 @@ public class IPPPrintService implements PrintService, SunPrinterJobService {
                                 gifImagesAdded = true;
                             } else if (mimeType.equals("image/jpeg")) {
                                 jpgImagesAdded = true;
-                            } else if (mimeType.indexOf("postscript") != -1) {
+                            } else if (mimeType.contains("postscript")) {
                                 psSupported = true;
                             }
                             break;
@@ -1555,7 +1555,7 @@ public class IPPPrintService implements PrintService, SunPrinterJobService {
                     return mediaSizeNames[defaultMediaIndex];
                 } else {
                     for (int i=0; i< mediaSizeNames.length; i++) {
-                        if (mediaSizeNames[i].toString().indexOf(name) != -1) {
+                        if (mediaSizeNames[i].toString().contains(name)) {
                             defaultMediaIndex = i;
                             return mediaSizeNames[defaultMediaIndex];
                         }

--- a/src/java.desktop/windows/classes/sun/awt/windows/WDataTransferer.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WDataTransferer.java
@@ -606,10 +606,10 @@ class HTMLCodec extends InputStream {
             //to avoid HTML and BODY tags doubling
             String stContext = new String(bytes);
             String stUpContext = stContext.toUpperCase();
-            if( -1 == stUpContext.indexOf("<HTML") ) {
+            if (!stUpContext.contains("<HTML")) {
                 htmlPrefix = "<HTML>";
                 htmlSuffix = "</HTML>";
-                if( -1 == stUpContext.indexOf("<BODY") ) {
+                if (!stUpContext.contains("<BODY")) {
                     htmlPrefix = htmlPrefix +"<BODY>";
                     htmlSuffix = "</BODY>" + htmlSuffix;
                 };


### PR DESCRIPTION
String.contains was introduced in Java 5.
Some code in java.desktop still uses old approach with String.indexOf to check if String contains specified substring.
I propose to migrate such usages. Makes code shorter and easier to read.