### PR TITLE
8272759: (fc) java/nio/channels/FileChannel/Transfer2GPlus.java failed in timeout

### DIFF
--- a/test/jdk/java/nio/channels/FileChannel/Transfer2GPlus.java
+++ b/test/jdk/java/nio/channels/FileChannel/Transfer2GPlus.java
@@ -27,7 +27,7 @@
  * @summary Verify that transferTo() copies more than Integer.MAX_VALUE bytes
  * @library .. /test/lib
  * @build jdk.test.lib.Platform
- * @run main Transfer2GPlus
+ * @run main/othervm Transfer2GPlus
  */
 
 import java.io.File;


### PR DESCRIPTION
Change the test to run in `othervm` mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272759](https://bugs.openjdk.java.net/browse/JDK-8272759): (fc) java/nio/channels/FileChannel/Transfer2GPlus.java failed in timeout


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5593/head:pull/5593` \
`$ git checkout pull/5593`

Update a local copy of the PR: \
`$ git checkout pull/5593` \
`$ git pull https://git.openjdk.java.net/jdk pull/5593/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5593`

View PR using the GUI difftool: \
`$ git pr show -t 5593`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5593.diff">https://git.openjdk.java.net/jdk/pull/5593.diff</a>

</details>
