### PR TITLE
8262945: [macos] Regression Manual Test for Key Events Fails

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTEvent.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTEvent.m
@@ -460,15 +460,6 @@ NsCharToJavaVirtualKeyCode(unichar ch, BOOL isDeadChar,
     }
 
     if ([[NSCharacterSet letterCharacterSet] characterIsMember:ch]) {
-        TISInputSourceRef source = TISCopyCurrentKeyboardInputSource();
-        NSString* lang;
-        NSArray* languages = (NSArray *) TISGetInputSourceProperty(source, kTISPropertyInputSourceLanguages);
-        if (languages && [languages count] > 0) {
-            lang = [languages objectAtIndex:0];
-        } else {
-            lang = languages;
-        }
-
         // key is an alphabetic character
         unichar lower;
         lower = tolower(ch);
@@ -480,8 +471,8 @@ NsCharToJavaVirtualKeyCode(unichar ch, BOOL isDeadChar,
             *keyCode = java_awt_event_KeyEvent_VK_A + offset;
             *keyLocation = java_awt_event_KeyEvent_KEY_LOCATION_STANDARD;
             return;
-        } else if([lang isEqualToString:@"ru"]) {
-            // checking for Russian characters
+        } else {
+            // checking for non-english characters
             offset += 0x01000000;
             *postsTyped = YES;
             // do quick conversion, add 32 for Russian

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTEvent.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTEvent.m
@@ -473,9 +473,11 @@ NsCharToJavaVirtualKeyCode(unichar ch, BOOL isDeadChar,
             return;
         } else {
             // checking for non-english characters
+            // this value comes from ExtendedKeyCodes.java
             offset += 0x01000000;
             *postsTyped = YES;
-            // do quick conversion, add 32 for Russian
+            // do quick conversion
+            // the keyCode is off by 32, so adding it here
             *keyCode = java_awt_event_KeyEvent_VK_A + offset + 32;
             *keyLocation = java_awt_event_KeyEvent_KEY_LOCATION_STANDARD;
 return;

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTEvent.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTEvent.m
@@ -460,19 +460,35 @@ NsCharToJavaVirtualKeyCode(unichar ch, BOOL isDeadChar,
     }
 
     if ([[NSCharacterSet letterCharacterSet] characterIsMember:ch]) {
+        TISInputSourceRef source = TISCopyCurrentKeyboardInputSource();
+        NSString* lang;
+        NSArray* languages = (NSArray *) TISGetInputSourceProperty(source, kTISPropertyInputSourceLanguages);
+        if (languages && [languages count] > 0) {
+            lang = [languages objectAtIndex:0];
+        } else {
+            lang = languages;
+        }
+
         // key is an alphabetic character
         unichar lower;
         lower = tolower(ch);
         offset = lower - 'a';
         if (offset >= 0 && offset <= 25) {
-            // some chars in letter set are NOT actually A-Z characters?!
-            // skip them...
+            // checking for A-Z characters
             *postsTyped = YES;
             // do quick conversion
             *keyCode = java_awt_event_KeyEvent_VK_A + offset;
             *keyLocation = java_awt_event_KeyEvent_KEY_LOCATION_STANDARD;
             return;
-        }
+        } else if([lang isEqualToString:@"ru"]) {
+            // checking for Russian characters
+            offset += 0x01000000;
+            *postsTyped = YES;
+            // do quick conversion, add 32 for Russian
+            *keyCode = java_awt_event_KeyEvent_VK_A + offset + 32;
+            *keyLocation = java_awt_event_KeyEvent_KEY_LOCATION_STANDARD;
+return;
+         }
     }
 
     if ([[NSCharacterSet decimalDigitCharacterSet] characterIsMember:ch]) {


### PR DESCRIPTION
Added a check for active keyboard language and added support for Russian NSEvent keyCodes to JavaVirtualKeyCode translation. Originally, only English characters were checked for even if other languages were in native letterCharacterSet. Can be easily expanded to include other languages as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262945](https://bugs.openjdk.java.net/browse/JDK-8262945): [macos] Regression Manual Test for Key Events Fails


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5617/head:pull/5617` \
`$ git checkout pull/5617`

Update a local copy of the PR: \
`$ git checkout pull/5617` \
`$ git pull https://git.openjdk.java.net/jdk pull/5617/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5617`

View PR using the GUI difftool: \
`$ git pr show -t 5617`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5617.diff">https://git.openjdk.java.net/jdk/pull/5617.diff</a>

</details>
