### PR TITLE
8274136: -XX:+ExitOnOutOfMemoryError calls exit while threads are running

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -732,6 +732,10 @@ void os::exit(int num) {
   ::exit(num);
 }
 
+void os::_exit(int num) {
+  ::_exit(num);
+}
+
 // Builds a platform dependent Agent_OnLoad_<lib_name> function name
 // which is used to find statically linked in agents.
 // Parameters:

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4159,8 +4159,8 @@ int os::win32::exit_process_or_thread(Ept what, int exit_code) {
     _endthreadex((unsigned)exit_code);
   } else if (what == EPT_PROCESS) {
     ::exit(exit_code);
-  } else {
-    _exit(exit_code);
+  } else { // EPT_PROCESS_DIE
+    ::_exit(exit_code);
   }
 
   // Should not reach here
@@ -4761,6 +4761,10 @@ int os::close(int fd) {
 
 void os::exit(int num) {
   win32::exit_process_or_thread(win32::EPT_PROCESS, num);
+}
+
+void os::_exit(int num) {
+  win32::exit_process_or_thread(win32::EPT_PROCESS_DIE, num);
 }
 
 // Is a (classpath) directory empty?

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -520,8 +520,12 @@ class os: AllStatic {
   // child process (ignored on AIX, which always uses vfork).
   static int fork_and_exec(const char *cmd, bool prefer_vfork = false);
 
-  // Call ::exit() on all platforms but Windows
+  // Call ::exit() on all platforms
   static void exit(int num);
+
+  // Call ::_exit() on all platforms. Similar semantics to die() except we never
+  // want a core dump.
+  static void _exit(int num);
 
   // Terminate the VM, but don't exit the process
   static void shutdown();

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -366,7 +366,7 @@ void report_java_out_of_memory(const char* message) {
 
     if (ExitOnOutOfMemoryError) {
       tty->print_cr("Terminating due to java.lang.OutOfMemoryError: %s", message);
-      os::exit(3);
+      os::_exit(3); // quick exit with no cleanup hooks run
     }
   }
 }


### PR DESCRIPTION
Please see bug report for more detailed discussion.

We introduce `os::_exit()` to `call _exit()` to allow us to terminate without running the at_exit handlers and global destructors, which lead to the crashes during termination.

Testing: tiers 1-3 (includes the ExitOnOutOfMemoryError test)

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274136](https://bugs.openjdk.java.net/browse/JDK-8274136): -XX:+ExitOnOutOfMemoryError calls exit while threads are running


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5668/head:pull/5668` \
`$ git checkout pull/5668`

Update a local copy of the PR: \
`$ git checkout pull/5668` \
`$ git pull https://git.openjdk.java.net/jdk pull/5668/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5668`

View PR using the GUI difftool: \
`$ git pr show -t 5668`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5668.diff">https://git.openjdk.java.net/jdk/pull/5668.diff</a>

</details>
