### PR TITLE
8177814: jdk/editpad is not in jdk TEST.groups

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -382,6 +382,9 @@ jdk_accessibility = \
 jfc_demo = \
      demo/jfc
 
+jdk_editpad = \
+     jdk/editpad
+
 jdk_desktop = \
     :jdk_awt \
     :jdk_2d \
@@ -391,7 +394,8 @@ jdk_desktop = \
     :jdk_imageio \
     :jdk_accessibility \
     :jfc_demo \
-    :jdk_client_sanity
+    :jdk_client_sanity \
+    :jdk_editpad
 
 # SwingSet3 tests.
 jdk_client_sanity = \


### PR DESCRIPTION
@prrace notices this here: https://github.com/openjdk/jdk/pull/5544#issuecomment-925396869. And I think it is the already open issue that this patch is fixing. While the original patch added the test in `jdk_other`, Phil suggests it to be added to `jdk_desktop`.

Additional testing:
 - [x] `jdk_editpad` is passing