### PR TITLE
8274687: JDWP can deadlock VM if Java thread waits in blockOnDebuggerSuspend

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/debugLoop.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/debugLoop.c
@@ -180,9 +180,6 @@ debugLoop_run(void)
             shouldListen = !lastCommand(cmd);
         }
     }
-    /* Sleep to trigger deadlock in test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003 */
-    fprintf(stderr, "debugLoop: sleep\n");
-    sleep(1);
     threadControl_onDisconnect();
     standardHandlers_onDisconnect();
 

--- a/src/jdk.jdwp.agent/share/native/libjdwp/debugLoop.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/debugLoop.c
@@ -180,6 +180,9 @@ debugLoop_run(void)
             shouldListen = !lastCommand(cmd);
         }
     }
+    /* Sleep to trigger deadlock in test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003 */
+    fprintf(stderr, "debugLoop: sleep\n");
+    sleep(1);
     threadControl_onDisconnect();
     standardHandlers_onDisconnect();
 


### PR DESCRIPTION
This change fixes the deadlock described in the JBS-bug by:

* Releasing `handlerLock` before waiting on `threadLock` in `blockOnDebuggerSuspend()`

* Notifying on `threadLock` after resuming all threads in `threadControl_reset()`

The PR has 3 commits:

The first commit delays the cleanup actions after leaving the loop in
`debugLoop_run()` because of a Dispose command. The delay allows to reproduce the deadlock
running the dispose003 test with the command

```
make run-test TEST=test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003
```

The second commit contains the fix described above. With it the deadlock
cannot be reproduced anymore.

The third commit removes the diagnostic code introduced with the first commit again.

The fix passed our nightly regression testing: JCK and JTREG, also in Xcomp mode with fastdebug and release builds on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8274687](https://bugs.openjdk.java.net/browse/JDK-8274687): JDWP can deadlock VM if Java thread waits in blockOnDebuggerSuspend


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5805/head:pull/5805` \
`$ git checkout pull/5805`

Update a local copy of the PR: \
`$ git checkout pull/5805` \
`$ git pull https://git.openjdk.java.net/jdk pull/5805/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5805`

View PR using the GUI difftool: \
`$ git pr show -t 5805`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5805.diff">https://git.openjdk.java.net/jdk/pull/5805.diff</a>

</details>
