### PR TITLE
8274925: Shenandoah: shenandoah/TestAllocHumongousFragment.java test failed on lock rank check

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -47,8 +47,8 @@
 
 ShenandoahControlThread::ShenandoahControlThread() :
   ConcurrentGCThread(),
-  _alloc_failure_waiters_lock(Mutex::safepoint-2, "ShenandoahAllocFailureGC_lock", true),
-  _gc_waiters_lock(Mutex::safepoint, "ShenandoahRequestedGC_lock", true),
+  _alloc_failure_waiters_lock(Mutex::safepoint-1, "ShenandoahAllocFailureGC_lock", true),
+  _gc_waiters_lock(Mutex::safepoint-1, "ShenandoahRequestedGC_lock", true),
   _periodic_task(this),
   _requested_gc_cause(GCCause::_no_cause_specified),
   _degen_point(ShenandoahGC::_degenerated_outside_cycle),


### PR DESCRIPTION
JDK-8273917 lowered MultiArray_lock rank from nonleaf+2 to nonleaf, that results several Shenandoah tests failed on lock rank check.

This patch lowers ShenandoahAllocFailureGC_lock rank by 2 to maintain original order.


Test:

- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274925](https://bugs.openjdk.java.net/browse/JDK-8274925): Shenandoah: shenandoah/TestAllocHumongousFragment.java test failed on lock rank check


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5865/head:pull/5865` \
`$ git checkout pull/5865`

Update a local copy of the PR: \
`$ git checkout pull/5865` \
`$ git pull https://git.openjdk.java.net/jdk pull/5865/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5865`

View PR using the GUI difftool: \
`$ git pr show -t 5865`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5865.diff">https://git.openjdk.java.net/jdk/pull/5865.diff</a>

</details>
