### PR TITLE
8274178: Occupancy value in logging and JRF event is inaccurate in G1IHOPControl

### DIFF
--- a/src/hotspot/share/gc/g1/g1IHOPControl.cpp
+++ b/src/hotspot/share/gc/g1/g1IHOPControl.cpp
@@ -59,7 +59,7 @@ void G1IHOPControl::print() {
                       cur_conc_mark_start_threshold,
                       percent_of(cur_conc_mark_start_threshold, _target_occupancy),
                       _target_occupancy,
-                      G1CollectedHeap::heap()->used(),
+                      G1CollectedHeap::heap()->non_young_capacity_bytes(),
                       _old_gen_alloc_tracker->last_period_old_gen_bytes(),
                       _last_allocation_time_s * 1000.0,
                       _last_allocation_time_s > 0.0 ? _old_gen_alloc_tracker->last_period_old_gen_bytes() / _last_allocation_time_s : 0.0,
@@ -70,7 +70,7 @@ void G1IHOPControl::send_trace_event(G1NewTracer* tracer) {
   assert(_target_occupancy > 0, "Target occupancy still not updated yet.");
   tracer->report_basic_ihop_statistics(get_conc_mark_start_threshold(),
                                        _target_occupancy,
-                                       G1CollectedHeap::heap()->used(),
+                                       G1CollectedHeap::heap()->non_young_capacity_bytes(),
                                        _old_gen_alloc_tracker->last_period_old_gen_bytes(),
                                        _last_allocation_time_s,
                                        last_marking_length_s());
@@ -175,7 +175,7 @@ void G1AdaptiveIHOPControl::print() {
                       get_conc_mark_start_threshold(),
                       percent_of(get_conc_mark_start_threshold(), actual_target),
                       actual_target,
-                      G1CollectedHeap::heap()->used(),
+                      G1CollectedHeap::heap()->non_young_capacity_bytes(),
                       _last_unrestrained_young_size,
                       predict(&_allocation_rate_s),
                       predict(&_marking_times_s) * 1000.0,
@@ -186,7 +186,7 @@ void G1AdaptiveIHOPControl::send_trace_event(G1NewTracer* tracer) {
   G1IHOPControl::send_trace_event(tracer);
   tracer->report_adaptive_ihop_statistics(get_conc_mark_start_threshold(),
                                           actual_target_threshold(),
-                                          G1CollectedHeap::heap()->used(),
+                                          G1CollectedHeap::heap()->non_young_capacity_bytes(),
                                           _last_unrestrained_young_size,
                                           predict(&_allocation_rate_s),
                                           predict(&_marking_times_s),


### PR DESCRIPTION
Improve occupancy logging message for G1 IHOP.

This brings the logging message more in line with what is actually being used to initiate a concurrent cycle.

Relevant OpenJDK bug: https://bugs.openjdk.java.net/browse/JDK-8274178

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8274178](https://bugs.openjdk.java.net/browse/JDK-8274178): Occupancy value in logging and JRF event is inaccurate in G1IHOPControl


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5688/head:pull/5688` \
`$ git checkout pull/5688`

Update a local copy of the PR: \
`$ git checkout pull/5688` \
`$ git pull https://git.openjdk.java.net/jdk pull/5688/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5688`

View PR using the GUI difftool: \
`$ git pr show -t 5688`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5688.diff">https://git.openjdk.java.net/jdk/pull/5688.diff</a>

</details>
