### PR TITLE
8274074: SIGFPE with C2 compiled code with -XX:+StressGCM

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1558,6 +1558,11 @@ void PhaseIdealLoop::try_sink_out_of_loop(Node* n) {
         _igvn.remove_dead_node(n);
       }
       _dom_lca_tags_round = 0;
+    } else if (n_loop == _ltree_root && n->in(0) != NULL && get_loop(n->in(0)) != _ltree_root) {
+      // n has a control input inside a loop but get_ctrl() is member of _ltree_root. This could happen, for example,
+      // for Div nodes inside a loop (control input inside loop) without a use except for an UCT (outside the loop).
+      // Rewire control of n to get_ctrl(n) to move it out of the loop, regardless if its input(s) are later sunk or not.
+      _igvn.replace_input_of(n, 0, n_ctrl);
     }
   }
 }

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1448,6 +1448,16 @@ void PhaseIdealLoop::try_sink_out_of_loop(Node* n) {
       n->Opcode() != Op_Opaque4) {
     Node *n_ctrl = get_ctrl(n);
     IdealLoopTree *n_loop = get_loop(n_ctrl);
+
+    if (n->in(0) != NULL) {
+      IdealLoopTree* loop_ctrl = get_loop(n->in(0));
+      if (n_loop != loop_ctrl && n_loop->is_member(loop_ctrl)) {
+        // n has a control input inside a loop but get_ctrl() is member of an outer loop. This could happen, for example,
+        // for Div nodes inside a loop (control input inside loop) without a use except for an UCT (outside the loop).
+        // Rewire control of n to get_ctrl(n) to move it out of the loop, regardless if its input(s) are later sunk or not.
+        _igvn.replace_input_of(n, 0, n_ctrl);
+      }
+    }
     if (n_loop != _ltree_root && n->outcnt() > 1) {
       // Compute early control: needed for anti-dependence analysis. It's also possible that as a result of
       // previous transformations in this loop opts round, the node can be hoisted now: early control will tell us.
@@ -1558,11 +1568,6 @@ void PhaseIdealLoop::try_sink_out_of_loop(Node* n) {
         _igvn.remove_dead_node(n);
       }
       _dom_lca_tags_round = 0;
-    } else if (n_loop == _ltree_root && n->in(0) != NULL && get_loop(n->in(0)) != _ltree_root) {
-      // n has a control input inside a loop but get_ctrl() is member of _ltree_root. This could happen, for example,
-      // for Div nodes inside a loop (control input inside loop) without a use except for an UCT (outside the loop).
-      // Rewire control of n to get_ctrl(n) to move it out of the loop, regardless if its input(s) are later sunk or not.
-      _igvn.replace_input_of(n, 0, n_ctrl);
     }
   }
 }

--- a/test/hotspot/jtreg/compiler/loopopts/TestSinkingDivisorLostPin.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestSinkingDivisorLostPin.java
@@ -28,7 +28,7 @@
  * @requires vm.compiler2.enabled
  * @summary Sinking a data node used as divisor of a DivI node into a zero check UCT loses its pin outside the loop due to
  *          optimizing the CastII node away, resulting in a div by zero crash (SIGFPE) due to letting the DivI node floating
- *          back into inside the loop.
+ *          back inside the loop.
  * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,compiler.loopopts.TestSinkingDivisorLostPin -XX:-TieredCompilation
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:StressSeed=4177789702 compiler.loopopts.TestSinkingDivisorLostPin
  * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,compiler.loopopts.TestSinkingDivisorLostPin -XX:-TieredCompilation

--- a/test/hotspot/jtreg/compiler/loopopts/TestSinkingDivisorLostPin.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestSinkingDivisorLostPin.java
@@ -64,12 +64,12 @@ public class TestSinkingDivisorLostPin {
                 // Zero check Z2 with UCT
                 // DivI node D is only used on IfFalse path of zero check Z2 into UCT (on IfTrue path, the result is not used anywhere
                 // because we directly overwrite it again with "y = (5 / iFld)). The IfFalse path of the zero check, however, is never
-                // taken because iFld = 1. But before applying the sinking algorithm, the DivI node D could be be executed during the
+                // taken because iFld = 1. But before applying the sinking algorithm, the DivI node D could be executed during the
                 // loop, as the zero check Z1 succeeds. Only after sinking the SubI node for "iFld - q" into the IfFalse path of Z2
                 // and optimizing it accordingly (iFld is found to be zero because the zero check Z2 failed, i.e. iFld is zero which is
                 // propagated into the CastII node whose type is improved to [0,0] and the node is replaced by constant zero), the
                 // DivI node must NOT be executed inside the loop anymore. But the DivI node is executed in the loop because of losing
-                // the CastII pin. The fix is to updated the control input of the DivI node to the get_ctrl() input outside the loop
+                // the CastII pin. The fix is to update the control input of the DivI node to the get_ctrl() input outside the loop
                 // (IfFalse of zero check Z2).
             } catch (ArithmeticException a_e) {
             }

