### PR TITLE
8274662: Replace 'while' cycles with iterator with enhanced-for in jdk.hotspot.agent

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/DeadlockDetector.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/DeadlockDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,16 +55,14 @@ public class DeadlockDetector {
         heap = VM.getVM().getObjectHeap();
         createThreadTable();
 
-        Iterator i = threadTable.entrySet().iterator();
-        while (i.hasNext()) {
-            Entry e = (Entry)i.next();
-            if (dfn(e) >= 0) {
+        for (Entry<JavaThread, Integer> e : threadTable.entrySet()) {
+            if (e.getValue() >= 0) {
                 // this thread was already visited
                 continue;
             }
 
             thisDfn = globalDfn;
-            JavaThread thread = (JavaThread)e.getKey();
+            JavaThread thread = e.getKey();
             previousThread = thread;
 
             // When there is a deadlock, all the monitors involved in the dependency
@@ -118,7 +116,7 @@ public class DeadlockDetector {
                     break;
                 }
                 previousThread = currentThread;
-                waitingToLockMonitor = (ObjectMonitor)currentThread.getCurrentPendingMonitor();
+                waitingToLockMonitor = currentThread.getCurrentPendingMonitor();
                 if (concurrentLocks) {
                     waitingToLockBlocker = currentThread.getCurrentParkBlocker();
                 }
@@ -160,10 +158,6 @@ public class DeadlockDetector {
             return ((Integer)obj).intValue();
         }
         return -1;
-    }
-
-    private static int dfn(Entry e) {
-        return ((Integer)e.getValue()).intValue();
     }
 
     private static void printOneDeadlock(PrintStream tty, JavaThread thread,

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/FindInHeapPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/FindInHeapPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 package sun.jvm.hotspot.ui;
 
 import java.util.*;
-import java.io.*;
 import java.awt.*;
 import java.awt.event.*;
 import javax.swing.*;
@@ -193,9 +192,8 @@ public class FindInHeapPanel extends JPanel {
 
   private synchronized void updateResultWindow() {
     if (updates.size() > 0) {
-      Iterator i = updates.iterator();
-      while (i.hasNext()) {
-        textArea.append((String)i.next());
+      for (String update : updates) {
+        textArea.append(update);
       }
       updates = new ArrayList<>();;
     }


### PR DESCRIPTION
There are few places in code where manual `while` loop is used with Iterator to iterate over Collection.
Instead of manual `while` cycles it's preferred to use _enhanced-for_ cycle instead: it's less verbose, makes code easier to read and it's less error-prone.
It doesn't have any performance impact: javac compiler generates similar code when compiling enhanced-for cycle.

Similar cleanups:
* https://bugs.openjdk.java.net/browse/JDK-8258006
* https://bugs.openjdk.java.net/browse/JDK-8257912

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274662](https://bugs.openjdk.java.net/browse/JDK-8274662): Replace 'while' cycles with iterator with enhanced-for in jdk.hotspot.agent


### Reviewers
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5630/head:pull/5630` \
`$ git checkout pull/5630`

Update a local copy of the PR: \
`$ git checkout pull/5630` \
`$ git pull https://git.openjdk.java.net/jdk pull/5630/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5630`

View PR using the GUI difftool: \
`$ git pr show -t 5630`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5630.diff">https://git.openjdk.java.net/jdk/pull/5630.diff</a>

</details>
