### PR TITLE
8217496: Matcher.group() can return null after usePattern

### DIFF
--- a/src/java.base/share/classes/java/util/regex/Matcher.java
+++ b/src/java.base/share/classes/java/util/regex/Matcher.java
@@ -593,7 +593,9 @@ public final class Matcher implements MatchResult {
      * successfully matches the empty string in the input.  </p>
      *
      * @return The (possibly empty) subsequence matched by the previous match,
-     *         in string form
+     *         in string form or {@code null} if a matcher with a previous
+     *         match has been changed to a new {@link java.util.regex.Pattern},
+     *         but no new match has yet been attempted
      *
      * @throws  IllegalStateException
      *          If no match has yet been attempted,
@@ -629,7 +631,9 @@ public final class Matcher implements MatchResult {
      *
      * @return  The (possibly empty) subsequence captured by the group
      *          during the previous match, or {@code null} if the group
-     *          failed to match part of the input
+     *          failed to match part of the input or if the matcher's
+     *          {@link java.util.regex.Pattern} has changed but a new match has
+     *          not been attempted
      *
      * @throws  IllegalStateException
      *          If no match has yet been attempted,


### PR DESCRIPTION
Specification update to clarify Matcher behavior to include a null return value.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ The change requires a CSR request to be approved.

### Issue
 * [JDK-8217496](https://bugs.openjdk.java.net/browse/JDK-8217496): Matcher.group() can return null after usePattern


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5827/head:pull/5827` \
`$ git checkout pull/5827`

Update a local copy of the PR: \
`$ git checkout pull/5827` \
`$ git pull https://git.openjdk.java.net/jdk pull/5827/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5827`

View PR using the GUI difftool: \
`$ git pr show -t 5827`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5827.diff">https://git.openjdk.java.net/jdk/pull/5827.diff</a>

</details>
