### PR TITLE
8274635: Use String.equals instead of String.compareTo in jdk.accessibility

### DIFF
--- a/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/AccessibilityEventMonitor.java
+++ b/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/AccessibilityEventMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,8 @@
 
 package com.sun.java.accessibility.util;
 
-import java.util.*;
 import java.beans.*;
 import java.awt.*;
-import java.awt.event.*;
 import javax.accessibility.*;
 
 /**
@@ -317,7 +315,7 @@ public class AccessibilityEventMonitor {
 
             // handle childbirth/death
             String name = e.getPropertyName();
-            if (name.compareTo(AccessibleContext.ACCESSIBLE_CHILD_PROPERTY) == 0) {
+            if (name.equals(AccessibleContext.ACCESSIBLE_CHILD_PROPERTY)) {
                 Object oldValue = e.getOldValue();
                 Object newValue = e.getNewValue();
 

--- a/src/jdk.accessibility/windows/classes/com/sun/java/accessibility/internal/AccessBridge.java
+++ b/src/jdk.accessibility/windows/classes/com/sun/java/accessibility/internal/AccessBridge.java
@@ -5240,7 +5240,7 @@ final public class AccessBridge {
                     accessBridge.debugString("[INFO]: AccessibleContext: " + ac);
                     String propertyName = e.getPropertyName();
 
-                    if (propertyName.compareTo(AccessibleContext.ACCESSIBLE_CARET_PROPERTY) == 0) {
+                    if (propertyName.equals(AccessibleContext.ACCESSIBLE_CARET_PROPERTY)) {
                         int oldValue = 0;
                         int newValue = 0;
 
@@ -5253,7 +5253,7 @@ final public class AccessBridge {
                         accessBridge.debugString("[INFO]:  - about to call propertyCaretChange()   old value: " + oldValue + "new value: " + newValue);
                         accessBridge.propertyCaretChange(e, ac, oldValue, newValue);
 
-                    } else if (propertyName.compareTo(AccessibleContext.ACCESSIBLE_DESCRIPTION_PROPERTY) == 0) {
+                    } else if (propertyName.equals(AccessibleContext.ACCESSIBLE_DESCRIPTION_PROPERTY)) {
                         String oldValue = null;
                         String newValue = null;
 
@@ -5266,7 +5266,7 @@ final public class AccessBridge {
                         accessBridge.debugString("[INFO]:  - about to call propertyDescriptionChange()   old value: " + oldValue + "new value: " + newValue);
                         accessBridge.propertyDescriptionChange(e, ac, oldValue, newValue);
 
-                    } else if (propertyName.compareTo(AccessibleContext.ACCESSIBLE_NAME_PROPERTY) == 0) {
+                    } else if (propertyName.equals(AccessibleContext.ACCESSIBLE_NAME_PROPERTY)) {
                         String oldValue = null;
                         String newValue = null;
 
@@ -5279,12 +5279,12 @@ final public class AccessBridge {
                         accessBridge.debugString("[INFO]:  - about to call propertyNameChange()   old value: " + oldValue + " new value: " + newValue);
                         accessBridge.propertyNameChange(e, ac, oldValue, newValue);
 
-                    } else if (propertyName.compareTo(AccessibleContext.ACCESSIBLE_SELECTION_PROPERTY) == 0) {
+                    } else if (propertyName.equals(AccessibleContext.ACCESSIBLE_SELECTION_PROPERTY)) {
                         accessBridge.debugString("[INFO]:  - about to call propertySelectionChange() " + ac +  "   " + Thread.currentThread() + "   " + e.getSource());
 
                         accessBridge.propertySelectionChange(e, ac);
 
-                    } else if (propertyName.compareTo(AccessibleContext.ACCESSIBLE_STATE_PROPERTY) == 0) {
+                    } else if (propertyName.equals(AccessibleContext.ACCESSIBLE_STATE_PROPERTY)) {
                         String oldValue = null;
                         String newValue = null;
 
@@ -5301,11 +5301,11 @@ final public class AccessBridge {
                         accessBridge.debugString("[INFO]:  - about to call propertyStateChange()");
                         accessBridge.propertyStateChange(e, ac, oldValue, newValue);
 
-                    } else if (propertyName.compareTo(AccessibleContext.ACCESSIBLE_TEXT_PROPERTY) == 0) {
+                    } else if (propertyName.equals(AccessibleContext.ACCESSIBLE_TEXT_PROPERTY)) {
                         accessBridge.debugString("[INFO]:  - about to call propertyTextChange()");
                         accessBridge.propertyTextChange(e, ac);
 
-                    } else if (propertyName.compareTo(AccessibleContext.ACCESSIBLE_VALUE_PROPERTY) == 0) {  // strings 'cause of floating point, etc.
+                    } else if (propertyName.equals(AccessibleContext.ACCESSIBLE_VALUE_PROPERTY)) {  // strings 'cause of floating point, etc.
                         String oldValue = null;
                         String newValue = null;
 
@@ -5318,10 +5318,10 @@ final public class AccessBridge {
                         accessBridge.debugString("[INFO]:  - about to call propertyDescriptionChange()");
                         accessBridge.propertyValueChange(e, ac, oldValue, newValue);
 
-                    } else if (propertyName.compareTo(AccessibleContext.ACCESSIBLE_VISIBLE_DATA_PROPERTY) == 0) {
+                    } else if (propertyName.equals(AccessibleContext.ACCESSIBLE_VISIBLE_DATA_PROPERTY)) {
                         accessBridge.propertyVisibleDataChange(e, ac);
 
-                    } else if (propertyName.compareTo(AccessibleContext.ACCESSIBLE_CHILD_PROPERTY) == 0) {
+                    } else if (propertyName.equals(AccessibleContext.ACCESSIBLE_CHILD_PROPERTY)) {
                         AccessibleContext oldAC = null;
                         AccessibleContext newAC = null;
                         Accessible a;
@@ -5337,7 +5337,7 @@ final public class AccessBridge {
                         accessBridge.debugString("[INFO]:  - about to call propertyChildChange()   old AC: " + oldAC + "new AC: " + newAC);
                         accessBridge.propertyChildChange(e, ac, oldAC, newAC);
 
-                    } else if (propertyName.compareTo(AccessibleContext.ACCESSIBLE_ACTIVE_DESCENDANT_PROPERTY) == 0) {
+                    } else if (propertyName.equals(AccessibleContext.ACCESSIBLE_ACTIVE_DESCENDANT_PROPERTY)) {
                         handleActiveDescendentEvent(e, ac);
                     }
                 }


### PR DESCRIPTION
In several places, String.compareTo was _compared_ with 0 ( via `== 0`).
Instead of this, we can use String.equals calls. `String.equals` is faster and shorter.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274635](https://bugs.openjdk.java.net/browse/JDK-8274635): Use String.equals instead of String.compareTo in jdk.accessibility


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5752/head:pull/5752` \
`$ git checkout pull/5752`

Update a local copy of the PR: \
`$ git checkout pull/5752` \
`$ git pull https://git.openjdk.java.net/jdk pull/5752/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5752`

View PR using the GUI difftool: \
`$ git pr show -t 5752`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5752.diff">https://git.openjdk.java.net/jdk/pull/5752.diff</a>

</details>
