### PR TITLE
8217501: Matcher.hitEnd returns false for incomplete surrogate pairs

### DIFF
--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -3937,6 +3937,9 @@ loop:   for(int x=0, offset=0; x<nCodePoints; x++, offset+=len) {
                 int ch = Character.codePointAt(seq, i);
                 i += Character.charCount(ch);
                 if (i <= matcher.to) {
+                    if (i == matcher.to) {
+                        matcher.hitEnd = true;
+                    }
                     return predicate.is(ch) &&
                            next.match(matcher, i, seq);
                 }

--- a/test/jdk/java/util/regex/RegExTest.java
+++ b/test/jdk/java/util/regex/RegExTest.java
@@ -4538,4 +4538,27 @@ public class RegExTest {
         var sep = System.lineSeparator();
         assertTrue(e.getMessage().contains(sep + "\t ^"));
     }
+
+
+    //Test for JDK-8217501
+    @Test
+    public static void testHitEndOnUmatchedSurrogatePairs(){
+        final String hexString = "1F30C";
+        final char[] chars = Character.toChars(Integer.parseInt(hexString, 16));
+        final Pattern pattern = Pattern.compile("\\x{" + hexString + "}");
+
+        final Matcher matcher1 = pattern.matcher(String.valueOf(chars[0]));
+        final Matcher matcher2 = pattern.matcher(String.valueOf(chars[0]));
+        final Matcher matcher3 = pattern.matcher(String.valueOf(chars[0]));
+
+
+        matcher1.matches();
+        assertTrue(matcher1.hitEnd());
+
+        matcher2.lookingAt();
+        assertTrue(matcher2.hitEnd());
+
+        matcher3.find();
+        assertTrue(matcher3.hitEnd());
+    }
 }


### PR DESCRIPTION
Fixing a bug where character matcher doesn't mark hitEnd as true if it's a code point with more than one character.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8217501](https://bugs.openjdk.java.net/browse/JDK-8217501): Matcher.hitEnd returns false for incomplete surrogate pairs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5725/head:pull/5725` \
`$ git checkout pull/5725`

Update a local copy of the PR: \
`$ git checkout pull/5725` \
`$ git pull https://git.openjdk.java.net/jdk pull/5725/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5725`

View PR using the GUI difftool: \
`$ git pr show -t 5725`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5725.diff">https://git.openjdk.java.net/jdk/pull/5725.diff</a>

</details>
