### PR TITLE
8274289: jdk/jfr/api/consumer/TestRecordedFrameType.java failed with "RuntimeException: assertNotEquals: expected Interpreted to not equal Interpreted"

### DIFF
--- a/test/jdk/jdk/jfr/api/consumer/TestRecordedFrameType.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestRecordedFrameType.java
@@ -105,7 +105,7 @@ public final class TestRecordedFrameType {
                 }
             }
         }
-        throw new Exception("Could not find frame with method named " + methodName);
+        throw new Exception("Could not find frame with method named: " + methodName);
     }
 
     public static void interpreted() {

--- a/test/jdk/jdk/jfr/api/consumer/TestRecordedFrameType.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestRecordedFrameType.java
@@ -51,44 +51,48 @@ public final class TestRecordedFrameType {
 
     public static void main(String[] args) throws Exception {
         WhiteBox WB = WhiteBox.getWhiteBox();
+        String directive =
+            """
+            [
+              {
+                match: "jdk/jfr/api/consumer/TestRecordedFrameType.interpreted()",
+                Exclude: true,
+              },
+              {
+                match: "jdk/jfr/api/consumer/TestRecordedFrameType.compiled()",
+                BackgroundCompilation: false,
+              },
+            ]
+            """;
+        WB.addCompilerDirective(directive);
+        while (true) { // Retry if method is being deoptimized
+            int count = 0;
+            try (Recording recording = new Recording()) {
+                recording.start();
+                Method mtd = TestRecordedFrameType.class.getMethod("compiled", new Class[0]);
+                if (!WB.enqueueMethodForCompilation(mtd, 1)) {
+                    throw new Exception("Could not enqueue method for CompLevel_simple");
+                }
+                Utils.waitForCondition(() -> WB.isMethodCompiled(mtd));
 
-        try (Recording recording = new Recording()) {
-            recording.start();
+                interpreted();
+                compiled();
 
-            String directive =
-                """
-                [
-                  {
-                    match: "jdk/jfr/api/consumer/TestRecordedFrameType.interpreted()",
-                    Exclude: true,
-                  },
-                  {
-                    match: "jdk/jfr/api/consumer/TestRecordedFrameType.compiled()",
-                    BackgroundCompilation: false,
-                  },
-                ]
-                """;
-            WB.addCompilerDirective(directive);
-            Method mtd = TestRecordedFrameType.class.getMethod("compiled", new Class[0]);
-            if (!WB.enqueueMethodForCompilation(mtd, 1)) {
-                throw new Exception("Could not enqueue method for CompLevel_simple");
+                List<RecordedEvent> events = Events.fromRecording(recording);
+
+                RecordedFrame interpreted = findFrame(events, "interpreted");
+                System.out.println(interpreted);
+                String iType = interpreted.getType();
+
+                RecordedFrame compiled = findFrame(events, "compiled");
+                System.out.println(compiled);
+                String cType = compiled.getType(); // Can be "JIT compiled" or "Inlined"
+                if (iType.equals("Interpreted") && !cType.equals("Interpreted"))  {
+                    return; // OK
+                }
+                count++;
+                System.out.println("Incorrect frame type. Retry " + count);
             }
-            Utils.waitForCondition(() -> WB.isMethodCompiled(mtd));
-
-            interpreted();
-            compiled();
-
-            List<RecordedEvent> events = Events.fromRecording(recording);
-
-            RecordedFrame interpreted = findFrame(events, "interpreted");
-            System.out.println(interpreted);
-            String iType = interpreted.getType();
-            Asserts.assertEquals(iType, "Interpreted");
-
-            RecordedFrame compiled = findFrame(events, "compiled");
-            System.out.println(compiled);
-            String cType = compiled.getType();
-            Asserts.assertNotEquals(cType, "Interpreted"); // "JIT compiled" or "Inlined"
         }
     }
 


### PR DESCRIPTION
Hi,

Could I have a review of test bug.

Most likely the test fails because of a deoptimization. The fix is to repeat the test until the test succeeds.

Testing: 100 times on linux-aarch64 and Windows, Mac and Linux on x86.

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274289](https://bugs.openjdk.java.net/browse/JDK-8274289): jdk/jfr/api/consumer/TestRecordedFrameType.java failed with "RuntimeException: assertNotEquals: expected Interpreted to not equal Interpreted"


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**) ⚠️ Review applies to 1b61fff60a01c305b9922e19f8751262cbf7eb70


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5703/head:pull/5703` \
`$ git checkout pull/5703`

Update a local copy of the PR: \
`$ git checkout pull/5703` \
`$ git pull https://git.openjdk.java.net/jdk pull/5703/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5703`

View PR using the GUI difftool: \
`$ git pr show -t 5703`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5703.diff">https://git.openjdk.java.net/jdk/pull/5703.diff</a>

</details>
