### PR TITLE
8274679: Remove unnecessary conversion to String in security code in java.base

### DIFF
--- a/src/java.base/share/classes/java/security/cert/PKIXCertPathBuilderResult.java
+++ b/src/java.base/share/classes/java/security/cert/PKIXCertPathBuilderResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,8 +110,8 @@ public class PKIXCertPathBuilderResult extends PKIXCertPathValidatorResult
         StringBuilder sb = new StringBuilder();
         sb.append("PKIXCertPathBuilderResult: [\n");
         sb.append("  Certification Path: " + certPath + "\n");
-        sb.append("  Trust Anchor: " + getTrustAnchor().toString() + "\n");
-        sb.append("  Policy Tree: " + String.valueOf(getPolicyTree()) + "\n");
+        sb.append("  Trust Anchor: " + getTrustAnchor() + "\n");
+        sb.append("  Policy Tree: " + getPolicyTree() + "\n");
         sb.append("  Subject Public Key: " + getPublicKey() + "\n");
         sb.append("]");
         return sb.toString();

--- a/src/java.base/share/classes/java/security/cert/PKIXCertPathValidatorResult.java
+++ b/src/java.base/share/classes/java/security/cert/PKIXCertPathValidatorResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -150,8 +150,8 @@ public class PKIXCertPathValidatorResult implements CertPathValidatorResult {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("PKIXCertPathValidatorResult: [\n");
-        sb.append("  Trust Anchor: " + trustAnchor.toString() + "\n");
-        sb.append("  Policy Tree: " + String.valueOf(policyTree) + "\n");
+        sb.append("  Trust Anchor: " + trustAnchor + "\n");
+        sb.append("  Policy Tree: " + policyTree + "\n");
         sb.append("  Subject Public Key: " + subjectPublicKey + "\n");
         sb.append("]");
         return sb.toString();

--- a/src/java.base/share/classes/java/security/cert/PKIXParameters.java
+++ b/src/java.base/share/classes/java/security/cert/PKIXParameters.java
@@ -696,8 +696,7 @@ public class PKIXParameters implements CertPathParameters {
 
         /* start with trusted anchor info */
         if (unmodTrustAnchors != null) {
-            sb.append("  Trust Anchors: " + unmodTrustAnchors.toString()
-                + "\n");
+            sb.append("  Trust Anchors: " + unmodTrustAnchors + "\n");
         }
 
         /* now, append initial state information */
@@ -706,13 +705,13 @@ public class PKIXParameters implements CertPathParameters {
                 sb.append("  Initial Policy OIDs: any\n");
             } else {
                 sb.append("  Initial Policy OIDs: ["
-                    + unmodInitialPolicies.toString() + "]\n");
+                    + unmodInitialPolicies + "]\n");
             }
         }
 
         /* now, append constraints on all certificates in the path */
-        sb.append("  Validity Date: " + String.valueOf(date) + "\n");
-        sb.append("  Signature Provider: " + String.valueOf(sigProvider) + "\n");
+        sb.append("  Validity Date: " + date + "\n");
+        sb.append("  Signature Provider: " + sigProvider + "\n");
         sb.append("  Default Revocation Enabled: " + revocationEnabled + "\n");
         sb.append("  Explicit Policy Required: " + explicitPolicyRequired + "\n");
         sb.append("  Policy Mapping Inhibited: " + policyMappingInhibited + "\n");
@@ -720,14 +719,14 @@ public class PKIXParameters implements CertPathParameters {
         sb.append("  Policy Qualifiers Rejected: " + policyQualifiersRejected + "\n");
 
         /* now, append target cert requirements */
-        sb.append("  Target Cert Constraints: " + String.valueOf(certSelector) + "\n");
+        sb.append("  Target Cert Constraints: " + certSelector + "\n");
 
         /* finally, append miscellaneous parameters */
         if (certPathCheckers != null)
             sb.append("  Certification Path Checkers: ["
-                + certPathCheckers.toString() + "]\n");
+                + certPathCheckers + "]\n");
         if (certStores != null)
