### PR TITLE
8274597: [TESTBUG] Two of the dnd tests times out and fails

### DIFF
--- a/test/jdk/java/awt/dnd/AcceptDropMultipleTimes/AcceptDropMultipleTimes.java
+++ b/test/jdk/java/awt/dnd/AcceptDropMultipleTimes/AcceptDropMultipleTimes.java
@@ -83,6 +83,7 @@ public class AcceptDropMultipleTimes {
                     new Point(FRAME_LOCATION + FRAME_SIZE / 3 * 2, FRAME_LOCATION + FRAME_SIZE / 3 * 2),
                     InputEvent.BUTTON1_MASK);
             Util.waitForIdle(r);
+            Thread.sleep(100);
         } finally {
             if (f != null) {
                 f.dispose();

--- a/test/jdk/java/awt/dnd/DropTargetEnterExitTest/MissedDragExitTest.java
+++ b/test/jdk/java/awt/dnd/DropTargetEnterExitTest/MissedDragExitTest.java
@@ -108,6 +108,7 @@ public class MissedDragExitTest {
             if (!dragExitCalled) {
                 throw new RuntimeException("Failed. Drag exit was not called" );
             }
+            Thread.sleep(100);
         } finally {
             if (f != null) {
                 f.dispose();


### PR DESCRIPTION
These two dnd tests fails most of the time with a time out, mostly noticed in windows 11 machines.
1. java/awt/dnd/AcceptDropMultipleTimes/AcceptDropMultipleTimes.java
2. java/awt/dnd/DropTargetEnterExitTest/MissedDragExitTest.java

Fix:
From the logs, I have noticed that some of the non-daemon threads are still waiting even after the test execution is complete. So it could be possible that java is waiting for these threads to be finished execution before the main thread exits.
As a fix for this, I have put a Thread.sleep(100) at the end of the main() in order to enable other non-daemon threads get a chance to finish their execution before the main thread completes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8274597](https://bugs.openjdk.java.net/browse/JDK-8274597): [TESTBUG] Two of the dnd tests times out and fails


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5777/head:pull/5777` \
`$ git checkout pull/5777`

Update a local copy of the PR: \
`$ git checkout pull/5777` \
`$ git pull https://git.openjdk.java.net/jdk pull/5777/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5777`

View PR using the GUI difftool: \
`$ git pr show -t 5777`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5777.diff">https://git.openjdk.java.net/jdk/pull/5777.diff</a>

</details>
