### PR TITLE
8274244: ReportOnImportedModuleAnnotation.java fails on rerun

### DIFF
--- a/test/langtools/tools/javac/processing/ReportOnImportedModuleAnnotation/ReportOnImportedModuleAnnotation.java
+++ b/test/langtools/tools/javac/processing/ReportOnImportedModuleAnnotation/ReportOnImportedModuleAnnotation.java
@@ -58,24 +58,8 @@ public class ReportOnImportedModuleAnnotation {
 
         final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
 
-        // Clean any existing class files in output directory
-        var tb = new ToolBox();
-        Files.walkFileTree(testOutputPath,
-                           new SimpleFileVisitor<Path>() {
-                               @Override
-                               public FileVisitResult visitFile(Path path,
-                                                         BasicFileAttributes attrs) {
-                                   File file = path.toFile();
-                                   if (file.getName().endsWith(".class")) {
-                                       try {
-                                           tb.deleteFiles(path);
-                                       } catch (java.io.IOException ioe) {
-                                           ; // ignore
-                                       }
-                                   }
-                                   return FileVisitResult.CONTINUE;
-                               }
-                           });
+        // Clean any existing files in output directory
+        (new ToolBox()).cleanDirectory(testOutputPath);
 
         // Compile annotation and processor modules
         StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null);

--- a/test/langtools/tools/javac/processing/ReportOnImportedModuleAnnotation/ReportOnImportedModuleAnnotation.java
+++ b/test/langtools/tools/javac/processing/ReportOnImportedModuleAnnotation/ReportOnImportedModuleAnnotation.java
@@ -33,14 +33,10 @@
  * @run main ReportOnImportedModuleAnnotation
  */
 
-import java.io.File;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
 import java.util.List;
 
 import javax.tools.JavaCompiler;

--- a/test/langtools/tools/javac/processing/ReportOnImportedModuleAnnotation/ReportOnImportedModuleAnnotation.java
+++ b/test/langtools/tools/javac/processing/ReportOnImportedModuleAnnotation/ReportOnImportedModuleAnnotation.java
@@ -27,7 +27,10 @@
  *      8235458
  * @summary javac shouldn't fail when an annotation processor report a message about an annotation on a module
  *          javac should process annotated module when imports statement are present
+ * @library /tools/lib
  * @modules jdk.compiler
+ * @build toolbox.ToolBox
+ * @run main ReportOnImportedModuleAnnotation
  */
 
 import java.io.File;
@@ -45,6 +48,8 @@ import javax.tools.StandardJavaFileManager;
 import javax.tools.StandardLocation;
 import javax.tools.ToolProvider;
 
+import toolbox.ToolBox;
+
 public class ReportOnImportedModuleAnnotation {
 
     public static void main(String[] args) throws Exception {
@@ -54,6 +59,7 @@ public class ReportOnImportedModuleAnnotation {
         final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
 
         // Clean any existing class files in output directory
+        var tb = new ToolBox();
         Files.walkFileTree(testOutputPath,
                            new SimpleFileVisitor<Path>() {
                                @Override
@@ -61,7 +67,11 @@ public class ReportOnImportedModuleAnnotation {
                                                          BasicFileAttributes attrs) {
                                    File file = path.toFile();
                                    if (file.getName().endsWith(".class")) {
-                                       file.delete();
+                                       try {
+                                           tb.deleteFiles(path);
+                                       } catch (java.io.IOException ioe) {
+                                           ; // ignore
+                                       }
                                    }
                                    return FileVisitResult.CONTINUE;
                                }

--- a/test/langtools/tools/javac/processing/ReportOnImportedModuleAnnotation/ReportOnImportedModuleAnnotation.java
+++ b/test/langtools/tools/javac/processing/ReportOnImportedModuleAnnotation/ReportOnImportedModuleAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,10 +30,14 @@
  * @modules jdk.compiler
  */
 
+import java.io.File;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
 import java.util.List;
 
 import javax.tools.JavaCompiler;
@@ -48,6 +52,20 @@ public class ReportOnImportedModuleAnnotation {
         final Path testOutputPath = Path.of(System.getProperty("test.classes"));
 
         final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+
+        // Clean any existing class files in output directory
+        Files.walkFileTree(testOutputPath,
+                           new SimpleFileVisitor<Path>() {
+                               @Override
+                               public FileVisitResult visitFile(Path path,
+                                                         BasicFileAttributes attrs) {
+                                   File file = path.toFile();
+                                   if (file.getName().endsWith(".class")) {
+                                       file.delete();
+                                   }
+                                   return FileVisitResult.CONTINUE;
+                               }
+                           });
 
         // Compile annotation and processor modules
         StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null);


### PR DESCRIPTION
In terms of jtreg build tags, semantically this test wants to:

* build annotation processing sources
* compile module sources, running build annotation processor

In particular, the test wants to always compile the module sources, even if class files are newer than the module-info.java files. Since the test is not written in terms of those tags, I've added a pre-step which delete any existing class files from the output directory. If needed, some extra care could be taken to only delete files from the one module.

With this addition, the test will pass even when run with an already populated JTwork directory. At present, the test fails since the implicit compilation of module-info.java is *not* done when the class files in the output directory are newer than the sources.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274244](https://bugs.openjdk.java.net/browse/JDK-8274244): ReportOnImportedModuleAnnotation.java fails on rerun


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to c161c3ced60e30e942019ed56fd5141e2e659abc


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5802/head:pull/5802` \
`$ git checkout pull/5802`

Update a local copy of the PR: \
`$ git checkout pull/5802` \
`$ git pull https://git.openjdk.java.net/jdk pull/5802/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5802`

View PR using the GUI difftool: \
`$ git pr show -t 5802`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5802.diff">https://git.openjdk.java.net/jdk/pull/5802.diff</a>

</details>
