### PR TITLE
8273977: Reduce unnecessary BadPaddingExceptions in RSAPadding

### DIFF
--- a/src/java.base/share/classes/sun/security/rsa/RSAPadding.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAPadding.java
@@ -366,10 +366,8 @@ public final class RSAPadding {
         byte[] data = new byte[n];
         System.arraycopy(padded, p, data, 0, n);
 
-        BadPaddingException bpe = new BadPaddingException("Decryption error");
-
         if (bp) {
-            throw bpe;
+            throw new BadPaddingException("Decryption error");
         } else {
             return data;
         }
@@ -485,10 +483,8 @@ public final class RSAPadding {
         byte [] m = new byte[EM.length - mStart];
         System.arraycopy(EM, mStart, m, 0, m.length);
 
-        BadPaddingException bpe = new BadPaddingException("Decryption error");
-
         if (bp) {
-            throw bpe;
+            throw new BadPaddingException("Decryption error");
         } else {
             return m;
         }


### PR DESCRIPTION
### Motivation

When profiling an application that uses JWT token authentication, it was noticed that a high number of `javax.crypto.BadPaddingException`s were created. When investigating the code in RSAPadding, one can see that BadPaddingException is created in all cases, also on the success path:
https://github.com/openjdk/jdk/blob/dc7f452acbe3afa5aa6e31d316bd5e669c86d6f6/src/java.base/share/classes/sun/security/rsa/RSAPadding.java#L369-L375

### Modifications

Inline the unnecessary local variable to prevent creating the exception on the success path.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8273977](https://bugs.openjdk.java.net/browse/JDK-8273977): Reduce unnecessary BadPaddingExceptions in RSAPadding


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5581/head:pull/5581` \
`$ git checkout pull/5581`

Update a local copy of the PR: \
`$ git checkout pull/5581` \
`$ git pull https://git.openjdk.java.net/jdk pull/5581/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5581`

View PR using the GUI difftool: \
`$ git pr show -t 5581`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5581.diff">https://git.openjdk.java.net/jdk/pull/5581.diff</a>

</details>
