### PR TITLE
8274255: Update javac messages to use "enum class" rather than "enum type"

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -131,7 +131,7 @@ compiler.err.annotation.not.valid.for.type=\
     annotation not valid for an element of type {0}
 
 compiler.err.annotation.type.not.applicable=\
-    annotation type not applicable to this kind of declaration
+    annotation interface not applicable to this kind of declaration
 
 # 0: type
 compiler.err.annotation.type.not.applicable.to.type=\
@@ -362,7 +362,7 @@ compiler.err.cant.extend.intf.annotation=\
     ''extends'' not allowed for @interfaces
 
 compiler.err.annotation.decl.not.allowed.here=\
-    annotation type declaration not allowed here
+    annotation interface declaration not allowed here
 
 # 0: symbol
 compiler.err.cant.inherit.from.final=\
@@ -416,7 +416,7 @@ compiler.err.concrete.inheritance.conflict=\
     methods {0} from {1} and {2} from {3} are inherited with the same signature
 
 compiler.err.default.allowed.in.intf.annotation.member=\
-    default value only allowed in an annotation type declaration
+    default value only allowed in an annotation interface declaration
 
 # 0: symbol
 compiler.err.doesnt.exist=\
@@ -432,7 +432,7 @@ compiler.err.duplicate.annotation.member.value=\
 
 # 0: type
 compiler.err.duplicate.annotation.missing.container=\
-    {0} is not a repeatable annotation type
+    {0} is not a repeatable annotation interface
 
 # 0: symbol
 compiler.err.invalid.repeatable.annotation=\
@@ -452,27 +452,27 @@ compiler.err.invalid.repeatable.annotation.invalid.value=\
 
 # 0: symbol or type, 1: type, 2: type
 compiler.err.invalid.repeatable.annotation.value.return=\
-    containing annotation type ({0}) must declare an element named ''value'' of type {2}
+    containing annotation interface ({0}) must declare an element named ''value'' of type {2}
 
 # 0: symbol or type, 1: symbol
 compiler.err.invalid.repeatable.annotation.elem.nondefault=\
-    containing annotation type ({0}) does not have a default value for element {1}
+    containing annotation interface ({0}) does not have a default value for element {1}
 
 # 0: symbol, 1: string, 2: symbol, 3: string
 compiler.err.invalid.repeatable.annotation.retention=\
-    retention of containing annotation type ({0}) is shorter than the retention of repeatable annotation type ({2})
+    retention of containing annotation interface ({0}) is shorter than the retention of repeatable annotation interface ({2})
 
 # 0: symbol, 1: symbol
 compiler.err.invalid.repeatable.annotation.not.documented=\
-    repeatable annotation type ({1}) is @Documented while containing annotation type ({0}) is not
+    repeatable annotation interface ({1}) is @Documented while containing annotation interface ({0}) is not
 
 # 0: symbol, 1: symbol
 compiler.err.invalid.repeatable.annotation.not.inherited=\
-    repeatable annotation type ({1}) is @Inherited while containing annotation type ({0}) is not
+    repeatable annotation interface ({1}) is @Inherited while containing annotation interface ({0}) is not
 
 # 0: symbol, 1: symbol
 compiler.err.invalid.repeatable.annotation.incompatible.target=\
-    containing annotation type ({0}) is applicable to more targets than repeatable annotation type ({1})
+    containing annotation interface ({0}) is applicable to more targets than repeatable annotation interface ({1})
 
 # 0: symbol
 compiler.err.invalid.repeatable.annotation.repeated.and.container.present=\
@@ -533,7 +533,7 @@ compiler.err.enum.annotation.must.be.enum.constant=\
     an enum annotation value must be an enum constant
 
 compiler.err.enum.cant.be.instantiated=\
-    enum types may not be instantiated
+    enum classes may not be instantiated
 
 compiler.err.enum.label.must.be.unqualified.enum=\
     an enum switch case label must be the unqualified name of an enumeration constant
@@ -542,7 +542,7 @@ compiler.err.enum.no.subclassing=\
     classes cannot directly extend java.lang.Enum
 
 compiler.err.enum.types.not.extensible=\
