### PR TITLE
8274245: sun/tools/jmap/BasicJMapTest.java Mutex rank failures

### DIFF
--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -384,14 +384,11 @@ void Mutex::check_rank(Thread* thread) {
   if (owned_by_self()) {
     // wait() case
     Mutex* least = get_least_ranked_lock_besides_this(locks_owned);
-    // We enforce not holding locks of rank nosafepoint or lower while waiting.
-    // Also "this" should be the monitor with lowest rank owned by this thread.
-    if (least != NULL && (least->rank() <= nosafepoint || least->rank() <= this->rank())) {
+    // "this" should be the monitor with lowest rank owned by this thread.
+    if (least != NULL && least->rank() <= this->rank()) {
       assert(false, "Attempting to wait on monitor %s/%d while holding lock %s/%d -- "
              "possible deadlock. %s", name(), rank(), least->name(), least->rank(),
-             least->rank() <= this->rank() ?
-              "Should wait on the least ranked monitor from all owned locks." :
-              "Should not block(wait) while holding a lock of rank nosafepoint or below.");
+              "Should wait on the least ranked monitor from all owned locks.");
     }
   } else {
     // lock()/lock_without_safepoint_check()/try_lock() case

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -748,7 +748,7 @@ class ParDumpWriter : public AbstractDumpWriter {
 
   static void before_work() {
     assert(_lock == NULL, "ParDumpWriter lock must be initialized only once");
-    _lock = new (std::nothrow) PaddedMonitor(Mutex::leaf, "Parallel HProf writer lock", Mutex::_safepoint_check_never);
+    _lock = new (std::nothrow) PaddedMonitor(Mutex::nosafepoint, "ParallelHProfWriter_lock", Mutex::_safepoint_check_never);
   }
 
   static void after_work() {
@@ -1814,7 +1814,7 @@ class DumperController : public CHeapObj<mtInternal> {
  public:
    DumperController(uint number) :
      _started(false),
-     _lock(new (std::nothrow) PaddedMonitor(Mutex::leaf, "Dumper Controller lock",
+     _lock(new (std::nothrow) PaddedMonitor(Mutex::nosafepoint, "DumperController_lock",
     Mutex::_safepoint_check_never)),
      _dumper_number(number),
      _complete_number(0) { }

--- a/src/hotspot/share/services/heapDumperCompression.cpp
+++ b/src/hotspot/share/services/heapDumperCompression.cpp
@@ -200,7 +200,7 @@ CompressionBackend::CompressionBackend(AbstractWriter* writer,
   _written(0),
   _writer(writer),
   _compressor(compressor),
-  _lock(new (std::nothrow) PaddedMonitor(Mutex::nosafepoint, "HProfCompressionBackend_lock",
+  _lock(new (std::nothrow) PaddedMonitor(Mutex::nosafepoint-1, "HProfCompressionBackend_lock",
     Mutex::_safepoint_check_never)) {
   if (_writer == NULL) {
     set_error("Could not allocate writer");

--- a/test/hotspot/gtest/runtime/test_mutex.cpp
+++ b/test/hotspot/gtest/runtime/test_mutex.cpp
@@ -204,54 +204,6 @@ TEST_VM_ASSERT_MSG(MutexRank, monitor_wait_rank_out_of_order_trylock,
   monitor_rankA->unlock();
 }
 
-TEST_VM_ASSERT_MSG(MutexRank, monitor_wait_rank_nosafepoint,
-                   ".* Attempting to wait on monitor monitor_rank_nosafepoint_minus_one/.* while holding lock monitor_rank_nosafepoint/.*"
-                   "-- possible deadlock. Should not block\\(wait\\) while holding a lock of rank nosafepoint or below.") {
-  JavaThread* THREAD = JavaThread::current();
-  ThreadInVMfromNative invm(THREAD);
-
-  Monitor* monitor_rank_nosafepoint = new Monitor(Mutex::nosafepoint, "monitor_rank_nosafepoint", Mutex::_safepoint_check_never);
-  Monitor* monitor_rank_nosafepoint_minus_one = new Monitor(Mutex::nosafepoint - 1, "monitor_rank_nosafepoint_minus_one", Mutex::_safepoint_check_never);
-
-  monitor_rank_nosafepoint->lock_without_safepoint_check();
-  monitor_rank_nosafepoint_minus_one->lock_without_safepoint_check();
-  monitor_rank_nosafepoint_minus_one->wait_without_safepoint_check(1);
-  monitor_rank_nosafepoint_minus_one->unlock();
-  monitor_rank_nosafepoint->unlock();
-}
-
-TEST_VM_ASSERT_MSG(MutexRank, monitor_wait_event_tty,
-                   ".* Attempting to wait on monitor monitor_rank_event/0 while holding lock monitor_rank_tty/.*"
-                   "-- possible deadlock. Should not block\\(wait\\) while holding a lock of rank nosafepoint or below.") {
-  JavaThread* THREAD = JavaThread::current();
-  ThreadInVMfromNative invm(THREAD);
-
-  Monitor* monitor_rank_tty = new Monitor(Mutex::tty, "monitor_rank_tty", Mutex::_safepoint_check_never);
-  Monitor* monitor_rank_event = new Monitor(Mutex::event, "monitor_rank_event", Mutex::_safepoint_check_never);
-
-  monitor_rank_tty->lock_without_safepoint_check();
-  monitor_rank_event->lock_without_safepoint_check();
-  monitor_rank_event->wait_without_safepoint_check(1);
-  monitor_rank_event->unlock();
-  monitor_rank_tty->unlock();
-}
-
-TEST_VM_ASSERT_MSG(MutexRank, monitor_wait_tty_nosafepoint,
-                   ".* Attempting to wait on monitor monitor_rank_tty/.* while holding lock monitor_rank_nosafepoint/.*"
-                   "-- possible deadlock. Should not block\\(wait\\) while holding a lock of rank nosafepoint or below.") {
-  JavaThread* THREAD = JavaThread::current();
-  ThreadInVMfromNative invm(THREAD);
-
-  Monitor* monitor_rank_nosafepoint = new Monitor(Mutex::nosafepoint, "monitor_rank_nosafepoint", Mutex::_safepoint_check_never);
-  Monitor* monitor_rank_tty = new Monitor(Mutex::tty, "monitor_rank_tty", Mutex::_safepoint_check_never);
-
-  monitor_rank_nosafepoint->lock_without_safepoint_check();
-  monitor_rank_tty->lock_without_safepoint_check();
-  monitor_rank_tty->wait_without_safepoint_check(1);
-  monitor_rank_tty->unlock();
-  monitor_rank_nosafepoint->unlock();
-}
-
 TEST_VM_ASSERT_MSG(MutexRank, monitor_nosafepoint_vm_block,
                    ".*Safepoint check never locks should always allow the vm to block") {
   JavaThread* THREAD = JavaThread::current();


### PR DESCRIPTION
This test fails due to Mutex rank assertions that I just added.  The new mutexes in the heapDumper needs to be ranked 'nosafepoint' and 'nosafepoint-1' since they don't cause safepoint checks.
This code also holds two no-safepoint checking locks and waits on the second.  This doesn't break rank ordering but does run afoul of an old assert that we had in the code, that is no longer has meaning.

The test still fails because of other bugs like JDK-8274196 but it doesn't get the mutex rank assertions anymore.

Testing with tier 5 and 6, where the failure was observed, in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274245](https://bugs.openjdk.java.net/browse/JDK-8274245): sun/tools/jmap/BasicJMapTest.java Mutex rank failures


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5669/head:pull/5669` \
`$ git checkout pull/5669`

Update a local copy of the PR: \
`$ git checkout pull/5669` \
`$ git pull https://git.openjdk.java.net/jdk pull/5669/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5669`

View PR using the GUI difftool: \
`$ git pr show -t 5669`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5669.diff">https://git.openjdk.java.net/jdk/pull/5669.diff</a>

</details>
