### PR TITLE
8273505: runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java#default-cl crashed with SIGSEGV in MetaspaceShared::link_shared_classes

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -302,9 +302,7 @@ bool ClassLoaderData::try_claim(int claim) {
 // it is being defined, therefore _keep_alive is not volatile or atomic.
 void ClassLoaderData::inc_keep_alive() {
   if (has_class_mirror_holder()) {
-    if (!Arguments::is_dumping_archive()) {
-      assert(_keep_alive > 0, "Invalid keep alive increment count");
-    }
+    assert(_keep_alive > 0, "Invalid keep alive increment count");
     _keep_alive++;
   }
 }


### PR DESCRIPTION
Please review this small patch for keeping the class loader, which is the holder of the `ClassLoaderData`, alive during class linking within `MetaspaceShared::link_shared_classes()`. Prior to this fix, the `ClassLoaderData::inc_keep_alive()` was used in an attempt to keep the `ClassLoaderData` alive but that was for hidden classes only.

Testing: tiers 1 - 4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273505](https://bugs.openjdk.java.net/browse/JDK-8273505): runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java#default-cl crashed with SIGSEGV in MetaspaceShared::link_shared_classes


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5566/head:pull/5566` \
`$ git checkout pull/5566`

Update a local copy of the PR: \
`$ git checkout pull/5566` \
`$ git pull https://git.openjdk.java.net/jdk pull/5566/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5566`

View PR using the GUI difftool: \
`$ git pr show -t 5566`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5566.diff">https://git.openjdk.java.net/jdk/pull/5566.diff</a>

</details>
