### PR TITLE
8275080: G1CollectedHeap::expand() returns the wrong value

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1311,7 +1311,7 @@ bool G1CollectedHeap::expand(size_t expand_bytes, WorkGang* pretouch_workers, do
       vm_exit_out_of_memory(aligned_expand_bytes, OOM_MMAP_ERROR, "G1 heap expansion");
     }
   }
-  return regions_to_expand > 0;
+  return expanded_by > 0;
 }
 
 bool G1CollectedHeap::expand_single_region(uint node_index) {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Errors
&nbsp;⚠️ OCA signatory status must be verified
&nbsp;⚠️ The pull request body must not be empty.

### Issue
 * [JDK-8275080](https://bugs.openjdk.java.net/browse/JDK-8275080): G1CollectedHeap::expand() returns the wrong value


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5902/head:pull/5902` \
`$ git checkout pull/5902`

Update a local copy of the PR: \
`$ git checkout pull/5902` \
`$ git pull https://git.openjdk.java.net/jdk pull/5902/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5902`

View PR using the GUI difftool: \
`$ git pr show -t 5902`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5902.diff">https://git.openjdk.java.net/jdk/pull/5902.diff</a>

</details>
