### PR TITLE
8274392: Suppress more warnings on non-serializable non-transient instance fields in java.sql.rowset

### DIFF
--- a/src/java.sql.rowset/share/classes/com/sun/rowset/CachedRowSetImpl.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/CachedRowSetImpl.java
@@ -60,6 +60,7 @@ public class CachedRowSetImpl extends BaseRowSet implements RowSet, RowSetIntern
     /**
      * The <code>SyncProvider</code> used by the CachedRowSet
      */
+    @SuppressWarnings("serial")
     private SyncProvider provider;
 
     /**
@@ -68,6 +69,7 @@ public class CachedRowSetImpl extends BaseRowSet implements RowSet, RowSetIntern
      * reader as part of its implementation.
      * @serial
      */
+    @SuppressWarnings("serial")
     private RowSetReader rowSetReader;
 
     /**
@@ -76,6 +78,7 @@ public class CachedRowSetImpl extends BaseRowSet implements RowSet, RowSetIntern
      * this writer as part of its implementation.
      * @serial
      */
+    @SuppressWarnings("serial")
     private RowSetWriter rowSetWriter;
 
     /**
@@ -315,6 +318,7 @@ public class CachedRowSetImpl extends BaseRowSet implements RowSet, RowSetIntern
     /**
      * The field object for a transactional RowSet writer
      */
+    @SuppressWarnings("serial")
     private TransactionalWriter tWriter = null;
 
     protected transient JdbcRowSetResourceBundle resBundle;

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/FilteredRowSetImpl.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/FilteredRowSetImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/FilteredRowSetImpl.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/FilteredRowSetImpl.java
@@ -47,6 +47,7 @@ import com.sun.rowset.internal.*;
 
 public class FilteredRowSetImpl extends WebRowSetImpl implements Serializable, Cloneable, FilteredRowSet {
 
+    @SuppressWarnings("serial")
     private Predicate p;
 
     private boolean onInsertRow = false;

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/JdbcRowSetImpl.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/JdbcRowSetImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/JdbcRowSetImpl.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/JdbcRowSetImpl.java
@@ -48,6 +48,7 @@ public class JdbcRowSetImpl extends BaseRowSet implements JdbcRowSet, Joinable {
      * current connection to the database.  This field is set
      * internally when the connection is established.
      */
+    @SuppressWarnings("serial")
     private Connection conn;
 
     /**
@@ -56,6 +57,7 @@ public class JdbcRowSetImpl extends BaseRowSet implements JdbcRowSet, Joinable {
      * {@code execute} creates the {@code PreparedStatement}
      * object.
      */
+    @SuppressWarnings("serial")
     private PreparedStatement ps;
 
     /**
@@ -64,6 +66,7 @@ public class JdbcRowSetImpl extends BaseRowSet implements JdbcRowSet, Joinable {
      * {@code execute} executes the rowset's command and thereby
      * creates the rowset's {@code ResultSet} object.
      */
+    @SuppressWarnings("serial")
     private ResultSet rs;
 
     /**
@@ -80,6 +83,7 @@ public class JdbcRowSetImpl extends BaseRowSet implements JdbcRowSet, Joinable {
      * {@code RowSetMetaDataImpl} is formed and which  helps in getting
      * the metadata information.
      */
+    @SuppressWarnings("serial")
     private ResultSetMetaData resMD;
 
 

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/JoinRowSetImpl.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/JoinRowSetImpl.java
@@ -108,6 +108,7 @@ public class JoinRowSetImpl extends WebRowSetImpl implements JoinRowSet {
      * object to leverage the properties and methods of a <code>WebRowSet</code>
      * object.
      */
+    @SuppressWarnings("serial")
     private WebRowSet wrs;
 
 

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/WebRowSetImpl.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/WebRowSetImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/WebRowSetImpl.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/WebRowSetImpl.java
@@ -68,6 +68,7 @@ public class WebRowSetImpl extends CachedRowSetImpl implements WebRowSet {
      */
     private int curPosBfrWrite;
 
+    @SuppressWarnings("serial")
     private SyncProvider provider;
 
     /**

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/internal/CachedRowSetWriter.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/internal/CachedRowSetWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/internal/CachedRowSetWriter.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/internal/CachedRowSetWriter.java
@@ -165,6 +165,7 @@ public class CachedRowSetWriter implements TransactionalWriter, Serializable {
  *
  * @serial
  */
+    @SuppressWarnings("serial")
     private ResultSetMetaData callerMd;
 
 /**

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/internal/SyncResolverImpl.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/internal/SyncResolverImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/internal/SyncResolverImpl.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/internal/SyncResolverImpl.java
@@ -96,6 +96,7 @@ public class SyncResolverImpl extends CachedRowSetImpl implements SyncResolver {
      * SyncResolver values. Synchronization takes place on a row by
      * row basis encapsulated as a CahedRowSet.
      */
+    @SuppressWarnings("serial")
     private CachedRowSet row;
 
     private JdbcRowSetResourceBundle resBundle;


### PR DESCRIPTION
Follow-up change to JDK-8231442, augmentations to javac's Xlint:serial checking are out for review (#5709) and java.sql.rowset would need some changes to pass under the expanded checks.

The changes are to suppress warnings where non-transient fields in serializable types are not declared with a type statically known to be serializable. That isn't necessarily a correctness issues, but it does merit further scrutiny.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274392](https://bugs.openjdk.java.net/browse/JDK-8274392): Suppress more warnings on non-serializable non-transient instance fields in java.sql.rowset


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to 70747989122f5503ec50a18d3682b9a41860c73b
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to 70747989122f5503ec50a18d3682b9a41860c73b


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5719/head:pull/5719` \
`$ git checkout pull/5719`

Update a local copy of the PR: \
`$ git checkout pull/5719` \
`$ git pull https://git.openjdk.java.net/jdk pull/5719/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5719`

View PR using the GUI difftool: \
`$ git pr show -t 5719`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5719.diff">https://git.openjdk.java.net/jdk/pull/5719.diff</a>

</details>
