### PR TITLE
JDK-8274729: Define Position.NOPOS == Diagnostic.NOPOS

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Position.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Position.java
@@ -29,6 +29,8 @@ import java.util.BitSet;
 
 import com.sun.tools.javac.util.DefinedBy.Api;
 
+import javax.tools.Diagnostic;
+
 import static com.sun.tools.javac.util.LayoutCharacters.*;
 
 /** A class that defines source code positions as simple character
@@ -45,7 +47,7 @@ import static com.sun.tools.javac.util.LayoutCharacters.*;
  *  deletion without notice.</b>
  */
 public class Position {
-    public static final int NOPOS        = -1;
+    public static final int NOPOS        = (int) Diagnostic.NOPOS;
 
     public static final int FIRSTPOS     = 0;
     public static final int FIRSTLINE    = 1;


### PR DESCRIPTION
Please review a trivial change to formally connect `Position.NOPOS` and `Diagnostic.NOPOS`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274729](https://bugs.openjdk.java.net/browse/JDK-8274729): Define Position.NOPOS == Diagnostic.NOPOS


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5813/head:pull/5813` \
`$ git checkout pull/5813`

Update a local copy of the PR: \
`$ git checkout pull/5813` \
`$ git pull https://git.openjdk.java.net/jdk pull/5813/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5813`

View PR using the GUI difftool: \
`$ git pr show -t 5813`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5813.diff">https://git.openjdk.java.net/jdk/pull/5813.diff</a>

</details>
