### PR TITLE
8274430: Remove some debug error printing code added in JDK-8017163

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -611,12 +611,11 @@ public:
           if (!_failures) {
             log.error("----------");
           }
-          LogStream ls(log.error());
-          to->rem_set()->print_info(&ls, p);
           log.error("Missing rem set entry:");
           log.error("Field " PTR_FORMAT " of obj " PTR_FORMAT " in region " HR_FORMAT,
                     p2i(p), p2i(_containing_obj), HR_FORMAT_PARAMS(from));
           ResourceMark rm;
+          LogStream ls(log.error());
           _containing_obj->print_on(&ls);
           log.error("points to obj " PTR_FORMAT " in region " HR_FORMAT " remset %s",
                     p2i(obj), HR_FORMAT_PARAMS(to), to->rem_set()->get_state_str());


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that undoes some logging changes from JDK-8017163, in particular it added the `XXX card set` lines in the output as shown in an example below:

``` [171.616s][1632757560415ms][error][gc,verify ] GC(129) Missing rem set entry:
[171.616s][1632757560415ms][error][gc,verify ] GC(129) Field 0x00000007fb1008f0 of obj 0x00000007fb1008d8 in region 1485:(O)[0x00000007fb000000,0x00000
[171.616s][1632757560415ms][error][gc,verify ] GC(129) NULL card setjava.lang.invoke.MethodType$ConcurrentWeakInternSet$WeakEntry
[...]
points to obj 0x00000004d9abd4c8 in region 683:(S)[0x00000004d9000000,0x00000004da000000,0x00000004da000000] remset Complete ```

This string would indicate which card set container does not have the requested remembered set entry. This is unnecessary information, as the "points to obj" string later shows that there should be a remset to this region already, and otherwise only interesting for debugging.

Testing: gha

Thanks,
  Thomas