### PR TITLE
8273152: Refactor CDS FileMapHeader loading code

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -1128,10 +1128,6 @@ void ArchiveBuilder::write_archive(FileMapInfo* mapinfo,
   print_region_stats(mapinfo, closed_heap_regions, open_heap_regions);
 
   mapinfo->set_requested_base((char*)MetaspaceShared::requested_base_address());
-  if (mapinfo->header()->magic() == CDS_DYNAMIC_ARCHIVE_MAGIC) {
-    mapinfo->set_header_base_archive_name_size(strlen(Arguments::GetSharedArchivePath()) + 1);
-    mapinfo->set_header_base_archive_is_default(FLAG_IS_DEFAULT(SharedArchiveFile));
-  }
   mapinfo->set_header_crc(mapinfo->compute_header_crc());
   // After this point, we should not write any data into mapinfo->header() since this
   // would corrupt its checksum we have calculated before.

--- a/src/hotspot/share/cds/cdsConstants.cpp
+++ b/src/hotspot/share/cds/cdsConstants.cpp
@@ -31,15 +31,17 @@
 #include "utilities/globalDefinitions.hpp"
 
 CDSConst CDSConstants::offsets[] = {
-  { "CDSFileMapHeaderBase::_magic",           offset_of(CDSFileMapHeaderBase, _magic)           },
-  { "CDSFileMapHeaderBase::_crc",             offset_of(CDSFileMapHeaderBase, _crc)             },
-  { "CDSFileMapHeaderBase::_version",         offset_of(CDSFileMapHeaderBase, _version)         },
-  { "CDSFileMapHeaderBase::_space[0]",        offset_of(CDSFileMapHeaderBase, _space)           },
-  { "FileMapHeader::_jvm_ident",              offset_of(FileMapHeader, _jvm_ident)              },
-  { "FileMapHeader::_base_archive_name_size", offset_of(FileMapHeader, _base_archive_name_size) },
-  { "CDSFileMapRegion::_crc",                 offset_of(CDSFileMapRegion, _crc)                 },
-  { "CDSFileMapRegion::_used",                offset_of(CDSFileMapRegion, _used)                },
-  { "DynamicArchiveHeader::_base_region_crc", offset_of(DynamicArchiveHeader, _base_region_crc) }
+  { "GenericCDSFileMapHeader::_magic",                     offset_of(GenericCDSFileMapHeader, _magic)          },
+  { "GenericCDSFileMapHeader::_crc",                       offset_of(GenericCDSFileMapHeader, _crc)            },
+  { "GenericCDSFileMapHeader::_version",                   offset_of(GenericCDSFileMapHeader, _version)        },
+  { "GenericCDSFileMapHeader::_header_size",               offset_of(GenericCDSFileMapHeader, _header_size)    },
+  { "GenericCDSFileMapHeader::_base_archive_path_offset",  offset_of(GenericCDSFileMapHeader, _base_archive_path_offset) },
+  { "GenericCDSFileMapHeader::_base_archive_name_size",    offset_of(GenericCDSFileMapHeader, _base_archive_name_size)   },
+  { "CDSFileMapHeaderBase::_space[0]",                     offset_of(CDSFileMapHeaderBase, _space)             },
+  { "FileMapHeader::_jvm_ident",                           offset_of(FileMapHeader, _jvm_ident)                },
+  { "CDSFileMapRegion::_crc",                              offset_of(CDSFileMapRegion, _crc)                   },
+  { "CDSFileMapRegion::_used",                             offset_of(CDSFileMapRegion, _used)                  },
+  { "DynamicArchiveHeader::_base_region_crc",              offset_of(DynamicArchiveHeader, _base_region_crc)   }
 };
 
 CDSConst CDSConstants::constants[] = {

--- a/src/hotspot/share/cds/dynamicArchive.cpp
+++ b/src/hotspot/share/cds/dynamicArchive.cpp
@@ -325,7 +325,7 @@ void DynamicArchiveBuilder::write_archive(char* serialized_data) {
   size_t file_size = pointer_delta(top, base, sizeof(char));
 
   log_info(cds, dynamic)("Written dynamic archive " PTR_FORMAT " - " PTR_FORMAT
-                         " [" SIZE_FORMAT " bytes header, " SIZE_FORMAT " bytes total]",
+                         " [" UINT32_FORMAT " bytes header, " SIZE_FORMAT " bytes total]",
                          p2i(base), p2i(top), _header->header_size(), file_size);
 
   log_info(cds, dynamic)("%d klasses; %d symbols", klasses()->length(), symbols()->length());

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -184,8 +184,6 @@ class FileMapHeader: private CDSFileMapHeaderBase {
   friend class VMStructs;
 
 private:
-  size_t _header_size;
-
   // The following fields record the states of the VM during dump time.
   // They are compared with the runtime states to see if the archive
   // can be used.
@@ -210,8 +208,6 @@ private:
   // will function correctly with this JVM and the bootclasspath it's
   // invoked with.
   char  _jvm_ident[JVM_IDENT_MAX];  // identifier string of the jvm that created this dump
-  // size of the base archive name including NULL terminator
-  size_t _base_archive_name_size;
 
   // The following is a table of all the boot/app/module path entries that were used
   // during dumping. At run time, we validate these entries according to their
@@ -243,17 +239,21 @@ private:
   }
   void set_as_offset(char* p, size_t *offset);
 public:
-  // Accessors -- fields declared in CDSFileMapHeaderBase
-  unsigned int magic()                    const { return _magic; }
-  int crc()                               const { return _crc; }
-  int version()                           const { return _version; }
+  // Accessors -- fields declared in GenericCDSFileMapHeader
+  unsigned int magic()                    const { return _generic_header._magic;    }
+  int crc()                               const { return _generic_header._crc;      }
+  int version()                           const { return _generic_header._version;  }
+  unsigned int header_size()              const { return _generic_header._header_size;              }
+  unsigned int base_archive_path_offset() const { return _generic_header._base_archive_path_offset; }
+  unsigned int base_archive_name_size()   const { return _generic_header._base_archive_name_size;   }
 
-  void set_crc(int crc_value)                   { _crc = crc_value; }
-  void set_version(int v)                       { _version = v; }
+  void set_magic(unsigned int m)                    { _generic_header._magic = m;       }
+  void set_crc(int crc_value)                       { _generic_header._crc = crc_value; }
+  void set_version(int v)                           { _generic_header._version = v;     }
+  void set_header_size(unsigned int s)              { _generic_header._header_size = s;              }
+  void set_base_archive_path_offset(unsigned int s) { _generic_header._base_archive_path_offset = s; }
+  void set_base_archive_name_size(unsigned int s)   { _generic_header._base_archive_name_size = s;   }
 
-  // Accessors -- fields declared in FileMapHeader
-
-  size_t header_size()                     const { return _header_size; }
   size_t core_region_alignment()           const { return _core_region_alignment; }
   int obj_alignment()                      const { return _obj_alignment; }
   address narrow_oop_base()                const { return _narrow_oop_base; }
@@ -269,7 +269,6 @@ public:
   address heap_end()                       const { return _heap_end; }
   bool base_archive_is_default()           const { return _base_archive_is_default; }
   const char* jvm_ident()                  const { return _jvm_ident; }
-  size_t base_archive_name_size()          const { return _base_archive_name_size; }
   char* requested_base_address()           const { return _requested_base_address; }
   char* mapped_base_address()              const { return _mapped_base_address; }
   bool has_platform_or_app_classes()       const { return _has_platform_or_app_classes; }
@@ -287,12 +286,11 @@ public:
   void set_has_platform_or_app_classes(bool v)   { _has_platform_or_app_classes = v; }
   void set_cloned_vtables(char* p)               { set_as_offset(p, &_cloned_vtables_offset); }
   void set_serialized_data(char* p)              { set_as_offset(p, &_serialized_data_offset); }
-  void set_base_archive_name_size(size_t s)      { _base_archive_name_size = s; }
   void set_base_archive_is_default(bool b)       { _base_archive_is_default = b; }
-  void set_header_size(size_t s)                 { _header_size = s; }
   void set_ptrmap_size_in_bits(size_t s)         { _ptrmap_size_in_bits = s; }
   void set_mapped_base_address(char* p)          { _mapped_base_address = p; }
   void set_heap_obj_roots(narrowOop r)           { _heap_obj_roots = r; }
+  void set_base_archive_name(const char* name);
 
   void set_shared_path_table(SharedPathTable table) {
     set_as_offset((char*)table.table(), &_shared_path_table_offset);
@@ -363,7 +361,7 @@ private:
 
 public:
   static bool get_base_archive_name_from_header(const char* archive_name,
-                                                int* size, char** base_archive_name);
+                                                char** base_archive_name);
   static bool check_archive(const char* archive_name, bool is_static);
   static SharedPathTable shared_path_table() {
     return _shared_path_table;
@@ -397,9 +395,6 @@ public:
   address narrow_klass_base()  const { return header()->narrow_klass_base(); }
   int     narrow_klass_shift() const { return header()->narrow_klass_shift(); }
   size_t  core_region_alignment() const { return header()->core_region_alignment(); }
-
-  void   set_header_base_archive_name_size(size_t size)      { header()->set_base_archive_name_size(size); }
-  void   set_header_base_archive_is_default(bool is_default) { header()->set_base_archive_is_default(is_default); }
 
   CompressedOops::Mode narrow_oop_mode()      const { return header()->narrow_oop_mode(); }
   jshort app_module_paths_start_index()       const { return header()->app_module_paths_start_index(); }

--- a/src/hotspot/share/include/cds.h
+++ b/src/hotspot/share/include/cds.h
@@ -38,10 +38,9 @@
 #define NUM_CDS_REGIONS 7 // this must be the same as MetaspaceShared::n_regions
 #define CDS_ARCHIVE_MAGIC 0xf00baba2
 #define CDS_DYNAMIC_ARCHIVE_MAGIC 0xf00baba8
-#define CURRENT_CDS_ARCHIVE_VERSION 11
-#define INVALID_CDS_ARCHIVE_VERSION -1
+#define CURRENT_CDS_ARCHIVE_VERSION 12
 
-struct CDSFileMapRegion {
+typedef struct CDSFileMapRegion {
   int     _crc;               // CRC checksum of this region.
   int     _read_only;         // read only region?
   int     _allow_exec;        // executable code in this region?
@@ -58,15 +57,37 @@ struct CDSFileMapRegion {
   size_t  _oopmap_offset;     // Bitmap for relocating embedded oops (offset from SharedBaseAddress).
   size_t  _oopmap_size_in_bits;
   char*   _mapped_base;       // Actually mapped address (NULL if this region is not mapped).
-};
+} CDSFileMapRegion;
 
-struct CDSFileMapHeaderBase {
-  unsigned int _magic;           // identify file type
-  int          _crc;             // header crc checksum
-  int          _version;         // must be CURRENT_CDS_ARCHIVE_VERSION
-  struct CDSFileMapRegion _space[NUM_CDS_REGIONS];
-};
+// This portion of the archive file header must remain unchanged for _version >= 12.
+// This makes it possible to read important information from a CDS archive created by
+// a different version of HotSpot, so that we can automatically regenerate the archive as necessary.
+typedef struct GenericCDSFileMapHeader {
+  unsigned int _magic;                    // identification of file type
+  int          _crc;                      // header crc checksum
+  int          _version;                  // CURRENT_CDS_ARCHIVE_VERSION of the jdk that dumped the this archive
+  unsigned int _header_size;              // total size of the header, in bytes
+  unsigned int _base_archive_path_offset; // offset where the base archive name is stored
+                                          //   static archive:  0
+                                          //   dynamic archive:
+                                          //     0 for default base archive
+                                          //     non-zero for non-default base archive
+                                          //       (char*)this + _base_archive_path_offset
+                                          //       points to a 0-terminated string for the base archive name
+  unsigned int _base_archive_name_size;   // size of base archive name including ending '\0'
+                                          //   static:  0
+                                          //   dynamic:
+                                          //     0 for default base archive
+                                          //     non-zero for non-default base archive
+} GenericCDSFileMapHeader;
 
-typedef struct CDSFileMapHeaderBase CDSFileMapHeaderBase;
+// This type is used by the Serviceability Agent to access the contents of
+// a memory-mapped CDS archive.
+typedef struct CDSFileMapHeaderBase {
+  // We cannot inherit from GenericCDSFileMapHeader as this type may be used
+  // by both C and C++ code.
+  GenericCDSFileMapHeader _generic_header;
+  CDSFileMapRegion _space[NUM_CDS_REGIONS];
+} CDSFileMapHeaderBase;
 
 #endif // SHARE_INCLUDE_CDS_H

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3531,9 +3531,8 @@ bool Arguments::init_shared_archive_paths() {
       }
       if (archives == 1) {
         char* temp_archive_path = os::strdup_check_oom(SharedArchiveFile, mtArguments);
-        int name_size;
         bool success =
-          FileMapInfo::get_base_archive_name_from_header(temp_archive_path, &name_size, &SharedArchivePath);
+          FileMapInfo::get_base_archive_name_from_header(temp_archive_path, &SharedArchivePath);
         if (!success) {
           SharedArchivePath = temp_archive_path;
         } else {

--- a/src/jdk.hotspot.agent/share/native/libsaproc/ps_core_common.c
+++ b/src/jdk.hotspot.agent/share/native/libsaproc/ps_core_common.c
@@ -356,26 +356,27 @@ bool init_classsharing_workaround(struct ps_prochandle* ph) {
       }
 
       // read CDSFileMapHeaderBase from the file
-      memset(&header, 0, sizeof(CDSFileMapHeaderBase));
-      if ((n = read(fd, &header, sizeof(CDSFileMapHeaderBase)))
-           != sizeof(CDSFileMapHeaderBase)) {
+      size_t header_size = sizeof(CDSFileMapHeaderBase);
+      memset(&header, 0, header_size);
+      if ((n = read(fd, &header, header_size))
+           != header_size) {
         print_debug("can't read shared archive file map header from %s\n", classes_jsa);
         close(fd);
         return false;
       }
 
       // check file magic
-      if (header._magic != CDS_ARCHIVE_MAGIC) {
+      if (header._generic_header._magic != CDS_ARCHIVE_MAGIC) {
         print_debug("%s has bad shared archive file magic number 0x%x, expecting 0x%x\n",
-                    classes_jsa, header._magic, CDS_ARCHIVE_MAGIC);
+                    classes_jsa, header._generic_header._magic, CDS_ARCHIVE_MAGIC);
         close(fd);
         return false;
       }
 
       // check version
-      if (header._version != CURRENT_CDS_ARCHIVE_VERSION) {
+      if (header._generic_header._version != CURRENT_CDS_ARCHIVE_VERSION) {
         print_debug("%s has wrong shared archive file version %d, expecting %d\n",
-                     classes_jsa, header._version, CURRENT_CDS_ARCHIVE_VERSION);
+                     classes_jsa, header._generic_header._version, CURRENT_CDS_ARCHIVE_VERSION);
         close(fd);
         return false;
       }

--- a/test/hotspot/jtreg/runtime/cds/appcds/SharedArchiveConsistency.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/SharedArchiveConsistency.java
@@ -58,6 +58,8 @@ public class SharedArchiveConsistency {
 
     public static int num_regions = shared_region_name.length;
     public static String[] matchMessages = {
+        "UseSharedSpaces: Header checksum verification failed.",
+        "The shared archive file has an incorrect header size.",
         "Unable to use shared archive",
         "An error has occurred while processing the shared archive file.",
         "Checksum verification failed.",
@@ -213,10 +215,22 @@ public class SharedArchiveConsistency {
         CDSArchiveUtils.deleteBytesAtRandomPositionAfterHeader(orgJsaFile, deleteBytes, 4096 /*bytes*/);
         testAndCheck(verifyExecArgs);
 
+        // modify contents in random area
         System.out.println("\n7. modify Content in random areas, should fail\n");
         String randomAreas = startNewArchive("random-areas");
         copiedJsa = CDSArchiveUtils.copyArchiveFile(orgJsaFile, randomAreas);
         CDSArchiveUtils.modifyRegionContentRandomly(copiedJsa);
+        testAndCheck(verifyExecArgs);
+
+        // modify _base_archive_path_offet to not zero
+        System.out.println("\n8. modify _base_archive_path_offset to not zero\n");
+        String baseArchivePathOffsetName = startNewArchive("base-arhive-path-offset");
+        copiedJsa = CDSArchiveUtils.copyArchiveFile(orgJsaFile, baseArchivePathOffsetName);
+        int baseArchivePathOffset = CDSArchiveUtils.baseArchivePathOffset(copiedJsa);
+        System.out.println("    baseArchivePathOffset = " + baseArchivePathOffset);
+        CDSArchiveUtils.writeData(copiedJsa, CDSArchiveUtils.offsetBaseArchivePathOffset, 1024);
+        baseArchivePathOffset = CDSArchiveUtils.baseArchivePathOffset(copiedJsa);
+        System.out.println("new baseArchivePathOffset = " + baseArchivePathOffset);
         testAndCheck(verifyExecArgs);
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchiveConsistency.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchiveConsistency.java
@@ -36,6 +36,7 @@
 import java.io.File;
 import java.io.IOException;
 import jdk.test.lib.cds.CDSArchiveUtils;
+import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.helpers.ClassFileInstaller;
 
 public class ArchiveConsistency extends DynamicArchiveTestBase {
@@ -50,6 +51,31 @@ public class ArchiveConsistency extends DynamicArchiveTestBase {
         String baseArchiveName = getNewArchiveName("base");
         TestCommon.dumpBaseArchive(baseArchiveName);
         doTest(baseArchiveName, topArchiveName);
+    }
+
+    static void runTwo(String base, String top,
+                       String jarName, String mainClassName, int exitValue,
+                       String ... checkMessages) throws Exception {
+        CDSTestUtils.Result result = run2(base, top,
+                "-Xlog:cds",
+                "-Xlog:cds+dynamic=debug",
+                "-XX:+VerifySharedSpaces",
+                "-cp",
+                jarName,
+                mainClassName);
+        if (exitValue == 0) {
+            result.assertNormalExit( output -> {
+                for (String s : checkMessages) {
+                    output.shouldContain(s);
+                }
+            });
+        } else {
+            result.assertAbnormalExit( output -> {
+                for (String s : checkMessages) {
+                    output.shouldContain(s);
+                }
+            });
+        }
     }
 
     private static void doTest(String baseArchiveName, String topArchiveName) throws Exception {
@@ -68,20 +94,68 @@ public class ArchiveConsistency extends DynamicArchiveTestBase {
             throw new IOException(jsa + " does not exist!");
         }
 
-        // Modify the CRC values in the header of the top archive.
+        // 1. Modify the CRC values in the header of the top archive.
+        System.out.println("\n1. Modify the CRC values in the header of the top archive");
         String modTop = getNewArchiveName("modTopRegionsCrc");
         File copiedJsa = CDSArchiveUtils.copyArchiveFile(jsa, modTop);
         CDSArchiveUtils.modifyAllRegionsCrc(copiedJsa);
 
-        run2(baseArchiveName, modTop,
-            "-Xlog:class+load",
-            "-Xlog:cds+dynamic=debug,cds=debug",
-            "-XX:+VerifySharedSpaces",
-            "-cp", appJar, mainClass)
-            .assertAbnormalExit(output -> {
-                    output.shouldContain("Header checksum verification failed")
-                          .shouldContain("Unable to use shared archive")
-                          .shouldHaveExitValue(1);
-                });
+        runTwo(baseArchiveName, modTop,
+               appJar, mainClass, 1,
+               new String[] {"Header checksum verification failed",
+                             "Unable to use shared archive"});
+
+        // 2. Make header size biger than the archive size
+        System.out.println("\n2. Make header size biger than the archive size");
+        String largerHeaderSize = getNewArchiveName("largerHeaderSize");
+        copiedJsa = CDSArchiveUtils.copyArchiveFile(jsa, largerHeaderSize);
+        CDSArchiveUtils.modifyHeaderIntField(copiedJsa, CDSArchiveUtils.offsetHeaderSize,  (int)copiedJsa.length() + 1024);
+        runTwo(baseArchiveName, largerHeaderSize,
+               appJar, mainClass, 1,
+               new String[] {"_header_size should be equal to _base_archive_path_offset plus _base_archive_name_size",
+                             "Unable to use shared archive"});
+
+        // 3. Make base archive path offset beyond of header size
+        System.out.println("\n3. Make base archive path offset beyond of header size.");
+        String wrongBaseArchivePathOffset = getNewArchiveName("wrongBaseArchivePathOffset");
+        copiedJsa = CDSArchiveUtils.copyArchiveFile(jsa, wrongBaseArchivePathOffset);
+        int fileHeaderSize = (int)CDSArchiveUtils.fileHeaderSize(copiedJsa);
+        int baseArchivePathOffset = CDSArchiveUtils.baseArchivePathOffset(copiedJsa);
+        CDSArchiveUtils.modifyHeaderIntField(copiedJsa, CDSArchiveUtils.offsetBaseArchivePathOffset, baseArchivePathOffset + 1024);
+        // any change to the header leads to checksum failed.
+        runTwo(baseArchiveName, wrongBaseArchivePathOffset,
+               appJar, mainClass, 1,
+               new String[] {"An error has occurred while processing the shared archive file.",
+                             "Header checksum verification failed",
+                             "Unable to use shared archive"});
+
+        // 4. Make base archive path offset points to middle of name size
+        System.out.println("\n4. Make base archive path offset points to middle of name size");
+        String wrongBasePathOffset = getNewArchiveName("wrongBasePathOffset");
+        copiedJsa = CDSArchiveUtils.copyArchiveFile(jsa, wrongBasePathOffset);
+        int baseArchiveNameSize = CDSArchiveUtils.baseArchiveNameSize(copiedJsa);
+        baseArchivePathOffset = CDSArchiveUtils.baseArchivePathOffset(copiedJsa);
+        CDSArchiveUtils.modifyHeaderIntField(copiedJsa, baseArchivePathOffset,
+                                             baseArchivePathOffset + baseArchiveNameSize/2);
+        // any change to the header leads to checksum failed.
+        runTwo(baseArchiveName, wrongBasePathOffset,
+               appJar, mainClass, 1,
+               new String[] {"An error has occurred while processing the shared archive file.",
+                             "Header checksum verification failed",
+                             "Unable to use shared archive"});
+        // 5. Make base archive name not terminated with '\0'
+        System.out.println("\n5. Make base archive name not terminated with '\0'");
+        String wrongBaseName = getNewArchiveName("wrongBaseName");
+        copiedJsa = CDSArchiveUtils.copyArchiveFile(jsa, wrongBaseName);
+        baseArchivePathOffset = CDSArchiveUtils.baseArchivePathOffset(copiedJsa);
+        baseArchiveNameSize = CDSArchiveUtils.baseArchiveNameSize(copiedJsa);
+        long offset = baseArchivePathOffset + baseArchiveNameSize - 1;  // end of line
+        CDSArchiveUtils.writeData(copiedJsa, offset, new byte[] {(byte)'X'});
+
+        runTwo(baseArchiveName, wrongBaseName,
+               appJar, mainClass, 1,
+               new String[] {"Base archive " + baseArchiveName,
+                             " does not exist",
+                             "Header checksum verification failed"});
     }
 }

--- a/test/lib/jdk/test/lib/cds/CDSArchiveUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSArchiveUtils.java
@@ -46,11 +46,14 @@ import sun.hotspot.WhiteBox;
 // This class performs operations on shared archive file
 public class CDSArchiveUtils {
     // offsets
-    public static int offsetMagic;                // CDSFileMapHeaderBase::_magic
-    public static int offsetVersion;              // CDSFileMapHeaderBase::_version
-    public static int offsetJvmIdent;             // FileMapHeader::_jvm_ident
-    public static int offsetBaseArchiveNameSize;  // FileMapHeader::_base_archive_name_size
-    public static int spOffsetCrc;                // CDSFileMapRegion::_crc
+    public static int offsetMagic;                // offset of GenericCDSFileMapHeader::_magic
+    public static int offsetCrc;                  // offset of GenericCDSFileMapHeader::_crc
+    public static int offsetVersion;              // offset of GenericCDSFileMapHeader::_version
+    public static int offsetHeaderSize;           // offset of GenericCDSFileMapHeader::_header_size
+    public static int offsetBaseArchivePathOffset;// offset of GenericCDSFileMapHeader::_base_archive_path_offset
+    public static int offsetBaseArchiveNameSize;  // offset of GenericCDSFileMapHeader::_base_archive_name_size
+    public static int offsetJvmIdent;             // offset of FileMapHeader::_jvm_ident
+    public static int spOffsetCrc;                // offset of CDSFileMapRegion::_crc
     public static int spOffset;                   // offset of CDSFileMapRegion
     public static int spUsedOffset;               // offset of CDSFileMapRegion::_used
     // constants
@@ -80,24 +83,26 @@ public class CDSArchiveUtils {
         try {
             wb = WhiteBox.getWhiteBox();
             // offsets
-            offsetMagic = wb.getCDSOffsetForName("CDSFileMapHeaderBase::_magic");
-            offsetVersion = wb.getCDSOffsetForName("CDSFileMapHeaderBase::_version");
+            offsetMagic = wb.getCDSOffsetForName("GenericCDSFileMapHeader::_magic");
+            offsetCrc = wb.getCDSOffsetForName("GenericCDSFileMapHeader::_crc");
+            offsetVersion = wb.getCDSOffsetForName("GenericCDSFileMapHeader::_version");
+            offsetHeaderSize = wb.getCDSOffsetForName("GenericCDSFileMapHeader::_header_size");
+            offsetBaseArchivePathOffset = wb.getCDSOffsetForName("GenericCDSFileMapHeader::_base_archive_path_offset");
+            offsetBaseArchiveNameSize = wb.getCDSOffsetForName("GenericCDSFileMapHeader::_base_archive_name_size");
             offsetJvmIdent = wb.getCDSOffsetForName("FileMapHeader::_jvm_ident");
-            offsetBaseArchiveNameSize = wb.getCDSOffsetForName("FileMapHeader::_base_archive_name_size");
             spOffsetCrc = wb.getCDSOffsetForName("CDSFileMapRegion::_crc");
             spUsedOffset = wb.getCDSOffsetForName("CDSFileMapRegion::_used") - spOffsetCrc;
             spOffset = wb.getCDSOffsetForName("CDSFileMapHeaderBase::_space[0]") - offsetMagic;
             // constants
             staticMagic = wb.getCDSConstantForName("static_magic");
             dynamicMagic = wb.getCDSConstantForName("dynamic_magic");
+            // following two sizes are runtime values
             staticArchiveHeaderSize = wb.getCDSConstantForName("static_file_header_size");
             dynamicArchiveHeaderSize = wb.getCDSConstantForName("dynamic_archive_header_size");
             sizetSize = wb.getCDSConstantForName("size_t_size");
             intSize = wb.getCDSConstantForName("int_size");
             cdsFileMapRegionSize  = wb.getCDSConstantForName("CDSFileMapRegion_size");
             alignment = wb.metaspaceSharedRegionAlignment();
-            // file_header_size is structure size, real size aligned with alignment
-            // so must be calculated after alignment is available
         } catch (Exception e) {
             throw new RuntimeException(e.getMessage());
         }
@@ -111,16 +116,27 @@ public class CDSArchiveUtils {
     }
 
     public static long fileHeaderSize(File jsaFile) throws Exception {
-      long magicValue = readInt(jsaFile, offsetMagic, 4);
-      if (magicValue == staticMagic) {
-          return alignUpWithAlignment((long)staticArchiveHeaderSize);
-      } else if (magicValue == dynamicMagic) {
-          // dynamic archive store base archive name after header, so we count it in header size.
-          int baseArchiveNameSize = (int)readInt(jsaFile, (long)offsetBaseArchiveNameSize, 4);
-          return alignUpWithAlignment((long)dynamicArchiveHeaderSize + baseArchiveNameSize);
-      } else {
-          throw new RuntimeException("Wrong magic value from archive file: " + magicValue);
-      }
+        long  headerSize = readInt(jsaFile, offsetHeaderSize, 4);
+        return headerSize;
+    }
+
+    public static long fileHeaderSizeAligned(File jsaFile) throws Exception {
+        long size = fileHeaderSize(jsaFile);
+        return alignUpWithAlignment(size);
+    }
+
+    public static int baseArchivePathOffset(File jsaFile) throws Exception {
+        return (int)readInt(jsaFile, offsetBaseArchivePathOffset, 4);
+    }
+
+    public static int baseArchiveNameSize(File jsaFile) throws Exception {
+        return (int)readInt(jsaFile, offsetBaseArchiveNameSize, 4);
+    }
+
+    public static String baseArchiveName(File jsaFile) throws Exception {
+        int size = baseArchiveNameSize(jsaFile);
+        int baseArchivePathOffset = (int)readInt(jsaFile, offsetBaseArchivePathOffset, 4);
+        return readString(jsaFile, baseArchivePathOffset, size - 1); // exclude including ending '\0'
     }
 
     private static long alignUpWithAlignment(long l) {
@@ -159,7 +175,7 @@ public class CDSArchiveUtils {
         int bufSize;
 
         System.out.printf("%-24s%12s%12s%16s\n", "Space Name", "Used bytes", "Reg Start", "Random Offset");
-        start0 = fileHeaderSize(jsaFile);
+        start0 = fileHeaderSizeAligned(jsaFile);
         for (int i = 0; i < num_regions; i++) {
             used[i] = usedRegionSizeAligned(jsaFile, i);
             start = start0;
@@ -188,7 +204,7 @@ public class CDSArchiveUtils {
         int bufSize;
 
         System.out.printf("%-24s%12s%12s%16s\n", "Space Name", "Used bytes", "Reg Start", "Random Offset");
-        start0 = fileHeaderSize(jsaFile);
+        start0 = fileHeaderSizeAligned(jsaFile);
         for (int i = 0; i < num_regions; i++) {
             used[i] = usedRegionSizeAligned(jsaFile, i);
             start = start0;
@@ -225,12 +241,12 @@ public class CDSArchiveUtils {
         }
         byte[] buf = new byte[4096];
         System.out.printf("%-24s%12d\n", "Total: ", total);
-        long regionStartOffset = fileHeaderSize(jsaFile);
+        long regionStartOffset = fileHeaderSizeAligned(jsaFile);
         for (int i = 0; i < region; i++) {
             regionStartOffset += used[i];
         }
         System.out.println("Corrupt " + shared_region_name[region] + " section, start = " + regionStartOffset
-                           + " (header_size + 0x" + Long.toHexString(regionStartOffset - fileHeaderSize(jsaFile)) + ")");
+                           + " (header_size + 0x" + Long.toHexString(regionStartOffset - fileHeaderSizeAligned(jsaFile)) + ")");
         long bytesWritten = 0L;
         while (bytesWritten < used[region]) {
             bytesWritten += writeData(jsaFile, regionStartOffset + bytesWritten, buf);
@@ -262,16 +278,17 @@ public class CDSArchiveUtils {
         writeData(jsaFile, 0, buf);
     }
 
+    public static void modifyFileHeaderSize(File jsaFile, int newHeaderSize) throws Exception {
+        modifyHeaderIntField(jsaFile, offsetHeaderSize, newHeaderSize);
+    }
+
     public static void modifyJvmIdent(File jsaFile, String newJvmIdent) throws Exception {
         byte[] buf = newJvmIdent.getBytes();
         writeData(jsaFile, (long)offsetJvmIdent, buf);
     }
 
     public static void modifyHeaderIntField(File jsaFile, long offset, int value) throws Exception {
-        System.out.println("    offset " + offset);
-
-        byte[] bytes = ByteBuffer.allocate(4).putInt(value).array();
-        writeData(jsaFile, offset, bytes);
+        writeData(jsaFile, offset, value);
     }
 
     // copy archive and set copied read/write permit
@@ -300,13 +317,27 @@ public class CDSArchiveUtils {
         return FileChannel.open(file.toPath(), new HashSet<StandardOpenOption>(arry));
     }
 
-    public static long readInt(File file, long offset, int nBytes) throws Exception {
+    private static long readInt(File file, long offset, int nBytes) throws Exception {
         try (FileChannel fc = getFileChannel(file, false /*read only*/)) {
-            ByteBuffer bb = ByteBuffer.allocate(nBytes);
-            bb.order(ByteOrder.nativeOrder());
+            ByteBuffer bb = ByteBuffer.allocate(nBytes).order(ByteOrder.nativeOrder());
             fc.position(offset);
             fc.read(bb);
+            bb.rewind();
             return  (nBytes > 4 ? bb.getLong(0) : bb.getInt(0));
+        }
+    }
+
+    private static String readString(File file, long offset, int nBytes) throws Exception {
+        try (FileChannel fc = getFileChannel(file, false /*read only*/)) {
+            ByteBuffer bb = ByteBuffer.allocate(nBytes).order(ByteOrder.nativeOrder());
+            fc.position(offset);
+            fc.read(bb);
+            byte[] arr = bb.flip().array();
+            for (byte i : arr) {
+                System.out.print((char)i);
+            }
+            System.out.println("");
+            return new String(arr);
         }
     }
 
@@ -318,13 +349,17 @@ public class CDSArchiveUtils {
     public static long writeData(File file, long offset, byte[] array) throws Exception {
         try (FileChannel fc = getFileChannel(file, true /*write*/)) {
             ByteBuffer bbuf = ByteBuffer.wrap(array);
+            bbuf.order(ByteOrder.nativeOrder());
             return writeData(fc, offset, bbuf);
          }
     }
 
     public static long writeData(File file, long offset, int value) throws Exception {
         try (FileChannel fc = getFileChannel(file, true /*write*/)) {
-            ByteBuffer bbuf = ByteBuffer.allocate(4).putInt(value).position(0);
+            ByteBuffer bbuf = ByteBuffer.allocate(4)
+                                        .order(ByteOrder.nativeOrder())
+                                        .putInt(value)
+                                        .rewind();
             return writeData(fc, offset, bbuf);
          }
     }


### PR DESCRIPTION
Please review,
  Refactor fundamental CDS FileMapHeader code for reliable reading of basic info from shared archive.
  With the change, it makes it possible to read an archive generated by different version of hotspot. Also it is possible to automatically generate a CDS archive If the archive supplied is not readable or fails to pass the check.

  Tests: tier1-4
   jtreg on sa.

Thanks
Yumin  