### PR TITLE
8273790: Potential cyclic dependencies between Gregorian and CalendarSystem

### DIFF
--- a/src/java.base/share/classes/sun/util/calendar/CalendarSystem.java
+++ b/src/java.base/share/classes/sun/util/calendar/CalendarSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,7 +111,7 @@ public abstract class CalendarSystem {
         }
     }
 
-    private static final Gregorian GREGORIAN_INSTANCE = new Gregorian();
+    private static volatile Gregorian GREGORIAN_INSTANCE;
 
     /**
      * Returns the singleton instance of the <code>Gregorian</code>
@@ -120,7 +120,17 @@ public abstract class CalendarSystem {
      * @return the <code>Gregorian</code> instance
      */
     public static Gregorian getGregorianCalendar() {
-        return GREGORIAN_INSTANCE;
+        var gCal = GREGORIAN_INSTANCE;
+        if (gCal != null) {
+            return gCal;
+        }
+        synchronized (CalendarSystem.class) {
+            gCal = GREGORIAN_INSTANCE;
+            if (gCal == null) {
+                gCal = GREGORIAN_INSTANCE = new Gregorian();
+            }
+        }
+        return gCal;
     }
 
     /**
@@ -135,7 +145,7 @@ public abstract class CalendarSystem {
      */
     public static CalendarSystem forName(String calendarName) {
         if ("gregorian".equals(calendarName)) {
-            return GREGORIAN_INSTANCE;
+            return getGregorianCalendar();
         }
 
         if (!initialized) {

--- a/src/java.base/share/classes/sun/util/calendar/CalendarSystem.java
+++ b/src/java.base/share/classes/sun/util/calendar/CalendarSystem.java
@@ -111,7 +111,9 @@ public abstract class CalendarSystem {
         }
     }
 
-    private static volatile Gregorian GREGORIAN_INSTANCE;
+    private static final class GregorianHolder {
+        private static final Gregorian GREGORIAN_INSTANCE = new Gregorian();
+    }
 
     /**
      * Returns the singleton instance of the <code>Gregorian</code>
@@ -120,17 +122,7 @@ public abstract class CalendarSystem {
      * @return the <code>Gregorian</code> instance
      */
     public static Gregorian getGregorianCalendar() {
-        var gCal = GREGORIAN_INSTANCE;
-        if (gCal != null) {
-            return gCal;
-        }
-        synchronized (CalendarSystem.class) {
-            gCal = GREGORIAN_INSTANCE;
-            if (gCal == null) {
-                gCal = GREGORIAN_INSTANCE = new Gregorian();
-            }
-        }
-        return gCal;
+        return GregorianHolder.GREGORIAN_INSTANCE;
     }
 
     /**
@@ -145,7 +137,7 @@ public abstract class CalendarSystem {
      */
     public static CalendarSystem forName(String calendarName) {
         if ("gregorian".equals(calendarName)) {
-            return getGregorianCalendar();
+            return GregorianHolder.GREGORIAN_INSTANCE;
         }
 
         if (!initialized) {

--- a/test/jdk/sun/util/calendar/CalendarSystemDeadLockTest.java
+++ b/test/jdk/sun/util/calendar/CalendarSystemDeadLockTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/**
+ * @test
+ * @bug 8273790
+ * @summary Verify that concurrent classloading of sun.util.calendar.Gregorian and
+ * sun.util.calendar.CalendarSystem doesn't lead to a deadlock
+ * @modules java.base/sun.util.calendar:open
+ * @run main/othervm CalendarSystemDeadLockTest
+ * @run main/othervm CalendarSystemDeadLockTest
+ * @run main/othervm CalendarSystemDeadLockTest
+ * @run main/othervm CalendarSystemDeadLockTest
+ * @run main/othervm CalendarSystemDeadLockTest
+ */
+public class CalendarSystemDeadLockTest {
+
+    public static void main(final String[] args) throws Exception {
+        testConcurrentClassLoad();
+    }
+
+    /**
+     * Loads {@code sun.util.calendar.Gregorian} and {@code sun.util.calendar.CalendarSystem}
+     * and invokes {@code sun.util.calendar.CalendarSystem#getGregorianCalendar()} concurrently
+     * in a thread of their own and expects the classloading of both those classes
+     * to succeed. Additionally, after these tasks are done, calls the
+     * sun.util.calendar.CalendarSystem#getGregorianCalendar() and expects it to return a singleton
+     * instance
+     */
+    private static void testConcurrentClassLoad() throws Exception {
+        final int numTasks = 7;
+        final CountDownLatch taskTriggerLatch = new CountDownLatch(numTasks);
+        final List<Callable<?>> tasks = new ArrayList<>();
+        // add the sun.util.calendar.Gregorian and sun.util.calendar.CalendarSystem for classloading.
+        // there are main 2 classes which had a cyclic call in their static init
+        tasks.add(new ClassLoadTask("sun.util.calendar.Gregorian", taskTriggerLatch));
+        tasks.add(new ClassLoadTask("sun.util.calendar.CalendarSystem", taskTriggerLatch));
+        // add a few other classes for classloading, those which call CalendarSystem#getGregorianCalendar()
+        // or CalendarSystem#forName() during their static init
+        tasks.add(new ClassLoadTask("java.util.GregorianCalendar", taskTriggerLatch));
+        tasks.add(new ClassLoadTask("java.util.Date", taskTriggerLatch));
+        tasks.add(new ClassLoadTask("java.util.JapaneseImperialCalendar", taskTriggerLatch));
+        // add a couple of tasks which directly invoke sun.util.calendar.CalendarSystem#getGregorianCalendar()
+        tasks.add(new GetGregorianCalTask(taskTriggerLatch));
+        tasks.add(new GetGregorianCalTask(taskTriggerLatch));
+        final ExecutorService executor = Executors.newFixedThreadPool(tasks.size());
+        try {
+            final Future<?>[] results = new Future[tasks.size()];
+            // submit
+            int i = 0;
+            for (final Callable<?> task : tasks) {
+                results[i++] = executor.submit(task);
+            }
+            // wait for completion
+            for (i = 0; i < tasks.size(); i++) {
+                results[i].get();
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+        // check that the sun.util.calendar.CalendarSystem#getGregorianCalendar() does indeed return
+        // a proper instance
+        final Object gCal = callCalSystemGetGregorianCal();
+        if (gCal == null) {
+            throw new RuntimeException("sun.util.calendar.CalendarSystem#getGregorianCalendar()" +
+                    " unexpectedly returned null");
+        }
+        // now verify that each call to getGregorianCalendar(), either in the tasks or here, returned the exact
+        // same instance
+        if (GetGregorianCalTask.instances.size() != 2) {
+            throw new RuntimeException("Unexpected number of results from call " +
+                    "to sun.util.calendar.CalendarSystem#getGregorianCalendar()");
+        }
+        // intentional identity check since sun.util.calendar.CalendarSystem#getGregorianCalendar() is
+        // expected to return a singleton instance
+        if ((gCal != GetGregorianCalTask.instances.get(0)) || (gCal != GetGregorianCalTask.instances.get(1))) {
+            throw new RuntimeException("sun.util.calendar.CalendarSystem#getGregorianCalendar()" +
+                    " returned different instances");
+        }
+    }
+
+    /**
+     * Reflectively calls sun.util.calendar.CalendarSystem#getGregorianCalendar() and returns
+     * the result
+     */
+    private static Object callCalSystemGetGregorianCal() throws Exception {
+        final Class<?> k = Class.forName("sun.util.calendar.CalendarSystem");
+        return k.getDeclaredMethod("getGregorianCalendar").invoke(null);
+    }
+
+    private static class ClassLoadTask implements Callable<Class<?>> {
+        private final String className;
+        private final CountDownLatch latch;
+
+        private ClassLoadTask(final String className, final CountDownLatch latch) {
+            this.className = className;
+            this.latch = latch;
+        }
+
+        @Override
+        public Class<?> call() {
+            System.out.println(Thread.currentThread().getName() + " loading " + this.className);
+            try {
+                // let the other tasks know we are ready to trigger our work
+                latch.countDown();
+                // wait for the other task to let us know they are ready to trigger their work too
+                latch.await();
+                return Class.forName(this.className);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private static class GetGregorianCalTask implements Callable<Object> {
+        // keeps track of the instances returned by calls to sun.util.calendar.CalendarSystem#getGregorianCalendar()
+        // by this task
+        private static final List<Object> instances = Collections.synchronizedList(new ArrayList<>());
+        private final CountDownLatch latch;
+
+        private GetGregorianCalTask(final CountDownLatch latch) {
+            this.latch = latch;
+        }
+
+        @Override
+        public Object call() {
+            System.out.println(Thread.currentThread().getName()
+                    + " calling  sun.util.calendar.CalendarSystem#getGregorianCalendar()");
+            try {
+                // let the other tasks know we are ready to trigger our work
+                latch.countDown();
+                // wait for the other task to let us know they are ready to trigger their work too
+                latch.await();
+                final Object inst = callCalSystemGetGregorianCal();
+                instances.add(inst);
+                return inst;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/test/jdk/sun/util/calendar/CalendarSystemDeadLockTest.java
+++ b/test/jdk/sun/util/calendar/CalendarSystemDeadLockTest.java
@@ -72,6 +72,12 @@ public class CalendarSystemDeadLockTest {
         // add a couple of tasks which directly invoke sun.util.calendar.CalendarSystem#getGregorianCalendar()
         tasks.add(new GetGregorianCalTask(taskTriggerLatch));
         tasks.add(new GetGregorianCalTask(taskTriggerLatch));
+        // before triggering the tests make sure we have created the correct number of tasks
+        // the countdown latch uses/expects
+        if (numTasks != tasks.size()) {
+            throw new RuntimeException("Test setup failure - unexpected number of tasks " + tasks.size()
+                    + ", expected " + numTasks);
+        }
         final ExecutorService executor = Executors.newFixedThreadPool(tasks.size());
         try {
             final Future<?>[] results = new Future[tasks.size()];


### PR DESCRIPTION
Can I please get a review for this change which proposes to fix the issue reported in https://bugs.openjdk.java.net/browse/JDK-8273790?

As noted in that issue, trying to class load `sun.util.calendar.CalendarSystem` and `sun.util.calendar.Gregorian` concurrently in separate threads can lead to a deadlock because of the cyclic nature of the code in their static initialization. More specifically, consider this case:

 - Thread T1 initiates a classload on the `sun.util.calendar.CalendarSystem`.
 - This gives T1 the implicit class init lock on `CalendarSystem`. 
 - Consider thread T2 which at the same time initiates a classload on `sun.util.calendar.Gregorian` class.
 - This gives T2 a implicit class init lock on `Gregorian`.
 - T1, still holding a lock on `CalendarSystem` attempts to load `Gregorian` since it wants to create a (singleton) instance of `Gregorian` and assign it to the `static final GREGORIAN_INSTANCE` member. Since T2 is holding a class init lock on `Gregorian`, T1 ends up waiting
 - T2 on the other hand is still loading the `Gregorian` class. `Gregorian` itself "is a" `CalendarSystem`, so during this loading of `Gregorian` class, T2 starts travelling up the class hierarchy and asks for a lock on `CalendarSystem`. However T1 is holding this lock and as a result T2 ends up waiting on T1 which is waiting on T2. That triggers this deadlock.

The linked JBS issue has a thread dump which shows this in action.

The commit here delays the instance creation of `Gregorian` by moving that instance creation logic from the static initialization of the `CalendarSystem` class, to the first call to `CalendarSystem#getGregorianCalendar()`. This prevents the `CalendarSystem` from needing a lock on `Gregorian` during its static init (of course, unless some code in this static init flow calls `CalendarSystem#getGregorianCalendar()`, in which case it is back to square one. I have verified, both manually and through the jtreg test, that the code in question doesn't have such calls)

A new jtreg test has been introduced to reproduce the issue and verify the fix. The test in addition to loading these 2 classes in question, also additionally loads a few other classes concurrently. These classes have specific static initialization which leads the calls to `CalendarSystem#getGregorianCalendar()` or `CalendarSystem#forName()`. Including these classes in the tests ensures that this deadlock hasn't "moved" to a different location. I have run multiple runs (approximately 25) of this test with the fix and I haven't seen it deadlock anymore.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273790](https://bugs.openjdk.java.net/browse/JDK-8273790): Potential cyclic dependencies between Gregorian and CalendarSystem


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Yi Yang](https://openjdk.java.net/census#yyang) (@kelthuzadx - Committer)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5683/head:pull/5683` \
`$ git checkout pull/5683`

Update a local copy of the PR: \
`$ git checkout pull/5683` \
`$ git pull https://git.openjdk.java.net/jdk pull/5683/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5683`

View PR using the GUI difftool: \
`$ git pr show -t 5683`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5683.diff">https://git.openjdk.java.net/jdk/pull/5683.diff</a>

</details>