-            sb.append("  CertStores: [" + certStores.toString() + "]\n");
+            sb.append("  CertStores: [" + certStores + "]\n");
         sb.append("]");
         return sb.toString();
     }

--- a/src/java.base/share/classes/java/security/cert/TrustAnchor.java
+++ b/src/java.base/share/classes/java/security/cert/TrustAnchor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@ import javax.security.auth.x500.X500Principal;
 
 import sun.security.util.AnchorCertificates;
 import sun.security.x509.NameConstraintsExtension;
-import sun.security.x509.X500Name;
 
 /**
  * A trust anchor or most-trusted Certification Authority (CA).
@@ -327,14 +326,13 @@ public class TrustAnchor {
         StringBuilder sb = new StringBuilder();
         sb.append("[\n");
         if (pubKey != null) {
-            sb.append("  Trusted CA Public Key: " + pubKey.toString() + "\n");
-            sb.append("  Trusted CA Issuer Name: "
-                + String.valueOf(caName) + "\n");
+            sb.append("  Trusted CA Public Key: " + pubKey + "\n");
+            sb.append("  Trusted CA Issuer Name: " + caName + "\n");
         } else {
-            sb.append("  Trusted CA cert: " + trustedCert.toString() + "\n");
+            sb.append("  Trusted CA cert: " + trustedCert + "\n");
         }
         if (nc != null)
-            sb.append("  Name Constraints: " + nc.toString() + "\n");
+            sb.append("  Name Constraints: " + nc + "\n");
         return sb.toString();
     }
 

--- a/src/java.base/share/classes/java/security/cert/X509CertSelector.java
+++ b/src/java.base/share/classes/java/security/cert/X509CertSelector.java
@@ -1763,10 +1763,10 @@ public class X509CertSelector implements CertSelector {
         StringBuilder sb = new StringBuilder();
         sb.append("X509CertSelector: [\n");
         if (x509Cert != null) {
-            sb.append("  Certificate: " + x509Cert.toString() + "\n");
+            sb.append("  Certificate: " + x509Cert + "\n");
         }
         if (serialNumber != null) {
-            sb.append("  Serial Number: " + serialNumber.toString() + "\n");
+            sb.append("  Serial Number: " + serialNumber + "\n");
         }
         if (issuer != null) {
             sb.append("  Issuer: " + getIssuerAsString() + "\n");
@@ -1775,7 +1775,7 @@ public class X509CertSelector implements CertSelector {
             sb.append("  Subject: " + getSubjectAsString() + "\n");
         }
         sb.append("  matchAllSubjectAltNames flag: "
-                  + String.valueOf(matchAllSubjectAltNames) + "\n");
+                  + matchAllSubjectAltNames + "\n");
         if (subjectAlternativeNames != null) {
             sb.append("  SubjectAlternativeNames:\n");
             for (List<?> list : subjectAlternativeNames) {
@@ -1795,29 +1795,29 @@ public class X509CertSelector implements CertSelector {
         }
         if (certificateValid != null) {
             sb.append("  Certificate Valid: " +
-                      certificateValid.toString() + "\n");
+                      certificateValid + "\n");
         }
         if (privateKeyValid != null) {
             sb.append("  Private Key Valid: " +
-                      privateKeyValid.toString() + "\n");
+                      privateKeyValid + "\n");
         }
         if (subjectPublicKeyAlgID != null) {
             sb.append("  Subject Public Key AlgID: " +
-                      subjectPublicKeyAlgID.toString() + "\n");
+                      subjectPublicKeyAlgID + "\n");
         }
         if (subjectPublicKey != null) {
             sb.append("  Subject Public Key: " +
-                      subjectPublicKey.toString() + "\n");
+                      subjectPublicKey + "\n");
         }
         if (keyUsage != null) {
             sb.append("  Key Usage: " + keyUsageToString(keyUsage) + "\n");
         }
         if (keyPurposeSet != null) {
             sb.append("  Extended Key Usage: " +
-                      keyPurposeSet.toString() + "\n");
+                      keyPurposeSet + "\n");
         }
         if (policy != null) {
-            sb.append("  Policy: " + policy.toString() + "\n");
+            sb.append("  Policy: " + policy + "\n");
         }
         if (pathToGeneralNames != null) {
             sb.append("  Path to names:\n");
@@ -2145,7 +2145,7 @@ public class X509CertSelector implements CertSelector {
                 debug.println("X509CertSelector.match: private key usage not "
                     + "within validity date; ext.NOT_BEFORE: "
                     + time + "; X509CertSelector: "
-                    + this.toString());
+                    + this);
                 e2.printStackTrace();
             }
             return false;
@@ -2153,7 +2153,7 @@ public class X509CertSelector implements CertSelector {
             if (debug != null) {
                 debug.println("X509CertSelector.match: IOException in "
                     + "private key usage check; X509CertSelector: "
-                    + this.toString());
+                    + this);
                 e4.printStackTrace();
             }
             return false;

--- a/src/java.base/share/classes/javax/crypto/Cipher.java
+++ b/src/java.base/share/classes/javax/crypto/Cipher.java
@@ -2833,7 +2833,7 @@ public class Cipher {
                 break;
             default:
                 // should never happen
-                sb.append("error:").append(Integer.toString(opmode));
+                sb.append("error:").append(opmode);
         }
         sb.append(", algorithm from: ").append(getProviderName());
         return sb.toString();

--- a/src/java.base/share/classes/javax/crypto/CryptoPolicyParser.java
+++ b/src/java.base/share/classes/javax/crypto/CryptoPolicyParser.java
@@ -395,7 +395,7 @@ final class CryptoPolicyParser {
         switch (lookahead) {
         case StreamTokenizer.TT_NUMBER:
             throw new ParsingException(st.lineno(), expect,
-                                       "number "+String.valueOf(st.nval));
+                                       "number " + st.nval);
         case StreamTokenizer.TT_EOF:
            throw new ParsingException("expected "+expect+", read end of file");
         case StreamTokenizer.TT_WORD:

--- a/src/java.base/share/classes/sun/security/provider/PolicyParser.java
+++ b/src/java.base/share/classes/sun/security/provider/PolicyParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -733,8 +733,7 @@ public class PolicyParser {
         switch (lookahead) {
         case StreamTokenizer.TT_NUMBER:
             throw new ParsingException(st.lineno(), expect,
-                LocalizedMessage.getNonlocalized("number.") +
-                    String.valueOf(st.nval));
+                LocalizedMessage.getNonlocalized("number.") + st.nval);
         case StreamTokenizer.TT_EOF:
             LocalizedMessage localizedMsg = new LocalizedMessage
                 ("expected.expect.read.end.of.file.");
@@ -826,8 +825,7 @@ public class PolicyParser {
             switch (lookahead) {
             case StreamTokenizer.TT_NUMBER:
                 throw new ParsingException(st.lineno(), ";",
-                        LocalizedMessage.getNonlocalized("number.") +
-                            String.valueOf(st.nval));
+                        LocalizedMessage.getNonlocalized("number.") + st.nval);
             case StreamTokenizer.TT_EOF:
                 throw new ParsingException(LocalizedMessage.getNonlocalized
                         ("expected.read.end.of.file."));

--- a/src/java.base/share/classes/sun/security/provider/certpath/Builder.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/Builder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.security.provider.certpath;
 
 import java.io.IOException;
-import java.security.AccessController;
 import java.security.GeneralSecurityException;
 import java.security.cert.*;
 import java.util.*;
@@ -337,7 +336,7 @@ public abstract class Builder {
 
         if (debug != null) {
             debug.println("Builder.targetDistance() merged constraints: "
-                + String.valueOf(constraints));
+                + constraints);
         }
         /* reduce permitted by excluded */
         GeneralSubtrees permitted =

