### PR TITLE
8275163: Deflater::deflate methods omit javadoc for ReadOnlyBufferException

### DIFF
--- a/src/java.base/share/classes/java/util/zip/Deflater.java
+++ b/src/java.base/share/classes/java/util/zip/Deflater.java
@@ -495,6 +495,7 @@ public class Deflater {
      * @param output the buffer for the compressed data
      * @return the actual number of bytes of compressed data written to the
      *         output buffer
+     * @throws ReadOnlyBufferException if the given output buffer is read-only
      * @since 11
      */
     public int deflate(ByteBuffer output) {
@@ -674,6 +675,7 @@ public class Deflater {
      *         the output buffer
      *
      * @throws IllegalArgumentException if the flush mode is invalid
+     * @throws ReadOnlyBufferException if the given output buffer is read-only
      * @since 11
      */
     public int deflate(ByteBuffer output, int flush) {


### PR DESCRIPTION
Hi all,

Please review the fix to  address a javadoc issue for the  Deflater::deflate methods that were added as part of JDK-6341887 that could throw a ReadOnlyBufferException. 

The` @throws ` clause for `ReadOnlyBufferException`  was inadvertently omitted from the javadoc for these new methods.

A CSR, JDK-8275164, has also been created for this issue.

Best
Lance

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275163](https://bugs.openjdk.java.net/browse/JDK-8275163): Deflater::deflate methods omit javadoc for ReadOnlyBufferException


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5931/head:pull/5931` \
`$ git checkout pull/5931`

Update a local copy of the PR: \
`$ git checkout pull/5931` \
`$ git pull https://git.openjdk.java.net/jdk pull/5931/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5931`

View PR using the GUI difftool: \
`$ git pr show -t 5931`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5931.diff">https://git.openjdk.java.net/jdk/pull/5931.diff</a>

</details>
