### PR TITLE
8274196: Crashes in VM_HeapDumper::work after JDK-8252842

### DIFF
--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -1598,7 +1598,7 @@ class JNILocalsDumper : public OopClosure {
 
 void JNILocalsDumper::do_oop(oop* obj_p) {
   // ignore null handles
-  oop o = NativeAccess<AS_NO_KEEPALIVE>::oop_load(obj_p);
+  oop o = *obj_p;
   if (o != NULL) {
     u4 size = 1 + sizeof(address) + 4 + 4;
     writer()->start_sub_record(HPROF_GC_ROOT_JNI_LOCAL, size);

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -748,7 +748,7 @@ class ParDumpWriter : public AbstractDumpWriter {
 
   static void before_work() {
     assert(_lock == NULL, "ParDumpWriter lock must be initialized only once");
-    _lock = new (std::nothrow) PaddedMonitor(Mutex::leaf, "Parallel HProf writer lock", Mutex::_safepoint_check_never);
+    _lock = new (std::nothrow) PaddedMonitor(Mutex::leaf, "ParallelHProfWriter_lock", Mutex::_safepoint_check_always);
   }
 
   static void after_work() {
@@ -1814,8 +1814,8 @@ class DumperController : public CHeapObj<mtInternal> {
  public:
    DumperController(uint number) :
      _started(false),
-     _lock(new (std::nothrow) PaddedMonitor(Mutex::leaf, "Dumper Controller lock",
-    Mutex::_safepoint_check_never)),
+     _lock(new (std::nothrow) PaddedMonitor(Mutex::leaf, "DumperController_lock",
+    Mutex::_safepoint_check_always)),
      _dumper_number(number),
      _complete_number(0) { }
 
@@ -1910,11 +1910,11 @@ class VM_HeapDumper : public VM_GC_Operation, public AbstractGangTask {
       _num_writer_threads = 1;
       _num_dumper_threads = num_total - _num_writer_threads;
     }
-    // Number of dumper threads that only iterate heap.
-    uint _heap_only_dumper_threads = _num_dumper_threads - 1 /* VMDumper thread */;
     // Prepare parallel writer.
     if (_num_dumper_threads > 1) {
       ParDumpWriter::before_work();
+      // Number of dumper threads that only iterate heap.
+      uint _heap_only_dumper_threads = _num_dumper_threads - 1 /* VMDumper thread */;
       _dumper_controller = new (std::nothrow) DumperController(_heap_only_dumper_threads);
       _poi = Universe::heap()->parallel_object_iterator(_num_dumper_threads);
     }
@@ -2252,6 +2252,9 @@ void VM_HeapDumper::doit() {
   WorkGang* gang = ch->safepoint_workers();
 
   if (gang == NULL) {
+    // Use serial dump, set dumper threads and writer threads number to 1.
+    _num_dumper_threads=1;
+    _num_writer_threads=1;
     work(0);
   } else {
     prepare_parallel_dump(gang->active_workers());
@@ -2305,23 +2308,8 @@ void VM_HeapDumper::work(uint worker_id) {
       ClassLoaderDataGraph::classes_do(&locked_dump_class);
     }
     Universe::basic_type_classes_do(&do_basic_type_array_class_dump);
-
-    // HPROF_GC_ROOT_THREAD_OBJ + frames + jni locals
-    do_threads();
-
-    // HPROF_GC_ROOT_JNI_GLOBAL
-    JNIGlobalsDumper jni_dumper(writer());
-    JNIHandles::oops_do(&jni_dumper);
-    // technically not jni roots, but global roots
-    // for things like preallocated throwable backtraces
-    Universe::vm_global()->oops_do(&jni_dumper);
-
-    // HPROF_GC_ROOT_STICKY_CLASS
-    // These should be classes in the NULL class loader data, and not all classes
-    // if !ClassUnloading
-    StickyClassDumper class_dumper(writer());
-    ClassLoaderData::the_null_class_loader_data()->classes_do(&class_dumper);
   }
+
   // writes HPROF_GC_INSTANCE_DUMP records.
   // After each sub-record is written check_segment_length will be invoked
   // to check if the current segment exceeds a threshold. If so, a new
@@ -2353,10 +2341,8 @@ void VM_HeapDumper::work(uint worker_id) {
          _dumper_controller->wait_all_dumpers_complete();
          // clear internal buffer;
          pw.finish_dump_segment(true);
-
          // refresh the global_writer's buffer and position;
          writer()->refresh();
-
        } else {
          pw.finish_dump_segment(true);
          _dumper_controller->dumper_complete();
@@ -2366,6 +2352,22 @@ void VM_HeapDumper::work(uint worker_id) {
   }
 
   assert(get_worker_type(worker_id) == VMDumperType, "Heap dumper must be VMDumper");
+  // HPROF_GC_ROOT_THREAD_OBJ + frames + jni locals
+  do_threads();
+
+  // HPROF_GC_ROOT_JNI_GLOBAL
+  JNIGlobalsDumper jni_dumper(writer());
+  JNIHandles::oops_do(&jni_dumper);
+  // technically not jni roots, but global roots
+  // for things like preallocated throwable backtraces
+  Universe::vm_global()->oops_do(&jni_dumper);
+
+  // HPROF_GC_ROOT_STICKY_CLASS
+  // These should be classes in the NULL class loader data, and not all classes
+  // if !ClassUnloading
+  StickyClassDumper class_dumper(writer());
+  ClassLoaderData::the_null_class_loader_data()->classes_do(&class_dumper);
+
   // Use writer() rather than ParDumpWriter to avoid memory consumption.
   HeapObjectDumper obj_dumper(writer());
   dump_large_objects(&obj_dumper);

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -2318,14 +2318,12 @@ void VM_HeapDumper::work(uint worker_id) {
     // technically not jni roots, but global roots
     // for things like preallocated throwable backtraces
     Universe::vm_global()->oops_do(&jni_dumper);
-  
     // HPROF_GC_ROOT_STICKY_CLASS
     // These should be classes in the NULL class loader data, and not all classes
     // if !ClassUnloading
     StickyClassDumper class_dumper(writer());
     ClassLoaderData::the_null_class_loader_data()->classes_do(&class_dumper);
   }
-
   // writes HPROF_GC_INSTANCE_DUMP records.
   // After each sub-record is written check_segment_length will be invoked
   // to check if the current segment exceeds a threshold. If so, a new

--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -44,6 +44,3 @@ serviceability/sa/TestJmapCoreMetaspace.java                  8268722,8268636   
 serviceability/sa/TestJhsdbJstackMixed.java                   8248912   generic-all
 serviceability/sa/ClhsdbPstack.java#process                   8248912   generic-all
 serviceability/sa/ClhsdbPstack.java#core                      8248912   generic-all
-
-serviceability/dcmd/gc/HeapDumpAllTest.java                   8274196   linux-all,windows-all
-serviceability/dcmd/gc/HeapDumpTest.java                      8274196   linux-all,windows-all

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -818,11 +818,6 @@ sun/tools/jstat/jstatLineCounts2.sh                             8268211 linux-aa
 sun/tools/jstat/jstatLineCounts3.sh                             8268211 linux-aarch64
 sun/tools/jstat/jstatLineCounts4.sh                             8268211 linux-aarch64
 
-sun/tools/jmap/BasicJMapTest.java#G1                            8274245 generic-all
-sun/tools/jmap/BasicJMapTest.java#Parallel                      8274245 generic-all
-sun/tools/jmap/BasicJMapTest.java#Serial                        8274245 generic-all
-sun/tools/jmap/BasicJMapTest.java#Z                             8274245 generic-all
-
 ############################################################################
 
 # jdk_other


### PR DESCRIPTION
The root cause for crash in ZGC is that the JNIHandles are processed before object iteration. And ZGC would update the JNIHandles at object iteration with read barrier. So the crash is cause by accessing the invalid address which can be dummy info after zgc, and hence crash.

The lock rank issue can be fixed because the related mutexes are acquired in safepoint. so the safepoint_check_required could be safepoint_check_always.

The Epsilon issue is caused by wrong _num_dumper_thread calculated when the gang==NULL.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8274196](https://bugs.openjdk.java.net/browse/JDK-8274196): Crashes in VM_HeapDumper::work after JDK-8252842
 * [JDK-8274245](https://bugs.openjdk.java.net/browse/JDK-8274245): sun/tools/jmap/BasicJMapTest.java Mutex rank failures


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to fca03cb619678001ae2827f09deea0e6e070a980
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5681/head:pull/5681` \
`$ git checkout pull/5681`

Update a local copy of the PR: \
`$ git checkout pull/5681` \
`$ git pull https://git.openjdk.java.net/jdk pull/5681/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5681`

View PR using the GUI difftool: \
`$ git pr show -t 5681`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5681.diff">https://git.openjdk.java.net/jdk/pull/5681.diff</a>

</details>
