### PR TITLE
8274797: ProblemList resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java on macosx-x64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -120,6 +120,8 @@ serviceability/sa/ClhsdbFindPC.java#xcomp-core 8269982 macosx-aarch64
 serviceability/sa/ClhsdbFindPC.java#no-xcomp-core 8269982 macosx-aarch64
 serviceability/sa/ClhsdbPstack.java#core 8269982 macosx-aarch64
 
+resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java 8274620 macosx-x64
+
 #############################################################################
 
 # :hotspot_misc


### PR DESCRIPTION
A trivial fix to ProblemList resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java
on macosx-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274797](https://bugs.openjdk.java.net/browse/JDK-8274797): ProblemList resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java on macosx-x64


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5829/head:pull/5829` \
`$ git checkout pull/5829`

Update a local copy of the PR: \
`$ git checkout pull/5829` \
`$ git pull https://git.openjdk.java.net/jdk pull/5829/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5829`

View PR using the GUI difftool: \
`$ git pr show -t 5829`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5829.diff">https://git.openjdk.java.net/jdk/pull/5829.diff</a>

</details>
