### PR TITLE
8270139: jshell InternalError crash for import of @Repeatable followed by unresolved ref

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -3102,7 +3102,9 @@ public class Check {
         List<Pair<MethodSymbol,Attribute>> l = repeatable.values;
         if (!l.isEmpty()) {
             Assert.check(l.head.fst.name == names.value);
-            t = ((Attribute.Class)l.head.snd).getValue();
+            if (l.head.snd instanceof Attribute.Class) {
+                t = ((Attribute.Class)l.head.snd).getValue();
+            }
         }
 
         if (t == null) {

--- a/test/langtools/jdk/jshell/ErrorRecoveryTest.java
+++ b/test/langtools/jdk/jshell/ErrorRecoveryTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8270139
+ * @summary Verify error recovery in JShell
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.jdeps/com.sun.tools.javap
+ *          jdk.jshell/jdk.internal.jshell.tool
+ * @library /tools/lib
+ * @build KullaTesting TestingInputStream ExpectedDiagnostic toolbox.ToolBox Compiler
+ * @run testng ErrorRecoveryTest
+ */
+
+import org.testng.annotations.Test;
+import static jdk.jshell.Snippet.Status.NONEXISTENT;
+import static jdk.jshell.Snippet.Status.RECOVERABLE_NOT_DEFINED;
+
+@Test
+public class ErrorRecoveryTest extends KullaTesting {
+
+    public void testExceptionErrors() {
+        assertEval("import java.lang.annotation.Repeatable;");
+        assertEval("""
+                   @Repeatable(FooContainer.class)
+                   @interface Foo { int value(); }
+                   """,
+                   ste(MAIN_SNIPPET, NONEXISTENT, RECOVERABLE_NOT_DEFINED, false, null));
+    }
+}

--- a/test/langtools/tools/javac/recovery/AnnotationRecovery.java
+++ b/test/langtools/tools/javac/recovery/AnnotationRecovery.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8270139
+ * @summary Verify error recovery w.r.t. annotations
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.jdeps/com.sun.tools.classfile
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main AnnotationRecovery
+ */
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+
+import toolbox.JavacTask;
+import toolbox.Task.Expect;
+import toolbox.Task.OutputKind;
+import toolbox.TestRunner;
+import toolbox.ToolBox;
+
+public class AnnotationRecovery extends TestRunner {
+
+    ToolBox tb;
+
+    public AnnotationRecovery() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    public static void main(String[] args) throws Exception {
+        AnnotationRecovery t = new AnnotationRecovery();
+        t.runTests();
+    }
+
+    @Test
+    public void testRepeatableAnnotationMissingContainer() throws Exception {
+        String code = """
+                      import java.lang.annotation.Repeatable;
+
+                      @Repeatable(TestContainer.class)
+                      @interface Test { int value(); }
+                      """;
+        Path curPath = Path.of(".");
+        List<String> actual = new JavacTask(tb)
+                .options("-XDrawDiagnostics", "-XDdev")
+                .sources(code)
+                .outdir(curPath)
+                .run(Expect.FAIL)
+                .getOutputLines(OutputKind.DIRECT);
+
+        List<String> expected = List.of(
+                "Test.java:3:13: compiler.err.cant.resolve: kindname.class, TestContainer, , ",
+                "1 error"
+        );
+
+        if (!Objects.equals(actual, expected)) {
+            error("Expected: " + expected + ", but got: " + actual);
+        }
+    }
+
+    @Test
+    public void testRepeatableAnnotationWrongAttribute() throws Exception {
+        String code = """
+                      import java.lang.annotation.Repeatable;
+
+                      @Repeatable(wrong=TestContainer.class)
+                      @interface Test { int value(); }
+                      @interface TestContainer { Test value(); }
+                      """;
+        Path curPath = Path.of(".");
+        List<String> actual = new JavacTask(tb)
+                .options("-XDrawDiagnostics", "-XDdev")
+                .sources(code)
+                .outdir(curPath)
+                .run(Expect.FAIL)
+                .getOutputLines(OutputKind.DIRECT);
+
+        List<String> expected = List.of(
+                "Test.java:3:13: compiler.err.cant.resolve.location.args: kindname.method, wrong, , , (compiler.misc.location: kindname.annotation, java.lang.annotation.Repeatable, null)",
+                "Test.java:3:1: compiler.err.annotation.missing.default.value: java.lang.annotation.Repeatable, value",
+                "2 errors"
+        );
+
+        if (!Objects.equals(actual, expected)) {
+            error("Expected: " + expected + ", but got: " + actual);
+        }
+    }
+
+}


### PR DESCRIPTION
For code like:
```
import java.lang.annotation.Repeatable;
@Repeatable(TestContainer.class)
@interface Test { int value(); }
```

javac crashes like this:
```
$ javac -XDdev /tmp/Test.java 
/tmp/Test.java:2: error: cannot find symbol
@Repeatable(TestContainer.class)
            ^
  symbol: class TestContainer
1 error
An exception has occurred in the compiler (18-internal). Please file a bug against the Java compiler via the Java bug reporting page (http://bugreport.java.com) after checking the Bug Database (http://bugs.java.com) for duplicates. Include your program, the following diagnostic, and the parameters passed to the Java compiler in your report. Thank you.
java.lang.ClassCastException: class com.sun.tools.javac.code.Attribute$UnresolvedClass cannot be cast to class com.sun.tools.javac.code.Attribute$Class (com.sun.tools.javac.code.Attribute$UnresolvedClass and com.sun.tools.javac.code.Attribute$Class are in module jdk.compiler of loader 'app')
        at jdk.compiler/com.sun.tools.javac.comp.Check.validateRepeatable(Check.java:3105)
        at jdk.compiler/com.sun.tools.javac.comp.Attr.attribClassBody(Attr.java:5445)
        at jdk.compiler/com.sun.tools.javac.comp.Attr.attribClass(Attr.java:5372)
        at jdk.compiler/com.sun.tools.javac.comp.Attr.attribClass(Attr.java:5196)
        at jdk.compiler/com.sun.tools.javac.comp.Attr.attrib(Attr.java:5141)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.attribute(JavaCompiler.java:1317)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:946)
        at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:317)
        at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:176)
        at jdk.compiler/com.sun.tools.javac.Main.compile(Main.java:64)
        at jdk.compiler/com.sun.tools.javac.Main.main(Main.java:50)
printing javac parameters to: /home/jlahoda/src/jdk/jdk/javac.20210921_130231.args
```

The reason is that the value of the `Repeatable.value` is cast to `Class` without any checks - would be better to ignore resolution errors at this place, which the proposed patch is attempting to do.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270139](https://bugs.openjdk.java.net/browse/JDK-8270139): jshell InternalError crash for import of @Repeatable followed by unresolved ref


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5604/head:pull/5604` \
`$ git checkout pull/5604`

Update a local copy of the PR: \
`$ git checkout pull/5604` \
`$ git pull https://git.openjdk.java.net/jdk pull/5604/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5604`

View PR using the GUI difftool: \
`$ git pr show -t 5604`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5604.diff">https://git.openjdk.java.net/jdk/pull/5604.diff</a>

</details>
