### PR TITLE
[PATCH] Use Collections.singletonList instead Arrays.asList in java.desktop

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JViewport.java
+++ b/src/java.desktop/share/classes/javax/swing/JViewport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,6 @@ import javax.swing.border.*;
 import javax.accessibility.*;
 
 import java.io.Serializable;
-import java.util.Arrays;
 import java.util.Collections;
 
 import sun.awt.AWTAccessor;
@@ -924,7 +923,7 @@ public class JViewport extends JComponent implements Accessible
 
         @Override
         public java.util.List<Image> getResolutionVariants() {
-            return Collections.unmodifiableList(Arrays.asList(rvImage));
+            return Collections.singletonList(rvImage);
         }
     }
 

--- a/src/java.desktop/share/classes/sun/swing/CachedPainter.java
+++ b/src/java.desktop/share/classes/sun/swing/CachedPainter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import java.awt.image.AbstractMultiResolutionImage;
 import java.awt.image.BufferedImage;
 import java.awt.image.ImageObserver;
 import java.awt.image.VolatileImage;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -327,7 +327,7 @@ public abstract class CachedPainter {
 
         @Override
         public java.util.List<Image> getResolutionVariants() {
-            return Arrays.asList(getResolutionVariant(baseWidth, baseHeight));
+            return Collections.singletonList(getResolutionVariant(baseWidth, baseHeight));
         }
     }
 }


### PR DESCRIPTION
No need to create redundant vararg array for Arrays.asList call if there is only one element.
Bonus point is that we don't need to wrap it into unmodifiableList anymore.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5763/head:pull/5763` \
`$ git checkout pull/5763`

Update a local copy of the PR: \
`$ git checkout pull/5763` \
`$ git pull https://git.openjdk.java.net/jdk pull/5763/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5763`

View PR using the GUI difftool: \
`$ git pr show -t 5763`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5763.diff">https://git.openjdk.java.net/jdk/pull/5763.diff</a>

</details>
