### PR TITLE
8275004: CDS build failure with gcc11

### DIFF
--- a/src/hotspot/share/cds/cdsConstants.hpp
+++ b/src/hotspot/share/cds/cdsConstants.hpp
@@ -25,8 +25,8 @@
 #ifndef SHARE_CDS_CDSCONSTANTS_HPP
 #define SHARE_CDS_CDSCONSTANTS_HPP
 
-#include <cstddef>
 #include "memory/allStatic.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 typedef struct {
   const char* _name;


### PR DESCRIPTION
Hi all,

Please review this trivial change which fix the build failure with gcc11.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275004](https://bugs.openjdk.java.net/browse/JDK-8275004): CDS build failure with gcc11


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5880/head:pull/5880` \
`$ git checkout pull/5880`

Update a local copy of the PR: \
`$ git checkout pull/5880` \
`$ git pull https://git.openjdk.java.net/jdk pull/5880/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5880`

View PR using the GUI difftool: \
`$ git pr show -t 5880`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5880.diff">https://git.openjdk.java.net/jdk/pull/5880.diff</a>

</details>
