### PR TITLE
8274397: [macOS] Stop setting env. var JAVA_MAIN_CLASS_<pid> in launcher code

### DIFF
--- a/src/java.base/macosx/native/libjli/java_md_macosx.m
+++ b/src/java.base/macosx/native/libjli/java_md_macosx.m
@@ -793,7 +793,7 @@ SetXDockArgForAWT(const char *arg)
          * change drastically between update release, and it may even be
          * removed or replaced with another mechanism.
          *
-         * NOTE: It is used by SWT, and JavaFX.
+         * NOTE: It is used by SWT
          */
         snprintf(envVar, sizeof(envVar), "APP_NAME_%d", getpid());
         setenv(envVar, (arg + 12), 1);
@@ -830,38 +830,53 @@ SetMainClassForAWT(JNIEnv *env, jclass mainClass) {
 
     jstring mainClassString = (*env)->CallObjectMethod(env, mainClass, getCanonicalNameMID);
     if ((*env)->ExceptionCheck(env) || NULL == mainClassString) {
-        /*
-         * Clears all errors caused by getCanonicalName() on the mainclass and
-         * leaves the JAVA_MAIN_CLASS__<pid> empty.
-         */
         (*env)->ExceptionClear(env);
         return;
     }
 
-    const char *mainClassName = NULL;
-    NULL_CHECK(mainClassName = (*env)->GetStringUTFChars(env, mainClassString, NULL));
-
-    char envVar[80];
-    /*
-     * The JAVA_MAIN_CLASS_<pid> environment variable is used to pass
-     * the name of a Java class whose main() method is invoked by
-     * the Java launcher code to start the application, to the AWT code
-     * in order to assign the name to the Apple menu bar when the app
-     * is active on the Mac.
-     * The _<pid> part is added to avoid collisions with child processes.
-     *
-     * WARNING: This environment variable is an implementation detail and
-     * isn't meant for use outside of the core platform. The mechanism for
-     * passing this information from Java launcher to other modules may
-     * change drastically between update release, and it may even be
-     * removed or replaced with another mechanism.
-     *
-     * NOTE: It is used by SWT, and JavaFX.
+    /* There are multiple apple.awt.*" system properties that AWT(the desktop module)
+     * references that are inherited from Apple JDK.
+     * This inherited AWT code looks for this property and uses it for the name
+     * of the app as it appears in the system menu bar.
+     * 
+     * Not idea if how much external code ever sets it, but use it if set, else
+     * if not set (the high probability event) set it to the application class name.
      */
-    snprintf(envVar, sizeof(envVar), "JAVA_MAIN_CLASS_%d", getpid());
-    setenv(envVar, mainClassName, 1);
+    const char* propName = "apple.awt.application.name";
+    jstring jKey = NULL;
+    NULL_CHECK(jKey = (*env)->NewStringUTF(env, propName));
 
-    (*env)->ReleaseStringUTFChars(env, mainClassString, mainClassName);
+    jclass sysClass = NULL;
+    NULL_CHECK(sysClass = (*env)->FindClass(env, "java/lang/System")); 
+
+    jmethodID getPropertyMID = NULL;
+    NULL_CHECK(getPropertyMID = (*env)->GetStaticMethodID(env, sysClass,
+               "getProperty", "(Ljava/lang/String;)Ljava/lang/String;"));
+
+    jmethodID setPropertyMID = NULL;
+    NULL_CHECK(setPropertyMID = (*env)->GetStaticMethodID(env, sysClass,
+               "setProperty",
+               "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;"));
+
+    jstring jValue = (*env)->CallStaticObjectMethod(env, sysClass, getPropertyMID, jKey);
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionClear(env);
+        (*env)->DeleteLocalRef(env, jKey);
+        return;
+    }
+    if (jValue == NULL) {
+        (*env)->CallStaticObjectMethod(env, sysClass, setPropertyMID,
+                                       jKey, mainClassString);
+        if ((*env)->ExceptionCheck(env)) {
+            (*env)->ExceptionClear(env);
+            (*env)->DeleteLocalRef(env, jKey);
+            return;
+        }
+    } else {
+        (*env)->DeleteLocalRef(env, jValue);
+    }
+
+    (*env)->DeleteLocalRef(env, jKey);
 }
 
 void

