### PR TITLE
8274178: Occupancy value in logging and JFR event is inaccurate in G1IHOPControl

### DIFF
--- a/src/hotspot/share/gc/g1/g1IHOPControl.cpp
+++ b/src/hotspot/share/gc/g1/g1IHOPControl.cpp
@@ -59,7 +59,7 @@ void G1IHOPControl::print() {
                       cur_conc_mark_start_threshold,
                       percent_of(cur_conc_mark_start_threshold, _target_occupancy),
                       _target_occupancy,
-                      G1CollectedHeap::heap()->used(),
+                      G1CollectedHeap::heap()->non_young_capacity_bytes(),
                       _old_gen_alloc_tracker->last_period_old_gen_bytes(),
                       _last_allocation_time_s * 1000.0,
                       _last_allocation_time_s > 0.0 ? _old_gen_alloc_tracker->last_period_old_gen_bytes() / _last_allocation_time_s : 0.0,
@@ -70,7 +70,7 @@ void G1IHOPControl::send_trace_event(G1NewTracer* tracer) {
   assert(_target_occupancy > 0, "Target occupancy still not updated yet.");
   tracer->report_basic_ihop_statistics(get_conc_mark_start_threshold(),
                                        _target_occupancy,
-                                       G1CollectedHeap::heap()->used(),
+                                       G1CollectedHeap::heap()->non_young_capacity_bytes(),
                                        _old_gen_alloc_tracker->last_period_old_gen_bytes(),
                                        _last_allocation_time_s,
                                        last_marking_length_s());
@@ -175,7 +175,7 @@ void G1AdaptiveIHOPControl::print() {
                       get_conc_mark_start_threshold(),
                       percent_of(get_conc_mark_start_threshold(), actual_target),
                       actual_target,
-                      G1CollectedHeap::heap()->used(),
+                      G1CollectedHeap::heap()->non_young_capacity_bytes(),
                       _last_unrestrained_young_size,
                       predict(&_allocation_rate_s),
                       predict(&_marking_times_s) * 1000.0,
@@ -186,7 +186,7 @@ void G1AdaptiveIHOPControl::send_trace_event(G1NewTracer* tracer) {
   G1IHOPControl::send_trace_event(tracer);
   tracer->report_adaptive_ihop_statistics(get_conc_mark_start_threshold(),
                                           actual_target_threshold(),
-                                          G1CollectedHeap::heap()->used(),
+                                          G1CollectedHeap::heap()->non_young_capacity_bytes(),
                                           _last_unrestrained_young_size,
                                           predict(&_allocation_rate_s),
                                           predict(&_marking_times_s),


### PR DESCRIPTION
Hi all,

Could we have reviews for this minor fix for logging and JFR event occupancy number for G1? See https://bugs.openjdk.java.net/browse/JDK-8274178 for more details.

This fix is contributed by colleague Jonathan Joo <jonathanjoo@google.com>.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8274178](https://bugs.openjdk.java.net/browse/JDK-8274178): Occupancy value in logging and JFR event is inaccurate in G1IHOPControl


### Contributors
 * Jonathan Joo `<jonathanjoo@google.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5762/head:pull/5762` \
`$ git checkout pull/5762`

Update a local copy of the PR: \
`$ git checkout pull/5762` \
`$ git pull https://git.openjdk.java.net/jdk pull/5762/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5762`

View PR using the GUI difftool: \
`$ git pr show -t 5762`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5762.diff">https://git.openjdk.java.net/jdk/pull/5762.diff</a>

</details>
