### PR TITLE
8262912: ciReplay: replay does not simulate unresolved classes

### DIFF
--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -636,8 +636,15 @@ ciKlass* ciEnv::get_klass_by_index_impl(const constantPoolHandle& cpool,
   }
 
   // It is known to be accessible, since it was found in the constant pool.
+  ciKlass* ciKlass = get_klass(klass);
   is_accessible = true;
-  return get_klass(klass);
+#ifndef PRODUCT
+  if (ReplayCompiles && ciKlass == _unloaded_ciinstance_klass) {
+    // Klass was unresolved at replay dump time and therefore not accessible.
+    is_accessible = false;
+  }
+#endif
+  return ciKlass;
 }
 
 // ------------------------------------------------------------------

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -27,6 +27,7 @@
 
 #include "ci/ciClassList.hpp"
 #include "ci/ciObjectFactory.hpp"
+#include "ci/ciReplay.hpp"
 #include "classfile/vmClassMacros.hpp"
 #include "code/debugInfoRec.hpp"
 #include "code/dependencies.hpp"
@@ -187,6 +188,15 @@ private:
     if (o == NULL) {
       return NULL;
     } else {
+#ifndef PRODUCT
+      if (ReplayCompiles && o->is_klass()) {
+        Klass* k = (Klass*)o;
+        if (k->is_instance_klass() && ciReplay::is_klass_unresolved((InstanceKlass*)k)) {
+          // Klass was unresolved at replay dump time. Simulate this case.
+          return ciEnv::_unloaded_ciinstance_klass;
+        }
+      }
+#endif
       return _factory->get_metadata(o);
     }
   }

