### PR TITLE
8254267: javax/xml/crypto/dsig/LogParameters.java failed with "RuntimeException: Unexpected log output:"

### DIFF
--- a/test/jdk/javax/xml/crypto/dsig/LogParameters.java
+++ b/test/jdk/javax/xml/crypto/dsig/LogParameters.java
@@ -29,13 +29,16 @@ import java.util.logging.*;
 /**
  * @test
  * @bug 8247907 8254267
+ * @summary Tests that parameterized log messages (the ones that use "{}") generated
+ * through the use of com.sun.org.slf4j.internal.Logger work as expected and the parameter
+ * values are properly replaced in the logged message.
  * @library /test/lib
  * @modules java.xml.crypto/com.sun.org.slf4j.internal
  * @run main/othervm LogParameters
  */
 public class LogParameters {
 
-    private static final Logger julLogger = Logger.getLogger(String.class.getName());
+    private static final Logger julLogger = Logger.getLogger(LogParameters.class.getName());
 
     public static void main(String[] args) {
 
@@ -45,8 +48,11 @@ public class LogParameters {
         h.setLevel(Level.ALL);
         julLogger.addHandler(h);
 
+        // now create a com.sun.org.slf4j.internal.Logger for the same class
+        // for which we just configured the java.util.logging.Logger instance
         com.sun.org.slf4j.internal.Logger log =
-                com.sun.org.slf4j.internal.LoggerFactory.getLogger(String.class);
+                com.sun.org.slf4j.internal.LoggerFactory.getLogger(LogParameters.class);
+        // issue a parameterized log message
         log.debug("I have {} {}s.", 10, "apple");
 
         h.flush();


### PR DESCRIPTION
The commit here tries to address an intermittent failure reported in https://bugs.openjdk.java.net/browse/JDK-8254267.

The `LogParameters` test case sets the log level to `ALL` for the `java.lang.String.class` and then attaches a handler to it. It then proceeds to write out a log message at `DEBUG` level and expects the log message to have been delivered to the handler.  This should all work fine and does work fine except for those intermittent failures.

Looking at the output attached in that JBS issue, there's this:

```
command: main LogParameters
reason: Assumed action based on file name: run main LogParameters
Mode: agentvm 
```
which states that the test is using `agentvm` mode, since the test itself doesn't specify a specific mode. For a test like this one which deals with log level management of `java.util.logging` infrastructure, in theory, there are chances that some other tests within the same JVM instance might impact the output and can potentially contribute to intermittent failures like this one.

The commit in this PR tries to address that issue by explicitly running the test in `othervm` mode.

P.S: Every once in a while my logins to JBS don't work and if I just wait for a few hours, things get sorted on its own. Today is one such occasion - successful login, but it still shows me as logged out and doesn't allow me to do anything. So I decided to directly create this PR instead of first commenting there.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254267](https://bugs.openjdk.java.net/browse/JDK-8254267): javax/xml/crypto/dsig/LogParameters.java failed with "RuntimeException: Unexpected log output:"


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**) ⚠️ Review applies to 856c361ab7611da4cfbaa0d0a7bdf848a9e00ad7
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5927/head:pull/5927` \
`$ git checkout pull/5927`

Update a local copy of the PR: \
`$ git checkout pull/5927` \
`$ git pull https://git.openjdk.java.net/jdk pull/5927/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5927`

View PR using the GUI difftool: \
`$ git pr show -t 5927`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5927.diff">https://git.openjdk.java.net/jdk/pull/5927.diff</a>

</details>