--- a/src/java.base/macosx/native/libjli/java_md_macosx.m
+++ b/src/java.base/macosx/native/libjli/java_md_macosx.m
@@ -838,7 +838,7 @@ SetMainClassForAWT(JNIEnv *env, jclass mainClass) {
      * references that are inherited from Apple JDK.
      * This inherited AWT code looks for this property and uses it for the name
      * of the app as it appears in the system menu bar.
-     * 
+     *
      * Not idea if how much external code ever sets it, but use it if set, else
      * if not set (the high probability event) set it to the application class name.
      */
@@ -847,7 +847,7 @@ SetMainClassForAWT(JNIEnv *env, jclass mainClass) {
     NULL_CHECK(jKey = (*env)->NewStringUTF(env, propName));
 
     jclass sysClass = NULL;
-    NULL_CHECK(sysClass = (*env)->FindClass(env, "java/lang/System")); 
+    NULL_CHECK(sysClass = (*env)->FindClass(env, "java/lang/System"));
 
     jmethodID getPropertyMID = NULL;
     NULL_CHECK(getPropertyMID = (*env)->GetStaticMethodID(env, sysClass,

--- a/src/java.desktop/macosx/native/libosxapp/NSApplicationAWT.m
+++ b/src/java.desktop/macosx/native/libosxapp/NSApplicationAWT.m
@@ -180,24 +180,9 @@ AWT_ASSERT_APPKIT_THREAD;
     }
 
     // If it wasn't specified as an argument, see if it was specified as a system property.
+    // The launcher code sets this if it is not already set on the command line.
     if (fApplicationName == nil) {
         fApplicationName = [PropertiesUtilities javaSystemPropertyForKey:@"apple.awt.application.name" withEnv:env];
-    }
-
-    // If we STILL don't have it, the app name is retrieved from an environment variable (set in java.c) It should be UTF8.
-    if (fApplicationName == nil) {
-        char mainClassEnvVar[80];
-        snprintf(mainClassEnvVar, sizeof(mainClassEnvVar), "JAVA_MAIN_CLASS_%d", getpid());
-        char *mainClass = getenv(mainClassEnvVar);
-        if (mainClass != NULL) {
-            fApplicationName = [NSString stringWithUTF8String:mainClass];
-            unsetenv(mainClassEnvVar);
-
-            NSRange lastPeriod = [fApplicationName rangeOfString:@"." options:NSBackwardsSearch];
-            if (lastPeriod.location != NSNotFound) {
-                fApplicationName = [fApplicationName substringFromIndex:lastPeriod.location + 1];
-            }
-        }
     }
 
     // The dock name is nil for double-clickable Java apps (bundled and Web Start apps)

--- a/test/jdk/tools/launcher/MacOSAppNamePropertyTest.java
+++ b/test/jdk/tools/launcher/MacOSAppNamePropertyTest.java
@@ -54,6 +54,8 @@ public class MacOSAppNamePropertyTest extends TestHelper {
     static void execTest(String propSetting, String expect) {
         List<String> cmdList = new ArrayList<>();
         cmdList.add(javaCmd);
+        cmdList.add("-cp");
+        cmdList.add(TEST_CLASSES_DIR.getAbsolutePath());
         if (propSetting != null) {
             cmdList.add(propSetting);
         }

--- a/test/jdk/tools/launcher/MacOSAppNamePropertyTest.java
+++ b/test/jdk/tools/launcher/MacOSAppNamePropertyTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8274397
+ * @summary Ensure the app name system property is set on macOS
+ * @requires os.family == "mac"
+ * @compile MacOSAppNamePropertyTest.java SystemPropertyTest.java
+ * @run main MacOSAppNamePropertyTest
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+/*
+ * If the system property apple.awt.application.name is unset, it should default
+ * to the name of this test class.
+ * If it is set, then it should be used instead of the class.
+ * The arg. to the test indicates the *expected* name.
+ * The test will fail if the property is not set or does not match
+ */
+public class MacOSAppNamePropertyTest extends TestHelper {
+
+    static final String APPNAME = "SystemPropertyTest";
+
+    public static void main(String[]args) {
+        if (!isMacOSX) {
+            return;
+        }
+        execTest(null, APPNAME);
+        execTest("-Dapple.awt.application.name=Foo", "Foo");
+    }
+
+    static void execTest(String propSetting, String expect) {
+        List<String> cmdList = new ArrayList<>();
+        cmdList.add(javaCmd);
+        if (propSetting != null) {
+            cmdList.add(propSetting);
+        }
+        cmdList.add(APPNAME);
+        cmdList.add(expect);
+        TestResult tr = doExec(cmdList.toArray(new String[cmdList.size()]));
+        if (!tr.isOK()) {
+            System.err.println(tr.toString());
+            throw new RuntimeException("Test Fails");
+        }
+    }
+}

--- a/test/jdk/tools/launcher/SystemPropertyTest.java
+++ b/test/jdk/tools/launcher/SystemPropertyTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+/*
+ * Child launched by MacOSAppNamePropertyTest.java
+ * If the system property apple.awt.application.name is unset, it should default
+ * to the name of this main program class, less any package name.
+ * If it is set, then it should be used instead of the class name.
+ * The arg. to the test indicates the *expected* name.
+ * The test will fail if the property is not set or does not match
+ */
+public class SystemPropertyTest {
+
+    public static void main(String[]args) {
+        String prop = System.getProperty("apple.awt.application.name");
+        if (prop == null) {
+            throw new RuntimeException("Property not set");
+        }
+        if (!prop.equals(args[0])) {
+            throw new RuntimeException("Got " + prop + " expected " + args[0]);
+        }
+    }
+}

--- a/test/jdk/tools/launcher/TestSpecialArgs.java
+++ b/test/jdk/tools/launcher/TestSpecialArgs.java
@@ -83,15 +83,11 @@ public class TestSpecialArgs extends TestHelper {
         Set<String> envToRemove = new HashSet<>();
         Map<String, String> map = System.getenv();
         for (String s : map.keySet()) {
-            if (s.startsWith("JAVA_MAIN_CLASS_")
-                    || s.startsWith("APP_NAME_")
+            if (s.startsWith("APP_NAME_")
                     || s.startsWith("APP_ICON_")) {
                 envToRemove.add(s);
             }
         }
-        runTest(envToRemove, javaCmd, "-cp", TEST_CLASSES_DIR.getAbsolutePath(),
-                "EnvironmentVariables", "JAVA_MAIN_CLASS_*",
-                "EnvironmentVariables");
 
         runTest(envToRemove, javaCmd, "-cp", TEST_CLASSES_DIR.getAbsolutePath(),
                 "-Xdock:name=TestAppName", "EnvironmentVariables",


### PR DESCRIPTION
macOS launcher code sets JAVA_MAIN_CLASS_<pid> which is read by AWT to set the name of the application in the system menu bar.

Because this set shortly after the VM is running, it causes a thread safety issue described in https://bugs.openjdk.java.net/browse/JDK-8270549

Since the AWT already looks for the system property "apple.awt.application.name" for this same purpose,
we can set that instead of the env. var and avoid the threading issue.

This trades the JAVA_MAIN_CLASS_<pid> pollution of the environment for setting a system property which is visible to apps as well but it seems a reasonable trade-off since we already (implicitly) support this variable anyway in preference to the env. var.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274397](https://bugs.openjdk.java.net/browse/JDK-8274397): [macOS] Stop setting env. var JAVA_MAIN_CLASS_<pid> in launcher code


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to 93108c5931c610808fc838602ca5755c0e9e1caa
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5724/head:pull/5724` \
`$ git checkout pull/5724`

Update a local copy of the PR: \
`$ git checkout pull/5724` \
`$ git pull https://git.openjdk.java.net/jdk pull/5724/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5724`

View PR using the GUI difftool: \
`$ git pr show -t 5724`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5724.diff">https://git.openjdk.java.net/jdk/pull/5724.diff</a>

</details>
