### PR TITLE
8275086: compiler/c2/irTests/TestPostParseCallDevirtualization.java fails when compiler1 is disabled

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestPostParseCallDevirtualization.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestPostParseCallDevirtualization.java
@@ -154,6 +154,7 @@ public class TestPostParseCallDevirtualization {
 
     @Test
     @IR(failOn = {IRNode.STATIC_CALL_OF_METHOD, "invokeBasic"},
+        applyIf = {"TieredCompilation", "true"},
         counts = {IRNode.STATIC_CALL_OF_METHOD, "invokeStatic", "= 1"})
     public int testMethodHandleCallWithLoop() throws Throwable {
         MethodHandle mh = mh1;
@@ -175,6 +176,7 @@ public class TestPostParseCallDevirtualization {
 
     @Test
     @IR(failOn = {IRNode.STATIC_CALL_OF_METHOD, "invokeBasic"},
+        applyIf = {"TieredCompilation", "true"},
         counts = {IRNode.STATIC_CALL_OF_METHOD, "invokeStatic", "= 1"})
     public int testMethodHandleCallWithCCP() throws Throwable {
         MethodHandle mh = mh1;

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestPostParseCallDevirtualization.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestPostParseCallDevirtualization.java
@@ -156,6 +156,9 @@ public class TestPostParseCallDevirtualization {
     @IR(failOn = {IRNode.STATIC_CALL_OF_METHOD, "invokeBasic"},
         applyIf = {"TieredCompilation", "true"},
         counts = {IRNode.STATIC_CALL_OF_METHOD, "invokeStatic", "= 1"})
+    @IR(failOn = {IRNode.STATIC_CALL_OF_METHOD, "invokeBasic"},
+        applyIfAnd = {"TieredCompilation", "false", "CompileThresholdScaling", "<0.14"},
+        counts = {IRNode.STATIC_CALL_OF_METHOD, "invokeStatic", "= 1"})
     public int testMethodHandleCallWithLoop() throws Throwable {
         MethodHandle mh = mh1;
         for (int i = 0; i < 3; ++i) {
@@ -177,6 +180,9 @@ public class TestPostParseCallDevirtualization {
     @Test
     @IR(failOn = {IRNode.STATIC_CALL_OF_METHOD, "invokeBasic"},
         applyIf = {"TieredCompilation", "true"},
+        counts = {IRNode.STATIC_CALL_OF_METHOD, "invokeStatic", "= 1"})
+    @IR(failOn = {IRNode.STATIC_CALL_OF_METHOD, "invokeBasic"},
+        applyIfAnd = {"TieredCompilation", "false", "CompileThresholdScaling", "<0.14"},
         counts = {IRNode.STATIC_CALL_OF_METHOD, "invokeStatic", "= 1"})
     public int testMethodHandleCallWithCCP() throws Throwable {
         MethodHandle mh = mh1;

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestPostParseCallDevirtualization.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestPostParseCallDevirtualization.java
@@ -154,10 +154,6 @@ public class TestPostParseCallDevirtualization {
 
     @Test
     @IR(failOn = {IRNode.STATIC_CALL_OF_METHOD, "invokeBasic"},
-        applyIf = {"TieredCompilation", "true"},
-        counts = {IRNode.STATIC_CALL_OF_METHOD, "invokeStatic", "= 1"})
-    @IR(failOn = {IRNode.STATIC_CALL_OF_METHOD, "invokeBasic"},
-        applyIfAnd = {"TieredCompilation", "false", "CompileThresholdScaling", "<0.14"},
         counts = {IRNode.STATIC_CALL_OF_METHOD, "invokeStatic", "= 1"})
     public int testMethodHandleCallWithLoop() throws Throwable {
         MethodHandle mh = mh1;
@@ -173,16 +169,13 @@ public class TestPostParseCallDevirtualization {
     }
 
     @Run(test = "testMethodHandleCallWithLoop")
+    @Warmup(5000)
     public void checkTestMethodHandleCallWithLoop() throws Throwable {
-        Asserts.assertEquals(testMethodHandleCallWithLoop(), 42);
+        Asserts.assertEquals( (int)mh2.invokeExact(), 42);
     }
 
     @Test
     @IR(failOn = {IRNode.STATIC_CALL_OF_METHOD, "invokeBasic"},
-        applyIf = {"TieredCompilation", "true"},
-        counts = {IRNode.STATIC_CALL_OF_METHOD, "invokeStatic", "= 1"})
-    @IR(failOn = {IRNode.STATIC_CALL_OF_METHOD, "invokeBasic"},
-        applyIfAnd = {"TieredCompilation", "false", "CompileThresholdScaling", "<0.14"},
         counts = {IRNode.STATIC_CALL_OF_METHOD, "invokeStatic", "= 1"})
     public int testMethodHandleCallWithCCP() throws Throwable {
         MethodHandle mh = mh1;
@@ -202,7 +195,8 @@ public class TestPostParseCallDevirtualization {
     }
 
     @Run(test = "testMethodHandleCallWithCCP")
+    @Warmup(5000)
     public void checkTestMethodHandleCallWithCCP() throws Throwable {
-        Asserts.assertEquals(testMethodHandleCallWithCCP(), 42);
+        Asserts.assertEquals( (int)mh2.invokeExact(), 42);
     }
 }


### PR DESCRIPTION
Hi all,
Jtreg test case compiler/c2/irTests/TestPostParseCallDevirtualization.java fails for fastdebug mode on x86/aarch64/mips architecture when "--with-jvm-features=-compiler1" be used. the failed info is:

<pre><code class="shell">
One or more @IR rules failed:

Failed IR Rules (1)
------------------
- Method "public int compiler.c2.irTests.TestPostParseCallDevirtualization.testMethodHandleCallWithCCP() throws java.lang.Throwable":
  * @IR rule 1: "@compiler.lib.ir_framework.IR(failOn={"#PRE#(\\\\d+(\\\\s){2}(CallStaticJava.*)+(\\\\s){2}===.*#IS_REPLACED#)", "invokeBasic"}, applyIf={}, applyIfAnd={}, applyIfOr={}, counts={"#PRE#(\\\\d+(\\\\s){2}(CallStaticJava.*)+(\\\\s){2}===.*#IS_REPLACED#)", "invokeStatic", "= 1"}, applyIfNot={})" 
    - failOn: Graph contains forbidden nodes:
        Regex 1: (\\d+(\\s){2}(CallStaticJava.*)+(\\s){2}===.*invokeBasic)
        Matched forbidden node:
          280  CallStaticJava  ===  5  6  7  8  1 ( 188  1  1  1  1  1  1 ) [[ 281  282  283  285 ]] # Static  java.lang.invoke.MethodHandle::invokeBasic
    - counts: Graph contains wrong number of nodes:
        Regex 1: (\\d+(\\s){2}(CallStaticJava.*)+(\\s){2}===.*invokeStatic)
        Expected 1 but found 0 nodes.

>>> Check stdout for compilation output of the failed methods
</code></pre>

This is a patch to fix this problem. Please help review it.

Thanks,
Sun Guoyun

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275086](https://bugs.openjdk.java.net/browse/JDK-8275086): compiler/c2/irTests/TestPostParseCallDevirtualization.java fails when compiler1 is disabled


### Reviewers
 * [Igor Veresov](https://openjdk.java.net/census#iveresov) (@veresov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5903/head:pull/5903` \
`$ git checkout pull/5903`

Update a local copy of the PR: \
`$ git checkout pull/5903` \
`$ git pull https://git.openjdk.java.net/jdk pull/5903/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5903`

View PR using the GUI difftool: \
`$ git pr show -t 5903`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5903.diff">https://git.openjdk.java.net/jdk/pull/5903.diff</a>

</details>
