### PR TITLE
8274070: Rectify problemlist platform for failing test on macos12

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -258,7 +258,7 @@ sun/java2d/SunGraphics2D/SimplePrimQuality.java 6992007 generic-all
 sun/java2d/SunGraphics2D/SourceClippingBlitTest/SourceClippingBlitTest.java 8196185 generic-all
 
 sun/java2d/X11SurfaceData/SharedMemoryPixmapsTest/SharedMemoryPixmapsTest.sh 8221451 linux-all
-java/awt/FullScreen/DisplayChangeVITest/DisplayChangeVITest.java 8169469,8273618 windows-all,macosx-all
+java/awt/FullScreen/DisplayChangeVITest/DisplayChangeVITest.java 8169469,8273618 windows-all,macosx-aarch64
 java/awt/FullScreen/UninitializedDisplayModeChangeTest/UninitializedDisplayModeChangeTest.java 8273617 macosx-all
 java/awt/print/PrinterJob/PSQuestionMark.java 7003378 generic-all
 java/awt/print/PrinterJob/GlyphPositions.java 7003378 generic-all


### PR DESCRIPTION
It was mentioned in JDK-8273618

> java/awt/FullScreen/DisplayChangeVITest/DisplayChangeVITest.java is timing out on a macOS 12 aarch64 (an Apple Silicon Mac Mini) system.
> I'm not seeing the same on x64.

but it is problemlisted for macos-all..It should be problemlisted only for macos-aarch64. 
Mach5 jobs (listed in JBS) also shows this test pass for macos-x64 but fails for macos-aarch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274070](https://bugs.openjdk.java.net/browse/JDK-8274070): Rectify problemlist platform for failing test on macos12


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5608/head:pull/5608` \
`$ git checkout pull/5608`

Update a local copy of the PR: \
`$ git checkout pull/5608` \
`$ git pull https://git.openjdk.java.net/jdk pull/5608/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5608`

View PR using the GUI difftool: \
`$ git pr show -t 5608`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5608.diff">https://git.openjdk.java.net/jdk/pull/5608.diff</a>

</details>
