### PR TITLE
JDK-8274930: sun/tools/jps/TestJps.java can fail with long VM arguments string

### DIFF
--- a/test/jdk/sun/tools/jps/JpsHelper.java
+++ b/test/jdk/sun/tools/jps/JpsHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,6 +106,7 @@ public final class JpsHelper {
     private static String[] testVmArgs = {
       "-XX:+UsePerfData", "-Xmx512m", "-Xlog:gc",
       "-Dmultiline.prop=value1\nvalue2\r\nvalue3",
+      "-XX:PerfMaxStringConstLength=8K",    // avoid VM flags truncations for "jps -v"
       null /* lazily initialized -XX:Flags */};
     private static File manifestFile = null;
 


### PR DESCRIPTION
The fix adds "-XX:PerfMaxStringConstLength" argument running target app (default is 1024, 8K should be enough for any environments)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274930](https://bugs.openjdk.java.net/browse/JDK-8274930): sun/tools/jps/TestJps.java can fail with long VM arguments string


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5858/head:pull/5858` \
`$ git checkout pull/5858`

Update a local copy of the PR: \
`$ git checkout pull/5858` \
`$ git pull https://git.openjdk.java.net/jdk pull/5858/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5858`

View PR using the GUI difftool: \
`$ git pr show -t 5858`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5858.diff">https://git.openjdk.java.net/jdk/pull/5858.diff</a>

</details>
