### PR TITLE
8274237: Replace 'for' cycles with iterator with enhanced-for in java.base

### DIFF
--- a/src/java.base/share/classes/java/security/Security.java
+++ b/src/java.base/share/classes/java/security/Security.java
@@ -622,8 +622,7 @@ public final class Security {
 
         // For each selection criterion, remove providers
         // which don't satisfy the criterion from the candidate set.
-        for (Iterator<String> ite = keySet.iterator(); ite.hasNext(); ) {
-            String key = ite.next();
+        for (String key : keySet) {
             String value = filter.get(key);
 
             LinkedHashSet<Provider> newCandidates = getAllQualifyingCandidates(key, value,

--- a/src/java.base/share/classes/java/security/cert/PKIXParameters.java
+++ b/src/java.base/share/classes/java/security/cert/PKIXParameters.java
@@ -200,8 +200,8 @@ public class PKIXParameters implements CertPathParameters {
             throw new InvalidAlgorithmParameterException("the trustAnchors " +
                 "parameter must be non-empty");
         }
-        for (Iterator<TrustAnchor> i = trustAnchors.iterator(); i.hasNext(); ) {
-            if (!(i.next() instanceof TrustAnchor)) {
+        for (Object trustAnchor : trustAnchors) {
+            if (!(trustAnchor instanceof TrustAnchor)) {
                 throw new ClassCastException("all elements of set must be "
                     + "of type java.security.cert.TrustAnchor");
             }
@@ -249,9 +249,8 @@ public class PKIXParameters implements CertPathParameters {
      */
     public void setInitialPolicies(Set<String> initialPolicies) {
         if (initialPolicies != null) {
-            for (Iterator<String> i = initialPolicies.iterator();
-                        i.hasNext();) {
-                if (!(i.next() instanceof String))
+            for (Object initialPolicy : initialPolicies) {
+                if (!(initialPolicy instanceof String))
                     throw new ClassCastException("all elements of set must be "
                         + "of type java.lang.String");
             }
@@ -282,8 +281,8 @@ public class PKIXParameters implements CertPathParameters {
         if (stores == null) {
             this.certStores = new ArrayList<>();
         } else {
-            for (Iterator<CertStore> i = stores.iterator(); i.hasNext();) {
-                if (!(i.next() instanceof CertStore)) {
+            for (Object store : stores) {
+                if (!(store instanceof CertStore)) {
                     throw new ClassCastException("all elements of list must be "
                         + "of type java.security.cert.CertStore");
                 }

--- a/src/java.base/share/classes/java/security/cert/X509CRLSelector.java
+++ b/src/java.base/share/classes/java/security/cert/X509CRLSelector.java
@@ -364,8 +364,7 @@ public class X509CRLSelector implements CRLSelector {
     private static HashSet<X500Principal> parseIssuerNames(Collection<Object> names)
     throws IOException {
         HashSet<X500Principal> x500Principals = new HashSet<>();
-        for (Iterator<Object> t = names.iterator(); t.hasNext(); ) {
-            Object nameObject = t.next();
+        for (Object nameObject : names) {
             if (nameObject instanceof String) {
                 x500Principals.add(new X500Name((String)nameObject).asX500Principal());
             } else {

--- a/src/java.base/share/classes/sun/net/ProgressMonitor.java
+++ b/src/java.base/share/classes/sun/net/ProgressMonitor.java
@@ -68,9 +68,7 @@ public class ProgressMonitor
 
         try {
             synchronized(progressSourceList)    {
-                for (Iterator<ProgressSource> iter = progressSourceList.iterator(); iter.hasNext();)    {
-                    ProgressSource pi = iter.next();
-
+                for (ProgressSource pi : progressSourceList) {
                     // Clone ProgressSource and add to snapshot
                     snapshot.add((ProgressSource)pi.clone());
                 }
@@ -114,18 +112,15 @@ public class ProgressMonitor
         if (progressListenerList.size() > 0)
         {
             // Notify progress listener if there is progress change
-            ArrayList<ProgressListener> listeners = new ArrayList<>();
+            ArrayList<ProgressListener> listeners;
 
             // Copy progress listeners to another list to avoid holding locks
             synchronized(progressListenerList) {
-                for (Iterator<ProgressListener> iter = progressListenerList.iterator(); iter.hasNext();) {
-                    listeners.add(iter.next());
-                }
+                listeners = new ArrayList<>(progressListenerList);
             }
 
             // Fire event on each progress listener
-            for (Iterator<ProgressListener> iter = listeners.iterator(); iter.hasNext();) {
-                ProgressListener pl = iter.next();
+            for (ProgressListener pl : listeners) {
                 ProgressEvent pe = new ProgressEvent(pi, pi.getURL(), pi.getMethod(), pi.getContentType(), pi.getState(), pi.getProgress(), pi.getExpected());
                 pl.progressStart(pe);
             }
@@ -151,18 +146,15 @@ public class ProgressMonitor
         if (progressListenerList.size() > 0)
         {
             // Notify progress listener if there is progress change
-            ArrayList<ProgressListener> listeners = new ArrayList<>();
+            ArrayList<ProgressListener> listeners;
 
             // Copy progress listeners to another list to avoid holding locks
             synchronized(progressListenerList) {
-                for (Iterator<ProgressListener> iter = progressListenerList.iterator(); iter.hasNext();) {
-                    listeners.add(iter.next());
-                }
+                listeners = new ArrayList<>(progressListenerList);
             }
 
             // Fire event on each progress listener
-            for (Iterator<ProgressListener> iter = listeners.iterator(); iter.hasNext();) {
-                ProgressListener pl = iter.next();
+            for (ProgressListener pl : listeners) {
                 ProgressEvent pe = new ProgressEvent(pi, pi.getURL(), pi.getMethod(), pi.getContentType(), pi.getState(), pi.getProgress(), pi.getExpected());
                 pl.progressFinish(pe);
             }
@@ -183,18 +175,15 @@ public class ProgressMonitor
         if (progressListenerList.size() > 0)
         {
             // Notify progress listener if there is progress change
-            ArrayList<ProgressListener> listeners = new ArrayList<>();
+            ArrayList<ProgressListener> listeners;
 
             // Copy progress listeners to another list to avoid holding locks
             synchronized(progressListenerList)  {
-                for (Iterator<ProgressListener> iter = progressListenerList.iterator(); iter.hasNext();) {
-                    listeners.add(iter.next());
-                }
+                listeners = new ArrayList<>(progressListenerList);
             }
 
             // Fire event on each progress listener
-            for (Iterator<ProgressListener> iter = listeners.iterator(); iter.hasNext();) {
-                ProgressListener pl = iter.next();
+            for (ProgressListener pl : listeners) {
                 ProgressEvent pe = new ProgressEvent(pi, pi.getURL(), pi.getMethod(), pi.getContentType(), pi.getState(), pi.getProgress(), pi.getExpected());
                 pl.progressUpdate(pe);
             }


### PR DESCRIPTION
There are few places in code where manual `for` loop is used with Iterator to iterate over Collection.
Instead of manual `for` cycles it's preferred to use enhanced-for cycle instead: it's less verbose, makes code easier to read and it's less error-prone.
Sometimes we even don't need cycle at all: we can just create one ArrayList as a copy of another.
It doesn't have any performance impact: java compiler generates similar code when compiling enhanced-for cycle.
This is continuation of [JDK-8273261](https://bugs.openjdk.java.net/browse/JDK-8273261)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274237](https://bugs.openjdk.java.net/browse/JDK-8274237): Replace 'for' cycles with iterator with enhanced-for in java.base


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5665/head:pull/5665` \
`$ git checkout pull/5665`

Update a local copy of the PR: \
`$ git checkout pull/5665` \
`$ git pull https://git.openjdk.java.net/jdk pull/5665/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5665`

View PR using the GUI difftool: \
`$ git pr show -t 5665`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5665.diff">https://git.openjdk.java.net/jdk/pull/5665.diff</a>

</details>
