### PR TITLE
8274054: Add custom enqueue calls during reference processing

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -248,8 +248,9 @@ public:
     G1IsAliveClosure is_alive(&_collector);
     uint index = (_tm == RefProcThreadModel::Single) ? 0 : worker_id;
     G1FullKeepAliveClosure keep_alive(_collector.marker(index));
+    BarrierEnqueueDiscoveredFieldClosure enqueue;
     G1FollowStackClosure* complete_gc = _collector.marker(index)->stack_closure();
-    _rp_task->rp_work(worker_id, &is_alive, &keep_alive, complete_gc);
+    _rp_task->rp_work(worker_id, &is_alive, &keep_alive, &enqueue, complete_gc);
   }
 };
 

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -213,7 +213,7 @@ void G1ParScanThreadState::do_oop_evac(T* p) {
   assert(obj != NULL, "Must be");
   if (HeapRegion::is_in_same_region(p, obj)) {
     return;
-  }
+}
   HeapRegion* from = _g1h->heap_region_containing(p);
   if (!from->is_young()) {
     enqueue_card_if_tracked(_g1h->region_attr(obj), p, obj);

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -213,7 +213,7 @@ void G1ParScanThreadState::do_oop_evac(T* p) {
   assert(obj != NULL, "Must be");
   if (HeapRegion::is_in_same_region(p, obj)) {
     return;
-}
+  }
   HeapRegion* from = _g1h->heap_region_containing(p);
   if (!from->is_young()) {
     enqueue_card_if_tracked(_g1h->region_attr(obj), p, obj);

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -895,7 +895,7 @@ class G1STWRefProcProxyTask : public RefProcProxyTask {
   TaskTerminator _terminator;
   G1ScannerTasksQueueSet& _task_queues;
 
-  public:
+public:
   G1STWRefProcProxyTask(uint max_workers, G1CollectedHeap& g1h, G1ParScanThreadStateSet& pss, G1ScannerTasksQueueSet& task_queues)
     : RefProcProxyTask("G1STWRefProcProxyTask", max_workers),
       _g1h(g1h),

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -895,7 +895,7 @@ class G1STWRefProcProxyTask : public RefProcProxyTask {
   TaskTerminator _terminator;
   G1ScannerTasksQueueSet& _task_queues;
 
-public:
+  public:
   G1STWRefProcProxyTask(uint max_workers, G1CollectedHeap& g1h, G1ParScanThreadStateSet& pss, G1ScannerTasksQueueSet& task_queues)
     : RefProcProxyTask("G1STWRefProcProxyTask", max_workers),
       _g1h(g1h),
@@ -912,8 +912,9 @@ public:
 
     G1STWIsAliveClosure is_alive(&_g1h);
     G1CopyingKeepAliveClosure keep_alive(&_g1h, pss);
+    BarrierEnqueueDiscoveredFieldClosure enqueue;
     G1ParEvacuateFollowersClosure complete_gc(&_g1h, pss, &_task_queues, _tm == RefProcThreadModel::Single ? nullptr : &_terminator, G1GCPhaseTimes::ObjCopy);
-    _rp_task->rp_work(worker_id, &is_alive, &keep_alive, &complete_gc);
+    _rp_task->rp_work(worker_id, &is_alive, &keep_alive, &enqueue, &complete_gc);
 
     // We have completed copying any necessary live referent objects.
     assert(pss->queue_is_empty(), "both queue and overflow should be empty");

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -2067,8 +2067,9 @@ public:
     assert(worker_id < _max_workers, "sanity");
     ParCompactionManager* cm = (_tm == RefProcThreadModel::Single) ? ParCompactionManager::get_vmthread_cm() : ParCompactionManager::gc_thread_compaction_manager(worker_id);
     PCMarkAndPushClosure keep_alive(cm);
+    BarrierEnqueueDiscoveredFieldClosure enqueue;
     ParCompactionManager::FollowStackClosure complete_gc(cm, (_tm == RefProcThreadModel::Single) ? nullptr : &_terminator, worker_id);
-    _rp_task->rp_work(worker_id, PSParallelCompact::is_alive_closure(), &keep_alive, &complete_gc);
+    _rp_task->rp_work(worker_id, PSParallelCompact::is_alive_closure(), &keep_alive, &enqueue, &complete_gc);
   }
 
   void prepare_run_task_hook() override {

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -209,9 +209,10 @@ public:
     assert(worker_id < _max_workers, "sanity");
     PSPromotionManager* promotion_manager = (_tm == RefProcThreadModel::Single) ? PSPromotionManager::vm_thread_promotion_manager() : PSPromotionManager::gc_thread_promotion_manager(worker_id);
     PSIsAliveClosure is_alive;
-    PSKeepAliveClosure keep_alive(promotion_manager);;
+    PSKeepAliveClosure keep_alive(promotion_manager);
+    BarrierEnqueueDiscoveredFieldClosure enqueue;
     PSEvacuateFollowersClosure complete_gc(promotion_manager, (_marks_oops_alive && _tm == RefProcThreadModel::Multi) ? &_terminator : nullptr, worker_id);;
-    _rp_task->rp_work(worker_id, &is_alive, &keep_alive, &complete_gc);
+    _rp_task->rp_work(worker_id, &is_alive, &keep_alive, &enqueue, &complete_gc);
   }
 
   void prepare_run_task_hook() override {

--- a/src/hotspot/share/gc/serial/serialGcRefProcProxyTask.hpp
+++ b/src/hotspot/share/gc/serial/serialGcRefProcProxyTask.hpp
@@ -41,7 +41,8 @@ public:
 
   void work(uint worker_id) override {
     assert(worker_id < _max_workers, "sanity");
-    _rp_task->rp_work(worker_id, &_is_alive, &_keep_alive, &_complete_gc);
+    BarrierEnqueueDiscoveredFieldClosure enqueue;
+    _rp_task->rp_work(worker_id, &_is_alive, &_keep_alive, &enqueue, &_complete_gc);
   }
 };
 

--- a/src/hotspot/share/gc/shared/referenceProcessor.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.hpp
@@ -38,6 +38,26 @@ class ReferenceProcessorPhaseTimes;
 class RefProcTask;
 class RefProcProxyTask;
 
+// Provides a callback to the garbage collector to set the given value to the
+// discovered field of the j.l.ref.Reference instance. This is called during STW
+// reference processing when iterating over the discovered lists for all
+// discovered references.
+// Typically garbage collectors may just call the barrier, but for some garbage
+// collectors the barrier environment (e.g. card table) may not be set up correctly
+// at the point of invocation.
+class EnqueueDiscoveredFieldClosure {
+public:
+  // For the given j.l.ref.Reference reference, set the discovered field to value.
+  virtual void enqueue(oop reference, oop value) = 0;
+};
+
+// EnqueueDiscoveredFieldClosure that executes the default barrier on the discovered
+// field of the j.l.ref.Reference reference with the given value.
+class BarrierEnqueueDiscoveredFieldClosure : public EnqueueDiscoveredFieldClosure {
+public:
+  void enqueue(oop reference, oop value) override;
+};
+
 // List of discovered references.
 class DiscoveredList {
 public:
@@ -66,7 +86,6 @@ private:
 
 // Iterator for the list of discovered references.
 class DiscoveredListIterator {
-private:
   DiscoveredList&    _refs_list;
   HeapWord*          _prev_discovered_addr;
   oop                _prev_discovered;
@@ -78,6 +97,7 @@ private:
 
   OopClosure*        _keep_alive;
   BoolObjectClosure* _is_alive;
+  EnqueueDiscoveredFieldClosure* _enqueue;
 
   DEBUG_ONLY(
   oop                _first_seen; // cyclic linked list check
@@ -89,7 +109,8 @@ private:
 public:
   inline DiscoveredListIterator(DiscoveredList&    refs_list,
                                 OopClosure*        keep_alive,
-                                BoolObjectClosure* is_alive);
+                                BoolObjectClosure* is_alive,
+                                EnqueueDiscoveredFieldClosure* enqueue);
 
   // End Of List.
   inline bool has_next() const { return _current_discovered != NULL; }
@@ -255,12 +276,14 @@ private:
   size_t process_discovered_list_work(DiscoveredList&    refs_list,
                                       BoolObjectClosure* is_alive,
                                       OopClosure*        keep_alive,
+                                      EnqueueDiscoveredFieldClosure* enqueue,
                                       bool               do_enqueue_and_clear);
 
   // Keep alive followers of referents for FinalReferences. Must only be called for
   // those.
   size_t process_final_keep_alive_work(DiscoveredList& refs_list,
-                                       OopClosure* keep_alive);
+                                       OopClosure* keep_alive,
+                                       EnqueueDiscoveredFieldClosure* enqueue);
 
 
   void setup_policy(bool always_clear) {
@@ -291,6 +314,7 @@ public:
   // (or predicates involved) by other threads.
   void preclean_discovered_references(BoolObjectClosure* is_alive,
                                       OopClosure*        keep_alive,
+                                      EnqueueDiscoveredFieldClosure* enqueue,
                                       VoidClosure*       complete_gc,
                                       YieldClosure*      yield,
                                       GCTimer*           gc_timer);
@@ -307,6 +331,7 @@ private:
   bool preclean_discovered_reflist(DiscoveredList&    refs_list,
                                    BoolObjectClosure* is_alive,
                                    OopClosure*        keep_alive,
+                                   EnqueueDiscoveredFieldClosure* enqueue,
                                    VoidClosure*       complete_gc,
                                    YieldClosure*      yield);
 
@@ -542,7 +567,8 @@ protected:
   void process_discovered_list(uint worker_id,
                                ReferenceType ref_type,
                                BoolObjectClosure* is_alive,
-                               OopClosure* keep_alive);
+                               OopClosure* keep_alive,
+                               EnqueueDiscoveredFieldClosure* enqueue);
 public:
   RefProcTask(ReferenceProcessor& ref_processor,
               ReferenceProcessorPhaseTimes* phase_times)
@@ -552,6 +578,7 @@ public:
   virtual void rp_work(uint worker_id,
                        BoolObjectClosure* is_alive,
                        OopClosure* keep_alive,
+                       EnqueueDiscoveredFieldClosure* enqueue,
                        VoidClosure* complete_gc) = 0;
 };
 

--- a/src/hotspot/share/gc/shared/referenceProcessor.inline.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.inline.hpp
@@ -60,7 +60,8 @@ void DiscoveredList::clear() {
 
 DiscoveredListIterator::DiscoveredListIterator(DiscoveredList&    refs_list,
                                                OopClosure*        keep_alive,
-                                               BoolObjectClosure* is_alive):
+                                               BoolObjectClosure* is_alive,
+                                               EnqueueDiscoveredFieldClosure* enqueue):
   _refs_list(refs_list),
   _prev_discovered_addr(refs_list.adr_head()),
   _prev_discovered(NULL),
@@ -70,6 +71,7 @@ DiscoveredListIterator::DiscoveredListIterator(DiscoveredList&    refs_list,
   _referent(NULL),
   _keep_alive(keep_alive),
   _is_alive(is_alive),
+  _enqueue(enqueue),
 #ifdef ASSERT
   _first_seen(refs_list.head()),
 #endif


### PR DESCRIPTION
Hi all,

  can I have reviews for this split-out of JDK-8271880/PR#5037 that only adds the interface and the default implementation to add custom "enqueue" calls to the VM?

For G1, the default (wrong) queue call is still used, that will be added with the other modifications to g1 later.

Testing: tier1-3

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274054](https://bugs.openjdk.java.net/browse/JDK-8274054): Add custom enqueue calls during reference processing


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5603/head:pull/5603` \
`$ git checkout pull/5603`

Update a local copy of the PR: \
`$ git checkout pull/5603` \
`$ git pull https://git.openjdk.java.net/jdk pull/5603/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5603`

View PR using the GUI difftool: \
`$ git pr show -t 5603`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5603.diff">https://git.openjdk.java.net/jdk/pull/5603.diff</a>

</details>
