### PR TITLE
8273617: UninitializedDisplayModeChangeTest.java times out on macOS 12

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -259,7 +259,6 @@ sun/java2d/SunGraphics2D/SourceClippingBlitTest/SourceClippingBlitTest.java 8196
 
 sun/java2d/X11SurfaceData/SharedMemoryPixmapsTest/SharedMemoryPixmapsTest.sh 8221451 linux-all
 java/awt/FullScreen/DisplayChangeVITest/DisplayChangeVITest.java 8169469,8273618 windows-all,macosx-all
-java/awt/FullScreen/UninitializedDisplayModeChangeTest/UninitializedDisplayModeChangeTest.java 8273617 macosx-all
 java/awt/print/PrinterJob/PSQuestionMark.java 7003378 generic-all
 java/awt/print/PrinterJob/GlyphPositions.java 7003378 generic-all
 java/awt/Choice/ChoiceMouseWheelTest/ChoiceMouseWheelTest.java 7100044 macosx-all,linux-all

--- a/test/jdk/java/awt/FullScreen/UninitializedDisplayModeChangeTest/UninitializedDisplayModeChangeTest.java
+++ b/test/jdk/java/awt/FullScreen/UninitializedDisplayModeChangeTest/UninitializedDisplayModeChangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.TimeUnit;
 
 public class UninitializedDisplayModeChangeTest {
     public static volatile boolean failed = false;
@@ -87,7 +88,7 @@ public class UninitializedDisplayModeChangeTest {
             err.start();
             out.start();
 
-            childProc.waitFor();
+            childProc.waitFor(2, TimeUnit.SECONDS);
         } catch (Exception e) {
             failed = true;
             e.printStackTrace();

--- a/test/jdk/java/awt/FullScreen/UninitializedDisplayModeChangeTest/UninitializedDisplayModeChangeTest.java
+++ b/test/jdk/java/awt/FullScreen/UninitializedDisplayModeChangeTest/UninitializedDisplayModeChangeTest.java
@@ -88,7 +88,7 @@ public class UninitializedDisplayModeChangeTest {
             err.start();
             out.start();
 
-            childProc.waitFor(2, TimeUnit.SECONDS);
+            childProc.waitFor(30, TimeUnit.SECONDS);
         } catch (Exception e) {
             failed = true;
             e.printStackTrace();


### PR DESCRIPTION
java/awt/FullScreen/UninitializedDisplayModeChangeTest/UninitializedDisplayModeChangeTest.java is timing out every time on macOS 12 even though the test passed.
Looks like the the main process waits for child process created in the test forever, making it timeout after jtreg timeout of 2min.
Modified to wait for childprocess for 30secs.