### PR TITLE
8274952: jdk/jfr/api/consumer/TestRecordedFrameType.java failed when c1 disabled

### DIFF
--- a/test/jdk/jdk/jfr/api/consumer/TestRecordedFrameType.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestRecordedFrameType.java
@@ -40,7 +40,7 @@ import sun.hotspot.WhiteBox;
  * @test
  * @summary Test jdk.jfr.consumer.RecordedFrame::getType()
  * @key jfr
- * @requires vm.hasJFR
+ * @requires vm.hasJFR & vm.compiler1.enabled
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox


### PR DESCRIPTION
jdk/jfr/api/consumer/TestRecordedFrameType.java requires c1:

```
 73 if (!WB.enqueueMethodForCompilation(mtd, 1)) {
 74 throw new Exception("Could not enqueue method for CompLevel_simple");
 75 }
```

When c1 is disabled, the test failed:

```
STDOUT:
2 compiler directives added
WB error: no compiler for requested compilation level 1
STDERR:
java.lang.Exception: Could not enqueue method for CompLevel_simple
at jdk.jfr.api.consumer.TestRecordedFrameType.main(TestRecordedFrameType.java:74)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:76)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:51)
at java.base/java.lang.reflect.Method.invoke(Method.java:569)
at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
at java.base/java.lang.Thread.run(Thread.java:833)

JavaTest Message: Test threw exception: java.lang.Exception: Could not enqueue method for CompLevel_simple
JavaTest Message: shutting down test

STATUS:Failed.`main' threw exception: java.lang.Exception: Could not enqueue method for CompLevel_simple
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274952](https://bugs.openjdk.java.net/browse/JDK-8274952): jdk/jfr/api/consumer/TestRecordedFrameType.java failed when c1 disabled


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5862/head:pull/5862` \
`$ git checkout pull/5862`

Update a local copy of the PR: \
`$ git checkout pull/5862` \
`$ git pull https://git.openjdk.java.net/jdk pull/5862/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5862`

View PR using the GUI difftool: \
`$ git pr show -t 5862`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5862.diff">https://git.openjdk.java.net/jdk/pull/5862.diff</a>

</details>
