### PR TITLE
JDK-8273958: gtest/MetaspaceGtests executes unnecessary tests in debug builds

### DIFF
--- a/test/hotspot/jtreg/gtest/MetaspaceGtests.java
+++ b/test/hotspot/jtreg/gtest/MetaspaceGtests.java
@@ -32,10 +32,10 @@
 /* @test id=reclaim-none-debug
  * @bug 8251158
  * @summary Run metaspace-related gtests for reclaim policy none (with verifications)
- * @requires vm.debug
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.xml
+ * @requires vm.debug
  * @requires vm.flagless
  * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:MetaspaceReclaimPolicy=none -XX:+UnlockDiagnosticVMOptions -XX:VerifyMetaspaceInterval=3
  */
@@ -46,6 +46,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.xml
+ * @requires vm.debug == false
  * @requires vm.flagless
  * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:MetaspaceReclaimPolicy=none
  */
@@ -56,10 +57,10 @@
 /* @test id=reclaim-aggressive-debug
  * @bug 8251158
  * @summary Run metaspace-related gtests for reclaim policy aggressive (with verifications)
- * @requires vm.debug
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.xml
+ * @requires vm.debug
  * @requires vm.flagless
  * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:MetaspaceReclaimPolicy=aggressive -XX:+UnlockDiagnosticVMOptions -XX:VerifyMetaspaceInterval=3
  */
@@ -70,6 +71,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.xml
+ * @requires vm.debug == false
  * @requires vm.flagless
  * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:MetaspaceReclaimPolicy=aggressive
  */
@@ -79,10 +81,10 @@
 
 /* @test id=balanced-with-guards
  * @summary Run metaspace-related gtests with allocation guards enabled
- * @requires vm.debug
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.xml
+ * @requires vm.debug
  * @requires vm.flagless
  * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:+UnlockDiagnosticVMOptions -XX:VerifyMetaspaceInterval=3 -XX:+MetaspaceGuardAllocations
  */
@@ -92,10 +94,10 @@
 
 /* @test id=balanced-no-ccs
  * @summary Run metaspace-related gtests with compressed class pointers off
- * @requires vm.bits == 64
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.xml
+ * @requires vm.bits == 64
  * @requires vm.flagless
  * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:MetaspaceReclaimPolicy=balanced -XX:-UseCompressedClassPointers
  */


### PR DESCRIPTION
May I please have reviews for this trivial fix.

We miss two "debug==false" requires rules on tests meant for non-debug only. Taking them out reduces test runtime on debug by ~20 seconds.

I also shifted some of the existing requires tags down to cluster them together in one place, for better clarity.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273958](https://bugs.openjdk.java.net/browse/JDK-8273958): gtest/MetaspaceGtests executes unnecessary tests in debug builds


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5571/head:pull/5571` \
`$ git checkout pull/5571`

Update a local copy of the PR: \
`$ git checkout pull/5571` \
`$ git pull https://git.openjdk.java.net/jdk pull/5571/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5571`

View PR using the GUI difftool: \
`$ git pr show -t 5571`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5571.diff">https://git.openjdk.java.net/jdk/pull/5571.diff</a>

</details>
