### PR TITLE
8274053: [BACKOUT] JDK-8270842: G1: Only young regions need to redirty outside references in remset.

### DIFF
--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -81,7 +81,6 @@ class RemoveSelfForwardPtrObjClosure: public ObjectClosure {
   G1CollectedHeap* _g1h;
   G1ConcurrentMark* _cm;
   HeapRegion* _hr;
-  const bool _is_young;
   size_t _marked_bytes;
   UpdateLogBuffersDeferred* _log_buffer_cl;
   bool _during_concurrent_start;
@@ -96,7 +95,6 @@ public:
     _g1h(G1CollectedHeap::heap()),
     _cm(_g1h->concurrent_mark()),
     _hr(hr),
-    _is_young(hr->is_young()),
     _marked_bytes(0),
     _log_buffer_cl(log_buffer_cl),
     _during_concurrent_start(during_concurrent_start),
@@ -143,14 +141,19 @@ public:
       _marked_bytes += (obj_size * HeapWordSize);
       PreservedMarks::init_forwarded_mark(obj);
 
-      // During evacuation failure we do not record inter-region
-      // references referencing regions that need a remembered set
-      // update originating from young regions (including eden) that
-      // failed evacuation. Make up for that omission now by rescanning
-      // these failed objects.
-      if (_is_young) {
-        obj->oop_iterate(_log_buffer_cl);
-      }
+      // While we were processing RSet buffers during the collection,
+      // we actually didn't scan any cards on the collection set,
+      // since we didn't want to update remembered sets with entries
+      // that point into the collection set, given that live objects
+      // from the collection set are about to move and such entries
+      // will be stale very soon.
+      // This change also dealt with a reliability issue which
+      // involved scanning a card in the collection set and coming
+      // across an array that was being chunked and looking malformed.
+      // The problem is that, if evacuation fails, we might have
+      // remembered set entries missing given that we skipped cards on
+      // the collection set. So, we'll recreate such entries now.
+      obj->oop_iterate(_log_buffer_cl);
 
       HeapWord* obj_end = obj_addr + obj_size;
       _last_forwarded_object_end = obj_end;


### PR DESCRIPTION
Hi all,

  can I have reviews for this clean backout of JDK-8270842/PR#4853 because it is buggy - it drops re-scanning of failed objects in old generation during self-forward removal. However the previous attempt to mark the card of the discovered reference field for j.l.ref.References might not have been processed correctly as the card table may not be in a state to properly handle regular write barrier writes. More information in PR#5037.

I will follow-up with a correct solution.

Testing: GHA (this is a clean backout)

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274053](https://bugs.openjdk.java.net/browse/JDK-8274053): [BACKOUT] JDK-8270842: G1: Only young regions need to redirty outside references in remset.


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5600/head:pull/5600` \
`$ git checkout pull/5600`

Update a local copy of the PR: \
`$ git checkout pull/5600` \
`$ git pull https://git.openjdk.java.net/jdk pull/5600/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5600`

View PR using the GUI difftool: \
`$ git pr show -t 5600`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5600.diff">https://git.openjdk.java.net/jdk/pull/5600.diff</a>

</details>
