### PR TITLE
8275241: Unused ArrayList is created in RequestEngine.addHooks

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/RequestEngine.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/RequestEngine.java
@@ -28,7 +28,6 @@ package jdk.jfr.internal;
 import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -162,10 +161,8 @@ public final class RequestEngine {
     // Only to be used for JVM events. No access control contest
     // or check if hook already exists
     static void addHooks(List<RequestHook> newEntries) {
-        List<RequestHook> addEntries = new ArrayList<>();
         for (RequestHook rh : newEntries) {
             rh.type.setEventHook(true);
-            addEntries.add(rh);
             logHook("Added", rh.type);
         }
         entries.addAll(newEntries);


### PR DESCRIPTION
Local `ArrayList<RequestHook>`  is created in a method `RequestEngine.addHooks`. Elements are added to it, but then content is unused. Seems leftovers from some refactoring.
Found by IntelliJ IDEA inspection "Mismatched query and update of collection"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275241](https://bugs.openjdk.java.net/browse/JDK-8275241): Unused ArrayList is created in RequestEngine.addHooks


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5629/head:pull/5629` \
`$ git checkout pull/5629`

Update a local copy of the PR: \
`$ git checkout pull/5629` \
`$ git pull https://git.openjdk.java.net/jdk pull/5629/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5629`

View PR using the GUI difftool: \
`$ git pr show -t 5629`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5629.diff">https://git.openjdk.java.net/jdk/pull/5629.diff</a>

</details>
