### PR TITLE
8274016: Replace 'for' cycles with iterator with enhanced-for in java.desktop

### DIFF
--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/common/SimpleRenderedImage.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/common/SimpleRenderedImage.java
@@ -285,8 +285,8 @@ public abstract class SimpleRenderedImage implements RenderedImage {
         // Copy the strings from the Vector over to a String array.
         String[] prefixNames = new String[names.size()];
         int count = 0;
-        for (Iterator<String> it = names.iterator(); it.hasNext(); ) {
-            prefixNames[count++] = it.next();
+        for (String name : names) {
+            prefixNames[count++] = name;
         }
 
         return prefixNames;

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/common/SimpleRenderedImage.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/common/SimpleRenderedImage.java
@@ -282,13 +282,8 @@ public abstract class SimpleRenderedImage implements RenderedImage {
             return null;
         }
 
-        // Copy the strings from the Vector over to a String array.
-        String[] prefixNames = new String[names.size()];
-        int count = 0;
-        for (String name : names) {
-            prefixNames[count++] = name;
-        }
-
+        // Copy the strings from the ArrayList over to a String array.
+        String[] prefixNames = names.toArray(new String[0]);
         return prefixNames;
     }
 

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/common/SimpleRenderedImage.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/common/SimpleRenderedImage.java
@@ -34,7 +34,6 @@ import java.awt.image.WritableRaster;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Hashtable;
-import java.util.Iterator;
 import java.util.Vector;
 
 public abstract class SimpleRenderedImage implements RenderedImage {
@@ -282,7 +281,6 @@ public abstract class SimpleRenderedImage implements RenderedImage {
             return null;
         }
 
-        // Copy the strings from the ArrayList over to a String array.
         String[] prefixNames = names.toArray(new String[0]);
         return prefixNames;
     }

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JFIFMarkerSegment.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JFIFMarkerSegment.java
@@ -159,9 +159,7 @@ class JFIFMarkerSegment extends MarkerSegment {
         JFIFMarkerSegment newGuy = (JFIFMarkerSegment) super.clone();
         if (!extSegments.isEmpty()) { // Clone the list with a deep copy
             newGuy.extSegments = new ArrayList<>();
-            for (Iterator<JFIFExtensionMarkerSegment> iter =
-                    extSegments.iterator(); iter.hasNext();) {
-                JFIFExtensionMarkerSegment jfxx = iter.next();
+            for (JFIFExtensionMarkerSegment jfxx : extSegments) {
                 newGuy.extSegments.add((JFIFExtensionMarkerSegment) jfxx.clone());
             }
         }
@@ -231,9 +229,7 @@ class JFIFMarkerSegment extends MarkerSegment {
         if (!extSegments.isEmpty()) {
             IIOMetadataNode JFXXnode = new IIOMetadataNode("JFXX");
             node.appendChild(JFXXnode);
-            for (Iterator<JFIFExtensionMarkerSegment> iter =
-                    extSegments.iterator(); iter.hasNext();) {
-                JFIFExtensionMarkerSegment seg = iter.next();
+            for (JFIFExtensionMarkerSegment seg : extSegments) {
                 JFXXnode.appendChild(seg.getNativeNode());
             }
         }
@@ -635,9 +631,7 @@ class JFIFMarkerSegment extends MarkerSegment {
         System.out.print("Thumbnail Height: ");
         System.out.println(thumbHeight);
         if (!extSegments.isEmpty()) {
-            for (Iterator<JFIFExtensionMarkerSegment> iter =
-                    extSegments.iterator(); iter.hasNext();) {
-                JFIFExtensionMarkerSegment extSegment = iter.next();
+            for (JFIFExtensionMarkerSegment extSegment : extSegments) {
                 extSegment.print();
             }
         }

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JFIFMarkerSegment.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JFIFMarkerSegment.java
@@ -41,7 +41,6 @@ import java.awt.image.WritableRaster;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import javax.imageio.IIOException;

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JPEGImageReader.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JPEGImageReader.java
@@ -1275,9 +1275,8 @@ public class JPEGImageReader extends ImageReader {
         // and set knownPassCount
         if (imageIndex == imageMetadataIndex) { // We have metadata
             knownPassCount = 0;
-            for (Iterator<MarkerSegment> iter =
-                    imageMetadata.markerSequence.iterator(); iter.hasNext();) {
-                if (iter.next() instanceof SOSMarkerSegment) {
+            for (MarkerSegment markerSegment : imageMetadata.markerSequence) {
+                if (markerSegment instanceof SOSMarkerSegment) {
                     knownPassCount++;
                 }
             }

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JPEGImageWriter.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JPEGImageWriter.java
@@ -41,7 +41,6 @@ import java.awt.image.RenderedImage;
 import java.awt.image.WritableRaster;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import javax.imageio.IIOException;

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JPEGImageWriter.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JPEGImageWriter.java
@@ -1382,9 +1382,7 @@ public class JPEGImageWriter extends ImageWriter {
         List<SOSMarkerSegment> segments = new ArrayList<>();
         int SCAN_SIZE = 9;
         int MAX_COMPS_PER_SCAN = 4;
-        for (Iterator<MarkerSegment> iter = metadata.markerSequence.iterator();
-             iter.hasNext();) {
-            MarkerSegment seg = iter.next();
+        for (MarkerSegment seg : metadata.markerSequence) {
             if (seg instanceof SOSMarkerSegment) {
                 segments.add((SOSMarkerSegment) seg);
             }

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JPEGMetadata.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JPEGMetadata.java
@@ -1711,9 +1711,7 @@ public class JPEGMetadata extends IIOMetadata implements Cloneable {
                 }
                 if (idsDiffer) {
                     // update the ids in each SOS marker segment
-                    for (Iterator<MarkerSegment> iter = markerSequence.iterator();
-                            iter.hasNext();) {
-                        MarkerSegment seg = iter.next();
+                    for (MarkerSegment seg : markerSequence) {
                         if (seg instanceof SOSMarkerSegment) {
                             SOSMarkerSegment target = (SOSMarkerSegment) seg;
                             for (int i = 0; i < target.componentSpecs.length; i++) {
@@ -1766,9 +1764,7 @@ public class JPEGMetadata extends IIOMetadata implements Cloneable {
 
         if (updateQtables) {
             List<DQTMarkerSegment> tableSegments = new ArrayList<>();
-            for (Iterator<MarkerSegment> iter = markerSequence.iterator();
-                    iter.hasNext();) {
-                MarkerSegment seg = iter.next();
+            for (MarkerSegment seg : markerSequence) {
                 if (seg instanceof DQTMarkerSegment) {
                     tableSegments.add((DQTMarkerSegment) seg);
                 }
@@ -1784,12 +1780,8 @@ public class JPEGMetadata extends IIOMetadata implements Cloneable {
 
                 // Find the table with selector 1.
                 boolean found = false;
-                for (Iterator<DQTMarkerSegment> iter = tableSegments.iterator();
-                        iter.hasNext();) {
-                    DQTMarkerSegment testdqt = iter.next();
-                    for (Iterator<DQTMarkerSegment.Qtable> tabiter =
-                            testdqt.tables.iterator(); tabiter.hasNext();) {
-                        DQTMarkerSegment.Qtable tab = tabiter.next();
+                for (DQTMarkerSegment testdqt : tableSegments) {
+                    for (DQTMarkerSegment.Qtable tab : testdqt.tables) {
                         if (tab.tableID == 1) {
                             found = true;
                         }
@@ -1798,12 +1790,8 @@ public class JPEGMetadata extends IIOMetadata implements Cloneable {
                 if (!found) {
                     //    find the table with selector 0.  There should be one.
                     DQTMarkerSegment.Qtable table0 = null;
-                    for (Iterator<DQTMarkerSegment> iter =
-                            tableSegments.iterator(); iter.hasNext();) {
-                        DQTMarkerSegment testdqt = iter.next();
-                        for (Iterator<DQTMarkerSegment.Qtable> tabiter =
-                                testdqt.tables.iterator(); tabiter.hasNext();) {
-                            DQTMarkerSegment.Qtable tab = tabiter.next();
+                    for (DQTMarkerSegment testdqt : tableSegments) {
+                        for (DQTMarkerSegment.Qtable tab : testdqt.tables) {
                             if (tab.tableID == 0) {
                                 table0 = tab;
                             }
@@ -1821,9 +1809,7 @@ public class JPEGMetadata extends IIOMetadata implements Cloneable {
 
         if (updateHtables) {
             List<DHTMarkerSegment> tableSegments = new ArrayList<>();
-            for (Iterator<MarkerSegment> iter = markerSequence.iterator();
-                    iter.hasNext();) {
-                MarkerSegment seg = iter.next();
+            for (MarkerSegment seg : markerSequence) {
                 if (seg instanceof DHTMarkerSegment) {
                     tableSegments.add((DHTMarkerSegment) seg);
                 }
@@ -1838,12 +1824,8 @@ public class JPEGMetadata extends IIOMetadata implements Cloneable {
 
                 // find a table with selector 1. AC/DC is irrelevant
                 boolean found = false;
-                for (Iterator<DHTMarkerSegment> iter = tableSegments.iterator();
-                        iter.hasNext();) {
-                    DHTMarkerSegment testdht = iter.next();
-                    for (Iterator<DHTMarkerSegment.Htable> tabiter =
-                            testdht.tables.iterator(); tabiter.hasNext();) {
-                        DHTMarkerSegment.Htable tab = tabiter.next();
+                for (DHTMarkerSegment testdht : tableSegments) {
+                    for (DHTMarkerSegment.Htable tab : testdht.tables) {
                         if (tab.tableID == 1) {
                             found = true;
                         }

--- a/src/java.desktop/share/classes/java/awt/DefaultKeyboardFocusManager.java
+++ b/src/java.desktop/share/classes/java/awt/DefaultKeyboardFocusManager.java
@@ -1078,8 +1078,8 @@ public class DefaultKeyboardFocusManager extends KeyboardFocusManager {
      * @since 1.5
      */
     private boolean hasMarker(Component comp) {
-        for (Iterator<TypeAheadMarker> iter = typeAheadMarkers.iterator(); iter.hasNext(); ) {
-            if (iter.next().untilFocused == comp) {
+        for (TypeAheadMarker typeAheadMarker : typeAheadMarkers) {
+            if (typeAheadMarker.untilFocused == comp) {
                 return true;
             }
         }
@@ -1137,15 +1137,11 @@ public class DefaultKeyboardFocusManager extends KeyboardFocusManager {
 
         java.util.List<KeyEventDispatcher> dispatchers = getKeyEventDispatchers();
         if (dispatchers != null) {
-            for (java.util.Iterator<KeyEventDispatcher> iter = dispatchers.iterator();
-                 iter.hasNext(); )
-             {
-                 if (iter.next().
-                     dispatchKeyEvent(ke))
-                 {
-                     return true;
-                 }
-             }
+            for (KeyEventDispatcher dispatcher : dispatchers) {
+                if (dispatcher.dispatchKeyEvent(ke)) {
+                    return true;
+                }
+            }
         }
         return dispatchKeyEvent(ke);
     }

--- a/src/java.desktop/share/classes/java/awt/KeyboardFocusManager.java
+++ b/src/java.desktop/share/classes/java/awt/KeyboardFocusManager.java
@@ -2977,13 +2977,9 @@ public abstract class KeyboardFocusManager
             if (hwFocusRequest != null) {
                 heavyweightRequests.removeFirst();
                 if (hwFocusRequest.lightweightRequests != null) {
-                    for (Iterator<KeyboardFocusManager.LightweightFocusRequest> lwIter = hwFocusRequest.lightweightRequests.
-                             iterator();
-                         lwIter.hasNext(); )
-                    {
+                    for (LightweightFocusRequest lwFocusRequest : hwFocusRequest.lightweightRequests) {
                         manager.dequeueKeyEvents
-                            (-1, lwIter.next().
-                             component);
+                            (-1, lwFocusRequest.component);
                     }
                 }
             }

--- a/src/java.desktop/share/classes/java/beans/MetaData.java
+++ b/src/java.desktop/share/classes/java/beans/MetaData.java
@@ -28,13 +28,9 @@ import com.sun.beans.finder.PrimitiveWrapperMap;
 
 import java.awt.AWTKeyStroke;
 import java.awt.BorderLayout;
-import java.awt.Dimension;
 import java.awt.Color;
 import java.awt.Font;
-import java.awt.GridBagConstraints;
 import java.awt.Insets;
-import java.awt.Point;
-import java.awt.Rectangle;
 import java.awt.event.KeyEvent;
 import java.awt.font.TextAttribute;
 

--- a/src/java.desktop/share/classes/java/beans/MetaData.java
+++ b/src/java.desktop/share/classes/java/beans/MetaData.java
@@ -521,8 +521,8 @@ static class java_util_Collection_PersistenceDelegate extends DefaultPersistence
         if (newO.size() != 0) {
             invokeStatement(oldInstance, "clear", new Object[]{}, out);
         }
-        for (Iterator<?> i = oldO.iterator(); i.hasNext();) {
-            invokeStatement(oldInstance, "add", new Object[]{i.next()}, out);
+        for (Object o : oldO) {
+            invokeStatement(oldInstance, "add", new Object[]{o}, out);
         }
     }
 }

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
@@ -771,17 +771,15 @@ public class      BeanContextSupport extends BeanContextChildSupport
         }
 
         synchronized(children) {
-            for (Iterator<Object> i = children.keySet().iterator(); i.hasNext();) {
-                Object c = i.next();
-
+            for (Object c : children.keySet()) {
                 try {
-                        return ((Visibility)c).needsGui();
-                    } catch (ClassCastException cce) {
-                        // do nothing ...
-                    }
+                    return ((Visibility)c).needsGui();
+                } catch (ClassCastException cce) {
+                    // do nothing ...
+                }
 
-                    if (c instanceof Container || c instanceof Component)
-                        return true;
+                if (c instanceof Container || c instanceof Component)
+                    return true;
             }
         }
 
@@ -798,11 +796,11 @@ public class      BeanContextSupport extends BeanContextChildSupport
 
             // lets also tell the Children that can that they may not use their GUI's
             synchronized(children) {
-                for (Iterator<Object> i = children.keySet().iterator(); i.hasNext();) {
-                    Visibility v = getChildVisibility(i.next());
+                for (Object c : children.keySet()) {
+                    Visibility v = getChildVisibility(c);
 
                     if (v != null) v.dontUseGui();
-               }
+                }
             }
         }
     }
@@ -817,8 +815,8 @@ public class      BeanContextSupport extends BeanContextChildSupport
 
             // lets also tell the Children that can that they may use their GUI's
             synchronized(children) {
-                for (Iterator<Object> i = children.keySet().iterator(); i.hasNext();) {
-                    Visibility v = getChildVisibility(i.next());
+                for (Object c : children.keySet()) {
+                    Visibility v = getChildVisibility(c);
 
                     if (v != null) v.okToUseGui();
                 }

--- a/src/java.desktop/share/classes/javax/swing/RepaintManager.java
+++ b/src/java.desktop/share/classes/javax/swing/RepaintManager.java
@@ -799,8 +799,7 @@ public class RepaintManager
 
         Set<Window> windows = new HashSet<Window>();
         Set<Component> dirtyComps = dirtyComponents.keySet();
-        for (Iterator<Component> it = dirtyComps.iterator(); it.hasNext();) {
-            Component dirty = it.next();
+        for (Component dirty : dirtyComps) {
             Window window = dirty instanceof Window ?
                 (Window)dirty :
                 SwingUtilities.getWindowAncestor(dirty);

--- a/src/java.desktop/share/classes/sun/awt/SunToolkit.java
+++ b/src/java.desktop/share/classes/sun/awt/SunToolkit.java
@@ -82,7 +82,6 @@ import java.net.URL;
 import java.security.AccessController;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Vector;

--- a/src/java.desktop/share/classes/sun/awt/SunToolkit.java
+++ b/src/java.desktop/share/classes/sun/awt/SunToolkit.java
@@ -946,13 +946,12 @@ public abstract class SunToolkit extends Toolkit
         int bestHeight = 0;
         double bestSimilarity = 3; //Impossibly high value
         double bestScaleFactor = 0;
-        for (Iterator<Image> i = multiResAndnormalImages.iterator();i.hasNext();) {
+        for (Image im : multiResAndnormalImages) {
             //Iterate imageList looking for best matching image.
             //'Similarity' measure is defined as good scale factor and small insets.
             //best possible similarity is 0 (no scale, no insets).
             //It's found while the experiments that good-looking result is achieved
             //with scale factors x1, x3/4, x2/3, xN, x1/N.
-            Image im = i.next();
             if (im == null) {
                 continue;
             }

--- a/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
@@ -1992,9 +1992,7 @@ public final class XToolkit extends UNIXToolkit implements Runnable {
         while (time.compareTo(currentTime) <= 0) {
             java.util.List<Runnable> tasks = timeoutTasks.remove(time);
 
-            for (Iterator<Runnable> iter = tasks.iterator(); iter.hasNext();) {
-                Runnable task = iter.next();
-
+            for (Runnable task : tasks) {
                 if (timeoutTaskLog.isLoggable(PlatformLogger.Level.FINER)) {
                     timeoutTaskLog.finer("XToolkit.callTimeoutTasks(): current time={0}" +
                                          ";  about to run task={1}", Long.valueOf(currentTime), task);

--- a/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
@@ -306,8 +306,7 @@ class XWindowPeer extends XPanelPeer implements WindowPeer,
         if (iconImages.size() != 0) {
             //read icon images from target
             winAttr.iconsInherited = false;
-            for (Iterator<Image> i = iconImages.iterator(); i.hasNext(); ) {
-                Image image = i.next();
+            for (Image image : iconImages) {
                 if (image == null) {
                     if (log.isLoggable(PlatformLogger.Level.FINEST)) {
                         log.finest("XWindowPeer.updateIconImages: Skipping the image passed into Java because it's null.");
@@ -403,8 +402,8 @@ class XWindowPeer extends XPanelPeer implements WindowPeer,
     static void dumpIcons(java.util.List<IconInfo> icons) {
         if (iconLog.isLoggable(PlatformLogger.Level.FINEST)) {
             iconLog.finest(">>> Sizes of icon images:");
-            for (Iterator<IconInfo> i = icons.iterator(); i.hasNext(); ) {
-                iconLog.finest("    {0}", i.next());
+            for (IconInfo icon : icons) {
+                iconLog.finest("    {0}", icon);
             }
         }
     }

--- a/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
@@ -51,7 +51,6 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
 import java.util.Vector;
 import java.util.concurrent.atomic.AtomicBoolean;


### PR DESCRIPTION
There are few places in code where manual `for` loop is used with Iterator to iterate over Collection.
Instead of manual `for` cycles it's preferred to use enhanced-for cycle instead: it's less verbose, makes code easier to read and it's less error-prone.
It doesn't have any performance impact: java compiler generates similar code when compiling enhanced-for cycle.
This is continuation of [JDK-8258006](https://bugs.openjdk.java.net/browse/JDK-8258006)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274016](https://bugs.openjdk.java.net/browse/JDK-8274016): Replace 'for' cycles with iterator with enhanced-for in java.desktop


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5578/head:pull/5578` \
`$ git checkout pull/5578`

Update a local copy of the PR: \
`$ git checkout pull/5578` \
`$ git pull https://git.openjdk.java.net/jdk pull/5578/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5578`

View PR using the GUI difftool: \
`$ git pr show -t 5578`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5578.diff">https://git.openjdk.java.net/jdk/pull/5578.diff</a>

</details>
