### PR TITLE
8274773: [TESTBUG] UnsafeIntrinsicsTest intermittently fails on weak memory model platform

### DIFF
--- a/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
@@ -289,6 +289,7 @@ class Runner implements Runnable {
     private Node mergeImplLoad(Node startNode, Node expectedNext, Node head) {
         // Atomic load version
         Node temp = (Node) UNSAFE.getReference(startNode, offset);
+        UNSAFE.storeFence(); // Make all new Node fields visible to concurrent readers.
         startNode.setNext(head);
         return temp;
     }


### PR DESCRIPTION
The test creates new Nodes and publishes them to concurrent readers. This requires at least release and load_consume. A clean fix would be to make `Node.next` volatile. But that would be a sledgehammer. A minimalistic fix for our supported weak memory model platforms is to insert a `storeFence`. What is better?
(See JBS for failure description.)
