### PR TITLE
JDK-8275249: Suppress warnings on non-serializable array component types in jdk.jlink

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/TaskHelper.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/TaskHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,6 +81,7 @@ public final class TaskHelper {
             return this;
         }
         public final String key;
+        @SuppressWarnings("serial") // Array component type is not Serializable
         public final Object[] args;
         public boolean showUsage;
     }


### PR DESCRIPTION
After a refinement to the checks under development in #5709, the new checks examine array types of serial fields and warn if the underlying component type is not serializable. Per the JLS, all array types are serializable, but if the base component is not serializable, the serialization process can throw an exception.

From "Java Object Serialization Specification: 2 - Object Output Classes":

"If the object is an array, writeObject is called recursively to write the ObjectStreamClass of the array. The handle for the array is assigned. It is followed by the length of the array. Each element of the array is then written to the stream, after which writeObject returns."

The jdk.jlink module has one instance of this coding pattern that needs suppression to compile successfully under the future warning.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275249](https://bugs.openjdk.java.net/browse/JDK-8275249): Suppress warnings on non-serializable array component types in jdk.jlink


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5936/head:pull/5936` \
`$ git checkout pull/5936`

Update a local copy of the PR: \
`$ git checkout pull/5936` \
`$ git pull https://git.openjdk.java.net/jdk pull/5936/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5936`

View PR using the GUI difftool: \
`$ git pr show -t 5936`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5936.diff">https://git.openjdk.java.net/jdk/pull/5936.diff</a>

</details>
