### PR TITLE
8274282: Clarify special wait assert

### DIFF
--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -384,14 +384,20 @@ void Mutex::check_rank(Thread* thread) {
   if (owned_by_self()) {
     // wait() case
     Mutex* least = get_least_ranked_lock_besides_this(locks_owned);
-    // We enforce not holding locks of rank nosafepoint or lower while waiting.
+    // We enforce not holding locks of rank nosafepoint or lower while waiting for JavaThreads,
+    // because the held lock has a NoSafepointVerifier so waiting on a lock will block out safepoints.
+    // For NonJavaThreads, we enforce not waiting on the tty lock since that could block progress also.
     // Also "this" should be the monitor with lowest rank owned by this thread.
-    if (least != NULL && (least->rank() <= nosafepoint || least->rank() <= this->rank())) {
+    if (least != NULL && ((least->rank() <= Mutex::nosafepoint && thread->is_Java_thread()) ||
+                           least->rank() <= Mutex::tty ||
+                           least->rank() <= this->rank())) {
       assert(false, "Attempting to wait on monitor %s/%d while holding lock %s/%d -- "
              "possible deadlock. %s", name(), rank(), least->name(), least->rank(),
              least->rank() <= this->rank() ?
               "Should wait on the least ranked monitor from all owned locks." :
-              "Should not block(wait) while holding a lock of rank nosafepoint or below.");
+             thread->is_Java_thread() ?
+              "Should not block(wait) while holding a lock of rank nosafepoint or below." :
+              "Should not block(wait) while holding a lock of rank tty or below.");
     }
   } else {
     // lock()/lock_without_safepoint_check()/try_lock() case

--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -387,7 +387,7 @@ void Mutex::check_rank(Thread* thread) {
     // For JavaThreads, we enforce not holding locks of rank nosafepoint or lower while waiting
     // because the held lock has a NoSafepointVerifier so waiting on a lower ranked lock will not be
     // able to check for safepoints first with a TBIVM.
-    // For NonJavaThreads, we enforce not waiting on the tty lock since that could block progress also.
+    // For all threads, we enforce not waiting on the tty lock since that could block progress also.
     // Also "this" should be the monitor with lowest rank owned by this thread.
     if (least != NULL && ((least->rank() <= Mutex::nosafepoint && thread->is_Java_thread()) ||
                            least->rank() <= Mutex::tty ||

--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -384,8 +384,9 @@ void Mutex::check_rank(Thread* thread) {
   if (owned_by_self()) {
     // wait() case
     Mutex* least = get_least_ranked_lock_besides_this(locks_owned);
-    // We enforce not holding locks of rank nosafepoint or lower while waiting for JavaThreads,
-    // because the held lock has a NoSafepointVerifier so waiting on a lock will block out safepoints.
+    // For JavaThreads, we enforce not holding locks of rank nosafepoint or lower while waiting
+    // because the held lock has a NoSafepointVerifier so waiting on a lower ranked lock will not be
+    // able to check for safepoints first with a TBIVM.
     // For NonJavaThreads, we enforce not waiting on the tty lock since that could block progress also.
     // Also "this" should be the monitor with lowest rank owned by this thread.
     if (least != NULL && ((least->rank() <= Mutex::nosafepoint && thread->is_Java_thread()) ||

--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -387,7 +387,7 @@ void Mutex::check_rank(Thread* thread) {
     // For JavaThreads, we enforce not holding locks of rank nosafepoint or lower while waiting
     // because the held lock has a NoSafepointVerifier so waiting on a lower ranked lock will not be
     // able to check for safepoints first with a TBIVM.
-    // For all threads, we enforce not waiting on the tty lock since that could block progress also.
+    // For all threads, we enforce not holding the tty lock or below, since this could block progress also.
     // Also "this" should be the monitor with lowest rank owned by this thread.
     if (least != NULL && ((least->rank() <= Mutex::nosafepoint && thread->is_Java_thread()) ||
                            least->rank() <= Mutex::tty ||


### PR DESCRIPTION
This change removes the assert and tests for Mutex::wait() only allowed with greater than nosafepoint ranked held locks.
Tested with tier1-3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274282](https://bugs.openjdk.java.net/browse/JDK-8274282): Clarify special wait assert


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 5d988cdf93ef3847ba46ed7dceb9b963dd44356a
 * [Patricio Chilano Mateo](https://openjdk.java.net/census#pchilanomate) (@pchilano - Committer) ⚠️ Review applies to 5d988cdf93ef3847ba46ed7dceb9b963dd44356a


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5684/head:pull/5684` \
`$ git checkout pull/5684`

Update a local copy of the PR: \
`$ git checkout pull/5684` \
`$ git pull https://git.openjdk.java.net/jdk pull/5684/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5684`

View PR using the GUI difftool: \
`$ git pr show -t 5684`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5684.diff">https://git.openjdk.java.net/jdk/pull/5684.diff</a>

</details>
