### PR TITLE
[PATCH] Cleanup redundant casts, when type is actually known beforehand

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SourceToHTMLConverter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SourceToHTMLConverter.java
@@ -151,13 +151,13 @@ public class SourceToHTMLConverter {
         if (pkg == null) {
             return;
         }
-        for (Element te : utils.getAllClasses(pkg)) {
+        for (TypeElement te : utils.getAllClasses(pkg)) {
             // If -nodeprecated option is set and the class is marked as deprecated,
             // do not convert the package files to HTML. We do not check for
             // containing package deprecation since it is already check in
             // the calling method above.
             if (!(options.noDeprecated() && utils.isDeprecated(te)))
-                convertClass((TypeElement)te, outputdir);
+                convertClass(te, outputdir);
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/SerializedFormBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/SerializedFormBuilder.java
@@ -233,8 +233,7 @@ public class SerializedFormBuilder extends AbstractBuilder {
      */
     protected void buildSerialUIDInfo(Content classTree) {
         Content serialUidTree = writer.getSerialUIDInfoHeader();
-        for (Element e : utils.getFieldsUnfiltered(currentTypeElement)) {
-            VariableElement field = (VariableElement)e;
+        for (VariableElement field : utils.getFieldsUnfiltered(currentTypeElement)) {
             if (field.getSimpleName().toString().compareTo(SERIAL_VERSION_UID) == 0 &&
                 field.getConstantValue() != null) {
                 writer.addSerialUIDInfo(SERIAL_VERSION_UID_HEADER,

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/SummaryAPIListBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/SummaryAPIListBuilder.java
@@ -112,14 +112,13 @@ public class SummaryAPIListBuilder {
                 handleElement(pe);
             }
         }
-        for (Element e : configuration.getIncludedTypeElements()) {
-            TypeElement te = (TypeElement)e;
+        for (TypeElement te : configuration.getIncludedTypeElements()) {
             SortedSet<Element> eset;
-            if (belongsToSummary.test(e)) {
-                switch (e.getKind()) {
+            if (belongsToSummary.test(te)) {
+                switch (te.getKind()) {
                     case ANNOTATION_TYPE -> {
                         eset = summaryMap.get(SummaryElementKind.ANNOTATION_TYPE);
-                        eset.add(e);
+                        eset.add(te);
                     }
                     case CLASS -> {
                         if (utils.isError(te)) {
@@ -129,19 +128,19 @@ public class SummaryAPIListBuilder {
                         } else {
                             eset = summaryMap.get(SummaryElementKind.CLASS);
                         }
-                        eset.add(e);
+                        eset.add(te);
                     }
                     case INTERFACE -> {
                         eset = summaryMap.get(SummaryElementKind.INTERFACE);
-                        eset.add(e);
+                        eset.add(te);
                     }
                     case ENUM -> {
                         eset = summaryMap.get(SummaryElementKind.ENUM);
-                        eset.add(e);
+                        eset.add(te);
                     }
                     case RECORD -> {
                         eset = summaryMap.get(SummaryElementKind.RECORD_CLASS);
-                        eset.add(e);
+                        eset.add(te);
                     }
                 }
                 handleElement(te);
@@ -152,7 +151,7 @@ public class SummaryAPIListBuilder {
                     utils.getMethods(te));
             composeSummaryList(summaryMap.get(SummaryElementKind.CONSTRUCTOR),
                     utils.getConstructors(te));
-            if (utils.isEnum(e)) {
+            if (utils.isEnum(te)) {
                 composeSummaryList(summaryMap.get(SummaryElementKind.ENUM_CONSTANT),
                         utils.getEnumConstants(te));
             }
@@ -165,7 +164,7 @@ public class SummaryAPIListBuilder {
                     }
                 }
             }
-            if (utils.isAnnotationType(e)) {
+            if (utils.isAnnotationType(te)) {
                 composeSummaryList(summaryMap.get(SummaryElementKind.ANNOTATION_TYPE_MEMBER),
                         utils.getAnnotationMembers(te));
 


### PR DESCRIPTION
There are several redundant casts, caused by fact, that related declared variable has too weak type.
We can change declaration type and remove redundant cast. It makes code more clear and easier to read.

Found by IntelliJ IDEA inspection 'Too weak variable type leads to unnecessary cast' 