### PR TITLE
8274024: Use regular accessors to internal fields of oopDesc

### DIFF
--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -416,17 +416,15 @@ void HeapShared::copy_roots() {
   HeapWord* mem = G1CollectedHeap::heap()->archive_mem_allocate(size);
 
   memset(mem, 0, size * BytesPerWord);
-  {
-    // This is copied from MemAllocator::finish
-    oopDesc::set_mark(mem, markWord::prototype());
-    oopDesc::release_set_klass(mem, k);
-  }
-  {
-    // This is copied from ObjArrayAllocator::initialize
-    arrayOopDesc::set_length(mem, length);
-  }
+  arrayOop array = arrayOop(cast_to_oop(mem));
 
-  _roots = OopHandle(Universe::vm_global(), cast_to_oop(mem));
+  // This is copied from MemAllocator::finish
+  array->set_mark(markWord::prototype());
+  array->release_set_klass(k);
+  // This is copied from ObjArrayAllocator::initialize
+  array->set_length(length);
+
+  _roots = OopHandle(Universe::vm_global(), array);
   for (int i = 0; i < length; i++) {
     roots()->obj_at_put(i, _pending_roots->at(i));
   }

--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -376,19 +376,20 @@ void MemAllocator::mem_clear(HeapWord* mem) const {
   assert(mem != NULL, "cannot initialize NULL object");
   const size_t hs = oopDesc::header_size();
   assert(_word_size >= hs, "unexpected object size");
-  oopDesc::set_klass_gap(mem, 0);
+  cast_to_oop(mem)->set_klass_gap(0);
   Copy::fill_to_aligned_words(mem + hs, _word_size - hs);
 }
 
 oop MemAllocator::finish(HeapWord* mem) const {
   assert(mem != NULL, "NULL object pointer");
   // May be bootstrapping
-  oopDesc::set_mark(mem, markWord::prototype());
+  oop obj = cast_to_oop(mem);
+  obj->set_mark(markWord::prototype());
   // Need a release store to ensure array/class length, mark word, and
   // object zeroing are visible before setting the klass non-NULL, for
   // concurrent collectors.
-  oopDesc::release_set_klass(mem, _klass);
-  return cast_to_oop(mem);
+  obj->release_set_klass(_klass);
+  return obj;
 }
 
 oop ObjAllocator::initialize(HeapWord* mem) const {
@@ -413,7 +414,7 @@ oop ObjArrayAllocator::initialize(HeapWord* mem) const {
   if (_do_zero) {
     mem_clear(mem);
   }
-  arrayOopDesc::set_length(mem, _length);
+  arrayOop(cast_to_oop(mem))->set_length(_length);
   return finish(mem);
 }
 

--- a/src/hotspot/share/oops/arrayOop.hpp
+++ b/src/hotspot/share/oops/arrayOop.hpp
@@ -118,10 +118,6 @@ class arrayOopDesc : public oopDesc {
     return length_addr_impl(this);
   }
 
-  static void set_length(HeapWord* mem, int length) {
-    *length_addr_impl(mem) = length;
-  }
-
   // Should only be called with constants as argument
   // (will not constant fold otherwise)
   // Returns the header size in words aligned to the requirements of the

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -63,7 +63,6 @@ class oopDesc {
   inline markWord* mark_addr() const;
 
   inline void set_mark(markWord m);
-  static inline void set_mark(HeapWord* mem, markWord m);
 
   inline void release_set_mark(markWord m);
   inline markWord cas_set_mark(markWord new_mark, markWord old_mark);
@@ -79,12 +78,11 @@ class oopDesc {
 
   void set_narrow_klass(narrowKlass nk) NOT_CDS_JAVA_HEAP_RETURN;
   inline void set_klass(Klass* k);
-  static inline void release_set_klass(HeapWord* mem, Klass* k);
+  inline void release_set_klass(Klass* k);
 
   // For klass field compression
   inline int klass_gap() const;
   inline void set_klass_gap(int z);
-  static inline void set_klass_gap(HeapWord* mem, int z);
 
   // size of object header, aligned to platform wordSize
   static int header_size() { return sizeof(oopDesc)/HeapWordSize; }


### PR DESCRIPTION
Currently, we are using 'raw' accessors to initialize the mark, Klass*, (array-)length and klass_gap of oops. This is ugly and confusing and we should just use the regular accessors.

Testing:
 - [ ] tier1
 - [ ] tier2
 - [ ] hotspot_gc