### PR TITLE
 8273935: (zipfs) Files.getFileAttributeView() throws UOE instead of returning null when view not supported

### DIFF
--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipPath.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipPath.java
@@ -713,7 +713,7 @@ final class ZipPath implements Path {
             if (type == FileOwnerAttributeView.class)
                 return (V)new ZipPosixFileAttributeView(this,true);
         }
-        return (V) null;
+        return null;
     }
 
     private ZipFileAttributeView getFileAttributeView(String type) {

--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipPath.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipPath.java
@@ -713,7 +713,7 @@ final class ZipPath implements Path {
             if (type == FileOwnerAttributeView.class)
                 return (V)new ZipPosixFileAttributeView(this,true);
         }
-        throw new UnsupportedOperationException("view <" + type + "> is not supported");
+        return (V) null;
     }
 
     private ZipFileAttributeView getFileAttributeView(String type) {

--- a/test/jdk/jdk/nio/zipfs/TestPosix.java
+++ b/test/jdk/jdk/nio/zipfs/TestPosix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 SAP SE. All rights reserved.
+ * Copyright (c) 2019, 2021, SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,7 @@ import static org.testng.Assert.fail;
 
 /**
  * @test
- * @bug 8213031
+ * @bug 8213031 8273935
  * @modules jdk.zipfs
  *          jdk.jartool
  * @run testng TestPosix
@@ -595,7 +595,7 @@ public class TestPosix {
             assertTrue(throwsUOE(()->Files.setPosixFilePermissions(entry, UW)));
             assertTrue(throwsUOE(()->Files.getOwner(entry)));
             assertTrue(throwsUOE(()->Files.setOwner(entry, DUMMY_USER)));
-            assertTrue(throwsUOE(()->Files.getFileAttributeView(entry, PosixFileAttributeView.class)));
+            assertNull(Files.getFileAttributeView(entry, PosixFileAttributeView.class));
         }
 
         // test with posix = true -> default values

--- a/test/jdk/jdk/nio/zipfs/testng/test/PosixAttributeViewTest.java
+++ b/test/jdk/jdk/nio/zipfs/testng/test/PosixAttributeViewTest.java
@@ -1,0 +1,89 @@
+package test;
+
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import util.ZipFsBaseTest;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+
+/**
+ * @test
+ * @bug 8273935
+ * @summary Validate that Files.getFileAttributeView will not throw
+ * UnsupportedOperationException when the attribute view
+ * PosixFileAttributeView is not available
+ */
+public class PosixAttributeViewTest extends ZipFsBaseTest {
+    public static final String ZIP_ENTRY = "Entry-0";
+    private static final Path ZIP_FILE = Path.of("posixTest.zip");
+
+    @BeforeTest
+    public void setup() throws IOException {
+        Files.deleteIfExists(ZIP_FILE);
+        Entry e0 = Entry.of(ZIP_ENTRY, ZipEntry.DEFLATED,
+                "Tennis Anyone");
+        zip(ZIP_FILE, Map.of("create", "true"), e0);
+    }
+
+    /**
+     * DataProvider used to specify the Map indicating whether Posix
+     * file attributes have been enabled
+     * @return  map of the Zip FS properties to configure
+     */
+    @DataProvider
+    protected Object[][] zipfsMap() {
+        return new Object[][]{
+                {Map.of()},
+                { Map.of("enablePosixFileAttributes", "true")}
+        };
+    }
+
+    /**
+     * Verify that Files.getFileAttributeView will not throw
+     * UnsupportedOperationException when the attribute view
+     * PosixFileAttributeView is not available
+     * @param env map of the Zip FS properties to configure
+     * @throws Exception if an error occurs
+     */
+    @Test(dataProvider = "zipfsMap")
+    public void testPosixAttributeView(Map<String, String> env) throws Exception {
+
+        try (FileSystem fs = FileSystems.newFileSystem(ZIP_FILE, env)) {
+            Path entry = fs.getPath(ZIP_ENTRY);
+            PosixFileAttributeView view = Files.getFileAttributeView(entry,
+                    PosixFileAttributeView.class);
+            System.out.printf("View returned: %s%n", view);
+        }
+    }
+}

--- a/test/jdk/jdk/nio/zipfs/testng/test/PosixAttributeViewTest.java
+++ b/test/jdk/jdk/nio/zipfs/testng/test/PosixAttributeViewTest.java
@@ -41,7 +41,7 @@ import java.util.zip.ZipEntry;
 /**
  * @test
  * @bug 8273935
- * @summary Validate that Files.getFileAttributeView will not throw
+ * @summary Validate that Files.getFileAttributeView will not throw an
  * Exception when the attribute view PosixFileAttributeView is not available
  */
 public class PosixAttributeViewTest extends ZipFsBaseTest {

--- a/test/jdk/jdk/nio/zipfs/testng/test/PosixAttributeViewTest.java
+++ b/test/jdk/jdk/nio/zipfs/testng/test/PosixAttributeViewTest.java
@@ -23,6 +23,7 @@
  */
 package test;
 
+import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -48,12 +49,25 @@ public class PosixAttributeViewTest extends ZipFsBaseTest {
     public static final String ZIP_ENTRY = "Entry-0";
     private static final Path ZIP_FILE = Path.of("posixTest.zip");
 
+    /**
+     * Create initial Zip File
+     * @throws IOException if an error occurs
+     */
     @BeforeTest
     public void setup() throws IOException {
         Files.deleteIfExists(ZIP_FILE);
         Entry e0 = Entry.of(ZIP_ENTRY, ZipEntry.DEFLATED,
                 "Tennis Anyone");
         zip(ZIP_FILE, Map.of("create", "true"), e0);
+    }
+
+    /**
+     * Remove Zip File used by Test
+     * @throws IOException if an error occurs
+     */
+    @AfterTest
+    public void cleanup() throws IOException {
+        Files.deleteIfExists(ZIP_FILE);
     }
 
     /**

--- a/test/jdk/jdk/nio/zipfs/testng/test/PosixAttributeViewTest.java
+++ b/test/jdk/jdk/nio/zipfs/testng/test/PosixAttributeViewTest.java
@@ -42,8 +42,7 @@ import java.util.zip.ZipEntry;
  * @test
  * @bug 8273935
  * @summary Validate that Files.getFileAttributeView will not throw
- * UnsupportedOperationException when the attribute view
- * PosixFileAttributeView is not available
+ * Exception when the attribute view PosixFileAttributeView is not available
  */
 public class PosixAttributeViewTest extends ZipFsBaseTest {
     public static final String ZIP_ENTRY = "Entry-0";
@@ -56,9 +55,9 @@ public class PosixAttributeViewTest extends ZipFsBaseTest {
     @BeforeTest
     public void setup() throws IOException {
         Files.deleteIfExists(ZIP_FILE);
-        Entry e0 = Entry.of(ZIP_ENTRY, ZipEntry.DEFLATED,
+        Entry entry = Entry.of(ZIP_ENTRY, ZipEntry.DEFLATED,
                 "Tennis Anyone");
-        zip(ZIP_FILE, Map.of("create", "true"), e0);
+        zip(ZIP_FILE, Map.of("create", "true"), entry);
     }
 
     /**
@@ -79,25 +78,25 @@ public class PosixAttributeViewTest extends ZipFsBaseTest {
     protected Object[][] zipfsMap() {
         return new Object[][]{
                 {Map.of()},
-                { Map.of("enablePosixFileAttributes", "true")}
+                {Map.of("enablePosixFileAttributes", "true")}
         };
     }
 
     /**
      * Verify that Files.getFileAttributeView will not throw
-     * UnsupportedOperationException when the attribute view
+     * an Exception when the attribute view
      * PosixFileAttributeView is not available
      * @param env map of the Zip FS properties to configure
      * @throws Exception if an error occurs
      */
     @Test(dataProvider = "zipfsMap")
     public void testPosixAttributeView(Map<String, String> env) throws Exception {
-
         try (FileSystem fs = FileSystems.newFileSystem(ZIP_FILE, env)) {
             Path entry = fs.getPath(ZIP_ENTRY);
             PosixFileAttributeView view = Files.getFileAttributeView(entry,
                     PosixFileAttributeView.class);
-            System.out.printf("View returned: %s%n", view);
+            System.out.printf("View returned: %s, Map= %s%n", view,
+                    formatMap(env));
         }
     }
 }

--- a/test/jdk/jdk/nio/zipfs/testng/test/PosixAttributeViewTest.java
+++ b/test/jdk/jdk/nio/zipfs/testng/test/PosixAttributeViewTest.java
@@ -1,5 +1,3 @@
-package test;
-
 /*
  * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -23,6 +21,8 @@ package test;
  * questions.
  *
  */
+package test;
+
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;

--- a/test/jdk/jdk/nio/zipfs/testng/util/ZipFsBaseTest.java
+++ b/test/jdk/jdk/nio/zipfs/testng/util/ZipFsBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,7 +105,7 @@ public class ZipFsBaseTest {
      * @param env Map to format
      * @return Formatted string of the Map entries
      */
-    private static String formatMap(Map<String, ?> env) {
+    protected static String formatMap(Map<String, ?> env) {
         return env.entrySet().stream()
                 .map(e -> format("(%s:%s)", e.getKey(), e.getValue()))
                 .collect(joining(", "));


### PR DESCRIPTION
Hi all,

Please review this patch which addresses the issue where Zip FS will throw a UOE instead of returning null  when  Files.getFileAttributeView() is invoked and  the view not supported.

Mach5 tiers1 - tier3 are clean.

Best
Lance

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273935](https://bugs.openjdk.java.net/browse/JDK-8273935): (zipfs) Files.getFileAttributeView() throws UOE instead of returning null when view not supported


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5579/head:pull/5579` \
`$ git checkout pull/5579`

Update a local copy of the PR: \
`$ git checkout pull/5579` \
`$ git pull https://git.openjdk.java.net/jdk pull/5579/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5579`

View PR using the GUI difftool: \
`$ git pr show -t 5579`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5579.diff">https://git.openjdk.java.net/jdk/pull/5579.diff</a>

</details>
