### PR TITLE
8274642: jdk/jshell/CommandCompletionTest.java fails with NoSuchElementException after JDK-8271287

### DIFF
--- a/test/langtools/jdk/jshell/CommandCompletionTest.java
+++ b/test/langtools/jdk/jshell/CommandCompletionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,10 +49,13 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import org.testng.SkipException;
 import org.testng.annotations.Test;
+
 import jdk.internal.jshell.tool.JShellTool;
 import jdk.internal.jshell.tool.JShellToolBuilder;
 import jdk.jshell.SourceCodeAnalysis.Suggestion;
+
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -337,7 +340,10 @@ public class CommandCompletionTest extends ReplToolTesting {
             selectedFile = content.filter(CLASSPATH_FILTER)
                                   .findAny()
                                   .map(file -> file.getFileName().toString())
-                                  .get();
+                                  .orElse(null);
+        }
+        if (selectedFile == null) {
+            throw new SkipException("No suitable file(s) found for this test in " + home);
         }
         try (Stream<Path> content = Files.list(home)) {
             completions = content.filter(CLASSPATH_FILTER)


### PR DESCRIPTION
Sometimes user.home might not contain any files that would match CLASSPATH_FILTER. This is a suggestion
to skip the test in this case. I'm open to alternative solutions, though.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274642](https://bugs.openjdk.java.net/browse/JDK-8274642): jdk/jshell/CommandCompletionTest.java fails with NoSuchElementException after JDK-8271287


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5787/head:pull/5787` \
`$ git checkout pull/5787`

Update a local copy of the PR: \
`$ git checkout pull/5787` \
`$ git pull https://git.openjdk.java.net/jdk pull/5787/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5787`

View PR using the GUI difftool: \
`$ git pr show -t 5787`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5787.diff">https://git.openjdk.java.net/jdk/pull/5787.diff</a>

</details>
