### PR TITLE
8273618: DisplayChangeVITest.java is timing out on macOS 12 aarch64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -258,7 +258,6 @@ sun/java2d/SunGraphics2D/SimplePrimQuality.java 6992007 generic-all
 sun/java2d/SunGraphics2D/SourceClippingBlitTest/SourceClippingBlitTest.java 8196185 generic-all
 
 sun/java2d/X11SurfaceData/SharedMemoryPixmapsTest/SharedMemoryPixmapsTest.sh 8221451 linux-all
-java/awt/FullScreen/DisplayChangeVITest/DisplayChangeVITest.java 8169469,8273618 windows-all,macosx-aarch64
 java/awt/FullScreen/UninitializedDisplayModeChangeTest/UninitializedDisplayModeChangeTest.java 8273617 macosx-all
 java/awt/print/PrinterJob/PSQuestionMark.java 7003378 generic-all
 java/awt/print/PrinterJob/GlyphPositions.java 7003378 generic-all

--- a/test/jdk/java/awt/FullScreen/DisplayChangeVITest/DisplayChangeVITest.java
+++ b/test/jdk/java/awt/FullScreen/DisplayChangeVITest/DisplayChangeVITest.java
@@ -235,7 +235,7 @@ public class DisplayChangeVITest implements Runnable {
                 gd.setFullScreenWindow(frame);
                 Thread t = new Thread(test);
                 t.run();
-		sleep(1000);
+                sleep(1000);
                 synchronized (lock) {
                     while (!done) {
                         try {


### PR DESCRIPTION
java/awt/FullScreen/DisplayChangeVITest/DisplayChangeVITest.java is timing out on a macOS 12 aarch64 (an Apple Silicon Mac Mini) system due to getting locked on frame.dispose() even though test passed.
Modified test to use JFrame in EDT and revert the frame back to windowed mode before dispose frame in finally block.

Modified test pass in CI system for several iterations in all platforms (including macos x64 and aarch64)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8273618](https://bugs.openjdk.java.net/browse/JDK-8273618): DisplayChangeVITest.java is timing out on macOS 12 aarch64


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5653/head:pull/5653` \
`$ git checkout pull/5653`

Update a local copy of the PR: \
`$ git checkout pull/5653` \
`$ git pull https://git.openjdk.java.net/jdk pull/5653/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5653`

View PR using the GUI difftool: \
`$ git pr show -t 5653`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5653.diff">https://git.openjdk.java.net/jdk/pull/5653.diff</a>

</details>
