### PR TITLE
8274506: TestPids.java and TestPidsLimit.java fail with podman run as root

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestPids.java
+++ b/test/hotspot/jtreg/containers/docker/TestPids.java
@@ -40,11 +40,15 @@ import jdk.test.lib.containers.docker.Common;
 import jdk.test.lib.containers.docker.DockerRunOptions;
 import jdk.test.lib.containers.docker.DockerTestUtils;
 import jdk.test.lib.Asserts;
+import jdk.test.lib.Container;
 import jdk.test.lib.Platform;
 import jdk.test.lib.Utils;
 
 public class TestPids {
     private static final String imageName = Common.imageName("pids");
+    private static final boolean IS_PODMAN = Container.ENGINE_COMMAND.contains("podman");
+    private static final int UNLIMITED_PIDS_PODMAN = 0;
+    private static final int UNLIMITED_PIDS_DOCKER = -1;
 
     public static void main(String[] args) throws Exception {
         if (!DockerTestUtils.canTestDocker()) {
@@ -126,7 +130,8 @@ public class TestPids {
 
         DockerRunOptions opts = commonOpts();
         if (value.equals("Unlimited")) {
-            opts.addDockerOpts("--pids-limit=-1");
+            int unlimited = IS_PODMAN ? UNLIMITED_PIDS_PODMAN : UNLIMITED_PIDS_DOCKER;
+            opts.addDockerOpts("--pids-limit=" + unlimited);
         } else {
             opts.addDockerOpts("--pids-limit="+value);
         }

--- a/test/jdk/jdk/internal/platform/docker/TestPidsLimit.java
+++ b/test/jdk/jdk/internal/platform/docker/TestPidsLimit.java
@@ -39,9 +39,13 @@ import jdk.test.lib.containers.docker.DockerRunOptions;
 import jdk.test.lib.containers.docker.DockerTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.Asserts;
+import jdk.test.lib.Container;
 
 public class TestPidsLimit {
     private static final String imageName = Common.imageName("pids");
+    private static final boolean IS_PODMAN = Container.ENGINE_COMMAND.contains("podman");
+    private static final int UNLIMITED_PIDS_PODMAN = 0;
+    private static final int UNLIMITED_PIDS_DOCKER = -1;
 
     public static void main(String[] args) throws Exception {
         if (!DockerTestUtils.canTestDocker()) {
@@ -107,7 +111,8 @@ public class TestPidsLimit {
         Common.logNewTestCase("testPidsLimit (limit: " + pidsLimit + ")");
         DockerRunOptions opts = Common.newOptsShowSettings(imageName);
         if (pidsLimit.equals("Unlimited")) {
-            opts.addDockerOpts("--pids-limit=-1");
+            int unlimited = IS_PODMAN ? UNLIMITED_PIDS_PODMAN : UNLIMITED_PIDS_DOCKER;
+            opts.addDockerOpts("--pids-limit=" + unlimited);
         } else {
             opts.addDockerOpts("--pids-limit="+pidsLimit);
         }


### PR DESCRIPTION
Please review this test fix to work around a podman issue[1]. `podman` expects for the "unlimited" option of `--pids-limit` to be `0` whereas `docker` wants `-1`. See the JBS bug for details. Thoughts?

Testing: hotspot/jdk container tests with docker and podman. Two pids tests used to fail and pass with the patch.

[1] https://github.com/containers/podman/issues/11782

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274506](https://bugs.openjdk.java.net/browse/JDK-8274506): TestPids.java and TestPidsLimit.java fail with podman run as root


### Reviewers
 * [Matthias Baesken](https://openjdk.java.net/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5750/head:pull/5750` \
`$ git checkout pull/5750`

Update a local copy of the PR: \
`$ git checkout pull/5750` \
`$ git pull https://git.openjdk.java.net/jdk pull/5750/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5750`

View PR using the GUI difftool: \
`$ git pr show -t 5750`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5750.diff">https://git.openjdk.java.net/jdk/pull/5750.diff</a>

</details>
