### PR TITLE
8273965: some testlibrary_tests/ir_framework tests fail when c1 disabled

### DIFF
--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestCompLevels.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestCompLevels.java
@@ -30,7 +30,7 @@ import java.lang.reflect.Method;
 
 /*
  * @test
- * @requires vm.flagless
+ * @requires vm.flagless & vm.compiler1.enabled
  * @summary Test if compilation levels are used correctly in the framework.
  *          This test partly runs directly the test VM which normally does and should not happen in user tests.
  * @library /test/lib /

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestControls.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestControls.java
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
 
 /*
  * @test
- * @requires vm.debug == true & vm.compMode != "Xint" & vm.compiler2.enabled & vm.flagless
+ * @requires vm.debug == true & vm.compMode != "Xint" & vm.compiler1.enabled & vm.compiler2.enabled & vm.flagless
  * @summary Test if compilation control annotaions are handled correctly in the framework.
  *          This test partly runs directly the test VM which normally does and should not happen in user tests.
  * @library /test/lib /

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestRunTests.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestRunTests.java
@@ -32,7 +32,7 @@ import java.util.Arrays;
 
 /*
  * @test
- * @requires vm.debug == true & vm.compMode != "Xint" & vm.compiler2.enabled & vm.flagless
+ * @requires vm.debug == true & vm.compMode != "Xint" & vm.compiler1.enabled & vm.compiler2.enabled & vm.flagless
  * @summary Test different custom run tests.
  * @library /test/lib /testlibrary_tests /
  * @run driver ir_framework.tests.TestRunTests


### PR DESCRIPTION
These tests failed with c2-only build:
```
test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestCompLevels.java
test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestControls.java
test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestRunTests.java
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273965](https://bugs.openjdk.java.net/browse/JDK-8273965): some testlibrary_tests/ir_framework tests fail when c1 disabled


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5576/head:pull/5576` \
`$ git checkout pull/5576`

Update a local copy of the PR: \
`$ git checkout pull/5576` \
`$ git pull https://git.openjdk.java.net/jdk pull/5576/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5576`

View PR using the GUI difftool: \
`$ git pr show -t 5576`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5576.diff">https://git.openjdk.java.net/jdk/pull/5576.diff</a>

</details>
