### PR TITLE
8272968: AArch64: Remove redundant matching rules for commutative ops

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -10884,7 +10884,6 @@ instruct msubI(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, iRegIorL2I src3)
 
 instruct mnegI(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immI0 zero) %{
   match(Set dst (MulI (SubI zero src1) src2));
-  match(Set dst (MulI src1 (SubI zero src2)));
 
   ins_cost(INSN_COST * 3);
   format %{ "mneg  $dst, $src1, $src2" %}
@@ -10936,7 +10935,6 @@ instruct msubL(iRegLNoSp dst, iRegL src1, iRegL src2, iRegL src3) %{
 
 instruct mnegL(iRegLNoSp dst, iRegL src1, iRegL src2, immL0 zero) %{
   match(Set dst (MulL (SubL zero src1) src2));
-  match(Set dst (MulL src1 (SubL zero src2)));
 
   ins_cost(INSN_COST * 5);
   format %{ "mneg  $dst, $src1, $src2" %}
@@ -10986,7 +10984,6 @@ instruct smsubL(iRegLNoSp dst, iRegIorL2I src1, iRegIorL2I src2, iRegLNoSp src3)
 
 instruct smnegL(iRegLNoSp dst, iRegIorL2I src1, iRegIorL2I src2, immL0 zero) %{
   match(Set dst (MulL (SubL zero (ConvI2L src1)) (ConvI2L src2)));
-  match(Set dst (MulL (ConvI2L src1) (SubL zero (ConvI2L src2))));
 
   ins_cost(INSN_COST * 3);
   format %{ "smnegl  $dst, $src1, $src2" %}


### PR DESCRIPTION
Match rules for commutative operations mnegI/mnegL/smnegL might
become redundant after function matchrule_clone_and_swap(),
and hence can be reduced.

In adlc part, while parsing the contents of an instruction
definition, function instr_parse always do the check
for commutative operations with subtree operands, create
clones and swap operands by function matchrule_clone_and_swap.
It means that another operand-swapped and partially
symmetrical match rule should be generated automatically for
these commutative operations.

The pattern to construct mnegI, mnegL or smnegL consists of
a subtraction with zero and then a multiplication. In function
count_commutative_op, both mulI and mulL are recognized as
commutative opcodes. Therefore, we need only one match rule
to specify that a multipilication consists of a number and
a subtraction with zero for these three instructions and the
extra one can be deleted.

Take mnegL as an example.

Without my patch, four match rules will be created finally for
instruction selection.

Two of them are created by ad files:

Match Rule 1:
dst = MulL (SubL zero src1) src2
===>
dst = mnegl src1 src2

Match Rule 2:
dst = MulL src1 (SubL zero src2)
===>
dst = mnegl src1 src2

The other two are automatically generated by function
matchrule_clone_and_swap based on the two rules above:

Match Rule 3 (generated by match rule 1):
dst = MulL src2 (SubL zero src1)
===>
dst = mnegl src1 src2

Match Rule 4 (generated by match rule 2):
dst = MulL (SubL zero src2) src1
===>
dst = mnegl src1 src2

As mnegl is commutative, Rule 3 is equivalent to
Rule 2, and Rule 1 is equivalent to Rule 4. Also, if we only
keep the original Match Rule 1, as showed above, Rule 3 will
be generated automatically later. In this way, Rule 2 and Rule 4
are redundant and hence Rule 2 can be eliminated.

With my patch, Rule 2 is removed and Rule 4 won't be generated as well.
Only Rule 1 and 3 are kept in the final rule chain. In my local release
build, as redundant code got removed, the size of libjvm.so decreased
from 23.30 MB to 23.27 MB, with a reduction of 33.11 KB(around 0.14%).
