### PR TITLE
8271737: Only normalize the cached user.dir property once

### DIFF
--- a/src/java.base/windows/classes/java/io/WinNTFileSystem.java
+++ b/src/java.base/windows/classes/java/io/WinNTFileSystem.java
@@ -356,7 +356,7 @@ class WinNTFileSystem extends FileSystem {
         if (sm != null) {
             sm.checkPropertyAccess("user.dir");
         }
-        return normalize(userDir);
+        return userDir;
     }
 
     private String getDrive(String path) {


### PR DESCRIPTION
The change completes the fix of [JDK-8198997](https://bugs.openjdk.java.net/browse/JDK-8198997) which has added normalisation in a constructor but not removed it from the get method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271737](https://bugs.openjdk.java.net/browse/JDK-8271737): Only normalize the cached user.dir property once


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5850/head:pull/5850` \
`$ git checkout pull/5850`

Update a local copy of the PR: \
`$ git checkout pull/5850` \
`$ git pull https://git.openjdk.java.net/jdk pull/5850/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5850`

View PR using the GUI difftool: \
`$ git pr show -t 5850`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5850.diff">https://git.openjdk.java.net/jdk/pull/5850.diff</a>

</details>