-    enum types are not extensible
+    enum classes are not extensible
 
 compiler.err.enum.no.finalize=\
     enums cannot have finalize methods
@@ -701,18 +701,18 @@ compiler.err.int.number.too.large=\
     integer number too large
 
 compiler.err.intf.annotation.members.cant.have.params=\
-    elements in annotation type declarations cannot declare formal parameters
+    elements in annotation interface declarations cannot declare formal parameters
 
 # 0: symbol
 compiler.err.intf.annotation.cant.have.type.params=\
-    annotation type {0} cannot be generic
+    annotation interface {0} cannot be generic
 
 compiler.err.intf.annotation.members.cant.have.type.params=\
-    elements in annotation type declarations cannot be generic methods
+    elements in annotation interface declarations cannot be generic methods
 
 # 0: symbol, 1: type
 compiler.err.intf.annotation.member.clash=\
-    annotation type {1} declares an element with the same name as method {0}
+    annotation interface {1} declares an element with the same name as method {0}
 
 compiler.err.intf.expected.here=\
     interface expected here
@@ -721,7 +721,7 @@ compiler.err.intf.meth.cant.have.body=\
     interface abstract methods cannot have body
 
 compiler.err.invalid.annotation.member.type=\
-    invalid type for annotation type element
+    invalid type for annotation interface element
 
 compiler.err.invalid.binary.number=\
     binary numbers must contain at least one binary digit
@@ -759,7 +759,7 @@ compiler.err.local.var.accessed.from.icls.needs.final=\
     local variable {0} is accessed from within inner class; needs to be declared final
 
 compiler.err.local.enum=\
-    enum types must not be local
+    enum classes must not be local
 
 compiler.err.cannot.create.array.with.type.arguments=\
     cannot create array with type arguments
@@ -926,7 +926,7 @@ compiler.err.no.match.entry=\
 
 # 0: type
 compiler.err.not.annotation.type=\
-    {0} is not an annotation type
+    {0} is not an annotation interface
 
 # 0: symbol, 1: symbol, 2: message segment
 compiler.err.not.def.access.package.cant.access=\
@@ -1987,7 +1987,7 @@ compiler.warn.proc.file.create.last.round=\
 
 # 0: string, 1: string
 compiler.warn.proc.malformed.supported.string=\
-    Malformed string ''{0}'' for a supported annotation type returned by processor ''{1}''
+    Malformed string ''{0}'' for a supported annotation interface returned by processor ''{1}''
 
 # 0: set of string
 compiler.warn.proc.annotations.without.processors=\
@@ -2003,11 +2003,11 @@ compiler.warn.proc.duplicate.option.name=\
 
 # 0: string, 1: string
 compiler.warn.proc.duplicate.supported.annotation=\
-    Duplicate supported annotation type ''{0}'' returned by annotation processor ''{1}''
+    Duplicate supported annotation interface ''{0}'' returned by annotation processor ''{1}''
 
 # 0: string
 compiler.warn.proc.redundant.types.with.wildcard=\
-    Annotation processor ''{0}'' redundantly supports both ''*'' and other annotation types
+    Annotation processor ''{0}'' redundantly supports both ''*'' and other annotation interfaces
 
 compiler.warn.proc.proc-only.requested.no.procs=\
     Annotation processing without compilation requested but no processors were found.


### PR DESCRIPTION
As a belated part of the terminology update (JDK-8246772), change

enum type -> enum class
annotation type -> annotation interface

in javac's compiler.properties files. General analysis of the use of "type" in that file is beyond the scope of this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274255](https://bugs.openjdk.java.net/browse/JDK-8274255): Update javac messages to use "enum class" rather than "enum type"


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5689/head:pull/5689` \
`$ git checkout pull/5689`

Update a local copy of the PR: \
`$ git checkout pull/5689` \
`$ git pull https://git.openjdk.java.net/jdk pull/5689/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5689`

View PR using the GUI difftool: \
`$ git pr show -t 5689`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5689.diff">https://git.openjdk.java.net/jdk/pull/5689.diff</a>

</details>
