### PR TITLE
8274687: JDWP deadlocks if some Java thread reaches wait in blockOnDebuggerSuspend

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/debugLoop.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/debugLoop.c
@@ -180,9 +180,6 @@ debugLoop_run(void)
             shouldListen = !lastCommand(cmd);
         }
     }
-    /* Sleep to trigger deadlock in test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003 */
-    fprintf(stderr, "debugLoop: sleep\n");
-    sleep(1);
     threadControl_onDisconnect();
     standardHandlers_onDisconnect();
 

--- a/src/jdk.jdwp.agent/share/native/libjdwp/debugLoop.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/debugLoop.c
@@ -180,6 +180,9 @@ debugLoop_run(void)
             shouldListen = !lastCommand(cmd);
         }
     }
+    /* Sleep to trigger deadlock in test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003 */
+    fprintf(stderr, "debugLoop: sleep\n");
+    sleep(1);
     threadControl_onDisconnect();
     standardHandlers_onDisconnect();
 

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -756,6 +756,9 @@ blockOnDebuggerSuspend(jthread thread)
     }
 }
 
+/*
+ * The caller is expected to hold threadLock. It will be temporarily released though.
+ */
 static void
 trackAppResume(jthread thread)
 {
@@ -764,11 +767,12 @@ trackAppResume(jthread thread)
     ThreadNode *node;
 
     /*
-     * Set up the tracking of the Thread.resume() call. This requires
-     * handlerLock which has to be acquired before threadLock.
+     * Set up the tracking of the Thread.resume() call.
+     * This requires handlerLock during eventHandler_createInternalThreadOnly()
+     * calls. For proper lock order handlerLock has to be acquired before threadLock.
      */
     debugMonitorExit(threadLock);
-    eventHandler_lock(); /* for proper lock order */
+    eventHandler_lock();
     debugMonitorEnter(threadLock);
 
     fnum = 0;

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -2186,7 +2186,7 @@ doPendingTasks(JNIEnv *env, ThreadNode *node)
         jthread resumee = getResumee(resumer);
 
         /*
-         * trackAppResume() (indirectly) aquires handlerLock. For proper lock
+         * trackAppResume indirectly aquires handlerLock. For proper lock
          * ordering handlerLock has to be acquired before threadLock.
          */
         debugMonitorExit(threadLock);

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -2207,9 +2207,11 @@ doPendingTasks(JNIEnv *env, ThreadNode *node)
         }
 
         /*
-         * handlerLock is not needed anymore. We release it before calling
-         * blockOnDebuggerSuspend() because it is required for resumes by the
-         * debugger so we cannot wait for that holding handlerLock.
+         * handlerLock is not needed anymore. We must release it before calling
+         * blockOnDebuggerSuspend() because it is required for resumes done by
+         * the debugger. If resumee is currently suspended by the debugger, then
+         * blockOnDebuggerSuspend() will block until a debugger resume is done.
+         * If it blocks while holding the handlerLock, then the resume will deadlock.
          */
         eventHandler_unlock();
 

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -741,10 +741,11 @@ handleAppResumeCompletion(JNIEnv *env, EventInfo *evinfo,
 
 /*
  * The caller must own handlerLock and threadLock.
- * The current thread waits on threadLock if the suspendCount of the given
- * thread is greather than 0 but before it releases the handlerLock. This is
- * necessary because threadControl_resumeThread() and threadControl_resumeAll()
- * need it.
+ * If the suspendCount of the given thread is greater than 0, then the
+ * current thread will release the handlerLock and wait on the threadLock. It
+ * must release the handlerLock first, because threadControl_resumeThread()
+ * and threadControl_resumeAll() need it, and calling them is how suspendCount
+ * will eventually be decremented to 0.
  * handlerLock and threadLock are owned when returning and the suspendCount of
  * the given thread is 0.
  */

--- a/test/jdk/com/sun/jdi/ResumeAfterThreadResumeCallTest.java
+++ b/test/jdk/com/sun/jdi/ResumeAfterThreadResumeCallTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2021 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8274687
+ * @summary Test if a thread R can be resumed by ThreadReference.resume() and
+ *          check if another thread T is unblocked afterwards if T is blocked by
+ *          the JDWP agent (in blockOnDebuggerSuspend()) because it called
+ *          j.l.Thread.resume() on a thread R that was suspended by the
+ *          debugger.
+ * @author Richard Reingruber richard DOT reingruber AT sap DOT com
+ *
+ * @library /test/lib
+ *
+ * @run build TestScaffold VMConnection TargetListener TargetAdapter
+ * @run compile -g ResumeAfterThreadResumeCallTest.java
+ * @run driver ResumeAfterThreadResumeCallTest
+ */
+import com.sun.jdi.*;
+import com.sun.jdi.event.*;
+import jdk.test.lib.Asserts;
+
+import java.util.*;
+
+// Target program for the debugger
+class ResumeAfterThreadResumeCallTarg extends Thread {
+
+    public boolean reachedBreakpoint;
+    public boolean mainThreadReturnedFromResumeCall;
+    public boolean testFinished;
+
+    public ResumeAfterThreadResumeCallTarg(String name) {
+        super(name);
+    }
+
+    public static void log(String m) {
+        String threadName = Thread.currentThread().getName();
+        System.out.println();
+        System.out.println("###(Target,"+ threadName +") " + m);
+        System.out.println();
+    }
+
+    public static void main(String[] args) {
+        log("Entered main()");
+
+        // Start Resumee thread.
+        ResumeAfterThreadResumeCallTarg resumee = new ResumeAfterThreadResumeCallTarg("Resumee");
+        resumee.start();
+
+        // Wait for Resumee to reach the breakpoint in methodWithBreakpoint().
+        while (!resumee.reachedBreakpoint) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) { /* ignored */ }
+        }
+
+        // Resumee is suspended now because of the breakpoint
+        // Calling Thread.resume() will block this thread.
+
+        log("Calling Thread.resume()");
+        resumee.resume();
+        resumee.mainThreadReturnedFromResumeCall = true;
+        log("Thread.resume() returned");
+
+        // Wait for debugger
+        while (!resumee.testFinished) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) { /* ignored */ }
+        }
+    }
+
+    public void run() {
+        log("up and running.");
+        methodWithBreakpoint();
+    }
+
+    public void methodWithBreakpoint() {
+        log("Entered methodWithBreakpoint()");
+    }
+}
+
+
+// Debugger program
+
+public class ResumeAfterThreadResumeCallTest extends TestScaffold {
+    public static final String TARGET_CLS_NAME = ResumeAfterThreadResumeCallTarg.class.getName();
+    public static final long UNBLOCK_TIMEOUT = 10000;
+
+    ResumeAfterThreadResumeCallTest (String args[]) {
+        super(args);
+    }
+
+    public static void main(String[] args)      throws Exception {
+        new ResumeAfterThreadResumeCallTest(args).startTests();
+    }
+
+    /**
+     * Set a breakpoint in the given method and resume all threads. The
+     * breakpoint is configured to suspend just the thread that reaches it
+     * instead of all threads.
+     */
+    public BreakpointEvent resumeTo(String clsName, String methodName, String signature) {
+        boolean suspendThreadOnly = true;
+        return resumeTo(clsName, methodName, signature, suspendThreadOnly);
+    }
+
+    protected void runTests() throws Exception {
+        BreakpointEvent bpe = startToMain(TARGET_CLS_NAME);
+        mainThread = bpe.thread();
+
+        log("Resuming to methodWithBreakpoint()");
+        bpe = resumeTo(TARGET_CLS_NAME, "methodWithBreakpoint", "()V");
+
+        log("Resumee has reached the breakpoint and is suspended now.");
+        ThreadReference resumee = bpe.thread();
+        ObjectReference resumeeThreadObj = resumee.frame(1).thisObject();
+        printStack(resumee);
+        log("resumee.isSuspended() -> " + resumee.isSuspended());
+        log("mainThread.isSuspended() -> " + mainThread.isSuspended());
+        log("Notify target main thread to continue by setting reachedBreakpoint = true.");
+        setField(resumeeThreadObj, "reachedBreakpoint", vm().mirrorOf(true));
+
+        log("Sleeping 500ms shows that the main thread is blocked calling Thread.resume() on 'Resumee' Thread.");
+        Thread.sleep(500);
+        log("After sleep.");
+
+        boolean mainThreadReturnedFromResumeCall = false;
+        boolean resumedResumee = false;
+        for (long sleepTime = 50; sleepTime < UNBLOCK_TIMEOUT && !mainThreadReturnedFromResumeCall; sleepTime <<= 1) {
+            log("mainThread.isSuspended() -> " + mainThread.isSuspended());
+            Value v = getField(resumeeThreadObj, "mainThreadReturnedFromResumeCall");
+            mainThreadReturnedFromResumeCall = ((PrimitiveValue) v).booleanValue();
+            if (!resumedResumee) {
+                // main thread should be still blocked.
+                Asserts.assertFalse(mainThreadReturnedFromResumeCall, "main Thread was not blocked");
+                log("Resuming 'Resumee' will unblock the main thread.");
+                resumee.resume();
+                resumedResumee = true;
+            }
+            log("Sleeping " + sleepTime + "ms");
+            Thread.sleep(sleepTime);
+        }
+        Asserts.assertTrue(mainThreadReturnedFromResumeCall, "main Thread was not unblocked");
+
+        setField(resumeeThreadObj, "testFinished", vm().mirrorOf(true));
+
+        // Resume the target listening for events
+        listenUntilVMDisconnect();
+    }
+
+    public void printStack(ThreadReference thread) throws Exception {
+        log("Stack of thread '" + thread.name() + "':");
+        List<StackFrame> stack_frames = thread.frames();
+        int i = 0;
+        for (StackFrame ff : stack_frames) {
+            System.out.println("frame[" + i++ +"]: " + ff.location().method() + " (bci:" + ff.location().codeIndex() + ")");
+        }
+    }
+
+    public void setField(ObjectReference obj, String fName, Value val) throws Exception {
+        log("set field " + fName + " = " + val);
+        ReferenceType rt = obj.referenceType();
+        Field fld = rt.fieldByName(fName);
+        obj.setValue(fld, val);
+        log("ok");
+    }
+
+    public Value getField(ObjectReference obj, String fName) throws Exception {
+        log("get field " + fName);
+        ReferenceType rt = obj.referenceType();
+        Field fld = rt.fieldByName(fName);
+        Value val = obj.getValue(fld);
+        log("result : " + val);
+        return val;
+    }
+
+    public void log(String m) {
+        System.out.println();
+        System.out.println("###(Debugger) " + m);
+        System.out.println();
+    }
+}

