### PR TITLE
8274718: runtime/cds/appcds/LambdaEagerInit.java fails with -XX:-CompactStrings

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/LambdaEagerInit.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/LambdaEagerInit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This test uses the default CDS archive with -Xshare:on. However, the default CDS archive may fail to load when a few VM flags are mismatched.
Using  -Xshare:auto instead of -Xshare:on for testDefaultArchiveWithEagerInitializationEnabled() and testDefaultArchiveWithEagerInitializationDisabled() method calls

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274718](https://bugs.openjdk.java.net/browse/JDK-8274718): runtime/cds/appcds/LambdaEagerInit.java fails with -XX:-CompactStrings


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to b6c517bd50a46da8df3ac09784a93211a212f201
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**) ⚠️ Review applies to b6c517bd50a46da8df3ac09784a93211a212f201


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5906/head:pull/5906` \
`$ git checkout pull/5906`

Update a local copy of the PR: \
`$ git checkout pull/5906` \
`$ git pull https://git.openjdk.java.net/jdk pull/5906/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5906`

View PR using the GUI difftool: \
`$ git pr show -t 5906`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5906.diff">https://git.openjdk.java.net/jdk/pull/5906.diff</a>

</details>
