### PR TITLE
8174819: java/nio/file/WatchService/LotsOfEvents.java fails intermittently

### DIFF
--- a/test/jdk/java/nio/file/WatchService/LotsOfEvents.java
+++ b/test/jdk/java/nio/file/WatchService/LotsOfEvents.java
@@ -108,7 +108,7 @@ public class LotsOfEvents {
         boolean gotOverflow = false;
         while (key != null) {
             List<WatchEvent<?>> events = key.pollEvents();
-            System.out.println("Polling retrieved " + events.size() + " events");
+            System.out.println("Polling retrieved " + events.size() + " event(s)");
             for (WatchEvent<?> event: events) {
                 WatchEvent.Kind<?> kind = event.kind();
                 if (kind == expectedKind) {
@@ -148,7 +148,6 @@ public class LotsOfEvents {
                 // count for each kind of event
                 Map<WatchEvent.Kind, Long> countPerEventType = events.stream()
                         .collect(Collectors.groupingBy(WatchEvent::kind, Collectors.counting()));
-                System.err.println("After extra polling, found:");
                 countPerEventType.forEach((kind, num)
                         -> System.err.println(num + " events of type " + kind));
             }

--- a/test/jdk/java/nio/file/WatchService/LotsOfEvents.java
+++ b/test/jdk/java/nio/file/WatchService/LotsOfEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 6907760 6929532
+ * @bug 6907760 6929532 8174819
  * @summary Tests WatchService behavior when lots of events are pending (use -Dseed=X to set PRNG seed)
  * @library ..
  * @library /test/lib
@@ -37,6 +37,8 @@ import java.nio.file.*;
 import static java.nio.file.StandardWatchEventKinds.*;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
 import jdk.test.lib.RandomFactory;
 
 public class LotsOfEvents {
@@ -106,6 +108,7 @@ public class LotsOfEvents {
         boolean gotOverflow = false;
         while (key != null) {
             List<WatchEvent<?>> events = key.pollEvents();
+            System.out.println("Polling retrieved " + events.size() + " events");
             for (WatchEvent<?> event: events) {
                 WatchEvent.Kind<?> kind = event.kind();
                 if (kind == expectedKind) {
@@ -123,7 +126,7 @@ public class LotsOfEvents {
             }
             if (!key.reset())
                 throw new RuntimeException("Key is no longer valid");
-            key = watcher.poll(2, TimeUnit.SECONDS);
+            key = watcher.poll(15, TimeUnit.SECONDS);
         }
 
         // check that all expected events were received or there was an overflow
@@ -131,6 +134,8 @@ public class LotsOfEvents {
             System.err.printf("Test directory %s contains %d files%n",
                 dir, Files.list(dir).count());
 
+            // the additional polling here is just for diagnostics and doesn't
+            // change the test result (which is a failed test)
             long timeBeforePoll = System.nanoTime();
             key = watcher.poll(15, TimeUnit.SECONDS);
             long timeAfterPoll = System.nanoTime();
@@ -140,6 +145,12 @@ public class LotsOfEvents {
                 List<WatchEvent<?>> events = key.pollEvents();
                 System.err.printf("Retrieved key with %d events after %d ns%n",
                     events.size(), timeAfterPoll - timeBeforePoll);
+                // count for each kind of event
+                Map<WatchEvent.Kind, Long> countPerEventType = events.stream()
+                        .collect(Collectors.groupingBy(WatchEvent::kind, Collectors.counting()));
+                System.err.println("After extra polling, found:");
+                countPerEventType.forEach((kind, num)
+                        -> System.err.println(num + " events of type " + kind));
             }
 
             throw new RuntimeException("Insufficient "


### PR DESCRIPTION
Can I please get a review for this test-only change that aims to fix an intermittent failure in `LotsOfEvents` testcase?

As noted by Alan in the JBS issue https://bugs.openjdk.java.net/browse/JDK-8174819, the test failure is likely due to the relatively smaller poll timeout that it currently uses. IMO, this guess is proved right by the diagnostic logs that the test is currently printing, as I note in my comment in that JBS issue.

The commit in this PR increases the 2 second timeout that was used (only) in the loop to 15 seconds to make it match the poll timeout that is used outside the loop. IMO, this increase in timeout shouldn't really slow down the test, since this is the "max amount of time to wait". The 13 second additional wait would ideally only show for the "last" poll where there are no more events.

Additionally, this commit also adds a few more diagnostic logs for future use, if this test fails in future.

Do note that there's also a `testModifyEventsQueuing` test method which too uses a 2 second timeout in a loop. I haven't touched/changed that timeout, since that test hasn't yet failed (perhaps because the number of events generated there are just 100 as against 1024 in this `testOverflowEvent` test). If at all that other test fails any time in future, we can perhaps consider increasing the timeout there too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8174819](https://bugs.openjdk.java.net/browse/JDK-8174819): java/nio/file/WatchService/LotsOfEvents.java fails intermittently


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5693/head:pull/5693` \
`$ git checkout pull/5693`

Update a local copy of the PR: \
`$ git checkout pull/5693` \
`$ git pull https://git.openjdk.java.net/jdk pull/5693/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5693`

View PR using the GUI difftool: \
`$ git pr show -t 5693`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5693.diff">https://git.openjdk.java.net/jdk/pull/5693.diff</a>

</details>
