### PR TITLE
JDK-8274977: Remove expandPacked and extendEdge from awt_ImagingLib.c

### DIFF
--- a/src/java.desktop/share/native/libawt/awt/medialib/awt_ImagingLib.c
+++ b/src/java.desktop/share/native/libawt/awt/medialib/awt_ImagingLib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1801,49 +1801,6 @@ Java_sun_awt_image_ImagingLib_init(JNIEnv *env, jclass thisClass) {
     return JNI_TRUE;
 }
 
-/* REMIND: How to specify border? */
-static void extendEdge(JNIEnv *env, BufImageS_t *imageP,
-                       int *widthP, int *heightP) {
-    RasterS_t *rasterP = &imageP->raster;
-    int width;
-    int height;
-    /* Useful for convolution? */
-
-    jobject jbaseraster = (*env)->GetObjectField(env, rasterP->jraster,
-                                                 g_RasterBaseRasterID);
-    width = rasterP->width;
-    height = rasterP->height;
-#ifdef WORKING
-    if (! JNU_IsNull(env, jbaseraster) &&
-        !(*env)->IsSameObject(env, rasterP->jraster, jbaseraster)) {
-        int xOff;
-        int yOff;
-        int baseWidth;
-        int baseHeight;
-        int baseXoff;
-        int baseYoff;
-        /* Not the same object so get the width and height */
-        xOff = (*env)->GetIntField(env, rasterP->jraster, g_RasterXOffsetID);
-        yOff = (*env)->GetIntField(env, rasterP->jraster, g_RasterYOffsetID);
-        baseWidth  = (*env)->GetIntField(env, jbaseraster, g_RasterWidthID);
-        baseHeight = (*env)->GetIntField(env, jbaseraster, g_RasterHeightID);
-        baseXoff   = (*env)->GetIntField(env, jbaseraster, g_RasterXOffsetID);
-        baseYoff   = (*env)->GetIntField(env, jbaseraster, g_RasterYOffsetID);
-
-        if (xOff + rasterP->width < baseXoff + baseWidth) {
-            /* Can use edge */
-            width++;
-        }
-        if (yOff + rasterP->height < baseYoff + baseHeight) {
-            /* Can use edge */
-            height++;
-        }
-
-    }
-#endif
-
-}
-
 static int
 setImageHints(JNIEnv *env, BufImageS_t *srcP, BufImageS_t *dstP,
               int expandICM, int useAlpha,
@@ -2014,47 +1971,6 @@ setImageHints(JNIEnv *env, BufImageS_t *srcP, BufImageS_t *dstP,
     }
 
     return nbands;
-}
-
-
-static int
-expandPacked(JNIEnv *env, BufImageS_t *img, ColorModelS_t *cmP,
-             RasterS_t *rasterP, int component, unsigned char *bdataP) {
-
-    if (rasterP->rasterType == COMPONENT_RASTER_TYPE) {
-        switch (rasterP->dataType) {
-        case BYTE_DATA_TYPE:
-            if (expandPackedBCR(env, rasterP, component, bdataP) < 0) {
-                /* Must have been an error */
-                return -1;
-            }
-            break;
-
-        case SHORT_DATA_TYPE:
-            if (expandPackedICR(env, rasterP, component, bdataP) < 0) {
-                /* Must have been an error */
-                return -1;
-            }
-            break;
-
-        case INT_DATA_TYPE:
-            if (expandPackedICR(env, rasterP, component, bdataP) < 0) {
-                /* Must have been an error */
-                return -1;
-            }
-            break;
-
-        default:
-            /* REMIND: Return some sort of error */
-            return -1;
-        }
-    }
-    else {
-        /* REMIND: Return some sort of error */
-        return -1;
-    }
-
-    return 0;
 }
 
 #define NUM_LINES    10


### PR DESCRIPTION
Please review this small cleanup change.
Looks like expandPacked and extendEdge from awt_ImagingLib.c are unreferenced/unused and can be removed.

Thanks, Matthias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8274977](https://bugs.openjdk.java.net/browse/JDK-8274977): Remove expandPacked and extendEdge from awt_ImagingLib.c


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5866/head:pull/5866` \
`$ git checkout pull/5866`

Update a local copy of the PR: \
`$ git checkout pull/5866` \
`$ git pull https://git.openjdk.java.net/jdk pull/5866/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5866`

View PR using the GUI difftool: \
`$ git pr show -t 5866`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5866.diff">https://git.openjdk.java.net/jdk/pull/5866.diff</a>

</details>
