### PR TITLE
JDK-8275244: Suppress warnings on non-serializable array component types in jdk.management

### DIFF
--- a/src/jdk.management/share/classes/com/sun/management/internal/GcInfoCompositeData.java
+++ b/src/jdk.management/share/classes/com/sun/management/internal/GcInfoCompositeData.java
@@ -55,6 +55,7 @@ public class GcInfoCompositeData extends LazyCompositeData {
     private final GcInfo info;
     @SuppressWarnings("serial") // Type of field is not Serializable
     private final GcInfoBuilder builder;
+    @SuppressWarnings("serial") // Array component type is not Serializable
     private final Object[] gcExtItemValues;
 
     public GcInfoCompositeData(GcInfo info,


### PR DESCRIPTION
After a refinement to the checks under development in #5709, the new checks examine array types of serial fields and warn if the underlying component type is not serializable. Per the JLS, all array types are serializable, but if the base component is not serializable, the serialization process can throw an exception.

From "Java Object Serialization Specification: 2 - Object Output Classes":

"If the object is an array, writeObject is called recursively to write the ObjectStreamClass of the array. The handle for the array is assigned. It is followed by the length of the array. Each element of the array is then written to the stream, after which writeObject returns."

The jdk.management module has an instance of this coding pattern that need suppression to compile successfully under the future warning.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275244](https://bugs.openjdk.java.net/browse/JDK-8275244): Suppress warnings on non-serializable array component types in jdk.management


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5934/head:pull/5934` \
`$ git checkout pull/5934`

Update a local copy of the PR: \
`$ git checkout pull/5934` \
`$ git pull https://git.openjdk.java.net/jdk pull/5934/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5934`

View PR using the GUI difftool: \
`$ git pr show -t 5934`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5934.diff">https://git.openjdk.java.net/jdk/pull/5934.diff</a>

</details>
