### PR TITLE
8274276: Cache normalizedBase URL in URLClassPath.FileLoader

### DIFF
--- a/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
+++ b/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
@@ -1193,7 +1193,8 @@ public class URLClassPath {
      */
     private static class FileLoader extends Loader {
         /* Canonicalized File */
-        private File dir;
+        private final File dir;
+        private final URL normalizedBase;
 
         /*
          * Creates a new FileLoader for the specified URL with a file protocol.
@@ -1203,6 +1204,7 @@ public class URLClassPath {
             String path = url.getFile().replace('/', File.separatorChar);
             path = ParseUtil.decode(path);
             dir = (new File(path)).getCanonicalFile();
+            normalizedBase = new URL(getBaseURL(), ".");
         }
 
         /*
@@ -1221,7 +1223,6 @@ public class URLClassPath {
         Resource getResource(final String name, boolean check) {
             final URL url;
             try {
-                URL normalizedBase = new URL(getBaseURL(), ".");
                 url = new URL(getBaseURL(), ParseUtil.encodePath(name, false));
 
                 if (url.getFile().startsWith(normalizedBase.getFile()) == false) {

--- a/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
+++ b/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
@@ -593,7 +593,7 @@ public class URLClassPath {
         /*
          * Returns the base URL for this Loader.
          */
-        URL getBaseURL() {
+        final URL getBaseURL() {
             return base;
         }
 


### PR DESCRIPTION
Currently on each invocation of `URLClassPath.FileLoader.getResource()` `normalizedBase` URL is recalculated using same final `baseURL` from parent class. This can be avoided giving significant improvement in memory consumption. Consider the benchmark:
```java
@State(Scope.Benchmark)
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@Fork(jvmArgsAppend = {"-Xms2g", "-Xmx2g"})
public class URLClassPathBenchmark {
    private final ClassLoader classLoader = getClass().getClassLoader();

    @Benchmark
    public URL getResource() {
        return classLoader.getResource("file:./config/application.properties");
    }
}
```
it demonstrates improvement brought in by this patch:
```
before
Benchmark                                                           Mode  Cnt     Score     Error   Units
URLClassPathBenchmark.getResource                                   avgt   50  2840,746 ±  22,206   ns/op
URLClassPathBenchmark.getResource:·gc.alloc.rate                    avgt   50   645,313 ±   8,072  MB/sec
URLClassPathBenchmark.getResource:·gc.alloc.rate.norm               avgt   50  2403,258 ±  17,639    B/op
URLClassPathBenchmark.getResource:·gc.churn.G1_Eden_Space           avgt   50   656,624 ± 116,090  MB/sec
URLClassPathBenchmark.getResource:·gc.churn.G1_Eden_Space.norm      avgt   50  2450,175 ± 440,011    B/op
URLClassPathBenchmark.getResource:·gc.churn.G1_Survivor_Space       avgt   50     0,123 ±   0,149  MB/sec
URLClassPathBenchmark.getResource:·gc.churn.G1_Survivor_Space.norm  avgt   50     0,459 ±   0,556    B/op
URLClassPathBenchmark.getResource:·gc.count                         avgt   50    67,000            counts
URLClassPathBenchmark.getResource:·gc.time                          avgt   50   117,000                ms

after
Benchmark                                                           Mode  Cnt     Score    Error   Units
URLClassPathBenchmark.getResource                                   avgt  100  2596,719 ±  9,786   ns/op
URLClassPathBenchmark.getResource:·gc.alloc.rate                    avgt  100   448,780 ±  1,684  MB/sec
URLClassPathBenchmark.getResource:·gc.alloc.rate.norm               avgt  100  1528,040 ±  0,005    B/op
URLClassPathBenchmark.getResource:·gc.churn.G1_Eden_Space           avgt  100   479,905 ± 23,369  MB/sec
URLClassPathBenchmark.getResource:·gc.churn.G1_Eden_Space.norm      avgt  100  1634,314 ± 79,821    B/op
URLClassPathBenchmark.getResource:·gc.churn.G1_Survivor_Space       avgt  100     0,101 ±  0,097  MB/sec
URLClassPathBenchmark.getResource:·gc.churn.G1_Survivor_Space.norm  avgt  100     0,345 ±  0,329    B/op
URLClassPathBenchmark.getResource:·gc.count                         avgt  100    98,000           counts
URLClassPathBenchmark.getResource:·gc.time                          avgt  100   218,000               ms
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274276](https://bugs.openjdk.java.net/browse/JDK-8274276): Cache normalizedBase URL in URLClassPath.FileLoader


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5677/head:pull/5677` \
`$ git checkout pull/5677`

Update a local copy of the PR: \
`$ git checkout pull/5677` \
`$ git pull https://git.openjdk.java.net/jdk pull/5677/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5677`

View PR using the GUI difftool: \
`$ git pr show -t 5677`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5677.diff">https://git.openjdk.java.net/jdk/pull/5677.diff</a>

</details>
