### PR TITLE
JDK-8272392 Lanai: SwingSet2. Black background on expanding tree node

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
@@ -488,7 +488,8 @@ MTLBlitLoops_IsoBlit(JNIEnv *env,
     J2dTraceImpl(J2D_TRACE_VERBOSE, JNI_TRUE," [via sampling]");
 #endif //TRACE_ISOBLIT
     drawTex2Tex(mtlc, srcTex, dstTex,
-            srcOps->isOpaque, dstOps->isOpaque,
+            [mtlc.composite getRule] == java_awt_AlphaComposite_SRC ? JNI_TRUE : srcOps->isOpaque,
+            dstOps->isOpaque,
             hint, sx1, sy1, sx2, sy2, dx1, dy1, dx2, dy2);
 }
 
@@ -595,7 +596,7 @@ MTLBlitLoops_Blit(JNIEnv *env,
             }
 
 #ifdef TRACE_BLIT
-            J2dTraceImpl(J2D_TRACE_VERBOSE, JNI_FALSE,
+            J2dTraceImpl(J2D_TRACE_VERBOSE, JNI_TRUE,
                     "MTLBlitLoops_Blit [tx=%d, xf=%d, AC=%s]: bdst=%s, src=%p (%dx%d) O=%d premul=%d | (%d, %d, %d, %d)->(%1.2f, %1.2f, %1.2f, %1.2f)",
                     texture, xform, [mtlc getCompositeDescription].cString,
                     getSurfaceDescription(dstOps).cString, srcOps,


### PR DESCRIPTION
Handled SRC composite mode in MTLBlitLoops_IsoBlit

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8272392](https://bugs.openjdk.java.net/browse/JDK-8272392): Lanai: SwingSet2. Black background on expanding tree node


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5882/head:pull/5882` \
`$ git checkout pull/5882`

Update a local copy of the PR: \
`$ git checkout pull/5882` \
`$ git pull https://git.openjdk.java.net/jdk pull/5882/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5882`

View PR using the GUI difftool: \
`$ git pr show -t 5882`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5882.diff">https://git.openjdk.java.net/jdk/pull/5882.diff</a>

</details>
