### PR TITLE
8274562: (fs) UserDefinedFileAttributeView doesn't correctly determine if supported when using OverlayFS

### DIFF
--- a/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
+++ b/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
@@ -317,7 +317,7 @@ Java_sun_nio_fs_UnixNativeDispatcher_init(JNIEnv* env, jclass this)
 
     /* supports extended attributes */
 
-#ifdef _SYS_XATTR_H_
+#if defined(_SYS_XATTR_H) || defined(_SYS_XATTR_H_)
     capabilities |= sun_nio_fs_UnixNativeDispatcher_SUPPORTS_XATTR;
 #endif
 


### PR DESCRIPTION
Add extended attributes to capabilities flag if `_SYS_XATTR_H` is defined.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274562](https://bugs.openjdk.java.net/browse/JDK-8274562): (fs) UserDefinedFileAttributeView doesn't correctly determine if supported when using OverlayFS


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5782/head:pull/5782` \
`$ git checkout pull/5782`

Update a local copy of the PR: \
`$ git checkout pull/5782` \
`$ git pull https://git.openjdk.java.net/jdk pull/5782/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5782`

View PR using the GUI difftool: \
`$ git pr show -t 5782`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5782.diff">https://git.openjdk.java.net/jdk/pull/5782.diff</a>

</details>