--- a/src/java.base/share/classes/sun/security/provider/certpath/ConstraintsChecker.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/ConstraintsChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -185,14 +185,14 @@ class ConstraintsChecker extends PKIXCertPathChecker {
 
         if (debug != null) {
             debug.println("prevNC = " + prevNC +
-                        ", newNC = " + String.valueOf(newConstraints));
+                        ", newNC = " + newConstraints);
         }
 
         // if there are no previous name constraints, we just return the
         // new name constraints.
         if (prevNC == null) {
             if (debug != null) {
-                debug.println("mergedNC = " + String.valueOf(newConstraints));
+                debug.println("mergedNC = " + newConstraints);
             }
             if (newConstraints == null) {
                 return newConstraints;

--- a/src/java.base/share/classes/sun/security/provider/certpath/ForwardBuilder.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/ForwardBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,6 @@ import java.security.cert.CertPathValidatorException;
 import java.security.cert.PKIXReason;
 import java.security.cert.CertStore;
 import java.security.cert.CertStoreException;
-import java.security.cert.PKIXBuilderParameters;
 import java.security.cert.PKIXCertPathChecker;
 import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
@@ -598,8 +597,8 @@ class ForwardBuilder extends Builder {
                 X500Name tAo1 = tSubjectName.commonAncestor(cIssuer1Name);
                 X500Name tAo2 = tSubjectName.commonAncestor(cIssuer2Name);
                 if (debug != null) {
-                    debug.println(METHOD_NME +" tAo1: " + String.valueOf(tAo1));
-                    debug.println(METHOD_NME +" tAo2: " + String.valueOf(tAo2));
+                    debug.println(METHOD_NME +" tAo1: " + tAo1);
+                    debug.println(METHOD_NME +" tAo2: " + tAo2);
                 }
                 if (tAo1 != null || tAo2 != null) {
                     if (tAo1 != null && tAo2 != null) {

--- a/src/java.base/share/classes/sun/security/provider/certpath/ForwardState.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/ForwardState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -117,9 +117,8 @@ class ForwardState implements State {
         sb.append("State [");
         sb.append("\n  issuerDN of last cert: ").append(issuerDN);
         sb.append("\n  traversedCACerts: ").append(traversedCACerts);
-        sb.append("\n  init: ").append(String.valueOf(init));
-        sb.append("\n  keyParamsNeeded: ").append
-                 (String.valueOf(keyParamsNeededFlag));
+        sb.append("\n  init: ").append(init);
+        sb.append("\n  keyParamsNeeded: ").append(keyParamsNeededFlag);
         sb.append("\n  subjectNamesTraversed: \n").append
                  (subjectNamesTraversed);
         sb.append("]\n");

--- a/src/java.base/share/classes/sun/security/x509/CertificateIssuerExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateIssuerExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -170,7 +170,7 @@ public class CertificateIssuerExtension extends Extension
      */
     public String toString() {
         return super.toString() + "Certificate Issuer [\n" +
-            String.valueOf(names) + "]\n";
+            names + "]\n";
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/InvalidityDateExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/InvalidityDateExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -168,7 +168,7 @@ public class InvalidityDateExtension extends Extension
      * Returns a printable representation of the Invalidity Date.
      */
     public String toString() {
-        return super.toString() + "    Invalidity Date: " + String.valueOf(date);
+        return super.toString() + "    Invalidity Date: " + date;
     }
 
     /**


### PR DESCRIPTION
Cleanup unnecessary String.valueOf calls (and similar) when conversion will happen implicitly anyway.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274679](https://bugs.openjdk.java.net/browse/JDK-8274679): Remove unnecessary conversion to String in security code in java.base


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5798/head:pull/5798` \
`$ git checkout pull/5798`

Update a local copy of the PR: \
`$ git checkout pull/5798` \
`$ git pull https://git.openjdk.java.net/jdk pull/5798/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5798`

View PR using the GUI difftool: \
`$ git pr show -t 5798`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5798.diff">https://git.openjdk.java.net/jdk/pull/5798.diff</a>

</details>
