### PR TITLE
8274304: Update or Problem List tests which may fail with uiScale=2 on macOS

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -750,10 +750,18 @@ javax/swing/JButton/8151303/PressedIconTest.java 8266246 macosx-aarch64
 javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.java 8273573 macosx-all
 
 # Several tests which fail on some hidpi systems
+java/awt/Dialog/SiblingChildOrder/SiblingChildOrderTest.java 8274106 macosx-aarch64
 java/awt/GraphicsDevice/DisplayModes/CycleDMImage.java 8274106 macosx-aarch64
+java/awt/Paint/PaintNativeOnUpdate.java 8274106 macosx-aarch64
 java/awt/Window/8159168/SetShapeTest.java 8274106 macosx-aarch64
+java/awt/Window/BackgroundIsNotUpdated/BackgroundIsNotUpdated.java 8274106 macosx-aarch64
+java/awt/Window/MultiWindowApp/ChildAlwaysOnTopTest.java 8274106 macosx-aarch64
+java/awt/Window/TranslucentJAppletTest/TranslucentJAppletTest.java 8274106 macosx-aarch64
 java/awt/image/multiresolution/MultiResolutionJOptionPaneIconTest.java 8274106 macosx-aarch64
 javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8274106 macosx-aarch64
+javax/swing/JTabbedPane/TestBackgroundScrollPolicy.java 8274106 macosx-aarch64
+javax/swing/plaf/nimbus/TestNimbusBGColor.java 8274106 macosx-aarch64
+javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java 8274106 macosx-aarch64
 
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8225012 windows-all,macosx-all
 sanity/client/SwingSet/src/ScrollPaneDemoTest.java 8225013 linux-all

--- a/test/jdk/java/awt/Dialog/SiblingChildOrder/SiblingChildOrderTest.java
+++ b/test/jdk/java/awt/Dialog/SiblingChildOrder/SiblingChildOrderTest.java
@@ -26,7 +26,7 @@
  * @bug 8190230 8196360
  * @summary [macosx] Order of overlapping of modal dialogs is wrong
  * @key headful
- * @run main/othervm -Dsun.java2d.uiScale=1 SiblingChildOrderTest
+ * @run main SiblingChildOrderTest
  */
 
 import java.awt.Color;

--- a/test/jdk/java/awt/Paint/PaintNativeOnUpdate.java
+++ b/test/jdk/java/awt/Paint/PaintNativeOnUpdate.java
@@ -36,7 +36,7 @@ import java.awt.Point;
  * @library /lib/client
  * @build ExtendedRobot
  * @author Sergey Bylokhov
- * @run main/othervm -Dsun.java2d.uiScale=1 PaintNativeOnUpdate
+ * @run main PaintNativeOnUpdate
  */
 public final class PaintNativeOnUpdate extends Label {
 

--- a/test/jdk/java/awt/Window/BackgroundIsNotUpdated/BackgroundIsNotUpdated.java
+++ b/test/jdk/java/awt/Window/BackgroundIsNotUpdated/BackgroundIsNotUpdated.java
@@ -37,7 +37,7 @@ import java.awt.Window;
  * @author Sergey Bylokhov
  * @library /lib/client
  * @build ExtendedRobot
- * @run main/othervm -Dsun.java2d.uiScale=1 BackgroundIsNotUpdated
+ * @run main BackgroundIsNotUpdated
  */
 public final class BackgroundIsNotUpdated extends Window {
 

--- a/test/jdk/java/awt/Window/MultiWindowApp/ChildAlwaysOnTopTest.java
+++ b/test/jdk/java/awt/Window/MultiWindowApp/ChildAlwaysOnTopTest.java
@@ -28,7 +28,7 @@
  *          certain scenarios
  * @bug 8021961
  * @author Semyon Sadetsky
- * @run main/othervm -Dsun.java2d.uiScale=1 ChildAlwaysOnTopTest
+ * @run main ChildAlwaysOnTopTest
  */
 
 import javax.swing.*;

--- a/test/jdk/java/awt/Window/TranslucentJAppletTest/TranslucentJAppletTest.java
+++ b/test/jdk/java/awt/Window/TranslucentJAppletTest/TranslucentJAppletTest.java
@@ -27,7 +27,7 @@
  * @bug 6683728
  * @summary Tests that a JApplet in a translucent JFrame works properly
  * @compile -XDignore.symbol.file=true TranslucentJAppletTest.java
- * @run main/othervm -Dsun.java2d.uiScale=1 TranslucentJAppletTest
+ * @run main TranslucentJAppletTest
  */
 
 import java.awt.*;

--- a/test/jdk/javax/swing/JTabbedPane/TestBackgroundScrollPolicy.java
+++ b/test/jdk/javax/swing/JTabbedPane/TestBackgroundScrollPolicy.java
@@ -36,7 +36,7 @@ import javax.swing.UnsupportedLookAndFeelException;
  * @key headful
  * @bug 8172269 8244557
  * @summary Tests JTabbedPane background for SCROLL_TAB_LAYOUT
- * @run main/othervm -Dsun.java2d.uiScale=1 TestBackgroundScrollPolicy
+ * @run main TestBackgroundScrollPolicy
  */
 
 public class TestBackgroundScrollPolicy {

--- a/test/jdk/javax/swing/plaf/nimbus/TestNimbusBGColor.java
+++ b/test/jdk/javax/swing/plaf/nimbus/TestNimbusBGColor.java
@@ -25,7 +25,7 @@
  * @bug 8058704 6789980
  * @key headful
  * @summary  Verifies if Nimbus honor JTextPane and JEditorPane background color
- * @run main/othervm -Dsun.java2d.uiScale=1 TestNimbusBGColor
+ * @run main TestNimbusBGColor
  */
 import java.awt.Color;
 import java.awt.Dimension;

--- a/test/jdk/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
+++ b/test/jdk/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
@@ -28,7 +28,7 @@
  * @build Util
  * @author Romain Guy
  * @summary Tests PRESSED and MOUSE_OVER and FOCUSED state for buttons with Synth.
- * @run main/othervm -Dsun.java2d.uiScale=1 bug6276188
+ * @run main bug6276188
  */
 import java.awt.*;
 import java.awt.image.*;


### PR DESCRIPTION
The fix for 8274296 added uiScale=1 to some of the tests to fix the problem of incorrect pixel color capture by the robot.
In both cases uiScale=1 or uiScale=2 the same call should be made to the macOS. But if uiScale=1 is set we just read one pixel on the screen, but if uiScale=2 is set we prepare the data in some clumsy way(at the end we should also read just one pixel).

Since uiScale=1 affects the test case execution means that we probably have some bugs in the coordinate/size calculation of the area. Note that none of these tests have dependencies on the precise rendering, so it is quite a common use-case and may affect any external applications.

This is a request to update the https://github.com/openjdk/jdk/pull/5687/files
and move all tests to the problem list.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8274304](https://bugs.openjdk.java.net/browse/JDK-8274304): Update or Problem List tests which may fail with uiScale=2 on macOS


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5766/head:pull/5766` \
`$ git checkout pull/5766`

Update a local copy of the PR: \
`$ git checkout pull/5766` \
`$ git pull https://git.openjdk.java.net/jdk pull/5766/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5766`

View PR using the GUI difftool: \
`$ git pr show -t 5766`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5766.diff">https://git.openjdk.java.net/jdk/pull/5766.diff</a>

</details>
