### PR TITLE
8274522: java/lang/management/ManagementFactory/MXBeanException.java test fails with Shenandoah

### DIFF
--- a/test/jdk/java/lang/management/ManagementFactory/MXBeanException.java
+++ b/test/jdk/java/lang/management/ManagementFactory/MXBeanException.java
@@ -27,7 +27,7 @@
  * @summary Check if a RuntimeException is wrapped by RuntimeMBeanException
  *          only once.
  *
- * @requires vm.gc != "Z"
+ * @requires vm.gc != "Z" & vm.gc != "Shenandoah"
  * @author  Mandy Chung
  *
  * @build MXBeanException


### PR DESCRIPTION
Fails like this:

```
$ CONF=linux-x86_64-server-fastdebug make run-test TEST=java/lang/management/ManagementFactory/MXBeanException.java TEST_VM_OPTS="-XX:+UseShenandoahGC"

...

java.lang.NullPointerException: Cannot invoke "java.lang.management.MemoryPoolMXBean.setUsageThreshold(long)" because "MXBeanException.pool" is null
```

This test tries to find the pool that is `!p.isUsageThresholdSupported()`, and for Shenandoah there is no such pool. Likewise with ZGC, which is already filtered.

Additional testing:
 - [x] Affected test is now skipped for Shenandoah
 - [x] Affected test is still skipped for Z
 - [x] Affected test is still passing for G1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274522](https://bugs.openjdk.java.net/browse/JDK-8274522): java/lang/management/ManagementFactory/MXBeanException.java test fails with Shenandoah


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5757/head:pull/5757` \
`$ git checkout pull/5757`

Update a local copy of the PR: \
`$ git checkout pull/5757` \
`$ git pull https://git.openjdk.java.net/jdk pull/5757/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5757`

View PR using the GUI difftool: \
`$ git pr show -t 5757`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5757.diff">https://git.openjdk.java.net/jdk/pull/5757.diff</a>

</details>
