### PR TITLE
8274946: Cleanup unnecessary calls to Throwable.initCause() in java.rmi

### DIFF
--- a/src/java.rmi/share/classes/java/rmi/server/RMIClassLoader.java
+++ b/src/java.rmi/share/classes/java/rmi/server/RMIClassLoader.java
@@ -694,10 +694,8 @@ public class RMIClassLoader {
             } catch (InstantiationException e) {
                 throw new InstantiationError(e.getMessage());
             } catch (ClassCastException e) {
-                Error error = new LinkageError(
-                    "provider class not assignable to RMIClassLoaderSpi");
-                error.initCause(e);
-                throw error;
+                throw new LinkageError(
+                    "provider class not assignable to RMIClassLoaderSpi", e);
             }
         }
 
@@ -711,10 +709,8 @@ public class RMIClassLoader {
             try {
                 return iter.next();
             } catch (ClassCastException e) {
-                Error error = new LinkageError(
-                    "provider class not assignable to RMIClassLoaderSpi");
-                error.initCause(e);
-                throw error;
+                throw new LinkageError(
+                    "provider class not assignable to RMIClassLoaderSpi", e);
             }
         }
 

--- a/src/java.rmi/share/classes/java/rmi/server/RemoteObjectInvocationHandler.java
+++ b/src/java.rmi/share/classes/java/rmi/server/RemoteObjectInvocationHandler.java
@@ -221,8 +221,7 @@ public class RemoteObjectInvocationHandler
                     method = cl.getMethod(method.getName(),
                                           method.getParameterTypes());
                 } catch (NoSuchMethodException nsme) {
-                    throw (IllegalArgumentException)
-                        new IllegalArgumentException().initCause(nsme);
+                    throw new IllegalArgumentException(nsme);
                 }
                 Class<?> thrownType = e.getClass();
                 for (Class<?> declaredType : method.getExceptionTypes()) {

--- a/src/java.rmi/share/classes/javax/rmi/ssl/SslRMIClientSocketFactory.java
+++ b/src/java.rmi/share/classes/javax/rmi/ssl/SslRMIClientSocketFactory.java
@@ -133,8 +133,7 @@ public class SslRMIClientSocketFactory
             try {
                 sslSocket.setEnabledCipherSuites(enabledCipherSuitesList);
             } catch (IllegalArgumentException e) {
-                throw (IOException)
-                    new IOException(e.getMessage()).initCause(e);
+                throw new IOException(e.getMessage(), e);
             }
         }
         // Set the SSLSocket Enabled Protocols
@@ -151,8 +150,7 @@ public class SslRMIClientSocketFactory
             try {
                 sslSocket.setEnabledProtocols(enabledProtocolsList);
             } catch (IllegalArgumentException e) {
-                throw (IOException)
-                    new IOException(e.getMessage()).initCause(e);
+                throw new IOException(e.getMessage(), e);
             }
         }
         // Return the preconfigured SSLSocket

--- a/src/java.rmi/share/classes/javax/rmi/ssl/SslRMIServerSocketFactory.java
+++ b/src/java.rmi/share/classes/javax/rmi/ssl/SslRMIServerSocketFactory.java
@@ -185,8 +185,7 @@ public class SslRMIServerSocketFactory implements RMIServerSocketFactory {
             } catch (Exception e) {
                 final String msg = "Unable to check if the cipher suites " +
                         "and protocols to enable are supported";
-                throw (IllegalArgumentException)
-                new IllegalArgumentException(msg).initCause(e);
+                throw new IllegalArgumentException(msg, e);
             }
         }
 

--- a/src/java.rmi/share/classes/sun/rmi/log/ReliableLog.java
+++ b/src/java.rmi/share/classes/sun/rmi/log/ReliableLog.java
@@ -285,8 +285,7 @@ public class ReliableLog {
         } catch (IOException e) {
             throw e;
         } catch (Exception e) {
-            throw (IOException)
-                new IOException("write update failed").initCause(e);
+            throw new IOException("write update failed", e);
         }
         log.sync();
 
@@ -547,8 +546,7 @@ public class ReliableLog {
                    new LogFile(logName, "rw") :
                    logClassConstructor.newInstance(logName, "rw"));
         } catch (Exception e) {
-            throw (IOException) new IOException(
-                "unable to construct LogFile instance").initCause(e);
+            throw new IOException("unable to construct LogFile instance", e);
         }
 
         if (truncate) {


### PR DESCRIPTION
Pass cause exception as constructor parameter is shorter and easier to read.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274946](https://bugs.openjdk.java.net/browse/JDK-8274946): Cleanup unnecessary calls to Throwable.initCause() in java.rmi


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5854/head:pull/5854` \
`$ git checkout pull/5854`

Update a local copy of the PR: \
`$ git checkout pull/5854` \
`$ git pull https://git.openjdk.java.net/jdk pull/5854/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5854`

View PR using the GUI difftool: \
`$ git pr show -t 5854`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5854.diff">https://git.openjdk.java.net/jdk/pull/5854.diff</a>

</details>
