### PR TITLE
[PATCH] Replace 'while' cycles with iterator with enhanced-for in jdk.jdi

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/ConcreteMethodImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/ConcreteMethodImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,8 +37,6 @@ import com.sun.jdi.AbsentInformationException;
 import com.sun.jdi.LocalVariable;
 import com.sun.jdi.Location;
 import com.sun.jdi.VirtualMachine;
-import com.sun.tools.jdi.JDWP.Method.VariableTable;
-import com.sun.tools.jdi.JDWP.Method.VariableTableWithGeneric;
 
 /**
  * Represents methods with method bodies.
@@ -220,9 +218,7 @@ public class ConcreteMethodImpl extends MethodImpl {
         List<LocalVariable> variables = getVariables();
 
         List<LocalVariable> retList = new ArrayList<>(2);
-        Iterator<LocalVariable> iter = variables.iterator();
-        while(iter.hasNext()) {
-            LocalVariable variable = iter.next();
+        for (LocalVariable variable : variables) {
             if (variable.name().equals(name)) {
                 retList.add(variable);
             }
@@ -234,9 +230,7 @@ public class ConcreteMethodImpl extends MethodImpl {
         List<LocalVariable> variables = getVariables();
 
         List<LocalVariable> retList = new ArrayList<>(variables.size());
-        Iterator<LocalVariable> iter = variables.iterator();
-        while(iter.hasNext()) {
-            LocalVariable variable = iter.next();
+        for (LocalVariable variable : variables) {
             if (variable.isArgument()) {
                 retList.add(variable);
             }
@@ -289,9 +283,8 @@ public class ConcreteMethodImpl extends MethodImpl {
         int highestLine = -1;
         SDE.LineStratum lastLineStratum = null;
         SDE.Stratum baseStratum = declaringType.stratum(SDE.BASE_STRATUM_NAME);
-        Iterator<Location> it = getBaseLocations().lineLocations.iterator();
-        while(it.hasNext()) {
-            LocationImpl loc = (LocationImpl)it.next();
+        for (Location lineLocation : getBaseLocations().lineLocations) {
+            LocationImpl loc = (LocationImpl) lineLocation;
             int baseLineNumber = loc.lineNumber(baseStratum);
             SDE.LineStratum lineStratum =
                   stratum.lineStratum(declaringType, baseLineNumber);

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/ConnectorImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/ConnectorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,9 +51,8 @@ abstract class ConnectorImpl implements Connector {
         Map<String,Argument> defaults = new LinkedHashMap<>();
         Collection<Argument> values = defaultArguments.values();
 
-        Iterator<Argument> iter = values.iterator();
-        while (iter.hasNext()) {
-            ArgumentImpl argument = (ArgumentImpl)iter.next();
+        for (Argument a : values) {
+            ArgumentImpl argument = (ArgumentImpl) a;
             defaults.put(argument.name(), (Argument)argument.clone());
         }
         return defaults;

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/EventRequestManagerImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/EventRequestManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package com.sun.tools.jdi;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -611,9 +610,7 @@ class EventRequestManagerImpl extends MirrorImpl
              * Make sure this isn't a duplicate
              */
             List<StepRequest> requests = stepRequests();
