### PR TITLE
JDK-8274686 : java.util.UUID#hashCode() should use Long.hashCode()

### DIFF
--- a/src/java.base/share/classes/java/util/UUID.java
+++ b/src/java.base/share/classes/java/util/UUID.java
@@ -468,8 +468,7 @@ public final class UUID implements java.io.Serializable, Comparable<UUID> {
      */
     @Override
     public int hashCode() {
-        long hilo = mostSigBits ^ leastSigBits;
-        return ((int)(hilo >> 32)) ^ (int) hilo;
+        return Long.hashCode(mostSigBits ^ leastSigBits);
     }
 
     /**


### PR DESCRIPTION
This is trivial fix of [JDK-8274686](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8274686) which replaces manually-computed `int`-based `long` hash-code.

Because `Long#hashCode(long)` uses other hashing function than the one currently used here:

https://github.com/openjdk/jdk/blob/75d6688df9845ecb8f370b4cd2d5a36f13d3cdc0/src/java.base/share/classes/java/lang/Long.java#L1440-L1442

the value of `hashCode()` will produce different result, however this does not seem to be a breaking change as `UUID#hashCode()` is not specified.

---

Note: the comment to the bug states:

> Moved to JDK for further discussions of the proposed enhancement.

But as there seemed to be no corresponding discussion in core-libs-dev and the change looks trivial, I considered that it is appropriate to open a PR which (if needed) may be used for discussion (especially, considering the fact that its comments get mirrored to the ML).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274686](https://bugs.openjdk.java.net/browse/JDK-8274686): java.util.UUID#hashCode() should use Long.hashCode()


### Reviewers
 * @stsypanov (no known github.com user name / role)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5811/head:pull/5811` \
`$ git checkout pull/5811`

Update a local copy of the PR: \
`$ git checkout pull/5811` \
`$ git pull https://git.openjdk.java.net/jdk pull/5811/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5811`

View PR using the GUI difftool: \
`$ git pr show -t 5811`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5811.diff">https://git.openjdk.java.net/jdk/pull/5811.diff</a>

</details>
