### PR TITLE
8273887: [macos] java/awt/color/ICC_ColorSpace/MTTransformReplacedProfile.java timed out

### DIFF
--- a/test/jdk/java/awt/color/ICC_ColorSpace/MTTransformReplacedProfile.java
+++ b/test/jdk/java/awt/color/ICC_ColorSpace/MTTransformReplacedProfile.java
@@ -110,7 +110,7 @@ public final class MTTransformReplacedProfile {
         float[] colorvalue = new float[3];
         Thread transform = new Thread(() -> {
             boolean rgb = true;
-            while (!stop.get()) {
+            while (!stop.get() && !isComplete()) {
                 try {
                     if (rgb) {
                         cs.toRGB(colorvalue);


### PR DESCRIPTION
This testcase creates two threads for each tag, one thread continuously change the profiles, the second thread use that profiles for color conversion. The first thread executed no more than 15 seconds, and the second thread should be stopped when the first thread end.

Unfortunately on the slow systems the second thread may occupy all cpu time, and will run forever since the first thread will not be able make even one iteration to stop the second thread. I was able to reproduce it by changing implementation of color conversion so it will do x10 more work.

The fix add a check to stop the second thread after 15 seconds.

@lawrence-andrew please take a look and confirm that it will work fine on your system

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273887](https://bugs.openjdk.java.net/browse/JDK-8273887): [macos] java/awt/color/ICC_ColorSpace/MTTransformReplacedProfile.java timed out


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5587/head:pull/5587` \
`$ git checkout pull/5587`

Update a local copy of the PR: \
`$ git checkout pull/5587` \
`$ git pull https://git.openjdk.java.net/jdk pull/5587/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5587`

View PR using the GUI difftool: \
`$ git pr show -t 5587`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5587.diff">https://git.openjdk.java.net/jdk/pull/5587.diff</a>

</details>