--- a/test/jdk/com/sun/jdi/ResumeAfterThreadResumeCallTest.java
+++ b/test/jdk/com/sun/jdi/ResumeAfterThreadResumeCallTest.java
@@ -37,7 +37,7 @@
  *                  breakpoint in Thread.resume() so the JDWP agent receives a
  *                  breakpoint event. It finds that "resumee" is suspended because
  *                  of JDWP actions. The resume() call would interfere with the
- *                  debugger therefore "main" is blocked.
+ *                  debugger therefore "main" is blocked in JDWP's blockOnDebuggerSuspend().
  *
  *          Debugger: Resumes "resumee" by calling ThreadReference.resume().
  *                    The JDWP agent notifies "main" about it.
@@ -46,6 +46,8 @@
  *
  *          "main": Receives the notification, finds that "resumee" is not
  *                  suspended anymore and continues execution.
+ *
+ *          Debugger: Verifies that "main" is no longer blocked.
  *
  * @author Richard Reingruber richard DOT reingruber AT sap DOT com
  *

--- a/test/jdk/com/sun/jdi/ResumeAfterThreadResumeCallTest.java
+++ b/test/jdk/com/sun/jdi/ResumeAfterThreadResumeCallTest.java
@@ -37,7 +37,10 @@
  *                  breakpoint in Thread.resume() so the JDWP agent receives a
  *                  breakpoint event. It finds that "resumee" is suspended because
  *                  of JDWP actions. The resume() call would interfere with the
