### PR TITLE
8274610: Add linux-aarch64 to bootcycle build profiles

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -633,7 +633,7 @@ var getJibProfilesProfiles = function (input, common, data) {
     // Bootcycle profiles runs the build with itself as the boot jdk. This can
     // be done in two ways. Either using the builtin bootcycle target in the
     // build system. Or by supplying the main jdk build as bootjdk to configure.
-    [ "linux-x64", "macosx-x64", "windows-x64" ]
+    [ "linux-x64", "macosx-x64", "windows-x64", "linux-aarch64" ]
         .forEach(function (name) {
             var bootcycleName = name + "-bootcycle";
             var bootcyclePrebuiltName = name + "-bootcycle-prebuilt";


### PR DESCRIPTION
Please review this simple/trivial change that add linux-aarch64 platform to bootcycle build profiles.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274610](https://bugs.openjdk.java.net/browse/JDK-8274610): Add linux-aarch64 to bootcycle build profiles


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5783/head:pull/5783` \
`$ git checkout pull/5783`

Update a local copy of the PR: \
`$ git checkout pull/5783` \
`$ git pull https://git.openjdk.java.net/jdk pull/5783/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5783`

View PR using the GUI difftool: \
`$ git pr show -t 5783`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5783.diff">https://git.openjdk.java.net/jdk/pull/5783.diff</a>

</details>
