### PR TITLE
ImmutableCollections.MapN avoid extra table creation

### DIFF
--- a/src/java.base/share/classes/java/util/ImmutableCollections.java
+++ b/src/java.base/share/classes/java/util/ImmutableCollections.java
@@ -1170,20 +1170,26 @@ class ImmutableCollections {
         final int size; // number of pairs
 
         MapN(Object... input) {
-            if ((input.length & 1) != 0) { // implicit nullcheck of input
+            this(i -> input[i], i -> input[i + 1], input.length);
+        }
+
+        MapN(Function<Integer, Object> accessKey,
+             Function<Integer, Object> accessValue,
+             int length) {
+            if ((length & 1) != 0) { // implicit nullcheck of input
                 throw new InternalError("length is odd");
             }
-            size = input.length >> 1;
+            size = length >> 1;
 
-            int len = EXPAND_FACTOR * input.length;
+            int len = EXPAND_FACTOR * length;
             len = (len + 1) & ~1; // ensure table is even length
             table = new Object[len];
 
-            for (int i = 0; i < input.length; i += 2) {
+            for (int i = 0; i < length; i += 2) {
                 @SuppressWarnings("unchecked")
-                    K k = Objects.requireNonNull((K)input[i]);
+                    K k = Objects.requireNonNull((K)accessKey.apply(i));
                 @SuppressWarnings("unchecked")
-                    V v = Objects.requireNonNull((V)input[i+1]);
+                    V v = Objects.requireNonNull((V)accessValue.apply(i));
                 int idx = probe(k);
                 if (idx >= 0) {
                     throw new IllegalArgumentException("duplicate key: " + k);

--- a/src/java.base/share/classes/java/util/Map.java
+++ b/src/java.base/share/classes/java/util/Map.java
@@ -1658,14 +1658,10 @@ public interface Map<K, V> {
             return new ImmutableCollections.Map1<>(entries[0].getKey(),
                     entries[0].getValue());
         } else {
-            Object[] kva = new Object[entries.length << 1];
-            int a = 0;
-            for (Entry<? extends K, ? extends V> entry : entries) {
-                // implicit null checks of each array slot
-                kva[a++] = entry.getKey();
-                kva[a++] = entry.getValue();
-            }
-            return new ImmutableCollections.MapN<>(kva);
+            return new ImmutableCollections.MapN<>(
+                    i -> entries[i].getKey(),
+                    i -> entries[i].getValue(),
+                    entries.length << 1);
         }
     }
 


### PR DESCRIPTION
This small improvement(in terms of memory allocation rate) of new Map#ofEntries method

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5915/head:pull/5915` \
`$ git checkout pull/5915`

Update a local copy of the PR: \
`$ git checkout pull/5915` \
`$ git pull https://git.openjdk.java.net/jdk pull/5915/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5915`

View PR using the GUI difftool: \
`$ git pr show -t 5915`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5915.diff">https://git.openjdk.java.net/jdk/pull/5915.diff</a>

</details>
