### PR TITLE
8185429: [macos] After the dialog is closed, there is no window become active.

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
@@ -1026,6 +1026,10 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
         }
 
         execute(ptr -> nativeSetEnabled(ptr, !blocked));
+        if (!blocked) {
+            execute(ptr -> nativePushNSWindowToFront(ptr));
+        }
+
         checkBlockingAndOrder();
     }
 

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
@@ -1027,7 +1027,7 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
 
         execute(ptr -> nativeSetEnabled(ptr, !blocked));
         if (!blocked) {
-            execute(ptr -> nativePushNSWindowToFront(ptr));
+            orderAboveSiblings();
         }
 
         checkBlockingAndOrder();

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -861,7 +861,6 @@ javax/swing/JTabbedPane/4666224/bug4666224.html 8144124  macosx-all
 java/awt/event/MouseEvent/AltGraphModifierTest/AltGraphModifierTest.java 8162380 generic-all
 java/awt/image/VolatileImage/VolatileImageConfigurationTest.java 8171069 macosx-all,linux-all
 java/awt/Modal/InvisibleParentTest/InvisibleParentTest.java 8172245 linux-all
-java/awt/print/Dialog/RestoreActiveWindowTest/RestoreActiveWindowTest.java 8185429 macosx-all
 java/awt/TrayIcon/DblClickActionEventTest/DblClickActionEventTest.html 8203867 macosx-all
 java/awt/Frame/FrameStateTest/FrameStateTest.html 8203920 macosx-all,linux-all
 javax/swing/SwingUtilities/TestTextPosInPrint.java 8227025 windows-all


### PR DESCRIPTION
After a modal dialog is closed, its parent window should be pushed to the front and made key.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8185429](https://bugs.openjdk.java.net/browse/JDK-8185429): [macos] After the dialog is closed, there is no window become active.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5884/head:pull/5884` \
`$ git checkout pull/5884`

Update a local copy of the PR: \
`$ git checkout pull/5884` \
`$ git pull https://git.openjdk.java.net/jdk pull/5884/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5884`

View PR using the GUI difftool: \
`$ git pr show -t 5884`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5884.diff">https://git.openjdk.java.net/jdk/pull/5884.diff</a>

</details>
