### PR TITLE
JDK-8223356: Bad placement of marker comment in module-summary.html

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriterImpl.java
@@ -815,10 +815,10 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
     public void addModuleDescription(Content moduleContentTree) {
         addPreviewInfo(mdle, moduleContentTree);
         if (!utils.getFullBody(mdle).isEmpty()) {
+            moduleContentTree.add(MarkerComments.START_OF_MODULE_DESCRIPTION);
             HtmlTree tree = HtmlTree.SECTION(HtmlStyle.moduleDescription)
                     .setId(HtmlIds.MODULE_DESCRIPTION);
             addDeprecationInfo(tree);
-            tree.add(MarkerComments.START_OF_MODULE_DESCRIPTION);
             addInlineComment(mdle, tree);
             addTagsInfo(mdle, tree);
             moduleContentTree.add(tree);

--- a/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
+++ b/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
@@ -28,6 +28,7 @@
  *      8175823 8166306 8178043 8181622 8183511 8169819 8074407 8183037 8191464
  *      8164407 8192007 8182765 8196200 8196201 8196202 8196202 8205593 8202462
  *      8184205 8219060 8223378 8234746 8239804 8239816 8253117 8245058 8261976
+ *      8223356
  * @summary Test modules support in javadoc.
  * @library ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -464,6 +465,7 @@ public class TestModules extends JavadocTester {
         checkOutput("moduleA/module-summary.html", found,
                 """
                     <!-- ============ MODULE DESCRIPTION =========== -->
+                    <section class="module-description" id="module-description">
                     <a name="module-description">
                     <!--   -->
                     </a>
@@ -473,6 +475,7 @@ public class TestModules extends JavadocTester {
         checkOutput("moduleB/module-summary.html", found,
                 """
                     <!-- ============ MODULE DESCRIPTION =========== -->
+                    <section class="module-description" id="module-description">
                     <a name="module-description">
                     <!--   -->
                     </a>
@@ -501,19 +504,19 @@ public class TestModules extends JavadocTester {
     void checkHtml5Description(boolean found) {
         checkOutput("moduleA/module-summary.html", found,
                 """
+                    <!-- ============ MODULE DESCRIPTION =========== -->
                     <section class="module-description" id="module-description">
                     <div class="deprecation-block"><span class="deprecated-label">Deprecated, for re\
                     moval: This API element is subject to removal in a future version.</span>
                     <div class="deprecation-comment">This module is deprecated.</div>
                     </div>
-                    <!-- ============ MODULE DESCRIPTION =========== -->
                     <div class="block">This is a test description for the moduleA module with a Sear\
                     ch phrase <span id="searchphrase" class="search-tag-result">search phrase</span>\
                     .</div>""");
         checkOutput("moduleB/module-summary.html", found,
                 """
-                    <section class="module-description" id="module-description">
                     <!-- ============ MODULE DESCRIPTION =========== -->
+                    <section class="module-description" id="module-description">
                     <div class="block">This is a test description for the moduleB module. Search wor\
                     d <span id="search_word" class="search-tag-result">search_word</span> with no de\
                     scription.</div>""");

--- a/test/langtools/jdk/javadoc/doclet/testValueTag/TestValueTagInModule.java
+++ b/test/langtools/jdk/javadoc/doclet/testValueTag/TestValueTagInModule.java
@@ -69,8 +69,8 @@ public class TestValueTagInModule extends JavadocTester {
 
         checkOutput("m1/module-summary.html", true,
                 """
-                    <section class="module-description" id="module-description">
                     <!-- ============ MODULE DESCRIPTION =========== -->
+                    <section class="module-description" id="module-description">
                     <div class="block">value of field CONS : <a href="pkg/A.html#CONS">100</a></div>""");
     }
 


### PR DESCRIPTION
Please review this simple change to move the marker comment for the start of the module description up one line to make it precede the `<section>` element.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8223356](https://bugs.openjdk.java.net/browse/JDK-8223356): Bad placement of marker comment in module-summary.html


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5946/head:pull/5946` \
`$ git checkout pull/5946`

Update a local copy of the PR: \
`$ git checkout pull/5946` \
`$ git pull https://git.openjdk.java.net/jdk pull/5946/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5946`

View PR using the GUI difftool: \
`$ git pr show -t 5946`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5946.diff">https://git.openjdk.java.net/jdk/pull/5946.diff</a>

</details>
