### PR TITLE
8274265: Suspicious string concatenation in logTestUtils.inline.hpp

### DIFF
--- a/test/hotspot/gtest/logging/logTestUtils.inline.hpp
+++ b/test/hotspot/gtest/logging/logTestUtils.inline.hpp
@@ -32,7 +32,7 @@
 #define LOG_TEST_STRING_LITERAL "a (hopefully) unique log message for testing"
 
 static const char* invalid_selection_substr[] = {
-  "=", "+", " ", "+=", "+=*", "*+", " +", "**", "++", ".", ",", ",," ",+",
+  "=", "+", " ", "+=", "+=*", "*+", " +", "**", "++", ".", ",", ",,", ",+",
   " *", "all+", "all*", "+all", "+all=Warning", "==Info", "=InfoWarning",
   "BadTag+", "logging++", "logging*+", ",=", "gc+gc+"
 };

--- a/test/hotspot/gtest/logging/test_logFileOutput.cpp
+++ b/test/hotspot/gtest/logging/test_logFileOutput.cpp
@@ -74,7 +74,7 @@ TEST_VM(LogFileOutput, parse_invalid) {
     "filecount= 2", "filesize=2 ",
     "filecount=ab", "filesize=0xz",
     "filecount=1MB", "filesize=99bytes",
-    "filesize=9999999999999999999999999"
+    "filesize=9999999999999999999999999",
     "filecount=9999999999999999999999999"
   };
 


### PR DESCRIPTION
This patch fixes the mishap, and lets JDK compile under XCode 13 / LLVM 13.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274265](https://bugs.openjdk.java.net/browse/JDK-8274265): Suspicious string concatenation in logTestUtils.inline.hpp


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)
 * [Matthias Baesken](https://openjdk.java.net/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5675/head:pull/5675` \
`$ git checkout pull/5675`

Update a local copy of the PR: \
`$ git checkout pull/5675` \
`$ git pull https://git.openjdk.java.net/jdk pull/5675/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5675`

View PR using the GUI difftool: \
`$ git pr show -t 5675`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5675.diff">https://git.openjdk.java.net/jdk/pull/5675.diff</a>

</details>
