### PR TITLE
8274318: Replace 'for' cycles with iterator with enhanced-for in java.management

### DIFF
--- a/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIServerImpl.java
+++ b/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIServerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -494,8 +494,7 @@ public abstract class RMIServerImpl implements Closeable, RMIServer {
         if (subject != null) {
             Set<Principal> principals = subject.getPrincipals();
             String sep = "";
-            for (Iterator<Principal> it = principals.iterator(); it.hasNext(); ) {
-                Principal p = it.next();
+            for (Principal p : principals) {
                 String name = p.getName().replace(' ', '_').replace(';', ':');
                 buf.append(sep).append(name);
                 sep = ";";

--- a/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java
+++ b/src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java
@@ -33,7 +33,6 @@ import java.security.Principal;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -314,8 +313,7 @@ public class MBeanServerFileAccessController
         if (s == null) return; /* security has not been enabled */
         final Set<Principal> principals = s.getPrincipals();
         String newPropertyValue = null;
-        for (Iterator<Principal> i = principals.iterator(); i.hasNext(); ) {
-            final Principal p = i.next();
+        for (Principal p : principals) {
             Access access = accessMap.get(p.getName());
             if (access != null) {
                 boolean ok;

--- a/src/java.management/share/classes/javax/management/relation/RoleResult.java
+++ b/src/java.management/share/classes/javax/management/relation/RoleResult.java
@@ -35,7 +35,6 @@ import java.io.ObjectStreamField;
 import java.io.Serializable;
 
 import java.security.AccessController;
-import java.util.Iterator;
 
 /**
  * Represents the result of a multiple access to several roles of a relation
@@ -173,10 +172,9 @@ public class RoleResult implements Serializable {
 
             roleList = new RoleList();
 
-            for (Iterator<?> roleIter = list.iterator();
-                 roleIter.hasNext();) {
-                Role currRole = (Role)(roleIter.next());
-                roleList.add((Role)(currRole.clone()));
+            for (Object o : list) {
+                Role currRole = (Role) o;
+                roleList.add((Role) currRole.clone());
             }
         } else {
             roleList = null;
@@ -196,11 +194,9 @@ public class RoleResult implements Serializable {
 
             unresolvedRoleList = new RoleUnresolvedList();
 
-            for (Iterator<?> roleUnresIter = unresolvedList.iterator();
-                 roleUnresIter.hasNext();) {
-                RoleUnresolved currRoleUnres =
-                    (RoleUnresolved)(roleUnresIter.next());
-                unresolvedRoleList.add((RoleUnresolved)(currRoleUnres.clone()));
+            for (Object o : unresolvedList) {
+                RoleUnresolved currRoleUnres = (RoleUnresolved) o;
+                unresolvedRoleList.add((RoleUnresolved) currRoleUnres.clone());
             }
         } else {
             unresolvedRoleList = null;

--- a/src/java.management/share/classes/javax/management/relation/RoleResult.java
+++ b/src/java.management/share/classes/javax/management/relation/RoleResult.java
@@ -131,7 +131,6 @@ public class RoleResult implements Serializable {
 
         setRoles(list);
         setRolesUnresolved(unresolvedList);
-        return;
     }
 
     //
@@ -173,13 +172,12 @@ public class RoleResult implements Serializable {
             roleList = new RoleList();
 
             for (Object o : list) {
-                Role currRole = (Role) o;
-                roleList.add((Role) currRole.clone());
+                Role currRole = (Role)o;
+                roleList.add((Role)currRole.clone());
             }
         } else {
             roleList = null;
         }
-        return;
     }
 
     /**
@@ -195,13 +193,12 @@ public class RoleResult implements Serializable {
             unresolvedRoleList = new RoleUnresolvedList();
 
             for (Object o : unresolvedList) {
-                RoleUnresolved currRoleUnres = (RoleUnresolved) o;
-                unresolvedRoleList.add((RoleUnresolved) currRoleUnres.clone());
+                RoleUnresolved currRoleUnres = (RoleUnresolved)o;
+                unresolvedRoleList.add((RoleUnresolved)currRoleUnres.clone());
             }
         } else {
             unresolvedRoleList = null;
         }
-        return;
     }
 
     /**


### PR DESCRIPTION
There are a few places in code, where manual `for` loop is used with Iterator to iterate over Collection.
Instead of manual `for` cycles, it's preferred to use enhanced-for cycle instead: it's less verbose, makes code easier to read and it's less error-prone.
It doesn't have any performance impact: javac compiler generates similar code when compiling enhanced-for cycle.
Similar cleanups:
1. [JDK-8274016](https://bugs.openjdk.java.net/browse/JDK-8274016) java.desktop
2. [JDK-8274237](https://bugs.openjdk.java.net/browse/JDK-8274237) java.base
3. [JDK-8274261](https://bugs.openjdk.java.net/browse/JDK-8274261) jdk.jcmd

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274318](https://bugs.openjdk.java.net/browse/JDK-8274318): Replace 'for' cycles with iterator with enhanced-for in java.management


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to e3884614418473f5767bfed6f7929a43b48c5cef
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5695/head:pull/5695` \
`$ git checkout pull/5695`

Update a local copy of the PR: \
`$ git checkout pull/5695` \
`$ git pull https://git.openjdk.java.net/jdk pull/5695/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5695`

View PR using the GUI difftool: \
`$ git pr show -t 5695`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5695.diff">https://git.openjdk.java.net/jdk/pull/5695.diff</a>

</details>
