### PR TITLE
[PATCH] Remove unnecessary conversion to String in java.net.http

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/AuthenticationFilter.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/AuthenticationFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -323,7 +323,7 @@ class AuthenticationFilter implements HeaderFilter {
             return req;
         } else if (au.retries > retry_limit) {
             throw new IOException("too many authentication attempts. Limit: " +
-                    Integer.toString(retry_limit));
+                    retry_limit);
         } else {
             // we sent credentials, but they were rejected
             if (au.fromcache) {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1AsyncReceiver.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1AsyncReceiver.java
@@ -116,7 +116,7 @@ class Http1AsyncReceiver {
         public AbstractSubscription subscription();
 
         /**
-         * Called to make sure resources are released when the
+         * Called to make sure resources are released
          * when the Http1AsyncReceiver is stopped.
          * @param error The Http1AsyncReceiver pending error ref,
          *              if any.
@@ -478,7 +478,7 @@ class Http1AsyncReceiver {
                 // the pool.
                 if (retry && (ex instanceof IOException)) {
                     // could be either EOFException, or
-                    // IOException("connection reset by peer), or
+                    // IOException("connection reset by peer"), or
                     // SSLHandshakeException resulting from the server having
                     // closed the SSL session.
                     if (received.get() == 0) {
@@ -709,7 +709,7 @@ class Http1AsyncReceiver {
         for (ByteBuffer b : lbb) {
             if (!sbb.remove(b)) {
                 msg.append(sep)
-                   .append(String.valueOf(b))
+                   .append(b)
                    .append("[remaining=")
                    .append(b.remaining())
                    .append(", position=")
@@ -732,7 +732,7 @@ class Http1AsyncReceiver {
             Object flow = (exchg != null)
                     ? exchg.connection().getConnectionFlow()
                     : null;
-            flowTag = tag = flow == null ? null: (String.valueOf(flow));
+            flowTag = flow == null ? null: flow.toString();
             if (flowTag != null) {
                 dbgTag = tag = "Http1AsyncReceiver("+ flowTag + ")";
             } else {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Request.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Request.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -236,7 +236,7 @@ class Http1Request {
         if (defaultPort) {
             return host;
         } else {
-            return host + ":" + Integer.toString(port);
+            return host + ":" + port;
         }
     }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Response.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Response.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -114,7 +114,7 @@ class Http1Response<T> {
     }
 
     // The ClientRefCountTracker is used to track the state
-    // of a pending operation. Altough there usually is a single
+    // of a pending operation. Although there usually is a single
     // point where the operation starts, it may terminate at
     // different places.
     private final class ClientRefCountTracker {
@@ -828,7 +828,7 @@ class Http1Response<T> {
 
         @Override
         public String toString() {
-            return super.toString() + "/parser=" + String.valueOf(parser);
+            return super.toString() + "/parser=" + parser;
         }
     }
 }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -1008,7 +1008,7 @@ class Http2Connection  {
         throws IOException
     {
         shutdown(new IOException(
-                        String.valueOf(connection.channel().getLocalAddress())
+                        connection.channel().getLocalAddress()
                         +": GOAWAY received"));
     }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpRequestImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpRequestImpl.java
@@ -44,7 +44,6 @@ import java.net.http.HttpRequest;
 
 import jdk.internal.net.http.common.HttpHeadersBuilder;
 import jdk.internal.net.http.common.Utils;
-import jdk.internal.net.http.websocket.OpeningHandshake;
 import jdk.internal.net.http.websocket.WebSocketRequest;
 
 import static jdk.internal.net.http.common.Utils.ALLOWED_HEADERS;
@@ -216,7 +215,7 @@ public class HttpRequestImpl extends HttpRequest implements WebSocketRequest {
         this.systemHeadersBuilder.map().putAll(headers.systemHeaders().map());
         this.userHeaders = headers.userHeaders();
         this.uri = URI.create("socket://" + authority.getHostString() + ":"
-                              + Integer.toString(authority.getPort()) + "/");
+                              + authority.getPort() + "/");
         this.proxy = null;
         this.requestPublisher = null;
         this.authority = authority;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/Demand.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/Demand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ public final class Demand {
      */
     public boolean increase(long n) {
         if (n <= 0) {
-            throw new IllegalArgumentException("non-positive subscription request: " + String.valueOf(n));
+            throw new IllegalArgumentException("non-positive subscription request: " + n);
         }
         long prev = val.getAndAccumulate(n, (p, i) -> p + i < 0 ? Long.MAX_VALUE : p + i);
         return prev == 0;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLFlowDelegate.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLFlowDelegate.java
@@ -938,7 +938,7 @@ public class SSLFlowDelegate {
         @Override
         public String toString() {
             return "WRITER: " + super.toString()
-                    + ", writeList size: " + Integer.toString(writeList.size())
+                    + ", writeList size: " + writeList.size()
                     + ", scheduler: " + (scheduler.isStopped() ? "stopped" : "running")
                     + ", status: " + lastWrappedStatus;
                     //" writeList: " + writeList.toString();
@@ -1113,7 +1113,7 @@ public class SSLFlowDelegate {
         exec.execute(() -> {
             try {
                 List<Runnable> nextTasks = tasks;
-                if (debug.on()) debug.log("#tasks to execute: " + Integer.toString(nextTasks.size()));
+                if (debug.on()) debug.log("#tasks to execute: " + nextTasks.size());
                 do {
                     nextTasks.forEach(Runnable::run);
                     if (engine.getHandshakeStatus() == HandshakeStatus.NEED_TASK) {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/SubscriberWrapper.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/SubscriberWrapper.java
@@ -490,13 +490,13 @@ public abstract class SubscriberWrapper
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("SubscriberWrapper:")
-          .append(" upstreamCompleted: ").append(Boolean.toString(upstreamCompleted))
-          .append(" upstreamWindow: ").append(upstreamWindow.toString())
-          .append(" downstreamCompleted: ").append(Boolean.toString(downstreamCompleted))
-          .append(" completionAcknowledged: ").append(Boolean.toString(completionAcknowledged))
-          .append(" outputQ size: ").append(Integer.toString(outputQ.size()))
+          .append(" upstreamCompleted: ").append(upstreamCompleted)
+          .append(" upstreamWindow: ").append(upstreamWindow)
+          .append(" downstreamCompleted: ").append(downstreamCompleted)
+          .append(" completionAcknowledged: ").append(completionAcknowledged)
+          .append(" outputQ size: ").append(outputQ.size())
           //.append(" outputQ: ").append(outputQ.toString())
-          .append(" cf: ").append(cf.toString())
+          .append(" cf: ").append(cf)
           .append(" downstreamSubscription: ").append(downstreamSubscription)
           .append(" downstreamSubscriber: ").append(downstreamSubscriber);
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/Utils.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/Utils.java
@@ -873,7 +873,7 @@ public final class Utils {
         if (defaultPort) {
             return host;
         } else {
-            return host + ":" + Integer.toString(port);
+            return host + ":" + port;
         }
     }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/ErrorFrame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/ErrorFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ public abstract class ErrorFrame extends Http2Frame {
         }
 
         if (code > LAST_ERROR) {
-            return "Error: " + Integer.toString(code);
+            return "Error: " + code;
         } else {
             return errorStrings[code];
         }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/Http2Frame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/Http2Frame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,7 +101,7 @@ public abstract class Http2Frame {
         StringBuilder sb = new StringBuilder();
         sb.append(typeAsString())
                 .append(": length=")
-                .append(Integer.toString(length()))
+                .append(length())
                 .append(", streamid=")
                 .append(streamid)
                 .append(", flags=");

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/SettingsFrame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/SettingsFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ public class SettingsFrame extends Http2Frame {
             if (parameters[i] != -1) {
                 sb.append(name(i))
                   .append("=")
-                  .append(Integer.toString(parameters[i]))
+                  .append(parameters[i])
                   .append(' ');
             }
         }


### PR DESCRIPTION
Cleanup unnecessary String.valueOf calls (and similar) when conversion will happen implicitly anyway