### PR TITLE
8274190: Use String.equals instead of String.compareTo in jdk.internal.jvmstat

### DIFF
--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/monitor/HostIdentifier.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/monitor/HostIdentifier.java
@@ -106,7 +106,7 @@ public class HostIdentifier {
      * by the string.
      */
     private URI canonicalize(String uriString) throws URISyntaxException {
-        if ((uriString == null) || (uriString.equals("localhost"))) {
+        if (uriString == null || uriString.equals("localhost")) {
             uriString = "//localhost";
             return new URI(uriString);
         }

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/monitor/HostIdentifier.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/monitor/HostIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,7 +106,7 @@ public class HostIdentifier {
      * by the string.
      */
     private URI canonicalize(String uriString) throws URISyntaxException {
-        if ((uriString == null) || (uriString.compareTo("localhost") == 0)) {
+        if ((uriString == null) || (uriString.equals("localhost"))) {
             uriString = "//localhost";
             return new URI(uriString);
         }
@@ -247,7 +247,7 @@ public class HostIdentifier {
         String authority = vmid.getAuthority();
 
         // check for 'file:' VmIdentifiers and handled as a special case.
-        if ((scheme != null) && (scheme.compareTo("file") == 0)) {
+        if ("file".equals(scheme)) {
             try {
                 uri = new URI("file://localhost");
             } catch (URISyntaxException e) { };
@@ -343,7 +343,7 @@ public class HostIdentifier {
         String host = vmid.getHost();
         String authority = vmid.getAuthority();
 
-        if ((scheme != null) && (scheme.compareTo("file") == 0)) {
+        if ("file".equals(scheme)) {
             // don't attempt to resolve a file based VmIdentifier.
             return vmid;
         }

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/monitor/MonitoredHost.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/monitor/MonitoredHost.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -203,7 +203,7 @@ public abstract class MonitoredHost {
         assert hostname != null;
 
         if (scheme == null) {
-            if (hostname.compareTo("localhost") == 0) {
+            if (hostname.equals("localhost")) {
                 scheme = LOCAL_PROTOCOL;
             } else {
                 scheme = REMOTE_PROTOCOL;

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/monitor/MonitoredVmUtil.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/monitor/MonitoredVmUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,7 +82,7 @@ public class MonitoredVmUtil {
         int firstSpace = commandLine.indexOf(' ');
         if (firstSpace > 0) {
             return commandLine.substring(firstSpace + 1);
-        } else if (commandLine.compareTo("Unknown") == 0) {
+        } else if (commandLine.equals("Unknown")) {
             return commandLine;
         } else {
             return null;

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/monitor/VmIdentifier.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/monitor/VmIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -174,7 +174,7 @@ public class VmIdentifier {
     private void validate() throws URISyntaxException {
         // file:// uri, which is a special case where the lvmid is not required.
         String s = getScheme();
-        if ((s != null) && (s.compareTo("file") == 0)) {
+        if ("file".equals(s)) {
             return;
         }
         if (getLocalVmId() == -1) {

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/AliasFileParser.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/AliasFileParser.java
@@ -126,7 +126,7 @@ public class AliasFileParser {
         while (currentToken.ttype != StreamTokenizer.TT_EOF) {
             // look for the start symbol
             if ((currentToken.ttype != StreamTokenizer.TT_WORD)
-                    || (!currentToken.sval.equals(ALIAS))) {
+                    || !currentToken.sval.equals(ALIAS)) {
                 nextToken();
                 continue;
             }
@@ -142,7 +142,7 @@ public class AliasFileParser {
                 match(StreamTokenizer.TT_WORD);
 
             } while ((currentToken.ttype != StreamTokenizer.TT_EOF)
-                     && (!currentToken.sval.equals(ALIAS)));
+                     && !currentToken.sval.equals(ALIAS));
 
             map.put(name, aliases);
         }

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/AliasFileParser.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/AliasFileParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package sun.jvmstat.perfdata.monitor;
 import java.net.*;
 import java.io.*;
 import java.util.*;
-import java.util.regex.*;
 
 /**
  * Class for parsing alias files. File format is expected to follow
@@ -127,7 +126,7 @@ public class AliasFileParser {
         while (currentToken.ttype != StreamTokenizer.TT_EOF) {
             // look for the start symbol
             if ((currentToken.ttype != StreamTokenizer.TT_WORD)
-                    || (currentToken.sval.compareTo(ALIAS) != 0)) {
+                    || (!currentToken.sval.equals(ALIAS))) {
                 nextToken();
                 continue;
             }
@@ -143,7 +142,7 @@ public class AliasFileParser {
                 match(StreamTokenizer.TT_WORD);
 
             } while ((currentToken.ttype != StreamTokenizer.TT_EOF)
-                     && (currentToken.sval.compareTo(ALIAS) != 0));
+                     && (!currentToken.sval.equals(ALIAS)));
 
             map.put(name, aliases);
         }

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/file/PerfDataBuffer.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/file/PerfDataBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package sun.jvmstat.perfdata.monitor.protocol.file;
 import sun.jvmstat.monitor.*;
 import sun.jvmstat.perfdata.monitor.*;
 import java.io.*;
-import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 
@@ -60,9 +59,9 @@ public class PerfDataBuffer extends AbstractPerfDataBuffer {
             FileChannel fc = new RandomAccessFile(f, mode).getChannel();
             ByteBuffer bb = null;
 
-            if (mode.compareTo("r") == 0) {
+            if (mode.equals("r")) {
                 bb = fc.map(FileChannel.MapMode.READ_ONLY, 0L, (int)fc.size());
-            } else if (mode.compareTo("rw") == 0) {
+            } else if (mode.equals("rw")) {
                 bb = fc.map(FileChannel.MapMode.READ_WRITE, 0L, (int)fc.size());
             } else {
                 throw new IllegalArgumentException("Invalid mode: " + mode);

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/v1_0/PerfDataBuffer.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/v1_0/PerfDataBuffer.java
@@ -28,7 +28,6 @@ package sun.jvmstat.perfdata.monitor.v1_0;
 import sun.jvmstat.monitor.*;
 import sun.jvmstat.perfdata.monitor.*;
 import java.util.*;
-import java.util.regex.*;
 import java.nio.*;
 
 /**
@@ -360,7 +359,7 @@ public class PerfDataBuffer extends PerfDataBufferImpl {
         String cname = "hotspot.gc.collector.0.name";
         StringMonitor collector = (StringMonitor)map.get(cname);
 
-        if (collector.stringValue().compareTo("PSScavenge") == 0) {
+        if (collector.stringValue().equals("PSScavenge")) {
             boolean adaptiveSizePolicy = true;
 
             /*


### PR DESCRIPTION
In several places, String.compareTo was _compared_ with 0 ( via `== 0` or `!= 0`).
Instead of this, we can use String.equals calls. `String.equals` is faster and shorter.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274190](https://bugs.openjdk.java.net/browse/JDK-8274190): Use String.equals instead of String.compareTo in jdk.internal.jvmstat


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to f5e58485140f2a6cf96dc2607b9485cf23f4d259
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to f5e58485140f2a6cf96dc2607b9485cf23f4d259


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5638/head:pull/5638` \
`$ git checkout pull/5638`

Update a local copy of the PR: \
`$ git checkout pull/5638` \
`$ git pull https://git.openjdk.java.net/jdk pull/5638/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5638`

View PR using the GUI difftool: \
`$ git pr show -t 5638`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5638.diff">https://git.openjdk.java.net/jdk/pull/5638.diff</a>

</details>
