### PR TITLE
8274527: Minimal VM build fails after JDK-8273459

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1177,7 +1177,13 @@ void MacroAssembler::align64() {
   align(64, (unsigned long long) pc());
 }
 
+void MacroAssembler::align32() {
+  align(32, (unsigned long long) pc());
+}
+
 void MacroAssembler::align(int modulus) {
+  // 8273459: Ensure alignment is possible with current segment alignment
+  assert(modulus <= CodeEntryAlignment, "Alignment must be <= CodeEntryAlignment");
   align(modulus, offset());
 }
 
@@ -6903,7 +6909,7 @@ void MacroAssembler::kernel_crc32(Register crc, Register buf, Register len, Regi
   // 128 bits per each of 4 parallel streams.
   movdqu(xmm0, ExternalAddress(StubRoutines::x86::crc_by128_masks_addr() + 32));
 
-  align(32);
+  align32();
   BIND(L_fold_512b_loop);
   fold_128bit_crc32(xmm1, xmm0, xmm5, buf,  0);
   fold_128bit_crc32(xmm2, xmm0, xmm5, buf, 16);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1178,8 +1178,6 @@ void MacroAssembler::align64() {
 }
 
 void MacroAssembler::align(int modulus) {
-  // 8273459: Ensure alignment is possible with current segment alignment
-  assert(modulus <= CodeEntryAlignment, "Alignment must be <= CodeEntryAlignment");
   align(modulus, offset());
 }
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -194,6 +194,7 @@ class MacroAssembler: public Assembler {
   void incrementq(AddressLiteral dst);
 
   // Alignment
+  void align32();
   void align64();
   void align(int modulus);
   void align(int modulus, int target);

--- a/src/hotspot/cpu/x86/macroAssembler_x86_adler.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_adler.cpp
@@ -80,7 +80,7 @@ void MacroAssembler::updateBytesAdler32(Register init_d, Register data, Register
       cmpptr(data, end);
       jcc(Assembler::aboveEqual, SKIP_LOOP_1A);
 
-      align(32);
+      align32();
       bind(SLOOP1A);
       vbroadcastf128(ydata, Address(data, 0), Assembler::AVX_256bit);
       addptr(data, CHUNKSIZE);
@@ -178,7 +178,7 @@ void MacroAssembler::updateBytesAdler32(Register init_d, Register data, Register
       movdl(rax, xb);
       addl(b_d, rax);
 
-      align(32);
+      align32();
       bind(FINAL_LOOP);
       movzbl(rax, Address(data, 0)); //movzx   eax, byte[data]
       addl(a_d, rax);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -1484,7 +1484,7 @@ class StubGenerator: public StubCodeGenerator {
         __ subq(temp1, loop_size[shift]);
 
         // Main loop with aligned copy block size of 192 bytes at 32 byte granularity.
-        __ align(32);
+        __ align32();
         __ BIND(L_main_loop);
            __ copy64_avx(to, from, temp4, xmm1, false, shift, 0);
            __ copy64_avx(to, from, temp4, xmm1, false, shift, 64);
@@ -1551,7 +1551,7 @@ class StubGenerator: public StubCodeGenerator {
 
         // Main loop with aligned copy block size of 192 bytes at
         // 64 byte copy granularity.
-        __ align(32);
+        __ align32();
         __ BIND(L_main_loop_64bytes);
            __ copy64_avx(to, from, temp4, xmm1, false, shift, 0 , true);
            __ copy64_avx(to, from, temp4, xmm1, false, shift, 64, true);
@@ -1691,7 +1691,7 @@ class StubGenerator: public StubCodeGenerator {
         __ BIND(L_main_pre_loop);
 
         // Main loop with aligned copy block size of 192 bytes at 32 byte granularity.
-        __ align(32);
+        __ align32();
         __ BIND(L_main_loop);
            __ copy64_avx(to, from, temp1, xmm1, true, shift, -64);
            __ copy64_avx(to, from, temp1, xmm1, true, shift, -128);
@@ -1724,7 +1724,7 @@ class StubGenerator: public StubCodeGenerator {
 
         // Main loop with aligned copy block size of 192 bytes at
         // 64 byte copy granularity.
-        __ align(32);
+        __ align32();
         __ BIND(L_main_loop_64bytes);
            __ copy64_avx(to, from, temp1, xmm1, true, shift, -64 , true);
            __ copy64_avx(to, from, temp1, xmm1, true, shift, -128, true);
@@ -4274,7 +4274,7 @@ class StubGenerator: public StubCodeGenerator {
 
   //Mask for byte-swapping a couple of qwords in an XMM register using (v)pshufb.
   address generate_pshuffle_byte_flip_mask_sha512() {
-    __ align(32);
+    __ align32();
     StubCodeMark mark(this, "StubRoutines", "pshuffle_byte_flip_mask_sha512");
     address start = __ pc();
     if (VM_Version::supports_avx2()) {
@@ -5401,7 +5401,7 @@ address generate_avx_ghash_processBlocks() {
 
   address base64_avx2_shuffle_addr()
   {
-    __ align(32);
+    __ align32();
     StubCodeMark mark(this, "StubRoutines", "avx2_shuffle_base64");
     address start = __ pc();
     __ emit_data64(0x0809070805060405, relocInfo::none);
@@ -5413,7 +5413,7 @@ address generate_avx_ghash_processBlocks() {
 
   address base64_avx2_input_mask_addr()
   {
-    __ align(32);
+    __ align32();
     StubCodeMark mark(this, "StubRoutines", "avx2_input_mask_base64");
     address start = __ pc();
     __ emit_data64(0x8000000000000000, relocInfo::none);
@@ -5425,7 +5425,7 @@ address generate_avx_ghash_processBlocks() {
 
   address base64_avx2_lut_addr()
   {
-    __ align(32);
+    __ align32();
     StubCodeMark mark(this, "StubRoutines", "avx2_lut_base64");
     address start = __ pc();
     __ emit_data64(0xfcfcfcfcfcfc4741, relocInfo::none);
@@ -5530,7 +5530,7 @@ address generate_avx_ghash_processBlocks() {
       __ evmovdquq(xmm2, Address(encode_table, 0), Assembler::AVX_512bit);
       __ evpbroadcastq(xmm1, rax, Assembler::AVX_512bit);
 
-      __ align(32);
+      __ align32();
       __ BIND(L_vbmiLoop);
 
       __ vpermb(xmm0, xmm3, Address(source, start_offset), Assembler::AVX_512bit);
@@ -5730,7 +5730,7 @@ address generate_avx_ghash_processBlocks() {
       __ cmpl(length, 31);
       __ jcc(Assembler::belowEqual, L_process3);
 
-      __ align(32);
+      __ align32();
       __ BIND(L_32byteLoop);
 
       // Get next 32 bytes
@@ -6177,7 +6177,7 @@ address generate_avx_ghash_processBlocks() {
       __ evmovdquq(join12, ExternalAddress(StubRoutines::x86::base64_vbmi_join_1_2_addr()), Assembler::AVX_512bit, r13);
       __ evmovdquq(join23, ExternalAddress(StubRoutines::x86::base64_vbmi_join_2_3_addr()), Assembler::AVX_512bit, r13);
 
-      __ align(32);
+      __ align32();
       __ BIND(L_process256);
       // Grab input data
       __ evmovdquq(input0, Address(source, start_offset, Address::times_1, 0x00), Assembler::AVX_512bit);
@@ -6259,7 +6259,7 @@ address generate_avx_ghash_processBlocks() {
       __ cmpl(length, 63);
       __ jcc(Assembler::lessEqual, L_finalBit);
 
-      __ align(32);
+      __ align32();
       __ BIND(L_process64Loop);
 
       // Handle first 64-byte block
@@ -6395,7 +6395,7 @@ address generate_avx_ghash_processBlocks() {
       __ shrq(rax, 1);
       __ jmp(L_donePadding);
 
-      __ align(32);
+      __ align32();
       __ BIND(L_bruteForce);
     }   // End of if(avx512_vbmi)
 
@@ -6439,7 +6439,7 @@ address generate_avx_ghash_processBlocks() {
 
     __ jmp(L_bottomLoop);
 
-    __ align(32);
+    __ align32();
     __ BIND(L_forceLoop);
     __ shll(byte1, 18);
     __ shll(byte2, 12);


### PR DESCRIPTION
Hi all,

The broken was observed when
```
(gdb) bt
#0  MacroAssembler::align (this=0x7ffff0025b98, modulus=32) at /home/jvm/jiefu/docker/jdk/src/hotspot/cpu/x86/macroAssembler_x86.cpp:1182
#1  0x00007ffff67fc6c5 in MacroAssembler::kernel_crc32 (this=0x7ffff0025b98, crc=0x7, buf=0x6, len=0x2, table=0x1, tmp=0xb)
    at /home/jvm/jiefu/docker/jdk/src/hotspot/cpu/x86/macroAssembler_x86.cpp:6911
#2  0x00007ffff69a3555 in StubGenerator::generate_updateBytesCRC32 (this=0x7ffff5e9c900) at /home/jvm/jiefu/docker/jdk/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp:6532
#3  0x00007ffff69a589b in StubGenerator::generate_initial (this=0x7ffff5e9c900) at /home/jvm/jiefu/docker/jdk/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp:7583
#4  0x00007ffff69a6801 in StubGenerator::StubGenerator (this=0x7ffff5e9c900, code=0x7ffff5e9c9c0, all=false)
    at /home/jvm/jiefu/docker/jdk/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp:7909
#5  0x00007ffff697fa21 in StubGenerator_generate (code=0x7ffff5e9c9c0, all=false) at /home/jvm/jiefu/docker/jdk/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp:7919
#6  0x00007ffff69a6c13 in StubRoutines::initialize1 () at /home/jvm/jiefu/docker/jdk/src/hotspot/share/runtime/stubRoutines.cpp:223
#7  0x00007ffff69a790d in stubRoutines_init1 () at /home/jvm/jiefu/docker/jdk/src/hotspot/share/runtime/stubRoutines.cpp:366
#8  0x00007ffff672044d in init_globals () at /home/jvm/jiefu/docker/jdk/src/hotspot/share/runtime/init.cpp:119
#9  0x00007ffff69fb39f in Threads::create_vm (args=0x7ffff5e9ce10, canTryAgain=0x7ffff5e9cd33) at /home/jvm/jiefu/docker/jdk/src/hotspot/share/runtime/thread.cpp:2827
#10 0x00007ffff6787879 in JNI_CreateJavaVM_inner (vm=0x7ffff5e9ce68, penv=0x7ffff5e9ce70, args=0x7ffff5e9ce10)
    at /home/jvm/jiefu/docker/jdk/src/hotspot/share/prims/jni.cpp:3616
#11 0x00007ffff6787a72 in JNI_CreateJavaVM (vm=0x7ffff5e9ce68, penv=0x7ffff5e9ce70, args=0x7ffff5e9ce10)
    at /home/jvm/jiefu/docker/jdk/src/hotspot/share/prims/jni.cpp:3704
#12 0x00007ffff79b8141 in InitializeJVM (pvm=0x7ffff5e9ce68, penv=0x7ffff5e9ce70, ifn=0x7ffff5e9cec0)
    at /home/jvm/jiefu/docker/jdk/src/java.base/share/native/libjli/java.c:1459
#13 0x00007ffff79b4f39 in JavaMain (_args=0x7fffffffb1a0) at /home/jvm/jiefu/docker/jdk/src/java.base/share/native/libjli/java.c:411
#14 0x00007ffff79bba79 in ThreadJavaMain (args=0x7fffffffb1a0) at /home/jvm/jiefu/docker/jdk/src/java.base/unix/native/libjli/java_md.c:651
#15 0x00007ffff779cea5 in start_thread () from /lib64/libpthread.so.0
#16 0x00007ffff72c19fd in clone () from /lib64/libc.so.6
```

In this case, modulus=32 and CodeEntryAlignment=16.

So this assert shouldn't be added in `align` since we may use it (modulus > CodeEntryAlignment) in highly optimized hand-crafted assembly code.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274527](https://bugs.openjdk.java.net/browse/JDK-8274527): Minimal VM build fails after JDK-8273459


### Reviewers
 * @asgibbons (no known github.com user name / role)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5764/head:pull/5764` \
`$ git checkout pull/5764`

Update a local copy of the PR: \
`$ git checkout pull/5764` \
`$ git pull https://git.openjdk.java.net/jdk pull/5764/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5764`

View PR using the GUI difftool: \
`$ git pr show -t 5764`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5764.diff">https://git.openjdk.java.net/jdk/pull/5764.diff</a>

</details>
