### PR TITLE
8274312: ProblemList 2 serviceability/dcmd/gc tests with ZGC on macos-all

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -45,5 +45,5 @@ serviceability/sa/TestJhsdbJstackMixed.java                   8248912   generic-
 serviceability/sa/ClhsdbPstack.java#process                   8248912   generic-all
 serviceability/sa/ClhsdbPstack.java#core                      8248912   generic-all
 
-serviceability/dcmd/gc/HeapDumpAllTest.java                   8274196   linux-all,windows-all
-serviceability/dcmd/gc/HeapDumpTest.java                      8274196   linux-all,windows-all
+serviceability/dcmd/gc/HeapDumpAllTest.java                   8274196   generic-all
+serviceability/dcmd/gc/HeapDumpTest.java                      8274196   generic-all

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -818,7 +818,10 @@ sun/tools/jstat/jstatLineCounts2.sh                             8268211 linux-aa
 sun/tools/jstat/jstatLineCounts3.sh                             8268211 linux-aarch64
 sun/tools/jstat/jstatLineCounts4.sh                             8268211 linux-aarch64
 
-sun/tools/jmap/BasicJMapTest.java                               8274245 generic-all
+sun/tools/jmap/BasicJMapTest.java#G1                            8274245 generic-all
+sun/tools/jmap/BasicJMapTest.java#Parallel                      8274245 generic-all
+sun/tools/jmap/BasicJMapTest.java#Serial                        8274245 generic-all
+sun/tools/jmap/BasicJMapTest.java#Z                             8274245 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList 2 serviceability/dcmd/gc tests with ZGC on macOS-all.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8274312](https://bugs.openjdk.java.net/browse/JDK-8274312): ProblemList 2 serviceability/dcmd/gc tests with ZGC on macos-all
 * [JDK-8274313](https://bugs.openjdk.java.net/browse/JDK-8274313): ProblemList sun/tools/jmap/BasicJMapTest.java subtests


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5691/head:pull/5691` \
`$ git checkout pull/5691`

Update a local copy of the PR: \
`$ git checkout pull/5691` \
`$ git pull https://git.openjdk.java.net/jdk pull/5691/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5691`

View PR using the GUI difftool: \
`$ git pr show -t 5691`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5691.diff">https://git.openjdk.java.net/jdk/pull/5691.diff</a>

</details>
