### PR TITLE
8272562: C2: assert(false) failed: Bad graph detected in build_loop_late

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1446,7 +1446,7 @@ void PhaseIdealLoop::try_sink_out_of_loop(Node* n) {
       !n->is_CMove() &&
       !is_raw_to_oop_cast && // don't extend live ranges of raw oops
       n->Opcode() != Op_Opaque4 &&
-      (n->Opcode() == Op_CastII && ((CastIINode*)n)->has_range_check())) {
+      !n->is_Type()) {
     Node *n_ctrl = get_ctrl(n);
     IdealLoopTree *n_loop = get_loop(n_ctrl);
     if (n_loop != _ltree_root && n->outcnt() > 1) {

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1445,7 +1445,8 @@ void PhaseIdealLoop::try_sink_out_of_loop(Node* n) {
       !n->is_MergeMem() &&
       !n->is_CMove() &&
       !is_raw_to_oop_cast && // don't extend live ranges of raw oops
-      n->Opcode() != Op_Opaque4) {
+      n->Opcode() != Op_Opaque4 &&
+      (n->Opcode() == Op_CastII && ((CastIINode*)n)->has_range_check())) {
     Node *n_ctrl = get_ctrl(n);
     IdealLoopTree *n_loop = get_loop(n_ctrl);
     if (n_loop != _ltree_root && n->outcnt() > 1) {

--- a/test/hotspot/jtreg/compiler/loopopts/TestSunkCastOnUnreachablePath.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestSunkCastOnUnreachablePath.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8272562
+ * @summary C2: assert(false) failed: Bad graph detected in build_loop_late
+ *
+ * @run main/othervm -XX:CompileOnly=TestSunkCastOnUnreachablePath -XX:-TieredCompilation -Xbatch TestSunkCastOnUnreachablePath
+ *
+ */
+
+public class TestSunkCastOnUnreachablePath {
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 1000; i++) {
+            vMeth();
+        }
+    }
+
+    static int vMeth() {
+        int i2 = 3, iArr1[] = new int[200];
+
+        for (int i9 = 3; i9 < 100; i9++) {
+            try {
+                int i10 = (iArr1[i9 - 1]);
+                i2 = (i10 / i9);
+            } catch (ArithmeticException a_e) {
+            }
+        }
+        return i2;
+    }
+}


### PR DESCRIPTION
A counted loop has an array access:

(LoadI (AddP (AddP (ConvI2L (CastII (AddI (Phi ...)))))))

that is

array[iv - 1]

The Phi is the iv Phi. The ConvI2L/CastII are from a range check
and capture type: 0..maxint-1 The loop is unrolled once, the
LoadI is cloned.

array[iv - 1]
array[iv]

The first LoadI is only used out of loop and is sunk with 2
clones. One of the clones is on the IfFalse branch of a test
for iv != 0.

(LoadI (AddP (AddP (ConvI2L (CastII (AddI (CastII ...)))))))

The second CastII pins the nodes out of the loop. The ConvI2L and
CastII are pushed thru the AddI (for -1). As a result the ConvI2L
has type:
1..maxint-1

The CastII, because it has the same input as the input for iv != 0,
becomes 0 which is not part of 1..maxint-1. The ConvI2L and all its
uses including the LoadI become top. The use of the LoadI is a Phi
that is transformed into its remaining input and the graph is broken.

The root cause is that the loop body initially contains:

if (iv - 1 >=u array.length) { // range check
  trap();
}

if (iv == 0) {
  // path where nodes are sunk later on
}

And obviously if iv - 1 >= 0 then iv == 0 is always false but c2 fails
to prove it. I tried to implement a simple fix for this issue but
while it fixes this bug, I couldn't convince myself that it was robust
enough.

So instead I propose following the suggestion Christian and Vladimir I.
made in:

https://github.com/openjdk/jdk/pull/5199

that is to more generally exclude cast nodes from sinking as a
workaround for now.

I've been looking for a more general solution to this problem and I
have a prototype that fixes this failure but is a lot more
complicated. I'll revisit this workaround when it's ready.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272562](https://bugs.openjdk.java.net/browse/JDK-8272562): C2: assert(false) failed: Bad graph detected in build_loop_late


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5716/head:pull/5716` \
`$ git checkout pull/5716`

Update a local copy of the PR: \
`$ git checkout pull/5716` \
`$ git pull https://git.openjdk.java.net/jdk pull/5716/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5716`

View PR using the GUI difftool: \
`$ git pr show -t 5716`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5716.diff">https://git.openjdk.java.net/jdk/pull/5716.diff</a>

</details>
