### PR TITLE
8274920: ProblemList 2 VectorAPI tests failing due to "assert(!vbox->is_Phi()) failed"

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -38,3 +38,6 @@ vmTestbase/nsk/jvmti/scenarios/sampling/SP07/sp07t002/TestDescription.java 82456
 vmTestbase/vm/mlvm/hiddenloader/stress/oome/heap/Test.java 8273095 generic-all
 
 serviceability/sa/TestJhsdbJstackMixed.java 8248675 linux-aarch64
+
+compiler/vectorapi/VectorCastShape64Test.java 8274855 generic-x64
+compiler/vectorapi/VectorCastShape128Test.java 8274855 generic-x64


### PR DESCRIPTION
A trivial fix to ProblemList 2 VectorAPI tests failing due to "assert(!vbox->is_Phi()) failed".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274920](https://bugs.openjdk.java.net/browse/JDK-8274920): ProblemList 2 VectorAPI tests failing due to "assert(!vbox->is_Phi()) failed"


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5853/head:pull/5853` \
`$ git checkout pull/5853`

Update a local copy of the PR: \
`$ git checkout pull/5853` \
`$ git pull https://git.openjdk.java.net/jdk pull/5853/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5853`

View PR using the GUI difftool: \
`$ git pr show -t 5853`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5853.diff">https://git.openjdk.java.net/jdk/pull/5853.diff</a>

</details>
