### PR TITLE
8274060: C2: Incorrect computation after JDK-8273454

### DIFF
--- a/test/hotspot/jtreg/compiler/integerArithmetic/TestNegAnd.java
+++ b/test/hotspot/jtreg/compiler/integerArithmetic/TestNegAnd.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @key randomness
+ * @bug 8274060
+ * @summary Test broken transformation (-a) & (-b) = a & b does not happen
+ *
+ * @library /test/lib
+ *
+ * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:CompileCommand="dontinline,TestNegAnd::test*" TestNegAnd
+ *
+ */
+
+import java.util.Random;
+import jdk.test.lib.Utils;
+import jdk.test.lib.Asserts;
+
+public class TestNegAnd {
+    private static final Random random = Utils.getRandomInstance();
+    // Enough cycles to ensure test methods are JIT-ed
+    private static final int TEST_COUNT = 20_000;
+
+    private static int testInt(int a, int b) {
+        return (-a) & (-b);
+    }
+    private static long testLong(long a, long b) {
+        return (-a) & (-b);
+    }
+
+    private static void runIntTests() {
+        for (int index = 0; index < TEST_COUNT; index ++) {
+            int a = random.nextInt();
+            int b = random.nextInt();
+            int expected = (-a) & (-b);
+            int res = testInt(a, b);
+            Asserts.assertEQ(res, expected);
+        }
+    }
+
+    private static void runLongTests() {
+        for (int index = 0; index < TEST_COUNT; index ++) {
+            long a = random.nextLong();
+            long b = random.nextLong();
+            long expected = (-a) & (-b);
+            long res = testLong(a, b);
+            Asserts.assertEQ(res, expected);
+        }
+    }
+
+    public static void main(String[] args) {
+        runIntTests();
+        runLongTests();
+    }
+}


### PR DESCRIPTION
A Fuzzer test caught a serious regression after [JDK-8273454](https://bugs.openjdk.java.net/browse/JDK-8273454): the results are different in (interpreter, C1) vs C2. See the original test cases in the bug. I believe the trouble is due to `And*Node`-s sharing code with `MulNode` (for [reasons](https://github.com/openjdk/jdk/blob/42d5d2abaad8a88a5e1326ea8b4494aeb8b5748b/src/hotspot/share/opto/mulnode.hpp#L168-L169)), which means we enter the new transformation here:

```
Node *AndINode::Ideal(PhaseGVN *phase, bool can_reshape) {
  // Special case constant AND mask
  const TypeInt *t2 = phase->type( in(2) )->isa_int();
  if( !t2 || !t2->is_con() ) return MulNode::Ideal(phase, can_reshape); // <--- calls new code through here
```

So while new optimization `((-x) * (-y)) => (x * y)` is correct, doing the same for `((-x) & (-y)) => (x & y)` is not!

I opted to test the opcodes directly instead of introducing virtual methods in `MulNode`. Let me know if you prefer otherwise.

Additional testing:
 - [x] Original tests now pass
 - [x] New regression test is copied from original for JDK-8273454, but new copy verifies that `&` operate the same (fails without the C2 fix)
 - [ ] `tier1` tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274060](https://bugs.openjdk.java.net/browse/JDK-8274060): C2: Incorrect computation after JDK-8273454


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5612/head:pull/5612` \
`$ git checkout pull/5612`

Update a local copy of the PR: \
`$ git checkout pull/5612` \
`$ git pull https://git.openjdk.java.net/jdk pull/5612/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5612`

View PR using the GUI difftool: \
`$ git pr show -t 5612`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5612.diff">https://git.openjdk.java.net/jdk/pull/5612.diff</a>

</details>
