### PR TITLE
8274501: c2i entry barriers read int as long on AArch64

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.cpp
@@ -276,7 +276,7 @@ void BarrierSetAssembler::c2i_entry_barrier(MacroAssembler* masm) {
   __ load_method_holder_cld(rscratch1, rmethod);
 
   // Is it a strong CLD?
-  __ ldr(rscratch2, Address(rscratch1, ClassLoaderData::keep_alive_offset()));
+  __ ldrw(rscratch2, Address(rscratch1, ClassLoaderData::keep_alive_offset()));
   __ cbnz(rscratch2, method_live);
 
   // Is it a weak but alive CLD?


### PR DESCRIPTION
There was a bug in the x86_64 implementation of the c2i entry barriers. We read the CLD::_keep_alive int as a 64 bit integer, while it is of course in fact a 32 bit integer. It was fixed in the patch that ported it to x86_32 (JDK-8235262). However, somewhere in-between I think the wrong code was used as a basis for the AArch64 implementation, which now seemingly has inherited that same bug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274501](https://bugs.openjdk.java.net/browse/JDK-8274501): c2i entry barriers read int as long on AArch64


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5754/head:pull/5754` \
`$ git checkout pull/5754`

Update a local copy of the PR: \
`$ git checkout pull/5754` \
`$ git pull https://git.openjdk.java.net/jdk pull/5754/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5754`

View PR using the GUI difftool: \
`$ git pr show -t 5754`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5754.diff">https://git.openjdk.java.net/jdk/pull/5754.diff</a>

</details>
