### PR TITLE
8274523: java/lang/management/MemoryMXBean/MemoryTest.java test should handle Shenandoah

### DIFF
--- a/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
@@ -26,7 +26,7 @@
  * @bug     4530538
  * @summary Basic unit test of MemoryMXBean.getMemoryPools() and
  *          MemoryMXBean.getMemoryManager().
- * @requires vm.gc != "Z"
+ * @requires vm.gc != "Z" & vm.gc != "Shenandoah"
  * @author  Mandy Chung
  *
  * @modules jdk.management
@@ -38,7 +38,7 @@
  * @bug     4530538
  * @summary Basic unit test of MemoryMXBean.getMemoryPools() and
  *          MemoryMXBean.getMemoryManager().
- * @requires vm.gc == "Z"
+ * @requires vm.gc == "Z" | vm.gc == "Shenandoah"
  * @author  Mandy Chung
  *
  * @modules jdk.management


### PR DESCRIPTION
Currently it fails with:

```
$ CONF=linux-x86_64-server-fastdebug make run-test TEST=java/lang/management/MemoryMXBean/MemoryTest.java

STDERR:
java.lang.RuntimeException: TEST FAILED: Number of heap pools = 1 but expected <= 3 and >= 3
```

Z already handles it with a special configuration, Shenandoah should do the same. 

Additional testing:
 - [x] Affected test now works for Shenandoah
 - [x] Affected test still works for Z
 - [x] Affected test still works for G1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274523](https://bugs.openjdk.java.net/browse/JDK-8274523): java/lang/management/MemoryMXBean/MemoryTest.java test should handle Shenandoah


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5758/head:pull/5758` \
`$ git checkout pull/5758`

Update a local copy of the PR: \
`$ git checkout pull/5758` \
`$ git pull https://git.openjdk.java.net/jdk pull/5758/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5758`

View PR using the GUI difftool: \
`$ git pr show -t 5758`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5758.diff">https://git.openjdk.java.net/jdk/pull/5758.diff</a>

</details>