--- a/test/hotspot/jtreg/compiler/loopopts/TestSinkingDivisorLostPin.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestSinkingDivisorLostPin.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key stress randomness
+ * @bug 8274074
+ * @requires vm.compiler2.enabled
+ * @summary Sinking a data node used as divisor of a DivI node into a zero check UCT loses its pin outside the loop due to
+ *          optimizing the CastII node away, resulting in a div by zero crash (SIGFPE) due to letting the DivI node floating
+ *          back into inside the loop.
+ * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,compiler.loopopts.TestSinkingDivisorLostPin -XX:-TieredCompilation
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:StressSeed=4177789702 compiler.loopopts.TestSinkingDivisorLostPin
+ * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,compiler.loopopts.TestSinkingDivisorLostPin -XX:-TieredCompilation
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM compiler.loopopts.TestSinkingDivisorLostPin
+ */
+
+package compiler.loopopts;
+
+public class TestSinkingDivisorLostPin {
+    static int iFld = 1;
+    static int x = 1;
+    static int q = 0;
+    static int iArrFld[] = new int[100];
+
+    public static void main(String[] strArr) {
+        test();
+    }
+
+    static void test() {
+        int y = 1;
+        int i = 1;
+        do {
+            int j;
+            for (j = 1; j < 88; j++) {
+                iArrFld[1] = x;
+            }
+            try {
+                y = iFld - q; // y = 1 - 0
+                y = (iArrFld[2] / y); // y = iArrFld[2] / 1
+                // Zero check Z1 with UCT
+                // DivI node D on IfTrue path of zero check
+                y = (5 / iFld); // y = 5 / 1
+                // Zero check Z2 with UCT
+                // DivI node D is only used on IfFalse path of zero check Z2 into UCT (on IfTrue path, the result is not used anywhere
+                // because we directly overwrite it again with "y = (5 / iFld)). The IfFalse path of the zero check, however, is never
+                // taken because iFld = 1. But before applying the sinking algorithm, the DivI node D could be be executed during the
+                // loop, as the zero check Z1 succeeds. Only after sinking the SubI node for "iFld - q" into the IfFalse path of Z2
+                // and optimizing it accordingly (iFld is found to be zero because the zero check Z2 failed, i.e. iFld is zero which is
+                // propagated into the CastII node whose type is improved to [0,0] and the node is replaced by constant zero), the
+                // DivI node must NOT be executed inside the loop anymore. But the DivI node is executed in the loop because of losing
+                // the CastII pin. The fix is to updated the control input of the DivI node to the get_ctrl() input outside the loop
+                // (IfFalse of zero check Z2).
+            } catch (ArithmeticException a_e) {
+            }
+
+            iFld -= 8;
+            if (y == 3) {
+            }
+            i++;
+        } while (i < 10);
+    }
+
+}
+


### PR DESCRIPTION
In the testcase, the divisor input node of a `DivI` node is sunk out of a loop to a div by zero UCT and is pinned with a `CastII` node to ensure it's not floating back into the loop. The divisor is optimized by taking into account that it's only executed on the uncommon path. The `CastII`, however, is removed later and the division floats back into the loop which results in a SIGFPE crash.

The relevent lines in the testcase are the following two divisions:
```
static int iFld = 1;
static int q = 0;
...
y = iFld - q; // divisor
y = (iArrFld[2] / y); // division 1
y = (5 / iFld); // division 2
```
After sinking the `divisor` of `division 1` in the testcase to the div by zero UCT of `division 2`, the graph looks like this:

![Screenshot from 2021-09-21 14-40-37](https://user-images.githubusercontent.com/17833009/134506632-9904da7b-8210-4301-85dc-04441324fe55.png)

- `201 If` is the zero check of `division 2` (will always succeed because `iFld = 1`, i.e. UCT is never taken).
- `193 DivI` (`division 1`) is not sunk because its `get_ctrl()` is `203 IfFalse` (outside the loop already because there is no use inside the loop since the local `y` is directly overwritten again).
- `275 SubI` (`divisor`) was sunk out of the loop and is pinned by `276 CastII` (unconditional dependency).
 
In IGVN, `CastII::Value()` is called for `276 CastII`. It sees an `If/Cmp` (zero check of `division 2`) with the same `137 LoadI` input as for the `276 CastII`. Therefore, we set its type to [0,0] here:
https://github.com/openjdk/jdk/blob/d0987513665def1b6b2981ab5932b6f1b8b310d8/src/hotspot/share/opto/castnode.cpp#L248-L252

As a result, we replace `276 CastII` with a constant zero in IGVN. But now we lost the pin to the uncommon path of the zero check of `division 2` for `275 SubI` and `193 DivI`. `193 DivI` is only used on the uncommon path but can now float around again, also inside the loop itself, which happens in the testcase. Inside the loop, we execute the division with the now optimized divisor `0 - q = 0` which is a division by zero and we crash.

In summary, it's not a problem that a `Div` node floats above its zero check here but rather that we optimize an input node used as divisor by assuming that we only execute the division on the uncommon path when the zero check of `division 2` failed (which never happens). This divisor optimization would be wrong when the division is executed inside the loop. But due to losing the pin, we end up doing exactly that which results in a SIGFPE crash.

The suggested fix is to extend the sinking algorithm to rewire data nodes with a control input inside a loop whose `get_ctrl()` is actually completely outside loops on uncommon paths. The control input is set to `get_ctrl()` to force the nodes out of loops. In the example above, the control input of `193 DivI` is set to `203 IfFalse`, ensuring that it is still pinned to the uncommon path after `276 CastII` is removed. This fix is also beneficial if we do not sink any nodes at all later.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274074](https://bugs.openjdk.java.net/browse/JDK-8274074): SIGFPE with C2 compiled code with -XX:+StressGCM


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to 941420c11b5fd328e55d129b538659f6267a149d


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5651/head:pull/5651` \
`$ git checkout pull/5651`

Update a local copy of the PR: \
`$ git checkout pull/5651` \
`$ git pull https://git.openjdk.java.net/jdk pull/5651/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5651`

View PR using the GUI difftool: \
`$ git pr show -t 5651`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5651.diff">https://git.openjdk.java.net/jdk/pull/5651.diff</a>

</details>
