### PR TITLE
JDK-8274283: string-concatenation build warning as error with clang 13 on macOS aarch64

### DIFF
--- a/test/hotspot/gtest/logging/logTestUtils.inline.hpp
+++ b/test/hotspot/gtest/logging/logTestUtils.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@
 #define LOG_TEST_STRING_LITERAL "a (hopefully) unique log message for testing"
 
 static const char* invalid_selection_substr[] = {
-  "=", "+", " ", "+=", "+=*", "*+", " +", "**", "++", ".", ",", ",," ",+",
+  "=", "+", " ", "+=", "+=*", "*+", " +", "**", "++", ".", ",", ",,", ",+",
   " *", "all+", "all*", "+all", "+all=Warning", "==Info", "=InfoWarning",
   "BadTag+", "logging++", "logging*+", ",=", "gc+gc+"
 };


### PR DESCRIPTION
Please review this small fix fixing builds using clang 13.
We run into this error when compiling with clang version 13.0.0 (clang-1300.0.29.3) :

/test/hotspot/gtest/logging/logTestUtils.inline.hpp:35:70: error: suspicious concatenation of string literals in an array initialization; did you mean to separate the elements with a comma? [-Werror,-Wstring-concatenation]
  "=", "+", " ", "+=", "+=*", "*+", " +", "**", "++", ".", ",", ",," ",+",

Looks like the is a "," missing ? Or if it was intentional should we write ",,,+" ?

Thanks, Matthias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8274283](https://bugs.openjdk.java.net/browse/JDK-8274283): string-concatenation build warning as error with clang 13 on macOS aarch64


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5680/head:pull/5680` \
`$ git checkout pull/5680`

Update a local copy of the PR: \
`$ git checkout pull/5680` \
`$ git pull https://git.openjdk.java.net/jdk pull/5680/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5680`

View PR using the GUI difftool: \
`$ git pr show -t 5680`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5680.diff">https://git.openjdk.java.net/jdk/pull/5680.diff</a>

</details>
