### PR TITLE
8274296: Update or Problem List tests which may fail with uiScale=2 on macOS

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -749,6 +749,12 @@ javax/swing/JPopupMenu/4634626/bug4634626.java 8017175 macosx-all
 javax/swing/JButton/8151303/PressedIconTest.java 8266246 macosx-aarch64
 javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.java 8273573 macosx-all
 
+# Several tests which fail on some hidpi systems
+java/awt/GraphicsDevice/DisplayModes/CycleDMImage.java 8274106 macosx-aarch64
+java/awt/Window/8159168/SetShapeTest.java 8274106 macosx-aarch64
+java/awt/image/multiresolution/MultiResolutionJOptionPaneIconTest.java 8274106 macosx-aarch64
+javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8274106 macosx-aarch64
+
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8225012 windows-all,macosx-all
 sanity/client/SwingSet/src/ScrollPaneDemoTest.java 8225013 linux-all
 sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java 8265770 macosx-all

--- a/test/jdk/java/awt/Dialog/SiblingChildOrder/SiblingChildOrderTest.java
+++ b/test/jdk/java/awt/Dialog/SiblingChildOrder/SiblingChildOrderTest.java
@@ -26,7 +26,7 @@
  * @bug 8190230 8196360
  * @summary [macosx] Order of overlapping of modal dialogs is wrong
  * @key headful
- * @run main SiblingChildOrderTest
+ * @run main/othervm -Dsun.java2d.uiScale=1 SiblingChildOrderTest
  */
 
 import java.awt.Color;

--- a/test/jdk/java/awt/Paint/PaintNativeOnUpdate.java
+++ b/test/jdk/java/awt/Paint/PaintNativeOnUpdate.java
@@ -36,7 +36,7 @@ import java.awt.Point;
  * @library /lib/client
  * @build ExtendedRobot
  * @author Sergey Bylokhov
- * @run main PaintNativeOnUpdate
+ * @run main/othervm -Dsun.java2d.uiScale=1 PaintNativeOnUpdate
  */
 public final class PaintNativeOnUpdate extends Label {
 

--- a/test/jdk/java/awt/Window/BackgroundIsNotUpdated/BackgroundIsNotUpdated.java
+++ b/test/jdk/java/awt/Window/BackgroundIsNotUpdated/BackgroundIsNotUpdated.java
@@ -37,7 +37,7 @@ import java.awt.Window;
  * @author Sergey Bylokhov
  * @library /lib/client
  * @build ExtendedRobot
- * @run main BackgroundIsNotUpdated
+ * @run main/othervm -Dsun.java2d.uiScale=1 BackgroundIsNotUpdated
  */
 public final class BackgroundIsNotUpdated extends Window {
 

--- a/test/jdk/java/awt/Window/MultiWindowApp/ChildAlwaysOnTopTest.java
+++ b/test/jdk/java/awt/Window/MultiWindowApp/ChildAlwaysOnTopTest.java
@@ -28,7 +28,7 @@
  *          certain scenarios
  * @bug 8021961
  * @author Semyon Sadetsky
- * @run main ChildAlwaysOnTopTest
+ * @run main/othervm -Dsun.java2d.uiScale=1 ChildAlwaysOnTopTest
  */
 
 import javax.swing.*;

--- a/test/jdk/java/awt/Window/TranslucentJAppletTest/TranslucentJAppletTest.java
+++ b/test/jdk/java/awt/Window/TranslucentJAppletTest/TranslucentJAppletTest.java
@@ -27,7 +27,7 @@
  * @bug 6683728
  * @summary Tests that a JApplet in a translucent JFrame works properly
  * @compile -XDignore.symbol.file=true TranslucentJAppletTest.java
- * @run main TranslucentJAppletTest
+ * @run main/othervm -Dsun.java2d.uiScale=1 TranslucentJAppletTest
  */
 
 import java.awt.*;

--- a/test/jdk/javax/swing/JTabbedPane/TestBackgroundScrollPolicy.java
+++ b/test/jdk/javax/swing/JTabbedPane/TestBackgroundScrollPolicy.java
@@ -36,7 +36,7 @@ import javax.swing.UnsupportedLookAndFeelException;
  * @key headful
  * @bug 8172269 8244557
  * @summary Tests JTabbedPane background for SCROLL_TAB_LAYOUT
- * @run main TestBackgroundScrollPolicy
+ * @run main/othervm -Dsun.java2d.uiScale=1 TestBackgroundScrollPolicy
  */
 
 public class TestBackgroundScrollPolicy {

--- a/test/jdk/javax/swing/plaf/nimbus/TestNimbusBGColor.java
+++ b/test/jdk/javax/swing/plaf/nimbus/TestNimbusBGColor.java
@@ -25,7 +25,7 @@
  * @bug 8058704 6789980
  * @key headful
  * @summary  Verifies if Nimbus honor JTextPane and JEditorPane background color
- * @run main TestNimbusBGColor
+ * @run main/othervm -Dsun.java2d.uiScale=1 TestNimbusBGColor
  */
 import java.awt.Color;
 import java.awt.Dimension;

--- a/test/jdk/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
+++ b/test/jdk/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
@@ -28,7 +28,7 @@
  * @build Util
  * @author Romain Guy
  * @summary Tests PRESSED and MOUSE_OVER and FOCUSED state for buttons with Synth.
- * @run main bug6276188
+ * @run main/othervm -Dsun.java2d.uiScale=1 bug6276188
  */
 import java.awt.*;
 import java.awt.image.*;


### PR DESCRIPTION
As described in https://bugs.openjdk.java.net/browse/JDK-8274106 a number of tests fail due to some inaccuracy in pixels copied from the screen when scaling down from device space to user space.
The subject of most of these tests is such that uiScale isn't important and we can have them pass with -Dsun.java2d.uiScale=1.
For the rest we can problem list them - as narrowly as we can on macos-aarch64 which is the only place we've seen the problem (not happening on retina displays with x64 it seems) whilst we try to figure out the root cause which is either in Apple code or something we are doing to trigger that Apple API misbehaviour.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274296](https://bugs.openjdk.java.net/browse/JDK-8274296): Update or Problem List tests which may fail with uiScale=2 on macOS


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5687/head:pull/5687` \
`$ git checkout pull/5687`

Update a local copy of the PR: \
`$ git checkout pull/5687` \
`$ git pull https://git.openjdk.java.net/jdk pull/5687/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5687`

View PR using the GUI difftool: \
`$ git pr show -t 5687`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5687.diff">https://git.openjdk.java.net/jdk/pull/5687.diff</a>

</details>
