### PR TITLE
8231107: Allow store password to be null when saving a PKCS12 KeyStore

### DIFF
--- a/src/java.base/share/classes/java/security/KeyStore.java
+++ b/src/java.base/share/classes/java/security/KeyStore.java
@@ -1384,7 +1384,9 @@ public class KeyStore {
      * integrity with the given password.
      *
      * @param stream the output stream to which this keystore is written.
-     * @param password the password to generate the keystore integrity check
+     * @param password the password to generate the keystore integrity check.
+     *                 May be {@code null} if the keystore does not support
+     *                 or require an integrity check.
      *
      * @throws    KeyStoreException if the keystore has not been initialized
      * (loaded).

--- a/src/java.base/share/classes/java/security/KeyStoreSpi.java
+++ b/src/java.base/share/classes/java/security/KeyStoreSpi.java
@@ -289,7 +289,9 @@ public abstract class KeyStoreSpi {
      * integrity with the given password.
      *
      * @param stream the output stream to which this keystore is written.
-     * @param password the password to generate the keystore integrity check
+     * @param password the password to generate the keystore integrity check.
+     *                 May be {@code null} if the keystore does not support
+     *                 or require an integrity check.
      *
      * @throws    IOException if there was an I/O problem with data
      * @throws    NoSuchAlgorithmException if the appropriate data integrity

--- a/test/jdk/sun/security/pkcs12/EmptyPassword.java
+++ b/test/jdk/sun/security/pkcs12/EmptyPassword.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8202299
+ * @bug 8202299 8231107
  * @modules java.base/sun.security.tools.keytool
  *          java.base/sun.security.x509
  * @library /test/lib
@@ -38,6 +38,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
+import java.util.Arrays;
 
 public class EmptyPassword {
 
@@ -52,13 +53,35 @@ public class EmptyPassword {
                 new Certificate[] {
                         gen.getSelfCertificate(new X500Name("CN=Me"), 100)
                 });
-        try (FileOutputStream fos = new FileOutputStream("p12")) {
-            ks.store(fos, new char[1]);
-        }
+
+        // 8202299: interop before new char[0] and new char[1]
+        store(ks, "p12", new char[1]);
 
         // It can be loaded with password "".
         ks = KeyStore.getInstance(new File("p12"), new char[0]);
         Asserts.assertTrue(ks.getKey("a", new char[0]) != null);
         Asserts.assertTrue(ks.getCertificate("a") != null);
+
+        // 8231107: Store with null password makes it password-less
+        store(ks, "p00", null);
+
+        // Can read cert and key with any password
+        for (char[] pass: new char[][] {
+                new char[0],    // password actually used before 8202299
+                new char[1],    // the interoperability before 8202299
+                null,           // password-less after 8202299
+                "whatever".toCharArray()
+        }) {
+            System.out.println("with password " + Arrays.toString(pass));
+            ks = KeyStore.getInstance(new File("p00"), pass);
+            Asserts.assertTrue(ks.getKey("a", new char[1]) != null);
+            Asserts.assertTrue(ks.getCertificate("a") != null);
+        }
+    }
+
+    static void store(KeyStore ks, String file, char[] pass) throws Exception {
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            ks.store(fos, pass);
+        }
     }
 }

--- a/test/jdk/sun/security/pkcs12/EmptyPassword.java
+++ b/test/jdk/sun/security/pkcs12/EmptyPassword.java
@@ -27,7 +27,7 @@
  * @modules java.base/sun.security.tools.keytool
  *          java.base/sun.security.x509
  * @library /test/lib
- * @summary Java Keystore fails to load PKCS12/PFX certificates created in WindowsServer2016
+ * @summary Testing empty (any of null, "", "\0") password behaviors
  */
 
 import jdk.test.lib.Asserts;
@@ -54,12 +54,16 @@ public class EmptyPassword {
                         gen.getSelfCertificate(new X500Name("CN=Me"), 100)
                 });
 
-        // 8202299: interop before new char[0] and new char[1]
+        // 8202299: interop between new char[0] and new char[1]
         store(ks, "p12", new char[1]);
 
         // It can be loaded with password "".
         ks = KeyStore.getInstance(new File("p12"), new char[0]);
         Asserts.assertTrue(ks.getKey("a", new char[0]) != null);
+        Asserts.assertTrue(ks.getCertificate("a") != null);
+
+        ks = KeyStore.getInstance(new File("p12"), new char[1]);
+        Asserts.assertTrue(ks.getKey("a", new char[1]) != null);
         Asserts.assertTrue(ks.getCertificate("a") != null);
 
         // 8231107: Store with null password makes it password-less


### PR DESCRIPTION
You can create a password-less PKCS12 KeyStore file now by calling `ks.store(outStream, null)` no matter what the default cert protection algorithm and Mac algorithm are defined in `java.security`.

Note: the system properties set in `ToolsJDK.gmk` to generate `cacerts` must be retained (at the moment) because the tool is launched with BOOT_JDK.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8231107](https://bugs.openjdk.java.net/browse/JDK-8231107): Allow store password to be null when saving a PKCS12 KeyStore
 * [JDK-8274862](https://bugs.openjdk.java.net/browse/JDK-8274862): Allow store password to be null when saving a PKCS12 KeyStore (**CSR**) ⚠️ Issue is not open.


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**) ⚠️ Review applies to 7d789775cdf6ef45f0f849682ffc45c5689c723d


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5950/head:pull/5950` \
`$ git checkout pull/5950`

Update a local copy of the PR: \
`$ git checkout pull/5950` \
`$ git pull https://git.openjdk.java.net/jdk pull/5950/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5950`

View PR using the GUI difftool: \
`$ git pr show -t 5950`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5950.diff">https://git.openjdk.java.net/jdk/pull/5950.diff</a>

</details>
