### PR TITLE
8274333: Redundant null comparison after Pattern.split

### DIFF
--- a/src/java.base/share/classes/sun/launcher/LauncherHelper.java
+++ b/src/java.base/share/classes/sun/launcher/LauncherHelper.java
@@ -34,11 +34,6 @@ package sun.launcher;
  *
  */
 
-/**
- * A utility package for the java(1), javaw(1) launchers.
- * The following are helper methods that the native launcher uses
- * to perform checks etc. using JNI, see src/share/bin/java.c
- */
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -88,7 +83,11 @@ import jdk.internal.module.Modules;
 import jdk.internal.platform.Container;
 import jdk.internal.platform.Metrics;
 
-
+/**
+ * A utility package for the java(1), javaw(1) launchers.
+ * The following are helper methods that the native launcher uses
+ * to perform checks etc. using JNI, see src/share/bin/java.c
+ */
 public final class LauncherHelper {
 
     // No instantiation
@@ -154,8 +153,8 @@ public final class LauncherHelper {
             long initialHeapSize, long maxHeapSize, long stackSize) {
 
         initOutput(printToStderr);
-        String opts[] = optionFlag.split(":");
-        String optStr = (opts.length > 1 && opts[1] != null)
+        String[] opts = optionFlag.split(":");
+        String optStr = opts.length > 1
                 ? opts[1].trim()
                 : "all";
         switch (optStr) {

--- a/src/java.base/share/classes/sun/security/util/AlgorithmDecomposer.java
+++ b/src/java.base/share/classes/sun/security/util/AlgorithmDecomposer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ public class AlgorithmDecomposer {
         String[] transTokens = algorithm.split("/");
 
         for (String transToken : transTokens) {
-            if (transToken == null || transToken.isEmpty()) {
+            if (transToken.isEmpty()) {
                 continue;
             }
 
@@ -60,7 +60,7 @@ public class AlgorithmDecomposer {
             String[] tokens = PATTERN.split(transToken);
 
             for (String token : tokens) {
-                if (token == null || token.isEmpty()) {
+                if (token.isEmpty()) {
                     continue;
                 }
 


### PR DESCRIPTION
In couple of classes, result part of arrays of Pattern.split is compared with `null`. Pattern.split (and hence String.split) never returns `null` in array elements. Such comparisons are redundant.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274333](https://bugs.openjdk.java.net/browse/JDK-8274333): Redundant null comparison after Pattern.split


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5708/head:pull/5708` \
`$ git checkout pull/5708`

Update a local copy of the PR: \
`$ git checkout pull/5708` \
`$ git pull https://git.openjdk.java.net/jdk pull/5708/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5708`

View PR using the GUI difftool: \
`$ git pr show -t 5708`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5708.diff">https://git.openjdk.java.net/jdk/pull/5708.diff</a>

</details>
