### PR TITLE
8274039: codestrings gtest fails when hsdis is present

### DIFF
--- a/test/hotspot/gtest/code/test_codestrings.cpp
+++ b/test/hotspot/gtest/code/test_codestrings.cpp
@@ -43,7 +43,7 @@ static const char* replace_addr_expr(const char* str)
     // Padding: aarch64
     std::basic_string<char> tmp2 = std::regex_replace(tmp1, std::regex("\\s+<addr>:\\s+\\.inst\\t<addr> ; undefined"), "");
     // Padding: x64
-    std::basic_string<char> red  = std::regex_replace(tmp2, std::regex("[ \\t]+<addr>:\\s+hlt\\s+\\n(?!\\s+;;)"), "");
+    std::basic_string<char> red  = std::regex_replace(tmp2, std::regex("\\s+<addr>:\\s+hlt[ \\t]+(?!\\n\\s+;;)"), "");
 
     return os::strdup(red.c_str());
 }

--- a/test/hotspot/gtest/code/test_codestrings.cpp
+++ b/test/hotspot/gtest/code/test_codestrings.cpp
@@ -37,10 +37,13 @@ static const char* replace_addr_expr(const char* str)
 {
     // Remove any address expression "0x0123456789abcdef" found in order to
     // aid string comparison. Also remove any trailing printout from a padded
-    // buffer.
+    // buffer (too brittle?).
 
-    std::basic_string<char> tmp = std::regex_replace(str, std::regex("0x[0-9a-fA-F]+"), "<addr>");
-    std::basic_string<char> red = std::regex_replace(tmp, std::regex("\\s+<addr>:\\s+\\.inst\\t<addr> ; undefined"), "");
+    std::basic_string<char> tmp1 = std::regex_replace(str, std::regex("0x[0-9a-fA-F]+"), "<addr>");
+    // Padding: aarch64
+    std::basic_string<char> tmp2 = std::regex_replace(tmp1, std::regex("\\s+<addr>:\\s+\\.inst\\t<addr> ; undefined"), "");
+    // Padding: x64
+    std::basic_string<char> red  = std::regex_replace(tmp2, std::regex("  <addr>:   hlt    \\n"), "");
 
     return os::strdup(red.c_str());
 }

--- a/test/hotspot/gtest/code/test_codestrings.cpp
+++ b/test/hotspot/gtest/code/test_codestrings.cpp
@@ -43,7 +43,7 @@ static const char* replace_addr_expr(const char* str)
     // Padding: aarch64
     std::basic_string<char> tmp2 = std::regex_replace(tmp1, std::regex("\\s+<addr>:\\s+\\.inst\\t<addr> ; undefined"), "");
     // Padding: x64
-    std::basic_string<char> red  = std::regex_replace(tmp2, std::regex("  <addr>:   hlt    \\n"), "");
+    std::basic_string<char> red  = std::regex_replace(tmp2, std::regex("[ \\t]+<addr>:\\s+hlt\\s+\\n(?!\\s+;;)"), "");
 
     return os::strdup(red.c_str());
 }


### PR DESCRIPTION
Please review this change to the (g)test-case "codestrings".

Adding missing regexp pattern to remove trailing **hsdis** printout due to padding on x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274039](https://bugs.openjdk.java.net/browse/JDK-8274039): codestrings gtest fails when hsdis is present


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to 597e779b1e0db5b8cf2c1c9bd1e7d832694434e7


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5606/head:pull/5606` \
`$ git checkout pull/5606`

Update a local copy of the PR: \
`$ git checkout pull/5606` \
`$ git pull https://git.openjdk.java.net/jdk pull/5606/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5606`

View PR using the GUI difftool: \
`$ git pr show -t 5606`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5606.diff">https://git.openjdk.java.net/jdk/pull/5606.diff</a>

</details>
