### PR TITLE
8233749: Files.exists javadoc doesn't mention eating IOException

### DIFF
--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -2514,6 +2514,7 @@ public final class Files {
      *          read access to the file.
      *
      * @see #notExists
+     * @see FileSystemProvider#checkAccess
      */
     public static boolean exists(Path path, LinkOption... options) {
         if (options.length == 0) {


### PR DESCRIPTION
Add `@see FileSystemProvider#checkAccess` link per the suggestion in the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8233749](https://bugs.openjdk.java.net/browse/JDK-8233749): Files.exists javadoc doesn't mention eating IOException


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5856/head:pull/5856` \
`$ git checkout pull/5856`

Update a local copy of the PR: \
`$ git checkout pull/5856` \
`$ git pull https://git.openjdk.java.net/jdk pull/5856/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5856`

View PR using the GUI difftool: \
`$ git pr show -t 5856`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5856.diff">https://git.openjdk.java.net/jdk/pull/5856.diff</a>

</details>
