### PR TITLE
8274216: ProblemList 2 serviceability/dcmd/gc tests with ZGC on linux-all and windows-all

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -44,3 +44,6 @@ serviceability/sa/TestJmapCoreMetaspace.java                  8268722,8268636   
 serviceability/sa/TestJhsdbJstackMixed.java                   8248912   generic-all
 serviceability/sa/ClhsdbPstack.java#process                   8248912   generic-all
 serviceability/sa/ClhsdbPstack.java#core                      8248912   generic-all
+
+serviceability/dcmd/gc/HeapDumpAllTest.java                   8274196   linux-all,windows-all
+serviceability/dcmd/gc/HeapDumpTest.java                      8274196   linux-all,windows-all


### PR DESCRIPTION
A trivial fix to ProblemList 2 serviceability/dcmd/gc tests with ZGC on linux-all and windows-all.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274216](https://bugs.openjdk.java.net/browse/JDK-8274216): ProblemList 2 serviceability/dcmd/gc tests with ZGC on linux-all and windows-all


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5657/head:pull/5657` \
`$ git checkout pull/5657`

Update a local copy of the PR: \
`$ git checkout pull/5657` \
`$ git pull https://git.openjdk.java.net/jdk pull/5657/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5657`

View PR using the GUI difftool: \
`$ git pr show -t 5657`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5657.diff">https://git.openjdk.java.net/jdk/pull/5657.diff</a>

</details>
