### PR TITLE
8273924: ArrayIndexOutOfBoundsException thrown in java.util.JapaneseImperialCalendar.add()

### DIFF
--- a/src/java.base/share/classes/sun/util/calendar/BaseCalendar.java
+++ b/src/java.base/share/classes/sun/util/calendar/BaseCalendar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -277,6 +277,10 @@ public abstract class BaseCalendar extends AbstractCalendar {
             long xm = 1L - month;
             year -= (int)((xm / 12) + 1);
             month = 13 - (xm % 12);
+            if (month == 13) {
+                year ++;
+                month = 1;
+            }
             bdate.setNormalizedYear(year);
             bdate.setMonth((int) month);
         } else if (month > DECEMBER) {

--- a/src/java.base/share/classes/sun/util/calendar/BaseCalendar.java
+++ b/src/java.base/share/classes/sun/util/calendar/BaseCalendar.java
@@ -278,7 +278,7 @@ public abstract class BaseCalendar extends AbstractCalendar {
             year -= (int)((xm / 12) + 1);
             month = 13 - (xm % 12);
             if (month == 13) {
-                year ++;
+                year++;
                 month = 1;
             }
             bdate.setNormalizedYear(year);

--- a/test/jdk/java/util/Calendar/CalendarTestScripts/JapaneseTests.java
+++ b/test/jdk/java/util/Calendar/CalendarTestScripts/JapaneseTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @summary tests Japanese Calendar.
- * @bug 4609228 8187649
+ * @bug 4609228 8187649 8273924
  * @modules java.base/sun.util
  *          java.base/sun.util.calendar
  * @compile

--- a/test/jdk/java/util/Calendar/CalendarTestScripts/japanese/japanese_add.cts
+++ b/test/jdk/java/util/Calendar/CalendarTestScripts/japanese/japanese_add.cts
@@ -354,6 +354,26 @@ test add MONTH
 #	check date Heisei $max Aug 16
 #	check timeofday 23 59 59 999
 
+#	JDK-8273924
+	set date Reiwa 2 Mar 1
+	add month -10
+	check date Reiwa 1 May 1
+	set date Reiwa 2 Mar 1
+	add month -11
+	check date Heisei 31 Apr 1
+	set date Reiwa 2 Mar 1
+	add month -12
+	check date Heisei 31 Mar 1
+	set date Reiwa 2 Mar 1
+	add month -13
+	check date Heisei 31 Feb 1
+	set date Reiwa 2 Mar 1
+	add month -14
+	check date Heisei 31 Jan 1
+	set date Reiwa 2 Mar 1
+	add month -15
+	check date Heisei 30 Dec 1
+
 test add WEEK_OF_YEAR
     use jcal
 	clear all


### PR DESCRIPTION
Fixing an AIOOBE on normalizing the month value.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273924](https://bugs.openjdk.java.net/browse/JDK-8273924): ArrayIndexOutOfBoundsException thrown in java.util.JapaneseImperialCalendar.add()


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to 92f81963d43ef74d77357e39ca7f76b2f59507a6
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5611/head:pull/5611` \
`$ git checkout pull/5611`

Update a local copy of the PR: \
`$ git checkout pull/5611` \
`$ git pull https://git.openjdk.java.net/jdk pull/5611/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5611`

View PR using the GUI difftool: \
`$ git pr show -t 5611`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5611.diff">https://git.openjdk.java.net/jdk/pull/5611.diff</a>

</details>
