### PR TITLE
JDK-8275187: Suppress warnings on non-serializable array component types in java.sql.rowset

### DIFF
--- a/src/java.sql.rowset/share/classes/com/sun/rowset/internal/BaseRow.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/internal/BaseRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,6 +61,7 @@ private static final long serialVersionUID = 4152013523511412238L;
  * object.
  * @serial
  */
+    @SuppressWarnings("serial") // Array component type is not Serializable
     protected Object[] origVals;
 
 /**

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/internal/CachedRowSetWriter.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/internal/CachedRowSetWriter.java
@@ -147,6 +147,7 @@ public class CachedRowSetWriter implements TransactionalWriter, Serializable {
  *
  * @serial
  */
+    @SuppressWarnings("serial") // Array component type is not Serializable
     private Object[] params;
 
 /**

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/internal/Row.java
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/internal/Row.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,6 +53,7 @@ static final long serialVersionUID = 5047859032611314762L;
  * object.
  * @serial
  */
+    @SuppressWarnings("serial") // Array component type is not Serializable
     private Object[] currentVals;
 
 /**


### PR DESCRIPTION
After a refinement to the checks under development in #5709, the new checks examine array types of serial fields and warn if the underlying component type is not serializable. Per the JLS, all array types are serializable, but if the base component is not serializable, the serialization process can throw an exception.

From "Java Object Serialization Specification: 2 - Object Output Classes":

"If the object is an array, writeObject is called recursively to write the ObjectStreamClass of the array. The handle for the array is assigned. It is followed by the length of the array. Each element of the array is then written to the stream, after which writeObject returns."

The java.sql.rowset module has several instances of this coding pattern that need suppression to compile successfully under the future warning.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275187](https://bugs.openjdk.java.net/browse/JDK-8275187): Suppress warnings on non-serializable array component types in java.sql.rowset


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5925/head:pull/5925` \
`$ git checkout pull/5925`

Update a local copy of the PR: \
`$ git checkout pull/5925` \
`$ git pull https://git.openjdk.java.net/jdk pull/5925/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5925`

View PR using the GUI difftool: \
`$ git pr show -t 5925`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5925.diff">https://git.openjdk.java.net/jdk/pull/5925.diff</a>

</details>
