### PR TITLE
Maintain the canonical order in module-info.java

### DIFF
--- a/src/jdk.management.jfr/share/classes/module-info.java
+++ b/src/jdk.management.jfr/share/classes/module-info.java
@@ -30,10 +30,10 @@
  * @since 9
  */
 module jdk.management.jfr {
-    requires transitive jdk.jfr;
     requires jdk.management;
 
     requires transitive java.management;
+    requires transitive jdk.jfr;
 
     exports jdk.management.jfr;
 


### PR DESCRIPTION
The canonical order of declarations inside the module-info.java file seems to follow the order:

`module some.module.name {
  requires ...
 
  requires transitive ...

  exports ... 

  exports ... to ... 

  opens ... to ...

  uses ...

  provides ... with ...
}
`

The "requires" was changed to "requires transitive" as part of a larger change [8248564](https://github.com/openjdk/jdk/commit/738efea9c6306308fbb134003796b2bdd3f888dd), but not reordered.

This is the only module-info.java file in the src/** directory that deviates from what appears to be the canonical order. 