### PR TITLE
8274945: Cleanup unnecessary calls to Throwable.initCause() in java.desktop

### DIFF
--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/MarkerSegment.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/MarkerSegment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,11 +98,8 @@ class MarkerSegment implements Cloneable {
             try {
                 data = (byte []) iioNode.getUserObject();
             } catch (Exception e) {
-                IIOInvalidTreeException newGuy =
-                    new IIOInvalidTreeException
-                    ("Can't get User Object", node);
-                newGuy.initCause(e);
-                throw newGuy;
+                throw new IIOInvalidTreeException
+                        ("Can't get User Object", e, node);
             }
         } else {
             throw new IIOInvalidTreeException

--- a/src/java.desktop/share/classes/javax/imageio/metadata/IIOMetadata.java
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/IIOMetadata.java
@@ -407,10 +407,7 @@ public abstract class IIOMetadata {
             Method meth = cls.getMethod("getInstance");
             return (IIOMetadataFormat) meth.invoke(null);
         } catch (Exception e) {
-            RuntimeException ex =
-                new IllegalStateException ("Can't obtain format");
-            ex.initCause(e);
-            throw ex;
+            throw new IllegalStateException("Can't obtain format", e);
         }
     }
 

--- a/src/java.desktop/share/classes/javax/imageio/spi/ImageReaderWriterSpi.java
+++ b/src/java.desktop/share/classes/javax/imageio/spi/ImageReaderWriterSpi.java
@@ -25,18 +25,12 @@
 
 package javax.imageio.spi;
 
-import java.io.IOException;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.Arrays;
-import java.util.Iterator;
-import javax.imageio.ImageReader;
 import javax.imageio.metadata.IIOMetadata;
 import javax.imageio.metadata.IIOMetadataFormat;
 import javax.imageio.metadata.IIOMetadataFormatImpl;
-import javax.imageio.stream.ImageInputStream;
 
 /**
  * A superclass containing instance variables and methods common to
@@ -597,10 +591,7 @@ public abstract class ImageReaderWriterSpi extends IIOServiceProvider {
             Method meth = cls.getMethod("getInstance");
             return (IIOMetadataFormat) meth.invoke(null);
         } catch (Exception e) {
-            RuntimeException ex =
-                new IllegalStateException ("Can't obtain format");
-            ex.initCause(e);
-            throw ex;
+            throw new IllegalStateException("Can't obtain format", e);
         }
     }
 

--- a/src/java.desktop/share/classes/sun/awt/datatransfer/TransferableProxy.java
+++ b/src/java.desktop/share/classes/sun/awt/datatransfer/TransferableProxy.java
@@ -91,7 +91,7 @@ public class TransferableProxy implements Transferable {
                                                      oos.getClassLoaderMap());
                 data = ois.readObject();
             } catch (ClassNotFoundException cnfe) {
-                throw (IOException)new IOException().initCause(cnfe);
+                throw new IOException(cnfe);
             }
         }
 


### PR DESCRIPTION
Pass cause exception as constructor parameter is shorter and easier to read.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274945](https://bugs.openjdk.java.net/browse/JDK-8274945): Cleanup unnecessary calls to Throwable.initCause() in java.desktop


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5847/head:pull/5847` \
`$ git checkout pull/5847`

Update a local copy of the PR: \
`$ git checkout pull/5847` \
`$ git pull https://git.openjdk.java.net/jdk pull/5847/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5847`

View PR using the GUI difftool: \
`$ git pr show -t 5847`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5847.diff">https://git.openjdk.java.net/jdk/pull/5847.diff</a>

</details>
