### PR TITLE
8274031: Typo in StringBuilder.readObject

### DIFF
--- a/src/java.base/share/classes/java/lang/StringBuilder.java
+++ b/src/java.base/share/classes/java/lang/StringBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -479,7 +479,7 @@ public final class StringBuilder
     }
 
     /**
-     * readObject is called to restore the state of the StringBuffer from
+     * readObject is called to restore the state of the StringBuilder from
      * a stream.
      *
      * @param  s the {@code ObjectInputStream} from which data is read


### PR DESCRIPTION
Fix of a typo in the javadoc of StringBuilder,readObject, as previously reported to core-libs-dev:

https://mail.openjdk.java.net/pipermail/core-libs-dev/2021-September/081277.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274031](https://bugs.openjdk.java.net/browse/JDK-8274031): Typo in StringBuilder.readObject


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5592/head:pull/5592` \
`$ git checkout pull/5592`

Update a local copy of the PR: \
`$ git checkout pull/5592` \
`$ git pull https://git.openjdk.java.net/jdk pull/5592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5592`

View PR using the GUI difftool: \
`$ git pr show -t 5592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5592.diff">https://git.openjdk.java.net/jdk/pull/5592.diff</a>

</details>
