### PR TITLE
8273152: Store base archive path in CDSFileMapHeaderBase

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -1129,6 +1129,7 @@ void ArchiveBuilder::write_archive(FileMapInfo* mapinfo,
 
   mapinfo->set_requested_base((char*)MetaspaceShared::requested_base_address());
   if (mapinfo->header()->magic() == CDS_DYNAMIC_ARCHIVE_MAGIC) {
+    mapinfo->set_header_base_archive_path_offset();
     mapinfo->set_header_base_archive_name_size(strlen(Arguments::GetSharedArchivePath()) + 1);
     mapinfo->set_header_base_archive_is_default(FLAG_IS_DEFAULT(SharedArchiveFile));
   }

--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -1130,7 +1130,7 @@ void ArchiveBuilder::write_archive(FileMapInfo* mapinfo,
   mapinfo->set_requested_base((char*)MetaspaceShared::requested_base_address());
   if (mapinfo->header()->magic() == CDS_DYNAMIC_ARCHIVE_MAGIC) {
     mapinfo->set_header_base_archive_path_offset();
-    mapinfo->set_header_base_archive_name_size(strlen(Arguments::GetSharedArchivePath()) + 1);
+    mapinfo->set_header_base_archive_name_size((unsigned int)strlen(Arguments::GetSharedArchivePath()) + 1);
     mapinfo->set_header_base_archive_is_default(FLAG_IS_DEFAULT(SharedArchiveFile));
   }
   mapinfo->set_header_crc(mapinfo->compute_header_crc());

--- a/src/hotspot/share/cds/cdsConstants.cpp
+++ b/src/hotspot/share/cds/cdsConstants.cpp
@@ -31,15 +31,16 @@
 #include "utilities/globalDefinitions.hpp"
 
 CDSConst CDSConstants::offsets[] = {
-  { "CDSFileMapHeaderBase::_magic",           offset_of(CDSFileMapHeaderBase, _magic)           },
-  { "CDSFileMapHeaderBase::_crc",             offset_of(CDSFileMapHeaderBase, _crc)             },
-  { "CDSFileMapHeaderBase::_version",         offset_of(CDSFileMapHeaderBase, _version)         },
-  { "CDSFileMapHeaderBase::_space[0]",        offset_of(CDSFileMapHeaderBase, _space)           },
-  { "FileMapHeader::_jvm_ident",              offset_of(FileMapHeader, _jvm_ident)              },
-  { "FileMapHeader::_base_archive_name_size", offset_of(FileMapHeader, _base_archive_name_size) },
-  { "CDSFileMapRegion::_crc",                 offset_of(CDSFileMapRegion, _crc)                 },
-  { "CDSFileMapRegion::_used",                offset_of(CDSFileMapRegion, _used)                },
-  { "DynamicArchiveHeader::_base_region_crc", offset_of(DynamicArchiveHeader, _base_region_crc) }
+  { "CDSFileMapHeaderBase::_magic",                     offset_of(CDSFileMapHeaderBase, _magic)             },
+  { "CDSFileMapHeaderBase::_crc",                       offset_of(CDSFileMapHeaderBase, _crc)               },
+  { "CDSFileMapHeaderBase::_version",                   offset_of(CDSFileMapHeaderBase, _version)           },
+  { "CDSFileMapHeaderBase::_space[0]",                  offset_of(CDSFileMapHeaderBase, _space)             },
+  { "CDSFileMapHeaderBase::_base_archive_path_offset",  offset_of(FileMapHeader, _base_archive_path_offset) },
+  { "FileMapHeader::_jvm_ident",                        offset_of(FileMapHeader, _jvm_ident)                },
+  { "FileMapHeader::_base_archive_name_size",           offset_of(FileMapHeader, _base_archive_name_size)   },
+  { "CDSFileMapRegion::_crc",                           offset_of(CDSFileMapRegion, _crc)                   },
+  { "CDSFileMapRegion::_used",                          offset_of(CDSFileMapRegion, _used)                  },
+  { "DynamicArchiveHeader::_base_region_crc",           offset_of(DynamicArchiveHeader, _base_region_crc)   }
 };
 
 CDSConst CDSConstants::constants[] = {

--- a/src/hotspot/share/cds/cdsConstants.cpp
+++ b/src/hotspot/share/cds/cdsConstants.cpp
@@ -35,6 +35,7 @@ CDSConst CDSConstants::offsets[] = {
   { "CDSFileMapHeaderBase::_crc",                       offset_of(CDSFileMapHeaderBase, _crc)               },
   { "CDSFileMapHeaderBase::_version",                   offset_of(CDSFileMapHeaderBase, _version)           },
   { "CDSFileMapHeaderBase::_space[0]",                  offset_of(CDSFileMapHeaderBase, _space)             },
+  { "CDSFileMapHeaderBase::_header_size",               offset_of(CDSFileMapHeaderBase, _header_size)       },
   { "CDSFileMapHeaderBase::_base_archive_path_offset",  offset_of(FileMapHeader, _base_archive_path_offset) },
   { "FileMapHeader::_jvm_ident",                        offset_of(FileMapHeader, _jvm_ident)                },
   { "FileMapHeader::_base_archive_name_size",           offset_of(FileMapHeader, _base_archive_name_size)   },

--- a/src/hotspot/share/cds/dynamicArchive.cpp
+++ b/src/hotspot/share/cds/dynamicArchive.cpp
@@ -325,7 +325,7 @@ void DynamicArchiveBuilder::write_archive(char* serialized_data) {
   size_t file_size = pointer_delta(top, base, sizeof(char));
 
   log_info(cds, dynamic)("Written dynamic archive " PTR_FORMAT " - " PTR_FORMAT
-                         " [" SIZE_FORMAT " bytes header, " SIZE_FORMAT " bytes total]",
+                         " [" UINT32_FORMAT " bytes header, " SIZE_FORMAT " bytes total]",
                          p2i(base), p2i(top), _header->header_size(), file_size);
 
   log_info(cds, dynamic)("%d klasses; %d symbols", klasses()->length(), symbols()->length());

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -184,8 +184,6 @@ class FileMapHeader: private CDSFileMapHeaderBase {
   friend class VMStructs;
 
 private:
-  size_t _header_size;
-
   // The following fields record the states of the VM during dump time.
   // They are compared with the runtime states to see if the archive
   // can be used.
@@ -253,7 +251,8 @@ public:
 
   // Accessors -- fields declared in FileMapHeader
 
-  size_t header_size()                     const { return _header_size; }
+  unsigned int header_size()               const { return _header_size; }
+  unsigned int base_archive_path_offset()  const { return _base_archive_path_offset; }
   size_t core_region_alignment()           const { return _core_region_alignment; }
   int obj_alignment()                      const { return _obj_alignment; }
   address narrow_oop_base()                const { return _narrow_oop_base; }
@@ -290,7 +289,7 @@ public:
   void set_base_archive_path_offset();
   void set_base_archive_name_size(size_t s)      { _base_archive_name_size = s; }
   void set_base_archive_is_default(bool b)       { _base_archive_is_default = b; }
-  void set_header_size(size_t s)                 { _header_size = s; }
+  void set_header_size(unsigned int s)           { _header_size = s; }
   void set_ptrmap_size_in_bits(size_t s)         { _ptrmap_size_in_bits = s; }
   void set_mapped_base_address(char* p)          { _mapped_base_address = p; }
   void set_heap_obj_roots(narrowOop r)           { _heap_obj_roots = r; }

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -208,8 +208,6 @@ private:
   // will function correctly with this JVM and the bootclasspath it's
   // invoked with.
   char  _jvm_ident[JVM_IDENT_MAX];  // identifier string of the jvm that created this dump
-  // size of the base archive name including NULL terminator
-  size_t _base_archive_name_size;
 
   // The following is a table of all the boot/app/module path entries that were used
   // during dumping. At run time, we validate these entries according to their
@@ -253,6 +251,7 @@ public:
 
   unsigned int header_size()               const { return _header_size; }
   unsigned int base_archive_path_offset()  const { return _base_archive_path_offset; }
+  unsigned int base_archive_name_size()    const { return _base_archive_name_size; }
   size_t core_region_alignment()           const { return _core_region_alignment; }
   int obj_alignment()                      const { return _obj_alignment; }
   address narrow_oop_base()                const { return _narrow_oop_base; }
@@ -268,7 +267,6 @@ public:
   address heap_end()                       const { return _heap_end; }
   bool base_archive_is_default()           const { return _base_archive_is_default; }
   const char* jvm_ident()                  const { return _jvm_ident; }
-  size_t base_archive_name_size()          const { return _base_archive_name_size; }
   char* requested_base_address()           const { return _requested_base_address; }
   char* mapped_base_address()              const { return _mapped_base_address; }
   bool has_platform_or_app_classes()       const { return _has_platform_or_app_classes; }
@@ -286,10 +284,10 @@ public:
   void set_has_platform_or_app_classes(bool v)   { _has_platform_or_app_classes = v; }
   void set_cloned_vtables(char* p)               { set_as_offset(p, &_cloned_vtables_offset); }
   void set_serialized_data(char* p)              { set_as_offset(p, &_serialized_data_offset); }
-  void set_base_archive_path_offset();
-  void set_base_archive_name_size(size_t s)      { _base_archive_name_size = s; }
-  void set_base_archive_is_default(bool b)       { _base_archive_is_default = b; }
   void set_header_size(unsigned int s)           { _header_size = s; }
+  void set_base_archive_path_offset();
+  void set_base_archive_name_size(unsigned int s) { _base_archive_name_size = s; }
+  void set_base_archive_is_default(bool b)       { _base_archive_is_default = b; }
   void set_ptrmap_size_in_bits(size_t s)         { _ptrmap_size_in_bits = s; }
   void set_mapped_base_address(char* p)          { _mapped_base_address = p; }
   void set_heap_obj_roots(narrowOop r)           { _heap_obj_roots = r; }
@@ -398,9 +396,9 @@ public:
   int     narrow_klass_shift() const { return header()->narrow_klass_shift(); }
   size_t  core_region_alignment() const { return header()->core_region_alignment(); }
 
-  void   set_header_base_archive_path_offset()               { header()->set_base_archive_path_offset(); }
-  void   set_header_base_archive_name_size(size_t size)      { header()->set_base_archive_name_size(size); }
-  void   set_header_base_archive_is_default(bool is_default) { header()->set_base_archive_is_default(is_default); }
+  void   set_header_base_archive_path_offset()                { header()->set_base_archive_path_offset(); }
+  void   set_header_base_archive_name_size(unsigned int size) { header()->set_base_archive_name_size(size); }
+  void   set_header_base_archive_is_default(bool is_default)  { header()->set_base_archive_is_default(is_default); }
 
   CompressedOops::Mode narrow_oop_mode()      const { return header()->narrow_oop_mode(); }
   jshort app_module_paths_start_index()       const { return header()->app_module_paths_start_index(); }

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -287,6 +287,7 @@ public:
   void set_has_platform_or_app_classes(bool v)   { _has_platform_or_app_classes = v; }
   void set_cloned_vtables(char* p)               { set_as_offset(p, &_cloned_vtables_offset); }
   void set_serialized_data(char* p)              { set_as_offset(p, &_serialized_data_offset); }
+  void set_base_archive_path_offset();
   void set_base_archive_name_size(size_t s)      { _base_archive_name_size = s; }
   void set_base_archive_is_default(bool b)       { _base_archive_is_default = b; }
   void set_header_size(size_t s)                 { _header_size = s; }
@@ -363,7 +364,7 @@ private:
 
 public:
   static bool get_base_archive_name_from_header(const char* archive_name,
-                                                int* size, char** base_archive_name);
+                                                char** base_archive_name);
   static bool check_archive(const char* archive_name, bool is_static);
   static SharedPathTable shared_path_table() {
     return _shared_path_table;
@@ -398,6 +399,7 @@ public:
   int     narrow_klass_shift() const { return header()->narrow_klass_shift(); }
   size_t  core_region_alignment() const { return header()->core_region_alignment(); }
 
+  void   set_header_base_archive_path_offset()               { header()->set_base_archive_path_offset(); }
   void   set_header_base_archive_name_size(size_t size)      { header()->set_base_archive_name_size(size); }
   void   set_header_base_archive_is_default(bool is_default) { header()->set_base_archive_is_default(is_default); }
 

--- a/src/hotspot/share/include/cds.h
+++ b/src/hotspot/share/include/cds.h
@@ -38,7 +38,7 @@
 #define NUM_CDS_REGIONS 7 // this must be the same as MetaspaceShared::n_regions
 #define CDS_ARCHIVE_MAGIC 0xf00baba2
 #define CDS_DYNAMIC_ARCHIVE_MAGIC 0xf00baba8
-#define CURRENT_CDS_ARCHIVE_VERSION 11
+#define CURRENT_CDS_ARCHIVE_VERSION 12
 #define INVALID_CDS_ARCHIVE_VERSION -1
 
 struct CDSFileMapRegion {
@@ -60,15 +60,19 @@ struct CDSFileMapRegion {
   char*   _mapped_base;       // Actually mapped address (NULL if this region is not mapped).
 };
 
+// The declaration of the following 5 fields must never be changed
+// in any future versions of HotSpot
 struct CDSFileMapHeaderBase {
   unsigned int _magic;           // identify file type
   int          _crc;             // header crc checksum
   int          _version;         // must be CURRENT_CDS_ARCHIVE_VERSION
-  int _base_archive_path_offset; // This field is present with (_version >= 12). It's declaration
-                                 // must never be changed in any future versions of HotSpot.
-                                 // If this is a dynamic archive, (((char*)this) + _base_archive_path_offset)
-                                 // stores a 0-terminated string for the pathname of the base archive.
-                                 // If this is a static archive, this field is 0.
+  unsigned int _header_size;     // total size of the header, in bytes
+  // This field is present with (_version >= 12). It's declaration
+  // must never be changed in any future versions of HotSpot.
+  // If this is a dynamic archive, (((char*)this) + _base_archive_path_offset)
+  // stores a 0-terminated string for the pathname of the base archive.
+  // If this is a static archive, this field is 0.
+  unsigned int _base_archive_path_offset;
   struct CDSFileMapRegion _space[NUM_CDS_REGIONS];
 };
 

--- a/src/hotspot/share/include/cds.h
+++ b/src/hotspot/share/include/cds.h
@@ -64,6 +64,11 @@ struct CDSFileMapHeaderBase {
   unsigned int _magic;           // identify file type
   int          _crc;             // header crc checksum
   int          _version;         // must be CURRENT_CDS_ARCHIVE_VERSION
+  int _base_archive_path_offset; // This field is present with (_version >= 12). It's declaration
+                                 // must never be changed in any future versions of HotSpot.
+                                 // If this is a dynamic archive, (((char*)this) + _base_archive_path_offset)
+                                 // stores a 0-terminated string for the pathname of the base archive.
+                                 // If this is a static archive, this field is 0.
   struct CDSFileMapRegion _space[NUM_CDS_REGIONS];
 };
 

--- a/src/hotspot/share/include/cds.h
+++ b/src/hotspot/share/include/cds.h
@@ -67,7 +67,7 @@ struct CDSFileMapHeaderBase {
   int          _crc;             // header crc checksum
   int          _version;         // must be CURRENT_CDS_ARCHIVE_VERSION
   unsigned int _header_size;     // total size of the header, in bytes
-  // This field is present with (_version >= 12). It's declaration
+  // This field is present with (_version >= 12). Its declaration
   // must never be changed in any future versions of HotSpot.
   // If this is a dynamic archive, (((char*)this) + _base_archive_path_offset)
   // stores a 0-terminated string for the pathname of the base archive.

--- a/src/hotspot/share/include/cds.h
+++ b/src/hotspot/share/include/cds.h
@@ -73,6 +73,8 @@ struct CDSFileMapHeaderBase {
   // stores a 0-terminated string for the pathname of the base archive.
   // If this is a static archive, this field is 0.
   unsigned int _base_archive_path_offset;
+  // size of the base archive name including NULL terminator
+  unsigned int _base_archive_name_size;
   struct CDSFileMapRegion _space[NUM_CDS_REGIONS];
 };
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3531,9 +3531,8 @@ bool Arguments::init_shared_archive_paths() {
       }
       if (archives == 1) {
         char* temp_archive_path = os::strdup_check_oom(SharedArchiveFile, mtArguments);
-        int name_size;
         bool success =
-          FileMapInfo::get_base_archive_name_from_header(temp_archive_path, &name_size, &SharedArchivePath);
+          FileMapInfo::get_base_archive_name_from_header(temp_archive_path, &SharedArchivePath);
         if (!success) {
           SharedArchivePath = temp_archive_path;
         } else {

--- a/test/hotspot/jtreg/runtime/cds/appcds/SharedArchiveConsistency.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/SharedArchiveConsistency.java
@@ -58,7 +58,7 @@ public class SharedArchiveConsistency {
 
     public static int num_regions = shared_region_name.length;
     public static String[] matchMessages = {
-        "_base_archive_path_offset should be 0",
+        "UseSharedSpaces: Header checksum verification failed.",
         "The shared archive file has an incorrect header size.",
         "Unable to use shared archive",
         "An error has occurred while processing the shared archive file.",

--- a/test/hotspot/jtreg/runtime/cds/appcds/SharedArchiveConsistency.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/SharedArchiveConsistency.java
@@ -58,6 +58,8 @@ public class SharedArchiveConsistency {
 
     public static int num_regions = shared_region_name.length;
     public static String[] matchMessages = {
+        "_base_archive_path_offset should be 0",
+        "The shared archive file has an incorrect header size.",
         "Unable to use shared archive",
         "An error has occurred while processing the shared archive file.",
         "Checksum verification failed.",
@@ -213,10 +215,18 @@ public class SharedArchiveConsistency {
         CDSArchiveUtils.deleteBytesAtRandomPositionAfterHeader(orgJsaFile, deleteBytes, 4096 /*bytes*/);
         testAndCheck(verifyExecArgs);
 
+        // modify contents in random area
         System.out.println("\n7. modify Content in random areas, should fail\n");
         String randomAreas = startNewArchive("random-areas");
         copiedJsa = CDSArchiveUtils.copyArchiveFile(orgJsaFile, randomAreas);
         CDSArchiveUtils.modifyRegionContentRandomly(copiedJsa);
+        testAndCheck(verifyExecArgs);
+
+        // modify _base_archive_path_offet to not zero
+        System.out.println("\n8. modify _base_archive_path_offset to not zero\n");
+        String baseArchivePathOffset = startNewArchive("base-arhive-path-offset");
+        copiedJsa = CDSArchiveUtils.copyArchiveFile(orgJsaFile, baseArchivePathOffset);
+        CDSArchiveUtils.modifyHeaderIntField(copiedJsa, CDSArchiveUtils.offsetBaseArchivePathOffset, 1024);
         testAndCheck(verifyExecArgs);
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchiveConsistency.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchiveConsistency.java
@@ -106,7 +106,7 @@ public class ArchiveConsistency extends DynamicArchiveTestBase {
 
         runTwo(baseArchiveName, largerHeaderSize,
                appJar, mainClass, 1,
-               new String[] {"The shared archive file has an incorrect header size.",
+               new String[] {"_base_archive_path_offset should be equal to _header_size",
                              "Unable to use shared archive"});
 
         // Make base archive path offset beyond of header size
@@ -117,7 +117,7 @@ public class ArchiveConsistency extends DynamicArchiveTestBase {
         CDSArchiveUtils.modifyHeaderIntField(copiedJsa, CDSArchiveUtils.offsetBaseArchivePathOffset,  fileHeaderSize + 1024);
         runTwo(baseArchiveName, largerHeaderSize,
                appJar, mainClass, 1,
-               new String[] {"The shared archive file has an incorrect header size.",
+               new String[] {"_base_archive_path_offset should be equal to _header_size",
                              "Unable to use shared archive"});
 
         // Make base archive path offset points to middle of name size
@@ -143,7 +143,7 @@ public class ArchiveConsistency extends DynamicArchiveTestBase {
         runTwo(baseArchiveName, wrongBaseName,
                appJar, mainClass, 1,
                new String[] {"Error occurred during initialization of VM",
-                             "Header checksum verification failed.",
+                             "Read base archive name from " + wrongBaseName + " failed",
                              "Unable to use shared archive"});
     }
 }


### PR DESCRIPTION
Store base archive path offset in CDSFileMapHeaderBase (which should be invariant in evolving versions) so we can read the base archive name reliably from dynamic archive even with variant header sizes over versions.

tests: tier1-4

Thanks
Yumin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8273152](https://bugs.openjdk.java.net/browse/JDK-8273152): Store base archive path in CDSFileMapHeaderBase


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5584/head:pull/5584` \
`$ git checkout pull/5584`

Update a local copy of the PR: \
`$ git checkout pull/5584` \
`$ git pull https://git.openjdk.java.net/jdk pull/5584/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5584`

View PR using the GUI difftool: \
`$ git pr show -t 5584`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5584.diff">https://git.openjdk.java.net/jdk/pull/5584.diff</a>

</details>
