### PR TITLE
8274317: Unnecessary reentrant synchronized block in java.awt.Cursor

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Cursor.java
+++ b/src/java.desktop/share/classes/java/awt/Cursor.java
@@ -295,10 +295,7 @@ public class Cursor implements java.io.Serializable {
         Cursor cursor = systemCustomCursors.get(name);
 
         if (cursor == null) {
-            synchronized(systemCustomCursors) {
-                if (systemCustomCursorProperties == null)
-                    loadSystemCustomCursorProperties();
-            }
+            loadSystemCustomCursorProperties();
 
             String prefix = CURSOR_DOT_PREFIX + name;
             String key    = prefix + DOT_FILE_SUFFIX;
@@ -433,7 +430,10 @@ public class Cursor implements java.io.Serializable {
      */
     @SuppressWarnings("removal")
     private static void loadSystemCustomCursorProperties() throws AWTException {
-        synchronized(systemCustomCursors) {
+        synchronized (systemCustomCursors) {
+            if (systemCustomCursorProperties != null) {
+                return;
+            }
             systemCustomCursorProperties = new Properties();
 
             try {


### PR DESCRIPTION
No need to use 'synchronized(systemCustomCursors)' in 2 places. One is enough.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274317](https://bugs.openjdk.java.net/browse/JDK-8274317): Unnecessary reentrant synchronized block in java.awt.Cursor


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5597/head:pull/5597` \
`$ git checkout pull/5597`

Update a local copy of the PR: \
`$ git checkout pull/5597` \
`$ git pull https://git.openjdk.java.net/jdk pull/5597/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5597`

View PR using the GUI difftool: \
`$ git pr show -t 5597`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5597.diff">https://git.openjdk.java.net/jdk/pull/5597.diff</a>

</details>
