### PR TITLE
8274606: Fix jaxp/javax/xml/jaxp/unittest/transform/SurrogateTest.java test

### DIFF
--- a/test/jaxp/javax/xml/jaxp/unittest/transform/SurrogateTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/transform/SurrogateTest.java
@@ -26,8 +26,9 @@ package transform;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.FileReader;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -43,7 +44,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
 import static jaxp.library.JAXPTestUtilities.compareWithGold;
-import static jaxp.library.JAXPTestUtilities.compareStringWithGold;
+import static jaxp.library.JAXPTestUtilities.compareLinesWithGold;
 import org.testng.Assert;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
@@ -64,10 +65,11 @@ public class SurrogateTest {
     public void toHTMLTest() throws Exception {
         String out = "SurrogateTest1out.html";
         String expected = TEST_SRC + File.separator + "SurrogateTest1.html";
+        String xml = TEST_SRC + File.separator + "SurrogateTest1.xml";
         String xsl = TEST_SRC + File.separator + "SurrogateTest1.xsl";
 
         try (FileInputStream tFis = new FileInputStream(xsl);
-            InputStream fis = this.getClass().getResourceAsStream("SurrogateTest1.xml");
+            InputStream fis = new FileInputStream(xml);
             FileOutputStream fos = new FileOutputStream(out)) {
 
             Source tSrc = new StreamSource(tFis);
@@ -79,7 +81,7 @@ public class SurrogateTest {
             Result res = new StreamResult(fos);
             t.transform(src, res);
         }
-        compareWithGold(expected, out);
+        Assert.assertTrue(compareWithGold(expected, out));
     }
 
     @Test
@@ -90,15 +92,15 @@ public class SurrogateTest {
         SAXParser sp = spf.newSAXParser();
         TestHandler th = new TestHandler();
         sp.parse(xmlFile, th);
-        compareStringWithGold(TEST_SRC + File.separator + "SurrogateTest2.txt", th.sb.toString());
+        Assert.assertTrue(compareLinesWithGold(TEST_SRC + File.separator + "SurrogateTest2.txt", th.lines));
     }
 
     private static class TestHandler extends DefaultHandler {
-        private StringBuilder sb = new StringBuilder();
+        private List<String> lines = new ArrayList<>();
 
         @Override
         public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
-            sb.append( localName + "@attr:" + attributes.getValue("attr") + '\n');
+            lines.add( localName + "@attr:" + attributes.getValue("attr"));
         }
     }
 }


### PR DESCRIPTION
I was working on backporting JDK-8268457 and found minor problems with the test introduced there:

1. `compareWith*` helper methods are used without `Assert.assertTrue()` wrapping, so they are effectively ignored

2. `this.getClass().getResourceAsStream()` is used to load test input data, it actually returns null in test run, so transformation is done without input data

Note, that SurrogateTest.zip reproducer attached to JDK-8268457 is valid and fully functional, problems likely were introduced when it was adapted into test.

The change is to the test only, it wraps `compareWith*` helpers and loads data the same way as XSL is loaded. Additionally `compareStringWithGold` was changed to `compareLinesWithGold` to exclude possible line endings problems.

Testing: checked that the test fails when JDK-8268457 code fix is reverted, checked that is passes on master.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274606](https://bugs.openjdk.java.net/browse/JDK-8274606): Fix jaxp/javax/xml/jaxp/unittest/transform/SurrogateTest.java test


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5779/head:pull/5779` \
`$ git checkout pull/5779`

Update a local copy of the PR: \
`$ git checkout pull/5779` \
`$ git pull https://git.openjdk.java.net/jdk pull/5779/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5779`

View PR using the GUI difftool: \
`$ git pr show -t 5779`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5779.diff">https://git.openjdk.java.net/jdk/pull/5779.diff</a>

</details>
