### PR TITLE
8274780: ChannelInputStream.readNBytes(int) incorrectly calls readAll…

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
@@ -168,7 +168,7 @@ public class ChannelInputStream
             return new byte[0];
 
         if (!(ch instanceof SeekableByteChannel sbc))
-            return super.readAllBytes();
+            return super.readNBytes(len);
 
         long length = sbc.size();
         long position = sbc.position();


### PR DESCRIPTION
…Bytes()