### PR TITLE
8274525: Replace uses of StringBuffer with StringBuilder in java.xml

### DIFF
--- a/src/java.xml/share/classes/com/sun/xml/internal/stream/Entity.java
+++ b/src/java.xml/share/classes/com/sun/xml/internal/stream/Entity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -461,13 +461,10 @@ public abstract class Entity {
 
         /** Returns a string representation of this object. */
         public String toString() {
-
-            StringBuffer str = new StringBuffer();
-            str.append("name=\""+name+'"');
-            str.append(",ch="+ new String(ch));
-            str.append(",position="+position);
-            str.append(",count="+count);
-            return str.toString();
+            return "name=\"" + name + '"' +
+                    ",ch=" + new String(ch) +
+                    ",position=" + position +
+                    ",count=" + count;
 
         } // toString():String
 

--- a/src/java.xml/share/classes/com/sun/xml/internal/stream/StaxErrorReporter.java
+++ b/src/java.xml/share/classes/com/sun/xml/internal/stream/StaxErrorReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,7 +93,7 @@ public class StaxErrorReporter extends XMLErrorReporter {
             message = messageFormatter.formatMessage(fLocale, key, arguments);
         }
         else {
-            StringBuffer str = new StringBuffer();
+            StringBuilder str = new StringBuilder();
             str.append(domain);
             str.append('#');
             str.append(key);

--- a/src/java.xml/share/classes/com/sun/xml/internal/stream/XMLEventReaderImpl.java
+++ b/src/java.xml/share/classes/com/sun/xml/internal/stream/XMLEventReaderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -142,8 +142,8 @@ public class XMLEventReaderImpl implements javax.xml.stream.XMLEventReader{
                 return "";
             }
 
-            //create the string buffer and add initial data
-            StringBuffer buffer = new StringBuffer();
+            //create the string builder and add initial data
+            StringBuilder buffer = new StringBuilder();
             if(data != null && data.length() > 0 ) {
                 buffer.append(data);
             }

--- a/src/java.xml/share/classes/com/sun/xml/internal/stream/events/LocationImpl.java
+++ b/src/java.xml/share/classes/com/sun/xml/internal/stream/events/LocationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,18 +67,11 @@ public class LocationImpl implements Location{
     }
 
     public String toString(){
-        StringBuffer sbuffer = new StringBuffer() ;
-        sbuffer.append("Line number = " + getLineNumber());
-        sbuffer.append("\n") ;
-        sbuffer.append("Column number = " + getColumnNumber());
-        sbuffer.append("\n") ;
-        sbuffer.append("System Id = " + getSystemId());
-        sbuffer.append("\n") ;
-        sbuffer.append("Public Id = " + getPublicId());
-        sbuffer.append("\n") ;
-        sbuffer.append("CharacterOffset = " + getCharacterOffset());
-        sbuffer.append("\n") ;
-        return sbuffer.toString();
+        return "Line number = " + getLineNumber() + "\n" +
+                "Column number = " + getColumnNumber() + "\n" +
+                "System Id = " + getSystemId() + "\n" +
+                "Public Id = " + getPublicId() + "\n" +
+                "CharacterOffset = " + getCharacterOffset() + "\n";
     }
 
 }

--- a/src/java.xml/share/classes/javax/xml/datatype/Duration.java
+++ b/src/java.xml/share/classes/javax/xml/datatype/Duration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -885,8 +885,7 @@ public abstract class Duration {
      * @return A non-{@code null} valid {@code String} representation of this {@code Duration}.
      */
     public String toString() {
-
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
 
         if (getSign() < 0) {
             buf.append('-');
@@ -946,15 +945,15 @@ public abstract class Duration {
         }
 
         /* Insert decimal point */
-        StringBuffer buf;
+        StringBuilder buf;
         int insertionPoint = intString.length() - scale;
         if (insertionPoint == 0) { /* Point goes right before intVal */
             return "0." + intString;
         } else if (insertionPoint > 0) { /* Point goes inside intVal */
-            buf = new StringBuffer(intString);
+            buf = new StringBuilder(intString);
             buf.insert(insertionPoint, '.');
         } else { /* We must insert zeros between point and intVal */
-            buf = new StringBuffer(3 - insertionPoint + intString.length());
+            buf = new StringBuilder(3 - insertionPoint + intString.length());
             buf.append("0.");
             for (int i = 0; i < -insertionPoint; i++) {
                 buf.append('0');


### PR DESCRIPTION
StringBuffer is a legacy synchronized class. There are more modern alternatives which perform better:
1. Plain String concatenation should be preferred
2. StringBuilder is a direct replacement to StringBuffer which generally have better performance

Similar cleanups:
1. [JDK-8264029](https://bugs.openjdk.java.net/browse/JDK-8264029) java.base
2. [JDK-8264428](https://bugs.openjdk.java.net/browse/JDK-8264428) java.desktop
3. [JDK-8264484](https://bugs.openjdk.java.net/browse/JDK-8264484) jdk.hotspot.agent

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274525](https://bugs.openjdk.java.net/browse/JDK-8274525): Replace uses of StringBuffer with StringBuilder in java.xml


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5759/head:pull/5759` \
`$ git checkout pull/5759`

Update a local copy of the PR: \
`$ git checkout pull/5759` \
`$ git pull https://git.openjdk.java.net/jdk pull/5759/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5759`

View PR using the GUI difftool: \
`$ git pr show -t 5759`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5759.diff">https://git.openjdk.java.net/jdk/pull/5759.diff</a>

</details>
