### PR TITLE
8273940: vmTestbase/vm/mlvm/meth/stress/gc/callSequencesDuringGC/Test.java crashes in full gc during VM exit

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -2036,8 +2036,9 @@ void G1ConcurrentMark::concurrent_cycle_abort() {
   for (uint i = 0; i < _max_num_tasks; ++i) {
     _tasks[i]->clear_region_fields();
   }
-
-  abort_marking_threads();
+  _first_overflow_barrier_sync.abort();
+  _second_overflow_barrier_sync.abort();
+  _has_aborted = true;
 
   SATBMarkQueueSet& satb_mq_set = G1BarrierSet::satb_mark_queue_set();
   satb_mq_set.abandon_partial_marking();
@@ -2046,12 +2047,6 @@ void G1ConcurrentMark::concurrent_cycle_abort() {
   satb_mq_set.set_active_all_threads(
                                  false, /* new active value */
                                  satb_mq_set.is_active() /* expected_active */);
-}
-
-void G1ConcurrentMark::abort_marking_threads() {
-  _has_aborted = true;
-  _first_overflow_barrier_sync.abort();
-  _second_overflow_barrier_sync.abort();
 }
 
 static void print_ms_time_info(const char* prefix, const char* name,

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -495,10 +495,6 @@ public:
   void concurrent_cycle_abort();
   void concurrent_cycle_end();
 
-  // Notifies marking threads to abort. This is a best-effort notification. Does not
-  // guarantee or update any state after the call.
-  void abort_marking_threads();
-
   void update_accum_task_vtime(int i, double vtime) {
     _accum_task_vtime[i] += vtime;
   }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
@@ -159,8 +159,6 @@ void G1ConcurrentMarkThread::run_service() {
 }
 
 void G1ConcurrentMarkThread::stop_service() {
-  _cm->abort_marking_threads();
-
   MutexLocker ml(CGC_lock, Mutex::_no_safepoint_check_flag);
   CGC_lock->notify_all();
 }


### PR DESCRIPTION
Hi all,

  this change fixes random crashes at VM exit by reverting JDK-8273605 (02af541b7427a4b74eecab9513a770026d1a8426). Testing showed that without that change, around 2000 executions of the failing tests passes, while otherwise there is a failure rate of around 2% (13 out of 600).

Since I do not have time to fix this properly, and this is an annoying issue, I propose to remove that change and re-implement later (I'll file a new issue for the original change).

Revert applies cleanly.

Testing: tier1, the failing test a few thousand times

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273940](https://bugs.openjdk.java.net/browse/JDK-8273940): vmTestbase/vm/mlvm/meth/stress/gc/callSequencesDuringGC/Test.java crashes in full gc during VM exit


### Reviewers
 * [Leo Korinth](https://openjdk.java.net/census#lkorinth) (@lkorinth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5583/head:pull/5583` \
`$ git checkout pull/5583`

Update a local copy of the PR: \
`$ git checkout pull/5583` \
`$ git pull https://git.openjdk.java.net/jdk pull/5583/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5583`

View PR using the GUI difftool: \
`$ git pr show -t 5583`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5583.diff">https://git.openjdk.java.net/jdk/pull/5583.diff</a>

</details>
