### PR TITLE
8271303: jcmd VM.cds {static, dynamic}_dump should print more info

### DIFF
--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -697,7 +697,7 @@
                                                                                                                   \
   /* CDS */                                                                                                       \
   template(dumpSharedArchive,                               "dumpSharedArchive")                                  \
-  template(dumpSharedArchive_signature,                     "(ZLjava/lang/String;)V")                             \
+  template(dumpSharedArchive_signature,                     "(ZLjava/lang/String;)Ljava/lang/String;")            \
   template(generateLambdaFormHolderClasses,                 "generateLambdaFormHolderClasses")                    \
   template(generateLambdaFormHolderClasses_signature,       "([Ljava/lang/String;)[Ljava/lang/Object;")           \
   template(java_lang_invoke_Invokers_Holder,                "java/lang/invoke/Invokers$Holder")                   \

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -964,10 +964,10 @@ void DumpSharedArchiveDCmd::execute(DCmdSource source, TRAPS) {
 
   if (strcmp(scmd, "static_dump") == 0) {
     is_static = JNI_TRUE;
-    output()->print_cr("Static dump:");
+    output()->print("Static dump: ");
   } else if (strcmp(scmd, "dynamic_dump") == 0) {
     is_static = JNI_FALSE;
-    output()->print_cr("Dynamic dump:");
+    output()->print("Dynamic dump: ");
     if (!UseSharedSpaces) {
       output()->print_cr("Dynamic dump is unsupported when base CDS archive is not loaded");
       return;
@@ -988,7 +988,7 @@ void DumpSharedArchiveDCmd::execute(DCmdSource source, TRAPS) {
   }
   Symbol* cds_name  = vmSymbols::jdk_internal_misc_CDS();
   Klass*  cds_klass = SystemDictionary::resolve_or_fail(cds_name, true /*throw error*/,  CHECK);
-  JavaValue result(T_VOID);
+  JavaValue result(T_OBJECT);
   JavaCallArguments args;
   args.push_int(is_static);
   args.push_oop(fileh);
@@ -997,6 +997,12 @@ void DumpSharedArchiveDCmd::execute(DCmdSource source, TRAPS) {
                          vmSymbols::dumpSharedArchive(),
                          vmSymbols::dumpSharedArchive_signature(),
                          &args, CHECK);
+  if (!HAS_PENDING_EXCEPTION) {
+    assert(result.get_type() == T_OBJECT, "Sanity check");
+    // result contains the archive name
+    char* archive_name = java_lang_String::as_utf8_string(result.get_oop());
+    output()->print_cr("%s", archive_name);
+  }
 }
 #endif // INCLUDE_CDS
 

--- a/src/java.base/share/classes/jdk/internal/misc/CDS.java
+++ b/src/java.base/share/classes/jdk/internal/misc/CDS.java
@@ -254,8 +254,9 @@ public class CDS {
     * called from jcmd VM.cds to dump static or dynamic shared archive
     * @param isStatic true for dump static archive or false for dynnamic archive.
     * @param fileName user input archive name, can be null.
+    * @return The archive name if successfully dumped.
     */
-    private static void dumpSharedArchive(boolean isStatic, String fileName) throws Exception {
+    private static String dumpSharedArchive(boolean isStatic, String fileName) throws Exception {
         String cwd = new File("").getAbsolutePath(); // current dir used for printing message.
         String currentPid = String.valueOf(ProcessHandle.current().pid());
         String archiveFileName =  fileName != null ? fileName :
@@ -333,6 +334,8 @@ public class CDS {
             throw new RuntimeException("Cannot rename temp file " + tempArchiveFileName + " to archive file" + archiveFileName);
         }
         // Everyting goes well, print out the file name.
-        System.out.println((isStatic ? "Static" : " Dynamic") + " dump to file " + cwd + File.separator + archiveFileName);
+        String archiveFilePath = cwd + File.separator + archiveFileName;
+        System.out.println("The process was attached by jcmd and do a " + (isStatic ? "static" : "dynamic") + " dump to file " + archiveFilePath);
+        return archiveFilePath;
     }
 }

--- a/src/java.base/share/classes/jdk/internal/misc/CDS.java
+++ b/src/java.base/share/classes/jdk/internal/misc/CDS.java
@@ -334,8 +334,8 @@ public class CDS {
             throw new RuntimeException("Cannot rename temp file " + tempArchiveFileName + " to archive file" + archiveFileName);
         }
         // Everyting goes well, print out the file name.
-        String archiveFilePath = cwd + File.separator + archiveFileName;
-        System.out.println("The process was attached by jcmd and do a " + (isStatic ? "static" : "dynamic") + " dump to file " + archiveFilePath);
+        String archiveFilePath = new File(archiveFileName).getAbsolutePath();
+        System.out.println("The process was attached by jcmd and dumped a " + (isStatic ? "static" : "dynamic") + " archive " + archiveFilePath);
         return archiveFilePath;
     }
 }


### PR DESCRIPTION
Hi, please review the change for printing more info in jcmd terminal when dump shared archives. The ultimate shared archive file name is formed in java function (CDS.dumpSharedArchive) so to get the final archive name, the signature of CDS.dumpSharedArchive changed to return the archive name. At the end of dumping, return the archive name back to the caller so we can print out it in jcmd terminal.

Tests: ter1-4
           manually checked the output of jcmd execution.

Thanks
Yumin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271303](https://bugs.openjdk.java.net/browse/JDK-8271303): jcmd VM.cds {static, dynamic}_dump should print more info


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5643/head:pull/5643` \
`$ git checkout pull/5643`

Update a local copy of the PR: \
`$ git checkout pull/5643` \
`$ git pull https://git.openjdk.java.net/jdk pull/5643/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5643`

View PR using the GUI difftool: \
`$ git pr show -t 5643`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5643.diff">https://git.openjdk.java.net/jdk/pull/5643.diff</a>

</details>
