### PR TITLE
8274314: Typo in WatchService#poll(long timeout, TimeUnit unit) javadoc

### DIFF
--- a/src/java.base/share/classes/java/nio/file/WatchService.java
+++ b/src/java.base/share/classes/java/nio/file/WatchService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -143,7 +143,7 @@ public interface WatchService
      * specified wait time if none are yet present.
      *
      * @param   timeout
-     *          how to wait before giving up, in units of unit
+     *          how long to wait before giving up, in units of unit
      * @param   unit
      *          a {@code TimeUnit} determining how to interpret the timeout
      *          parameter


### PR DESCRIPTION
Could I please get a review for this trivial fix in the javadoc of WatchService#poll(long timeout, TimeUnit unit)?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274314](https://bugs.openjdk.java.net/browse/JDK-8274314): Typo in WatchService#poll(long timeout, TimeUnit unit) javadoc


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5692/head:pull/5692` \
`$ git checkout pull/5692`

Update a local copy of the PR: \
`$ git checkout pull/5692` \
`$ git pull https://git.openjdk.java.net/jdk pull/5692/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5692`

View PR using the GUI difftool: \
`$ git pr show -t 5692`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5692.diff">https://git.openjdk.java.net/jdk/pull/5692.diff</a>

</details>
