### PR TITLE
8275002: Remove unused AbstractStringBuilder.MAX_ARRAY_SIZE

### DIFF
--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -236,7 +236,7 @@ abstract class AbstractStringBuilder implements Appendable, CharSequence {
      * Returns the current capacity increased by the current length + 2 if
      * that suffices.
      * Will not return a capacity greater than
-     * <code>({@link ArraysSupport#SOFT_MAX_ARRAY_LENGTH} >> coder)</code>
+     * {@code (SOFT_MAX_ARRAY_LENGTH >> coder)}
      * unless the given minimum capacity is greater than that.
      *
      * @param  minCapacity the desired minimum capacity


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275002](https://bugs.openjdk.java.net/browse/JDK-8275002): Remove unused AbstractStringBuilder.MAX_ARRAY_SIZE


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**) ⚠️ Review applies to d679bd3ab8b41a14359d3bfb9763a1178d02ecb0
 * [Martin Buchholz](https://openjdk.java.net/census#martin) (@Martin-Buchholz - **Reviewer**) ⚠️ Review applies to 4ba785b35e767c42c4a2349b4224f839428dfd14


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5878/head:pull/5878` \
`$ git checkout pull/5878`

Update a local copy of the PR: \
`$ git checkout pull/5878` \
`$ git pull https://git.openjdk.java.net/jdk pull/5878/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5878`

View PR using the GUI difftool: \
`$ git pr show -t 5878`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5878.diff">https://git.openjdk.java.net/jdk/pull/5878.diff</a>

</details>
