### PR TITLE
JDK-8223357: No marker comment for a package in package-summary.html

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MarkerComments.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MarkerComments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,6 +60,12 @@ public class MarkerComments {
      */
     public static final Comment START_OF_MODULES_SUMMARY =
             new Comment("============ MODULES SUMMARY ===========");
+
+    /**
+     * Marker to identify start of package description.
+     */
+    public static final Comment START_OF_PACKAGE_DESCRIPTION =
+            new Comment("============ PACKAGE DESCRIPTION ===========");
 
     /**
      * Marker to identify start of packages summary.

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
@@ -334,6 +334,7 @@ public class PackageWriterImpl extends HtmlDocletWriter
     public void addPackageDescription(Content packageContentTree) {
         addPreviewInfo(packageElement, packageContentTree);
         if (!utils.getBody(packageElement).isEmpty()) {
+            packageContentTree.add(MarkerComments.START_OF_PACKAGE_DESCRIPTION);
             HtmlTree tree = sectionTree;
             tree.setId(HtmlIds.PACKAGE_DESCRIPTION);
             addDeprecationInfo(tree);

--- a/test/langtools/jdk/javadoc/doclet/testPackageDescription/TestPackageDescription.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageDescription/TestPackageDescription.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug      8185194 8182765 8261976
+ * @bug      8185194 8182765 8261976 8223357
  * @summary  Test anchor for package description in package summary page
   * @library  ../../lib/
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -49,8 +49,10 @@ public class TestPackageDescription extends JavadocTester {
 
         checkOutput("pkg/package-summary.html", true,
                 """
+                    <!-- ============ PACKAGE DESCRIPTION =========== -->
                     <section class="package-description" id="package-description">
                     <div class="block">package description</div>
+                    </section>
                     """);
     }
 }


### PR DESCRIPTION
Please review yet another simple fix to add a marker comment to the start of the package description in `package-summary.html` files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8223357](https://bugs.openjdk.java.net/browse/JDK-8223357): No marker comment for a package in package-summary.html


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5947/head:pull/5947` \
`$ git checkout pull/5947`

Update a local copy of the PR: \
`$ git checkout pull/5947` \
`$ git pull https://git.openjdk.java.net/jdk pull/5947/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5947`

View PR using the GUI difftool: \
`$ git pr show -t 5947`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5947.diff">https://git.openjdk.java.net/jdk/pull/5947.diff</a>

</details>
