### PR TITLE
8274559: JFR: Typo in 'jfr help configure' text

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Configure.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Configure.java
@@ -86,7 +86,7 @@ final class Configure extends Command {
         stream.println("                          (default.jfc). If 'none' is specified, the new");
         stream.println("                          configuration starts empty.");
         stream.println();
-        stream.println("  --ouput <file>          The filename of the generated output file. If not");
+        stream.println("  --output <file>         The filename of the generated output file. If not");
         stream.println("                          specified, the filename custom.jfc will be used.");
         stream.println();
         stream.println("  option=value            The option value to modify. For available options,");


### PR DESCRIPTION
Hi,

Could I have review of a typo. 

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274559](https://bugs.openjdk.java.net/browse/JDK-8274559): JFR: Typo in 'jfr help configure' text


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5803/head:pull/5803` \
`$ git checkout pull/5803`

Update a local copy of the PR: \
`$ git checkout pull/5803` \
`$ git pull https://git.openjdk.java.net/jdk pull/5803/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5803`

View PR using the GUI difftool: \
`$ git pr show -t 5803`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5803.diff">https://git.openjdk.java.net/jdk/pull/5803.diff</a>

</details>
