### PR TITLE
8274406: RunThese30M.java failed "assert(!LCA_orig->dominates(pred_block) || early->dominates(pred_block)) failed: early is high enough"

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1454,8 +1454,8 @@ void PhaseIdealLoop::try_sink_out_of_loop(Node* n) {
       if (n_loop != loop_ctrl && n_loop->is_member(loop_ctrl)) {
         // n has a control input inside a loop but get_ctrl() is member of an outer loop. This could happen, for example,
         // for Div nodes inside a loop (control input inside loop) without a use except for an UCT (outside the loop).
-        // Rewire control of n to get_ctrl(n) to move it out of the loop, regardless if its input(s) are later sunk or not.
-        _igvn.replace_input_of(n, 0, n_ctrl);
+        // Rewire control of n to right outside of the loop, regardless if its input(s) are later sunk or not.
+        _igvn.replace_input_of(n, 0, place_outside_loop(n_ctrl, loop_ctrl));
       }
     }
     if (n_loop != _ltree_root && n->outcnt() > 1) {

--- a/test/hotspot/jtreg/compiler/loopopts/TestSinkingDivisorLostPin.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestSinkingDivisorLostPin.java
@@ -29,9 +29,9 @@
  * @summary Sinking a data node used as divisor of a DivI node into a zero check UCT loses its pin outside the loop due to
  *          optimizing the CastII node away, resulting in a div by zero crash (SIGFPE) due to letting the DivI node floating
  *          back inside the loop.
- * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,compiler.loopopts.TestSinkingDivisorLostPin -XX:-TieredCompilation
+ * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,compiler.loopopts.TestSinkingDivisorLostPin::* -XX:-TieredCompilation
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:StressSeed=4177789702 compiler.loopopts.TestSinkingDivisorLostPin
- * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,compiler.loopopts.TestSinkingDivisorLostPin -XX:-TieredCompilation
+ * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,compiler.loopopts.TestSinkingDivisorLostPin::* -XX:-TieredCompilation
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM compiler.loopopts.TestSinkingDivisorLostPin
  */
 


### PR DESCRIPTION
[JDK-8274074](https://bugs.openjdk.java.net/browse/JDK-8274074) enabled the sinking of pinned nodes inside a loop whose actual `get_ctrl()` is outside of the loop. This fix now rewired a `LoadN` node to the output projection of an `Allocate` node (right before the `Catch` node). This is unexpected and thus when expanding the `Allocate` macro node later, the `LoadN` is put into one path of an `If` that is inserted here:
https://github.com/openjdk/jdk/blob/756d22c3563ac92e74bb68d5eecb86d4fbab2c6b/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp#L758

As a result, the load's early block does not dominate its LCA block later when inserting anti dependencies and we fail with the assertion.

To avoid the need to special case certain nodes obtained with `get_ctrl()`, I propose to simply use `place_outside_loop()` to rewire the control input to the first node right outside of the loop.

I additionally fixed the wrong format of the compile command in the test added by JDK-8274074 which produced a printed warning/error but the test still worked.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274406](https://bugs.openjdk.java.net/browse/JDK-8274406): RunThese30M.java failed "assert(!LCA_orig->dominates(pred_block) || early->dominates(pred_block)) failed: early is high enough"


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5747/head:pull/5747` \
`$ git checkout pull/5747`

Update a local copy of the PR: \
`$ git checkout pull/5747` \
`$ git pull https://git.openjdk.java.net/jdk pull/5747/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5747`

View PR using the GUI difftool: \
`$ git pr show -t 5747`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5747.diff">https://git.openjdk.java.net/jdk/pull/5747.diff</a>

</details>
