### PR TITLE
8275049: [ZGC] missing null check in ZNMethod::log_register

### DIFF
--- a/src/hotspot/share/gc/z/zNMethod.cpp
+++ b/src/hotspot/share/gc/z/zNMethod.cpp
@@ -126,11 +126,10 @@ void ZNMethod::log_register(const nmethod* nm) {
     oop* const begin = nm->oops_begin();
     oop* const end = nm->oops_end();
     for (oop* p = begin; p < end; p++) {
-      oop o = Atomic::load(p); // C1 PatchingStub may replace it concurrently.
-      const char* external_name = o == nullptr ? "N/A"
-                                               : o->klass()->external_name();
+      const oop o = Atomic::load(p); // C1 PatchingStub may replace it concurrently.
+      const char* external_name = (o == nullptr) ? "N/A" : o->klass()->external_name();
       log_oops.print("           Oop[" SIZE_FORMAT "] " PTR_FORMAT " (%s)",
-                     (p - begin), p2i(*p), external_name);
+                     (p - begin), p2i(o), external_name);
     }
   }
 


### PR DESCRIPTION
The VM crashes while trying to read (*p)->klass() in "ZNMethod::log_register" on PPC64. We need a null check. See JBS for details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275049](https://bugs.openjdk.java.net/browse/JDK-8275049): [ZGC] missing null check in ZNMethod::log_register


### Reviewers
 * [Niklas Radomski](https://openjdk.java.net/census#nradomski) (@Quaffel - Author) ⚠️ Review applies to bf1a79e1a1da4aa6891c5fb5c8ba21935ccbee5c
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5892/head:pull/5892` \
`$ git checkout pull/5892`

Update a local copy of the PR: \
`$ git checkout pull/5892` \
`$ git pull https://git.openjdk.java.net/jdk pull/5892/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5892`

View PR using the GUI difftool: \
`$ git pr show -t 5892`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5892.diff">https://git.openjdk.java.net/jdk/pull/5892.diff</a>

</details>
