### PR TITLE
8274168: Avoid String.compareTo == 0 to check String equality in java.management

### DIFF
--- a/src/java.management/share/classes/javax/management/BinaryRelQueryExp.java
+++ b/src/java.management/share/classes/javax/management/BinaryRelQueryExp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -177,7 +177,7 @@ class BinaryRelQueryExp extends QueryEval implements QueryExp {
             case Query.LE:
                 return sval1.compareTo(sval2) <= 0;
             case Query.EQ:
-                return sval1.compareTo(sval2) == 0;
+                return sval1.equals(sval2);
             }
         }
 

--- a/src/java.management/share/classes/javax/management/BinaryRelQueryExp.java
+++ b/src/java.management/share/classes/javax/management/BinaryRelQueryExp.java
@@ -167,17 +167,18 @@ class BinaryRelQueryExp extends QueryEval implements QueryExp {
             String sval1 = ((StringValueExp)val1).getValue();
             String sval2 = ((StringValueExp)val2).getValue();
 
+            int cmp = sval1.compareTo(sval2);
             switch (relOp) {
             case Query.GT:
-                return sval1.compareTo(sval2) > 0;
+                return cmp > 0;
             case Query.LT:
-                return sval1.compareTo(sval2) < 0;
+                return cmp < 0;
             case Query.GE:
-                return sval1.compareTo(sval2) >= 0;
+                return cmp >= 0;
             case Query.LE:
-                return sval1.compareTo(sval2) <= 0;
+                return cmp <= 0;
             case Query.EQ:
-                return sval1.equals(sval2);
+                return cmp == 0;
             }
         }
 

--- a/src/java.management/share/classes/javax/management/loading/MLet.java
+++ b/src/java.management/share/classes/javax/management/loading/MLet.java
@@ -25,16 +25,12 @@
 
 package javax.management.loading;
 
-// Java import
-import com.sun.jmx.defaults.JmxProperties;
-
 import com.sun.jmx.defaults.ServiceName;
 
 import com.sun.jmx.remote.util.EnvHelp;
 
 import java.io.Externalizable;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInput;
@@ -71,7 +67,6 @@ import javax.management.ReflectionException;
 
 import static com.sun.jmx.defaults.JmxProperties.MLET_LIB_DIR;
 import static com.sun.jmx.defaults.JmxProperties.MLET_LOGGER;
-import com.sun.jmx.defaults.ServiceName;
 import javax.management.ServiceNotFoundException;
 
 /**
@@ -1267,24 +1262,16 @@ public class MLet extends java.net.URLClassLoader
                 MLET_LOGGER.log(Level.DEBUG, "Got unexpected exception", e);
             }
         }
-        if (type.compareTo("java.lang.Boolean") == 0)
-             return Boolean.valueOf(param);
-        if (type.compareTo("java.lang.Byte") == 0)
-             return Byte.valueOf(param);
-        if (type.compareTo("java.lang.Short") == 0)
-             return Short.valueOf(param);
-        if (type.compareTo("java.lang.Long") == 0)
-             return Long.valueOf(param);
-        if (type.compareTo("java.lang.Integer") == 0)
-             return Integer.valueOf(param);
-        if (type.compareTo("java.lang.Float") == 0)
-             return Float.valueOf(param);
-        if (type.compareTo("java.lang.Double") == 0)
-             return Double.valueOf(param);
-        if (type.compareTo("java.lang.String") == 0)
-             return param;
-
-        return param;
+         return switch (type) {
+             case "java.lang.Boolean" -> Boolean.valueOf(param);
+             case "java.lang.Byte" -> Byte.valueOf(param);
+             case "java.lang.Short" -> Short.valueOf(param);
+             case "java.lang.Long" -> Long.valueOf(param);
+             case "java.lang.Integer" -> Integer.valueOf(param);
+             case "java.lang.Float" -> Float.valueOf(param);
+             case "java.lang.Double" -> Double.valueOf(param);
+             default -> param;
+         };
      }
 
     @SuppressWarnings("removal")


### PR DESCRIPTION
Cleanup places, where String.compareTo is used to check String's equality.
Instead String.equals or switch expression could be used. They are faster and code is cleaner.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274168](https://bugs.openjdk.java.net/browse/JDK-8274168): Avoid String.compareTo == 0 to check String equality in java.management


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5640/head:pull/5640` \
`$ git checkout pull/5640`

Update a local copy of the PR: \
`$ git checkout pull/5640` \
`$ git pull https://git.openjdk.java.net/jdk pull/5640/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5640`

View PR using the GUI difftool: \
`$ git pr show -t 5640`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5640.diff">https://git.openjdk.java.net/jdk/pull/5640.diff</a>

</details>
