### PR TITLE
8274882: Cleanup redundant boxing in java.desktop

### DIFF
--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java
@@ -1708,7 +1708,7 @@ class Metacity implements SynthConstants {
     protected boolean getBooleanAttr(Node node, String name, boolean fallback) {
         String str = getStringAttr(node, name);
         if (str != null) {
-            return Boolean.valueOf(str).booleanValue();
+            return Boolean.parseBoolean(str);
         }
         return fallback;
     }

--- a/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
+++ b/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
@@ -78,7 +78,7 @@ public class SwingUtilities implements SwingConstants
     @SuppressWarnings("removal")
     private static boolean getSuppressDropTarget() {
         if (!checkedSuppressDropSupport) {
-            suppressDropSupport = Boolean.valueOf(
+            suppressDropSupport = Boolean.parseBoolean(
                 AccessController.doPrivileged(
                     new GetPropertyAction("suppressSwingDropSupport")));
             checkedSuppressDropSupport = true;

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
@@ -125,8 +125,7 @@ public class MetalLookAndFeel extends BasicLookAndFeel
                 @SuppressWarnings("removal")
                 String systemFonts = AccessController.doPrivileged(
                     new GetPropertyAction("swing.useSystemFontSettings"));
-                useSystemFonts = (systemFonts != null &&
-                               (Boolean.valueOf(systemFonts).booleanValue()));
+                useSystemFonts = Boolean.parseBoolean(systemFonts);
             }
             checkedWindows = true;
         }
@@ -1398,8 +1397,8 @@ public class MetalLookAndFeel extends BasicLookAndFeel
             "Tree.openIcon",(LazyValue) t -> MetalIconFactory.getTreeFolderIcon(),
             "Tree.closedIcon",(LazyValue) t -> MetalIconFactory.getTreeFolderIcon(),
             "Tree.leafIcon",(LazyValue) t -> MetalIconFactory.getTreeLeafIcon(),
-            "Tree.expandedIcon",(LazyValue) t -> MetalIconFactory.getTreeControlIcon(Boolean.valueOf(MetalIconFactory.DARK)),
-            "Tree.collapsedIcon",(LazyValue) t -> MetalIconFactory.getTreeControlIcon(Boolean.valueOf( MetalIconFactory.LIGHT )),
+            "Tree.expandedIcon",(LazyValue) t -> MetalIconFactory.getTreeControlIcon(MetalIconFactory.DARK),
+            "Tree.collapsedIcon",(LazyValue) t -> MetalIconFactory.getTreeControlIcon(MetalIconFactory.LIGHT),
 
             "Tree.line", primaryControl, // horiz lines
             "Tree.hash", primaryControl,  // legs

--- a/src/java.desktop/share/classes/sun/awt/SunToolkit.java
+++ b/src/java.desktop/share/classes/sun/awt/SunToolkit.java
@@ -127,7 +127,7 @@ public abstract class SunToolkit extends Toolkit
         if (AccessController.doPrivileged(new GetBooleanAction("sun.awt.nativedebug"))) {
             DebugSettings.init();
         }
-        touchKeyboardAutoShowIsEnabled = Boolean.valueOf(
+        touchKeyboardAutoShowIsEnabled = Boolean.parseBoolean(
             GetPropertyAction.privilegedGetProperty(
                 "awt.touchKeyboardAutoShowIsEnabled", "true"));
     };
@@ -1767,8 +1767,7 @@ public abstract class SunToolkit extends Toolkit
                          new GetPropertyAction("awt.useSystemAAFontSettings"));
             }
             if (systemAAFonts != null) {
-                useSystemAAFontSettings =
-                    Boolean.valueOf(systemAAFonts).booleanValue();
+                useSystemAAFontSettings = Boolean.parseBoolean(systemAAFonts);
                 /* If it is anything other than "true", then it may be
                  * a hint name , or it may be "off, "default", etc.
                  */

--- a/src/java.desktop/share/classes/sun/awt/image/VSyncedBSManager.java
+++ b/src/java.desktop/share/classes/sun/awt/image/VSyncedBSManager.java
@@ -37,7 +37,7 @@ public abstract class VSyncedBSManager {
 
     @SuppressWarnings("removal")
     private static final boolean vSyncLimit =
-        Boolean.valueOf(java.security.AccessController.doPrivileged(
+        Boolean.parseBoolean(java.security.AccessController.doPrivileged(
                 new sun.security.action.GetPropertyAction(
                     "sun.java2d.vsynclimit", "true")));
 

--- a/src/java.desktop/share/classes/sun/java2d/marlin/MarlinProperties.java
+++ b/src/java.desktop/share/classes/sun/java2d/marlin/MarlinProperties.java
@@ -241,7 +241,7 @@ public final class MarlinProperties {
     // system property utilities
     @SuppressWarnings("removal")
     static boolean getBoolean(final String key, final String def) {
-        return Boolean.valueOf(AccessController.doPrivileged(
+        return Boolean.parseBoolean(AccessController.doPrivileged(
                   new GetPropertyAction(key, def)));
     }
 

--- a/src/java.desktop/unix/classes/sun/awt/X11/MotifColorUtilities.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/MotifColorUtilities.java
@@ -428,9 +428,9 @@ class MotifColorUtilities {
         for (int i=0;i<8;i++) {
             temp = bfr.readLine();
             color = temp.substring(1,temp.length());
-            r = Integer.valueOf(color.substring(0,4),16).intValue() >> 8;
-            g = Integer.valueOf(color.substring(4,8),16).intValue() >> 8;
-            b = Integer.valueOf(color.substring(8,12),16).intValue() >> 8;
+            r = Integer.parseInt(color.substring(0, 4), 16) >> 8;
+            g = Integer.parseInt(color.substring(4, 8), 16) >> 8;
+            b = Integer.parseInt(color.substring(8, 12), 16) >> 8;
             colors[i] = 0xff000000 | r<<16 | g<<8 | b;
             //  System.out.println("color["+i+"]="+Integer.toHexString(colors[i]) + "r = " +r + "g="+g+"b="+b);
         }

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsLookAndFeel.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsLookAndFeel.java
@@ -186,8 +186,7 @@ public class WindowsLookAndFeel extends BasicLookAndFeel
         @SuppressWarnings("removal")
         String systemFonts = java.security.AccessController.doPrivileged(
                new GetPropertyAction("swing.useSystemFontSettings"));
-        useSystemFontSettings = (systemFonts == null ||
-                                 Boolean.valueOf(systemFonts).booleanValue());
+        useSystemFontSettings = systemFonts == null || Boolean.parseBoolean(systemFonts);
 
         if (useSystemFontSettings) {
             Object value = UIManager.get("Application.useSystemFontSettings");

--- a/src/java.desktop/windows/classes/sun/awt/windows/TranslucentWindowPainter.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/TranslucentWindowPainter.java
@@ -68,11 +68,11 @@ abstract class TranslucentWindowPainter {
     // REMIND: we probably would want to remove this later
     @SuppressWarnings("removal")
     private static final boolean forceOpt  =
-        Boolean.valueOf(AccessController.doPrivileged(
+        Boolean.parseBoolean(AccessController.doPrivileged(
             new GetPropertyAction("sun.java2d.twp.forceopt", "false")));
     @SuppressWarnings("removal")
     private static final boolean forceSW  =
-        Boolean.valueOf(AccessController.doPrivileged(
+        Boolean.parseBoolean(AccessController.doPrivileged(
             new GetPropertyAction("sun.java2d.twp.forcesw", "false")));
 
     /**


### PR DESCRIPTION
I missed a few places in https://bugs.openjdk.java.net/browse/JDK-8273168

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274882](https://bugs.openjdk.java.net/browse/JDK-8274882): Cleanup redundant boxing in java.desktop


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5834/head:pull/5834` \
`$ git checkout pull/5834`

Update a local copy of the PR: \
`$ git checkout pull/5834` \
`$ git pull https://git.openjdk.java.net/jdk pull/5834/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5834`

View PR using the GUI difftool: \
`$ git pr show -t 5834`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5834.diff">https://git.openjdk.java.net/jdk/pull/5834.diff</a>

</details>