--- a/src/hotspot/share/ci/ciInstanceKlass.hpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.hpp
@@ -43,6 +43,7 @@ class ciInstanceKlass : public ciKlass {
   friend class ciExceptionHandler;
   friend class ciMethod;
   friend class ciField;
+  friend class ciReplay;
 
 private:
   enum SubklassValue { subklass_unknown, subklass_false, subklass_true };

--- a/src/hotspot/share/ci/ciObjectFactory.cpp
+++ b/src/hotspot/share/ci/ciObjectFactory.cpp
@@ -378,6 +378,7 @@ ciMetadata* ciObjectFactory::create_new_metadata(Metadata* o) {
   if (o->is_klass()) {
     Klass* k = (Klass*)o;
     if (k->is_instance_klass()) {
+      assert(!ReplayCompiles || ciReplay::no_replay_state() || !ciReplay::is_klass_unresolved((InstanceKlass*)k), "must be whitelisted for replay compilation");
       return new (arena()) ciInstanceKlass(k);
     } else if (k->is_objArray_klass()) {
       return new (arena()) ciObjArrayKlass(k);

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -49,6 +49,7 @@
 #include "runtime/fieldDescriptor.inline.hpp"
 #include "runtime/globals_extension.hpp"
 #include "runtime/handles.inline.hpp"
+#include "runtime/jniHandles.inline.hpp"
 #include "runtime/java.hpp"
 #include "utilities/copy.hpp"
 #include "utilities/macros.hpp"
@@ -90,6 +91,11 @@ typedef struct _ciMethodRecord {
   int _backedge_counter;
 } ciMethodRecord;
 
+typedef struct _ciInstanceKlassRecord {
+  const InstanceKlass* _klass;
+  jobject _java_mirror; // Global handle to java mirror to prevent unloading
+} ciInstanceKlassRecord;
+
 typedef struct _ciInlineRecord {
   const char* _klass_name;
   const char* _method_name;
@@ -111,6 +117,7 @@ class CompileReplay : public StackObj {
 
   GrowableArray<ciMethodRecord*>     _ci_method_records;
   GrowableArray<ciMethodDataRecord*> _ci_method_data_records;
+  GrowableArray<ciInstanceKlassRecord*> _ci_instance_klass_records;
 
   // Use pointer because we may need to return inline records
   // without destroying them.
@@ -882,7 +889,7 @@ class CompileReplay : public StackObj {
   // constant pool is the same length as 'length' and make sure the
   // constant pool tags are in the same state.
   void process_ciInstanceKlass(TRAPS) {
-    InstanceKlass* k = (InstanceKlass *)parse_klass(CHECK);
+    InstanceKlass* k = (InstanceKlass*)parse_klass(CHECK);
     if (k == NULL) {
       return;
     }
@@ -905,6 +912,7 @@ class CompileReplay : public StackObj {
     } else if (is_linked) {
       k->link_class(CHECK);
     }
+    new_ciInstanceKlass(k);
     ConstantPool* cp = k->constants();
     if (length != cp->length()) {
       report_error("constant pool length mismatch: wrong class files?");
@@ -951,10 +959,10 @@ class CompileReplay : public StackObj {
           break;
 
         case JVM_CONSTANT_Class:
-          if (tag == JVM_CONSTANT_Class) {
-          } else if (tag == JVM_CONSTANT_UnresolvedClass) {
-            tty->print_cr("Warning: entry was unresolved in the replay data");
-          } else {
+          if (tag == JVM_CONSTANT_UnresolvedClass) {
+            Klass* k = cp->klass_at(i, CHECK);
+            tty->print_cr("Warning: entry was unresolved in the replay data: %s", k->name()->as_utf8());
+          } else if (tag != JVM_CONSTANT_Class) {
             report_error("Unexpected tag");
             return;
           }
@@ -1132,6 +1140,28 @@ class CompileReplay : public StackObj {
     return NULL;
   }
 
+  // Create and initialize a record for a ciInstanceKlass which was present at replay dump time.
+  void new_ciInstanceKlass(const InstanceKlass* klass) {
+    ciInstanceKlassRecord* rec = NEW_RESOURCE_OBJ(ciInstanceKlassRecord);
+    rec->_klass = klass;
+    oop java_mirror = klass->java_mirror();
+    Handle h_java_mirror(_thread, java_mirror);
+    rec->_java_mirror = JNIHandles::make_global(h_java_mirror);
+    _ci_instance_klass_records.append(rec);
+  }
+
+  // Check if a ciInstanceKlass was present at replay dump time for a klass.
+  ciInstanceKlassRecord* find_ciInstanceKlass(const InstanceKlass* klass) {
+    for (int i = 0; i < _ci_instance_klass_records.length(); i++) {
+      ciInstanceKlassRecord* rec = _ci_instance_klass_records.at(i);
+      if (klass == rec->_klass) {
+        // ciInstanceKlass for this klass was resolved.
+        return rec;
+      }
+    }
+    return NULL;
+  }
+
   // Create and initialize a record for a ciMethodData
   ciMethodDataRecord* new_ciMethodData(Method* method) {
     ciMethodDataRecord* rec = NEW_RESOURCE_OBJ(ciMethodDataRecord);
@@ -1265,6 +1295,10 @@ void ciReplay::replay(TRAPS) {
   vm_exit(exit_code);
 }
 
+bool ciReplay::no_replay_state() {
+  return replay_state == NULL;
+}
+
 void* ciReplay::load_inline_data(ciMethod* method, int entry_bci, int comp_level) {
   if (FLAG_IS_DEFAULT(InlineDataFile)) {
     tty->print_cr("ERROR: no inline replay data file specified (use -XX:InlineDataFile=inline_pid12345.txt).");
@@ -1336,7 +1370,7 @@ int ciReplay::replay_impl(TRAPS) {
 }
 
 void ciReplay::initialize(ciMethodData* m) {
-  if (replay_state == NULL) {
+  if (no_replay_state()) {
     return;
   }
 
@@ -1390,7 +1424,7 @@ void ciReplay::initialize(ciMethodData* m) {
 
 
 bool ciReplay::should_not_inline(ciMethod* method) {
-  if (replay_state == NULL) {
+  if (no_replay_state()) {
     return false;
   }
   VM_ENTRY_MARK;
@@ -1427,7 +1461,7 @@ bool ciReplay::should_not_inline(void* data, ciMethod* method, int bci, int inli
 }
 
 void ciReplay::initialize(ciMethod* m) {
-  if (replay_state == NULL) {
+  if (no_replay_state()) {
     return;
   }
 
@@ -1456,8 +1490,17 @@ void ciReplay::initialize(ciMethod* m) {
   }
 }
 
+void ciReplay::initialize(ciInstanceKlass* ci_ik, InstanceKlass* ik) {
+  assert(!no_replay_state(), "must have replay state");
+
+  ASSERT_IN_VM;
+  ciInstanceKlassRecord* rec = replay_state->find_ciInstanceKlass(ik);
+  assert(rec != NULL, "ciInstanceKlass must be whitelisted");
+  ci_ik->_java_mirror = CURRENT_ENV->get_instance(JNIHandles::resolve(rec->_java_mirror));
+}
+
 bool ciReplay::is_loaded(Method* method) {
-  if (replay_state == NULL) {
+  if (no_replay_state()) {
     return true;
   }
 
@@ -1466,6 +1509,16 @@ bool ciReplay::is_loaded(Method* method) {
 
   ciMethodRecord* rec = replay_state->find_ciMethodRecord(method);
   return rec != NULL;
+}
+
+bool ciReplay::is_klass_unresolved(const InstanceKlass* klass) {
+  if (no_replay_state()) {
+    return false;
+  }
+
+  // Check if klass is found on whitelist.
+  ciInstanceKlassRecord* rec = replay_state->find_ciInstanceKlass(klass);
+  return rec == NULL;
 }
 #endif // PRODUCT
 

--- a/src/hotspot/share/ci/ciReplay.hpp
+++ b/src/hotspot/share/ci/ciReplay.hpp
@@ -106,6 +106,7 @@ class ciReplay {
  public:
   // Replay specified compilation and exit VM.
   static void replay(TRAPS);
+  static bool no_replay_state();
   // Load inlining decisions from file and use them
   // during compilation of specified method.
   static void* load_inline_data(ciMethod* method, int entry_bci, int comp_level);
@@ -114,7 +115,9 @@ class ciReplay {
   // replay file when replaying compiles.
   static void initialize(ciMethodData* method);
   static void initialize(ciMethod* method);
+  static void initialize(ciInstanceKlass* ciKlass, InstanceKlass* ik);
 
+  static bool is_klass_unresolved(const InstanceKlass* klass);
   static bool is_loaded(Method* method);
 
   static bool should_not_inline(ciMethod* method);

--- a/test/hotspot/jtreg/compiler/ciReplay/CiReplayBase.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/CiReplayBase.java
@@ -132,7 +132,7 @@ public abstract class CiReplayBase {
 
     public abstract void testAction();
 
-    private static void remove(String item) {
+    public static void remove(String item) {
         File toDelete = new File(item);
         toDelete.delete();
         if (Platform.isWindows()) {
@@ -164,14 +164,14 @@ public abstract class CiReplayBase {
             options.add(needCoreDump ? ENABLE_COREDUMP_ON_CRASH : DISABLE_COREDUMP_ON_CRASH);
             if (needCoreDump) {
                 // CiReplayBase$TestMain needs to be quoted because of shell eval
-                options.add("-XX:CompileOnly='" + TestMain.class.getName() + "::test'");
-                options.add("'" + TestMain.class.getName() + "'");
+                options.add("-XX:CompileOnly='" + getTestClass() + "::test'");
+                options.add("'" + getTestClass() + "'");
                 crashOut = ProcessTools.executeProcess(
                         CoreUtils.addCoreUlimitCommand(
                                 ProcessTools.createTestJvm(options.toArray(new String[0]))));
             } else {
-                options.add("-XX:CompileOnly=" + TestMain.class.getName() + "::test");
-                options.add(TestMain.class.getName());
+                options.add("-XX:CompileOnly=" + getTestClass() + "::test");
+                options.add(getTestClass());
                 crashOut = ProcessTools.executeProcess(ProcessTools.createTestJvm(options));
             }
             crashOutputString = crashOut.getOutput();
@@ -192,6 +192,10 @@ public abstract class CiReplayBase {
         }
         removeFromCurrentDirectoryStartingWith(HS_ERR_NAME);
         return true;
+    }
+
+    public String getTestClass() {
+        return TestMain.class.getName();
     }
 
     public void commonTests() {

--- a/test/hotspot/jtreg/compiler/ciReplay/TestUnresolvedClasses.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/TestUnresolvedClasses.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8262912
+ * @library / /test/lib
+ * @summary Test class resolution based on whitelist created by ciInstanceKlass entries in replay file.
+ * @requires vm.flightRecorder != true & vm.compMode != "Xint" & vm.debug == true & vm.compiler2.enabled
+ * @modules java.base/jdk.internal.misc
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      compiler.ciReplay.TestUnresolvedClasses
+ */
+
+package compiler.ciReplay;
+
+import jdk.test.lib.Asserts;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestUnresolvedClasses extends CiReplayBase {
+    private static final String LOG_FILE = "hotspot.log";
+    private static final String[] COMMAND_LINE = new String[] {"-XX:LogFile='" + LOG_FILE + "'", "-XX:+LogCompilation", "-XX:+PrintIdeal",
+                                                               "-XX:CompileCommand=dontinline,compiler.ciReplay.Test::dontInline"};
+    public static void main(String[] args) {
+        new TestUnresolvedClasses().runTest(false, TIERED_DISABLED_VM_OPTION);
+    }
+
+    @Override
+    public String getTestClass() {
+        return Test.class.getName();
+    }
+
+    @Override
+    public void testAction() {
+        positiveTest(COMMAND_LINE);
+        // Should find CallStaticJava node for dontInline() as f.bar() is resolved and parsing completes.
+        checkLogFile(true);
+
+        // Remove ciInstanceKlass entry for Foo in replay file.
+        try {
+            Path replayFilePath = Paths.get(REPLAY_FILE_NAME);
+            List<String> replayContent = Files.readAllLines(replayFilePath);
+            List<String> newReplayContent = new ArrayList<>();
+            boolean foundFoo = false;
+            for (String line : replayContent) {
+                if (!line.startsWith("ciInstanceKlass compiler/ciReplay/Foo")) {
+                    newReplayContent.add(line);
+                } else {
+                    foundFoo = true;
+                }
+            }
+            Asserts.assertTrue(foundFoo, "Did not find ciInstanceKlass compiler/ciReplay/Foo entry");
+            Files.write(replayFilePath, newReplayContent, StandardOpenOption.TRUNCATE_EXISTING);
+        } catch (IOException ioe) {
+            throw new Error("Failed to read/write replay data: " + ioe, ioe);
+        }
+
+        positiveTest(COMMAND_LINE);
+        // No ciInstanceKlass entry for Foo is found in the replay. Replay compilation simulates that Foo is unresolved.
+        // Therefore, C2 cannot resolve f.bar() at parsing time. It emits an UCT to resolve Foo and stops parsing.
+        // The call to dontInline() will not be parsed and thus we should not find a CallStaticJava node for it.
+        checkLogFile(false);
+        remove(LOG_FILE);
+    }
+
+    // Parse <ideal> entry in hotspot.log file and try to find the call for dontInline().
+    private void checkLogFile(boolean shouldMatch) {
+        String toMatch = "Test::dontInline";
+        try (var br = Files.newBufferedReader(Paths.get(LOG_FILE))) {
+            String line;
+            boolean printIdealLine = false;
+            while ((line = br.readLine()) != null) {
+                if (printIdealLine) {
+                    if (line.startsWith("</ideal")) {
+                        break;
+                    }
+                    if (line.contains(toMatch)) {
+                        Asserts.assertTrue(line.contains("CallStaticJava"), "must be CallStaticJava node");
+                        Asserts.assertTrue(shouldMatch, "Should not have found " + toMatch);
+                        return;
+                    }
+                } else {
+                    printIdealLine = line.startsWith("<ideal");
+                }
+            }
+        } catch (IOException e) {
+            throw new Error("Failed to read " + LOG_FILE + " data: " + e, e);
+        }
+        Asserts.assertFalse(shouldMatch, "Should have found " + toMatch);
+    }
+}
+
+class Test {
+    static Foo f = new Foo();
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10000; i++) {
+            test();
+        }
+    }
+
+    public static void test() {
+        f.bar();
+        // At replay compilation: Should emit UCT for f.bar() because class Foo is unloaded. Parsing stops here.
+        // dontInline() is not parsed anymore.
+        dontInline();
+    }
+
+    // Not inlined
+    public static void dontInline() {
+    }
+}
+
+class Foo {
+    public int bar() {
+        return 3;
+    }
+}


### PR DESCRIPTION
When trying to replay compile, the JVM will always resolve some classes before actually doing the replay compilation. When finally replay compiling the method, the state of `ciInstanceKlasses` which are resolved/unresolved could be different compared to the state at which the replay file was dumped. This will even be a bigger problem when tackling [JDK-8254110](https://bugs.openjdk.java.net/browse/JDK-8254110).

This change intends to fix this by only treating a `ciInstanceKlass` as *not* unresolved if there is a corresponding entry for it in the replay file. This is achieved by a whitelist (`ciInstanceKlassRecord`). All accesses to get a pointer to a `ciInstanceKlass` are eventually routed through `ciEnv::get_metadata()`. This method is hooked to compare it against the replay compilation whitelist. If the corresponding `Klass` is not on the list, an unresolved `ciInstanceKlass` is returned instead.

Finding a way to reliably test this feature was difficult. I therefore came up with a test which first creates a replay file with `CICrashAt` and then removes the `ciInstanceKlass` entry for class `Foo` to simulate that `Foo` was unresolved at replay dump time. This will result in a different C2 IR which is verified by checking the `PrintIdeal` output (see comments in test).

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262912](https://bugs.openjdk.java.net/browse/JDK-8262912): ciReplay: replay does not simulate unresolved classes


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5926/head:pull/5926` \
`$ git checkout pull/5926`

Update a local copy of the PR: \
`$ git checkout pull/5926` \
`$ git pull https://git.openjdk.java.net/jdk pull/5926/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5926`

View PR using the GUI difftool: \
`$ git pr show -t 5926`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5926.diff">https://git.openjdk.java.net/jdk/pull/5926.diff</a>

</details>
