### PR TITLE
8274029 : Remove jtreg tag manual=yesno for java/awt/print/Dialog/DialogOrient.java

### DIFF
--- a/test/jdk/java/awt/print/Dialog/DialogOrient.java
+++ b/test/jdk/java/awt/print/Dialog/DialogOrient.java
@@ -25,7 +25,7 @@
   @test
   @bug 6594374
   @summary  Confirm that the orientation is as specified.
-  @run main/manual=yesno DialogOrient
+  @run main/manual DialogOrient
 */
 
 import java.awt.*;


### PR DESCRIPTION
Problem : Testcase was failing with parser exception 
test result: Error. Parse Exception: Arguments to `manual' option not supported: yesno 
Fix : Removed =yesno and run the testcase and Test UI ( instruction and print dialog ) is visible

@shurymury 