### PR TITLE
Langtools commands usage were grabled on Japanese Windows

### DIFF
--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -53,6 +53,7 @@
 
 #include "java.h"
 #include "jni.h"
+#include <string.h>
 
 /*
  * A NOTE TO DEVELOPERS: For performance reasons it is important that
@@ -1428,6 +1429,36 @@ ParseArguments(int *pargc, char ***pargv,
     return JNI_TRUE;
 }
 
+#define FILE_ENCODING "-Dfile.encoding="
+static char* prgnames[] = {
+    "java",
+    "javaw",
+    NULL
+};
+static void
+AddFileEncoding()
+{
+    size_t felen = strlen(FILE_ENCODING);
+    int i = 0;
+    int flg = 0;
+    for (i = 0; prgnames[i] != NULL; i++) {
+        if (strcmp(_program_name, prgnames[i]) == 0) {
+            flg = 1;
+            break;
+        }
+    }
+    if (flg == 0) {
+        for (i = 0; i < numOptions; i++) {
+            if (strncmp(options[i].optionString, FILE_ENCODING, felen) == 0) {
+                break;
+            }
+        }
+        if (i == numOptions) {
+            AddOption(FILE_ENCODING "COMPAT", NULL);
+        }
+    }
+}
+
 /*
  * Initializes the Java Virtual Machine. Also frees options array when
  * finished.
@@ -1438,6 +1469,7 @@ InitializeJVM(JavaVM **pvm, JNIEnv **penv, InvocationFunctions *ifn)
     JavaVMInitArgs args;
     jint r;
 
+    AddFileEncoding();
     memset(&args, 0, sizeof(args));
     args.version  = JNI_VERSION_1_2;
     args.nOptions = numOptions;

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/JdiInitiator.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/JdiInitiator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,6 +86,8 @@ public class JdiInitiator {
             Map<String, String> customConnectorArgs) {
         this.remoteAgent = remoteAgent;
         this.connectTimeout = (int) (timeout * CONNECT_TIMEOUT_FACTOR);
+        remoteVMOptions.add("-Dfile.encoding="
+            +System.getProperty("file.encoding"));
         String connectorName
                 = isLaunch
                         ? "com.sun.jdi.CommandLineLaunch"


### PR DESCRIPTION
JEP-400 (UTF-8 by Default) was eabled on JDK18-b13.
After JDK18-b13, javac and some other langtool command's usage were garbled on Japanese Windows.
These commands use PrintWriter instead of standard ouput/err with PrintStream.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5769/head:pull/5769` \
`$ git checkout pull/5769`

Update a local copy of the PR: \
`$ git checkout pull/5769` \
`$ git pull https://git.openjdk.java.net/jdk pull/5769/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5769`

View PR using the GUI difftool: \
`$ git pr show -t 5769`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5769.diff">https://git.openjdk.java.net/jdk/pull/5769.diff</a>

</details>
