### PR TITLE
8273714: jdk/jfr/api/consumer/TestRecordedFrame.java still times out after JDK-8273047

### DIFF
--- a/test/jdk/jdk/jfr/api/consumer/TestRecordedFrame.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestRecordedFrame.java
@@ -42,8 +42,7 @@ import jdk.test.lib.jfr.SimpleEvent;
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib
- * @run main/othervm -Xint  -XX:+UseInterpreter -Dinterpreted=true  jdk.jfr.api.consumer.TestRecordedFrame
- * @run main/othervm/timeout=180 -Xcomp -XX:-UseInterpreter -Dinterpreted=false jdk.jfr.api.consumer.TestRecordedFrame
+ * @run main/othervm jdk.jfr.api.consumer.TestRecordedFrame
  */
 public final class TestRecordedFrame {
 
@@ -86,10 +85,6 @@ public final class TestRecordedFrame {
                     Asserts.assertTrue(types.contains(type));
                     // Line number
                     Asserts.assertEquals(getLineNumber("main"), frame.getLineNumber());
-                    // Interpreted
-                    boolean isInterpreted = "Interpreted".equals(type);
-                    boolean expectedInterpreted = "true".equals(System.getProperty("interpreted"));
-                    Asserts.assertEquals(isInterpreted, expectedInterpreted);
                     // BCI
                     int bci = frame.getBytecodeIndex();
                     System.out.println("bci: " + bci);

--- a/test/jdk/jdk/jfr/api/consumer/TestRecordedFrameType.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestRecordedFrameType.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.jfr.api.consumer;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Set;
+
+import jdk.jfr.Event;
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedFrame;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
+import jdk.test.lib.jfr.Events;
+import jdk.test.lib.jfr.SimpleEvent;
+import sun.hotspot.WhiteBox;
+
+/**
+ * @test
+ * @summary Test jdk.jfr.consumer.RecordedFrame::getType()
+ * @key jfr
+ * @requires vm.hasJFR
+ * @library /test/lib
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *      -XX:+WhiteBoxAPI jdk.jfr.api.consumer.TestRecordedFrameType
+ */
+public final class TestRecordedFrameType {
+
+    public static void main(String[] args) throws Exception {
+        WhiteBox WB = WhiteBox.getWhiteBox();
+
+        try (Recording recording = new Recording()) {
+            recording.start();
+
+            String directive =
+                """
+                [
+                  {
+                    match: "jdk/jfr/api/consumer/TestRecordedFrameType.interpreted()",
+                    Exclude: true,
+                  },
+                  {
+                    match: "jdk/jfr/api/consumer/TestRecordedFrameType.compiled()",
+                    BackgroundCompilation: false,
+                  },
+                ]
+                """;
+            WB.addCompilerDirective(directive);
+            Method mtd = TestRecordedFrameType.class.getMethod("compiled", new Class[0]);
+            WB.enqueueMethodForCompilation(mtd, 1);
+            Utils.waitForCondition(() -> WB.isMethodCompiled(mtd));
+
+            interpreted();
+            compiled();
+
+            List<RecordedEvent> events = Events.fromRecording(recording);
+
+            RecordedFrame interpreted = findFrame(events, "interpreted");
+            System.out.println(interpreted);
+            String iType = interpreted.getType();
+            Asserts.assertEquals(iType, "Interpreted");
+
+            RecordedFrame compiled = findFrame(events, "compiled");
+            System.out.println(compiled);
+            String cType = compiled.getType();
+            Asserts.assertNotEquals(cType, "Interpreted"); // "JIT compiled" or "Inlined"
+        }
+    }
+
+    private static RecordedFrame findFrame(List<RecordedEvent> events, String methodName) throws Exception {
+        for (RecordedEvent event : events) {
+            for (RecordedFrame frame : event.getStackTrace().getFrames()) {
+                if (frame.getMethod().getName().equals(methodName)) {
+                    System.out.println("Found frame with method named: " + methodName);
+                    return frame;
+                }
+            }
+        }
+        throw new Exception("Could not find frame with method named " + methodName);
+    }
+
+    public static void interpreted() {
+        SimpleEvent event = new SimpleEvent();
+        event.id = 1;
+        event.commit();
+    }
+
+    public static void compiled() {
+        SimpleEvent event = new SimpleEvent();
+        event.id = 2;
+        event.commit();
+    }
+}

--- a/test/jdk/jdk/jfr/api/consumer/TestRecordedFrameType.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestRecordedFrameType.java
@@ -70,7 +70,9 @@ public final class TestRecordedFrameType {
                 """;
             WB.addCompilerDirective(directive);
             Method mtd = TestRecordedFrameType.class.getMethod("compiled", new Class[0]);
-            WB.enqueueMethodForCompilation(mtd, 1);
+            if (!WB.enqueueMethodForCompilation(mtd, 1)) {
+                throw new Exception("Could not enqueue method for CompLevel_simple");
+            }
             Utils.waitForCondition(() -> WB.isMethodCompiled(mtd));
 
             interpreted();


### PR DESCRIPTION
Hi,

Could I have review of a test fix that removes the use of -Xcomp to make the test execute faster. The RecordedFrame::getType() method is now tested using WhiteBox API and in a separate file to make the test code easier to read.

Testing: 100 times jdk/jfr/api/consumer/TestRecordedFrame.Type.java

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273714](https://bugs.openjdk.java.net/browse/JDK-8273714): jdk/jfr/api/consumer/TestRecordedFrame.java	still times out after JDK-8273047


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5634/head:pull/5634` \
`$ git checkout pull/5634`

Update a local copy of the PR: \
`$ git checkout pull/5634` \
`$ git pull https://git.openjdk.java.net/jdk pull/5634/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5634`

View PR using the GUI difftool: \
`$ git pr show -t 5634`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5634.diff">https://git.openjdk.java.net/jdk/pull/5634.diff</a>

</details>
