### PR TITLE
8274605: Fix predicate guarantees on returned values in (Doc)SourcePositions

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/source/util/DocSourcePositions.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/DocSourcePositions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,9 +49,9 @@ public interface DocSourcePositions extends SourcePositions {
      * is for any sub-tree of this tree, the following must hold:
      *
      * <p>
-     * {@code tree.getStartPosition() <= subtree.getStartPosition()} or <br>
-     * {@code tree.getStartPosition() == NOPOS} or <br>
-     * {@code subtree.getStartPosition() == NOPOS}
+     * {@code getStartPosition(file, comment, tree) <= getStartPosition(file, comment, subtree)} or <br>
+     * {@code getStartPosition(file, comment, tree) == NOPOS} or <br>
+     * {@code getStartPosition(file, comment, subtree) == NOPOS}
      * </p>
      *
      * @param file compilation unit in which to find tree
@@ -73,17 +73,17 @@ public interface DocSourcePositions extends SourcePositions {
      * that is for any sub-tree of this tree, the following must hold:
      *
      * <p>
-     * {@code tree.getEndPosition() >= subtree.getEndPosition()} or <br>
-     * {@code tree.getEndPosition() == NOPOS} or <br>
-     * {@code subtree.getEndPosition() == NOPOS}
+     * {@code getEndPosition(file, comment, tree) >= getEndPosition(file, comment, subtree)} or <br>
+     * {@code getEndPosition(file, comment, tree) == NOPOS} or <br>
+     * {@code getEndPosition(file, comment, subtree) == NOPOS}
      * </p>
      *
      * In addition, the following must hold:
      *
      * <p>
-     * {@code tree.getStartPosition() <= tree.getEndPosition()} or <br>
-     * {@code tree.getStartPosition() == NOPOS} or <br>
-     * {@code tree.getEndPosition() == NOPOS}
+     * {@code getStartPosition(file, comment, tree) <= getEndPosition(file, comment, tree)} or <br>
+     * {@code getStartPosition(file, comment, tree) == NOPOS} or <br>
+     * {@code getEndPosition(file, comment, tree) == NOPOS}
      * </p>
      *
      * @param file compilation unit in which to find tree

--- a/src/jdk.compiler/share/classes/com/sun/source/util/SourcePositions.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/SourcePositions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,9 +45,9 @@ public interface SourcePositions {
      * is for any sub-tree of this tree, the following must hold:
      *
      * <p>
-     * {@code tree.getStartPosition() <= subtree.getStartPosition()} or <br>
-     * {@code tree.getStartPosition() == NOPOS} or <br>
-     * {@code subtree.getStartPosition() == NOPOS}
+     * {@code getStartPosition(file, tree) <= getStartPosition(file, subtree)} or <br>
+     * {@code getStartPosition(file, tree) == NOPOS} or <br>
+     * {@code getStartPosition(file, subtree) == NOPOS}
      * </p>
      *
      * @param file CompilationUnit in which to find tree
@@ -64,17 +64,17 @@ public interface SourcePositions {
      * that is for any sub-tree of this tree, the following must hold:
      *
      * <p>
-     * {@code tree.getEndPosition() >= subtree.getEndPosition()} or <br>
-     * {@code tree.getEndPosition() == NOPOS} or <br>
-     * {@code subtree.getEndPosition() == NOPOS}
+     * {@code getEndPosition(file, tree) >= getEndPosition(file, subtree)} or <br>
+     * {@code getEndPosition(file, tree) == NOPOS} or <br>
+     * {@code getEndPosition(file, subtree) == NOPOS}
      * </p>
      *
      * In addition, the following must hold:
      *
      * <p>
-     * {@code tree.getStartPosition() <= tree.getEndPosition()} or <br>
-     * {@code tree.getStartPosition() == NOPOS} or <br>
-     * {@code tree.getEndPosition() == NOPOS}
+     * {@code getStartPosition(file, tree) <= getEndPosition(file, tree)} or <br>
+     * {@code getStartPosition(file, tree) == NOPOS} or <br>
+     * {@code getEndPosition(file, tree) == NOPOS}
      * </p>
      *
      * @param file CompilationUnit in which to find tree


### PR DESCRIPTION
Please review this documentation change. The result might look verbose, but at least it is no longer confusing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274605](https://bugs.openjdk.java.net/browse/JDK-8274605): Fix predicate guarantees on returned values in (Doc)SourcePositions


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5781/head:pull/5781` \
`$ git checkout pull/5781`

Update a local copy of the PR: \
`$ git checkout pull/5781` \
`$ git pull https://git.openjdk.java.net/jdk pull/5781/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5781`

View PR using the GUI difftool: \
`$ git pr show -t 5781`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5781.diff">https://git.openjdk.java.net/jdk/pull/5781.diff</a>

</details>
