### PR TITLE
8274330: Incorrect encoding of the DistributionPointName object in IssuingDistributionPointExtension

### DIFF
--- a/src/java.base/share/classes/sun/security/x509/IssuingDistributionPointExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/IssuingDistributionPointExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -393,7 +393,8 @@ public class IssuingDistributionPointExtension extends Extension
         if (distributionPoint != null) {
             DerOutputStream tmp = new DerOutputStream();
             distributionPoint.encode(tmp);
-            tagged.writeImplicit(DerValue.createTag(DerValue.TAG_CONTEXT, true,
+            // DistributionPointName is CHOICE. Do not writeImplicit.
+            tagged.write(DerValue.createTag(DerValue.TAG_CONTEXT, true,
                 TAG_DISTRIBUTION_POINT), tmp);
         }
 

--- a/test/jdk/sun/security/x509/Extensions/IssuingDistributionPointExtensionEncoding.java
+++ b/test/jdk/sun/security/x509/Extensions/IssuingDistributionPointExtensionEncoding.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Incorrect encoding of the DistributionPointName object
+ *          in IssuingDistributionPointExtension
+ * @bug 8274330
+ * @modules java.base/sun.security.x509
+ */
+
+import sun.security.x509.DistributionPointName;
+import sun.security.x509.GeneralName;
+import sun.security.x509.GeneralNames;
+import sun.security.x509.IssuingDistributionPointExtension;
+import sun.security.x509.URIName;
+
+public class IssuingDistributionPointExtensionEncoding {
+    public static void main(String [] args) throws Exception {
+        var names = new GeneralNames();
+        names.add(new GeneralName(new URIName("http://here")));
+        // write one
+        var ext = new IssuingDistributionPointExtension(
+                new DistributionPointName(names),
+                null, true, false, false, false);
+        // read it
+        new IssuingDistributionPointExtension(true, ext.getValue());
+    }
+}


### PR DESCRIPTION
`DistributionPointName` in `IssuingDistributionPointExtension` is a CHOICE and should not be encoded as IMPLICIT.

Please note that the parsing side (at https://github.com/openjdk/jdk/blob/a9db70418f7bc6b2f95afdd36a36024f865c04bf/src/java.base/share/classes/sun/security/x509/IssuingDistributionPointExtension.java#L195) is aware of this and has not called `resetTag()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274330](https://bugs.openjdk.java.net/browse/JDK-8274330): Incorrect encoding of the DistributionPointName object in IssuingDistributionPointExtension


### Reviewers
 * [Anthony Scarpino](https://openjdk.java.net/census#ascarpino) (@ascarpino - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5706/head:pull/5706` \
`$ git checkout pull/5706`

Update a local copy of the PR: \
`$ git checkout pull/5706` \
`$ git pull https://git.openjdk.java.net/jdk pull/5706/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5706`

View PR using the GUI difftool: \
`$ git pr show -t 5706`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5706.diff">https://git.openjdk.java.net/jdk/pull/5706.diff</a>

</details>
