### PR TITLE
8269175: [macosx-aarch64] wrong CPU speed in hs_err file

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1315,8 +1315,9 @@ void os::get_summary_cpu_info(char* buf, size_t buflen) {
   if (VM_Version::is_cpu_emulated()) {
     snprintf(buf, buflen, "\"%s\" %s (EMULATED) %d MHz", model, machine, mhz);
   } else {
-    // M1 doesn't report CPU speed
-    snprintf(buf, buflen, "\"%s\" %s", model, machine);
+    NOT_AARCH64(snprintf(buf, buflen, "\"%s\" %s %d MHz", model, machine, mhz));
+    // aarch64 CPU doesn't report its speed
+    AARCH64_ONLY(snprintf(buf, buflen, "\"%s\" %s", model, machine));
   }
 #else
   snprintf(buf, buflen, "\"%s\" %s %d MHz", model, machine, mhz);


### PR DESCRIPTION
macOS does not provide CPU speed for M1, but we currently try to report it in hs_err log file:

`  Host: gerard-mac, "Macmini9,1" arm64 1 MHz, 8 cores, 16G, Darwin 20.5.0, macOS 11.4 (20F71)`

and end up with a bogus "1MHz" value, so we will simply skip the CPU speed from now on for M1 machines:

`  Host: gerard-mac, "Macmini9,1" arm64, 8 cores, 16G, Darwin 20.5.0, macOS 11.4 (20F71)`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269175](https://bugs.openjdk.java.net/browse/JDK-8269175): [macosx-aarch64] wrong CPU speed in hs_err file


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5916/head:pull/5916` \
`$ git checkout pull/5916`

Update a local copy of the PR: \
`$ git checkout pull/5916` \
`$ git pull https://git.openjdk.java.net/jdk pull/5916/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5916`

View PR using the GUI difftool: \
`$ git pr show -t 5916`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5916.diff">https://git.openjdk.java.net/jdk/pull/5916.diff</a>

</details>
