### PR TITLE
8274169: HotSpot Style Guide has stale link to chromium style guide

### DIFF
--- a/doc/hotspot-style.html
+++ b/doc/hotspot-style.html
@@ -194,7 +194,7 @@ while ( test_foo(args...) ) { // No, excess spaces around control</code></pre></
 <p>Similar discussions for some other projects:</p>
 <ul>
 <li><p><a href="https://google.github.io/styleguide/cppguide.html">Google C++ Style Guide</a> — Currently (2020) targeting C++17.</p></li>
-<li><p><a href="https://chromium-cpp.appspot.com">C++11 and C++14 use in Chromium</a> — Categorizes features as allowed, banned, or to be discussed.</p></li>
+<li><p><a href="https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++11.md">C++11 and C++14 use in Chromium</a> — Categorizes features as allowed, banned, or to be discussed.</p></li>
 <li><p><a href="https://llvm.org/docs/CodingStandards.html">llvm Coding Standards</a> — Currently (2020) targeting C++14.</p></li>
 <li><p><a href="https://firefox-source-docs.mozilla.org/code-quality/coding-style/using_cxx_in_firefox_code.html">Using C++ in Mozilla code</a> — C++17 support is required for recent versions (2020).</p></li>
 </ul>

--- a/doc/hotspot-style.md
+++ b/doc/hotspot-style.md
@@ -409,7 +409,7 @@ Similar discussions for some other projects:
 * [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) &mdash;
 Currently (2020) targeting C++17.
 
-* [C++11 and C++14 use in Chromium](https://chromium-cpp.appspot.com) &mdash;
+* [C++11 and C++14 use in Chromium](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++11.md) &mdash;
 Categorizes features as allowed, banned, or to be discussed.
 
 * [llvm Coding Standards](https://llvm.org/docs/CodingStandards.html) &mdash;


### PR DESCRIPTION
Update links to the chromium style guide in the HotSpot Style Guide.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274169](https://bugs.openjdk.java.net/browse/JDK-8274169): HotSpot Style Guide has stale link to chromium style guide


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5641/head:pull/5641` \
`$ git checkout pull/5641`

Update a local copy of the PR: \
`$ git checkout pull/5641` \
`$ git pull https://git.openjdk.java.net/jdk pull/5641/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5641`

View PR using the GUI difftool: \
`$ git pr show -t 5641`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5641.diff">https://git.openjdk.java.net/jdk/pull/5641.diff</a>

</details>
