### PR TITLE
[PATCH] Reuse static empty String array in SuntFontManager to avoid allocation new arrays each time

### DIFF
--- a/src/java.desktop/share/classes/sun/font/SunFontManager.java
+++ b/src/java.desktop/share/classes/sun/font/SunFontManager.java
@@ -228,7 +228,7 @@ public abstract class SunFontManager implements FontSupport, FontManagerForSGE {
     public static boolean noType1Font;
 
     /* Used to indicate required return type from toArray(..); */
-    private static String[] STR_ARRAY = new String[0];
+    private static final String[] STR_ARRAY = new String[0];
 
     /**
      * Deprecated, unsupported hack - actually invokes a bug!
@@ -1131,7 +1131,7 @@ public abstract class SunFontManager implements FontSupport, FontManagerForSGE {
                     File dir = new File(pathDirs[0]);
                     String[] files = dir.list(filter);
                     if (files == null) {
-                        return new String[0];
+                        return STR_ARRAY;
                     }
                     for (int f=0; f<files.length; f++) {
                         files[f] = files[f].toLowerCase();
@@ -2852,7 +2852,7 @@ public abstract class SunFontManager implements FontSupport, FontManagerForSGE {
             }
         } catch (NoSuchElementException e) {
         }
-        pathDirs = pathList.toArray(new String[0]);
+        pathDirs = pathList.toArray(STR_ARRAY);
         return pathDirs;
     }
 
@@ -3352,7 +3352,7 @@ public abstract class SunFontManager implements FontSupport, FontManagerForSGE {
                 }
             }
 
-            String[] fontNames = fontMapNames.keySet().toArray(new String[0]);
+            String[] fontNames = fontMapNames.keySet().toArray(STR_ARRAY);
             Font[] fonts = new Font[fontNames.length];
             for (int i=0; i < fontNames.length; i++) {
                 fonts[i] = new Font(fontNames[i], Font.PLAIN, 1);
@@ -3421,7 +3421,7 @@ public abstract class SunFontManager implements FontSupport, FontManagerForSGE {
         // Add any native font family names here
         addNativeFontFamilyNames(familyNames, requestedLocale);
 
-        String[] retval = familyNames.values().toArray(new String[0]);
+        String[] retval = familyNames.values().toArray(STR_ARRAY);
         if (requestedLocale.equals(Locale.getDefault())) {
             lastDefaultLocale = requestedLocale;
             allFamilies = new String[retval.length];


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5721/head:pull/5721` \
`$ git checkout pull/5721`

Update a local copy of the PR: \
`$ git checkout pull/5721` \
`$ git pull https://git.openjdk.java.net/jdk pull/5721/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5721`

View PR using the GUI difftool: \
`$ git pr show -t 5721`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5721.diff">https://git.openjdk.java.net/jdk/pull/5721.diff</a>

</details>
