### PR TITLE
8275197: Remove unused fields in ThaiBuddhistChronology

### DIFF
--- a/src/java.base/share/classes/java/time/chrono/ThaiBuddhistChronology.java
+++ b/src/java.base/share/classes/java/time/chrono/ThaiBuddhistChronology.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,6 @@ import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalField;
 import java.time.temporal.ValueRange;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -121,41 +120,6 @@ public final class ThaiBuddhistChronology extends AbstractChronology implements 
      * Containing the offset to add to the ISO year.
      */
     static final int YEARS_DIFFERENCE = 543;
-    /**
-     * Narrow names for eras.
-     */
-    private static final HashMap<String, String[]> ERA_NARROW_NAMES = new HashMap<>();
-    /**
-     * Short names for eras.
-     */
-    private static final HashMap<String, String[]> ERA_SHORT_NAMES = new HashMap<>();
-    /**
-     * Full names for eras.
-     */
-    private static final HashMap<String, String[]> ERA_FULL_NAMES = new HashMap<>();
-    /**
-     * Fallback language for the era names.
-     */
-    private static final String FALLBACK_LANGUAGE = "en";
-    /**
-     * Language that has the era names.
-     */
-    private static final String TARGET_LANGUAGE = "th";
-    /**
-     * Name data.
-     */
-    static {
-        ERA_NARROW_NAMES.put(FALLBACK_LANGUAGE, new String[]{"BB", "BE"});
-        ERA_NARROW_NAMES.put(TARGET_LANGUAGE, new String[]{"BB", "BE"});
-        ERA_SHORT_NAMES.put(FALLBACK_LANGUAGE, new String[]{"B.B.", "B.E."});
-        ERA_SHORT_NAMES.put(TARGET_LANGUAGE,
-                new String[]{"\u0e1e.\u0e28.",
-                "\u0e1b\u0e35\u0e01\u0e48\u0e2d\u0e19\u0e04\u0e23\u0e34\u0e2a\u0e15\u0e4c\u0e01\u0e32\u0e25\u0e17\u0e35\u0e48"});
-        ERA_FULL_NAMES.put(FALLBACK_LANGUAGE, new String[]{"Before Buddhist", "Budhhist Era"});
-        ERA_FULL_NAMES.put(TARGET_LANGUAGE,
-                new String[]{"\u0e1e\u0e38\u0e17\u0e18\u0e28\u0e31\u0e01\u0e23\u0e32\u0e0a",
-                "\u0e1b\u0e35\u0e01\u0e48\u0e2d\u0e19\u0e04\u0e23\u0e34\u0e2a\u0e15\u0e4c\u0e01\u0e32\u0e25\u0e17\u0e35\u0e48"});
-    }
 
     /**
      * Restricted constructor.


### PR DESCRIPTION
Remove 3 unused HashMap's.
Reported here https://mail.openjdk.java.net/pipermail/core-libs-dev/2021-September/081866.html
I did the similar PR to treetenbp and it was merged https://github.com/ThreeTen/threetenbp/pull/155

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275197](https://bugs.openjdk.java.net/browse/JDK-8275197): Remove unused fields in ThaiBuddhistChronology


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5917/head:pull/5917` \
`$ git checkout pull/5917`

Update a local copy of the PR: \
`$ git checkout pull/5917` \
`$ git pull https://git.openjdk.java.net/jdk pull/5917/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5917`

View PR using the GUI difftool: \
`$ git pr show -t 5917`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5917.diff">https://git.openjdk.java.net/jdk/pull/5917.diff</a>

</details>
