### PR TITLE
8274321: Standardize values of @since tags in javax.lang.model

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/element/Element.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/Element.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -292,7 +292,7 @@ public interface Element extends javax.lang.model.AnnotatedConstruct {
      * <p>Note that any annotations returned by this method are
      * declaration annotations.
      *
-     * @since 8
+     * @since 1.8
      */
     @Override
     <A extends Annotation> A[] getAnnotationsByType(Class<A> annotationType);

--- a/src/java.compiler/share/classes/javax/lang/model/type/TypeMirror.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/TypeMirror.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -149,7 +149,7 @@ public interface TypeMirror extends javax.lang.model.AnnotatedConstruct {
      * <p>Note that any annotations returned by this method are type
      * annotations.
      *
-     * @since 8
+     * @since 1.8
      */
     @Override
     List<? extends AnnotationMirror> getAnnotationMirrors();
@@ -160,7 +160,7 @@ public interface TypeMirror extends javax.lang.model.AnnotatedConstruct {
      * <p>Note that any annotation returned by this method is a type
      * annotation.
      *
-     * @since 8
+     * @since 1.8
      */
     @Override
     <A extends Annotation> A getAnnotation(Class<A> annotationType);
@@ -171,7 +171,7 @@ public interface TypeMirror extends javax.lang.model.AnnotatedConstruct {
      * <p>Note that any annotations returned by this method are type
      * annotations.
      *
-     * @since 8
+     * @since 1.8
      */
     @Override
     <A extends Annotation> A[] getAnnotationsByType(Class<A> annotationType);


### PR DESCRIPTION
This changes values of four `@since` tags from 8 to 1.8, which is predominantly used to refer to JDK 1.8.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274321](https://bugs.openjdk.java.net/browse/JDK-8274321): Standardize values of @since tags in javax.lang.model


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5699/head:pull/5699` \
`$ git checkout pull/5699`

Update a local copy of the PR: \
`$ git checkout pull/5699` \
`$ git pull https://git.openjdk.java.net/jdk pull/5699/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5699`

View PR using the GUI difftool: \
`$ git pr show -t 5699`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5699.diff">https://git.openjdk.java.net/jdk/pull/5699.diff</a>

</details>
