### PR TITLE
8274003: ProcessHandleImpl.Info toString has an if check which is always true

### DIFF
--- a/src/java.base/share/classes/java/lang/ProcessHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/ProcessHandleImpl.java
@@ -642,27 +642,27 @@ final class ProcessHandleImpl implements ProcessHandle {
                 sb.append(user());
             }
             if (command != null) {
-                if (sb.length() != 0) sb.append(", ");
+                if (sb.length() > 1) sb.append(", ");
                 sb.append("cmd: ");
                 sb.append(command);
             }
             if (arguments != null && arguments.length > 0) {
-                if (sb.length() != 0) sb.append(", ");
+                if (sb.length() > 1) sb.append(", ");
                 sb.append("args: ");
                 sb.append(Arrays.toString(arguments));
             }
             if (commandLine != null) {
-                if (sb.length() != 0) sb.append(", ");
+                if (sb.length() > 1) sb.append(", ");
                 sb.append("cmdLine: ");
                 sb.append(commandLine);
             }
             if (startTime > 0) {
-                if (sb.length() != 0) sb.append(", ");
+                if (sb.length() > 1) sb.append(", ");
                 sb.append("startTime: ");
                 sb.append(startInstant());
             }
             if (totalTime != -1) {
-                if (sb.length() != 0) sb.append(", ");
+                if (sb.length() > 1) sb.append(", ");
                 sb.append("totalTime: ");
                 sb.append(totalCpuDuration().toString());
             }


### PR DESCRIPTION
Correct the check if any field has been appended to the StringBuilder in ProcessHandleImpl.Info.toString().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274003](https://bugs.openjdk.java.net/browse/JDK-8274003): ProcessHandleImpl.Info toString has an if check which is always true


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5618/head:pull/5618` \
`$ git checkout pull/5618`

Update a local copy of the PR: \
`$ git checkout pull/5618` \
`$ git pull https://git.openjdk.java.net/jdk pull/5618/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5618`

View PR using the GUI difftool: \
`$ git pr show -t 5618`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5618.diff">https://git.openjdk.java.net/jdk/pull/5618.diff</a>

</details>
