### PR TITLE
8274261: Use enhanced-for instead of plain 'for' in jdk.jcmd

### DIFF
--- a/src/jdk.jcmd/share/classes/sun/tools/jmap/JMap.java
+++ b/src/jdk.jcmd/share/classes/sun/tools/jmap/JMap.java
@@ -31,7 +31,6 @@ import java.io.InputStream;
 import java.util.Collection;
 
 import com.sun.tools.attach.VirtualMachine;
-import com.sun.tools.attach.VirtualMachineDescriptor;
 import com.sun.tools.attach.AttachNotSupportedException;
 import sun.tools.attach.HotSpotVirtualMachine;
 import sun.tools.common.ProcessArgumentMatcher;
@@ -171,8 +170,7 @@ public class JMap {
         String parallel = null;
         String subopts[] = options.split(",");
 
-        for (int i = 0; i < subopts.length; i++) {
-            String subopt = subopts[i];
+        for (String subopt : subopts) {
             if (subopt.equals("") || subopt.equals("all")) {
                 // pass
             } else if (subopt.equals("live")) {
@@ -184,11 +182,11 @@ public class JMap {
                     usage(1);
                 }
             } else if (subopt.startsWith("parallel=")) {
-               parallel = subopt.substring("parallel=".length());
-               if (parallel == null) {
+                parallel = subopt.substring("parallel=".length());
+                if (parallel == null) {
                     System.err.println("Fail: no number provided in option: '" + subopt + "'");
                     usage(1);
-               }
+                }
             } else {
                 System.err.println("Fail: invalid option: '" + subopt + "'");
                 usage(1);
@@ -209,8 +207,7 @@ public class JMap {
         String liveopt = "-all";
         String compress_level = null;
 
-        for (int i = 0; i < subopts.length; i++) {
-            String subopt = subopts[i];
+        for (String subopt : subopts) {
             if (subopt.equals("") || subopt.equals("all")) {
                 // pass
             } else if (subopt.equals("live")) {

--- a/src/jdk.jcmd/share/classes/sun/tools/jstat/Arguments.java
+++ b/src/jdk.jcmd/share/classes/sun/tools/jstat/Arguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,8 +115,8 @@ public class Arguments {
         String unitString = null;
         String valueString = s;
 
-        for (int i = 0; i < unitStrings.length; i++) {
-            int index = s.indexOf(unitStrings[i]);
+        for (String unit : unitStrings) {
+            int index = s.indexOf(unit);
             if (index > 0) {
                 unitString = s.substring(index);
                 valueString = s.substring(0, index);

--- a/src/jdk.jcmd/share/classes/sun/tools/jstat/ColumnFormat.java
+++ b/src/jdk.jcmd/share/classes/sun/tools/jstat/ColumnFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,6 @@
  */
 
 package sun.tools.jstat;
-
-import java.util.*;
 
 /**
  * A class to represent the format for a column of data.
@@ -156,9 +154,8 @@ public class ColumnFormat extends OptionFormat {
                 + ";scale=" + scale.toString() + ";align=" + align.toString()
                 + ";required=" + required);
 
-        for (Iterator<OptionFormat> i = children.iterator();  i.hasNext(); /* empty */) {
-            OptionFormat of = i.next();
-            of.printFormat(indentLevel+1);
+        for (OptionFormat of : children) {
+            of.printFormat(indentLevel + 1);
         }
 
         System.out.println(indent + "}");

--- a/src/jdk.jcmd/share/classes/sun/tools/jstat/OptionFormat.java
+++ b/src/jdk.jcmd/share/classes/sun/tools/jstat/OptionFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,15 +77,14 @@ public class OptionFormat {
 
     public void apply(Closure c) throws MonitorException {
 
-      for (Iterator<OptionFormat> i = children.iterator(); i.hasNext(); /* empty */) {
-          OptionFormat o = i.next();
-          c.visit(o, i.hasNext());
-      }
+        for (Iterator<OptionFormat> i = children.iterator(); i.hasNext(); /* empty */) {
+            OptionFormat o = i.next();
+            c.visit(o, i.hasNext());
+        }
 
-      for (Iterator <OptionFormat>i = children.iterator(); i.hasNext(); /* empty */) {
-          OptionFormat o = i.next();
-          o.apply(c);
-      }
+        for (OptionFormat o : children) {
+            o.apply(c);
+        }
     }
 
     public void printFormat() {

--- a/src/jdk.jcmd/share/classes/sun/tools/jstat/Parser.java
+++ b/src/jdk.jcmd/share/classes/sun/tools/jstat/Parser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,7 +80,7 @@ public class Parser {
     };
 
 
-    private static Set<String> reservedWords;
+    private static final Set<String> reservedWords = Set.of(otherKeyWords);
 
     private StreamTokenizer st;
     private String filename;
@@ -103,17 +103,12 @@ public class Parser {
         st.slashSlashComments(true);
         st.slashStarComments(true);
 
-        reservedWords = new HashSet<String>();
-        for (int i = 0; i < otherKeyWords.length; i++) {
-            reservedWords.add(otherKeyWords[i]);
+        for (char delimiter : delimiters) {
+            st.ordinaryChar(delimiter);
         }
 
-        for (int i = 0; i < delimiters.length; i++ ) {
-            st.ordinaryChar(delimiters[i]);
-        }
-
-        for (int i = 0; i < infixOps.length; i++ ) {
-            st.ordinaryChar(infixOps[i]);
+        for (char infixOp : infixOps) {
+            st.ordinaryChar(infixOp);
         }
     }
 
@@ -231,8 +226,8 @@ public class Parser {
      * determine if the give work is a reserved key word
      */
     private boolean isInfixOperator(char op) {
-        for (int i = 0; i < infixOps.length; i++) {
-            if (op == infixOps[i]) {
+        for (char infixOp : infixOps) {
+            if (op == infixOp) {
                 return true;
             }
         }

--- a/src/jdk.jcmd/share/classes/sun/tools/jstat/RawOutputFormatter.java
+++ b/src/jdk.jcmd/share/classes/sun/tools/jstat/RawOutputFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,8 +48,7 @@ public class RawOutputFormatter implements OutputFormatter {
         if (header == null) {
             // build the header string and prune out any unwanted monitors
             StringBuilder headerBuilder = new StringBuilder();
-            for (Iterator<Monitor> i = logged.iterator(); i.hasNext(); /* empty */ ) {
-                Monitor m = i.next();
+            for (Monitor m : logged) {
                 headerBuilder.append(m.getName()).append(' ');
             }
             header = headerBuilder.toString();
@@ -60,8 +59,7 @@ public class RawOutputFormatter implements OutputFormatter {
     public String getRow() throws MonitorException {
         StringBuilder row = new StringBuilder();
         int count = 0;
-        for (Iterator<Monitor> i = logged.iterator(); i.hasNext(); /* empty */ ) {
-            Monitor m = i.next();
+        for (Monitor m : logged) {
             if (count++ > 0) {
                 row.append(" ");
             }


### PR DESCRIPTION
There are few places in code where manual `for` loop is used with Iterator to iterate over Collection or Array.
Instead of manual `for` cycles it's preferred to use enhanced-for cycle instead: it's less verbose, makes code easier to read and it's less error-prone.
It doesn't have any performance impact: javac compiler generates similar code when compiling enhanced-for cycle.

One strange thing I also noticed is static field `sun.tools.jstat.Parser#reservedWords`, which filled in `Parser` constructor. Reworked to initialize it once.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274261](https://bugs.openjdk.java.net/browse/JDK-8274261): Use enhanced-for instead of plain 'for' in jdk.jcmd


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5673/head:pull/5673` \
`$ git checkout pull/5673`

Update a local copy of the PR: \
`$ git checkout pull/5673` \
`$ git pull https://git.openjdk.java.net/jdk pull/5673/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5673`

View PR using the GUI difftool: \
`$ git pr show -t 5673`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5673.diff">https://git.openjdk.java.net/jdk/pull/5673.diff</a>

</details>
