### PR TITLE
8274730: AArch64: AES/GCM acceleration is broken by the fix for JDK-8273297

### DIFF
--- a/src/hotspot/cpu/aarch64/matcher_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/matcher_aarch64.hpp
@@ -56,7 +56,7 @@
   static const bool supports_generic_vector_operands = false;
 
   // No support for 48 extra htbl entries in aes-gcm intrinsic
-  static const int htbl_entries = -1;
+  static const int htbl_entries = 0;
 
   static constexpr bool isSimpleConstant64(jlong value) {
     // Will one (StoreL ConL) be cheaper than two (StoreI ConI)?.

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -3094,7 +3094,8 @@ class StubGenerator: public StubCodeGenerator {
   // key = c_rarg4
   // state = c_rarg5 - GHASH.state
   // subkeyHtbl = c_rarg6 - powers of H
-  // counter = c_rarg7 - pointer to 16 bytes of CTR
+  // subkeyHtbl_48_entries = c_rarg7 (not used)
+  // counter = [sp, #0] pointer to 16 bytes of CTR
   // return - number of processed bytes
   address generate_galoisCounterMode_AESCrypt() {
     address ghash_polynomial = __ pc();
@@ -3107,6 +3108,8 @@ class StubGenerator: public StubCodeGenerator {
     __ align(CodeEntryAlignment);
      StubCodeMark mark(this, "StubRoutines", "galoisCounterMode_AESCrypt");
     address start = __ pc();
+    __ enter();
+
     const Register in = c_rarg0;
     const Register len = c_rarg1;
     const Register ct = c_rarg2;
@@ -3118,10 +3121,12 @@ class StubGenerator: public StubCodeGenerator {
 
     const Register subkeyHtbl = c_rarg6;
 
+    // Pointer to CTR is passed on the stack before the (fp, lr) pair.
+    const Address counter_mem(sp, 2 * wordSize);
     const Register counter = c_rarg7;
+    __ ldr(counter, counter_mem);
 
     const Register keylen = r10;
-    __ enter();
     // Save state before entering routine
     __ sub(sp, sp, 4 * 16);
     __ st1(v12, v13, v14, v15, __ T16B, Address(sp));

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -6794,14 +6794,20 @@ bool LibraryCallKit::inline_galoisCounterMode_AESCrypt() {
   ciKlass* klass = ciTypeArrayKlass::make(T_LONG);
   Node* klass_node = makecon(TypeKlassPtr::make(klass));
 
-  // htbl entries is set to 96 only fox x86-64
+  // Does this target support this intrinsic?
   if (Matcher::htbl_entries == -1) return false;
 
   // new array to hold 48 computed htbl entries
-  Node* subkeyHtbl_48_entries = new_array(klass_node, intcon(Matcher::htbl_entries), 0);
-  if (subkeyHtbl_48_entries == NULL) return false;
-
-  Node* subkeyHtbl_48_entries_start = array_element_address(subkeyHtbl_48_entries, intcon(0), T_LONG);
+  Node* subkeyHtbl_48_entries_start;
+  if (Matcher::htbl_entries != 0) {
+    Node* subkeyHtbl_48_entries = new_array(klass_node, intcon(Matcher::htbl_entries), 0);
+    if (subkeyHtbl_48_entries == NULL) return false;
+    subkeyHtbl_48_entries_start
+      = array_element_address(subkeyHtbl_48_entries, intcon(0), T_LONG);
+  } else {
+    // This target doesn't need the extra-large Htbl.
+    subkeyHtbl_48_entries_start = ConvL2X(intcon(0));
+  }
 
   // Call the stub, passing params
   Node* gcmCrypt = make_runtime_call(RC_LEAF|RC_NO_FP,

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -6797,13 +6797,12 @@ bool LibraryCallKit::inline_galoisCounterMode_AESCrypt() {
   // Does this target support this intrinsic?
   if (Matcher::htbl_entries == -1) return false;
 
-  // new array to hold 48 computed htbl entries
   Node* subkeyHtbl_48_entries_start;
   if (Matcher::htbl_entries != 0) {
+    // new array to hold 48 computed htbl entries
     Node* subkeyHtbl_48_entries = new_array(klass_node, intcon(Matcher::htbl_entries), 0);
     if (subkeyHtbl_48_entries == NULL) return false;
-    subkeyHtbl_48_entries_start
-      = array_element_address(subkeyHtbl_48_entries, intcon(0), T_LONG);
+    subkeyHtbl_48_entries_start = array_element_address(subkeyHtbl_48_entries, intcon(0), T_LONG);
   } else {
     // This target doesn't need the extra-large Htbl.
     subkeyHtbl_48_entries_start = ConvL2X(intcon(0));


### PR DESCRIPTION
The recent AES/GCM acceleration on AArch64 was broken by https://bugs.openjdk.java.net/browse/JDK-8273297 . This was entirely expected, and I approved the patch, but now we must make AArch64 acceleration work again. 
The only significant change from the point of view of this patch is that one argument was added to the call to the intrinsic, and that argument caused another argument to spill onto the stack.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274730](https://bugs.openjdk.java.net/browse/JDK-8274730): AArch64: AES/GCM acceleration is broken by the fix for JDK-8273297


### Reviewers
 * [Andrew Dinn](https://openjdk.java.net/census#adinn) (@adinn - **Reviewer**) ⚠️ Review applies to adfcc75cd34425b020f4cd868a628491c7fc6947
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**) ⚠️ Review applies to adfcc75cd34425b020f4cd868a628491c7fc6947
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5819/head:pull/5819` \
`$ git checkout pull/5819`

Update a local copy of the PR: \
`$ git checkout pull/5819` \
`$ git pull https://git.openjdk.java.net/jdk pull/5819/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5819`

View PR using the GUI difftool: \
`$ git pr show -t 5819`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5819.diff">https://git.openjdk.java.net/jdk/pull/5819.diff</a>

</details>
