### PR TITLE
JDK-8274311: Make build.tools.jigsaw.GenGraphs more configurable

### DIFF
--- a/make/jdk/src/classes/build/tools/jigsaw/javadoc-graphs.properties
+++ b/make/jdk/src/classes/build/tools/jigsaw/javadoc-graphs.properties
@@ -1,2 +1,35 @@
+# Configuration file for build.tools.jigsaw.GenGraphs
+
+nodesep=.5
+node-margin=.2,.2
+ranksep=0.6
+fontsize=12
+fontcolor=#000000
+fontname=DejaVuSans
+arrowsize=1
+arrowwidth=2
+
+# requires edge: gray
 arrowcolor=#999999
-requiresMandatedColor=#999999
+
+# requires mandated java.base edge: light gray
+requiresMandatedColor=#dddddd
+
+requiresTransitiveStyle=
+requiresStyle=dashed
+
+# java.* modules: orange
+javaSubgraphColor=#e76f00
+
+# jdk.* modules: blue
+jdkSubgraphColor=#437291
+
+# configure the group of modules in the same rank
+ranks.1=java.logging,java.scripting,java.xml
+ranks.2=java.sql
+ranks.4=java.compiler,java.instrument
+ranks.5=java.desktop,java.management
+
+# configure the edges A -> B -> C .... with the same weight
+# that should get these modules lined in a straight line
+weights=java.se,java.sql.rowset,java.sql,java.xml


### PR DESCRIPTION
GenGraphs tool generates the module graph. It currently supports the configuration via javadoc-graphs.properties. However, `make/jdk/src/classes/build/tools/jigsaw/javadoc-graphs.properties` only documents two properties. It should be updated to cover all configurable properties.

There are a couple other properties not configurable such as nodesep and node margin. This extends the configuration to allow to set additional properties. 

This also fixes `requiresMandatedColor` in javadoc-graphs.properties to light gray to match the default configuration in the implementation, i.e. the color of the edge to java.base.  It seems a bug that was unnoticed until Alex and Iris spotted it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274311](https://bugs.openjdk.java.net/browse/JDK-8274311): Make build.tools.jigsaw.GenGraphs  more configurable


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5690/head:pull/5690` \
`$ git checkout pull/5690`

Update a local copy of the PR: \
`$ git checkout pull/5690` \
`$ git pull https://git.openjdk.java.net/jdk pull/5690/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5690`

View PR using the GUI difftool: \
`$ git pr show -t 5690`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5690.diff">https://git.openjdk.java.net/jdk/pull/5690.diff</a>

</details>
