### PR TITLE
8274425: Remove unused Modules.extraLimitMods

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java
@@ -52,7 +52,6 @@ import javax.tools.JavaFileObject.Kind;
 import javax.tools.StandardLocation;
 
 import com.sun.source.tree.ModuleTree.ModuleKind;
-import com.sun.tools.javac.code.ClassFinder;
 import com.sun.tools.javac.code.DeferredLintHandler;
 import com.sun.tools.javac.code.Directive;
 import com.sun.tools.javac.code.Directive.ExportsDirective;
@@ -163,7 +162,6 @@ public class Modules extends JCTree.Visitor {
     private final String addModsOpt;
     private final Set<String> extraAddMods = new HashSet<>();
     private final String limitModsOpt;
-    private final Set<String> extraLimitMods = new HashSet<>();
     private final String moduleVersionOpt;
 
     private final boolean lintOptions;
@@ -1223,18 +1221,13 @@ public class Modules extends JCTree.Visitor {
 
         Set<ModuleSymbol> observable;
 
-        if (limitModsOpt == null && extraLimitMods.isEmpty()) {
+        if (limitModsOpt == null) {
             observable = null;
         } else {
             Set<ModuleSymbol> limitMods = new HashSet<>();
-            if (limitModsOpt != null) {
-                for (String limit : limitModsOpt.split(",")) {
-                    if (!isValidName(limit))
-                        continue;
-                    limitMods.add(syms.enterModule(names.fromString(limit)));
-                }
-            }
-            for (String limit : extraLimitMods) {
+            for (String limit : limitModsOpt.split(",")) {
+                if (!isValidName(limit))
+                    continue;
                 limitMods.add(syms.enterModule(names.fromString(limit)));
             }
             observable = computeTransitiveClosure(limitMods, rootModules, null);


### PR DESCRIPTION
HashSet `com.sun.tools.javac.comp.Modules.extraLimitMods` is always empty. Code only check its content, but no content added.
There was a method `addExtraLimitModules`, but it was removed under [JDK-8175191](https://bugs.openjdk.java.net/browse/JDK-8175191) 253fdcd0b26
Method `addExtraLimitModules` itself was added in ec9ca2997f4, but was never actually used .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8274425](https://bugs.openjdk.java.net/browse/JDK-8274425): Remove unused Modules.extraLimitMods


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5628/head:pull/5628` \
`$ git checkout pull/5628`

Update a local copy of the PR: \
`$ git checkout pull/5628` \
`$ git pull https://git.openjdk.java.net/jdk pull/5628/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5628`

View PR using the GUI difftool: \
`$ git pr show -t 5628`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5628.diff">https://git.openjdk.java.net/jdk/pull/5628.diff</a>

</details>
