### PR TITLE
8274071: Clean up java.lang.ref comments and documentation

### DIFF
--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -134,7 +134,7 @@ public abstract class Reference<T> {
      *   [inactive/unregistered]
      *
      * Unreachable states (because enqueue also clears):
-     *   [active/enqeued]
+     *   [active/enqueued]
      *   [active/dequeued]
      *
      * [1] Unregistered is not permitted for FinalReferences.
@@ -510,8 +510,7 @@ public abstract class Reference<T> {
      * this method.  Invocation of this method does not itself initiate garbage
      * collection or finalization.
      *
-     * <p> This method establishes an ordering for
-     * <a href="package-summary.html#reachability"><em>strong reachability</em></a>
+     * <p> This method establishes an ordering for <em>strong reachability</em>
      * with respect to garbage collection.  It controls relations that are
      * otherwise only implicit in a program -- the reachability conditions
      * triggering garbage collection.  This method is designed for use in
@@ -609,7 +608,6 @@ public abstract class Reference<T> {
      *
      * @param ref the reference. If {@code null}, this method has no effect.
      * @since 9
-     * @jls 12.6 Finalization of Class Instances
      */
     @ForceInline
     public static void reachabilityFence(Object ref) {


### PR DESCRIPTION
This PR fixes an inline comment typo and reduces "overlinking" in a doc comment in `java.lang.ref.Reference`. Overlinking happens because the `reachabilityFence` method:
 * Links `package-summary.html#reachability` twice.
 * Refers to JLS 12.6 twice: once from a block tag and once from an inline tag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274071](https://bugs.openjdk.java.net/browse/JDK-8274071): Clean up java.lang.ref comments and documentation


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5609/head:pull/5609` \
`$ git checkout pull/5609`

Update a local copy of the PR: \
`$ git checkout pull/5609` \
`$ git pull https://git.openjdk.java.net/jdk pull/5609/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5609`

View PR using the GUI difftool: \
`$ git pr show -t 5609`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5609.diff">https://git.openjdk.java.net/jdk/pull/5609.diff</a>

</details>
