### PR TITLE
8275171: ProblemList compiler/codegen/aes/TestAESMain.java on linux-x64 and windows-x64 in -Xcomp mode

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -41,3 +41,5 @@ serviceability/sa/TestJhsdbJstackMixed.java 8248675 linux-aarch64
 
 compiler/vectorapi/VectorCastShape64Test.java 8274855 generic-x64
 compiler/vectorapi/VectorCastShape128Test.java 8274855 generic-x64
+
+compiler/codegen/aes/TestAESMain.java 8274323 linux-x64,windows-x64


### PR DESCRIPTION
A trivial fix to ProblemList compiler/codegen/aes/TestAESMain.java on linux-x64
and windows-x64 in -Xcomp mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275171](https://bugs.openjdk.java.net/browse/JDK-8275171): ProblemList compiler/codegen/aes/TestAESMain.java on linux-x64 and windows-x64 in -Xcomp mode


### Reviewers
 * [Igor Ignatyev](https://openjdk.java.net/census#iignatyev) (@iignatev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5919/head:pull/5919` \
`$ git checkout pull/5919`

Update a local copy of the PR: \
`$ git checkout pull/5919` \
`$ git pull https://git.openjdk.java.net/jdk pull/5919/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5919`

View PR using the GUI difftool: \
`$ git pr show -t 5919`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5919.diff">https://git.openjdk.java.net/jdk/pull/5919.diff</a>

</details>
