### PR TITLE
8275031: runtime/ErrorHandling/MachCodeFramesInErrorFile.java fails when hsdis is present

### DIFF
--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -2892,7 +2892,10 @@ void nmethod::decode2(outputStream* ost) const {
   //---<  Print real disassembly  >---
   //----------------------------------
   if (! use_compressed_format) {
+    st->print_cr("[Disassembly]");
     Disassembler::decode(const_cast<nmethod*>(this), st);
+    st->bol();
+    st->print_cr("[/Disassembly]");
     return;
   }
 #endif

--- a/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
@@ -110,6 +110,12 @@ public class MachCodeFramesInErrorFile {
         List<String> nativeFrames = extractNativeFrames(hsErr);
         int compiledJavaFrames = (int) nativeFrames.stream().filter(f -> f.startsWith("J ")).count();
 
+        Matcher matcherDisasm = Pattern.compile("\\[Disassembly\\].*\\[/Disassembly\\]", Pattern.DOTALL).matcher(hsErr);
+        if (matcherDisasm.find()) {
+            // Real disassembly is present, no MachCode is expected.
+            return;
+        }
+
         Matcher matcher = Pattern.compile("\\[MachCode\\]\\s*\\[Verified Entry Point\\]\\s*  # \\{method\\} \\{[^}]*\\} '([^']+)' '([^']+)' in '([^']+)'", Pattern.DOTALL).matcher(hsErr);
         List<String> machCodeHeaders = matcher.results().map(mr -> String.format("'%s' '%s' in '%s'", mr.group(1), mr.group(2), mr.group(3))).collect(Collectors.toList());
         String message = "Mach code headers: " + machCodeHeaders +


### PR DESCRIPTION
tier1 test that is newly added by [JDK-8272586](https://bugs.openjdk.java.net/browse/JDK-8272586) fails on hsdis-enabled machine. I chose to fix it by annotating the real disassembly with `[Disassembly]`, and checking for its existence in the test.

Additional testing:
 - [x] Test now passes when `hsdis` is installed
 - [x] Test still passes when `hsdis` is not installed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275031](https://bugs.openjdk.java.net/browse/JDK-8275031): runtime/ErrorHandling/MachCodeFramesInErrorFile.java fails when hsdis is present


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Doug Simon](https://openjdk.java.net/census#dnsimon) (@dougxc - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5888/head:pull/5888` \
`$ git checkout pull/5888`

Update a local copy of the PR: \
`$ git checkout pull/5888` \
`$ git pull https://git.openjdk.java.net/jdk pull/5888/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5888`

View PR using the GUI difftool: \
`$ git pr show -t 5888`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5888.diff">https://git.openjdk.java.net/jdk/pull/5888.diff</a>

</details>
