### PR TITLE
8274391: Suppress more warnings on non-serializable non-transient instance fields in java.util.concurrent

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
@@ -2778,6 +2778,7 @@ public class ForkJoinPool extends AbstractExecutorService {
         @SuppressWarnings("serial") // Conditionally serializable
         volatile E result;
         final AtomicInteger count;  // in case all throw
+        @SuppressWarnings("serial")
         final ForkJoinPool pool;    // to check shutdown while collecting
         InvokeAnyRoot(int n, ForkJoinPool p) {
             pool = p;

--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinTask.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinTask.java
@@ -1444,8 +1444,8 @@ public abstract class ForkJoinTask<V> implements Future<V>, Serializable {
         implements RunnableFuture<T> {
         @SuppressWarnings("serial") // Conditionally serializable
         final Callable<? extends T> callable;
-        @SuppressWarnings("serial") // Conditionally serializable
         transient volatile Thread runner;
+        @SuppressWarnings("serial") // Conditionally serializable
         T result;
         AdaptedInterruptibleCallable(Callable<? extends T> callable) {
             if (callable == null) throw new NullPointerException();


### PR DESCRIPTION
Follow-up change to JDK-8232230, augmentations to javac's Xlint:serial checking are out for review (https://github.com/openjdk/jdk/pull/5709) and java.util.concurrent would need some changes to pass under the expanded checks.

The changes are to suppress warnings where non-transient fields in serializable types are not declared with a type statically known to be serializable. That isn't necessarily a correctness issues, but it does merit further scrutiny.

In ForkJoinTask, the SuppressWarnings annotation previously applied in JDK-8232230, seems to have been misplaced to a different field; this change corrects it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274391](https://bugs.openjdk.java.net/browse/JDK-8274391): Suppress more warnings on non-serializable non-transient instance fields in java.util.concurrent


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5718/head:pull/5718` \
`$ git checkout pull/5718`

Update a local copy of the PR: \
`$ git checkout pull/5718` \
`$ git pull https://git.openjdk.java.net/jdk pull/5718/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5718`

View PR using the GUI difftool: \
`$ git pr show -t 5718`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5718.diff">https://git.openjdk.java.net/jdk/pull/5718.diff</a>

</details>
