### PR TITLE
JDK-8274211: Test man page that options are documented

### DIFF
--- a/test/langtools/jdk/javadoc/tool/CheckManPageOptions.java
+++ b/test/langtools/jdk/javadoc/tool/CheckManPageOptions.java
@@ -60,7 +60,7 @@ public class CheckManPageOptions {
 
     static final PrintStream out = System.err;
 
-    // FIXME: JDK-8274295
+    // FIXME: JDK-8274295, JDK-8266666
     List<String> MISSING_IN_MAN_PAGE = List.of(
             "--legal-notices",
             "--link-platform-properties",
@@ -92,7 +92,7 @@ public class CheckManPageOptions {
         toolDocletOnly.removeAll(manPageOptions);
         toolDocletOnly.removeAll(MISSING_IN_MAN_PAGE);
         if (!toolDocletOnly.isEmpty()) {
-            error(" The following options are defined by the tool or doclet, but not defined in the man page:\n"
+            error("The following options are defined by the tool or doclet, but not defined in the man page:\n"
                     + toSimpleList(toolDocletOnly));
         }
 


### PR DESCRIPTION
Please review a new test to compare the set of options documented in the javadoc man page against the set of options declared in the source.

Since there is currently a disparity, an "exception" mechanism is included so that the test can pass.   When the options have been added to the man page, this test is designed to fail, and the relevant strings should be removed from the `MISSING_IN_MAN_PAGE` list.

Test runs on all supported platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274211](https://bugs.openjdk.java.net/browse/JDK-8274211): Test man page that options are documented


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**) ⚠️ Review applies to 81315dc25e49fb7515d2abb23d008fe7963650c9


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5833/head:pull/5833` \
`$ git checkout pull/5833`

Update a local copy of the PR: \
`$ git checkout pull/5833` \
`$ git pull https://git.openjdk.java.net/jdk pull/5833/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5833`

View PR using the GUI difftool: \
`$ git pr show -t 5833`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5833.diff">https://git.openjdk.java.net/jdk/pull/5833.diff</a>

</details>
