### PR TITLE
JDK-8274744: TestSnippetTag test fails after recent integration

### DIFF
--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -27,8 +27,6 @@
 #
 # javadoc
 
-jdk/javadoc/doclet/testSnippetTag/TestSnippetTag.java                           8274744   generic-all
-
 ###########################################################################
 #
 # jshell

--- a/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetTag.java
@@ -288,7 +288,7 @@ public class TestSnippetTag extends JavadocTester {
                 """
                 error: unexpected content
                 {@snippet :}
-                ^
+                          ^
                 """),
             new Capture.TestCase(
                 """
@@ -297,7 +297,7 @@ public class TestSnippetTag extends JavadocTester {
                 """
                 error: unexpected content
                 {@snippet : }
-                ^
+                          ^
                 """),
             new Capture.TestCase(
                 """
@@ -306,7 +306,7 @@ public class TestSnippetTag extends JavadocTester {
                 """
                 error: unexpected content
                 {@snippet :a}
-                ^
+                          ^
                 """),
             new Capture.TestCase(
                 """
@@ -315,7 +315,7 @@ public class TestSnippetTag extends JavadocTester {
                 """,
                 """
                 error: unexpected content
-                {@snippet
+                :}
                 ^
                 """),
             new Capture.TestCase(
@@ -325,7 +325,7 @@ public class TestSnippetTag extends JavadocTester {
                 """,
                 """
                 error: unexpected content
-                {@snippet
+                : }
                 ^
                 """),
             new Capture.TestCase(
@@ -335,7 +335,7 @@ public class TestSnippetTag extends JavadocTester {
                 """,
                 """
                 error: unexpected content
-                {@snippet
+                :a}
                 ^
                 """),
             new Capture.TestCase(
@@ -345,8 +345,8 @@ public class TestSnippetTag extends JavadocTester {
                 """,
                 """
                 error: unexpected content
-                {@snippet
-                ^
+                 :}
+                 ^
                 """),
             new Capture.TestCase(
                 """
@@ -355,8 +355,8 @@ public class TestSnippetTag extends JavadocTester {
                 """,
                 """
                 error: unexpected content
-                {@snippet
-                ^
+                 : }
+                 ^
                 """),
             new Capture.TestCase(
                 """
@@ -365,8 +365,8 @@ public class TestSnippetTag extends JavadocTester {
                 """,
                 """
                 error: unexpected content
-                {@snippet
-                ^
+                 :a}
+                 ^
                 """),
             // </editor-fold>
             // <editor-fold desc="unexpected end of attribute">
@@ -381,7 +381,7 @@ public class TestSnippetTag extends JavadocTester {
                 """
                 error: no content
                 {@snippet file="}
-                ^
+                                ^
                 """),
             new Capture.TestCase(
                 """
@@ -390,7 +390,7 @@ public class TestSnippetTag extends JavadocTester {
                 """,
                 """
                 error: no content
-                {@snippet file="
+                }
                 ^
                 """),
             new Capture.TestCase(
@@ -400,7 +400,7 @@ public class TestSnippetTag extends JavadocTester {
                 """
                 error: no content
                 {@snippet file='}
-                ^
+                                ^
                 """),
             new Capture.TestCase(
                 """
@@ -409,7 +409,7 @@ public class TestSnippetTag extends JavadocTester {
                 """,
                 """
                 error: no content
-                {@snippet file='
+                }
                 ^
                 """),
             new Capture.TestCase(
@@ -419,8 +419,8 @@ public class TestSnippetTag extends JavadocTester {
                 """,
                 """
                 error: no content
-                {@snippet file='
-                ^
+                    }
+                    ^
                 """),
             new Capture.TestCase(
                 """
@@ -430,8 +430,8 @@ public class TestSnippetTag extends JavadocTester {
                 """,
                 """
                 error: no content
-                {@snippet
-                ^
+                    }
+                    ^
                 """),
             new Capture.TestCase(
                 """
@@ -440,8 +440,8 @@ public class TestSnippetTag extends JavadocTester {
                 """,
                 """
                 error: no content
-                {@snippet
-                ^
+                file='}
+                      ^
                 """),
             // </editor-fold>
             // <editor-fold desc="missing attribute value">
@@ -484,7 +484,7 @@ public class TestSnippetTag extends JavadocTester {
                 """
                 error: unexpected content
                 {@snippet file=:}
-                ^
+                               ^
                 """),
             new Capture.TestCase(
                 """
@@ -493,7 +493,7 @@ public class TestSnippetTag extends JavadocTester {
                 """
                 error: no content
                 {@snippet
-                ^
+                        ^
                 """),
             new Capture.TestCase(
                 """
@@ -502,7 +502,7 @@ public class TestSnippetTag extends JavadocTester {
                 """
                 error: no content
                 {@snippet file
-                ^
+                             ^
                 """),
             new Capture.TestCase(
                 """
@@ -511,7 +511,7 @@ public class TestSnippetTag extends JavadocTester {
                 """
                 error: no content
                 {@snippet file=
-                ^
+                              ^
                 """),
             new Capture.TestCase(
                 """
@@ -520,7 +520,7 @@ public class TestSnippetTag extends JavadocTester {
                 """
                 error: no content
                 {@snippet file="
-                ^
+                               ^
                 """),
             new Capture.TestCase(
                 """
@@ -529,7 +529,7 @@ public class TestSnippetTag extends JavadocTester {
                 """
                 error: no content
                 {@snippet file='
-                ^
+                               ^
                 """),
             new Capture.TestCase(
                 """
@@ -537,7 +537,7 @@ public class TestSnippetTag extends JavadocTester {
                 """
                 error: no content
                 {@snippet :*/
-                ^
+                          ^
                 """),
             new Capture.TestCase(
                 """
@@ -545,8 +545,8 @@ public class TestSnippetTag extends JavadocTester {
                     Hello, World!""",
                 """
                 error: unterminated inline tag
-                {@snippet :
-                ^
+                    Hello, World!*/
+                                ^
                 """),
             new Capture.TestCase(
                 """
@@ -555,7 +555,7 @@ public class TestSnippetTag extends JavadocTester {
                 """
                 error: no content
                 {@snippet file="gibberish" :*/
-                ^
+                                           ^
                 """),
             new Capture.TestCase(
                 """
@@ -564,7 +564,7 @@ public class TestSnippetTag extends JavadocTester {
                 """
                 error: unterminated inline tag
                 {@snippet file="gibberish" :
-                ^
+                                           ^
                 """)
             // </editor-fold>
         ));


### PR DESCRIPTION
Please review the update to `TestSnippetTag.java`, to update the "expected error"  lines and caret positions, due to the improvements in JDK-8273244.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274744](https://bugs.openjdk.java.net/browse/JDK-8274744): TestSnippetTag test fails after recent integration


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5812/head:pull/5812` \
`$ git checkout pull/5812`

Update a local copy of the PR: \
`$ git checkout pull/5812` \
`$ git pull https://git.openjdk.java.net/jdk pull/5812/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5812`

View PR using the GUI difftool: \
`$ git pr show -t 5812`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5812.diff">https://git.openjdk.java.net/jdk/pull/5812.diff</a>

</details>
