### PR TITLE
8274934: Attempting to acquire lock JNICritical_lock/41 out of order with lock MultiArray_lock/41

### DIFF
--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -275,7 +275,6 @@ void mutex_init() {
   def(Terminator_lock              , PaddedMonitor, safepoint,      true);
   def(InitCompleted_lock           , PaddedMonitor, nosafepoint,    true);
   def(Notify_lock                  , PaddedMonitor, safepoint,      true);
-  def(JNICritical_lock             , PaddedMonitor, safepoint,      true); // used for JNI critical regions
   def(AdapterHandlerLibrary_lock   , PaddedMutex  , safepoint,      true);
 
   def(Heap_lock                    , PaddedMonitor, safepoint,      false); // Doesn't safepoint check during termination.
@@ -365,6 +364,7 @@ void mutex_init() {
   defl(OopMapCacheAlloc_lock       , PaddedMutex ,  Threads_lock,              true);
   defl(Module_lock                 , PaddedMutex ,  ClassLoaderDataGraph_lock, false);
   defl(SystemDictionary_lock       , PaddedMonitor, Module_lock,               true);
+  defl(JNICritical_lock            , PaddedMonitor, MultiArray_lock,           true); // used for JNI critical regions
 
 #if INCLUDE_JFR
   defl(JfrMsg_lock                 , PaddedMonitor, Module_lock,               true);


### PR DESCRIPTION
Fixed the lock ranking so that JNICritical_lock is MultiArray_lock-1.
Tested where there were observed failures:
tier1,tier2,tier3 -b linux-x64-debug,linux-x64,windows-x64-debug
tier5 -b linux-aarch64-debug
tier4 -b linux-x64-debug

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274934](https://bugs.openjdk.java.net/browse/JDK-8274934): Attempting to acquire lock JNICritical_lock/41 out of order with lock MultiArray_lock/41


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5869/head:pull/5869` \
`$ git checkout pull/5869`

Update a local copy of the PR: \
`$ git checkout pull/5869` \
`$ git pull https://git.openjdk.java.net/jdk pull/5869/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5869`

View PR using the GUI difftool: \
`$ git pr show -t 5869`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5869.diff">https://git.openjdk.java.net/jdk/pull/5869.diff</a>

</details>
