### PR TITLE
8274114: ProblemList serviceability/sa/TestJhsdbJstackMixed.java on linux-aarch64 in -Xcomp mode

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -36,3 +36,5 @@ vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java 8265295 lin
 vmTestbase/nsk/jvmti/scenarios/sampling/SP07/sp07t002/TestDescription.java 8245680 windows-x64
 
 vmTestbase/vm/mlvm/hiddenloader/stress/oome/heap/Test.java 8273095 generic-all
+
+serviceability/sa/TestJhsdbJstackMixed.java 8248675 linux-aarch64


### PR DESCRIPTION
A trivial fix to ProblemList serviceability/sa/TestJhsdbJstackMixed.java on linux-aarch64 in -Xcomp mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274114](https://bugs.openjdk.java.net/browse/JDK-8274114): ProblemList serviceability/sa/TestJhsdbJstackMixed.java on linux-aarch64 in -Xcomp mode


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5624/head:pull/5624` \
`$ git checkout pull/5624`

Update a local copy of the PR: \
`$ git checkout pull/5624` \
`$ git pull https://git.openjdk.java.net/jdk pull/5624/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5624`

View PR using the GUI difftool: \
`$ git pr show -t 5624`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5624.diff">https://git.openjdk.java.net/jdk/pull/5624.diff</a>

</details>
