### PR TITLE
8274163: Use String.equals instead of String.compareTo in jdk.jcmd

### DIFF
--- a/src/jdk.jcmd/share/classes/sun/tools/jps/Arguments.java
+++ b/src/jdk.jcmd/share/classes/sun/tools/jps/Arguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,11 +64,11 @@ public class Arguments {
         int argc = 0;
 
         if (args.length == 1) {
-            if ((args[0].compareTo("-?") == 0)
-                || (args[0].compareTo("-h")== 0)
-                || (args[0].compareTo("--help")== 0)
+            if ((args[0].equals("-?"))
+                || (args[0].equals("-h"))
+                || (args[0].equals("--help"))
                 // -help: legacy.
-                || (args[0].compareTo("-help")== 0)) {
+                || (args[0].equals("-help"))) {
               help = true;
               return;
             }
@@ -78,7 +78,7 @@ public class Arguments {
                 argc++) {
             String arg = args[argc];
 
-            if (arg.compareTo("-q") == 0) {
+            if (arg.equals("-q")) {
               quiet = true;
             } else if (arg.startsWith("-")) {
                 for (int j = 1; j < arg.length(); j++) {

--- a/src/jdk.jcmd/share/classes/sun/tools/jstat/Arguments.java
+++ b/src/jdk.jcmd/share/classes/sun/tools/jstat/Arguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -127,9 +127,9 @@ public class Arguments {
         try {
             int value = Integer.parseInt(valueString);
 
-            if (unitString == null || unitString.compareTo("ms") == 0) {
+            if (unitString == null || unitString.equals("ms")) {
                 return value;
-            } else if (unitString.compareTo("s") == 0) {
+            } else if (unitString.equals("s")) {
                 return value * 1000;
             } else {
                 throw new IllegalArgumentException(
@@ -149,17 +149,17 @@ public class Arguments {
             return;
         }
 
-        if ((args[0].compareTo("-?") == 0)
-                || (args[0].compareTo("-h") == 0)
-                || (args[0].compareTo("--help") == 0)
+        if ((args[0].equals("-?"))
+                || (args[0].equals("-h"))
+                || (args[0].equals("--help"))
                 // -help: legacy.
-                || (args[0].compareTo("-help") == 0)) {
+                || (args[0].equals("-help"))) {
             help = true;
             return;
-        } else if (args[0].compareTo("-options") == 0) {
+        } else if (args[0].equals("-options")) {
             options = true;
             return;
-        } else if (args[0].compareTo("-list") == 0) {
+        } else if (args[0].equals("-list")) {
             list = true;
             if (args.length > 2) {
               throw new IllegalArgumentException("invalid argument count");
@@ -171,23 +171,23 @@ public class Arguments {
         for ( ; (argc < args.length) && (args[argc].startsWith("-")); argc++) {
             String arg = args[argc];
 
-            if (arg.compareTo("-a") == 0) {
+            if (arg.equals("-a")) {
                 comparator = new AscendingMonitorComparator();
-            } else if (arg.compareTo("-d") == 0) {
+            } else if (arg.equals("-d")) {
                 comparator =  new DescendingMonitorComparator();
-            } else if (arg.compareTo("-t") == 0) {
+            } else if (arg.equals("-t")) {
                 timestamp = true;
-            } else if (arg.compareTo("-v") == 0) {
+            } else if (arg.equals("-v")) {
                 verbose = true;
-            } else if ((arg.compareTo("-constants") == 0)
-                       || (arg.compareTo("-c") == 0)) {
+            } else if ((arg.equals("-constants"))
+                       || (arg.equals("-c"))) {
                 constants = true;
-            } else if ((arg.compareTo("-strings") == 0)
-                       || (arg.compareTo("-s") == 0)) {
+            } else if ((arg.equals("-strings"))
+                       || (arg.equals("-s"))) {
                 strings = true;
             } else if (arg.startsWith("-h")) {
                 String value;
-                if (arg.compareTo("-h") != 0) {
+                if (!arg.equals("-h")) {
                     value = arg.substring(2);
                 } else {
                     argc++;
@@ -245,7 +245,7 @@ public class Arguments {
                 } catch (NumberFormatException nfe) {
                     // it didn't parse. check for the -snap or jstat_options
                     // file options.
-                    if ((argc == 0) && (args[argc].compareTo("-snap") == 0)) {
+                    if ((argc == 0) && (args[argc].equals("-snap"))) {
                         snap = true;
                     } else if (argc == 0) {
                         specialOption = args[argc].substring(1);

--- a/src/jdk.jcmd/share/classes/sun/tools/jstat/OptionLister.java
+++ b/src/jdk.jcmd/share/classes/sun/tools/jstat/OptionLister.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,7 +73,7 @@ public class OptionLister {
         }
 
         for ( OptionFormat of : options) {
-            if (of.getName().compareTo("timestamp") == 0) {
+            if (of.getName().equals("timestamp")) {
               // ignore the special timestamp OptionFormat.
               continue;
             }

--- a/src/jdk.jcmd/share/classes/sun/tools/jstat/Parser.java
+++ b/src/jdk.jcmd/share/classes/sun/tools/jstat/Parser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -473,19 +473,19 @@ public class Parser {
                 return;
             }
 
-            if (lookahead.sval.compareTo(DATA) == 0) {
+            if (lookahead.sval.equals(DATA)) {
                 dataStmt(cf);
-            } else if (lookahead.sval.compareTo(HEADER) == 0) {
+            } else if (lookahead.sval.equals(HEADER)) {
                 headerStmt(cf);
-            } else if (lookahead.sval.compareTo(WIDTH) == 0) {
+            } else if (lookahead.sval.equals(WIDTH)) {
                 widthStmt(cf);
-            } else if (lookahead.sval.compareTo(FORMAT) == 0) {
+            } else if (lookahead.sval.equals(FORMAT)) {
                 formatStmt(cf);
-            } else if (lookahead.sval.compareTo(ALIGN) == 0) {
+            } else if (lookahead.sval.equals(ALIGN)) {
                 alignStmt(cf);
-            } else if (lookahead.sval.compareTo(SCALE) == 0) {
+            } else if (lookahead.sval.equals(SCALE)) {
                 scaleStmt(cf);
-            } else if (lookahead.sval.compareTo(REQUIRED) == 0) {
+            } else if (lookahead.sval.equals(REQUIRED)) {
                 requiredStmt(cf);
             } else {
                 return;
@@ -544,7 +544,7 @@ public class Parser {
         while (lookahead.ttype != StreamTokenizer.TT_EOF) {
             // look for the start symbol
             if ((lookahead.ttype != StreamTokenizer.TT_WORD)
-                    || (lookahead.sval.compareTo(START) != 0)) {
+                    || (!lookahead.sval.equals(START))) {
                 // skip tokens until a start symbol is found
                 nextToken();
                 continue;
@@ -574,7 +574,7 @@ public class Parser {
         while (lookahead.ttype != StreamTokenizer.TT_EOF) {
             // look for the start symbol
             if ((lookahead.ttype != StreamTokenizer.TT_WORD)
-                    || (lookahead.sval.compareTo(START) != 0)) {
+                    || (!lookahead.sval.equals(START))) {
                 // skip tokens until a start symbol is found
                 nextToken();
                 continue;


### PR DESCRIPTION
In several places, String.compareTo was _compared_ with 0 ( via `== 0` or `!= 0`).
Instead of this, we can use String.equals calls. `String.equals` is faster and shorter.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274163](https://bugs.openjdk.java.net/browse/JDK-8274163): Use String.equals instead of String.compareTo in jdk.jcmd


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5637/head:pull/5637` \
`$ git checkout pull/5637`

Update a local copy of the PR: \
`$ git checkout pull/5637` \
`$ git pull https://git.openjdk.java.net/jdk pull/5637/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5637`

View PR using the GUI difftool: \
`$ git pr show -t 5637`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5637.diff">https://git.openjdk.java.net/jdk/pull/5637.diff</a>

</details>
