### PR TITLE
8274838: runtime/cds/appcds/TestSerialGCWithCDS.java fails on Windows

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/TestSerialGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestSerialGCWithCDS.java
@@ -118,7 +118,7 @@ public class TestSerialGCWithCDS {
                     String exp1 = "Too small maximum heap";
                     String exp2 = "GC triggered before VM initialization completed";
                     if (!output.contains(exp1) && !output.contains(exp2)) {
-                        throw new RuntimeException("'" + exp1 + "' or '" + exp2 + "' missing from stdout/stderr \n");
+                        throw new RuntimeException("Either '" + exp1 + "' or '" + exp2 + "' must be in stdout/stderr \n");
                     }
                 }
                 n++;


### PR DESCRIPTION
Hi all,

runtime/cds/appcds/TestSerialGCWithCDS.java fails on our Windows hosts.

This is because the failure msgs are different with `-Xmx2m` and `-Xmx1m` on Windows.
```
# ./java -Xmx2m -XX:+UseSerialGC -XX:ObjectAlignmentInBytes=64 -version
Error occurred during initialization of VM
GC triggered before VM initialization completed. Try increasing NewSize, current value 640K.

#  ./java -Xmx1m -XX:+UseSerialGC -XX:ObjectAlignmentInBytes=64 -version
Error occurred during initialization of VM
Too small maximum heap
```

The test only handles the `-Xmx1m` msg but fails with `-Xmx2m`.
The fix takes both error msgs into consideration.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274838](https://bugs.openjdk.java.net/browse/JDK-8274838): runtime/cds/appcds/TestSerialGCWithCDS.java fails on Windows


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to b6d75f66b6bbd7740c2297baa1c4bd1deb12c3d9
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5839/head:pull/5839` \
`$ git checkout pull/5839`

Update a local copy of the PR: \
`$ git checkout pull/5839` \
`$ git pull https://git.openjdk.java.net/jdk pull/5839/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5839`

View PR using the GUI difftool: \
`$ git pr show -t 5839`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5839.diff">https://git.openjdk.java.net/jdk/pull/5839.diff</a>

</details>
