### PR TITLE
JDK-8274562: fs determines unsupported UserDefinedFileAttributeView due to fastfail mechanism

### DIFF
--- a/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
+++ b/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
@@ -317,7 +317,7 @@ Java_sun_nio_fs_UnixNativeDispatcher_init(JNIEnv* env, jclass this)
 
     /* supports extended attributes */
 
-#ifdef _SYS_XATTR_H_
+#ifdef XATTR_CREATE
     capabilities |= sun_nio_fs_UnixNativeDispatcher_SUPPORTS_XATTR;
 #endif
 


### PR DESCRIPTION
**Summary**
JDK-8262957 (https://github.com/openjdk/jdk/pull/2816) introduced a fast-fail mechanism determining if a filesystem
supports `UserDefinedFileAttributeView` based on if `_SYS_XATTR_H_` is defined; which is defined by `xattr.h`. 

The problem with this approach is that this variable is not the same in both MacOS `_SYS_XATTR_H_` and Linux `_SYS_XATTR_H` which can cause the JDK to incorrectly determine that a Linux filesystem doesn't support user defined file attributes when it does using: 
```
Files.getFileStore(Paths.get( "/tmp/testfile"))
        .supportsFileAttributeView(UserDefinedFileAttributeView.class);
```

**Proposed Fix**
One solution is to cover both cases 
```
#if defined _SYS_XATTR_H || defined _SYS_XATTR_H_
    capabilities |= sun_nio_fs_UnixNativeDispatcher_SUPPORTS_XATTR;
#endif
```
The proposed solution here is to use `XATTR_CREATE` which is defined in both MacOS (https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/bsd/sys/xattr.h#L38) and Linux glibc (https://github.com/bminor/glibc/blob/88361b408b9dbd313f15413cc2e6be0f1cafb01a/misc/sys/xattr.h#L33)

**Testing**
The following was tested on Ubuntu 20.04 with overlayfs before and after the fix
```
import java.io.IOException;
import java.nio.file.Files;
import java.nio.file.Paths;
import java.nio.file.attribute.UserDefinedFileAttributeView;

public class ExtFileAttributeChecker {
    public static void main(String[] args) throws IOException {
        System.out.println(Files.getFileStore(Paths.get("/tmp/testfile")).supportsFileAttributeView(UserDefinedFileAttributeView.class));
    }
} 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8274562](https://bugs.openjdk.java.net/browse/JDK-8274562): fs determines unsupported UserDefinedFileAttributeView due to fastfail mechanism


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5767/head:pull/5767` \
`$ git checkout pull/5767`

Update a local copy of the PR: \
`$ git checkout pull/5767` \
`$ git pull https://git.openjdk.java.net/jdk pull/5767/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5767`

View PR using the GUI difftool: \
`$ git pr show -t 5767`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5767.diff">https://git.openjdk.java.net/jdk/pull/5767.diff</a>

</details>
