### PR TITLE
8275173: testlibrary_tests/ir_framework/tests/TestCheckedTests.java fails after JDK-8274911

### DIFF
--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestCheckedTests.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestCheckedTests.java
@@ -26,6 +26,8 @@ package ir_framework.tests;
 import compiler.lib.ir_framework.*;
 import compiler.lib.ir_framework.driver.IRViolationException;
 import compiler.lib.ir_framework.driver.TestVMException;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import jdk.test.lib.Asserts;
 
 /*
@@ -41,11 +43,17 @@ public class TestCheckedTests {
     public int iFld;
 
     public static void main(String[] args) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream ps = new PrintStream(baos);
+        PrintStream oldOut = System.out;
+        System.setOut(ps);
+
         TestFramework.run();
         try {
             TestFramework.run(BadIRAndRuntimeCheckedTests.class);
-            Utils.shouldHaveThrownException();
+            Utils.shouldHaveThrownException(baos.toString());
         } catch (TestVMException e) {
+            System.setOut(oldOut);
             Asserts.assertTrue(e.getExceptionInfo().contains("Test Failures (2)"));
             Asserts.assertTrue(e.getExceptionInfo().contains("checkTestBad3"));
             Asserts.assertTrue(e.getExceptionInfo().contains("checkTestBad5"));
@@ -53,10 +61,12 @@ public class TestCheckedTests {
             Asserts.assertFalse(e.getExceptionInfo().contains("Failed IR Rules"));
         }
 
+        System.setOut(ps);
         try {
             TestFramework.run(BadIRCheckedTests.class);
-            Utils.shouldHaveThrownException();
+            Utils.shouldHaveThrownException(baos.toString());
         } catch (IRViolationException e) {
+            System.setOut(oldOut);
             Asserts.assertTrue(e.getExceptionInfo().contains("Failed IR Rules (3)"));
         }
     }


### PR DESCRIPTION
Hi all,

May I get reviews for this change?

The fix just follows what is done for test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestRunTests.java in JDK-8274911.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275173](https://bugs.openjdk.java.net/browse/JDK-8275173): testlibrary_tests/ir_framework/tests/TestCheckedTests.java fails after JDK-8274911


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5921/head:pull/5921` \
`$ git checkout pull/5921`

Update a local copy of the PR: \
`$ git checkout pull/5921` \
`$ git pull https://git.openjdk.java.net/jdk pull/5921/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5921`

View PR using the GUI difftool: \
`$ git pr show -t 5921`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5921.diff">https://git.openjdk.java.net/jdk/pull/5921.diff</a>

</details>
