### PR TITLE
8274453: (sctp) com/sun/nio/sctp/SctpChannel/CloseDescriptors.java test should be resilient to lsof warnings

### DIFF
--- a/test/jdk/com/sun/nio/sctp/SctpChannel/CloseDescriptors.java
+++ b/test/jdk/com/sun/nio/sctp/SctpChannel/CloseDescriptors.java
@@ -120,7 +120,7 @@ public class CloseDescriptors {
     private static boolean check() throws Exception {
         long myPid = ProcessHandle.current().pid();
         ProcessBuilder pb = new ProcessBuilder(
-                        "lsof", "-U", "-a", "-p", Long.toString(myPid));
+                        "lsof", "-U", "-a", "-w", "-p", Long.toString(myPid));
         pb.redirectErrorStream(true);
         Process p = pb.start();
         p.waitFor();


### PR DESCRIPTION
Recently added test fails on my desktop in the course of newly added `tier4` runs. The reason is simple: the test verifies that lsof outputs no more than LIMIT_LINES (2) lines. And on my machine, lsof prints some warnings that blow that limit. In the patch, lsof -w is used to suppress the warnings.

Additional testing:
 - [x] Affected test now passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274453](https://bugs.openjdk.java.net/browse/JDK-8274453): (sctp) com/sun/nio/sctp/SctpChannel/CloseDescriptors.java test should be resilient to lsof warnings


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5739/head:pull/5739` \
`$ git checkout pull/5739`

Update a local copy of the PR: \
`$ git checkout pull/5739` \
`$ git pull https://git.openjdk.java.net/jdk pull/5739/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5739`

View PR using the GUI difftool: \
`$ git pr show -t 5739`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5739.diff">https://git.openjdk.java.net/jdk/pull/5739.diff</a>

</details>
