### PR TITLE
JDK-8273959: Some metaspace diagnostic switches should be develop

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1435,10 +1435,10 @@ const intx ObjectAlignmentInBytes = 8;
   product(bool, PrintMetaspaceStatisticsAtExit, false, DIAGNOSTIC,          \
           "Print metaspace statistics upon VM exit.")                       \
                                                                             \
-  product(bool, MetaspaceGuardAllocations, false, DIAGNOSTIC,               \
+  develop(bool, MetaspaceGuardAllocations, false,                           \
           "Metapace allocations are guarded.")                              \
                                                                             \
-  product(bool, MetaspaceHandleDeallocations, true, DIAGNOSTIC,             \
+  develop(bool, MetaspaceHandleDeallocations, true,                         \
           "Switch off Metapace deallocation handling.")                     \
                                                                             \
   product(uintx, MinHeapFreeRatio, 40, MANAGEABLE,                          \

--- a/test/hotspot/jtreg/gtest/MetaspaceGtests.java
+++ b/test/hotspot/jtreg/gtest/MetaspaceGtests.java
@@ -37,7 +37,7 @@
  *          java.xml
  * @requires vm.debug
  * @requires vm.flagless
- * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:MetaspaceReclaimPolicy=none -XX:+UnlockDiagnosticVMOptions -XX:VerifyMetaspaceInterval=3
+ * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:MetaspaceReclaimPolicy=none -XX:VerifyMetaspaceInterval=3
  */
 
 /* @test id=reclaim-none-ndebug
@@ -62,7 +62,7 @@
  *          java.xml
  * @requires vm.debug
  * @requires vm.flagless
- * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:MetaspaceReclaimPolicy=aggressive -XX:+UnlockDiagnosticVMOptions -XX:VerifyMetaspaceInterval=3
+ * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:MetaspaceReclaimPolicy=aggressive -XX:VerifyMetaspaceInterval=3
  */
 
 /* @test id=reclaim-aggressive-ndebug
@@ -86,7 +86,7 @@
  *          java.xml
  * @requires vm.debug
  * @requires vm.flagless
- * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:+UnlockDiagnosticVMOptions -XX:VerifyMetaspaceInterval=3 -XX:+MetaspaceGuardAllocations
+ * @run main/native GTestWrapper --gtest_filter=metaspace* -XX:VerifyMetaspaceInterval=3 -XX:+MetaspaceGuardAllocations
  */
 
 


### PR DESCRIPTION
May I have reviews please for this fix.

The switches `MetaspaceHandleDeallocations` and `MetaspaceGuardAllocations` control debug-only features and consequently should be develop instead.

Unnecessary usage of -XX:+UnlockDiagnosticVMOptions is removed (in two cases unrelated to the changed switches).

/label hotspot-runtime

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273959](https://bugs.openjdk.java.net/browse/JDK-8273959): Some metaspace diagnostic switches should be develop


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5573/head:pull/5573` \
`$ git checkout pull/5573`

Update a local copy of the PR: \
`$ git checkout pull/5573` \
`$ git pull https://git.openjdk.java.net/jdk pull/5573/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5573`

View PR using the GUI difftool: \
`$ git pr show -t 5573`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5573.diff">https://git.openjdk.java.net/jdk/pull/5573.diff</a>

</details>
