### PR TITLE
8274465: Mark javax/swing/text/ParagraphView/6364882/bug6364882.java as headful

### DIFF
--- a/test/jdk/javax/swing/text/ParagraphView/6364882/bug6364882.java
+++ b/test/jdk/javax/swing/text/ParagraphView/6364882/bug6364882.java
@@ -45,6 +45,7 @@ import static java.awt.image.BufferedImage.TYPE_INT_RGB;
 
 /*
  * @test
+ * @key headful
  * @bug 6364882 8273634
  * @summary tests if broken and last lines in paragraph are not justified
  * @run main bug6364882


### PR DESCRIPTION
Hi all,

javax/swing/text/ParagraphView/6364882/bug6364882.java was observed failing on our non-GUI platforms.
So I guess it should be marked as headful.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8274465](https://bugs.openjdk.java.net/browse/JDK-8274465): Mark javax/swing/text/ParagraphView/6364882/bug6364882.java as headful


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5744/head:pull/5744` \
`$ git checkout pull/5744`

Update a local copy of the PR: \
`$ git checkout pull/5744` \
`$ git pull https://git.openjdk.java.net/jdk pull/5744/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5744`

View PR using the GUI difftool: \
`$ git pr show -t 5744`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5744.diff">https://git.openjdk.java.net/jdk/pull/5744.diff</a>

</details>
