### PR TITLE
8273894: ConcurrentModificationException raised every time ReferralsCache drops referral

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/ReferralsCache.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/ReferralsCache.java
@@ -28,6 +28,7 @@ package sun.security.krb5.internal;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -174,10 +175,11 @@ final class ReferralsCache {
         Date now = new Date();
         Map<String, ReferralCacheEntry> entries = referralsMap.get(k);
         if (entries != null) {
-            for (Entry<String, ReferralCacheEntry> mapEntry :
-                    entries.entrySet()) {
+            Iterator<Entry<String, ReferralCacheEntry>> it = entries.entrySet().iterator();
+            while (it.hasNext()) {
+                Entry<String, ReferralCacheEntry> mapEntry = it.next();
                 if (mapEntry.getValue().getCreds().getEndTime().before(now)) {
-                    entries.remove(mapEntry.getKey());
+                    it.remove();
                 }
             }
         }


### PR DESCRIPTION
Can I please get a review for this change which proposes to fix the issue noted in https://bugs.openjdk.java.net/browse/JDK-8273894?

Given the nature of the code in `ReferralsCache`, I haven't been able to add a new jtreg test case to reproduce the issue and verify this fix. Just to be sure that this change indeed fixes a reproducible issue, I replicated that code in a pretty trivial Java application and then verified a similar fix.

Existing tests in `test/jdk/sun/security/krb5/auto/` continue to pass after this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273894](https://bugs.openjdk.java.net/browse/JDK-8273894): ConcurrentModificationException raised every time ReferralsCache drops referral


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5632/head:pull/5632` \
`$ git checkout pull/5632`

Update a local copy of the PR: \
`$ git checkout pull/5632` \
`$ git pull https://git.openjdk.java.net/jdk pull/5632/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5632`

View PR using the GUI difftool: \
`$ git pr show -t 5632`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5632.diff">https://git.openjdk.java.net/jdk/pull/5632.diff</a>

</details>
