### PR TITLE
8274396: Suppress more warnings on non-serializable non-transient instance fields in client libs

### DIFF
--- a/src/java.desktop/share/classes/com/sun/beans/editors/FontEditor.java
+++ b/src/java.desktop/share/classes/com/sun/beans/editors/FontEditor.java
@@ -220,6 +220,7 @@ public class FontEditor extends Panel implements java.beans.PropertyEditor {
     }
 
     private Font font;
+    @SuppressWarnings("serial")
     private Toolkit toolkit;
     private String sampleText = "Abcde...";
 

--- a/src/java.desktop/share/classes/com/sun/beans/editors/FontEditor.java
+++ b/src/java.desktop/share/classes/com/sun/beans/editors/FontEditor.java
@@ -220,7 +220,7 @@ public class FontEditor extends Panel implements java.beans.PropertyEditor {
     }
 
     private Font font;
-    @SuppressWarnings("serial")
+    @SuppressWarnings("serial") // Type of field is not Serializable
     private Toolkit toolkit;
     private String sampleText = "Abcde...";
 

--- a/src/java.desktop/share/classes/sun/awt/im/CompositionArea.java
+++ b/src/java.desktop/share/classes/sun/awt/im/CompositionArea.java
@@ -61,12 +61,12 @@ import javax.swing.border.LineBorder;
 // This class is final due to the 6607310 fix. Refer to the CR for details.
 public final class CompositionArea extends JPanel implements InputMethodListener {
 
-    @SuppressWarnings("serial")
+    @SuppressWarnings("serial") // Type of field is not Serializable
     private CompositionAreaHandler handler;
 
-    @SuppressWarnings("serial")
+    @SuppressWarnings("serial") // Type of field is not Serializable
     private TextLayout composedTextLayout;
-    @SuppressWarnings("serial")
+    @SuppressWarnings("serial") // Type of field is not Serializable
     private TextHitInfo caret = null;
     private JFrame compositionWindow;
     private static final int TEXT_ORIGIN_X = 5;

--- a/src/java.desktop/share/classes/sun/awt/im/CompositionArea.java
+++ b/src/java.desktop/share/classes/sun/awt/im/CompositionArea.java
@@ -61,9 +61,12 @@ import javax.swing.border.LineBorder;
 // This class is final due to the 6607310 fix. Refer to the CR for details.
 public final class CompositionArea extends JPanel implements InputMethodListener {
 
+    @SuppressWarnings("serial")
     private CompositionAreaHandler handler;
 
+    @SuppressWarnings("serial")
     private TextLayout composedTextLayout;
+    @SuppressWarnings("serial")
     private TextHitInfo caret = null;
     private JFrame compositionWindow;
     private static final int TEXT_ORIGIN_X = 5;

--- a/src/java.desktop/share/classes/sun/awt/im/InputMethodJFrame.java
+++ b/src/java.desktop/share/classes/sun/awt/im/InputMethodJFrame.java
@@ -40,6 +40,7 @@ public class InputMethodJFrame
         extends JFrame
         implements InputMethodWindow {
 
+    @SuppressWarnings("serial")
     InputContext inputContext = null;
 
     /**

--- a/src/java.desktop/share/classes/sun/awt/im/InputMethodJFrame.java
+++ b/src/java.desktop/share/classes/sun/awt/im/InputMethodJFrame.java
@@ -40,7 +40,7 @@ public class InputMethodJFrame
         extends JFrame
         implements InputMethodWindow {
 
-    @SuppressWarnings("serial")
+    @SuppressWarnings("serial") // Type of field is not Serializable
     InputContext inputContext = null;
 
     /**

--- a/src/java.desktop/share/classes/sun/awt/im/SimpleInputMethodWindow.java
+++ b/src/java.desktop/share/classes/sun/awt/im/SimpleInputMethodWindow.java
@@ -38,6 +38,7 @@ public class SimpleInputMethodWindow
         extends Frame
         implements InputMethodWindow {
 
+    @SuppressWarnings("serial")
     InputContext inputContext = null;
 
     /**

--- a/src/java.desktop/share/classes/sun/awt/im/SimpleInputMethodWindow.java
+++ b/src/java.desktop/share/classes/sun/awt/im/SimpleInputMethodWindow.java
@@ -38,7 +38,7 @@ public class SimpleInputMethodWindow
         extends Frame
         implements InputMethodWindow {
 
-    @SuppressWarnings("serial")
+    @SuppressWarnings("serial") // Type of field is not Serializable
     InputContext inputContext = null;
 
     /**

--- a/src/java.desktop/share/classes/sun/print/PrinterJobWrapper.java
+++ b/src/java.desktop/share/classes/sun/print/PrinterJobWrapper.java
@@ -39,6 +39,7 @@ public class PrinterJobWrapper implements PrintRequestAttribute {
     @Serial
     private static final long serialVersionUID = -8792124426995707237L;
 
+    @SuppressWarnings("serial")
     private PrinterJob job;
 
     public PrinterJobWrapper(PrinterJob job) {

--- a/src/java.desktop/share/classes/sun/print/PrinterJobWrapper.java
+++ b/src/java.desktop/share/classes/sun/print/PrinterJobWrapper.java
@@ -39,7 +39,7 @@ public class PrinterJobWrapper implements PrintRequestAttribute {
     @Serial
     private static final long serialVersionUID = -8792124426995707237L;
 
-    @SuppressWarnings("serial")
+    @SuppressWarnings("serial") // Type of field is not Serializable
     private PrinterJob job;
 
     public PrinterJobWrapper(PrinterJob job) {


### PR DESCRIPTION
Follow-up changes to JDK-8231334. , augmentations to javac's Xlint:serial checking are out for review (#5709) and various client libraries would need some changes to pass under the expanded checks.

The changes are to suppress warnings where non-transient fields in serializable types are not declared with a type statically known to be serializable. That isn't necessarily a correctness issues, but it does merit further scrutiny.

I'll run a script to update the copyright year before pushing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274396](https://bugs.openjdk.java.net/browse/JDK-8274396): Suppress more warnings on non-serializable non-transient instance fields in client libs


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to ab72612d52cb2f53a65079f7820f38f9278bcf4b
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to ab72612d52cb2f53a65079f7820f38f9278bcf4b
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5723/head:pull/5723` \
`$ git checkout pull/5723`

Update a local copy of the PR: \
`$ git checkout pull/5723` \
`$ git pull https://git.openjdk.java.net/jdk pull/5723/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5723`

View PR using the GUI difftool: \
`$ git pr show -t 5723`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5723.diff">https://git.openjdk.java.net/jdk/pull/5723.diff</a>

</details>
