### PR TITLE
8272992: Replace usages of Collections.sort with List.sort call in jdk.hotspot.agent

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/basic/BasicCDebugInfoDataBase.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/basic/BasicCDebugInfoDataBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -137,7 +137,7 @@ public class BasicCDebugInfoDataBase implements CDebugInfoDataBase {
 
     // Sort blocks in ascending order of starting address (but do not
     // change ordering among blocks with the same starting address)
-    Collections.sort(blocks, new Comparator<>() {
+    blocks.sort(new Comparator<>() {
         public int compare(BlockSym b1, BlockSym b2) {
           Address a1 = b1.getAddress();
           Address a2 = b2.getAddress();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/basic/BasicLineNumberMapping.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/cdbg/basic/BasicLineNumberMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public class BasicLineNumberMapping {
       counter. This must be done before any queries are made. */
   public void sort() {
     if (infoList == null) return;
-    Collections.sort(infoList, new Comparator<>() {
+    infoList.sort(new Comparator<>() {
         public int compare(BasicLineNumberInfo l1, BasicLineNumberInfo l2) {
           Address a1 = l1.getStartPC();
           Address a2 = l2.getStartPC();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHeap.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -365,7 +365,7 @@ public class ObjectHeap {
   }
 
   private void sortLiveRegions(List<Address> liveRegions) {
-    Collections.sort(liveRegions, new Comparator<Address>() {
+    liveRegions.sort(new Comparator<Address>() {
         public int compare(Address a1, Address a2) {
           if (AddressOps.lt(a1, a2)) {
             return -1;

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHistogram.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHistogram.java
@@ -50,11 +50,7 @@ public class ObjectHistogram implements HeapVisitor {
   public List<ObjectHistogramElement> getElements() {
     List<ObjectHistogramElement> list = new ArrayList<>();
     list.addAll(map.values());
-    Collections.sort(list, new Comparator<>() {
-      public int compare(ObjectHistogramElement o1, ObjectHistogramElement o2) {
-        return o1.compare(o2);
-      }
-    });
+    list.sort(ObjectHistogramElement::compare);
     return list;
   }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/FinalizerInfo.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/FinalizerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ import sun.jvm.hotspot.oops.*;
 import sun.jvm.hotspot.utilities.SystemDictionaryHelper;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 
@@ -126,11 +125,7 @@ public class FinalizerInfo extends Tool {
              */
             ArrayList<ObjectHistogramElement> list = new ArrayList<>();
             list.addAll(map.values());
-            Collections.sort(list, new Comparator<>() {
-              public int compare(ObjectHistogramElement o1, ObjectHistogramElement o2) {
-                  return o1.compare(o2);
-              }
-            });
+            list.sort(ObjectHistogramElement::compare);
 
             /*
              * Print summary of objects in queue

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/ProcessListPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/ProcessListPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ import java.awt.*;
 import java.awt.event.*;
 import java.util.*;
 import javax.swing.*;
-import javax.swing.event.*;
 import javax.swing.table.*;
 
 import sun.jvm.hotspot.debugger.*;
@@ -202,7 +201,7 @@ public class ProcessListPanel extends JPanel {
           }
         };
     }
-    Collections.sort(els, c);
+    els.sort(c);
   }
 
   private javax.swing.Timer getTimer() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/table/SortableTableModel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/table/SortableTableModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,6 @@
  */
 
 package sun.jvm.hotspot.ui.table;
-
-import java.util.Collections;
-import java.util.List;
 
 import javax.swing.event.TableModelEvent;
 import javax.swing.table.AbstractTableModel;
@@ -55,7 +52,7 @@ public abstract class SortableTableModel<T> extends AbstractTableModel {
         comparator.addColumn(column);
         comparator.setAscending(ascending);
 
-        Collections.sort(elements, comparator);
+        elements.sort(comparator);
 
         fireTableChanged(new TableModelEvent(this));
     }


### PR DESCRIPTION
Collections.sort is just a wrapper, so it is better to use an instance method directly.