### PR TITLE
8274561: sun/net/ftp/TestFtpTimeValue.java timed out on slow machines

### DIFF
--- a/test/jdk/sun/net/ftp/TestFtpTimeValue.java
+++ b/test/jdk/sun/net/ftp/TestFtpTimeValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/net/ftp/TestFtpTimeValue.java
+++ b/test/jdk/sun/net/ftp/TestFtpTimeValue.java
@@ -116,7 +116,7 @@ public class TestFtpTimeValue {
         public void handleClient(Socket client) throws IOException {
             String str;
 
-            client.setSoTimeout(2000);
+            client.setSoTimeout(10000);
             BufferedReader in = new BufferedReader(new InputStreamReader(client.getInputStream()));
             PrintWriter out = new PrintWriter(client.getOutputStream(), true);
             out.println("220 FTP serverSocket is ready.");


### PR DESCRIPTION
When we do fastdebug testing with -Xcomp, sun/net/ftp/TestFtpTimeValue.java timed out on slow machines. The parameter of setSoTimeout in the test should be set larger.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274561](https://bugs.openjdk.java.net/browse/JDK-8274561): sun/net/ftp/TestFtpTimeValue.java timed out on slow machines


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5774/head:pull/5774` \
`$ git checkout pull/5774`

Update a local copy of the PR: \
`$ git checkout pull/5774` \
`$ git pull https://git.openjdk.java.net/jdk pull/5774/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5774`

View PR using the GUI difftool: \
`$ git pr show -t 5774`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5774.diff">https://git.openjdk.java.net/jdk/pull/5774.diff</a>

</details>
