### PR TITLE
8275021: Test serviceability/sa/TestJmapCore.java fails with: java.io.IOException: Stack frame 0x4 not found

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/HeapHprofBinWriter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/HeapHprofBinWriter.java
@@ -615,8 +615,7 @@ public class HeapHprofBinWriter extends AbstractHeapGraphWriter {
         } else {
             out.writeByte((byte)HPROF_HEAP_DUMP);
             out.writeInt(0);
-            // remember position of dump length, we will fixup
-            // length later - hprof format require length.
+            // We must flush all data to the file before reading the current file position.
             out.flush();
             // record the current position in file, it will be use for calculating the size of written data
             currentSegmentStart = fos.getChannel().position();


### PR DESCRIPTION
The root cause for the fail is that there must be a flush for `BufferedOutputStream` before getting the `pos` of the file, otherwise the data length is wrongly calculated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275021](https://bugs.openjdk.java.net/browse/JDK-8275021): Test serviceability/sa/TestJmapCore.java fails with: java.io.IOException: Stack frame 0x4 not found


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 17da4f52b24e66a34309cbd4cf03623d108fe8ec
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5890/head:pull/5890` \
`$ git checkout pull/5890`

Update a local copy of the PR: \
`$ git checkout pull/5890` \
`$ git pull https://git.openjdk.java.net/jdk pull/5890/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5890`

View PR using the GUI difftool: \
`$ git pr show -t 5890`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5890.diff">https://git.openjdk.java.net/jdk/pull/5890.diff</a>

</details>
