### PR TITLE
8274143 Disable "invalid entry for security.provider.X" error message in log file when security.provider.X is empty

### DIFF
--- a/src/java.base/share/classes/sun/security/jca/ProviderList.java
+++ b/src/java.base/share/classes/sun/security/jca/ProviderList.java
@@ -178,8 +178,10 @@ public final class ProviderList {
         while ((entry = Security.getProperty("security.provider." + i)) != null) {
             entry = entry.trim();
             if (entry.isEmpty()) {
-                System.err.println("invalid entry for " +
+                if (debug != null) {
+                    debug.println("empty entry for " +
                                    "security.provider." + i);
+                }
                 break;
             }
             int k = entry.indexOf(' ');


### PR DESCRIPTION
The default list of providers defined in java.security file can be overridden with a custom file, declared with `-Djava.security.properties=/path/to/custom.security` command line parameter.
If the new list of providers is shorter than the original one, it is necessary to add an empty entry to terminate the list, like:
```
security.provider.1=BCFIPS C:HYBRID;ENABLE{All}
security.provider.2=SUN
security.provider.3=BCJSSE fips:BCFIPS
security.provider.4=
```
otherwise some providers from the default list will still be used.

Currently Java outputs an error message on standard error when it encounters an empty entry on the provider list. This PR silences that message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274143](https://bugs.openjdk.java.net/browse/JDK-8274143): Disable "invalid entry for security.provider.X" error message in log file when security.provider.X is empty


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5674/head:pull/5674` \
`$ git checkout pull/5674`

Update a local copy of the PR: \
`$ git checkout pull/5674` \
`$ git pull https://git.openjdk.java.net/jdk pull/5674/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5674`

View PR using the GUI difftool: \
`$ git pr show -t 5674`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5674.diff">https://git.openjdk.java.net/jdk/pull/5674.diff</a>

</details>
