### PR TITLE
8218885: Restore pop_frame and force_early_return functionality for Graal

### DIFF
--- a/src/hotspot/share/prims/jvmtiManageCapabilities.cpp
+++ b/src/hotspot/share/prims/jvmtiManageCapabilities.cpp
@@ -107,14 +107,6 @@ jvmtiCapabilities JvmtiManageCapabilities::init_onload_capabilities() {
 #ifndef ZERO
   jc.can_pop_frame = 1;
   jc.can_force_early_return = 1;
-  // Workaround for 8195635:
-  // disable pop_frame and force_early_return capabilities with Graal
-#if INCLUDE_JVMCI
-  if (UseJVMCICompiler) {
-    jc.can_pop_frame = 0;
-    jc.can_force_early_return = 0;
-  }
-#endif // INCLUDE_JVMCI
 #endif // !ZERO
   jc.can_get_source_debug_extension = 1;
   jc.can_access_local_variables = 1;


### PR DESCRIPTION
This logic no longer seems to be necessary since the adjustCompilationLevel callback has been removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8218885](https://bugs.openjdk.org/browse/JDK-8218885): Restore pop_frame and force_early_return functionality for Graal


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [96c9c334](https://git.openjdk.org/jdk/pull/5625/files/96c9c33497c51711e18caf9570204d86e5972702)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to [96c9c334](https://git.openjdk.org/jdk/pull/5625/files/96c9c33497c51711e18caf9570204d86e5972702)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [96c9c334](https://git.openjdk.org/jdk/pull/5625/files/96c9c33497c51711e18caf9570204d86e5972702)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**) ⚠️ Review applies to [96c9c334](https://git.openjdk.org/jdk/pull/5625/files/96c9c33497c51711e18caf9570204d86e5972702)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/5625/head:pull/5625` \
`$ git checkout pull/5625`

Update a local copy of the PR: \
`$ git checkout pull/5625` \
`$ git pull https://git.openjdk.org/jdk pull/5625/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5625`

View PR using the GUI difftool: \
`$ git pr show -t 5625`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/5625.diff">https://git.openjdk.org/jdk/pull/5625.diff</a>

</details>
