### PR TITLE
8274793: Suppress warnings on non-serializable non-transient instance fields in sun.net

### DIFF
--- a/src/java.base/share/classes/sun/net/www/http/KeepAliveCache.java
+++ b/src/java.base/share/classes/sun/net/www/http/KeepAliveCache.java
@@ -79,6 +79,7 @@ public class KeepAliveCache
 
     // This class is never serialized (see writeObject/readObject).
     private final ReentrantLock cacheLock = new ReentrantLock();
+    @SuppressWarnings("serial") // Type of field is not Serializable
     private Thread keepAliveTimer = null;
 
     /**

--- a/src/java.base/unix/classes/sun/net/www/protocol/http/ntlm/NTLMAuthentication.java
+++ b/src/java.base/unix/classes/sun/net/www/protocol/http/ntlm/NTLMAuthentication.java
@@ -119,8 +119,10 @@ public class NTLMAuthentication extends AuthenticationInfo {
         });
     };
 
+    @SuppressWarnings("serial") // Type of field is not Serializable
     PasswordAuthentication pw;
 
+    @SuppressWarnings("serial") // Type of field is not Serializable
     Client client;
     /**
      * Create a NTLMAuthentication:


### PR DESCRIPTION
Augmentations to javac's Xlint:serial checking are out for review (#5709) and the sun.net classes in this PR would need some changes to pass under the expanded checks.

The changes are to suppress warnings where non-transient fields in serializable types are not declared with a type statically known to be serializable. That isn't necessarily a correctness issues, but it does merit further scrutiny.

The changes in the PR are consistent with similar changes made in JDK libraries under the umbrella issue JDK-8231641.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274793](https://bugs.openjdk.java.net/browse/JDK-8274793): Suppress warnings on non-serializable non-transient instance fields in sun.net


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5826/head:pull/5826` \
`$ git checkout pull/5826`

Update a local copy of the PR: \
`$ git checkout pull/5826` \
`$ git pull https://git.openjdk.java.net/jdk pull/5826/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5826`

View PR using the GUI difftool: \
`$ git pr show -t 5826`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5826.diff">https://git.openjdk.java.net/jdk/pull/5826.diff</a>

</details>
