### PR TITLE
8274363: Transitively sealed classes not considered exhaustive in switches

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -773,7 +773,7 @@ public class Flow {
                     case TYP -> {
                         for (Type sup : types.directSupertypes(sym.type)) {
                             if (sup.tsym.kind == TYP) {
-                                if (isTransitivellyCovered(sup.tsym, covered) &&
+                                if (isTransitivelyCovered(sup.tsym, covered) &&
                                     covered.add(sup.tsym)) {
                                     todo = todo.prepend(sup.tsym);
                                 }
@@ -784,7 +784,7 @@ public class Flow {
             }
         }
 
-        private boolean isTransitivellyCovered(Symbol sealed, Set<Symbol> covered) {
+        private boolean isTransitivelyCovered(Symbol sealed, Set<Symbol> covered) {
             DeferredCompletionFailureHandler.Handler prevHandler =
                     dcfh.setHandler(dcfh.speculativeCodeHandler);
             try {
@@ -793,7 +793,7 @@ public class Flow {
                 if (sealed.kind == TYP && sealed.isAbstract() && sealed.isSealed()) {
                     return ((ClassSymbol) sealed).permitted
                                                  .stream()
-                                                 .allMatch(s -> isTransitivellyCovered(s, covered));
+                                                 .allMatch(s -> isTransitivelyCovered(s, covered));
                 }
                 return false;
             } catch (CompletionFailure cf) {

--- a/test/langtools/tools/javac/patterns/Exhaustiveness.java
+++ b/test/langtools/tools/javac/patterns/Exhaustiveness.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8262891 8268871
+ * @bug 8262891 8268871 8274363
  * @summary Check exhaustiveness of switches over sealed types.
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -773,6 +773,30 @@ public class Exhaustiveness extends TestRunner {
                "- compiler.note.preview.filename: Test.java, DEFAULT",
                "- compiler.note.preview.recompile",
                "1 error");
+    }
+
+    @Test
+    public void testTransitiveSealed(Path base) throws Exception {
+        doTest(base,
+               new String[0],
+               """
+               package test;
+               public class Test {
+                   sealed interface A {}
+                   sealed interface B1 extends A {}
+                   sealed interface B2 extends A {}
+                   sealed interface C extends A {}
+                   final class D1 implements B1, C {}
+                   final class D2 implements B2, C {}
+
+                   void test(A arg) {
+                       int i = switch (arg) {
+                           case B1 b1 -> 1;
+                           case B2 b2 -> 2;
+                       };
+                   }
+               }
+               """);
     }
 
     private void doTest(Path base, String[] libraryCode, String testCode, String... expectedErrors) throws IOException {

--- a/test/langtools/tools/javac/patterns/Exhaustiveness.java
+++ b/test/langtools/tools/javac/patterns/Exhaustiveness.java
@@ -801,21 +801,24 @@ public class Exhaustiveness extends TestRunner {
 
     private void doTest(Path base, String[] libraryCode, String testCode, String... expectedErrors) throws IOException {
         Path current = base.resolve(".");
-        Path libSrc = current.resolve("lib-src");
-        for (String code : libraryCode) {
-            tb.writeJavaFiles(libSrc, code);
-        }
-
         Path libClasses = current.resolve("libClasses");
 
         Files.createDirectories(libClasses);
 
-        new JavacTask(tb)
-                .options("--enable-preview",
-                         "-source", JAVA_VERSION)
-                .outdir(libClasses)
-                .files(tb.findJavaFiles(libSrc))
-                .run();
+        if (libraryCode.length != 0) {
+            Path libSrc = current.resolve("lib-src");
+
+            for (String code : libraryCode) {
+                tb.writeJavaFiles(libSrc, code);
+            }
+
+            new JavacTask(tb)
+                    .options("--enable-preview",
+                             "-source", JAVA_VERSION)
+                    .outdir(libClasses)
+                    .files(tb.findJavaFiles(libSrc))
+                    .run();
+        }
 
         Path src = current.resolve("src");
         tb.writeJavaFiles(src, testCode);


### PR DESCRIPTION
Consider code like:
```
public class SwitchCoverage {
    sealed interface A {}
    sealed interface B1 extends A {}
    sealed interface B2 extends A {}
    sealed interface C extends A {}
    final class D1 implements B1, C {}
    final class D2 implements B2, C {}
    
    void test(A arg) {
        int i = switch (arg) {
            case B1 b1 -> 1;
            case B2 b2 -> 2;
        };
    }
    
} 
```

Note that `B1` covers `D1` and `B2` covers `D2`. So, `B1` and `B2` cover `C`, and hence `B1` and `B2` cover `A`.  To detect this, when looking for coverage of permitted types of `A`, we need to transitively look if any of the permitted type is covered.

The check uses the `DeferredCompletionFailureHandler`, because if don't want to fail the compilation on unresolvable permitted subclass. (In case the permitted subclass is covered by some other means, of course.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274363](https://bugs.openjdk.java.net/browse/JDK-8274363): Transitively sealed classes not considered exhaustive in switches


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**) ⚠️ Review applies to 0a63b376bee89cf852d3b26148d4da30d8f0c257


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5717/head:pull/5717` \
`$ git checkout pull/5717`

Update a local copy of the PR: \
`$ git checkout pull/5717` \
`$ git pull https://git.openjdk.java.net/jdk pull/5717/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5717`

View PR using the GUI difftool: \
`$ git pr show -t 5717`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5717.diff">https://git.openjdk.java.net/jdk/pull/5717.diff</a>

</details>
