### PR TITLE
JDK-8274666: rename HtmlStyle.descfrmTypeLabel to be less cryptic

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Contents.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Contents.java
@@ -81,8 +81,8 @@ public class Contents {
     public final Content deprecatedLabel;
     public final Content deprecatedPhrase;
     public final Content deprecatedForRemovalPhrase;
-    public final Content descfrmClassLabel;
-    public final Content descfrmInterfaceLabel;
+    public final Content descriptionFromClassLabel;
+    public final Content descriptionFromInterfaceLabel;
     public final Content descriptionLabel;
     public final Content detailLabel;
     public final Content enclosingClassLabel;
@@ -227,8 +227,8 @@ public class Contents {
         deprecatedLabel = getContent("doclet.navDeprecated");
         deprecatedPhrase = getContent("doclet.Deprecated");
         deprecatedForRemovalPhrase = getContent("doclet.DeprecatedForRemoval");
-        descfrmClassLabel = getContent("doclet.Description_From_Class");
-        descfrmInterfaceLabel = getContent("doclet.Description_From_Interface");
+        descriptionFromClassLabel = getContent("doclet.Description_From_Class");
+        descriptionFromInterfaceLabel = getContent("doclet.Description_From_Interface");
         descriptionLabel = getContent("doclet.Description");
         detailLabel = getContent("doclet.Detail");
         enclosingClassLabel = getContent("doclet.Enclosing_Class");

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriterImpl.java
@@ -157,13 +157,13 @@ public class MethodWriterImpl extends AbstractExecutableMemberWriter
                                             ? utils.getSimpleName(holder)
                                             : utils.getFullyQualifiedName(holder));
                     Content codeLink = HtmlTree.CODE(link);
-                    Content descfrmLabel = HtmlTree.SPAN(HtmlStyle.descfrmTypeLabel,
+                    Content descriptionFromTypeLabel = HtmlTree.SPAN(HtmlStyle.descriptionFromTypeLabel,
                             utils.isClass(holder)
-                                    ? contents.descfrmClassLabel
-                                    : contents.descfrmInterfaceLabel);
-                    descfrmLabel.add(Entity.NO_BREAK_SPACE);
-                    descfrmLabel.add(codeLink);
-                    methodDocTree.add(HtmlTree.DIV(HtmlStyle.block, descfrmLabel));
+                                    ? contents.descriptionFromClassLabel
+                                    : contents.descriptionFromInterfaceLabel);
+                    descriptionFromTypeLabel.add(Entity.NO_BREAK_SPACE);
+                    descriptionFromTypeLabel.add(codeLink);
+                    methodDocTree.add(HtmlTree.DIV(HtmlStyle.block, descriptionFromTypeLabel));
                 }
                 writer.addInlineComment(method, methodDocTree);
             }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PropertyWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PropertyWriterImpl.java
@@ -118,13 +118,13 @@ public class PropertyWriterImpl extends AbstractMemberWriter
                                     utils.isIncluded(holder)
                                             ? holder.getSimpleName() : holder.getQualifiedName());
                     Content codeLink = HtmlTree.CODE(link);
-                    Content descfrmLabel = HtmlTree.SPAN(HtmlStyle.descfrmTypeLabel,
+                    Content descriptionFromLabel = HtmlTree.SPAN(HtmlStyle.descriptionFromTypeLabel,
                             utils.isClass(holder)
-                                    ? contents.descfrmClassLabel
-                                    : contents.descfrmInterfaceLabel);
-                    descfrmLabel.add(Entity.NO_BREAK_SPACE);
-                    descfrmLabel.add(codeLink);
-                    propertyDocTree.add(HtmlTree.DIV(HtmlStyle.block, descfrmLabel));
+                                    ? contents.descriptionFromClassLabel
+                                    : contents.descriptionFromInterfaceLabel);
+                    descriptionFromLabel.add(Entity.NO_BREAK_SPACE);
+                    descriptionFromLabel.add(codeLink);
+                    propertyDocTree.add(HtmlTree.DIV(HtmlStyle.block, descriptionFromLabel));
                 }
                 writer.addInlineComment(property, propertyDocTree);
             }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlStyle.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlStyle.java
