### PR TITLE
8274394: Use Optional.isEmpty instead of !Optional.isPresent in jdk.jlink

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/builder/DefaultImageBuilder.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/builder/DefaultImageBuilder.java
@@ -281,7 +281,7 @@ public final class DefaultImageBuilder implements ImageBuilder {
             if (mainClassName == null) {
                 String path = "/" + module + "/module-info.class";
                 Optional<ResourcePoolEntry> res = imageContent.findEntry(path);
-                if (!res.isPresent()) {
+                if (res.isEmpty()) {
                     throw new IOException("module-info.class not found for " + module + " module");
                 }
                 ByteArrayInputStream stream = new ByteArrayInputStream(res.get().contentBytes());
@@ -293,8 +293,8 @@ public final class DefaultImageBuilder implements ImageBuilder {
 
             if (mainClassName != null) {
                 // make sure main class exists!
-                if (!imageContent.findEntry("/" + module + "/" +
-                        mainClassName.replace('.', '/') + ".class").isPresent()) {
+                if (imageContent.findEntry("/" + module + "/" +
+                        mainClassName.replace('.', '/') + ".class").isEmpty()) {
                     throw new IllegalArgumentException(module + " does not have main class: " + mainClassName);
                 }
 

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JlinkTask.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JlinkTask.java
@@ -397,7 +397,7 @@ public class JlinkTask {
         }
 
         ModuleFinder finder = newModuleFinder(options.modulePath, options.limitMods, roots);
-        if (!finder.find("java.base").isPresent()) {
+        if (finder.find("java.base").isEmpty()) {
             Path defModPath = getDefaultModulePath();
             if (defModPath != null) {
                 options.modulePath.add(defModPath);
@@ -517,7 +517,7 @@ public class JlinkTask {
 
     private static Path toPathLocation(ResolvedModule m) {
         Optional<URI> ouri = m.reference().location();
-        if (!ouri.isPresent())
+        if (ouri.isEmpty())
             throw new InternalError(m + " does not have a location");
         URI uri = ouri.get();
         return Paths.get(uri);

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ResourcePoolManager.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ResourcePoolManager.java
@@ -54,7 +54,7 @@ public class ResourcePoolManager {
     static Attributes readModuleAttributes(ResourcePoolModule mod) {
         String p = "/" + mod.name() + "/module-info.class";
         Optional<ResourcePoolEntry> content = mod.findEntry(p);
-        if (!content.isPresent()) {
+        if (content.isEmpty()) {
               throw new PluginException("module-info.class not found for " +
                   mod.name() + " module");
         }

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/LegalNoticeFilePlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/LegalNoticeFilePlugin.java
@@ -111,7 +111,7 @@ public final class LegalNoticeFilePlugin extends AbstractPlugin {
             .filter(e -> e.linkedTarget() == null)
             .filter(e -> Arrays.equals(e.contentBytes(), entry.contentBytes()))
             .findFirst();
-        if (!otarget.isPresent()) {
+        if (otarget.isEmpty()) {
             if (errorIfNotSameContent) {
                 // all legal notices of the same file name are expected
                 // to contain the same content

--- a/src/jdk.jlink/share/classes/jdk/tools/jmod/JmodTask.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jmod/JmodTask.java
@@ -890,7 +890,7 @@ public class JmodTask {
             // filter modules resolved from the system module finder
             this.modules = config.modules().stream()
                 .map(ResolvedModule::name)
-                .filter(mn -> roots.contains(mn) && !system.find(mn).isPresent())
+                .filter(mn -> roots.contains(mn) && system.find(mn).isEmpty())
                 .collect(Collectors.toSet());
 
             this.hashesBuilder = new ModuleHashesBuilder(config, modules);


### PR DESCRIPTION
I propose to replace usages of !Optional.isPresent() with Optional.isEmpty method.
It's makes code a bit easier to read.
Noticing negation before long chain of method calls is hard.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274394](https://bugs.openjdk.java.net/browse/JDK-8274394): Use Optional.isEmpty instead of !Optional.isPresent in jdk.jlink


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5707/head:pull/5707` \
`$ git checkout pull/5707`

Update a local copy of the PR: \
`$ git checkout pull/5707` \
`$ git pull https://git.openjdk.java.net/jdk pull/5707/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5707`

View PR using the GUI difftool: \
`$ git pr show -t 5707`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5707.diff">https://git.openjdk.java.net/jdk/pull/5707.diff</a>

</details>
