### PR TITLE
8273342: Null pointer dereference in classFileParser.cpp:2817

### DIFF
--- a/src/hotspot/share/runtime/fieldDescriptor.cpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.cpp
@@ -55,7 +55,7 @@ Symbol* fieldDescriptor::generic_signature() const {
     }
   }
   assert(false, "should never happen");
-  return NULL;
+  return vmSymbols::void_signature(); // return a default value (for code analyzers)
 }
 
 bool fieldDescriptor::is_trusted_final() const {


### PR DESCRIPTION
Hi,

Please review this fix to always return a non-null value from fieldDescriptor::generic_signature() when a generic signature exists, even in places in the function that should never get executed.  This will prevent code analyzers from complaining about possible null dereferences by callers of generic_signature().

The change was tested with Mach5 tiers 1-2 on Linux, Mac OS, and Windows, and Mach5 tiers 3-5 on Linux x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273342](https://bugs.openjdk.java.net/browse/JDK-8273342): Null pointer dereference in classFileParser.cpp:2817


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5807/head:pull/5807` \
`$ git checkout pull/5807`

Update a local copy of the PR: \
`$ git checkout pull/5807` \
`$ git pull https://git.openjdk.java.net/jdk pull/5807/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5807`

View PR using the GUI difftool: \
`$ git pr show -t 5807`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5807.diff">https://git.openjdk.java.net/jdk/pull/5807.diff</a>

</details>
