### PR TITLE
8275265: java/nio/channels tests needing large heap sizes fail on x86_32

### DIFF
--- a/test/jdk/java/nio/channels/Channels/ReadXBytes.java
+++ b/test/jdk/java/nio/channels/Channels/ReadXBytes.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8268435 8274780
  * @summary Verify ChannelInputStream methods readAllBytes and readNBytes
+ * @requires vm.bits == 64
  * @library ..
  * @library /test/lib
  * @build jdk.test.lib.RandomFactory

--- a/test/jdk/java/nio/channels/FileChannel/LargeGatheringWrite.java
+++ b/test/jdk/java/nio/channels/FileChannel/LargeGatheringWrite.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8274548
  * @summary Test gathering write of more than INT_MAX bytes
+ * @requires vm.bits == 64
  * @library ..
  * @library /test/lib
  * @build jdk.test.lib.RandomFactory


### PR DESCRIPTION
Hi all,

java/nio/channels/FileChannel/LargeGatheringWrite.java and java/nio/channels/Channels/ReadXBytes.java fail on x86_32.

This is because they require `-Xmx4G` and `-Xmx8G`, which are invalid on 32-bit platforms.
So let's exclude them on 32-bit platforms.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275265](https://bugs.openjdk.java.net/browse/JDK-8275265): java/nio/channels tests needing large heap sizes fail on x86_32


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5942/head:pull/5942` \
`$ git checkout pull/5942`

Update a local copy of the PR: \
`$ git checkout pull/5942` \
`$ git pull https://git.openjdk.java.net/jdk pull/5942/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5942`

View PR using the GUI difftool: \
`$ git pr show -t 5942`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5942.diff">https://git.openjdk.java.net/jdk/pull/5942.diff</a>

</details>
