### PR TITLE
8275097: Wrong span of the 'default' tag

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3031,9 +3031,9 @@ public class JavacParser implements Parser {
         }
         case DEFAULT: {
             nextToken();
+            JCCaseLabel defaultPattern = toP(F.at(pos).DefaultCaseLabel());
             CaseTree.CaseKind caseKind;
             JCTree body = null;
-            int patternPos = token.pos;
             if (token.kind == ARROW) {
                 checkSourceLevel(Feature.SWITCH_RULE);
                 accept(ARROW);
@@ -3049,7 +3049,6 @@ public class JavacParser implements Parser {
                 caseKind = JCCase.STATEMENT;
                 stats = blockStatements();
             }
-            JCCaseLabel defaultPattern = toP(F.at(patternPos).DefaultCaseLabel());
             c = F.at(pos).Case(caseKind, List.of(defaultPattern), stats, body);
             if (stats.isEmpty())
                 storeEnd(c, S.prevToken().endPos);

--- a/test/langtools/tools/javac/parser/JavacParserTest.java
+++ b/test/langtools/tools/javac/parser/JavacParserTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7073631 7159445 7156633 8028235 8065753 8205418 8205913 8228451 8237041 8253584 8246774 8256411 8256149 8259050 8266436 8267221 8271928
+ * @bug 7073631 7159445 7156633 8028235 8065753 8205418 8205913 8228451 8237041 8253584 8246774 8256411 8256149 8259050 8266436 8267221 8271928 8275097
  * @summary tests error and diagnostics positions
  * @author  Jan Lahoda
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -52,7 +52,6 @@ import com.sun.source.tree.WhileLoopTree;
 import com.sun.source.util.JavacTask;
 import com.sun.source.util.SourcePositions;
 import com.sun.source.util.TreePath;
-import com.sun.source.util.TreePathScanner;
 import com.sun.source.util.TreeScanner;
 import com.sun.source.util.Trees;
 import com.sun.tools.javac.api.JavacTaskImpl;
@@ -83,6 +82,7 @@ import javax.tools.SimpleJavaFileObject;
 import javax.tools.ToolProvider;
 
 import com.sun.source.tree.CaseTree;
+import com.sun.source.tree.DefaultCaseLabelTree;
 import com.sun.source.util.TreePathScanner;
 import java.util.Objects;
 
@@ -1816,6 +1816,93 @@ public class JavacParserTest extends TestCase {
                     fail("Invalid source position for an ErroneousTree");
                 }
                 return scan(tree.getErrorTrees(), p);
+            }
+        }.scan(cut, null);
+    }
+
+    @Test //JDK-8275097
+    void testDefaultTagPosition() throws IOException {
+        String code = """
+                      package t;
+                      class Test {
+                          private void test1(int i) {
+                              switch (i) {
+                                  default:
+                              }
+                          }
+                          private void test2(int i) {
+                              switch (i) {
+                                  case default:
+                              }
+                          }
+                          private int test3(int i) {
+                              return switch (i) {
+                                  default: yield 0;
+                              }
+                          }
+                          private int test4(int i) {
+                              return switch (i) {
+                                  case default: yield 0;
+                              }
+                          }
+                          private void test5(int i) {
+                              switch (i) {
+                                  default -> {}
+                              }
+                          }
+                          private void test6(int i) {
+                              switch (i) {
+                                  case default -> {}
+                              }
+                          }
+                          private int test5(int i) {
+                              return switch (i) {
+                                  default -> { yield 0; }
+                              }
+                          }
+                          private int test6(int i) {
+                              return switch (i) {
+                                  case default -> { yield 0; }
+                              }
+                          }
+                          private int test7(int i) {
+                              return switch (i) {
+                                  default -> 0;
+                              }
+                          }
+                          private int test8(int i) {
+                              return switch (i) {
+                                  case default -> 0;
+                              }
+                          }
+                      }
+                      """;
+
+        JavacTaskImpl ct = (JavacTaskImpl) tool.getTask(null, fm, null, null,
+                null, Arrays.asList(new MyFileObject(code)));
+        CompilationUnitTree cut = ct.parse().iterator().next();
+        Trees t = Trees.instance(ct);
+        SourcePositions sp = t.getSourcePositions();
+        new TreeScanner<Void, Void>() {
+            @Override
+            public Void visitDefaultCaseLabel(DefaultCaseLabelTree tree, Void p) {
+                int start = (int) sp.getStartPosition(cut, tree);
+                int end   = (int) sp.getEndPosition(cut, tree);
+                String defaultName = code.substring(start, end);
+                if (!"default".equals(defaultName)) {
+                    throw new AssertionError("Incorrect span: " + defaultName);
+                }
+                return super.visitDefaultCaseLabel(tree, p);
+            }
+
+            @Override
+            public Void visitCase(CaseTree node, Void p) {
+                scan(node.getLabels(), p);
+                if (node.getCaseKind() == CaseTree.CaseKind.RULE)
+                    scan(node.getBody(), p);
+                else
+                    scan(node.getStatements(), p);
+                return null;
             }
         }.scan(cut, null);
     }

--- a/test/langtools/tools/javac/patterns/SwitchErrors.out
+++ b/test/langtools/tools/javac/patterns/SwitchErrors.out
@@ -5,13 +5,13 @@ SwitchErrors.java:23:18: compiler.err.prob.found.req: (compiler.misc.inconvertib
 SwitchErrors.java:28:18: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: compiler.misc.type.null, int)
 SwitchErrors.java:29:18: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.String, int)
 SwitchErrors.java:30:18: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: int, java.lang.CharSequence)
-SwitchErrors.java:36:20: compiler.err.total.pattern.and.default
+SwitchErrors.java:36:13: compiler.err.total.pattern.and.default
 SwitchErrors.java:42:18: compiler.err.pattern.dominated
 SwitchErrors.java:42:24: compiler.err.total.pattern.and.default
 SwitchErrors.java:48:18: compiler.err.total.pattern.and.default
 SwitchErrors.java:54:18: compiler.err.duplicate.total.pattern
-SwitchErrors.java:60:20: compiler.err.duplicate.default.label
-SwitchErrors.java:66:20: compiler.err.duplicate.default.label
+SwitchErrors.java:60:13: compiler.err.duplicate.default.label
+SwitchErrors.java:66:13: compiler.err.duplicate.default.label
 SwitchErrors.java:71:27: compiler.err.duplicate.default.label
 SwitchErrors.java:77:18: compiler.err.duplicate.case.label
 SwitchErrors.java:82:24: compiler.err.duplicate.case.label


### PR DESCRIPTION
The span of the 'default' case label AST node is wrong when `default:` is encountered. This patch fixes the positions to be reasonable (i.e. the span of the AST node should be the characters 'default').

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275097](https://bugs.openjdk.java.net/browse/JDK-8275097): Wrong span of the 'default' tag


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5905/head:pull/5905` \
`$ git checkout pull/5905`

Update a local copy of the PR: \
`$ git checkout pull/5905` \
`$ git pull https://git.openjdk.java.net/jdk pull/5905/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5905`

View PR using the GUI difftool: \
`$ git pr show -t 5905`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5905.diff">https://git.openjdk.java.net/jdk/pull/5905.diff</a>

</details>
