### PR TITLE
8273410: IR verification framework fails with "Should find method name in validIrRulesMap"

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
@@ -619,13 +619,16 @@ public class TestVM {
         DeclaredTest test = declaredTests.get(testMethod);
         checkCheckedTest(m, checkAnno, runAnno, testMethod, test);
         test.setAttachedMethod(m);
+        TestFormat.check(getAnnotation(testMethod, Arguments.class) != null || testMethod.getParameterCount() == 0,
+                         "Missing @Arguments annotation to define arguments of " + testMethod + " required by "
+                         + "checked test " + m);
         CheckedTest.Parameter parameter = getCheckedTestParameter(m, testMethod);
         dontCompileAndDontInlineMethod(m);
         CheckedTest checkedTest = new CheckedTest(test, m, checkAnno, parameter, shouldExcludeTest(testMethod.getName()));
         allTests.add(checkedTest);
         if (PRINT_VALID_IR_RULES) {
             // Only need to emit IR verification information if IR verification is actually performed.
-            irMatchRulePrinter.emitRuleEncoding(m, checkedTest.isSkipped());
+            irMatchRulePrinter.emitRuleEncoding(testMethod, checkedTest.isSkipped());
         }
     }
 

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestBadFormat.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestBadFormat.java
@@ -139,6 +139,13 @@ class BadArgumentsAnnotation {
     @Test
     public void noArgAnnotation(int a) {}
 
+    @FailCount(0) // Combined with both checkNoArgAnnotation2() below
+    @Test
+    public void noArgAnnotation2(int a) {}
+
+    @Check(test = "noArgAnnotation2")
+    public void checkNoArgAnnotation2() {}
+
     @Test
     @Arguments(Argument.DEFAULT)
     public void argNumberMismatch(int a, int b) {}

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestCheckedTests.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestCheckedTests.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package ir_framework.tests;
+
+import compiler.lib.ir_framework.*;
+import compiler.lib.ir_framework.driver.IRViolationException;
+import compiler.lib.ir_framework.driver.TestVMException;
+import jdk.test.lib.Asserts;
+
+/*
+ * @test
+ * @requires vm.debug == true & vm.compMode != "Xint" & vm.compiler2.enabled & vm.flagless
+ * @summary Test different custom run tests.
+ * @library /test/lib /testlibrary_tests /
+ * @run driver ir_framework.tests.TestCheckedTests
+ */
+
+public class TestCheckedTests {
+    public int iFld;
+
+    public static void main(String[] args) {
+        TestFramework.run();
+        try {
+            TestFramework.run(BadIRAndRuntimeCheckedTests.class);
+            Utils.shouldHaveThrownException();
+        } catch (TestVMException e) {
+            Asserts.assertTrue(e.getExceptionInfo().contains("Test Failures (2)"));
+            Asserts.assertTrue(e.getExceptionInfo().contains("checkTestBad3"));
+            Asserts.assertTrue(e.getExceptionInfo().contains("checkTestBad5"));
+            Asserts.assertTrue(e.getExceptionInfo().split("BadCheckedTestException").length == 3);
+            Asserts.assertFalse(e.getExceptionInfo().contains("Failed IR Rules"));
+        }
+
+        try {
+            TestFramework.run(BadIRCheckedTests.class);
+            Utils.shouldHaveThrownException();
+        } catch (IRViolationException e) {
+            Asserts.assertTrue(e.getExceptionInfo().contains("Failed IR Rules (3)"));
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.STORE_I, "1"})
+    public void testGood1() {
+        iFld = 3;
+    }
+
+    @Check(test = "testGood1")
+    public void checkTestGood1(TestInfo info) {
+    }
+
+    @Test
+    @IR(failOn = IRNode.LOAD)
+    public int testGood2() {
+        iFld = 3;
+        return 3;
+    }
+
+    @Check(test = "testGood2")
+    public void sameName(int retValue) {
+        if (retValue != 3) {
+            throw new RuntimeException("must be 3 but was " + retValue);
+        }
+    }
+
+    @Test
+    @Arguments(Argument.NUMBER_42)
+    @IR(failOn = IRNode.LOAD)
+    @IR(counts = {IRNode.STORE_I, "0"})
+    public int testGood3(int x) {
+        return x;
+    }
+
+    @Check(test = "testGood3")
+    public void sameName(int retValue, TestInfo info) {
+        if (retValue != 42) {
+            throw new RuntimeException("must be 42");
+        }
+    }
+}
+
+class BadIRAndRuntimeCheckedTests {
+    public int iFld;
+
+    @Test
+    @IR(counts = {IRNode.STORE_I, "2"})
+    public void testBad1() {
+        iFld = 3;
+    }
+
+    @Check(test = "testBad1")
+    public void checkTestBad1(TestInfo info) {
+    }
+
+    @Test
+    @IR(failOn = IRNode.STORE_I)
+    public int testBad2() {
+        iFld = 3;
+        return 3;
+    }
+
+    @Check(test = "testBad2")
+    public void sameName(int retValue) {
+        if (retValue != 3) {
+            throw new RuntimeException("must be 3");
+        }
+    }
+
+    @Test
+    @Arguments(Argument.NUMBER_42)
+    public int testBad3(int x) {
+        return x;
+    }
+
+    @Check(test = "testBad3")
+    public void checkTestBad3(int retValue) {
+        if (retValue == 42) {
+            // Always
+            throw new BadCheckedTestException("expected");
+        }
+    }
+
+    @Test
+    @Arguments(Argument.NUMBER_42)
+    @IR(failOn = IRNode.LOAD)
+    @IR(counts = {IRNode.STORE_I, "1"})
+    public int testBad4(int x) {
+        return x;
+    }
+
+    @Check(test = "testBad4")
+    public void sameName(int retValue, TestInfo info) {
+        if (retValue != 42) {
+            throw new RuntimeException("must be 42");
+        }
+    }
+
+    @Test
+    @Arguments(Argument.NUMBER_42)
+    public int testBad5(int x) {
+        return x;
+    }
+
+    @Check(test = "testBad5")
+    public void checkTestBad5(int retValue) {
+        if (retValue == 42) {
+            // Always
+            throw new BadCheckedTestException("expected");
+        }
+    }
+}
+
+class BadIRCheckedTests {
+    public int iFld;
+
+    @Test
+    @IR(counts = {IRNode.STORE_I, "2"})
+    public void testBad1() {
+        iFld = 3;
+    }
+
+    @Check(test = "testBad1")
+    public void checkTestBad1(TestInfo info) {
+    }
+
+    @Test
+    @IR(failOn = IRNode.STORE_I)
+    public int testBad2() {
+        iFld = 3;
+        return 3;
+    }
+
+    @Check(test = "testBad2")
+    public void sameName(int retValue) {
+        if (retValue != 3) {
+            throw new RuntimeException("must be 3");
+        }
+    }
+
+
+    @Test
+    @Arguments(Argument.NUMBER_42)
+    @IR(failOn = IRNode.LOAD)
+    @IR(counts = {IRNode.STORE_I, "1"})
+    public int testBad4(int x) {
+        return x;
+    }
+
+    @Check(test = "testBad4")
+    public void sameName(int retValue, TestInfo info) {
+        if (retValue != 42) {
+            throw new RuntimeException("must be 42");
+        }
+    }
+}
+
+class BadCheckedTestException extends RuntimeException {
+    BadCheckedTestException(String s) {
+        super(s);
+    }
+}

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestCheckedTests.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestCheckedTests.java
@@ -30,6 +30,7 @@ import jdk.test.lib.Asserts;
 
 /*
  * @test
+ * @bug 8273410
  * @requires vm.debug == true & vm.compMode != "Xint" & vm.compiler2.enabled & vm.flagless
  * @summary Test different custom run tests.
  * @library /test/lib /testlibrary_tests /
@@ -197,7 +198,6 @@ class BadIRCheckedTests {
             throw new RuntimeException("must be 3");
         }
     }
-
 
     @Test
     @Arguments(Argument.NUMBER_42)


### PR DESCRIPTION
The IR framework treated a `@Check` method as `@Test` method instead of the `@Test` method itself at IR matching time resulting in an internal framework exception.

While writing some tests for checked test I've noticed that a missing `@Arguments` annotation is not reported as `TestFormatException` but with a `RuntimeException` later when invoking the method in question. I also added the missing check for it.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273410](https://bugs.openjdk.java.net/browse/JDK-8273410): IR verification framework fails with "Should find method name in validIrRulesMap"


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to e2a5d83edc38c6b46768900c67078df1c9940696
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5678/head:pull/5678` \
`$ git checkout pull/5678`

Update a local copy of the PR: \
`$ git checkout pull/5678` \
`$ git pull https://git.openjdk.java.net/jdk pull/5678/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5678`

View PR using the GUI difftool: \
`$ git pr show -t 5678`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5678.diff">https://git.openjdk.java.net/jdk/pull/5678.diff</a>

</details>
