### PR TITLE
8269698: Specification for methods of java.awt.im.InputContext should mention that they do nothing

### DIFF
--- a/src/java.desktop/share/classes/java/awt/im/InputContext.java
+++ b/src/java.desktop/share/classes/java/awt/im/InputContext.java
@@ -67,6 +67,8 @@ import sun.awt.im.InputMethodContext;
  * input contexts can still be created and used; their behavior is specified with
  * the individual methods below.
  *
+ * @implSpec the default implementation does nothing and does not throw any exceptions
+ *
  * @see java.awt.Component#getInputContext
  * @see java.awt.Component#enableInputMethods
  * @author JavaSoft Asia/Pacific

--- a/src/java.desktop/share/classes/java/awt/im/InputContext.java
+++ b/src/java.desktop/share/classes/java/awt/im/InputContext.java
@@ -67,7 +67,8 @@ import sun.awt.im.InputMethodContext;
  * input contexts can still be created and used; their behavior is specified with
  * the individual methods below.
  *
- * @implSpec the default implementation does nothing and does not throw any exceptions
+ * @implSpec the default implementations of methods either return false, null
+ *           or do nothing and does not throw any exceptions
  *
  * @see java.awt.Component#getInputContext
  * @see java.awt.Component#enableInputMethods


### PR DESCRIPTION
This fix simply describes that the `java.awt.im.InputContext` is a dummy implementation, which may not conform its spec.