### PR TITLE
8275052: AArch64: Severe AES/GCM slowdown on MacOS for short blocks

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -7360,12 +7360,6 @@ class StubGenerator: public StubCodeGenerator {
     }
 #endif // COMPILER2
 
-    // generate GHASH intrinsics code
-    if (UseGHASHIntrinsics) {
-      // StubRoutines::_ghash_processBlocks = generate_ghash_processBlocks();
-      StubRoutines::_ghash_processBlocks = generate_ghash_processBlocks_wide();
-    }
-
     if (UseBASE64Intrinsics) {
         StubRoutines::_base64_encodeBlock = generate_base64_encodeBlock();
         StubRoutines::_base64_decodeBlock = generate_base64_decodeBlock();
@@ -7380,8 +7374,14 @@ class StubGenerator: public StubCodeGenerator {
       StubRoutines::_aescrypt_decryptBlock = generate_aescrypt_decryptBlock();
       StubRoutines::_cipherBlockChaining_encryptAESCrypt = generate_cipherBlockChaining_encryptAESCrypt();
       StubRoutines::_cipherBlockChaining_decryptAESCrypt = generate_cipherBlockChaining_decryptAESCrypt();
-      StubRoutines::_galoisCounterMode_AESCrypt = generate_galoisCounterMode_AESCrypt();
       StubRoutines::_counterMode_AESCrypt = generate_counterMode_AESCrypt();
+    }
+    if (UseGHASHIntrinsics) {
+      // StubRoutines::_ghash_processBlocks = generate_ghash_processBlocks();
+      StubRoutines::_ghash_processBlocks = generate_ghash_processBlocks_wide();
+    }
+    if (UseAESIntrinsics && UseGHASHIntrinsics) {
+      StubRoutines::_galoisCounterMode_AESCrypt = generate_galoisCounterMode_AESCrypt();
     }
 
     if (UseSHA1Intrinsics) {

--- a/src/hotspot/os_cpu/bsd_aarch64/vm_version_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/vm_version_bsd_aarch64.cpp
@@ -60,8 +60,8 @@ void VM_Version::get_os_cpu_info() {
   assert(cpu_has("hw.optional.neon"), "should be");
   _features = CPU_FP | CPU_ASIMD;
 
-  // All Apple-darwin Arm processors have AES.
-  _features |= CPU_AES;
+  // All Apple-darwin Arm processors have AES and PMULL.
+  _features |= CPU_AES | CPU_PMULL;
 
   // Only few features are available via sysctl, see line 614
   // https://opensource.apple.com/source/xnu/xnu-6153.141.1/bsd/kern/kern_mib.c.auto.html


### PR DESCRIPTION
This is more of the fallout from JDK-8273297.
We've noticed that blocks of less than 8kbytes are very slowly encrypted with AES/GCM . This is because of incorrect flag handline in vm_version_bsd_aarch64.cpp. 

Before this patch:

```
Benchmark            (dataSize)  (keyLength)  (provider)  Mode  Cnt      Score      Error  Units
AESGCMBench.decrypt        8191          256              avgt    6  95821.232 ± 2447.246  ns/op
AESGCMBench.decrypt        8192          256              avgt    6   3653.619 ±   83.432  ns/op
```

After:

```
Benchmark            (dataSize)  (keyLength)  (provider)  Mode  Cnt     Score    Error  Units
AESGCMBench.decrypt        8191          256              avgt    6  3371.735 ± 70.204  ns/op
AESGCMBench.decrypt        8192          256              avgt    6  3119.928 ± 80.375  ns/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275052](https://bugs.openjdk.java.net/browse/JDK-8275052): AArch64: Severe AES/GCM slowdown on MacOS for short blocks


### Reviewers
 * [Nick Gasson](https://openjdk.java.net/census#ngasson) (@nick-arm - **Reviewer**)
 * [Andrew Dinn](https://openjdk.java.net/census#adinn) (@adinn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5894/head:pull/5894` \
`$ git checkout pull/5894`

Update a local copy of the PR: \
`$ git checkout pull/5894` \
`$ git pull https://git.openjdk.java.net/jdk pull/5894/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5894`

View PR using the GUI difftool: \
`$ git pr show -t 5894`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5894.diff">https://git.openjdk.java.net/jdk/pull/5894.diff</a>

</details>
