### PR TITLE
8274670: Improve version string handling in SA

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
@@ -378,8 +378,8 @@ public class VM {
         } else {
            // Otherwise print warning to allow mismatch not release versions
            // during development.
-           System.err.println("WARNING: Hotspot VM version " + vmVersion.toString() +
-                              " does not match with SA version " + saVersion.toString() +
+           System.err.println("WARNING: Hotspot VM version " + vmVersion +
+                              " does not match with SA version " + saVersion +
                               "." + " You may see unexpected results. ");
         }
      } else {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
@@ -359,27 +359,27 @@ public class VM {
      if (System.getProperty("sun.jvm.hotspot.runtime.VM.disableVersionCheck") == null) {
         // read sa build version.
         String versionProp = "sun.jvm.hotspot.runtime.VM.saBuildVersion";
-        String saVersion = saProps.getProperty(versionProp);
-        if (saVersion == null)
+        String versionPropVal = saProps.getProperty(versionProp);
+        if (versionPropVal == null) {
            throw new RuntimeException("Missing property " + versionProp);
+        }
 
-        // Strip nonproduct VM version substring (note: saVersion doesn't have it).
-        String vmVersion = vmRelease.replaceAll("(-fastdebug)|(-debug)|(-jvmg)|(-optimized)|(-profiled)","");
+        var saVersion = Runtime.Version.parse(versionPropVal);
+        var vmVersion = Runtime.Version.parse(vmRelease);
 
         if (saVersion.equals(vmVersion)) {
            // Exact match
            return;
         }
-        if (saVersion.indexOf('-') == saVersion.lastIndexOf('-') &&
-            vmVersion.indexOf('-') == vmVersion.lastIndexOf('-')) {
+        if (!saVersion.equalsIgnoreOptional(vmVersion)) {
            // Throw exception if different release versions:
-           // <major>.<minor>-b<n>
-           throw new VMVersionMismatchException(saVersion, vmRelease);
+           // <version>+<build>
+           throw new VMVersionMismatchException(saVersion, vmVersion);
         } else {
            // Otherwise print warning to allow mismatch not release versions
            // during development.
-           System.err.println("WARNING: Hotspot VM version " + vmRelease +
-                              " does not match with SA version " + saVersion +
+           System.err.println("WARNING: Hotspot VM version " + vmVersion.toString() +
+                              " does not match with SA version " + saVersion.toString() +
                               "." + " You may see unexpected results. ");
         }
      } else {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VMVersionMismatchException.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VMVersionMismatchException.java
@@ -34,8 +34,8 @@ public class VMVersionMismatchException extends RuntimeException {
     }
 
     public String getMessage() {
-        return "Supported versions are " + supportedVersions.toString() +
-                ". Target VM is " + targetVersion.toString();
+        return "Supported versions are " + supportedVersions +
+                ". Target VM is " + targetVersion;
     }
 
     public Runtime.Version getSupportedVersions() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VMVersionMismatchException.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VMVersionMismatchException.java
@@ -27,25 +27,25 @@ package sun.jvm.hotspot.runtime;
 /** An instance of this exception is thrown when debuggee VM version
     is not supported current version of SA. */
 public class VMVersionMismatchException extends RuntimeException {
-    public VMVersionMismatchException(String supported, String target) {
+    public VMVersionMismatchException(Runtime.Version supported, Runtime.Version target) {
         super();
         supportedVersions = supported;
         targetVersion = target;
     }
 
     public String getMessage() {
-        return "Supported versions are " + supportedVersions +
-                ". Target VM is " + targetVersion;
+        return "Supported versions are " + supportedVersions.toString() +
+                ". Target VM is " + targetVersion.toString();
     }
 
-    public String getSupportedVersions() {
+    public Runtime.Version getSupportedVersions() {
         return supportedVersions;
     }
 
-    public String getTargetVersion() {
+    public Runtime.Version getTargetVersion() {
         return targetVersion;
     }
 
-    private String supportedVersions;
-    private String targetVersion;
+    private final Runtime.Version supportedVersions;
+    private final Runtime.Version targetVersion;
 }


### PR DESCRIPTION
Use [java.lang.Runtime.Version](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Runtime.Version.html) to check the version of debugee.

Currently `checkVMVersion()` in `sun.jvm.hotspot.runtime.VM` has following code to check the version of debugee.

```java
        if (saVersion.indexOf('-') == saVersion.lastIndexOf('-') &&
            vmVersion.indexOf('-') == vmVersion.lastIndexOf('-')) {
           // Throw exception if different release versions:
           // <major>.<minor>-b<n>
           throw new VMVersionMismatchException(saVersion, vmRelease);
        } else {
           // Otherwise print warning to allow mismatch not release versions
           // during development.
           System.err.println("WARNING: Hotspot VM version " + vmRelease +
                              " does not match with SA version " + saVersion +
                              "." + " You may see unexpected results. ");
        }
```

It seems to expect to allow the deference in option string only.
For example, `saVersion` is "17+35", and `vmVersion` is "17+35-2724", then it should be allowed because release version (17+35) is same. However current code would not do so.

I guess this code is not based on [JEP 223](https://openjdk.java.net/jeps/223) (New Version-String Scheme) because the comment says "\<major>.\<minor>-b\<n>". Fortunately we have `Runtime.Version` to handle version strings. We should refactor with it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274670](https://bugs.openjdk.java.net/browse/JDK-8274670): Improve version string handling in SA


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5797/head:pull/5797` \
`$ git checkout pull/5797`

Update a local copy of the PR: \
`$ git checkout pull/5797` \
`$ git pull https://git.openjdk.java.net/jdk pull/5797/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5797`

View PR using the GUI difftool: \
`$ git pr show -t 5797`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5797.diff">https://git.openjdk.java.net/jdk/pull/5797.diff</a>

</details>
