### PR TITLE
8274325: C4819 warning at vm_version_x86.cpp on Windows after JDK-8234160

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1766,58 +1766,58 @@ bool VM_Version::compute_has_intel_jcc_erratum() {
   // https://www.intel.com/content/dam/support/us/en/documents/processors/mitigations-jump-conditional-code-erratum.pdf
   switch (_model) {
   case 0x8E:
-    // 06_8EH | 9 | 8th Generation Intel® Core™ Processor Family based on microarchitecture code name Amber Lake Y
-    // 06_8EH | 9 | 7th Generation Intel® Core™ Processor Family based on microarchitecture code name Kaby Lake U
-    // 06_8EH | 9 | 7th Generation Intel® Core™ Processor Family based on microarchitecture code name Kaby Lake U 23e
-    // 06_8EH | 9 | 7th Generation Intel® Core™ Processor Family based on microarchitecture code name Kaby Lake Y
-    // 06_8EH | A | 8th Generation Intel® Core™ Processor Family based on microarchitecture code name Coffee Lake U43e
-    // 06_8EH | B | 8th Generation Intel® Core™ Processors based on microarchitecture code name Whiskey Lake U
-    // 06_8EH | C | 8th Generation Intel® Core™ Processor Family based on microarchitecture code name Amber Lake Y
-    // 06_8EH | C | 10th Generation Intel® Core™ Processor Family based on microarchitecture code name Comet Lake U42
-    // 06_8EH | C | 8th Generation Intel® Core™ Processors based on microarchitecture code name Whiskey Lake U
+    // 06_8EH | 9 | 8th Generation Intel Core Processor Family based on microarchitecture code name Amber Lake Y
+    // 06_8EH | 9 | 7th Generation Intel Core Processor Family based on microarchitecture code name Kaby Lake U
+    // 06_8EH | 9 | 7th Generation Intel Core Processor Family based on microarchitecture code name Kaby Lake U 23e
+    // 06_8EH | 9 | 7th Generation Intel Core Processor Family based on microarchitecture code name Kaby Lake Y
+    // 06_8EH | A | 8th Generation Intel Core Processor Family based on microarchitecture code name Coffee Lake U43e
+    // 06_8EH | B | 8th Generation Intel Core Processors based on microarchitecture code name Whiskey Lake U
+    // 06_8EH | C | 8th Generation Intel Core Processor Family based on microarchitecture code name Amber Lake Y
+    // 06_8EH | C | 10th Generation Intel Core Processor Family based on microarchitecture code name Comet Lake U42
+    // 06_8EH | C | 8th Generation Intel Core Processors based on microarchitecture code name Whiskey Lake U
     return _stepping == 0x9 || _stepping == 0xA || _stepping == 0xB || _stepping == 0xC;
   case 0x4E:
-    // 06_4E  | 3 | 6th Generation Intel® Core™ Processors based on microarchitecture code name Skylake U
-    // 06_4E  | 3 | 6th Generation Intel® Core™ Processor Family based on microarchitecture code name Skylake U23e
-    // 06_4E  | 3 | 6th Generation Intel® Core™ Processors based on microarchitecture code name Skylake Y
+    // 06_4E  | 3 | 6th Generation Intel Core Processors based on microarchitecture code name Skylake U
+    // 06_4E  | 3 | 6th Generation Intel Core Processor Family based on microarchitecture code name Skylake U23e
+    // 06_4E  | 3 | 6th Generation Intel Core Processors based on microarchitecture code name Skylake Y
     return _stepping == 0x3;
   case 0x55:
-    // 06_55H | 4 | Intel® Xeon® Processor D Family based on microarchitecture code name Skylake D, Bakerville
-    // 06_55H | 4 | Intel® Xeon® Scalable Processors based on microarchitecture code name Skylake Server
-    // 06_55H | 4 | Intel® Xeon® Processor W Family based on microarchitecture code name Skylake W
-    // 06_55H | 4 | Intel® Core™ X-series Processors based on microarchitecture code name Skylake X
-    // 06_55H | 4 | Intel® Xeon® Processor E3 v5 Family based on microarchitecture code name Skylake Xeon E3
-    // 06_55  | 7 | 2nd Generation Intel® Xeon® Scalable Processors based on microarchitecture code name Cascade Lake (server)
+    // 06_55H | 4 | Intel Xeon Processor D Family based on microarchitecture code name Skylake D, Bakerville
+    // 06_55H | 4 | Intel Xeon Scalable Processors based on microarchitecture code name Skylake Server
+    // 06_55H | 4 | Intel Xeon Processor W Family based on microarchitecture code name Skylake W
+    // 06_55H | 4 | Intel Core X-series Processors based on microarchitecture code name Skylake X
+    // 06_55H | 4 | Intel Xeon Processor E3 v5 Family based on microarchitecture code name Skylake Xeon E3
+    // 06_55  | 7 | 2nd Generation Intel Xeon Scalable Processors based on microarchitecture code name Cascade Lake (server)
     return _stepping == 0x4 || _stepping == 0x7;
   case 0x5E:
-    // 06_5E  | 3 | 6th Generation Intel® Core™ Processor Family based on microarchitecture code name Skylake H
-    // 06_5E  | 3 | 6th Generation Intel® Core™ Processor Family based on microarchitecture code name Skylake S
+    // 06_5E  | 3 | 6th Generation Intel Core Processor Family based on microarchitecture code name Skylake H
+    // 06_5E  | 3 | 6th Generation Intel Core Processor Family based on microarchitecture code name Skylake S
     return _stepping == 0x3;
   case 0x9E:
-    // 06_9EH | 9 | 8th Generation Intel® Core™ Processor Family based on microarchitecture code name Kaby Lake G
-    // 06_9EH | 9 | 7th Generation Intel® Core™ Processor Family based on microarchitecture code name Kaby Lake H
-    // 06_9EH | 9 | 7th Generation Intel® Core™ Processor Family based on microarchitecture code name Kaby Lake S
-    // 06_9EH | 9 | Intel® Core™ X-series Processors based on microarchitecture code name Kaby Lake X
-    // 06_9EH | 9 | Intel® Xeon® Processor E3 v6 Family Kaby Lake Xeon E3
-    // 06_9EH | A | 8th Generation Intel® Core™ Processor Family based on microarchitecture code name Coffee Lake H
-    // 06_9EH | A | 8th Generation Intel® Core™ Processor Family based on microarchitecture code name Coffee Lake S
-    // 06_9EH | A | 8th Generation Intel® Core™ Processor Family based on microarchitecture code name Coffee Lake S (6+2) x/KBP
-    // 06_9EH | A | Intel® Xeon® Processor E Family based on microarchitecture code name Coffee Lake S (6+2)
-    // 06_9EH | A | Intel® Xeon® Processor E Family based on microarchitecture code name Coffee Lake S (4+2)
-    // 06_9EH | B | 8th Generation Intel® Core™ Processor Family based on microarchitecture code name Coffee Lake S (4+2)
-    // 06_9EH | B | Intel® Celeron® Processor G Series based on microarchitecture code name Coffee Lake S (4+2)
-    // 06_9EH | D | 9th Generation Intel® Core™ Processor Family based on microarchitecturecode name Coffee Lake H (8+2)
-    // 06_9EH | D | 9th Generation Intel® Core™ Processor Family based on microarchitecture code name Coffee Lake S (8+2)
+    // 06_9EH | 9 | 8th Generation Intel Core Processor Family based on microarchitecture code name Kaby Lake G
+    // 06_9EH | 9 | 7th Generation Intel Core Processor Family based on microarchitecture code name Kaby Lake H
+    // 06_9EH | 9 | 7th Generation Intel Core Processor Family based on microarchitecture code name Kaby Lake S
+    // 06_9EH | 9 | Intel Core X-series Processors based on microarchitecture code name Kaby Lake X
+    // 06_9EH | 9 | Intel Xeon Processor E3 v6 Family Kaby Lake Xeon E3
+    // 06_9EH | A | 8th Generation Intel Core Processor Family based on microarchitecture code name Coffee Lake H
+    // 06_9EH | A | 8th Generation Intel Core Processor Family based on microarchitecture code name Coffee Lake S
+    // 06_9EH | A | 8th Generation Intel Core Processor Family based on microarchitecture code name Coffee Lake S (6+2) x/KBP
+    // 06_9EH | A | Intel Xeon Processor E Family based on microarchitecture code name Coffee Lake S (6+2)
+    // 06_9EH | A | Intel Xeon Processor E Family based on microarchitecture code name Coffee Lake S (4+2)
+    // 06_9EH | B | 8th Generation Intel Core Processor Family based on microarchitecture code name Coffee Lake S (4+2)
+    // 06_9EH | B | Intel Celeron Processor G Series based on microarchitecture code name Coffee Lake S (4+2)
+    // 06_9EH | D | 9th Generation Intel Core Processor Family based on microarchitecturecode name Coffee Lake H (8+2)
+    // 06_9EH | D | 9th Generation Intel Core Processor Family based on microarchitecture code name Coffee Lake S (8+2)
     return _stepping == 0x9 || _stepping == 0xA || _stepping == 0xB || _stepping == 0xD;
   case 0xA5:
     // Not in Intel documentation.
-    // 06_A5H |    | 10th Generation Intel® Core™ Processor Family based on microarchitecture code name Comet Lake S/H
+    // 06_A5H |    | 10th Generation Intel Core Processor Family based on microarchitecture code name Comet Lake S/H
     return true;
   case 0xA6:
-    // 06_A6H | 0  | 10th Generation Intel® Core™ Processor Family based on microarchitecture code name Comet Lake U62
+    // 06_A6H | 0  | 10th Generation Intel Core Processor Family based on microarchitecture code name Comet Lake U62
     return _stepping == 0x0;
   case 0xAE:
-    // 06_AEH | A | 8th Generation Intel® Core™ Processor Family based on microarchitecture code name Kaby Lake Refresh U (4+2)
+    // 06_AEH | A | 8th Generation Intel Core Processor Family based on microarchitecture code name Kaby Lake Refresh U (4+2)
     return _stepping == 0xA;
   default:
     // If we are running on another intel machine not recognized in the table, we are okay.

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1766,58 +1766,58 @@ bool VM_Version::compute_has_intel_jcc_erratum() {
   // https://www.intel.com/content/dam/support/us/en/documents/processors/mitigations-jump-conditional-code-erratum.pdf
   switch (_model) {
   case 0x8E:
-    // 06_8EH | 9 | 8th Generation Intel Core Processor Family based on microarchitecture code name Amber Lake Y
-    // 06_8EH | 9 | 7th Generation Intel Core Processor Family based on microarchitecture code name Kaby Lake U
-    // 06_8EH | 9 | 7th Generation Intel Core Processor Family based on microarchitecture code name Kaby Lake U 23e
-    // 06_8EH | 9 | 7th Generation Intel Core Processor Family based on microarchitecture code name Kaby Lake Y
-    // 06_8EH | A | 8th Generation Intel Core Processor Family based on microarchitecture code name Coffee Lake U43e
-    // 06_8EH | B | 8th Generation Intel Core Processors based on microarchitecture code name Whiskey Lake U
-    // 06_8EH | C | 8th Generation Intel Core Processor Family based on microarchitecture code name Amber Lake Y
-    // 06_8EH | C | 10th Generation Intel Core Processor Family based on microarchitecture code name Comet Lake U42
-    // 06_8EH | C | 8th Generation Intel Core Processors based on microarchitecture code name Whiskey Lake U
+    // 06_8EH | 9 | 8th Generation Intel(R) Core(TM) Processor Family based on microarchitecture code name Amber Lake Y
+    // 06_8EH | 9 | 7th Generation Intel(R) Core(TM) Processor Family based on microarchitecture code name Kaby Lake U
+    // 06_8EH | 9 | 7th Generation Intel(R) Core(TM) Processor Family based on microarchitecture code name Kaby Lake U 23e
+    // 06_8EH | 9 | 7th Generation Intel(R) Core(TM) Processor Family based on microarchitecture code name Kaby Lake Y
+    // 06_8EH | A | 8th Generation Intel(R) Core(TM) Processor Family based on microarchitecture code name Coffee Lake U43e
+    // 06_8EH | B | 8th Generation Intel(R) Core(TM) Processors based on microarchitecture code name Whiskey Lake U
+    // 06_8EH | C | 8th Generation Intel(R) Core(TM) Processor Family based on microarchitecture code name Amber Lake Y
+    // 06_8EH | C | 10th Generation Intel(R) Core(TM) Processor Family based on microarchitecture code name Comet Lake U42
+    // 06_8EH | C | 8th Generation Intel(R) Core(TM) Processors based on microarchitecture code name Whiskey Lake U
     return _stepping == 0x9 || _stepping == 0xA || _stepping == 0xB || _stepping == 0xC;
   case 0x4E:
-    // 06_4E  | 3 | 6th Generation Intel Core Processors based on microarchitecture code name Skylake U
-    // 06_4E  | 3 | 6th Generation Intel Core Processor Family based on microarchitecture code name Skylake U23e
-    // 06_4E  | 3 | 6th Generation Intel Core Processors based on microarchitecture code name Skylake Y
+    // 06_4E  | 3 | 6th Generation Intel(R) Core(TM) Processors based on microarchitecture code name Skylake U
+    // 06_4E  | 3 | 6th Generation Intel(R) Core(TM) Processor Family based on microarchitecture code name Skylake U23e
+    // 06_4E  | 3 | 6th Generation Intel(R) Core(TM) Processors based on microarchitecture code name Skylake Y
     return _stepping == 0x3;
   case 0x55:
-    // 06_55H | 4 | Intel Xeon Processor D Family based on microarchitecture code name Skylake D, Bakerville
-    // 06_55H | 4 | Intel Xeon Scalable Processors based on microarchitecture code name Skylake Server
-    // 06_55H | 4 | Intel Xeon Processor W Family based on microarchitecture code name Skylake W
-    // 06_55H | 4 | Intel Core X-series Processors based on microarchitecture code name Skylake X
-    // 06_55H | 4 | Intel Xeon Processor E3 v5 Family based on microarchitecture code name Skylake Xeon E3
-    // 06_55  | 7 | 2nd Generation Intel Xeon Scalable Processors based on microarchitecture code name Cascade Lake (server)
+    // 06_55H | 4 | Intel(R) Xeon(R) Processor D Family based on microarchitecture code name Skylake D, Bakerville
+    // 06_55H | 4 | Intel(R) Xeon(R) Scalable Processors based on microarchitecture code name Skylake Server
+    // 06_55H | 4 | Intel(R) Xeon(R) Processor W Family based on microarchitecture code name Skylake W
+    // 06_55H | 4 | Intel(R) Core(TM) X-series Processors based on microarchitecture code name Skylake X
+    // 06_55H | 4 | Intel(R) Xeon(R) Processor E3 v5 Family based on microarchitecture code name Skylake Xeon E3
+    // 06_55  | 7 | 2nd Generation Intel(R) Xeon(R) Scalable Processors based on microarchitecture code name Cascade Lake (server)
     return _stepping == 0x4 || _stepping == 0x7;
   case 0x5E:
-    // 06_5E  | 3 | 6th Generation Intel Core Processor Family based on microarchitecture code name Skylake H
-    // 06_5E  | 3 | 6th Generation Intel Core Processor Family based on microarchitecture code name Skylake S
+    // 06_5E  | 3 | 6th Generation Intel(R) Core(TM) Processor Family based on microarchitecture code name Skylake H
+    // 06_5E  | 3 | 6th Generation Intel(R) Core(TM) Processor Family based on microarchitecture code name Skylake S
     return _stepping == 0x3;
   case 0x9E:
-    // 06_9EH | 9 | 8th Generation Intel Core Processor Family based on microarchitecture code name Kaby Lake G
-    // 06_9EH | 9 | 7th Generation Intel Core Processor Family based on microarchitecture code name Kaby Lake H
-    // 06_9EH | 9 | 7th Generation Intel Core Processor Family based on microarchitecture code name Kaby Lake S
-    // 06_9EH | 9 | Intel Core X-series Processors based on microarchitecture code name Kaby Lake X
-    // 06_9EH | 9 | Intel Xeon Processor E3 v6 Family Kaby Lake Xeon E3
-    // 06_9EH | A | 8th Generation Intel Core Processor Family based on microarchitecture code name Coffee Lake H
-    // 06_9EH | A | 8th Generation Intel Core Processor Family based on microarchitecture code name Coffee Lake S
-    // 06_9EH | A | 8th Generation Intel Core Processor Family based on microarchitecture code name Coffee Lake S (6+2) x/KBP
-    // 06_9EH | A | Intel Xeon Processor E Family based on microarchitecture code name Coffee Lake S (6+2)
-    // 06_9EH | A | Intel Xeon Processor E Family based on microarchitecture code name Coffee Lake S (4+2)
-    // 06_9EH | B | 8th Generation Intel Core Processor Family based on microarchitecture code name Coffee Lake S (4+2)
-    // 06_9EH | B | Intel Celeron Processor G Series based on microarchitecture code name Coffee Lake S (4+2)
-    // 06_9EH | D | 9th Generation Intel Core Processor Family based on microarchitecturecode name Coffee Lake H (8+2)
-    // 06_9EH | D | 9th Generation Intel Core Processor Family based on microarchitecture code name Coffee Lake S (8+2)
+    // 06_9EH | 9 | 8th Generation Intel(R) Core(TM) Processor Family based on microarchitecture code name Kaby Lake G
+    // 06_9EH | 9 | 7th Generation Intel(R) Core(TM) Processor Family based on microarchitecture code name Kaby Lake H
+    // 06_9EH | 9 | 7th Generation Intel(R) Core(TM) Processor Family based on microarchitecture code name Kaby Lake S
+    // 06_9EH | 9 | Intel(R) Core(TM) X-series Processors based on microarchitecture code name Kaby Lake X
+    // 06_9EH | 9 | Intel(R) Xeon(R) Processor E3 v6 Family Kaby Lake Xeon E3
+    // 06_9EH | A | 8th Generation Intel(R) Core(TM) Processor Family based on microarchitecture code name Coffee Lake H
+    // 06_9EH | A | 8th Generation Intel(R) Core(TM) Processor Family based on microarchitecture code name Coffee Lake S
+    // 06_9EH | A | 8th Generation Intel(R) Core(TM) Processor Family based on microarchitecture code name Coffee Lake S (6+2) x/KBP
+    // 06_9EH | A | Intel(R) Xeon(R) Processor E Family based on microarchitecture code name Coffee Lake S (6+2)
+    // 06_9EH | A | Intel(R) Xeon(R) Processor E Family based on microarchitecture code name Coffee Lake S (4+2)
+    // 06_9EH | B | 8th Generation Intel(R) Core(TM) Processor Family based on microarchitecture code name Coffee Lake S (4+2)
+    // 06_9EH | B | Intel(R) Celeron(R) Processor G Series based on microarchitecture code name Coffee Lake S (4+2)
+    // 06_9EH | D | 9th Generation Intel(R) Core(TM) Processor Family based on microarchitecturecode name Coffee Lake H (8+2)
+    // 06_9EH | D | 9th Generation Intel(R) Core(TM) Processor Family based on microarchitecture code name Coffee Lake S (8+2)
     return _stepping == 0x9 || _stepping == 0xA || _stepping == 0xB || _stepping == 0xD;
   case 0xA5:
     // Not in Intel documentation.
-    // 06_A5H |    | 10th Generation Intel Core Processor Family based on microarchitecture code name Comet Lake S/H
+    // 06_A5H |    | 10th Generation Intel(R) Core(TM) Processor Family based on microarchitecture code name Comet Lake S/H
     return true;
   case 0xA6:
-    // 06_A6H | 0  | 10th Generation Intel Core Processor Family based on microarchitecture code name Comet Lake U62
+    // 06_A6H | 0  | 10th Generation Intel(R) Core(TM) Processor Family based on microarchitecture code name Comet Lake U62
     return _stepping == 0x0;
   case 0xAE:
-    // 06_AEH | A | 8th Generation Intel Core Processor Family based on microarchitecture code name Kaby Lake Refresh U (4+2)
+    // 06_AEH | A | 8th Generation Intel(R) Core(TM) Processor Family based on microarchitecture code name Kaby Lake Refresh U (4+2)
     return _stepping == 0xA;
   default:
     // If we are running on another intel machine not recognized in the table, we are okay.


### PR DESCRIPTION
Hi all,

I'd like to fix the C4819 warning at vm_version_x86.cpp on Windows after JDK-8234160.

The reason is that there are non-ASCII chars in the comments of vm_version_x86.cpp after JDK-8234160.
It makes the code to be less portable.

It would be better to fix it.

The fix just removing those chars in the comments.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274325](https://bugs.openjdk.java.net/browse/JDK-8274325): C4819 warning at vm_version_x86.cpp on Windows after JDK-8234160


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5701/head:pull/5701` \
`$ git checkout pull/5701`

Update a local copy of the PR: \
`$ git checkout pull/5701` \
`$ git pull https://git.openjdk.java.net/jdk pull/5701/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5701`

View PR using the GUI difftool: \
`$ git pr show -t 5701`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5701.diff">https://git.openjdk.java.net/jdk/pull/5701.diff</a>

</details>
