### PR TITLE
8274634: Use String.equals instead of String.compareTo in java.desktop

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
@@ -115,19 +115,19 @@ class CAccessible extends CFRetainedResource implements Accessible {
             if ( ptr != 0 ) {
                 Object newValue = e.getNewValue();
                 Object oldValue = e.getOldValue();
-                if (name.compareTo(ACCESSIBLE_CARET_PROPERTY) == 0) {
+                if (name.equals(ACCESSIBLE_CARET_PROPERTY)) {
                     selectedTextChanged(ptr);
-                } else if (name.compareTo(ACCESSIBLE_TEXT_PROPERTY) == 0) {
+                } else if (name.equals(ACCESSIBLE_TEXT_PROPERTY)) {
                     valueChanged(ptr);
-                } else if (name.compareTo(ACCESSIBLE_SELECTION_PROPERTY) == 0) {
+                } else if (name.equals(ACCESSIBLE_SELECTION_PROPERTY)) {
                     selectionChanged(ptr);
-                } else if (name.compareTo(ACCESSIBLE_TABLE_MODEL_CHANGED) == 0) {
+                } else if (name.equals(ACCESSIBLE_TABLE_MODEL_CHANGED)) {
                     valueChanged(ptr);
-                } else if (name.compareTo(ACCESSIBLE_ACTIVE_DESCENDANT_PROPERTY) == 0 ) {
+                } else if (name.equals(ACCESSIBLE_ACTIVE_DESCENDANT_PROPERTY)) {
                     if (newValue instanceof AccessibleContext) {
                         activeDescendant = (AccessibleContext)newValue;
                     }
-                } else if (name.compareTo(ACCESSIBLE_STATE_PROPERTY) == 0) {
+                } else if (name.equals(ACCESSIBLE_STATE_PROPERTY)) {
                     AccessibleContext thisAC = accessible.getAccessibleContext();
                     AccessibleRole thisRole = thisAC.getAccessibleRole();
                     Accessible parentAccessible = thisAC.getAccessibleParent();
@@ -167,12 +167,12 @@ class CAccessible extends CFRetainedResource implements Accessible {
                     if (thisRole == AccessibleRole.CHECK_BOX) {
                         valueChanged(ptr);
                     }
-                } else if (name.compareTo(ACCESSIBLE_NAME_PROPERTY) == 0) {
+                } else if (name.equals(ACCESSIBLE_NAME_PROPERTY)) {
                     //for now trigger only for JTabbedPane.
                     if (e.getSource() instanceof JTabbedPane) {
                         titleChanged(ptr);
                     }
-                } else if (name.compareTo(ACCESSIBLE_VALUE_PROPERTY) == 0) {
+                } else if (name.equals(ACCESSIBLE_VALUE_PROPERTY)) {
                     AccessibleRole thisRole = accessible.getAccessibleContext()
                                                         .getAccessibleRole();
                     if (thisRole == AccessibleRole.SLIDER ||

--- a/src/java.desktop/share/classes/javax/swing/JList.java
+++ b/src/java.desktop/share/classes/javax/swing/JList.java
@@ -2947,7 +2947,7 @@ public class JList<E> extends JComponent implements Scrollable, Accessible
             Object newValue = e.getNewValue();
 
                 // re-set listData listeners
-            if (name.compareTo("model") == 0) {
+            if (name.equals("model")) {
 
                 if (oldValue != null && oldValue instanceof ListModel) {
                     ((ListModel) oldValue).removeListDataListener(this);
@@ -2957,7 +2957,7 @@ public class JList<E> extends JComponent implements Scrollable, Accessible
                 }
 
                 // re-set listSelectionModel listeners
-            } else if (name.compareTo("selectionModel") == 0) {
+            } else if (name.equals("selectionModel")) {
 
                 if (oldValue != null && oldValue instanceof ListSelectionModel) {
                     ((ListSelectionModel) oldValue).removeListSelectionListener(this);

--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -6756,7 +6756,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
             Object newValue = e.getNewValue();
 
                 // re-set tableModel listeners
-            if (name.compareTo("model") == 0) {
+            if (name.equals("model")) {
 
                 if (oldValue != null && oldValue instanceof TableModel) {
                     ((TableModel) oldValue).removeTableModelListener(this);
@@ -6766,7 +6766,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
                 }
 
                 // re-set selectionModel listeners
-            } else if (name.compareTo("selectionModel") == 0) {
+            } else if (name.equals("selectionModel")) {
 
                 Object source = e.getSource();
                 if (source == JTable.this) {    // row selection model
@@ -6797,7 +6797,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
 
                 // re-set columnModel listeners
                 // and column's selection property listener as well
-            } else if (name.compareTo("columnModel") == 0) {
+            } else if (name.equals("columnModel")) {
 
                 if (oldValue != null && oldValue instanceof TableColumnModel) {
                     TableColumnModel tcm = (TableColumnModel) oldValue;
@@ -6811,7 +6811,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
                 }
 
                 // re-se cellEditor listeners
-            } else if (name.compareTo("tableCellEditor") == 0) {
+            } else if (name.equals("tableCellEditor")) {
 
                 if (oldValue != null && oldValue instanceof TableCellEditor) {
                     ((TableCellEditor) oldValue).removeCellEditorListener(this);


### PR DESCRIPTION
In several places, String.compareTo was _compared_ with 0 ( via `== 0`).
Instead of this, we can use String.equals calls. `String.equals` is faster and shorter.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274634](https://bugs.openjdk.java.net/browse/JDK-8274634): Use String.equals instead of String.compareTo in java.desktop


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5751/head:pull/5751` \
`$ git checkout pull/5751`

Update a local copy of the PR: \
`$ git checkout pull/5751` \
`$ git pull https://git.openjdk.java.net/jdk pull/5751/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5751`

View PR using the GUI difftool: \
`$ git pr show -t 5751`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5751.diff">https://git.openjdk.java.net/jdk/pull/5751.diff</a>

</details>
