### PR TITLE
8274234: Remove unnecessary boxing via primitive wrapper valueOf(String) methods in java.sql.rowset

### DIFF
--- a/src/java.sql.rowset/share/classes/com/sun/rowset/CachedRowSetImpl.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/CachedRowSetImpl.java
@@ -1805,7 +1805,7 @@ public class CachedRowSetImpl extends BaseRowSet implements RowSet, RowSetIntern
             return (byte)0;
         }
         try {
-            return ((Byte.valueOf(value.toString())).byteValue());
+            return Byte.parseByte(value.toString());
         } catch (NumberFormatException ex) {
             throw new SQLException(MessageFormat.format(resBundle.handleGetObject("cachedrowsetimpl.bytefail").toString(),
                   new Object[] {value.toString().trim(), columnIndex}));
@@ -1849,7 +1849,7 @@ public class CachedRowSetImpl extends BaseRowSet implements RowSet, RowSetIntern
         }
 
         try {
-            return ((Short.valueOf(value.toString().trim())).shortValue());
+            return Short.parseShort(value.toString().trim());
         } catch (NumberFormatException ex) {
             throw new SQLException(MessageFormat.format(resBundle.handleGetObject("cachedrowsetimpl.shortfail").toString(),
                   new Object[] {value.toString().trim(), columnIndex}));
@@ -1892,7 +1892,7 @@ public class CachedRowSetImpl extends BaseRowSet implements RowSet, RowSetIntern
         }
 
         try {
-            return ((Integer.valueOf(value.toString().trim())).intValue());
+            return Integer.parseInt(value.toString().trim());
         } catch (NumberFormatException ex) {
             throw new SQLException(MessageFormat.format(resBundle.handleGetObject("cachedrowsetimpl.intfail").toString(),
                   new Object[] {value.toString().trim(), columnIndex}));
@@ -1935,7 +1935,7 @@ public class CachedRowSetImpl extends BaseRowSet implements RowSet, RowSetIntern
             return (long)0;
         }
         try {
-            return ((Long.valueOf(value.toString().trim())).longValue());
+            return Long.parseLong(value.toString().trim());
         } catch (NumberFormatException ex) {
             throw new SQLException(MessageFormat.format(resBundle.handleGetObject("cachedrowsetimpl.longfail").toString(),
                   new Object[] {value.toString().trim(), columnIndex}));

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/internal/XmlReaderContentHandler.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/internal/XmlReaderContentHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -982,8 +982,7 @@ public class XmlReaderContentHandler extends DefaultHandler {
     }
 
     private boolean getBooleanValue(String s) {
-
-        return Boolean.valueOf(s).booleanValue();
+        return Boolean.parseBoolean(s);
     }
 
     private java.math.BigDecimal getBigDecimalValue(String s) {


### PR DESCRIPTION
Usages of methods Integer.valueOf, Byte.valueOf, Short.valueOf, Float.valueOf, Double.valueOf, Long.valueOf often can be simplified by using their pair methods parseInt/parseLong/parseShort/parseByte/parseFloat.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274234](https://bugs.openjdk.java.net/browse/JDK-8274234): Remove unnecessary boxing via primitive wrapper valueOf(String) methods in java.sql.rowset


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5662/head:pull/5662` \
`$ git checkout pull/5662`

Update a local copy of the PR: \
`$ git checkout pull/5662` \
`$ git pull https://git.openjdk.java.net/jdk pull/5662/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5662`

View PR using the GUI difftool: \
`$ git pr show -t 5662`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5662.diff">https://git.openjdk.java.net/jdk/pull/5662.diff</a>

</details>
