### PR TITLE
JDK-8274435: EXCEPTION_ACCESS_VIOLATION in BFSClosure::closure_impl

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/chains/bitset.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/bitset.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ BitSet::BitSet() :
     _bitmap_fragments(32),
     _fragment_list(NULL),
     _last_fragment_bits(NULL),
-    _last_fragment_granule(0) {
+    _last_fragment_granule(UINTPTR_MAX) {
 }
 
 BitSet::~BitSet() {

--- a/src/hotspot/share/jfr/leakprofiler/chains/bitset.inline.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/bitset.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,7 @@ inline BitMap::idx_t BitSet::addr_to_bit(uintptr_t addr) const {
 
 inline CHeapBitMap* BitSet::get_fragment_bits(uintptr_t addr) {
   uintptr_t granule = addr >> _bitmap_granularity_shift;
-  if (granule == _last_fragment_granule) {
+  if (granule == _last_fragment_granule && _last_fragment_bits != NULL) {
     return _last_fragment_bits;
   }
   CHeapBitMap* bits = NULL;

--- a/src/hotspot/share/jfr/leakprofiler/chains/bitset.inline.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/bitset.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,7 @@ inline BitMap::idx_t BitSet::addr_to_bit(uintptr_t addr) const {
 
 inline CHeapBitMap* BitSet::get_fragment_bits(uintptr_t addr) {
   uintptr_t granule = addr >> _bitmap_granularity_shift;
-  if (granule == _last_fragment_granule && _last_fragment_bits != NULL) {
+  if (granule == _last_fragment_granule) {
     return _last_fragment_bits;
   }
   CHeapBitMap* bits = NULL;


### PR DESCRIPTION
Hi,
please review this small change that prevents EXCEPTION_ACCESS_VIOLATION on some Windows machines.
The crash is intermittently reproducible on win32 client jvm when running e.g. jdk/jfr/jcmd/TestJcmdDumpPathToGCRoots.java test.
It is caused by BitSet::get_fragment_bits method which returns null for the newly initialized BitSet if granule (= addr >> _bitmap_granularity_shift) is equal to 0.

Testing:
jdk/jfr/* with win32 and win64 builds, no crashes or regression after the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274435](https://bugs.openjdk.java.net/browse/JDK-8274435): EXCEPTION_ACCESS_VIOLATION in BFSClosure::closure_impl


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5736/head:pull/5736` \
`$ git checkout pull/5736`

Update a local copy of the PR: \
`$ git checkout pull/5736` \
`$ git pull https://git.openjdk.java.net/jdk pull/5736/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5736`

View PR using the GUI difftool: \
`$ git pr show -t 5736`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5736.diff">https://git.openjdk.java.net/jdk/pull/5736.diff</a>

</details>
