### PR TITLE
8273614: Shenandoah: intermittent timeout with ConcurrentGCBreakpoint tests

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -51,7 +51,7 @@
 // Breakpoint support
 class ShenandoahBreakpointGCScope : public StackObj {
 private:
-  GCCause::Cause _cause;
+  const GCCause::Cause _cause;
 public:
   ShenandoahBreakpointGCScope(GCCause::Cause cause) : _cause(cause) {
     if (cause == GCCause::_wb_breakpoint) {
@@ -69,7 +69,7 @@ public:
 
 class ShenandoahBreakpointMarkScope : public StackObj {
 private:
-  GCCause::Cause _cause;
+  const GCCause::Cause _cause;
 public:
   ShenandoahBreakpointMarkScope(GCCause::Cause cause) : _cause(cause) {
     if (_cause == GCCause::_wb_breakpoint) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -505,8 +505,8 @@ void ShenandoahControlThread::handle_requested_gc(GCCause::Cause cause) {
   size_t current_gc_id = get_gc_id();
   size_t required_gc_id = current_gc_id + 1;
   while (current_gc_id < required_gc_id) {
-    _requested_gc_cause = cause;
     _gc_requested.set();
+    _requested_gc_cause = cause;
 
     if (cause != GCCause::_wb_breakpoint) {
       ml.wait();


### PR DESCRIPTION
I were able to reproduce with aggressive heuristics. 

A _wb_breakpoint GC request , while a concurrent GC is started. ShenandoahBreakpoint::_start_gc may not get set, as we bypass it if it is not a _wb_breakpoint GC, then we are forever blocked in ShenandoahBreakpoint::at_before_gc(), waiting for the flag to be set.

The solution is only run breakpoints during _wb_breakpoint GC.

Also, enforced _requested_gc_cause and _gc_requested order, ensure that read side sees latest _requested_gc_cause.

Test:

- [x] tier1 with Shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273614](https://bugs.openjdk.java.net/browse/JDK-8273614): Shenandoah: intermittent  timeout with ConcurrentGCBreakpoint tests


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5868/head:pull/5868` \
`$ git checkout pull/5868`

Update a local copy of the PR: \
`$ git checkout pull/5868` \
`$ git pull https://git.openjdk.java.net/jdk pull/5868/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5868`

View PR using the GUI difftool: \
`$ git pr show -t 5868`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5868.diff">https://git.openjdk.java.net/jdk/pull/5868.diff</a>

</details>
