### PR TITLE
8273917: Remove 'leaf' ranking for Mutex

### DIFF
--- a/src/hotspot/share/compiler/compileTask.hpp
+++ b/src/hotspot/share/compiler/compileTask.hpp
@@ -104,7 +104,7 @@ class CompileTask : public CHeapObj<mtCompiler> {
 
  public:
   CompileTask() : _failure_reason(NULL), _failure_reason_on_C_heap(false) {
-    _lock = new Monitor(Mutex::nonleaf+2, "CompileTaskLock", Mutex::_safepoint_check_always);
+    _lock = new Monitor(Mutex::nonleaf, "CompileTask_lock", Mutex::_safepoint_check_always);
   }
 
   void initialize(int compile_id, const methodHandle& method, int osr_bci, int comp_level,

--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -773,7 +773,7 @@ void OffsetTableContigSpace::alloc_block(HeapWord* start, HeapWord* end) {
 OffsetTableContigSpace::OffsetTableContigSpace(BlockOffsetSharedArray* sharedOffsetArray,
                                                MemRegion mr) :
   _offsets(sharedOffsetArray, mr),
-  _par_alloc_lock(Mutex::leaf, "OffsetTableContigSpace par alloc lock",
+  _par_alloc_lock(Mutex::nonleaf-2, "OffsetTableContigSpace par alloc lock",
                   Mutex::_safepoint_check_always, true)
 {
   _offsets.set_contig_space(this);

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -47,8 +47,8 @@
 
 ShenandoahControlThread::ShenandoahControlThread() :
   ConcurrentGCThread(),
-  _alloc_failure_waiters_lock(Mutex::leaf, "ShenandoahAllocFailureGC_lock", Monitor::_safepoint_check_always, true),
-  _gc_waiters_lock(Mutex::leaf, "ShenandoahRequestedGC_lock", Monitor::_safepoint_check_always, true),
+  _alloc_failure_waiters_lock(Mutex::nonleaf-2, "ShenandoahAllocFailureGC_lock", Monitor::_safepoint_check_always, true),
+  _gc_waiters_lock(Mutex::nonleaf-2, "ShenandoahRequestedGC_lock", Monitor::_safepoint_check_always, true),
   _periodic_task(this),
   _requested_gc_cause(GCCause::_no_cause_specified),
   _degen_point(ShenandoahGC::_degenerated_outside_cycle),

--- a/src/hotspot/share/gc/shenandoah/shenandoahPacer.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPacer.hpp
@@ -67,7 +67,7 @@ public:
           _heap(heap),
           _last_time(os::elapsedTime()),
           _progress_history(new TruncatedSeq(5)),
-          _wait_monitor(new Monitor(Mutex::leaf, "_wait_monitor", Monitor::_safepoint_check_always, true)),
+          _wait_monitor(new Monitor(Mutex::nonleaf-2, "_wait_monitor", Monitor::_safepoint_check_always, true)),
           _epoch(0),
           _tax_rate(1),
           _budget(0),

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -1206,7 +1206,8 @@ void MethodData::post_initialize(BytecodeStream* stream) {
 // Initialize the MethodData* corresponding to a given method.
 MethodData::MethodData(const methodHandle& method)
   : _method(method()),
-    _extra_data_lock(Mutex::leaf, "MDO extra data lock", Mutex::_safepoint_check_always),
+    // Holds Compile_lock
+    _extra_data_lock(Mutex::nonleaf-2, "MDOExtraData_lock", Mutex::_safepoint_check_always),
     _compiler_counters(),
     _parameters_type_data_di(parameters_uninitialized) {
   initialize();

--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -297,6 +297,7 @@ Mutex::Mutex(int Rank, const char * name, SafepointCheckRequired safepoint_check
          "Safepoint check never locks should always allow the vm to block: %s", name);
 
   assert(_rank >= 0, "Bad lock rank: %s", name);
+  assert(_rank <= nonleaf, "Bad lock rank: %s", name);
 #endif
 }
 

--- a/src/hotspot/share/runtime/mutex.hpp
+++ b/src/hotspot/share/runtime/mutex.hpp
@@ -53,10 +53,8 @@ class Mutex : public CHeapObj<mtSynchronizer> {
        tty            = stackwatermark +   3,
        oopstorage     = tty            +   3,
        nosafepoint    = oopstorage     +   6,
-       leaf           = nosafepoint    +   6,
-       barrier        = leaf           +  10,
-       nonleaf        = barrier        +   1,
-       max_nonleaf    = nonleaf        + 900
+       nonleaf        = nosafepoint    +  20,
+       max_nonleaf    = nonleaf
   };
 
  private:

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -748,7 +748,7 @@ class ParDumpWriter : public AbstractDumpWriter {
 
   static void before_work() {
     assert(_lock == NULL, "ParDumpWriter lock must be initialized only once");
-    _lock = new (std::nothrow) PaddedMonitor(Mutex::leaf, "Parallel HProf writer lock", Mutex::_safepoint_check_never);
+    _lock = new (std::nothrow) PaddedMonitor(Mutex::nosafepoint, "Parallel HProf writer lock", Mutex::_safepoint_check_never);
   }
 
   static void after_work() {
@@ -1814,7 +1814,7 @@ class DumperController : public CHeapObj<mtInternal> {
  public:
    DumperController(uint number) :
      _started(false),
-     _lock(new (std::nothrow) PaddedMonitor(Mutex::leaf, "Dumper Controller lock",
+     _lock(new (std::nothrow) PaddedMonitor(Mutex::nosafepoint, "Dumper Controller lock",
     Mutex::_safepoint_check_never)),
      _dumper_number(number),
      _complete_number(0) { }

--- a/src/hotspot/share/services/heapDumperCompression.cpp
+++ b/src/hotspot/share/services/heapDumperCompression.cpp
@@ -200,7 +200,7 @@ CompressionBackend::CompressionBackend(AbstractWriter* writer,
   _written(0),
   _writer(writer),
   _compressor(compressor),
-  _lock(new (std::nothrow) PaddedMonitor(Mutex::nosafepoint, "HProfCompressionBackend_lock",
+  _lock(new (std::nothrow) PaddedMonitor(Mutex::nosafepoint-1, "HProfCompressionBackend_lock",
     Mutex::_safepoint_check_never)) {
   if (_writer == NULL) {
     set_error("Could not allocate writer");

--- a/test/hotspot/gtest/runtime/test_mutex.cpp
+++ b/test/hotspot/gtest/runtime/test_mutex.cpp
@@ -53,14 +53,16 @@ TEST_VM(MutexName, mutex_name) {
 
 #ifdef ASSERT
 
-const int rankA = 50;
+const int rankA = Mutex::nonleaf-5;
+const int rankAplusOne = Mutex::nonleaf-4;
+const int rankAplusTwo = Mutex::nonleaf-3;
 
 TEST_OTHER_VM(MutexRank, mutex_lock_rank_in_order) {
   JavaThread* THREAD = JavaThread::current();
   ThreadInVMfromNative invm(THREAD);
 
   Mutex* mutex_rankA = new Mutex(rankA, "mutex_rankA", Mutex::_safepoint_check_always);
-  Mutex* mutex_rankA_plus_one = new Mutex(rankA + 1, "mutex_rankA_plus_one", Mutex::_safepoint_check_always);
+  Mutex* mutex_rankA_plus_one = new Mutex(rankAplusOne, "mutex_rankA_plus_one", Mutex::_safepoint_check_always);
 
   mutex_rankA_plus_one->lock();
   mutex_rankA->lock();
@@ -69,12 +71,12 @@ TEST_OTHER_VM(MutexRank, mutex_lock_rank_in_order) {
 }
 
 TEST_VM_ASSERT_MSG(MutexRank, mutex_lock_rank_out_of_orderA,
-                   ".* Attempting to acquire lock mutex_rankA_plus_one/51 out of order with lock mutex_rankA/50 -- possible deadlock") {
+                   ".* Attempting to acquire lock mutex_rankA_plus_one/.* out of order with lock mutex_rankA/.* -- possible deadlock") {
   JavaThread* THREAD = JavaThread::current();
   ThreadInVMfromNative invm(THREAD);
 
   Mutex* mutex_rankA = new Mutex(rankA, "mutex_rankA", Mutex::_safepoint_check_always);
-  Mutex* mutex_rankA_plus_one = new Mutex(rankA + 1, "mutex_rankA_plus_one", Mutex::_safepoint_check_always);
+  Mutex* mutex_rankA_plus_one = new Mutex(rankAplusOne, "mutex_rankA_plus_one", Mutex::_safepoint_check_always);
 
   mutex_rankA->lock();
   mutex_rankA_plus_one->lock();
@@ -83,7 +85,7 @@ TEST_VM_ASSERT_MSG(MutexRank, mutex_lock_rank_out_of_orderA,
 }
 
 TEST_VM_ASSERT_MSG(MutexRank, mutex_lock_rank_out_of_orderB,
-                   ".* Attempting to acquire lock mutex_rankB/50 out of order with lock mutex_rankA/50 -- possible deadlock") {
+                   ".* Attempting to acquire lock mutex_rankB/.* out of order with lock mutex_rankA/.* -- possible deadlock") {
   JavaThread* THREAD = JavaThread::current();
   ThreadInVMfromNative invm(THREAD);
 
@@ -101,8 +103,8 @@ TEST_OTHER_VM(MutexRank, mutex_trylock_rank_out_of_orderA) {
   ThreadInVMfromNative invm(THREAD);
 
   Mutex* mutex_rankA = new Mutex(rankA, "mutex_rankA", Mutex::_safepoint_check_always);
-  Mutex* mutex_rankA_plus_one = new Mutex(rankA + 1, "mutex_rankA_plus_one", Mutex::_safepoint_check_always);
-  Mutex* mutex_rankA_plus_two = new Mutex(rankA + 2, "mutex_rankA_plus_two", Mutex::_safepoint_check_always);
+  Mutex* mutex_rankA_plus_one = new Mutex(rankAplusOne, "mutex_rankA_plus_one", Mutex::_safepoint_check_always);
+  Mutex* mutex_rankA_plus_two = new Mutex(rankAplusTwo, "mutex_rankA_plus_two", Mutex::_safepoint_check_always);
 
   mutex_rankA_plus_one->lock();
   mutex_rankA_plus_two->try_lock_without_rank_check();
@@ -113,12 +115,12 @@ TEST_OTHER_VM(MutexRank, mutex_trylock_rank_out_of_orderA) {
 }
 
 TEST_VM_ASSERT_MSG(MutexRank, mutex_trylock_rank_out_of_orderB,
-                   ".* Attempting to acquire lock mutex_rankA_plus_one/51 out of order with lock mutex_rankA/50 -- possible deadlock") {
+                   ".* Attempting to acquire lock mutex_rankA_plus_one/.* out of order with lock mutex_rankA/.* -- possible deadlock") {
   JavaThread* THREAD = JavaThread::current();
   ThreadInVMfromNative invm(THREAD);
 
   Mutex* mutex_rankA = new Mutex(rankA, "mutex_rankA", Mutex::_safepoint_check_always);
-  Mutex* mutex_rankA_plus_one = new Mutex(rankA + 1, "mutex_rankA_plus_one", Mutex::_safepoint_check_always);
+  Mutex* mutex_rankA_plus_one = new Mutex(rankAplusOne, "mutex_rankA_plus_one", Mutex::_safepoint_check_always);
 
   mutex_rankA->lock();
   mutex_rankA_plus_one->try_lock_without_rank_check();
@@ -163,7 +165,7 @@ TEST_OTHER_VM(MutexRank, monitor_wait_rank_in_order) {
   ThreadInVMfromNative invm(THREAD);
 
   Monitor* monitor_rankA = new Monitor(rankA, "monitor_rankA", Mutex::_safepoint_check_always);
-  Monitor* monitor_rankA_plus_one = new Monitor(rankA + 1, "monitor_rankA_plus_one", Mutex::_safepoint_check_always);
+  Monitor* monitor_rankA_plus_one = new Monitor(rankAplusOne, "monitor_rankA_plus_one", Mutex::_safepoint_check_always);
 
   monitor_rankA_plus_one->lock();
   monitor_rankA->lock();
@@ -173,13 +175,13 @@ TEST_OTHER_VM(MutexRank, monitor_wait_rank_in_order) {
 }
 
 TEST_VM_ASSERT_MSG(MutexRank, monitor_wait_rank_out_of_order,
-                   ".* Attempting to wait on monitor monitor_rankA_plus_one/51 while holding lock monitor_rankA/50 "
+                   ".* Attempting to wait on monitor monitor_rankA_plus_one/.* while holding lock monitor_rankA/.* "
                    "-- possible deadlock. Should wait on the least ranked monitor from all owned locks.") {
   JavaThread* THREAD = JavaThread::current();
   ThreadInVMfromNative invm(THREAD);
 
   Monitor* monitor_rankA = new Monitor(rankA, "monitor_rankA", Mutex::_safepoint_check_always);
-  Monitor* monitor_rankA_plus_one = new Monitor(rankA + 1, "monitor_rankA_plus_one", Mutex::_safepoint_check_always);
+  Monitor* monitor_rankA_plus_one = new Monitor(rankAplusOne, "monitor_rankA_plus_one", Mutex::_safepoint_check_always);
 
   monitor_rankA_plus_one->lock();
   monitor_rankA->lock();
@@ -189,13 +191,13 @@ TEST_VM_ASSERT_MSG(MutexRank, monitor_wait_rank_out_of_order,
 }
 
 TEST_VM_ASSERT_MSG(MutexRank, monitor_wait_rank_out_of_order_trylock,
-                   ".* Attempting to wait on monitor monitor_rankA_plus_one/51 while holding lock monitor_rankA/50 "
+                   ".* Attempting to wait on monitor monitor_rankA_plus_one/.* while holding lock monitor_rankA/.* "
                    "-- possible deadlock. Should wait on the least ranked monitor from all owned locks.") {
   JavaThread* THREAD = JavaThread::current();
   ThreadInVMfromNative invm(THREAD);
 
   Monitor* monitor_rankA = new Monitor(rankA, "monitor_rankA", Mutex::_safepoint_check_always);
-  Monitor* monitor_rankA_plus_one = new Monitor(rankA + 1, "monitor_rankA_plus_one", Mutex::_safepoint_check_always);
+  Monitor* monitor_rankA_plus_one = new Monitor(rankAplusOne, "monitor_rankA_plus_one", Mutex::_safepoint_check_always);
 
   monitor_rankA->lock();
   monitor_rankA_plus_one->try_lock_without_rank_check();
@@ -273,12 +275,12 @@ TEST_VM_ASSERT_MSG(MutexRank, monitor_negative_rank,
 }
 
 TEST_VM_ASSERT_MSG(MutexRank, monitor_nosafepoint_rank,
-                   ".*failed: Locks above nosafepoint rank should safepoint: monitor_rank_leaf") {
+                   ".*failed: Locks above nosafepoint rank should safepoint: monitor_rank_nonleaf") {
   JavaThread* THREAD = JavaThread::current();
   ThreadInVMfromNative invm(THREAD);
 
-  Monitor* monitor_rank_leaf = new Monitor(Mutex::leaf, "monitor_rank_leaf", Mutex::_safepoint_check_never);
-  monitor_rank_leaf->lock_without_safepoint_check();
-  monitor_rank_leaf->unlock();
+  Monitor* monitor_rank_nonleaf = new Monitor(Mutex::nonleaf, "monitor_rank_nonleaf", Mutex::_safepoint_check_never);
+  monitor_rank_nonleaf->lock_without_safepoint_check();
+  monitor_rank_nonleaf->unlock();
 }
 #endif // ASSERT

--- a/test/hotspot/gtest/runtime/test_safepoint_locks.cpp
+++ b/test/hotspot/gtest/runtime/test_safepoint_locks.cpp
@@ -32,7 +32,7 @@
 // Test mismatched safepoint check flag on lock declaration vs. lock acquisition.
 TEST_VM_ASSERT_MSG(SafepointLockAssertTest, always_check,
     ".*This lock should always have a safepoint check for Java threads: SFPT_Test_lock") {
-  MutexLocker ml(new Mutex(Mutex::leaf, "SFPT_Test_lock", Mutex::_safepoint_check_always),
+  MutexLocker ml(new Mutex(Mutex::nonleaf, "SFPT_Test_lock", Mutex::_safepoint_check_always),
                  Mutex::_no_safepoint_check_flag);
 }
 


### PR DESCRIPTION
This change removes the 'leaf' ranking and moves all the safepoint_check_always locks into the range of nonleaf to nosafepoint.   All the locks are nonleaf minus some number where the number is determined by owning locks.  I generated a database of sorts of the locks taken relative to the locks held, which is where I observed these relative rankings.  If there's some test that was missed because I did this locally, the individual ranks are easy to fix.

The next change is going to change the name nonleaf to 'safepoint' and remove _safepoint_check_always/never, and adds range checking for Rank so that it can only go negative from a named rank.  This is the last change that should be difficult to review. I promise!

A macro was added to mutexLocker so that you can specify a lock to pick the rank based on that lock instead of doing nosafepoint-1 or  nonleaf-3 etc, where the held_lock is also initialized in mutexLocker.cpp.

Tested with tier1-8.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8273917](https://bugs.openjdk.java.net/browse/JDK-8273917): Remove 'leaf' ranking for Mutex


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5591/head:pull/5591` \
`$ git checkout pull/5591`

Update a local copy of the PR: \
`$ git checkout pull/5591` \
`$ git pull https://git.openjdk.java.net/jdk pull/5591/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5591`

View PR using the GUI difftool: \
`$ git pr show -t 5591`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5591.diff">https://git.openjdk.java.net/jdk/pull/5591.diff</a>

</details>
