### PR TITLE
8274319: Replace usages of Collections.sort with List.sort call in jdk.jfr

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataReader.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ import static jdk.jfr.internal.MetadataDescriptor.ELEMENT_TYPE;
 import java.io.DataInput;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -84,7 +84,7 @@ final class MetadataReader {
         descriptor.root = root;
         if (Logger.shouldLog(LogTag.JFR_SYSTEM_PARSER, LogLevel.TRACE)) {
              List<Type> ts = new ArrayList<>(types.values());
-             Collections.sort(ts, (x,y) -> x.getName().compareTo(y.getName()));
+             ts.sort(Comparator.comparing(Type::getName));
              for (Type t : ts) {
                  t.log("Found", LogTag.JFR_SYSTEM_PARSER, LogLevel.TRACE);
              }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
@@ -36,7 +36,6 @@ import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -437,7 +436,7 @@ public final class PlatformRecorder {
             }
             // n*log(n), should be able to do n*log(k) with a priority queue,
             // where k = number of recordings, n = number of chunks
-            Collections.sort(chunks, RepositoryChunk.END_TIME_COMPARATOR);
+            chunks.sort(RepositoryChunk.END_TIME_COMPARATOR);
             return chunks;
         }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/SettingsManager.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/SettingsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@ package jdk.jfr.internal;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -140,7 +140,7 @@ final class SettingsManager {
             }
         } else {
             if (Logger.shouldLog(LogTag.JFR_SETTING, LogLevel.INFO)) {
-                Collections.sort(eventControls, (x,y) -> x.getEventType().getName().compareTo(y.getEventType().getName()));
+                eventControls.sort(Comparator.comparing(x -> x.getEventType().getName()));
             }
             for (EventControl ec : eventControls) {
                 setEventControl(ec);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/TypeLibrary.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/TypeLibrary.java
@@ -36,6 +36,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -108,7 +109,7 @@ public final class TypeLibrary {
                 List<Type> jvmTypes;
                 try {
                     jvmTypes = MetadataLoader.createTypes();
-                    Collections.sort(jvmTypes, (a,b) -> Long.compare(a.getId(), b.getId()));
+                    jvmTypes.sort(Comparator.comparingLong(Type::getId));
                 } catch (IOException e) {
                     throw new Error("JFR: Could not read metadata");
                 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/RepositoryFiles.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/RepositoryFiles.java
@@ -213,7 +213,7 @@ public final class RepositoryFiles {
                 pathSet.remove(time);
                 pathLookup.remove(remove);
             }
-            Collections.sort(added, (p1, p2) -> p1.compareTo(p2));
+            Collections.sort(added);
             for (Path p : added) {
                 // Only add files that have a complete header
                 // as the JVM may be in progress writing the file

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
@@ -32,7 +32,6 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
@@ -170,7 +169,7 @@ abstract class AbstractDCmd {
 
     protected final List<Recording> getRecordings() {
         List<Recording> list = new ArrayList<>(getFlightRecorder().getRecordings());
-        Collections.sort(list, Comparator.comparing(Recording::getId));
+        list.sort(Comparator.comparing(Recording::getId));
         return list;
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
@@ -169,7 +169,7 @@ abstract class AbstractDCmd {
 
     protected final List<Recording> getRecordings() {
         List<Recording> list = new ArrayList<>(getFlightRecorder().getRecordings());
-        list.sort(Comparator.comparing(Recording::getId));
+        list.sort(Comparator.comparingLong(Recording::getId));
         return list;
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdCheck.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package jdk.jfr.internal.dcmd;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -135,12 +134,7 @@ final class DCmdCheck extends AbstractDCmd {
     private static List<EventType> sortByEventPath(Collection<EventType> events) {
         List<EventType> sorted = new ArrayList<>();
         sorted.addAll(events);
-        Collections.sort(sorted, new Comparator<EventType>() {
-            @Override
-            public int compare(EventType e1, EventType e2) {
-                return e1.getName().compareTo(e2.getName());
-            }
-        });
+        sorted.sort(Comparator.comparing(EventType::getName));
         return sorted;
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/EventPrintWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/EventPrintWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,7 +76,7 @@ abstract class EventPrintWriter extends StructuredWriter {
                     events.add(event);
                 }
                 if (PRIVATE_ACCESS.isLastEventInChunk(file)) {
-                    Collections.sort(events, PRIVATE_ACCESS.eventComparator());
+                    events.sort(PRIVATE_ACCESS.eventComparator());
                     print(events);
                     events.clear();
                 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Metadata.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Metadata.java
@@ -31,7 +31,6 @@ import java.io.PrintWriter;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Deque;
 import java.util.List;
@@ -206,7 +205,7 @@ final class Metadata extends Command {
             }
 
             List<Type> types = findTypes(file);
-            Collections.sort(types, new TypeComparator());
+            types.sort(new TypeComparator());
             for (Type type : types) {
                 if (filter != null) {
                     // If --events or --categories, only operate on events

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Summary.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Summary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
@@ -143,7 +143,7 @@ final class Summary extends Command {
             println(" Start: " + DATE_FORMAT.format(Instant.ofEpochSecond(epochSeconds, adjustNanos)) + " (UTC)");
             println(" Duration: " + (totalDuration + 500_000_000) / 1_000_000_000 + " s");
             List<Statistics> statsList = new ArrayList<>(stats.values());
-            Collections.sort(statsList, (u, v) -> Long.compare(v.count, u.count));
+            statsList.sort(Comparator.comparingLong(v -> v.count));
             println();
             String header = "      Count  Size (bytes) ";
             String typeHeader = " Event Type";

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Summary.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Summary.java
@@ -32,7 +32,6 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
@@ -143,7 +142,7 @@ final class Summary extends Command {
             println(" Start: " + DATE_FORMAT.format(Instant.ofEpochSecond(epochSeconds, adjustNanos)) + " (UTC)");
             println(" Duration: " + (totalDuration + 500_000_000) / 1_000_000_000 + " s");
             List<Statistics> statsList = new ArrayList<>(stats.values());
-            statsList.sort(Comparator.comparingLong(v -> v.count));
+            statsList.sort((u, v) -> Long.compare(v.count, u.count));
             println();
             String header = "      Count  Size (bytes) ";
             String typeHeader = " Event Type";


### PR DESCRIPTION
Collections.sort is just a wrapper, so it is better to use an instance method directly.

Also Comparator's implementation can be cleaned up with help of static methods in `Comparator` class.
E.g.
```
        Collections.sort(sorted, new Comparator<EventType>() {
            @Override
            public int compare(EventType e1, EventType e2) {
                return e1.getName().compareTo(e2.getName());
            }
        });
```
can be replaced with
```
sorted.sort(Comparator.comparing(EventType::getName));
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274319](https://bugs.openjdk.java.net/browse/JDK-8274319): Replace usages of Collections.sort with List.sort call in jdk.jfr


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5696/head:pull/5696` \
`$ git checkout pull/5696`

Update a local copy of the PR: \
`$ git checkout pull/5696` \
`$ git pull https://git.openjdk.java.net/jdk pull/5696/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5696`

View PR using the GUI difftool: \
`$ git pr show -t 5696`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5696.diff">https://git.openjdk.java.net/jdk/pull/5696.diff</a>

</details>
