### PR TITLE
8275013: Improve discussion of serialization method declarations in java.io.Object{Input, Output}Stream

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -145,8 +145,8 @@ import sun.security.action.GetIntegerAction;
  * entire graphs.
  *
  * <p>Serializable classes that require special handling during the
- * serialization and deserialization process should implement the following
- * methods:
+ * serialization and deserialization process should implement methods
+ * with the following signatures:
  *
  * <pre>
  * private void writeObject(java.io.ObjectOutputStream stream)
@@ -156,6 +156,12 @@ import sun.security.action.GetIntegerAction;
  * private void readObjectNoData()
  *     throws ObjectStreamException;
  * </pre>
+ *
+ * <p>The method name, modifiers, return type, and number and type of
+ * parameters must match exactly for the method to be used by
+ * serialization or deserialization. The methods should only be
+ * declared to throw checked exceptions consistent with these
+ * signatures.
  *
  * <p>The readObject method is responsible for reading and restoring the state
  * of the object for its particular class using data written to the stream by

--- a/src/java.base/share/classes/java/io/ObjectOutputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectOutputStream.java
@@ -83,9 +83,10 @@ import sun.reflect.misc.ReflectUtil;
  *      oos.close();
  * </pre>
  *
- * <p>Classes that require special handling during the serialization and
- * deserialization process must implement special methods with these exact
- * signatures:
+ * <p>Serializable classes that require special handling during the
+ * serialization and deserialization process should implement methods
+ * with the following signatures:
+ *
  * <br>
  * <pre>
  * private void readObject(java.io.ObjectInputStream stream)
@@ -95,6 +96,12 @@ import sun.reflect.misc.ReflectUtil;
  * private void readObjectNoData()
  *     throws ObjectStreamException;
  * </pre>
+ *
+ * <p>The method name, modifiers, return type, and number and type of
+ * parameters must match exactly for the method to be used by
+ * serialization or deserialization. The methods should only be
+ * declared to throw checked exceptions consistent with these
+ * signatures.
  *
  * <p>The writeObject method is responsible for writing the state of the object
  * for its particular class so that the corresponding readObject method can


### PR DESCRIPTION
The java.io.ObjectInputStream and java.io.ObjectOuputStream classes are part of the serialization feature. These classes contain brief descriptions of some of the methods serializable classes can define to interact with the serialization mechanism, readObject, readObjectNoData, and writeObject. These descriptions are not entirely consistent with one another and at least one is arguably misleading.

This PR makes the brief discussion the same in both classes and addresses the misleading point: the throws clauses of the methods will not effect whether or not the methods are found by serialization, but throwing unchecked exceptions not declared in the standard signatures is ill-advised. (The current implementation looks up the methods by name using core reflection; the method modifiers are checked to match but the throws information is not.)

Please also review the corresponding CSR : https://bugs.openjdk.java.net/browse/JDK-8275014

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275013](https://bugs.openjdk.java.net/browse/JDK-8275013): Improve discussion of serialization method declarations in java.io.Object{Input, Output}Stream


### Reviewers
 * [Stuart Marks](https://openjdk.java.net/census#smarks) (@stuart-marks - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5883/head:pull/5883` \
`$ git checkout pull/5883`

Update a local copy of the PR: \
`$ git checkout pull/5883` \
`$ git pull https://git.openjdk.java.net/jdk pull/5883/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5883`

View PR using the GUI difftool: \
`$ git pr show -t 5883`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5883.diff">https://git.openjdk.java.net/jdk/pull/5883.diff</a>

</details>
