### PR TITLE
8273546: DecimalFormat documentation contains literal HTML character references

### DIFF
--- a/src/java.base/share/classes/java/math/BigInteger.java
+++ b/src/java.base/share/classes/java/math/BigInteger.java
@@ -941,7 +941,7 @@ public class BigInteger extends Number implements Comparable<BigInteger> {
      * @param  certainty a measure of the uncertainty that the caller is
      *         willing to tolerate: if the call returns {@code true}
      *         the probability that this BigInteger is prime exceeds
-     *         {@code (1 - 1/2<sup>certainty</sup>)}.  The execution time of
+     *         <code>(1 - 1/2<sup>certainty</sup>)</code>.  The execution time of
      *         this method is proportional to the value of this parameter.
      * @return {@code true} if this BigInteger is probably prime,
      *         {@code false} if it's definitely composite.
@@ -2066,20 +2066,20 @@ public class BigInteger extends Number implements Comparable<BigInteger> {
     // Squaring
 
     /**
-     * Returns a BigInteger whose value is {@code (this<sup>2</sup>)}.
+     * Returns a BigInteger whose value is <code>(this<sup>2</sup>)</code>.
      *
-     * @return {@code this<sup>2</sup>}
+     * @return <code>this<sup>2</sup></code>
      */
     private BigInteger square() {
         return square(false);
     }
 
     /**
-     * Returns a BigInteger whose value is {@code (this<sup>2</sup>)}. If
+     * Returns a BigInteger whose value is <code>(this<sup>2</sup>)</code>. If
      * the invocation is recursive certain overflow checks are skipped.
      *
      * @param isRecursion whether this is a recursive invocation
-     * @return {@code this<sup>2</sup>}
+     * @return <code>this<sup>2</sup></code>
      */
     private BigInteger square(boolean isRecursion) {
         if (signum == 0) {

--- a/src/java.base/share/classes/java/text/CompactNumberFormat.java
+++ b/src/java.base/share/classes/java/text/CompactNumberFormat.java
@@ -169,10 +169,10 @@ import java.util.stream.Collectors;
  * <i>NegativePattern:</i>
  *        <i>Prefix<sub>optional</sub></i> <i>MinimumInteger</i> <i>Suffix<sub>optional</sub></i>
  * <i>Prefix:</i>
- *      Any Unicode characters except &#92;uFFFE, &#92;uFFFF, and
+ *      Any Unicode characters except {@code U+FFFE}, {@code U+FFFF}, and
  *      <a href = "DecimalFormat.html#special_pattern_character">special characters</a>.
  * <i>Suffix:</i>
- *      Any Unicode characters except &#92;uFFFE, &#92;uFFFF, and
+ *      Any Unicode characters except {@code U+FFFE}, {@code U+FFFF}, and
  *      <a href = "DecimalFormat.html#special_pattern_character">special characters</a>.
  * <i>MinimumInteger:</i>
  *      0

--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -96,9 +96,9 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  * <i>NegativePattern:</i>
  *         <i>Prefix<sub>opt</sub></i> <i>Number</i> <i>Suffix<sub>opt</sub></i>
  * <i>Prefix:</i>
- *         any Unicode characters except &#92;uFFFE, &#92;uFFFF, and special characters
+ *         any Unicode characters except {@code U+FFFE}, {@code U+FFFF}, and special characters
  * <i>Suffix:</i>
- *         any Unicode characters except &#92;uFFFE, &#92;uFFFF, and special characters
+ *         any Unicode characters except {@code U+FFFE}, {@code U+FFFF}, and special characters
  * <i>Number:</i>
  *         <i>Integer</i> <i>Exponent<sub>opt</sub></i>
  *         <i>Integer</i> . <i>Fraction</i> <i>Exponent<sub>opt</sub></i>
@@ -221,12 +221,12 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *          <td>Yes
  *          <td>Multiply by 100 and show as percentage
  *     <tr style="vertical-align:top">
- *          <th scope="row">{@code &#92;u2030}
+ *          <th scope="row">{@code U+2030}
  *          <td>Prefix or suffix
  *          <td>Yes
  *          <td>Multiply by 1000 and show as per mille value
  *     <tr style="vertical-align: top">
- *          <th scope="row">{@code &#164;} ({@code &#92;u00A4})
+ *          <th scope="row">&#164; ({@code U+00A4})
  *          <td>Prefix or suffix
  *          <td>No
  *          <td>Currency sign, replaced by currency symbol.  If
@@ -309,12 +309,12 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  * <h4>Special Values</h4>
  *
  * <p>{@code NaN} is formatted as a string, which typically has a single character
- * {@code &#92;uFFFD}.  This string is determined by the
+ * {@code U+FFFD}.  This string is determined by the
  * {@code DecimalFormatSymbols} object.  This is the only value for which
  * the prefixes and suffixes are not used.
  *
  * <p>Infinity is formatted as a string, which typically has a single character
- * {@code &#92;u221E}, with the positive or negative prefixes and suffixes
+ * {@code U+221E}, with the positive or negative prefixes and suffixes
  * applied.  The infinity string is determined by the
  * {@code DecimalFormatSymbols} object.
  *
@@ -2735,7 +2735,7 @@ public class DecimalFormat extends NumberFormat {
      * For a percent format, set the multiplier to 100 and the suffixes to
      * have '%' (for Arabic, use the Arabic percent sign).
      * For a per mille format, set the multiplier to 1000 and the suffixes to
-     * have '&#92;u2030'.
+     * have '{@code U+2030}'.
      *
      * <P>Example: with multiplier 100, 1.23 is formatted as "123", and
      * "123" is parsed into 1.23.


### PR DESCRIPTION
Simple doc fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273546](https://bugs.openjdk.java.net/browse/JDK-8273546): DecimalFormat documentation contains literal HTML character references


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5620/head:pull/5620` \
`$ git checkout pull/5620`

Update a local copy of the PR: \
`$ git checkout pull/5620` \
`$ git pull https://git.openjdk.java.net/jdk pull/5620/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5620`

View PR using the GUI difftool: \
`$ git pr show -t 5620`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5620.diff">https://git.openjdk.java.net/jdk/pull/5620.diff</a>

</details>
