### PR TITLE
8274232: Cleanup unnecessary null comparison before instanceof check in jdk.jdi

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/Commands.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/Commands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -704,9 +704,9 @@ class Commands {
         }
         String expr = t.nextToken("");
         Value val = evaluate(expr);
-        if ((val != null) && (val instanceof ObjectReference)) {
+        if (val instanceof ObjectReference object) {
             try {
-                thread.stop((ObjectReference)val);
+                thread.stop(object);
                 MessageOutput.println("killed", thread.toString());
             } catch (InvalidTypeException e) {
                 MessageOutput.println("Invalid exception object");
@@ -1778,8 +1778,7 @@ class Commands {
         Value val = evaluate(expr);
 
         try {
-            if ((val != null) && (val instanceof ObjectReference)) {
-                ObjectReference object = (ObjectReference)val;
+            if (val instanceof ObjectReference object) {
                 String strVal = getStringValue();
                 if (strVal != null) {
                     MessageOutput.println("Monitor information for expr",
@@ -1874,8 +1873,7 @@ class Commands {
 
         String expr = t.nextToken("");
         Value val = evaluate(expr);
-        if ((val != null) && (val instanceof ObjectReference)) {
-            ObjectReference object = (ObjectReference)val;
+        if (val instanceof ObjectReference object) {
             object.disableCollection();
             String strVal = getStringValue();
             if (strVal != null) {
@@ -1903,8 +1901,7 @@ class Commands {
 
         String expr = t.nextToken("");
         Value val = evaluate(expr);
-        if ((val != null) && (val instanceof ObjectReference)) {
-            ObjectReference object = (ObjectReference)val;
+        if (val instanceof ObjectReference object) {
             object.enableCollection();
             String strVal = getStringValue();
             if (strVal != null) {

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/BooleanValueImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/BooleanValueImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,8 +40,8 @@ public class BooleanValueImpl extends PrimitiveValueImpl
     }
 
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof BooleanValue)) {
-            return (value == ((BooleanValue)obj).value()) &&
+        if (obj instanceof BooleanValue other) {
+            return (value == other.value()) &&
                    super.equals(obj);
         } else {
             return false;

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/ByteValueImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/ByteValueImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,8 +41,8 @@ public class ByteValueImpl extends PrimitiveValueImpl
     }
 
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof ByteValue)) {
-            return (value == ((ByteValue)obj).value())
+        if (obj instanceof ByteValue other) {
+            return (value == other.value())
                    && super.equals(obj);
         } else {
             return false;

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/CharValueImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/CharValueImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,8 +41,8 @@ public class CharValueImpl extends PrimitiveValueImpl
     }
 
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof CharValue)) {
-            return (value == ((CharValue)obj).value()) &&
+        if (obj instanceof CharValue other) {
+            return (value == other.value()) &&
                    super.equals(obj);
         } else {
             return false;

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/ConnectorImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/ConnectorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -193,8 +193,7 @@ abstract class ConnectorImpl implements Connector {
         }
 
         public boolean equals(Object obj) {
-            if ((obj != null) && (obj instanceof Connector.Argument)) {
-                Connector.Argument other = (Connector.Argument)obj;
+            if (obj instanceof Argument other) {
                 return (name().equals(other.name())) &&
                        (description().equals(other.description())) &&
                        (mustSpecify() == other.mustSpecify()) &&

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/DoubleValueImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/DoubleValueImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,8 +40,8 @@ public class DoubleValueImpl extends PrimitiveValueImpl
     }
 
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof DoubleValue)) {
-            return (value == ((DoubleValue)obj).value()) &&
+        if (obj instanceof DoubleValue other) {
+            return (value == other.value()) &&
                    super.equals(obj);
         } else {
             return false;

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/FieldImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/FieldImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,8 +41,7 @@ public class FieldImpl extends TypeComponentImpl
     }
 
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof FieldImpl)) {
-            FieldImpl other = (FieldImpl)obj;
+        if (obj instanceof FieldImpl other) {
             return (declaringType().equals(other.declaringType())) &&
                    (ref() == other.ref()) &&
                    super.equals(obj);

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/FloatValueImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/FloatValueImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,8 +40,8 @@ public class FloatValueImpl extends PrimitiveValueImpl
     }
 
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof FloatValue)) {
-            return (value == ((FloatValue)obj).value()) &&
+        if (obj instanceof FloatValue other) {
+            return (value == other.value()) &&
                    super.equals(obj);
         } else {
             return false;

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/IntegerValueImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/IntegerValueImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,8 +40,8 @@ public class IntegerValueImpl extends PrimitiveValueImpl
     }
 
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof IntegerValue)) {
-            return (value == ((IntegerValue)obj).value()) &&
+        if (obj instanceof IntegerValue other) {
+            return (value == other.value()) &&
                    super.equals(obj);
         } else {
             return false;

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/LocalVariableImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/LocalVariableImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,8 +66,7 @@ public class LocalVariableImpl extends MirrorImpl
     }
 
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof LocalVariableImpl)) {
-            LocalVariableImpl other = (LocalVariableImpl)obj;
+        if (obj instanceof LocalVariableImpl other) {
             return ((slot() == other.slot()) &&
                     (scopeStart != null) &&
                     (scopeStart.equals(other.scopeStart)) &&

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/LocationImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/LocationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,8 +62,7 @@ public class LocationImpl extends MirrorImpl implements Location {
     }
 
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof Location)) {
-            Location other = (Location)obj;
+        if (obj instanceof Location other) {
             return (method().equals(other.method())) &&
                    (codeIndex() == other.codeIndex()) &&
                    super.equals(obj);

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/LongValueImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/LongValueImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,8 +40,8 @@ public class LongValueImpl extends PrimitiveValueImpl
     }
 
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof LongValue)) {
-            return (value == ((LongValue)obj).value()) &&
+        if (obj instanceof LongValue other) {
+            return (value == other.value()) &&
                    super.equals(obj);
         } else {
             return false;

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/MethodImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/MethodImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,8 +85,7 @@ public abstract class MethodImpl extends TypeComponentImpl
     }
 
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof MethodImpl)) {
-            MethodImpl other = (MethodImpl)obj;
+        if (obj instanceof MethodImpl other) {
             return (declaringType().equals(other.declaringType())) &&
                    (ref() == other.ref()) &&
                    super.equals(obj);

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/MirrorImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/MirrorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,8 +49,7 @@ abstract class MirrorImpl extends Object implements Mirror {
     }
 
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof Mirror)) {
-            Mirror other = (Mirror)obj;
+        if (obj instanceof Mirror other) {
             return vm.equals(other.virtualMachine());
         } else {
             return false;

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/ObjectReferenceImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/ObjectReferenceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -146,8 +146,7 @@ public class ObjectReferenceImpl extends ValueImpl
     }
 
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof ObjectReferenceImpl)) {
-            ObjectReferenceImpl other = (ObjectReferenceImpl)obj;
+        if (obj instanceof ObjectReferenceImpl other) {
             return (ref() == other.ref()) &&
                    super.equals(obj);
         } else {

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/ReferenceTypeImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/ReferenceTypeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -143,8 +143,7 @@ public abstract class ReferenceTypeImpl extends TypeImpl implements ReferenceTyp
     }
 
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof ReferenceTypeImpl)) {
-            ReferenceTypeImpl other = (ReferenceTypeImpl)obj;
+        if (obj instanceof ReferenceTypeImpl other) {
             return (ref() == other.ref()) &&
                 (vm.equals(other.virtualMachine()));
         } else {

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/ShortValueImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/ShortValueImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,8 +40,8 @@ public class ShortValueImpl extends PrimitiveValueImpl
     }
 
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof ShortValue)) {
-            return (value == ((ShortValue)obj).value()) &&
+        if (obj instanceof ShortValue other) {
+            return (value == other.value()) &&
                    super.equals(obj);
         } else {
             return false;

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/StackFrameImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/StackFrameImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,8 +111,7 @@ public class StackFrameImpl extends MirrorImpl
     }
 
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof StackFrameImpl)) {
-            StackFrameImpl other = (StackFrameImpl)obj;
+        if (obj instanceof StackFrameImpl other) {
             return (id == other.id) &&
                    (thread().equals(other.thread())) &&
                    (location().equals(other.location())) &&

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/TypeImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/TypeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,8 +46,7 @@ public abstract class TypeImpl extends MirrorImpl implements Type {
     }
 
     public boolean equals(Object obj) {
-        if ((obj != null) && (obj instanceof Type)) {
-            Type other = (Type)obj;
+        if (obj instanceof Type other) {
             return signature().equals(other.signature()) && super.equals(obj);
         } else {
             return false;

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/VoidValueImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/VoidValueImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ public class VoidValueImpl extends ValueImpl implements VoidValue {
     }
 
     public boolean equals(Object obj) {
-        return (obj != null) && (obj instanceof VoidValue) && super.equals(obj);
+        return (obj instanceof VoidValue) && super.equals(obj);
     }
 
     public int hashCode() {


### PR DESCRIPTION
Update code checks both non-null and instance of a class in jdk.jdi module classes.
The checks and explicit casts could also be replaced with pattern matching for the instanceof operator. 
Similar cleanups
1. [JDK-8273484](https://bugs.openjdk.java.net/browse/JDK-8273484) java.naming
2. [JDK-8258422](https://bugs.openjdk.java.net/browse/JDK-8258422) java.base

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274232](https://bugs.openjdk.java.net/browse/JDK-8274232): Cleanup unnecessary null comparison before instanceof check in jdk.jdi


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5659/head:pull/5659` \
`$ git checkout pull/5659`

Update a local copy of the PR: \
`$ git checkout pull/5659` \
`$ git pull https://git.openjdk.java.net/jdk pull/5659/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5659`

View PR using the GUI difftool: \
`$ git pr show -t 5659`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5659.diff">https://git.openjdk.java.net/jdk/pull/5659.diff</a>

</details>
