### PR TITLE
JDK-8274259: G1: assert(check_alignment(result)) failed: address not aligned: 0x00000008baadbabe after JDK-8270009

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2754,6 +2754,7 @@ void G1CollectedHeap::verify_before_young_collection(G1HeapVerifier::G1VerifyTyp
     return;
   }
   Ticks start = Ticks::now();
+  _verifier->prepare_for_verify();  
   _verifier->verify_region_sets_optional();
   _verifier->verify_dirty_young_regions();
   if (VerifyRememberedSets) {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2754,7 +2754,7 @@ void G1CollectedHeap::verify_before_young_collection(G1HeapVerifier::G1VerifyTyp
     return;
   }
   Ticks start = Ticks::now();
-  _verifier->prepare_for_verify();  
+  _verifier->prepare_for_verify();
   _verifier->verify_region_sets_optional();
   _verifier->verify_dirty_young_regions();
   if (VerifyRememberedSets) {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->
After JDK-8270009, the VerifyBeforeGC missed retired tlabs before verify remset

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274259](https://bugs.openjdk.java.net/browse/JDK-8274259): G1: assert(check_alignment(result)) failed: address not aligned: 0x00000008baadbabe after JDK-8270009


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5672/head:pull/5672` \
`$ git checkout pull/5672`

Update a local copy of the PR: \
`$ git checkout pull/5672` \
`$ git pull https://git.openjdk.java.net/jdk pull/5672/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5672`

View PR using the GUI difftool: \
`$ git pr show -t 5672`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5672.diff">https://git.openjdk.java.net/jdk/pull/5672.diff</a>

</details>
