### PR TITLE
8274521: jdk/jfr/event/gc/detailed/TestGCLockerEvent.java fails when other GC is selected

### DIFF
--- a/test/jdk/jdk/jfr/event/gc/detailed/TestGCLockerEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestGCLockerEvent.java
@@ -26,7 +26,7 @@
  * @test TestGCLockerEvent
  * @key jfr
  * @requires vm.hasJFR
- * @requires vm.gc == "G1" | vm.gc == null
+ * @requires vm.gc.G1
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox

--- a/test/jdk/jdk/jfr/event/gc/detailed/TestGCLockerEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestGCLockerEvent.java
@@ -26,6 +26,7 @@
  * @test TestGCLockerEvent
  * @key jfr
  * @requires vm.hasJFR
+ * @requires vm.gc == "G1" | vm.gc == null
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox


### PR DESCRIPTION
Simple test bug, need to check if G1 is enabled, or it is a default GC before asking `othervm` with `-XX:+UseG1GC`. Other tests in the same directory do exactly that.

Additional testing:
 - [x] Affected test skipped with Shenandoah now
 - [x] Affected test still passes with G1
 - [x] Affected test still passes default GC

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274521](https://bugs.openjdk.java.net/browse/JDK-8274521): jdk/jfr/event/gc/detailed/TestGCLockerEvent.java fails when other GC is selected


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5756/head:pull/5756` \
`$ git checkout pull/5756`

Update a local copy of the PR: \
`$ git checkout pull/5756` \
`$ git pull https://git.openjdk.java.net/jdk pull/5756/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5756`

View PR using the GUI difftool: \
`$ git pr show -t 5756`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5756.diff">https://git.openjdk.java.net/jdk/pull/5756.diff</a>

</details>