-            Iterator<StepRequest> iter = requests.iterator();
-            while (iter.hasNext()) {
-                StepRequest request = iter.next();
+            for (StepRequest request : requests) {
                 if ((request != this) &&
                         request.isEnabled() &&
                         request.thread().equals(thread)) {
@@ -880,9 +877,8 @@ class EventRequestManagerImpl extends MirrorImpl
     public void deleteEventRequests(List<? extends EventRequest> eventRequests) {
         validateMirrors(eventRequests);
         // copy the eventRequests to avoid ConcurrentModificationException
-        Iterator<? extends EventRequest> iter = (new ArrayList<>(eventRequests)).iterator();
-        while (iter.hasNext()) {
-            ((EventRequestImpl)iter.next()).delete();
+        for (EventRequest eventRequest : new ArrayList<>(eventRequests)) {
+            ((EventRequestImpl) eventRequest).delete();
         }
     }
 
@@ -969,9 +965,8 @@ class EventRequestManagerImpl extends MirrorImpl
     EventRequest request(int eventCmd, int requestId) {
         List<? extends EventRequest> rl = requestList(eventCmd);
         synchronized(rl) {   // Refer Collections.synchronizedList javadoc.
-            Iterator<? extends EventRequest> itr = rl.iterator();
-            while (itr.hasNext()){
-                EventRequestImpl er = (EventRequestImpl)itr.next();
+            for (EventRequest eventRequest : rl) {
+                EventRequestImpl er = (EventRequestImpl) eventRequest;
                 if (er.id == requestId)
                     return er;
             }

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/InvokableTypeImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/InvokableTypeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package com.sun.tools.jdi;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -141,9 +140,8 @@ abstract class InvokableTypeImpl extends ReferenceTypeImpl {
             return true;
         } else {
             List<InterfaceType> interfaces = interfaces();
-            Iterator<InterfaceType> iter = interfaces.iterator();
-            while (iter.hasNext()) {
-                InterfaceTypeImpl interfaze = (InterfaceTypeImpl) iter.next();
+            for (InterfaceType interfaceType : interfaces) {
+                InterfaceTypeImpl interfaze = (InterfaceTypeImpl) interfaceType;
                 if (interfaze.isAssignableTo(type)) {
                     return true;
                 }
@@ -159,9 +157,8 @@ abstract class InvokableTypeImpl extends ReferenceTypeImpl {
          * parent types first, so that the methods in this class will
          * overwrite them in the hash table
          */
-        Iterator<InterfaceType> iter = interfaces().iterator();
-        while (iter.hasNext()) {
-            InterfaceTypeImpl interfaze = (InterfaceTypeImpl) iter.next();
+        for (InterfaceType interfaceType : interfaces()) {
+            InterfaceTypeImpl interfaze = (InterfaceTypeImpl) interfaceType;
             if (!seenInterfaces.contains(interfaze)) {
                 interfaze.addVisibleMethods(methodMap, seenInterfaces);
                 seenInterfaces.add(interfaze);
@@ -177,9 +174,8 @@ abstract class InvokableTypeImpl extends ReferenceTypeImpl {
     final void addInterfaces(List<InterfaceType> list) {
         List<InterfaceType> immediate = interfaces();
         list.addAll(interfaces());
-        Iterator<InterfaceType> iter = immediate.iterator();
-        while (iter.hasNext()) {
-            InterfaceTypeImpl interfaze = (InterfaceTypeImpl) iter.next();
+        for (InterfaceType interfaceType : immediate) {
+            InterfaceTypeImpl interfaze = (InterfaceTypeImpl) interfaceType;
             interfaze.addInterfaces(list);
         }
         ClassTypeImpl superclass = (ClassTypeImpl) superclass();

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/ReferenceTypeImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/ReferenceTypeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -118,9 +118,8 @@ public abstract class ReferenceTypeImpl extends TypeImpl implements ReferenceTyp
         // Fetch all methods for the class, check performance impact
         // Needs no synchronization now, since methods() returns
         // unmodifiable local data
-        Iterator<Method> it = methods().iterator();
-        while (it.hasNext()) {
-            MethodImpl method = (MethodImpl)it.next();
+        for (Method m : methods()) {
+            MethodImpl method = (MethodImpl) m;
             if (method.ref() == ref) {
                 return method;
             }
@@ -132,9 +131,8 @@ public abstract class ReferenceTypeImpl extends TypeImpl implements ReferenceTyp
         // Fetch all fields for the class, check performance impact
         // Needs no synchronization now, since fields() returns
         // unmodifiable local data
-        Iterator<Field>it = fields().iterator();
-        while (it.hasNext()) {
-            FieldImpl field = (FieldImpl)it.next();
+        for (Field f : fields()) {
+            FieldImpl field = (FieldImpl) f;
             if (field.ref() == ref) {
                 return field;
             }
@@ -420,12 +418,11 @@ public abstract class ReferenceTypeImpl extends TypeImpl implements ReferenceTyp
 
         /* Add inherited, visible fields */
         List<? extends ReferenceType> types = inheritedTypes();
-        Iterator<? extends ReferenceType> iter = types.iterator();
-        while (iter.hasNext()) {
+        for (ReferenceType referenceType : types) {
             /*
              * TO DO: Be defensive and check for cyclic interface inheritance
              */
-            ReferenceTypeImpl type = (ReferenceTypeImpl)iter.next();
+            ReferenceTypeImpl type = (ReferenceTypeImpl) referenceType;
             type.addVisibleFields(visibleList, visibleTable, ambiguousNames);
         }
 
@@ -454,9 +451,8 @@ public abstract class ReferenceTypeImpl extends TypeImpl implements ReferenceTyp
 
             /* Add inherited fields */
             List<? extends ReferenceType> types = inheritedTypes();
-            Iterator<? extends ReferenceType> iter = types.iterator();
-            while (iter.hasNext()) {
-                ReferenceTypeImpl type = (ReferenceTypeImpl)iter.next();
+            for (ReferenceType referenceType : types) {
+                ReferenceTypeImpl type = (ReferenceTypeImpl) referenceType;
                 type.addAllFields(fieldList, typeSet);
             }
         }
@@ -916,9 +912,8 @@ public abstract class ReferenceTypeImpl extends TypeImpl implements ReferenceTyp
 
         List<Location> list = new ArrayList<Location>();
 
-        Iterator<Method> iter = methods.iterator();
-        while(iter.hasNext()) {
-            MethodImpl method = (MethodImpl)iter.next();
+        for (Method m : methods) {
+            MethodImpl method = (MethodImpl) m;
             // eliminate native and abstract to eliminate
             // false positives
             if (!method.isAbstract() &&

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/TargetVM.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/TargetVM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -187,19 +186,16 @@ public class TargetVM implements Runnable {
         // Closing a queue causes a VMDisconnectEvent to
         // be put onto the queue.
         synchronized(eventQueues) {
-            Iterator<EventQueue> iter = eventQueues.iterator();
-            while (iter.hasNext()) {
-                ((EventQueueImpl)iter.next()).close();
+            for (EventQueue eventQueue : eventQueues) {
+                ((EventQueueImpl) eventQueue).close();
             }
         }
 
         // indirectly throw VMDisconnectedException to
         // command requesters.
         synchronized(waitingQueue) {
-            Iterator<Packet> iter = waitingQueue.values().iterator();
-            while (iter.hasNext()) {
-                Packet packet = iter.next();
-                synchronized(packet) {
+            for (Packet packet : waitingQueue.values()) {
+                synchronized (packet) {
                     packet.notify();
                 }
             }
@@ -258,9 +254,8 @@ public class TargetVM implements Runnable {
     void notifyDequeueEventSet() {
         int maxQueueSize = 0;
         synchronized(eventQueues) {
-            Iterator<EventQueue> iter = eventQueues.iterator();
-            while (iter.hasNext()) {
-                EventQueueImpl queue = (EventQueueImpl)iter.next();
+            for (EventQueue eventQueue : eventQueues) {
+                EventQueueImpl queue = (EventQueueImpl) eventQueue;
                 maxQueueSize = Math.max(maxQueueSize, queue.size());
             }
         }
@@ -271,9 +266,8 @@ public class TargetVM implements Runnable {
         int maxQueueSize = 0;
 
         synchronized(eventQueues) {
-            Iterator<EventQueue> iter = eventQueues.iterator();
-            while (iter.hasNext()) {
-                EventQueueImpl queue = (EventQueueImpl)iter.next();
+            for (EventQueue eventQueue : eventQueues) {
+                EventQueueImpl queue = (EventQueueImpl) eventQueue;
                 queue.enqueue(eventSet);
                 maxQueueSize = Math.max(maxQueueSize, queue.size());
             }

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/ThreadReferenceImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/ThreadReferenceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -314,9 +314,7 @@ public class ThreadReferenceImpl extends ObjectReferenceImpl
             StackFrame frame = frame(0);
             Location location = frame.location();
             List<BreakpointRequest> requests = vm.eventRequestManager().breakpointRequests();
-            Iterator<BreakpointRequest> iter = requests.iterator();
-            while (iter.hasNext()) {
-                BreakpointRequest request = iter.next();
+            for (BreakpointRequest request : requests) {
                 if (location.equals(request.location())) {
                     return true;
                 }

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/VMState.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/VMState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -174,9 +174,7 @@ class VMState {
     }
 
     synchronized boolean hasListener(VMListener listener) {
-        Iterator<WeakReference<VMListener>> iter = listeners.iterator();
-        while (iter.hasNext()) {
-            WeakReference<VMListener> ref = iter.next();
+        for (WeakReference<VMListener> ref : listeners) {
             if (listener.equals(ref.get())) {
                 return true;
             }

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/VirtualMachineImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/VirtualMachineImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,6 @@ import com.sun.jdi.ByteType;
 import com.sun.jdi.ByteValue;
 import com.sun.jdi.CharType;
 import com.sun.jdi.CharValue;
-import com.sun.jdi.ClassLoaderReference;
 import com.sun.jdi.ClassNotLoadedException;
 import com.sun.jdi.DoubleType;
 import com.sun.jdi.DoubleValue;
@@ -1179,9 +1178,7 @@ class VirtualMachineImpl extends MirrorImpl
 
     Type findBootType(String signature) throws ClassNotLoadedException {
         List<ReferenceType> types = retrieveClassesBySignature(signature);
-        Iterator<ReferenceType> iter = types.iterator();
-        while (iter.hasNext()) {
-            ReferenceType type = iter.next();
+        for (ReferenceType type : types) {
             if (type.classLoader() == null) {
                 return type;
             }


### PR DESCRIPTION
There are few places in code where manual while loop is used with Iterator to iterate over Collection.
Instead of manual while cycles it's preferred to use enhanced-for cycle instead: it's less verbose, makes code easier to read and it's less error-prone.
It doesn't have any performance impact: java compiler generates similar code when compiling enhanced-for cycle.

Similar cleanups:
* https://bugs.openjdk.java.net/browse/JDK-8258006
* https://bugs.openjdk.java.net/browse/JDK-8257912