- *                  debugger therefore "main" is blocked in JDWP's blockOnDebuggerSuspend().
+ *                  debugger therefore "main" is blocked.
+ *
+ *          Debugger: Tests if the suspended "resumee" can be suspended a second
+ *                    time and resumes it again.
  *
  *          Debugger: Resumes "resumee" by calling ThreadReference.resume().
  *                    The JDWP agent notifies "main" about it.
@@ -178,8 +181,20 @@ public class ResumeAfterThreadResumeCallTest extends TestScaffold {
             if (!resumedResumee) {
                 // main thread should still be blocked.
                 Asserts.assertFalse(mainThreadReturnedFromResumeCall, "main Thread was not blocked");
-                log("Resuming \"resumee\" will unblock the main thread.");
+
+                // Test suspending the already suspended resumee thread.
+                Asserts.assertTrue(resumee.isSuspended(), "\"resumee\" is not suspended.");
+                log("Check if suspended \"resumee\" can be suspended a 2nd time.");
+                resumee.suspend();
+                log("resumee.isSuspended() -> " + resumee.isSuspended());
+                log("Resuming \"resumee\"");
                 resumee.resume();
+                Asserts.assertTrue(resumee.isSuspended(), "\"resumee\" is not suspended.");
+
+                // Really resume the resumee thread.
+                log("Resuming \"resumee\" a 2nd time will unblock the main thread.");
+                resumee.resume();
+                Asserts.assertFalse(resumee.isSuspended(), "\"resumee\" is still suspended.");
                 resumedResumee = true;
             }
             log("Sleeping " + sleepTime + "ms");

--- a/test/jdk/com/sun/jdi/ResumeAfterThreadResumeCallTest.java
+++ b/test/jdk/com/sun/jdi/ResumeAfterThreadResumeCallTest.java
@@ -76,9 +76,7 @@ class ResumeAfterThreadResumeCallTarg extends Thread {
 
     public static void log(String m) {
         String threadName = Thread.currentThread().getName();
-        System.out.println();
         System.out.println("###(Target,"+ threadName +") " + m);
-        System.out.println();
     }
 
     public static void main(String[] args) {
@@ -97,7 +95,6 @@ class ResumeAfterThreadResumeCallTarg extends Thread {
 
         // "resumee" is suspended now because of the breakpoint
         // Calling Thread.resume() will block this thread.
-
         log("Calling Thread.resume()");
         resumee.resume();
         resumee.mainThreadReturnedFromResumeCall = true;
@@ -157,14 +154,20 @@ public class ResumeAfterThreadResumeCallTest extends TestScaffold {
         ThreadReference resumee = bpe.thread();
         ObjectReference resumeeThreadObj = resumee.frame(1).thisObject();
         printStack(resumee);
+        mainThread.suspend();
+        printStack(mainThread);
+        mainThread.resume();
         log("resumee.isSuspended() -> " + resumee.isSuspended());
         log("mainThread.isSuspended() -> " + mainThread.isSuspended());
         log("Notify target main thread to continue by setting reachedBreakpoint = true.");
         setField(resumeeThreadObj, "reachedBreakpoint", vm().mirrorOf(true));
 
-        log("Sleeping 500ms shows that the main thread is blocked calling Thread.resume() on \"resumee\" Thread.");
+        log("Sleeping 500ms so that the main thread is blocked calling Thread.resume() on \"resumee\" Thread.");
         Thread.sleep(500);
         log("After sleep.");
+        mainThread.suspend();
+        printStack(mainThread);
+        mainThread.resume();
 
         boolean mainThreadReturnedFromResumeCall = false;
         boolean resumedResumee = false;
@@ -173,7 +176,7 @@ public class ResumeAfterThreadResumeCallTest extends TestScaffold {
             Value v = getField(resumeeThreadObj, "mainThreadReturnedFromResumeCall");
             mainThreadReturnedFromResumeCall = ((PrimitiveValue) v).booleanValue();
             if (!resumedResumee) {
-                // main thread should be still blocked.
+                // main thread should still be blocked.
                 Asserts.assertFalse(mainThreadReturnedFromResumeCall, "main Thread was not blocked");
                 log("Resuming \"resumee\" will unblock the main thread.");
                 resumee.resume();
@@ -217,8 +220,6 @@ public class ResumeAfterThreadResumeCallTest extends TestScaffold {
     }
 
     public void log(String m) {
-        System.out.println();
         System.out.println("###(Debugger) " + m);
-        System.out.println();
     }
 }

--- a/test/jdk/com/sun/jdi/ResumeAfterThreadResumeCallTest.java
+++ b/test/jdk/com/sun/jdi/ResumeAfterThreadResumeCallTest.java
@@ -40,7 +40,7 @@
  *                  debugger therefore "main" is blocked.
  *
  *          Debugger: Resumes "resumee" by calling ThreadReference.resume().
- *                    Notifies "main" about it.
+ *                    The JDWP agent notifies "main" about it.
  *
  *          "resumee": Continues execution.
  *

--- a/test/jdk/com/sun/jdi/ResumeAfterThreadResumeCallTest.java
+++ b/test/jdk/com/sun/jdi/ResumeAfterThreadResumeCallTest.java
@@ -198,7 +198,12 @@ public class ResumeAfterThreadResumeCallTest extends TestScaffold {
         List<StackFrame> stack_frames = thread.frames();
         int i = 0;
         for (StackFrame ff : stack_frames) {
-            System.out.println("frame[" + i++ +"]: " + ff.location().method() + " (bci:" + ff.location().codeIndex() + ")");
+            Location loc = ff.location();
+            String locString = "bci:" + loc.codeIndex();
+            try {
+                locString = loc.sourceName() + ":" + loc.lineNumber() + "," + locString;
+            } catch (AbsentInformationException e) {/* empty */};
+            log("  frame[" + i++ +"]: " + ff.location().method() + " (" + locString + ")");
         }
     }
 


### PR DESCRIPTION
This change fixes deadlocks described in the JBS-bug by:

* Releasing `handlerLock` before waiting on `threadLock` in `blockOnDebuggerSuspend()`

* Notifying on `threadLock` in `threadControl_reset()`

Also the actions in handleAppResumeBreakpoint() are moved/deferred until
doPendingTasks() runs. This is necessary because an event handler must not
release handlerLock first and foremost because handlers are called while
iterating the handler chain for an event type which is protected by handlerLock
(see https://github.com/openjdk/jdk/pull/5805)

The first commit delays the cleanup actions after leaving the loop in
`debugLoop_run()`. It allows to reproduce the deadlock running the dispose003
test with the command

```
make run-test TEST=test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose003
```

The second commit adds a new test that reproduces the deadlock when calling
threadControl_resumeThread() while a thread is waiting in
blockOnDebuggerSuspend().

The third commit contains the fix described above. With it the deadlocks
cannot be reproduced anymore.

The forth commit removes the diagnostic code introduced with the first commit again.

The fix passed

test/hotspot/jtreg/serviceability/jdwp
test/jdk/com/sun/jdi
test/hotspot/jtreg/vmTestbase/nsk/jdwp
test/hotspot/jtreg/vmTestbase/nsk/jdi

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274687](https://bugs.openjdk.java.net/browse/JDK-8274687): JDWP deadlocks if some Java thread reaches wait in blockOnDebuggerSuspend


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to 3383a2369f6acd8fc9e9c11c4a64bb167e634d13
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to 85dfaef1af3757196dce6b110160beee19f43d8b
 * [Ralf Schmelter](https://openjdk.java.net/census#rschmelter) (@schmelter-sap - **Reviewer**) ⚠️ Review applies to 3383a2369f6acd8fc9e9c11c4a64bb167e634d13


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5849/head:pull/5849` \
`$ git checkout pull/5849`

Update a local copy of the PR: \
`$ git checkout pull/5849` \
`$ git pull https://git.openjdk.java.net/jdk pull/5849/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5849`

View PR using the GUI difftool: \
`$ git pr show -t 5849`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5849.diff">https://git.openjdk.java.net/jdk/pull/5849.diff</a>

</details>
