### PR TITLE
8284638: store skip buffers in InputStream Object

### DIFF
--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -540,7 +540,6 @@ public abstract class InputStream implements Closeable {
      */
     public long skip(long n) throws IOException {
         long remaining = n;
-        int nr;
 
         if (n <= 0) {
             return 0;
@@ -554,7 +553,7 @@ public abstract class InputStream implements Closeable {
         }
 
         while (remaining > 0) {
-            nr = read(skipBuffer, 0, (int)Math.min(size, remaining));
+            int nr = read(skipBuffer, 0, (int)Math.min(size, remaining));
             if (nr < 0) {
                 break;
             }

--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -56,6 +56,13 @@ public abstract class InputStream implements Closeable {
 
     private static final int DEFAULT_BUFFER_SIZE = 8192;
 
+    /**
+     * Only used in {@link #skip(long)}, for avoiding multiple times byte array allocation for a same InputStream Object.
+     *
+     * Making this static would increase performance,
+     * but would make it possible to build a malicious subclass of InputStream to steal data from other InputStream Objects.
+     * So DO NOT try to make it static, for the sake of security.
+     */
     private SoftReference<byte[]> skipBufferReference;
 
     private byte[] skipBufferReference(long remaining) {

--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -53,6 +53,8 @@ public abstract class InputStream implements Closeable {
     // use when skipping.
     private static final int MAX_SKIP_BUFFER_SIZE = 2048;
 
+    private static final int MIN_SKIP_BUFFER_SIZE = 128;
+
     private static final int DEFAULT_BUFFER_SIZE = 8192;
 
     /** Skip buffer, null until allocated */
@@ -548,7 +550,7 @@ public abstract class InputStream implements Closeable {
 
         byte[] skipBuffer = this.skipBuffer;
         if ((skipBuffer == null) || (skipBuffer.length < size)) {
-            this.skipBuffer = skipBuffer = new byte[size];
+            this.skipBuffer = skipBuffer = new byte[size < MIN_SKIP_BUFFER_SIZE ? MIN_SKIP_BUFFER_SIZE : MAX_SKIP_BUFFER_SIZE];
         }
 
         while (remaining > 0) {

--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -58,9 +58,6 @@ public abstract class InputStream implements Closeable {
 
     private static final int DEFAULT_BUFFER_SIZE = 8192;
 
-    /** Skip buffer, null until allocated */
-    private byte[] skipBuffer = null;
-
     private SoftReference<byte[]> skipBufferReference;
 
     private byte[] skipBufferReference(long remaining) {

--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -57,7 +57,7 @@ public abstract class InputStream implements Closeable {
     private static final int DEFAULT_BUFFER_SIZE = 8192;
 
     /**
-     * Only used in {@link #skip(long)}, for avoiding multiple times byte array allocation for a same InputStream Object.
+     * Only used in {@link #skip(long) skip}, for avoiding multiple times byte array allocation for a same InputStream Object.
      *
      * Making this static would increase performance,
      * but would make it possible to build a malicious subclass of InputStream to steal data from other InputStream Objects.
@@ -65,6 +65,13 @@ public abstract class InputStream implements Closeable {
      */
     private SoftReference<byte[]> skipBufferReference;
 
+    /**
+     * Get or create a byte array for {@link #skip(long) skip}.
+     *
+     * @param size minimum length that the skip byte array must have.
+     *             notice that this param input MUST be equal or less than {@link #MAX_SKIP_BUFFER_SIZE MAX_SKIP_BUFFER_SIZE}.
+     * @return the byte array.
+     */
     private byte[] skipBufferReference(int size) {
         SoftReference<byte[]> ref = this.skipBufferReference;
         byte[] buffer;

--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -65,8 +65,7 @@ public abstract class InputStream implements Closeable {
      */
     private SoftReference<byte[]> skipBufferReference;
 
-    private byte[] skipBufferReference(long remaining) {
-        int size = (int) Math.min(MAX_SKIP_BUFFER_SIZE, remaining);
+    private byte[] skipBufferReference(int size) {
         SoftReference<byte[]> ref = this.skipBufferReference;
         byte[] buffer;
         if (ref == null || (buffer = ref.get()) == null || buffer.length < size) {

--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -54,8 +54,6 @@ public abstract class InputStream implements Closeable {
     // use when skipping.
     private static final int MAX_SKIP_BUFFER_SIZE = 2048;
 
-    private static final int MIN_SKIP_BUFFER_SIZE = 128;
-
     private static final int DEFAULT_BUFFER_SIZE = 8192;
 
     private SoftReference<byte[]> skipBufferReference;

--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -55,6 +55,9 @@ public abstract class InputStream implements Closeable {
 
     private static final int DEFAULT_BUFFER_SIZE = 8192;
 
+    /** Skip buffer, null until allocated */
+    private byte[] skipBuffer = null;
+
     /**
      * Constructor for subclasses to call.
      */
@@ -542,7 +545,12 @@ public abstract class InputStream implements Closeable {
         }
 
         int size = (int)Math.min(MAX_SKIP_BUFFER_SIZE, remaining);
-        byte[] skipBuffer = new byte[size];
+
+        byte[] skipBuffer = this.skipBuffer;
+        if ((skipBuffer == null) || (skipBuffer.length < size)) {
+            this.skipBuffer = skipBuffer = new byte[size];
+        }
+
         while (remaining > 0) {
             nr = read(skipBuffer, 0, (int)Math.min(size, remaining));
             if (nr < 0) {

--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -69,7 +69,6 @@ public abstract class InputStream implements Closeable {
      * Get or create a byte array for {@link #skip(long) skip}.
      *
      * @param size minimum length that the skip byte array must have.
-     *             notice that this param input MUST be equal or less than {@link #MAX_SKIP_BUFFER_SIZE MAX_SKIP_BUFFER_SIZE}.
      * @return the byte array.
      */
     private byte[] skipBuffer(int size) {

--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -68,16 +68,20 @@ public abstract class InputStream implements Closeable {
     /**
      * Get or create a byte array for {@link #skip(long) skip}.
      *
+     * <p> Would only allocate new buffer when either the old one be too small or it be destroyed during GC.
+     *
      * @param size minimum length that the skip byte array must have.
      * @return the byte array.
      */
     private byte[] skipBuffer(int size) {
         SoftReference<byte[]> ref = this.skipBufferReference;
         byte[] buffer;
-        if (ref == null || (buffer = ref.get()) == null || buffer.length < size) {
-            buffer = new byte[size];
-            this.skipBufferReference = new SoftReference<>(buffer);
+        if (ref != null && (buffer = ref.get()) != null && buffer.length >= size) {
+            return buffer;
         }
+        // allocate new or larger buffer
+        buffer = new byte[size];
+        this.skipBufferReference = new SoftReference<>(buffer);
         return buffer;
     }
 

--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -72,7 +72,7 @@ public abstract class InputStream implements Closeable {
      *             notice that this param input MUST be equal or less than {@link #MAX_SKIP_BUFFER_SIZE MAX_SKIP_BUFFER_SIZE}.
      * @return the byte array.
      */
-    private byte[] skipBufferReference(int size) {
+    private byte[] skipBuffer(int size) {
         SoftReference<byte[]> ref = this.skipBufferReference;
         byte[] buffer;
         if (ref == null || (buffer = ref.get()) == null || buffer.length < size) {
@@ -569,7 +569,7 @@ public abstract class InputStream implements Closeable {
 
         int size = (int) Math.min(MAX_SKIP_BUFFER_SIZE, remaining);
 
-        byte[] skipBuffer = this.skipBufferReference(size);
+        byte[] skipBuffer = this.skipBuffer(size);
 
         while (remaining > 0) {
             int nr = read(skipBuffer, 0, (int) Math.min(size, remaining));

--- a/test/micro/org/openjdk/bench/java/io/InputStreamSkipBenchmark.java
+++ b/test/micro/org/openjdk/bench/java/io/InputStreamSkipBenchmark.java
@@ -242,8 +242,6 @@ public class InputStreamSkipBenchmark {
             super(length);
         }
 
-        private static final int MIN_SKIP_BUFFER_SIZE = 128;
-
         private SoftReference<byte[]> skipBufferReference;
 
         private byte[] skipBufferReference(long remaining) {

--- a/test/micro/org/openjdk/bench/java/io/InputStreamSkipBenchmark.java
+++ b/test/micro/org/openjdk/bench/java/io/InputStreamSkipBenchmark.java
@@ -26,11 +26,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.ref.SoftReference;
 import java.util.Arrays;
-import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;

--- a/test/micro/org/openjdk/bench/java/io/InputStreamSkipBenchmark.java
+++ b/test/micro/org/openjdk/bench/java/io/InputStreamSkipBenchmark.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.ref.SoftReference;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Benchmark for {@link InputStream} skip functions.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(value = 3, jvmArgsAppend = {"-Xms1g", "-Xmx1g"})
+public class InputStreamSkipBenchmark {
+
+    @Benchmark
+    public long testSkip0(Data data) throws IOException {
+        TestBaseInputStream0 testBaseInputStream = new TestBaseInputStream0(data.inputStreamSize);
+        long res;
+        do {
+            res = testBaseInputStream.skip(data.skipLength);
+        } while (res != 0);
+        return res;
+    }
+
+    @Benchmark
+    public long testSkip1(Data data) throws IOException {
+        TestBaseInputStream1 testBaseInputStream = new TestBaseInputStream1(data.inputStreamSize);
+        long res;
+        do {
+            res = testBaseInputStream.skip(data.skipLength);
+        } while (res != 0);
+        return res;
+    }
+
+    @Benchmark
+    public long testSkip2(Data data) throws IOException {
+        TestBaseInputStream2 testBaseInputStream = new TestBaseInputStream2(data.inputStreamSize);
+        long res;
+        do {
+            res = testBaseInputStream.skip(data.skipLength);
+        } while (res != 0);
+        return res;
+    }
+
+    @Benchmark
+    public long testSkip3(Data data) throws IOException {
+        TestBaseInputStream3 testBaseInputStream = new TestBaseInputStream3(data.inputStreamSize);
+        long res;
+        do {
+            res = testBaseInputStream.skip(data.skipLength);
+        } while (res != 0);
+        return res;
+    }
+
+    @State(Scope.Thread)
+    public static class Data {
+
+        @Param({"1000000"})
+        private int inputStreamSize;
+
+        @Param({"1", "8", "32", "128", "512", "2048", "8192"})
+        private int skipLength;
+
+        @Setup
+        public void setup() {
+
+        }
+    }
+
+    static class TestBaseInputStream extends InputStream {
+
+        protected static final int MAX_SKIP_BUFFER_SIZE = 2048;
+
+        private int length;
+
+        public TestBaseInputStream(int length) {
+            this.length = length;
+        }
+
+        @Override
+        public int read() throws IOException {
+            if (length > 0) {
+                --length;
+                return 0;
+            }
+            return -1;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            if (length > len) {
+                length -= len;
+                return len;
+            } else if (length > 0) {
+                len = length;
+                length = 0;
+                return len;
+            } else {
+                return -1;
+            }
+        }
+
+    }
+
+    static class TestBaseInputStream0 extends TestBaseInputStream {
+
+        public TestBaseInputStream0(int length) {
+            super(length);
+        }
+
+        public long skip(long n) throws IOException {
+            long remaining = n;
+            int nr;
+
+            if (n <= 0) {
+                return 0;
+            }
+
+            int size = (int) Math.min(MAX_SKIP_BUFFER_SIZE, remaining);
+            byte[] skipBuffer = new byte[size];
+            while (remaining > 0) {
+                nr = read(skipBuffer, 0, (int) Math.min(size, remaining));
+                if (nr < 0) {
+                    break;
+                }
+                remaining -= nr;
+            }
+
+            return n - remaining;
+        }
+    }
+
+    static class TestBaseInputStream1 extends TestBaseInputStream {
+
+        public TestBaseInputStream1(int length) {
+            super(length);
+        }
+
+        private byte[] skipBuffer;
+
+        @Override
+        public long skip(long n) throws IOException {
+            long remaining = n;
+
+            if (n <= 0) {
+                return 0;
+            }
+
+            int size = (int) Math.min(MAX_SKIP_BUFFER_SIZE, remaining);
+
+            byte[] skipBuffer = this.skipBuffer;
+            if ((skipBuffer == null) || (skipBuffer.length < size)) {
+                this.skipBuffer = skipBuffer = new byte[size];
+            }
+
+            while (remaining > 0) {
+                int nr = read(skipBuffer, 0, (int) Math.min(size, remaining));
+                if (nr < 0) {
+                    break;
+                }
+                remaining -= nr;
+            }
+
+            return n - remaining;
+        }
+    }
+
+    static class TestBaseInputStream2 extends TestBaseInputStream {
+
+        public TestBaseInputStream2(int length) {
+            super(length);
+        }
+
+        private static final int MIN_SKIP_BUFFER_SIZE = 128;
+
+        private byte[] skipBuffer;
+
+        @Override
+        public long skip(long n) throws IOException {
+            long remaining = n;
+
+            if (n <= 0) {
+                return 0;
+            }
+
+            int size = (int) Math.min(MAX_SKIP_BUFFER_SIZE, remaining);
+
+            byte[] skipBuffer = this.skipBuffer;
+            if ((skipBuffer == null) || (skipBuffer.length < size)) {
+                this.skipBuffer = skipBuffer = new byte[size < MIN_SKIP_BUFFER_SIZE ? MIN_SKIP_BUFFER_SIZE :
+                        MAX_SKIP_BUFFER_SIZE];
+            }
+
+            while (remaining > 0) {
+                int nr = read(skipBuffer, 0, (int) Math.min(size, remaining));
+                if (nr < 0) {
+                    break;
+                }
+                remaining -= nr;
+            }
+
+            return n - remaining;
+        }
+    }
+
+    static class TestBaseInputStream3 extends TestBaseInputStream {
+
+        public TestBaseInputStream3(int length) {
+            super(length);
+        }
+
+        private static final int MIN_SKIP_BUFFER_SIZE = 128;
+
+        private SoftReference<byte[]> skipBufferReference;
+
+        private byte[] skipBufferReference(long remaining) {
+            int size = (int) Math.min(MAX_SKIP_BUFFER_SIZE, remaining);
+            SoftReference<byte[]> ref = this.skipBufferReference;
+            byte[] buffer;
+            if (ref == null || (buffer = ref.get()) == null || buffer.length < size) {
+                buffer = new byte[size];
+                this.skipBufferReference = new SoftReference<>(buffer);
+            }
+            return buffer;
+        }
+
+        @Override
+        public long skip(long n) throws IOException {
+            long remaining = n;
+
+            if (n <= 0) {
+                return 0;
+            }
+
+            int size = (int) Math.min(MAX_SKIP_BUFFER_SIZE, remaining);
+
+            byte[] skipBuffer = this.skipBufferReference(size);
+
+            while (remaining > 0) {
+                int nr = read(skipBuffer, 0, (int) Math.min(size, remaining));
+                if (nr < 0) {
+                    break;
+                }
+                remaining -= nr;
+            }
+
+            return n - remaining;
+        }
+    }
+
+}

--- a/test/micro/org/openjdk/bench/java/io/InputStreamSkipBenchmark.java
+++ b/test/micro/org/openjdk/bench/java/io/InputStreamSkipBenchmark.java
@@ -244,7 +244,7 @@ public class InputStreamSkipBenchmark {
 
         private SoftReference<byte[]> skipBufferReference;
 
-        private byte[] skipBufferReference(long remaining) {
+        private byte[] skipBuffer(long remaining) {
             int size = (int) Math.min(MAX_SKIP_BUFFER_SIZE, remaining);
             SoftReference<byte[]> ref = this.skipBufferReference;
             byte[] buffer;
@@ -265,7 +265,7 @@ public class InputStreamSkipBenchmark {
 
             int size = (int) Math.min(MAX_SKIP_BUFFER_SIZE, remaining);
 
-            byte[] skipBuffer = this.skipBufferReference(size);
+            byte[] skipBuffer = this.skipBuffer(size);
 
             while (remaining > 0) {
                 int nr = read(skipBuffer, 0, (int) Math.min(size, remaining));


### PR DESCRIPTION
@jmehrens what about this then?
I think it safe now(actually this mechanism is learned from Reader)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8284638](https://bugs.openjdk.java.net/browse/JDK-8284638): store skip buffers in InputStream Object


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5872/head:pull/5872` \
`$ git checkout pull/5872`

Update a local copy of the PR: \
`$ git checkout pull/5872` \
`$ git pull https://git.openjdk.java.net/jdk pull/5872/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5872`

View PR using the GUI difftool: \
`$ git pr show -t 5872`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5872.diff">https://git.openjdk.java.net/jdk/pull/5872.diff</a>

</details>
