### PR TITLE
[PATCH] Fields 'progressSourceList'/'progressListenerList' in ProgressMonitor accessed without synchronization

### DIFF
--- a/src/java.base/share/classes/sun/net/ProgressMonitor.java
+++ b/src/java.base/share/classes/sun/net/ProgressMonitor.java
@@ -68,7 +68,7 @@ public class ProgressMonitor {
             synchronized (progressSourceList) {
                 for (ProgressSource pi : progressSourceList) {
                     // Clone ProgressSource and add to snapshot
-                    snapshot.add((ProgressSource) pi.clone());
+                    snapshot.add((ProgressSource)pi.clone());
                 }
             }
         } catch (CloneNotSupportedException e) {
@@ -161,7 +161,7 @@ public class ProgressMonitor {
     public void updateProgress(ProgressSource pi) {
 
         synchronized (progressSourceList) {
-            if (progressSourceList.contains(pi) == false)
+            if (!progressSourceList.contains(pi))
                 return;
         }
 

--- a/src/java.base/share/classes/sun/net/ProgressMonitor.java
+++ b/src/java.base/share/classes/sun/net/ProgressMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.net;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.net.URL;
 
 /**
@@ -70,7 +69,7 @@ public class ProgressMonitor
             synchronized(progressSourceList)    {
                 for (ProgressSource pi : progressSourceList) {
                     // Clone ProgressSource and add to snapshot
-                    snapshot.add((ProgressSource)pi.clone());
+                    snapshot.add((ProgressSource) pi.clone());
                 }
             }
         }
@@ -215,10 +214,10 @@ public class ProgressMonitor
     private static ProgressMonitor pm = new ProgressMonitor();
 
     // ArrayList for outstanding progress sources
-    private ArrayList<ProgressSource> progressSourceList = new ArrayList<ProgressSource>();
+    private final ArrayList<ProgressSource> progressSourceList = new ArrayList<ProgressSource>();
 
     // ArrayList for progress listeners
-    private ArrayList<ProgressListener> progressListenerList = new ArrayList<ProgressListener>();
+    private final ArrayList<ProgressListener> progressListenerList = new ArrayList<ProgressListener>();
 }
 
 

--- a/src/java.base/share/classes/sun/net/ProgressMonitor.java
+++ b/src/java.base/share/classes/sun/net/ProgressMonitor.java
@@ -33,8 +33,7 @@ import java.net.URL;
  *
  * @author Stanley Man-Kit Ho
  */
-public class ProgressMonitor
-{
+public class ProgressMonitor {
     /**
      * Return default ProgressMonitor.
      */
@@ -45,7 +44,7 @@ public class ProgressMonitor
     /**
      * Change default ProgressMonitor implementation.
      */
-    public static synchronized void setDefault(ProgressMonitor m)   {
+    public static synchronized void setDefault(ProgressMonitor m) {
         if (m != null)
             pm = m;
     }
@@ -53,7 +52,7 @@ public class ProgressMonitor
     /**
      * Change progress metering policy.
      */
-    public static synchronized void setMeteringPolicy(ProgressMeteringPolicy policy)    {
+    public static synchronized void setMeteringPolicy(ProgressMeteringPolicy policy) {
         if (policy != null)
             meteringPolicy = policy;
     }
@@ -62,18 +61,17 @@ public class ProgressMonitor
     /**
      * Return a snapshot of the ProgressSource list
      */
-    public ArrayList<ProgressSource> getProgressSources()    {
+    public ArrayList<ProgressSource> getProgressSources() {
         ArrayList<ProgressSource> snapshot = new ArrayList<>();
 
         try {
-            synchronized(progressSourceList)    {
+            synchronized (progressSourceList) {
                 for (ProgressSource pi : progressSourceList) {
                     // Clone ProgressSource and add to snapshot
                     snapshot.add((ProgressSource) pi.clone());
                 }
             }
-        }
-        catch(CloneNotSupportedException e) {
+        } catch (CloneNotSupportedException e) {
             e.printStackTrace();
         }
 
@@ -83,7 +81,7 @@ public class ProgressMonitor
     /**
      * Return update notification threshold
      */
-    public synchronized int getProgressUpdateThreshold()    {
+    public synchronized int getProgressUpdateThreshold() {
         return meteringPolicy.getProgressUpdateThreshold();
     }
 
@@ -100,29 +98,28 @@ public class ProgressMonitor
      */
     public void registerSource(ProgressSource pi) {
 
-        synchronized(progressSourceList)    {
+        synchronized (progressSourceList) {
             if (progressSourceList.contains(pi))
                 return;
 
             progressSourceList.add(pi);
         }
 
-        // Notify only if there is at least one listener
-        if (progressListenerList.size() > 0)
-        {
-            // Notify progress listener if there is progress change
-            ArrayList<ProgressListener> listeners;
+        ArrayList<ProgressListener> listeners;
+        synchronized (progressListenerList) {
+            // Notify only if there is at least one listener
+            if (progressListenerList.isEmpty()) {
+                return;
+            }
 
             // Copy progress listeners to another list to avoid holding locks
-            synchronized(progressListenerList) {
-                listeners = new ArrayList<>(progressListenerList);
-            }
+            listeners = new ArrayList<>(progressListenerList);
+        }
 
-            // Fire event on each progress listener
-            for (ProgressListener pl : listeners) {
-                ProgressEvent pe = new ProgressEvent(pi, pi.getURL(), pi.getMethod(), pi.getContentType(), pi.getState(), pi.getProgress(), pi.getExpected());
-                pl.progressStart(pe);
-            }
+        // Fire event on each progress listener
+        for (ProgressListener pl : listeners) {
+            ProgressEvent pe = new ProgressEvent(pi, pi.getURL(), pi.getMethod(), pi.getContentType(), pi.getState(), pi.getProgress(), pi.getExpected());
+            pl.progressStart(pe);
         }
     }
 
@@ -131,9 +128,9 @@ public class ProgressMonitor
      */
     public void unregisterSource(ProgressSource pi) {
 
-        synchronized(progressSourceList) {
+        synchronized (progressSourceList) {
             // Return if ProgressEvent does not exist
-            if (progressSourceList.contains(pi) == false)
+            if (!progressSourceList.contains(pi))
                 return;
 
             // Close entry and remove from map
@@ -141,51 +138,48 @@ public class ProgressMonitor
             progressSourceList.remove(pi);
         }
 
-        // Notify only if there is at least one listener
-        if (progressListenerList.size() > 0)
-        {
-            // Notify progress listener if there is progress change
-            ArrayList<ProgressListener> listeners;
+        ArrayList<ProgressListener> listeners;
+        synchronized (progressListenerList) {
+            // Notify only if there is at least one listener
+            if (progressListenerList.isEmpty()) {
+                return;
+            }
 
             // Copy progress listeners to another list to avoid holding locks
-            synchronized(progressListenerList) {
-                listeners = new ArrayList<>(progressListenerList);
-            }
-
-            // Fire event on each progress listener
-            for (ProgressListener pl : listeners) {
-                ProgressEvent pe = new ProgressEvent(pi, pi.getURL(), pi.getMethod(), pi.getContentType(), pi.getState(), pi.getProgress(), pi.getExpected());
-                pl.progressFinish(pe);
-            }
+            listeners = new ArrayList<>(progressListenerList);
+        }
+        // Fire event on each progress listener
+        for (ProgressListener pl : listeners) {
+            ProgressEvent pe = new ProgressEvent(pi, pi.getURL(), pi.getMethod(), pi.getContentType(), pi.getState(), pi.getProgress(), pi.getExpected());
+            pl.progressFinish(pe);
         }
     }
 
     /**
      * Progress source is updated.
      */
-    public void updateProgress(ProgressSource pi)   {
+    public void updateProgress(ProgressSource pi) {
 
-        synchronized (progressSourceList)   {
+        synchronized (progressSourceList) {
             if (progressSourceList.contains(pi) == false)
                 return;
         }
 
-        // Notify only if there is at least one listener
-        if (progressListenerList.size() > 0)
-        {
-            // Notify progress listener if there is progress change
-            ArrayList<ProgressListener> listeners;
+        ArrayList<ProgressListener> listeners;
+        synchronized (progressListenerList) {
+            // Notify only if there is at least one listener
+            if (progressListenerList.isEmpty()) {
+                return;
+            }
 
             // Copy progress listeners to another list to avoid holding locks
-            synchronized(progressListenerList)  {
-                listeners = new ArrayList<>(progressListenerList);
-            }
+            listeners = new ArrayList<>(progressListenerList);
+        }
 
-            // Fire event on each progress listener
-            for (ProgressListener pl : listeners) {
-                ProgressEvent pe = new ProgressEvent(pi, pi.getURL(), pi.getMethod(), pi.getContentType(), pi.getState(), pi.getProgress(), pi.getExpected());
-                pl.progressUpdate(pe);
-            }
+        // Fire event on each progress listener
+        for (ProgressListener pl : listeners) {
+            ProgressEvent pe = new ProgressEvent(pi, pi.getURL(), pi.getMethod(), pi.getContentType(), pi.getState(), pi.getProgress(), pi.getExpected());
+            pl.progressUpdate(pe);
         }
     }
 
@@ -193,7 +187,7 @@ public class ProgressMonitor
      * Add progress listener in progress monitor.
      */
     public void addProgressListener(ProgressListener l) {
-        synchronized(progressListenerList) {
+        synchronized (progressListenerList) {
             progressListenerList.add(l);
         }
     }
@@ -202,7 +196,7 @@ public class ProgressMonitor
      * Remove progress listener from progress monitor.
      */
     public void removeProgressListener(ProgressListener l) {
-        synchronized(progressListenerList) {
+        synchronized (progressListenerList) {
             progressListenerList.remove(l);
         }
     }
@@ -214,22 +208,21 @@ public class ProgressMonitor
     private static ProgressMonitor pm = new ProgressMonitor();
 
     // ArrayList for outstanding progress sources
-    private final ArrayList<ProgressSource> progressSourceList = new ArrayList<ProgressSource>();
+    private final ArrayList<ProgressSource> progressSourceList = new ArrayList<>();
 
     // ArrayList for progress listeners
-    private final ArrayList<ProgressListener> progressListenerList = new ArrayList<ProgressListener>();
+    private final ArrayList<ProgressListener> progressListenerList = new ArrayList<>();
 }
 
 
 /**
  * Default progress metering policy.
  */
-class DefaultProgressMeteringPolicy implements ProgressMeteringPolicy  {
+class DefaultProgressMeteringPolicy implements ProgressMeteringPolicy {
     /**
      * Return true if metering should be turned on for a particular network input stream.
      */
-    public boolean shouldMeterInput(URL url, String method)
-    {
+    public boolean shouldMeterInput(URL url, String method) {
         // By default, no URL input stream is metered for
         // performance reason.
         return false;


### PR DESCRIPTION
ArrayList is not a thread-safe collection. And ProgressMonitor uses java synchronized blocks to access to ArrayList fields: 'progressSourceList' and 'progressListenerList'.
Unfortunately it's done not in all places. Even ArrayList.size() method should be called only under lock, to guarantee memory visibility.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5575/head:pull/5575` \
`$ git checkout pull/5575`

Update a local copy of the PR: \
`$ git checkout pull/5575` \
`$ git pull https://git.openjdk.java.net/jdk pull/5575/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5575`

View PR using the GUI difftool: \
`$ git pr show -t 5575`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5575.diff">https://git.openjdk.java.net/jdk/pull/5575.diff</a>

</details>