@@ -385,8 +385,7 @@ public enum HtmlStyle {
     /**
      * The class for a label indicating the element from which a description has been copied.
      */
-    // This should be renamed to something less cryptic
-    descfrmTypeLabel,
+    descriptionFromTypeLabel,
 
     /**
      * The class for a note providing information about the permitted subtypes of a

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/stylesheet.css
@@ -549,7 +549,7 @@ h1.hidden {
     margin:0 10px 5px 0;
     color:#474747;
 }
-.deprecated-label, .descfrm-type-label, .implementation-label, .member-name-label, .member-name-link,
+.deprecated-label, .description-from-type-label, .implementation-label, .member-name-label, .member-name-link,
 .module-label-in-package, .module-label-in-type, .override-specify-label, .package-label-in-type,
 .package-hierarchy-label, .type-name-label, .type-name-link, .search-tag-link, .preview-label {
     font-weight:bold;

--- a/test/langtools/jdk/javadoc/doclet/testInterface/TestInterface.java
+++ b/test/langtools/jdk/javadoc/doclet/testInterface/TestInterface.java
@@ -150,7 +150,7 @@ public class TestInterface extends JavadocTester {
                     <div class="member-signature"><span class="modifiers">public static</span>&nbsp;\
                     <span class="return-type">void</span>&nbsp;<span class="element-name">staticMethod</span\
                     >()</div>
-                    <div class="block"><span class="descfrm-type-label">Description copied from inte\
+                    <div class="block"><span class="description-from-type-label">Description copied from inte\
                     rface:&nbsp;<code><a href="InterfaceWithStaticMembers.html#staticMethod()">Inter\
                     faceWithStaticMembers</a></code></span></div>
                     <div class="block">A static method</div>

--- a/test/langtools/jdk/javadoc/doclet/testOptions/custom-stylesheet.css
+++ b/test/langtools/jdk/javadoc/doclet/testOptions/custom-stylesheet.css
@@ -609,7 +609,7 @@ h1.hidden {
     margin:3px 10px 2px 0px;
     color:#474747;
 }
-.deprecatedLabel, .descfrmTypeLabel, .memberNameLabel, .memberNameLink,
+.deprecatedLabel, .descriptionFromTypeLabel, .memberNameLabel, .memberNameLink,
 .overrideSpecifyLabel, .packageHierarchyLabel, .paramLabel, .returnLabel,
 .seeLabel, .simpleTagLabel, .throwsLabel, .typeNameLabel, .typeNameLink, .searchTagLink {
     font-weight:bold;

--- a/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverriddenMethodDocCopy.java
+++ b/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverriddenMethodDocCopy.java
@@ -54,7 +54,7 @@ public class TestOverriddenMethodDocCopy extends JavadocTester {
 
         checkOutput("pkg1/SubClass.html", true,
                 """
-                    <span class="descfrm-type-label">Description copied from class:&nbsp;<code><a hr\
+                    <span class="description-from-type-label">Description copied from class:&nbsp;<code><a hr\
                     ef="BaseClass.html#overriddenMethodWithDocsToCopy()">BaseClass</a></code></span>""");
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverrideMethods.java
+++ b/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverrideMethods.java
@@ -412,7 +412,7 @@ public class TestOverrideMethods  extends JavadocTester {
                     ="element-name">m1</span><wbr><span class="parameters">(java.lang.Class&lt;? ext\
                     ends java.lang.CharSequence&gt;&nbsp;p1,
                      int[]&nbsp;p2)</span></div>
-                    <div class="block"><span class="descfrm-type-label">Description copied from inte\
+                    <div class="block"><span class="description-from-type-label">Description copied from inte\
                     rface:&nbsp;<code><a href="AnnotatedBase.html#m1(java.lang.Class,int%5B%5D)">Ann\
                     otatedBase</a></code></span></div>
                     <div class="block">This is AnnotatedBase::m1.</div>
@@ -437,7 +437,7 @@ public class TestOverrideMethods  extends JavadocTester {
                     ="element-name">m1</span><wbr><span class="parameters">(java.lang.Class&lt;? ext\
                     ends java.lang.CharSequence&gt;&nbsp;p1,
                      int[]&nbsp;p2)</span></div>
-                    <div class="block"><span class="descfrm-type-label">Description copied from inte\
+                    <div class="block"><span class="description-from-type-label">Description copied from inte\
                     rface:&nbsp;<code><a href="AnnotatedBase.html#m1(java.lang.Class,int%5B%5D)">Ann\
                     otatedBase</a></code></span></div>
                     <div class="block">This is AnnotatedBase::m1.</div>
@@ -460,7 +460,7 @@ public class TestOverrideMethods  extends JavadocTester {
                     /span>&nbsp;<span class="element-name">m1</span><wbr><span class="parameters">(j\
                     ava.lang.Class&lt;? extends java.lang.CharSequence&gt;&nbsp;p1,
                      int[]&nbsp;p2)</span></div>
-                    <div class="block"><span class="descfrm-type-label">Description copied from inte\
+                    <div class="block"><span class="description-from-type-label">Description copied from inte\
                     rface:&nbsp;<code><a href="AnnotatedBase.html#m1(java.lang.Class,int%5B%5D)">Ann\
                     otatedBase</a></code></span></div>
                     <div class="block">This is AnnotatedBase::m1.</div>
@@ -484,7 +484,7 @@ public class TestOverrideMethods  extends JavadocTester {
                      <a href="A.html" title="annotation interface in pkg7">@A</a> java.lang.Class&lt\
                     ;? extends java.lang.CharSequence&gt;&nbsp;p1,
                      int[]&nbsp;p2)</span></div>
-                    <div class="block"><span class="descfrm-type-label">Description copied from inte\
+                    <div class="block"><span class="description-from-type-label">Description copied from inte\
                     rface:&nbsp;<code><a href="AnnotatedBase.html#m1(java.lang.Class,int%5B%5D)">Ann\
                     otatedBase</a></code></span></div>
                     <div class="block">This is AnnotatedBase::m1.</div>
@@ -507,7 +507,7 @@ public class TestOverrideMethods  extends JavadocTester {
                     ass="parameters">(java.lang.Class&lt;<a href="A.html" title="annotation interfac\
                     e in pkg7">@A</a> ? extends java.lang.CharSequence&gt;&nbsp;p1,
                      int[]&nbsp;p2)</span></div>
-                    <div class="block"><span class="descfrm-type-label">Description copied from inte\
+                    <div class="block"><span class="description-from-type-label">Description copied from inte\
                     rface:&nbsp;<code><a href="AnnotatedBase.html#m1(java.lang.Class,int%5B%5D)">Ann\
                     otatedBase</a></code></span></div>
                     <div class="block">This is AnnotatedBase::m1.</div>
@@ -530,7 +530,7 @@ public class TestOverrideMethods  extends JavadocTester {
                     ass="parameters">(java.lang.Class&lt;? extends <a href="A.html" title="annotatio\
                     n interface in pkg7">@A</a> java.lang.CharSequence&gt;&nbsp;p1,
                      int[]&nbsp;p2)</span></div>
-                    <div class="block"><span class="descfrm-type-label">Description copied from inte\
+                    <div class="block"><span class="description-from-type-label">Description copied from inte\
                     rface:&nbsp;<code><a href="AnnotatedBase.html#m1(java.lang.Class,int%5B%5D)">Ann\
                     otatedBase</a></code></span></div>
                     <div class="block">This is AnnotatedBase::m1.</div>
@@ -553,7 +553,7 @@ public class TestOverrideMethods  extends JavadocTester {
                     ass="parameters">(java.lang.Class&lt;? extends java.lang.CharSequence&gt;&nbsp;p1,
                      int <a href="A.html" title="annotation interface in pkg7">@A</a> []&nbsp;p2)</s\
                     pan></div>
-                    <div class="block"><span class="descfrm-type-label">Description copied from inte\
+                    <div class="block"><span class="description-from-type-label">Description copied from inte\
                     rface:&nbsp;<code><a href="AnnotatedBase.html#m1(java.lang.Class,int%5B%5D)">Ann\
                     otatedBase</a></code></span></div>
                     <div class="block">This is AnnotatedBase::m1.</div>

--- a/test/langtools/jdk/javadoc/doclet/testPrivateClasses/TestPrivateClasses.java
+++ b/test/langtools/jdk/javadoc/doclet/testPrivateClasses/TestPrivateClasses.java
@@ -224,7 +224,7 @@ public class TestPrivateClasses extends JavadocTester {
                 //Since private flag is used, we can document that private interface method
                 //with generic parameters has been implemented.
                 """
-                    <span class="descfrm-type-label">Description copied from interface:&nbsp;<code><\
+                    <span class="description-from-type-label">Description copied from interface:&nbsp;<code><\
                     a href="I.html#hello(T)">I</a></code></span>""",
                 """
                     <dt>Specified by:</dt>

--- a/test/langtools/jdk/javadoc/doclet/testReturnTag/TestReturnTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testReturnTag/TestReturnTag.java
@@ -379,7 +379,7 @@ public class TestReturnTag extends JavadocTester {
 
         checkOutput("C.html", true,
                 """
-                    <div class="block"><span class="descfrm-type-label">Description copied from class:&nbsp;<code>Super</code></span></div>
+                    <div class="block"><span class="description-from-type-label">Description copied from class:&nbsp;<code>Super</code></span></div>
                     <div class="block">Returns the result.</div>
                     <dl class="notes">
                     <dt>Overrides:</dt>


### PR DESCRIPTION
Please review s simple update to replace use of the cryptic string "descfrm" with either "descriptionFrom" or "description-from" as appropriate.  

While mostly internal, the name does show up in the stylesheet.

Note: there's a test file called `custom-stylesheet.css` which still uses _camelCase_ naming even though the main stylesheet has been converted to _kebab-case_. While this does not really affect the test, we might want to (separately) clean up this naming mismatch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274666](https://bugs.openjdk.java.net/browse/JDK-8274666): rename HtmlStyle.descfrmTypeLabel to be less cryptic


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.java.net/census#hannesw) (@hns - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5792/head:pull/5792` \
`$ git checkout pull/5792`

Update a local copy of the PR: \
`$ git checkout pull/5792` \
`$ git pull https://git.openjdk.java.net/jdk pull/5792/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5792`

View PR using the GUI difftool: \
`$ git pr show -t 5792`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5792.diff">https://git.openjdk.java.net/jdk/pull/5792.diff</a>

</details>
