### PR TITLE
8274651: Possible race in FontDesignMetrics.KeyReference.dispose

### DIFF
--- a/src/java.desktop/share/classes/sun/font/FontDesignMetrics.java
+++ b/src/java.desktop/share/classes/sun/font/FontDesignMetrics.java
@@ -188,16 +188,10 @@ public final class FontDesignMetrics extends FontMetrics {
         /* It is possible that since this reference object has been
          * enqueued, that a new metrics has been put into the table
          * for the same key value. So we'll test to see if the table maps
-         * to THIS reference. If its a new one, we'll leave it alone.
-         * It is possible that a new entry comes in after our test, but
-         * it is unlikely and if this were a problem we would need to
-         * synchronize all 'put' and 'remove' accesses to the cache which
-         * I would prefer not to do.
+         * to THIS reference. If it's a new one, we'll leave it alone.
          */
         public void dispose() {
-            if (metricsCache.get(key) == this) {
-                metricsCache.remove(key);
-            }
+            metricsCache.remove(key, this);
         }
     }
 
@@ -595,7 +589,7 @@ public final class FontDesignMetrics extends FontMetrics {
         // if the calculations in any other methods change this needs
         // to be changed too.
         // the 0.95 value used here and in the other methods allows some
-        // tiny fraction of leeway before rouding up. A higher value (0.99)
+        // tiny fraction of leeway before rounding up. A higher value (0.99)
         // caused some excessive rounding up.
         return
             (int)(roundingUpValue + descent + leading) -


### PR DESCRIPTION
Possible race condition could happen if another thread put value into 'metricsCache' by the same key.
We can use `ConcurrentHashMap.remove(key, value)` method to avoid it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274651](https://bugs.openjdk.java.net/browse/JDK-8274651): Possible race in FontDesignMetrics.KeyReference.dispose


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5753/head:pull/5753` \
`$ git checkout pull/5753`

Update a local copy of the PR: \
`$ git checkout pull/5753` \
`$ git pull https://git.openjdk.java.net/jdk pull/5753/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5753`

View PR using the GUI difftool: \
`$ git pr show -t 5753`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5753.diff">https://git.openjdk.java.net/jdk/pull/5753.diff</a>

</details>
