### PR TITLE
8274563: jfr/event/oldobject/TestClassLoaderLeak.java fails when GC cycles are not happening

### DIFF
--- a/test/jdk/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
@@ -40,10 +40,9 @@ import jdk.test.lib.jfr.Events;
  * @test
  * @key jfr
  * @requires vm.hasJFR
- * @requires vm.gc != "Serial"
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
- * @run main/othervm -XX:TLABSize=2k jdk.jfr.event.oldobject.TestClassLoaderLeak
+ * @run main/othervm -XX:TLABSize=2k -Xmx128m jdk.jfr.event.oldobject.TestClassLoaderLeak
  */
 public class TestClassLoaderLeak {
 


### PR DESCRIPTION
This reliably fails with Serial (ignored by @requires), Shenandoah and Z:

```
$ CONF=linux-x86_64-server-fastdebug make run-test TEST=jdk/jfr/event/oldobject/TestClassLoaderLeak.java TEST_VM_OPTS="-XX:+UseShenandoahGC"

...

STDERR:
java.lang.RuntimeException: Could not find class leak
at jdk.test.lib.Asserts.fail(Asserts.java:594)
at jdk.jfr.event.oldobject.TestClassLoaderLeak.main(TestClassLoaderLeak.java:80)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.base/java.lang.reflect.Method.invoke(Method.java:568)
at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
at java.base/java.lang.Thread.run(Thread.java:833)
```

I believe this test implicitly wants at least one GC cycle to happen so that `ObjectSampler::oop_storage_gc_notification` turns the sampled objects "old". An easy way to do this is to trim the Java heap size. If that does not work, we would need to go to MXBeans and watch GC cycles happening. 

Additional testing:
 - [x] Affected test with `-XX:+UseShenandoahGC`, 10 times
 - [x] Affected test with `-XX:+UseZGC`, 10 times
 - [x] Affected test with `-XX:+UseSerialGC`, 10 times
 - [x] Affected test with `-XX:+UseParallelGC`, 10 times
 - [x] Affected test with `-XX:+UseG1GC`, 10 times

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274563](https://bugs.openjdk.java.net/browse/JDK-8274563): jfr/event/oldobject/TestClassLoaderLeak.java fails when GC cycles are not happening


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5775/head:pull/5775` \
`$ git checkout pull/5775`

Update a local copy of the PR: \
`$ git checkout pull/5775` \
`$ git pull https://git.openjdk.java.net/jdk pull/5775/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5775`

View PR using the GUI difftool: \
`$ git pr show -t 5775`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5775.diff">https://git.openjdk.java.net/jdk/pull/5775.diff</a>

</details>
