### PR TITLE
8277535: Remove redundant Stream.distinct()/sorted() steps

### DIFF
--- a/src/java.base/share/classes/jdk/internal/module/ModulePath.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModulePath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/module/ModulePath.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModulePath.java
@@ -527,7 +527,6 @@ public class ModulePath implements ModuleFinder {
         Set<String> packages = classFiles.stream()
                 .map(this::toPackageName)
                 .flatMap(Optional::stream)
-                .distinct()
                 .collect(Collectors.toSet());
 
         // all packages are exported and open

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/ModuleDotGraph.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/ModuleDotGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/ModuleDotGraph.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/ModuleDotGraph.java
@@ -65,7 +65,6 @@ public class ModuleDotGraph {
         this(config,
              config.rootModules().stream()
                    .map(Module::name)
-                   .sorted()
                    .collect(toMap(Function.identity(), mn -> config.resolve(Set.of(mn)))),
              apiOnly);
     }

--- a/src/jdk.jlink/share/classes/jdk/tools/jmod/JmodTask.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jmod/JmodTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jlink/share/classes/jdk/tools/jmod/JmodTask.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jmod/JmodTask.java
@@ -680,7 +680,6 @@ public class JmodTask {
                         .filter(path -> isResource(path.toString()))
                         .map(path -> toPackageName(path))
                         .filter(pkg -> pkg.length() > 0)
-                        .distinct()
                         .collect(Collectors.toSet());
             } catch (IOException ioe) {
                 throw new UncheckedIOException(ioe);
@@ -695,7 +694,6 @@ public class JmodTask {
                      .filter(e -> !e.isDirectory() && isResource(e.getName()))
                      .map(e -> toPackageName(e))
                      .filter(pkg -> pkg.length() > 0)
-                     .distinct()
                      .collect(Collectors.toSet());
         }
 


### PR DESCRIPTION
1. Stream.distinct() is redundant before toSet() collector. Duplicates will be collapsed by Collector.
2. Stream.sorted() is redundant before toMap() collector. Keys will be shuffled by Collector (it's a HashMap in current implementation)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277535](https://bugs.openjdk.java.net/browse/JDK-8277535): Remove redundant Stream.distinct()/sorted() steps


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**) ⚠️ Review applies to b326898d767980660729d889015a89514b0e1f03


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5714/head:pull/5714` \
`$ git checkout pull/5714`

Update a local copy of the PR: \
`$ git checkout pull/5714` \
`$ git pull https://git.openjdk.java.net/jdk pull/5714/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5714`

View PR using the GUI difftool: \
`$ git pr show -t 5714`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5714.diff">https://git.openjdk.java.net/jdk/pull/5714.diff</a>

</details>
