### PR TITLE
8275008: gtest build failure due to stringop-overflow warning with gcc11

### DIFF
--- a/make/hotspot/lib/CompileGtest.gmk
+++ b/make/hotspot/lib/CompileGtest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Hi all,

gtest build fails due to stringop-overflow warning with gcc11.

This is because gcc11 seems to be smart enough to detect the following stringop-overflow at test/hotspot/gtest/memory/test_guardedMemory.cpp:125:11.
```
* For target hotspot_variant-server_libjvm_gtest_objs_test_guardedMemory.o:
In file included from /usr/include/string.h:495,
                 from /home/jdk/src/hotspot/share/utilities/globalDefinitions_gcc.hpp:35,
                 from /home/jdk/src/hotspot/share/utilities/globalDefinitions.hpp:35,
                 from /home/jdk/src/hotspot/share/memory/allocation.hpp:29,
                 from /home/jdk/test/hotspot/gtest/memory/test_guardedMemory.cpp:25:
In function 'void* memset(void*, int, size_t)',      
    inlined from 'virtual void GuardedMemory_buffer_overrun_tail_Test::TestBody()' at /home/jdk/test/hotspot/gtest/memory/test_guardedMemory.cpp:125:11:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:71:33: error: 'void* __builtin_memset(void*, int, long unsigned int)' writing between 2 and 262144 bytes into a region of size 0 overflows the destination [-Werror=stringop-overflow=]
   71 |   return __builtin___memset_chk (__dest, __ch, __len, __bos0 (__dest));
      |          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

So I suggest disabling the stringop-overflow warning for gcc when building gtest since this overflow is designed as a test case.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275008](https://bugs.openjdk.java.net/browse/JDK-8275008): gtest build failure due to stringop-overflow warning with gcc11


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5881/head:pull/5881` \
`$ git checkout pull/5881`

Update a local copy of the PR: \
`$ git checkout pull/5881` \
`$ git pull https://git.openjdk.java.net/jdk pull/5881/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5881`

View PR using the GUI difftool: \
`$ git pr show -t 5881`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5881.diff">https://git.openjdk.java.net/jdk/pull/5881.diff</a>

</details>
