### PR TITLE
8274738: ZGC: Use relaxed atomic load when reading bits in the live map

### DIFF
--- a/src/hotspot/share/gc/z/zLiveMap.inline.hpp
+++ b/src/hotspot/share/gc/z/zLiveMap.inline.hpp
@@ -98,9 +98,9 @@ inline BitMap::idx_t ZLiveMap::index_to_segment(BitMap::idx_t index) const {
 
 inline bool ZLiveMap::get(size_t index) const {
   BitMap::idx_t segment = index_to_segment(index);
-  return is_marked() &&              // Page is marked
-         is_segment_live(segment) && // Segment is marked
-         _bitmap.at(index);          // Object is marked
+  return is_marked() &&                               // Page is marked
+         is_segment_live(segment) &&                  // Segment is marked
+         _bitmap.par_at(index, memory_order_relaxed); // Object is marked
 }
 
 inline bool ZLiveMap::set(size_t index, bool finalizable, bool& inc_live) {


### PR DESCRIPTION
`ZLiveMap::get()` currently uses a non-atomic load to read bits in the live map. This should really be an relaxed atomic load.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274738](https://bugs.openjdk.java.net/browse/JDK-8274738): ZGC: Use relaxed atomic load when reading bits in the live map


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5809/head:pull/5809` \
`$ git checkout pull/5809`

Update a local copy of the PR: \
`$ git checkout pull/5809` \
`$ git pull https://git.openjdk.java.net/jdk pull/5809/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5809`

View PR using the GUI difftool: \
`$ git pr show -t 5809`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5809.diff">https://git.openjdk.java.net/jdk/pull/5809.diff</a>

</details>
