### PR TITLE
8275131: Exceptions after a touchpad gesture on macOS

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -128,7 +128,7 @@ AWT_NS_WINDOW_IMPLEMENTATION
 
             // send up to the GestureHandler to recursively dispatch on the AWT event thread
             DECLARE_CLASS(jc_GestureHandler, "com/apple/eawt/event/GestureHandler");
-            DECLARE_METHOD(sjm_handleGestureFromNative, jc_GestureHandler,
+            DECLARE_STATIC_METHOD(sjm_handleGestureFromNative, jc_GestureHandler,
                             "handleGestureFromNative", "(Ljava/awt/Window;IDDDD)V");
             (*env)->CallStaticVoidMethod(env, jc_GestureHandler, sjm_handleGestureFromNative,
                                awtWindow, type, (jdouble)loc.x, (jdouble)loc.y, (jdouble)a, (jdouble)b);


### PR DESCRIPTION
This is a small fix for a mistake in JDK-8257853 implementation, replacing DECLARE_METHOD JNI lookup macro with DECLARE_STATIC_METHOD in [AWTWindow_Normal postGesture:as:a:b:].
I did not created a test for the fix, as AWT Robot doesn't currently support touchpad gestures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275131](https://bugs.openjdk.java.net/browse/JDK-8275131): Exceptions after a touchpad gesture on macOS


### Reviewers
 * [Dmitry Markov](https://openjdk.java.net/census#dmarkov) (@dmarkov20 - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5910/head:pull/5910` \
`$ git checkout pull/5910`

Update a local copy of the PR: \
`$ git checkout pull/5910` \
`$ git pull https://git.openjdk.java.net/jdk pull/5910/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5910`

View PR using the GUI difftool: \
`$ git pr show -t 5910`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5910.diff">https://git.openjdk.java.net/jdk/pull/5910.diff</a>

</details>
