### PR TITLE
8274415: Suppress warnings on non-serializable non-transient instance fields in java.xml

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/TypeCheckError.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/TypeCheckError.java
@@ -29,7 +29,9 @@ import com.sun.org.apache.xalan.internal.xsltc.compiler.SyntaxTreeNode;
  */
 public class TypeCheckError extends Exception {
     static final long serialVersionUID = 3246224233917854640L;
+    @SuppressWarnings("serial") // Type of field is not Serializable
     ErrorMsg _error = null;
+    @SuppressWarnings("serial") // Type of field is not Serializable
     SyntaxTreeNode _node = null;
 
     public TypeCheckError(SyntaxTreeNode node) {

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/AttrImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/AttrImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/AttrImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/AttrImpl.java
@@ -132,6 +132,7 @@ public class AttrImpl
     //
 
     /** This can either be a String or the first child node. */
+    @SuppressWarnings("serial") // Type of field is not Serializable
     protected Object value = null;
 
     /** Attribute name. */

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/DocumentImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/DocumentImpl.java
@@ -507,6 +507,7 @@ public class DocumentImpl
 
         private static final long serialVersionUID = -8426757059492421631L;
         String type;
+        @SuppressWarnings("serial") // Type of field is not Serializable
         EventListener listener;
         boolean useCapture;
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/DocumentImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/DocumentImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/NamedNodeMapImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/NamedNodeMapImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/NamedNodeMapImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/NamedNodeMapImpl.java
@@ -79,6 +79,7 @@ public class NamedNodeMapImpl
     protected final static short HASDEFAULTS  = 0x1<<2;
 
     /** Nodes. */
+    @SuppressWarnings("serial") // Type of field is not Serializable
     protected List<Node> nodes;
 
     protected NodeImpl ownerNode; // the node this map belongs to

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/PSVIAttrNSImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/PSVIAttrNSImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/PSVIAttrNSImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/PSVIAttrNSImpl.java
@@ -60,9 +60,11 @@ public class PSVIAttrNSImpl extends AttrNSImpl implements AttributePSVI {
     }
 
     /** attribute declaration */
+    @SuppressWarnings("serial") // Type of field is not Serializable
     protected XSAttributeDeclaration fDeclaration = null;
 
     /** type of attribute, simpleType */
+    @SuppressWarnings("serial") // Type of field is not Serializable
     protected XSTypeDefinition fTypeDecl = null;
 
     /** If this attribute was explicitly given a
@@ -70,6 +72,7 @@ public class PSVIAttrNSImpl extends AttrNSImpl implements AttributePSVI {
     protected boolean fSpecified = true;
 
     /** Schema value */
+    @SuppressWarnings("serial") // Type of field is not Serializable
     protected ValidatedInfo fValue = new ValidatedInfo();
 
     /** validation attempted: none, partial, full */
@@ -79,9 +82,11 @@ public class PSVIAttrNSImpl extends AttrNSImpl implements AttributePSVI {
     protected short fValidity = AttributePSVI.VALIDITY_NOTKNOWN;
 
     /** error codes */
+    @SuppressWarnings("serial") // Type of field is not Serializable
     protected StringList fErrorCodes = null;
 
     /** error messages */
+    @SuppressWarnings("serial") // Type of field is not Serializable
     protected StringList fErrorMessages = null;
 
     /** validation context: could be QName or XPath expression*/

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/PSVIElementNSImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/PSVIElementNSImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/PSVIElementNSImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/PSVIElementNSImpl.java
@@ -60,9 +60,11 @@ public class PSVIElementNSImpl extends ElementNSImpl implements ElementPSVI {
     }
 
     /** element declaration */
+    @SuppressWarnings("serial") // Type of field is not Serializable
     protected XSElementDeclaration fDeclaration = null;
 
     /** type of element, could be xsi:type */
+    @SuppressWarnings("serial") // Type of field is not Serializable
     protected XSTypeDefinition fTypeDecl = null;
 
     /** true if clause 3.2 of Element Locally Valid (Element) (3.3.4)
@@ -75,9 +77,11 @@ public class PSVIElementNSImpl extends ElementNSImpl implements ElementPSVI {
     protected boolean fSpecified = true;
 
     /** Schema value */
+    @SuppressWarnings("serial") // Type of field is not Serializable
     protected ValidatedInfo fValue = new ValidatedInfo();
 
     /** http://www.w3.org/TR/xmlschema-1/#e-notation*/
+    @SuppressWarnings("serial") // Type of field is not Serializable
     protected XSNotationDeclaration fNotation = null;
 
     /** validation attempted: none, partial, full */
@@ -87,15 +91,18 @@ public class PSVIElementNSImpl extends ElementNSImpl implements ElementPSVI {
     protected short fValidity = ElementPSVI.VALIDITY_NOTKNOWN;
 
     /** error codes */
+    @SuppressWarnings("serial") // Type of field is not Serializable
     protected StringList fErrorCodes = null;
 
     /** error messages */
+    @SuppressWarnings("serial") // Type of field is not Serializable
     protected StringList fErrorMessages = null;
 
     /** validation context: could be QName or XPath expression*/
     protected String fValidationContext = null;
 
     /** the schema information property */
+    @SuppressWarnings("serial") // Type of field is not Serializable
     protected XSModel fSchemaInformation = null;
 
     //

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/ParentNode.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/ParentNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/ParentNode.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/ParentNode.java
@@ -1024,7 +1024,9 @@ public abstract class ParentNode
         /** Serialization version. */
         private static final long serialVersionUID = 3258126977134310455L;
 
+        @SuppressWarnings("serial") // Type of field is not Serializable
         Object fData;
+        @SuppressWarnings("serial") // Type of field is not Serializable
         UserDataHandler fHandler;
         UserDataRecord(Object data, UserDataHandler handler) {
             fData = data;

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/io/MalformedByteSequenceException.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/io/MalformedByteSequenceException.java
@@ -45,6 +45,7 @@ public class MalformedByteSequenceException extends CharConversionException {
     //
 
     /** message formatter **/
+    @SuppressWarnings("serial") // Type of field is not Serializable
     private MessageFormatter fFormatter;
 
     /** locale for error message **/

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/traversers/XSDComplexTypeTraverser.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/traversers/XSDComplexTypeTraverser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/traversers/XSDComplexTypeTraverser.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/traversers/XSDComplexTypeTraverser.java
@@ -132,6 +132,7 @@ class  XSDComplexTypeTraverser extends XSDAbstractParticleTraverser {
         private static final long serialVersionUID = 6802729912091130335L;
 
         Object[] errorSubstText=null;
+        @SuppressWarnings("serial") // Type of field is not Serializable
         Element  errorElem = null;
         ComplexTypeRecoverableError() {
             super();

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/utils/ObjectPool.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/utils/ObjectPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/utils/ObjectPool.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/utils/ObjectPool.java
@@ -43,6 +43,7 @@ public class ObjectPool implements java.io.Serializable
 
   /** Stack of given objects this points to.
    *  @serial          */
+  @SuppressWarnings("serial") // Type of field is not Serializable
   private final List<Object> freeStack;
 
   /**

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/utils/SAXSourceLocator.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/utils/SAXSourceLocator.java
@@ -41,6 +41,7 @@ public class SAXSourceLocator extends LocatorImpl
   /** The SAX Locator object.
    *  @serial
    */
+  @SuppressWarnings("serial") // Type of field is not Serializable
   Locator m_locator;
 
   /**

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/Expression.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/Expression.java
@@ -52,6 +52,7 @@ public abstract class Expression implements java.io.Serializable, ExpressionNode
    *  messages. May be null.
    *  @serial
    */
+  @SuppressWarnings("serial") // Type of field is not Serializable
   private ExpressionNode m_parent;
 
   /**

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/Expression.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/Expression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/NodeSetDTM.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/NodeSetDTM.java
@@ -358,6 +358,7 @@ public class NodeSetDTM extends NodeVector
   }
 
   /* An instance of the DTMManager. */
+  @SuppressWarnings("serial") // Type of field is not Serializable
   DTMManager m_manager;
 
   /**

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/XPathException.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/XPathException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/XPathException.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/XPathException.java
@@ -39,6 +39,7 @@ public class XPathException extends TransformerException
 
   /** The home of the expression that caused the error.
    *  @serial  */
+  @SuppressWarnings("serial") // Type of field is not Serializable
   Object m_styleNode = null;
 
   /**

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/AxesWalker.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/AxesWalker.java
@@ -463,6 +463,7 @@ public class AxesWalker extends PredicatedNodeTest
    * from multiple documents.
    * Never, ever, access this value without going through getDTM(int node).
    */
+  @SuppressWarnings("serial") // Type of field is not Serializable
   private DTM m_dtm;
 
   /**
@@ -587,5 +588,6 @@ public class AxesWalker extends PredicatedNodeTest
   protected int m_axis = -1;
 
   /** The DTM inner traversal class, that corresponds to the super axis. */
+  @SuppressWarnings("serial") // Type of field is not Serializable
   protected DTMAxisTraverser m_traverser;
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/AxesWalker.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/AxesWalker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/IteratorPool.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/IteratorPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/IteratorPool.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/IteratorPool.java
@@ -37,11 +37,13 @@ public final class IteratorPool implements java.io.Serializable
   /**
    * Type of objects in this pool.
    */
+  @SuppressWarnings("serial") // Type of field is not Serializable
   private final DTMIterator m_orig;
 
   /**
    * Stack of given objects this points to.
    */
+  @SuppressWarnings("serial") // Type of field is not Serializable
   private final List<DTMIterator> m_freeStack;
 
   /**

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/LocPathIterator.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/LocPathIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/LocPathIterator.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/LocPathIterator.java
@@ -978,6 +978,7 @@ public abstract class LocPathIterator extends PredicatedNodeTest
    * clear that this is needed.
    * @serial
    */
+  @SuppressWarnings("serial") // Type of field is not Serializable
   private PrefixResolver m_prefixResolver;
 
   /**

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/MatchPatternIterator.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/MatchPatternIterator.java
@@ -52,6 +52,7 @@ public class MatchPatternIterator extends LocPathIterator
   protected int m_superAxis = -1;
 
   /** The DTM inner traversal class, that corresponds to the super axis. */
+  @SuppressWarnings("serial") // Type of field is not Serializable
   protected DTMAxisTraverser m_traverser;
 
   /** DEBUG flag for diagnostic dumps. */

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/MatchPatternIterator.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/MatchPatternIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/NodeSequence.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/NodeSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/NodeSequence.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/NodeSequence.java
@@ -58,6 +58,7 @@ public class NodeSequence extends XObject
    * <p>
    * Multiple NodeSequence objects may share the same cache.
    */
+  @SuppressWarnings("serial") // Type of field is not Serializable
   private IteratorCache m_cache;
 
   /**
@@ -128,6 +129,7 @@ public class NodeSequence extends XObject
   /**
    * The functional iterator that fetches nodes.
    */
+  @SuppressWarnings("serial") // Type of field is not Serializable
   protected DTMIterator m_iter;
 
   /**
@@ -152,6 +154,7 @@ public class NodeSequence extends XObject
    * The DTMManager to use if we're using a NodeVector only.
    * We may well want to do away with this, and store it in the NodeVector.
    */
+  @SuppressWarnings("serial") // Type of field is not Serializable
   protected DTMManager m_dtmMgr;
 
   // ==== Constructors ====

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/OneStepIterator.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/OneStepIterator.java
@@ -43,6 +43,7 @@ public class OneStepIterator extends ChildTestIterator
   protected int m_axis = -1;
 
   /** The DTM inner traversal class, that corresponds to the super axis. */
+  @SuppressWarnings("serial") // Type of field is not Serializable
   protected DTMAxisIterator m_iterator;
 
   /**

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/ReverseAxesWalker.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/ReverseAxesWalker.java
@@ -244,5 +244,6 @@ public class ReverseAxesWalker extends AxesWalker
   }
 
   /** The DTM inner traversal class, that corresponds to the super axis. */
+  @SuppressWarnings("serial") // Type of field is not Serializable
   protected DTMAxisIterator m_iterator;
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/functions/FuncExtFunction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/functions/FuncExtFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/functions/FuncExtFunction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/functions/FuncExtFunction.java
@@ -64,6 +64,7 @@ public class FuncExtFunction extends Function
    *  order to allow caching of the method.
    *  @serial
    */
+  @SuppressWarnings("serial") // Type of field is not Serializable
   Object m_methodKey;
 
   /**
@@ -71,6 +72,7 @@ public class FuncExtFunction extends Function
    *  function.
    *  @serial
    */
+  @SuppressWarnings("serial") // Type of field is not Serializable
   List<Expression> m_argVec = new ArrayList<>();
 
   /**

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/objects/XNodeSetForDOM.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/objects/XNodeSetForDOM.java
@@ -36,6 +36,7 @@ import org.w3c.dom.traversal.NodeIterator;
 public class XNodeSetForDOM extends XNodeSet
 {
     static final long serialVersionUID = -8396190713754624640L;
+  @SuppressWarnings("serial") // Type of field is not Serializable
   Object m_origObj;
 
   public XNodeSetForDOM(Node node, DTMManager dtmMgr)

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/objects/XObject.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/objects/XObject.java
@@ -54,6 +54,7 @@ public class XObject extends Expression implements Serializable, Cloneable
    * The java object which this object wraps.
    *  @serial
    */
+  @SuppressWarnings("serial") // Type of field is not Serializable
   protected Object m_obj;  // This may be NULL!!!
 
   /**

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/objects/XObject.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/objects/XObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/objects/XRTreeFrag.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/objects/XRTreeFrag.java
@@ -39,6 +39,7 @@ import org.w3c.dom.NodeList;
 public class XRTreeFrag extends XObject implements Cloneable
 {
     static final long serialVersionUID = -3201553822254911567L;
+  @SuppressWarnings("serial") // Type of field is not Serializable
   private DTMXRTreeFrag m_DTMXRTreeFrag;
   private int m_dtmRoot = DTM.NULL;
   protected boolean m_allowRelease = false;
@@ -169,6 +170,7 @@ public class XRTreeFrag extends XObject implements Cloneable
     return true;
   }
 
+  @SuppressWarnings("serial") // Type of field is not Serializable
   private XMLString m_xmlStr = null;
 
   /**

--- a/src/java.xml/share/classes/javax/xml/stream/XMLStreamException.java
+++ b/src/java.xml/share/classes/javax/xml/stream/XMLStreamException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.xml/share/classes/javax/xml/stream/XMLStreamException.java
+++ b/src/java.xml/share/classes/javax/xml/stream/XMLStreamException.java
@@ -45,6 +45,7 @@ public class XMLStreamException extends Exception {
   /**
    * The location of the error.
    */
+  @SuppressWarnings("serial") // Type of field is not Serializable
   protected Location location;
 
   /**

--- a/src/java.xml/share/classes/javax/xml/transform/TransformerException.java
+++ b/src/java.xml/share/classes/javax/xml/transform/TransformerException.java
@@ -48,6 +48,7 @@ public class TransformerException extends Exception {
     private static final long serialVersionUID = 975798773772956428L;
 
     /** Field locator specifies where the error occurred */
+    @SuppressWarnings("serial") // Type of field is not Serializable
     SourceLocator locator;
 
     /**


### PR DESCRIPTION
Augmentations to javac's Xlint:serial checking are out for review (#5709) and the java.xml module would need some changes to pass under the expanded checks.

The changes are to suppress warnings where non-transient fields in serializable types are not declared with a type statically known to be serializable. That isn't necessarily a correctness issues, but it does merit further scrutiny.

I'll run a script to update the copyright years before pushing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274415](https://bugs.openjdk.java.net/browse/JDK-8274415): Suppress warnings on non-serializable non-transient instance fields in java.xml


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**) ⚠️ Review applies to 7f31bfdc4e91377c65989792fac5f79257653997


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5730/head:pull/5730` \
`$ git checkout pull/5730`

Update a local copy of the PR: \
`$ git checkout pull/5730` \
`$ git pull https://git.openjdk.java.net/jdk pull/5730/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5730`

View PR using the GUI difftool: \
`$ git pr show -t 5730`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5730.diff">https://git.openjdk.java.net/jdk/pull/5730.diff</a>

</details>
