### PR TITLE
8274195: Doc cleanup in java.nio.file

### DIFF
--- a/src/java.base/share/classes/java/nio/file/DirectoryStream.java
+++ b/src/java.base/share/classes/java/nio/file/DirectoryStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/nio/file/DirectoryStream.java
+++ b/src/java.base/share/classes/java/nio/file/DirectoryStream.java
@@ -65,7 +65,7 @@ import java.io.IOException;
  * using the {@code Iterator}, behaves as if the end of stream has been reached.
  * Due to read-ahead, the {@code Iterator} may return one or more elements
  * after the directory stream has been closed. Once these buffered elements
- * have been read, then subsequent calls to the {@code hasNext} method returns
+ * have been read, then subsequent calls to the {@code hasNext} method return
  * {@code false}, and subsequent calls to the {@code next} method will throw
  * {@code NoSuchElementException}.
  *

--- a/src/java.base/share/classes/java/nio/file/FileVisitResult.java
+++ b/src/java.base/share/classes/java/nio/file/FileVisitResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,9 +35,9 @@ package java.nio.file;
 
 public enum FileVisitResult {
     /**
-     * Continue. When returned from a {@link FileVisitor#preVisitDirectory
-     * preVisitDirectory} method then the entries in the directory should also
-     * be visited.
+     * Continue. If returned from the {@link FileVisitor#preVisitDirectory
+     * preVisitDirectory} method then the entries in the directory are also
+     * visited.
      */
     CONTINUE,
     /**

--- a/src/java.base/share/classes/java/nio/file/FileVisitResult.java
+++ b/src/java.base/share/classes/java/nio/file/FileVisitResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2009, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,9 +35,9 @@ package java.nio.file;
 
 public enum FileVisitResult {
     /**
-     * Continue. If returned from the {@link FileVisitor#preVisitDirectory
-     * preVisitDirectory} method then the entries in the directory are also
-     * visited.
+     * Continue. When returned from a {@link FileVisitor#preVisitDirectory
+     * preVisitDirectory} method then the entries in the directory should also
+     * be visited.
      */
     CONTINUE,
     /**

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -1203,8 +1203,8 @@ public final class Files {
      * which case the method completes without copying the file. File attributes
      * are not required to be copied to the target file. If symbolic links are
      * supported, and the file is a symbolic link, then the final target of the
-     * link is copied. If the file is a directory then it creates an empty
-     * directory in the target location (entries in the directory are not
+     * link is copied. If the file is a directory then an empty directory is
+     * created in the target location (entries in the directory are not
      * copied). This method can be used with the {@link #walkFileTree
      * walkFileTree} method to copy a directory and all entries in the directory,
      * or an entire <i>file-tree</i> where required.


### PR DESCRIPTION
Please review this trivial change triggered by reading the java.nio.file documentation for an unrelated code review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274195](https://bugs.openjdk.java.net/browse/JDK-8274195): Doc cleanup in java.nio.file


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5649/head:pull/5649` \
`$ git checkout pull/5649`

Update a local copy of the PR: \
`$ git checkout pull/5649` \
`$ git pull https://git.openjdk.java.net/jdk pull/5649/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5649`

View PR using the GUI difftool: \
`$ git pr show -t 5649`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5649.diff">https://git.openjdk.java.net/jdk/pull/5649.diff</a>

</details>
