### PR TITLE
8274345: make build-test-lib is broken

### DIFF
--- a/make/test/BuildTestLib.gmk
+++ b/make/test/BuildTestLib.gmk
@@ -36,9 +36,10 @@ TEST_LIB_SUPPORT := $(SUPPORT_OUTPUTDIR)/test/lib
 
 $(eval $(call SetupJavaCompilation, BUILD_WB_JAR, \
     TARGET_RELEASE := $(TARGET_RELEASE_NEWJDK_UPGRADED), \
-    SRC := $(TEST_LIB_SOURCE_DIR)/sun, \
+    SRC := $(TEST_LIB_SOURCE_DIR)/sun $(TEST_LIB_SOURCE_DIR)/jdk/test/whitebox/parser, \
     BIN := $(TEST_LIB_SUPPORT)/wb_classes, \
     JAR := $(TEST_LIB_SUPPORT)/wb.jar, \
+    DISABLED_WARNINGS := deprecation removal, \
 ))
 
 TARGETS += $(BUILD_WB_JAR)
@@ -50,7 +51,7 @@ $(eval $(call SetupJavaCompilation, BUILD_TEST_LIB_JAR, \
     BIN := $(TEST_LIB_SUPPORT)/test-lib_classes, \
     HEADERS := $(TEST_LIB_SUPPORT)/test-lib_headers, \
     JAR := $(TEST_LIB_SUPPORT)/test-lib.jar, \
-    DISABLED_WARNINGS := try deprecation rawtypes unchecked serial cast, \
+    DISABLED_WARNINGS := try deprecation rawtypes unchecked serial cast removal, \
 ))
 
 TARGETS += $(BUILD_TEST_LIB_JAR)


### PR DESCRIPTION
```java
/jdk/test/lib/sun/hotspot/WhiteBox.java:197: error: cannot find symbol
  public Object[] parseCommandLine(String commandline, char delim, DiagnosticCommand[] args) {
                                                                               ^
  symbol: class DiagnosticCommand
  location: class WhiteBox
```
WhiteBox can not find DiagnosticCommand when building lib

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274345](https://bugs.openjdk.java.net/browse/JDK-8274345): make build-test-lib is broken


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5710/head:pull/5710` \
`$ git checkout pull/5710`

Update a local copy of the PR: \
`$ git checkout pull/5710` \
`$ git pull https://git.openjdk.java.net/jdk pull/5710/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5710`

View PR using the GUI difftool: \
`$ git pr show -t 5710`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5710.diff">https://git.openjdk.java.net/jdk/pull/5710.diff</a>

</details>
