### PR TITLE
8273039: JShell crashes when naming variable or method "abstract" or "strictfp"

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5105,7 +5105,6 @@ public class Attr extends JCTree.Visitor {
         attribAnnotationTypes(tree.annotations, env);
     }
 
-    
     public void visitAnnotatedType(JCAnnotatedType tree) {
         attribAnnotationTypes(tree.annotations, env);
         Type underlyingType = attribType(tree.underlyingType, env);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5097,6 +5097,15 @@ public class Attr extends JCTree.Visitor {
         Assert.error("should be handled in annotate");
     }
 
+    @Override
+    public void visitModifiers(JCModifiers tree) {
+        //error recovery only:
+        Assert.check(resultInfo.pkind == KindSelector.ERR);
+
+        attribAnnotationTypes(tree.annotations, env);
+    }
+
+    
     public void visitAnnotatedType(JCAnnotatedType tree) {
         attribAnnotationTypes(tree.annotations, env);
         Type underlyingType = attribType(tree.underlyingType, env);

--- a/test/langtools/jdk/jshell/ErrorRecoveryTest.java
+++ b/test/langtools/jdk/jshell/ErrorRecoveryTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8270139
+ * @bug 8270139 8273039
  * @summary Verify error recovery in JShell
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
@@ -37,6 +37,7 @@
 import org.testng.annotations.Test;
 import static jdk.jshell.Snippet.Status.NONEXISTENT;
 import static jdk.jshell.Snippet.Status.RECOVERABLE_NOT_DEFINED;
+import static jdk.jshell.Snippet.Status.REJECTED;
 
 @Test
 public class ErrorRecoveryTest extends KullaTesting {
@@ -48,5 +49,12 @@ public class ErrorRecoveryTest extends KullaTesting {
                    @interface Foo { int value(); }
                    """,
                    ste(MAIN_SNIPPET, NONEXISTENT, RECOVERABLE_NOT_DEFINED, false, null));
+    }
+
+    public void testBrokenName() {
+        assertEval("int strictfp = 0;",
+                   DiagCheck.DIAG_ERROR,
+                   DiagCheck.DIAG_IGNORE,
+                   ste(MAIN_SNIPPET, NONEXISTENT, REJECTED, false, null));
     }
 }

--- a/test/langtools/tools/javac/attr/AttrRecoveryTest.java
+++ b/test/langtools/tools/javac/attr/AttrRecoveryTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8273039
+ * @summary Verify error recovery in Attr
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.compiler/com.sun.tools.javac.util
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main AttrRecoveryTest
+*/
+
+import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.ErroneousTree;
+import com.sun.source.util.TaskEvent;
+import com.sun.source.util.TaskListener;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.TreePathScanner;
+import com.sun.source.util.Trees;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import javax.lang.model.element.Element;
+
+import toolbox.TestRunner;
+import toolbox.JavacTask;
+import toolbox.Task;
+import toolbox.ToolBox;
+
+public class AttrRecoveryTest extends TestRunner {
+
+    ToolBox tb;
+
+    public static void main(String... args) throws Exception {
+        new AttrRecoveryTest().runTests();
+    }
+
+    AttrRecoveryTest() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    public void runTests() throws Exception {
+        runTests(m -> new Object[] { Paths.get(m.getName()) });
+    }
+
+    @Test
+    public void testModifiers(Path base) throws Exception {
+        record TestCase(String name, String source, String expectedAnnotation, String... errors) {}
+        TestCase[] tests = new TestCase[] {
+            new TestCase("a",
+                         """
+                         public class Test {
+                             Object i () { return int strictfp @Deprecated = 0; }
+                         }
+                         """,
+                         "java.lang.Deprecated",
+                         "Test.java:2:30: compiler.err.dot.class.expected",
+                         "Test.java:2:51: compiler.err.expected4: class, interface, enum, record",
+                         "Test.java:2:26: compiler.err.unexpected.type: kindname.value, kindname.class",
+                         "3 errors"),
+            new TestCase("b",
+                         """
+                         public class Test {
+                             Object i () { return int strictfp = 0; }
+                         }
+                         """,
+                         null,
+                         "Test.java:2:30: compiler.err.dot.class.expected",
+                         "Test.java:2:39: compiler.err.expected4: class, interface, enum, record",
+                         "Test.java:2:26: compiler.err.unexpected.type: kindname.value, kindname.class",
+                         "3 errors")
+        };
+        for (TestCase test : tests) {
+            Path current = base.resolve("" + test.name);
+            Path src = current.resolve("src");
+            Path classes = current.resolve("classes");
+            tb.writeJavaFiles(src,
+                              test.source);
+
+            Files.createDirectories(classes);
+
+            var log =
+                    new JavacTask(tb)
+                        .options("-XDrawDiagnostics",
+                                 "-XDshould-stop.at=FLOW",
+                                 "-Xlint:-preview")
+                        .outdir(classes)
+                        .files(tb.findJavaFiles(src))
+                        .callback(t -> {
+                            t.addTaskListener(new TaskListener() {
+                                CompilationUnitTree parsed;
+                                @Override
+                                public void finished(TaskEvent e) {
+                                    switch (e.getKind()) {
+                                        case PARSE -> parsed = e.getCompilationUnit();
+                                        case ANALYZE ->
+                                            checkAnnotationsValid(t, parsed, test.expectedAnnotation);
+                                    }
+                                }
+                            });
+                        })
+                        .run(Task.Expect.FAIL, 1)
+                        .writeAll()
+                        .getOutputLines(Task.OutputKind.DIRECT);
+            if (!List.of(test.errors).equals(log)) {
+                throw new AssertionError("Incorrect errors, expected: " + List.of(test.errors) +
+                                          ", actual: " + log);
+            }
+        }
+    }
+
+    private void checkAnnotationsValid(com.sun.source.util.JavacTask task,
+                                       CompilationUnitTree cut,
+                                       String expected) {
+        boolean[] foundAnnotation = new boolean[1];
+        Trees trees = Trees.instance(task);
+
+        new TreePathScanner<Void, Void>() {
+            @Override
+            public Void visitAnnotation(AnnotationTree node, Void p) {
+                TreePath typePath = new TreePath(getCurrentPath(), node.getAnnotationType());
+                Element el = trees.getElement(typePath);
+                if (el == null || !el.equals(task.getElements().getTypeElement(expected))) {
+                    throw new AssertionError();
+                }
+                foundAnnotation[0] = true;
+                return super.visitAnnotation(node, p);
+            }
+
+            @Override
+            public Void visitErroneous(ErroneousTree node, Void p) {
+                return scan(node.getErrorTrees(), p);
+            }
+        }.scan(cut, null);
+        if (foundAnnotation[0] ^ (expected != null)) {
+            throw new AssertionError();
+        }
+    }
+}


### PR DESCRIPTION
When JShell processes `int strictfp = 0;` (which is obviously erroneous), it will speculativelly try to parse and attribute code along these lines:
```
package REPL;
import java.io.*;import java.math.*;import java.net.*;import java.nio.file.*;import java.util.*;import java.util.concurrent.*;import java.util.function.*;import java.util.prefs.*;import java.util.regex.*;import java.util.stream.*;
class $JShell$DOESNOTMATTER {
    public static Object do_it$() throws Throwable {
        return int strictfp = 0;
    }
}
```

This crashes `Attr`, as the `strictfp` will be wrapped in `JCModifiers`, wrapped inside an erroneous tree, and `Attr` does not handle modifiers.

The proposal is to let `Attr` "handle" the `JCModifiers` in an error-recovery situation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273039](https://bugs.openjdk.java.net/browse/JDK-8273039): JShell crashes when naming variable or method "abstract" or "strictfp"


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5897/head:pull/5897` \
`$ git checkout pull/5897`

Update a local copy of the PR: \
`$ git checkout pull/5897` \
`$ git pull https://git.openjdk.java.net/jdk pull/5897/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5897`

View PR using the GUI difftool: \
`$ git pr show -t 5897`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5897.diff">https://git.openjdk.java.net/jdk/pull/5897.diff</a>

</details>
