### PR TITLE
8274120: [JVMCI] CompileBroker should resolve parameter types for JVMCI compiles

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -1400,7 +1400,7 @@ nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
 
   assert(!HAS_PENDING_EXCEPTION, "No exception should be present");
   // some prerequisites that are compiler specific
-  if (comp->is_c2()) {
+  if (comp->is_c2() || comp->is_jvmci()) {
     method->constants()->resolve_string_constants(CHECK_AND_CLEAR_NONASYNC_NULL);
     // Resolve all classes seen in the signature of the method
     // we are compiling.


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274120](https://bugs.openjdk.java.net/browse/JDK-8274120): [JVMCI] CompileBroker should resolve parameter types for JVMCI compiles


### Reviewers
 * [Doug Simon](https://openjdk.java.net/census#dnsimon) (@dougxc - Committer)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5627/head:pull/5627` \
`$ git checkout pull/5627`

Update a local copy of the PR: \
`$ git checkout pull/5627` \
`$ git pull https://git.openjdk.java.net/jdk pull/5627/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5627`

View PR using the GUI difftool: \
`$ git pr show -t 5627`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5627.diff">https://git.openjdk.java.net/jdk/pull/5627.diff</a>

</details>
