### PR TITLE
8274171: java/nio/file/Files/probeContentType/Basic.java failed on "Content type" mismatches

### DIFF
--- a/test/jdk/java/nio/file/Files/probeContentType/Basic.java
+++ b/test/jdk/java/nio/file/Files/probeContentType/Basic.java
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4313887 8129632 8129633 8162624 8146215 8162745 8273655
+ * @bug 4313887 8129632 8129633 8162624 8146215 8162745 8273655 8274171
  * @summary Unit test for probeContentType method
  * @library ../..
  * @build Basic SimpleFileTypeDetector
@@ -177,8 +177,8 @@ public class Basic {
                 new ExType("png", List.of("image/png")),
                 new ExType("ppt", List.of("application/vnd.ms-powerpoint")),
                 new ExType("pptx",List.of("application/vnd.openxmlformats-officedocument.presentationml.presentation")),
-                new ExType("py", List.of("text/plain", "text/x-python-script")),
-                new ExType("rar", List.of("application/vnd.rar")),
+                new ExType("py", List.of("text/plain", "text/x-python", "text/x-python-script")),
+                new ExType("rar", List.of("application/rar", "application/vnd.rar")),
                 new ExType("rtf", List.of("application/rtf", "text/rtf")),
                 new ExType("webm", List.of("video/webm")),
                 new ExType("webp", List.of("image/webp")),


### PR DESCRIPTION
This is a small follow-up to a recent update of the content-type.properties files [1]. The test fails on certain linux-x64 boxes, where the expected content type differs.

Testing: tier 1-3, plus 1k runs of test in question 

[1] https://bugs.openjdk.java.net/browse/JDK-8273655

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274171](https://bugs.openjdk.java.net/browse/JDK-8274171): java/nio/file/Files/probeContentType/Basic.java failed on "Content type" mismatches


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5656/head:pull/5656` \
`$ git checkout pull/5656`

Update a local copy of the PR: \
`$ git checkout pull/5656` \
`$ git pull https://git.openjdk.java.net/jdk pull/5656/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5656`

View PR using the GUI difftool: \
`$ git pr show -t 5656`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5656.diff">https://git.openjdk.java.net/jdk/pull/5656.diff</a>

</details>
