### PR TITLE
8269113: Javac throws when compiling switch (null)

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -277,9 +277,10 @@ public class TransPatterns extends TreeTranslator {
                               List<JCCase> cases,
                               boolean hasTotalPattern,
                               boolean patternSwitch) {
-        Type seltype = selector.type;
-
         if (patternSwitch) {
+            Type seltype = selector.type.hasTag(BOT) && false
+                    ? syms.objectType
+                    : selector.type;
             Assert.check(preview.isEnabled());
             Assert.check(preview.usesPreview(env.toplevel.sourcefile));
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -278,7 +278,7 @@ public class TransPatterns extends TreeTranslator {
                               boolean hasTotalPattern,
                               boolean patternSwitch) {
         if (patternSwitch) {
-            Type seltype = selector.type.hasTag(BOT) && false
+            Type seltype = selector.type.hasTag(BOT)
                     ? syms.objectType
                     : selector.type;
             Assert.check(preview.isEnabled());

--- a/test/langtools/tools/javac/patterns/SwitchErrors.java
+++ b/test/langtools/tools/javac/patterns/SwitchErrors.java
@@ -1,6 +1,6 @@
 /*
  * @test /nodynamiccopyright/
- * @bug 8262891 8269146
+ * @bug 8262891 8269146 8269113
  * @summary Verify errors related to pattern switches.
  * @compile/fail/ref=SwitchErrors.out --enable-preview -source ${jdk.version} -XDrawDiagnostics -XDshould-stop.at=FLOW SwitchErrors.java
  */
@@ -220,6 +220,12 @@ public class SwitchErrors {
     void exhaustiveAndNull(String s) {
         switch (s) {
             case null: break;
+        }
+    }
+    void referenceTypeTotalForNull() {
+        switch (null) {
+            case String s: break;
+            case CharSequence cs: break;
         }
     }
 }

--- a/test/langtools/tools/javac/patterns/SwitchErrors.out
+++ b/test/langtools/tools/javac/patterns/SwitchErrors.out
@@ -36,6 +36,7 @@ SwitchErrors.java:200:24: compiler.err.flows.through.to.pattern
 SwitchErrors.java:209:29: compiler.err.total.pattern.and.default
 SwitchErrors.java:216:42: compiler.err.flows.through.from.pattern
 SwitchErrors.java:216:45: compiler.err.flows.through.from.pattern
+SwitchErrors.java:228:18: compiler.err.duplicate.total.pattern
 SwitchErrors.java:9:9: compiler.err.not.exhaustive.statement
 SwitchErrors.java:15:9: compiler.err.not.exhaustive.statement
 SwitchErrors.java:21:9: compiler.err.not.exhaustive.statement
@@ -50,4 +51,4 @@ SwitchErrors.java:164:9: compiler.err.not.exhaustive.statement
 SwitchErrors.java:221:9: compiler.err.not.exhaustive.statement
 - compiler.note.preview.filename: SwitchErrors.java, DEFAULT
 - compiler.note.preview.recompile
-50 errors
+51 errors

--- a/test/langtools/tools/javac/patterns/Switches.java
+++ b/test/langtools/tools/javac/patterns/Switches.java
@@ -28,7 +28,7 @@ import java.util.function.Function;
 
 /*
  * @test
- * @bug 8262891 8268333 8268896 8269802 8269808 8270151
+ * @bug 8262891 8268333 8268896 8269802 8269808 8270151 8269113
  * @summary Check behavior of pattern switches.
  * @compile --enable-preview -source ${jdk.version} Switches.java
  * @run main/othervm --enable-preview Switches
@@ -71,6 +71,7 @@ public class Switches {
         runFallThrough(this::testFallThrough2Expression);
         npeTest(this::npeTestStatement);
         npeTest(this::npeTestExpression);
+        npeTest(this::switchOverNullNPE);
         exhaustiveStatementSane("");
         exhaustiveStatementSane(null);
         exhaustiveStatementSane2(null);
@@ -81,6 +82,9 @@ public class Switches {
         switchNestingTest(this::switchNestingExpressionStatement);
         switchNestingTest(this::switchNestingExpressionExpression);
         switchNestingTest(this::switchNestingIfSwitch);
+        assertEquals(2, switchOverNull1());
+        assertEquals(2, switchOverNull2());
+        assertEquals(2, switchOverNull3());
     }
 
     void run(Function<Object, Integer> mapper) {
@@ -571,6 +575,32 @@ public class Switches {
             }
         };
         return f.apply(o1, o2);
+    }
+
+    private void switchOverNullNPE(I i) {
+        int r = switch (null) {
+            default -> 1;
+        };
+    }
+
+    private int  switchOverNull1() {
+        return switch (null) {
+            case Object o -> 2;
+        };
+    }
+
+    private int  switchOverNull2() {
+        return switch (null) {
+            case null -> 2;
+            default -> 1;
+        };
+    }
+
+    private int  switchOverNull3() {
+        return switch (null) {
+            case null -> 2;
+            case Object o -> 1;
+        };
     }
 
     //verify that for cases like:


### PR DESCRIPTION
This handles a case of `switch (null)` (i.e. switch over a literal `null`). It is necessary to handle `BOT` (null type) in the switch's selector, similarly to how it is handled in `null instanceof ...`. Note that since any reference type is a supertype of the `null` (JLS 4.10.2.), any type pattern is total for `switch (null)`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269113](https://bugs.openjdk.java.net/browse/JDK-8269113): Javac throws when compiling switch (null)


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Contributors
 * Guoxiong Li `<gli@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5713/head:pull/5713` \
`$ git checkout pull/5713`

Update a local copy of the PR: \
`$ git checkout pull/5713` \
`$ git pull https://git.openjdk.java.net/jdk pull/5713/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5713`

View PR using the GUI difftool: \
`$ git pr show -t 5713`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5713.diff">https://git.openjdk.java.net/jdk/pull/5713.diff</a>

</details>
