### PR TITLE
8274130: C2: MulNode::Ideal chained transformations may act on wrong nodes

### DIFF
--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -59,8 +59,8 @@ Node* MulNode::Identity(PhaseGVN* phase) {
 // We also canonicalize the Node, moving constants to the right input,
 // and flatten expressions (so that 1+x+2 becomes x+3).
 Node *MulNode::Ideal(PhaseGVN *phase, bool can_reshape) {
-  const Type *t1 = phase->type( in(1) );
-  const Type *t2 = phase->type( in(2) );
+  Node *in1 = in(1);
+  Node *in2 = in(2);
   Node *progress = NULL;        // Progress flag
 
   // This code is used by And nodes too, but some conversions are
@@ -70,8 +70,6 @@ Node *MulNode::Ideal(PhaseGVN *phase, bool can_reshape) {
                   (op == Op_MulF) || (op == Op_MulD);
 
   // Convert "(-a)*(-b)" into "a*b".
-  Node *in1 = in(1);
-  Node *in2 = in(2);
   if (real_mul && in1->is_Sub() && in2->is_Sub()) {
     if (phase->type(in1->in(1))->is_zero_type() &&
         phase->type(in2->in(1))->is_zero_type()) {
@@ -82,6 +80,8 @@ Node *MulNode::Ideal(PhaseGVN *phase, bool can_reshape) {
         igvn->_worklist.push(in1);
         igvn->_worklist.push(in2);
       }
+      in1 = in(1);
+      in2 = in(2);
       progress = this;
     }
   }
@@ -104,9 +104,14 @@ Node *MulNode::Ideal(PhaseGVN *phase, bool can_reshape) {
         igvn->_worklist.push(in1);
         igvn->_worklist.push(in2);
       }
+      in1 = in(1);
+      in2 = in(2);
       progress = this;
     }
   }
+
+  const Type *t1 = phase->type(in1);
+  const Type *t2 = phase->type(in2);
 
   // We are OK if right is a constant, or right is a load and
   // left is a non-constant.

--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -59,9 +59,9 @@ Node* MulNode::Identity(PhaseGVN* phase) {
 // We also canonicalize the Node, moving constants to the right input,
 // and flatten expressions (so that 1+x+2 becomes x+3).
 Node *MulNode::Ideal(PhaseGVN *phase, bool can_reshape) {
-  Node *in1 = in(1);
-  Node *in2 = in(2);
-  Node *progress = NULL;        // Progress flag
+  Node* in1 = in(1);
+  Node* in2 = in(2);
+  Node* progress = NULL;        // Progress flag
 
   // This code is used by And nodes too, but some conversions are
   // only valid for the actual Mul nodes.
@@ -110,8 +110,8 @@ Node *MulNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     }
   }
 
-  const Type *t1 = phase->type(in1);
-  const Type *t2 = phase->type(in2);
+  const Type* t1 = phase->type(in1);
+  const Type* t2 = phase->type(in2);
 
   // We are OK if right is a constant, or right is a load and
   // left is a non-constant.


### PR DESCRIPTION
I was puzzled by it when fixing JDK-8274060. It looks that new optimizations added by [JDK-8273454](https://bugs.openjdk.java.net/browse/JDK-8273454) and [JDK-8263006](https://bugs.openjdk.java.net/browse/JDK-8263006) rewire `in(1)` and `in(2)` in `MulNode::Ideal`, which means the chained transformations should see them? Yet, both inputs and their `Type`-s are cached locally and not refreshed. I have not seen failures due to this yet, but it looks that the current code is subtly incorrect because of this. 

I thought about doing `return this` instead of `progress = true`, so that we leave `MulNode::Ideal` once we hit any transform and hope to return back, but I wondered if that would expose us to different graph shapes in-between successive `MulNode::Ideal` calls, which might have other unintended consequences. Therefore, I opted to a more conservative patch.

Additional testing:
 - [x] `compiler/` tests
 - [x] `tier1` tests
 - [x] 100K Fuzzer tests (one unrelated failure)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274130](https://bugs.openjdk.java.net/browse/JDK-8274130): C2: MulNode::Ideal chained transformations may act on wrong nodes


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5631/head:pull/5631` \
`$ git checkout pull/5631`

Update a local copy of the PR: \
`$ git checkout pull/5631` \
`$ git pull https://git.openjdk.java.net/jdk pull/5631/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5631`

View PR using the GUI difftool: \
`$ git pr show -t 5631`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5631.diff">https://git.openjdk.java.net/jdk/pull/5631.diff</a>

</details>
