### PR TITLE
[PATCH] Remove redundant HashMap.get call before HashMap.remove

### DIFF
--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystemProvider.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystemProvider.java
@@ -308,8 +308,7 @@ public class ZipFileSystemProvider extends FileSystemProvider {
             } catch (PrivilegedActionException e) {
                 throw (IOException) e.getException();
             }
-            if (filesystems.get(zfpath) == zfs)
-                filesystems.remove(zfpath);
+            filesystems.remove(zfpath, zfs);
         }
     }
 }


### PR DESCRIPTION
There is overload method HashMap.remove(key,value) which also checks value equality.
It's shorter and faster than pair get+remove.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5722/head:pull/5722` \
`$ git checkout pull/5722`

Update a local copy of the PR: \
`$ git checkout pull/5722` \
`$ git pull https://git.openjdk.java.net/jdk pull/5722/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5722`

View PR using the GUI difftool: \
`$ git pr show -t 5722`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5722.diff">https://git.openjdk.java.net/jdk/pull/5722.diff</a>

</details>
