### PR TITLE
8269850: Most JDK releases report macOS version 12 as 10.16 instead of 12.0

### DIFF
--- a/src/java.base/macosx/native/libjava/java_props_macosx.c
+++ b/src/java.base/macosx/native/libjava/java_props_macosx.c
@@ -262,18 +262,13 @@ void setOSNameAndVersion(java_props_t *sprops) {
             osVersionCStr = strdup([nsVerStr UTF8String]);
         } else {
             // Version 10.16, without explicit env setting of SYSTEM_VERSION_COMPAT
-            // AKA 11.x; compute the version number from the letter in the ProductBuildVersion
+            // AKA 11+ Read the *real* ProductVersion from the hidden link to avoid SYSTEM_VERSION_COMPAT
+            // If not found, fallback below to the SystemVersion.plist
             NSDictionary *version = [NSDictionary dictionaryWithContentsOfFile :
-                             @"/System/Library/CoreServices/SystemVersion.plist"];
+                             @"/System/Library/CoreServices/.SystemVersionPlatform.plist"];
             if (version != NULL) {
-                NSString *nsBuildVerStr = [version objectForKey : @"ProductBuildVersion"];
-                if (nsBuildVerStr != NULL && nsBuildVerStr.length >= 3) {
-                    int letter = [nsBuildVerStr characterAtIndex:2];
-                    if (letter >= 'B' && letter <= 'Z') {
-                        int vers = letter - 'A' - 1;
-                        asprintf(&osVersionCStr, "11.%d", vers);
-                    }
-                }
+                NSString *nsVerStr = [version objectForKey : @"ProductVersion"];
+                osVersionCStr = strdup([nsVerStr UTF8String]);
             }
         }
     }


### PR DESCRIPTION
The Mac OS specific code to determine the os.version property in java_props_macosx.c is updated
to replace the code extracting the version from the SystemVersion.plist by reading the version using the hidden link:
   `/System/Library/CoreServices/.SystemVersionPlatform.plist`

Its contents are not dependent on the SYSTEM_VERSION_COMPAT environment variable.
With this change, 11.5 reports the 11.5.1 minor version and os.version 11.6 is correctly reported.
The change can be backported to other versions as needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269850](https://bugs.openjdk.java.net/browse/JDK-8269850): Most JDK releases report macOS version 12 as 10.16 instead of 12.0


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5619/head:pull/5619` \
`$ git checkout pull/5619`

Update a local copy of the PR: \
`$ git checkout pull/5619` \
`$ git pull https://git.openjdk.java.net/jdk pull/5619/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5619`

View PR using the GUI difftool: \
`$ git pr show -t 5619`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5619.diff">https://git.openjdk.java.net/jdk/pull/5619.diff</a>

</details>
