### PR TITLE
8275137: jdk.unsupported/sun.reflect.ReflectionFactory.readObjectNoDataForSerialization uses wrong signature

### DIFF
--- a/src/java.base/share/classes/jdk/internal/reflect/ReflectionFactory.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/ReflectionFactory.java
@@ -478,7 +478,7 @@ public class ReflectionFactory {
     }
 
     public final MethodHandle readObjectNoDataForSerialization(Class<?> cl) {
-        return findReadWriteObjectForSerialization(cl, "readObjectNoData", ObjectInputStream.class);
+        return findReadWriteObjectForSerialization(cl, "readObjectNoData", null);
     }
 
     public final MethodHandle writeObjectForSerialization(Class<?> cl) {
@@ -493,7 +493,8 @@ public class ReflectionFactory {
         }
 
         try {
-            Method meth = cl.getDeclaredMethod(methodName, streamClass);
+            Method meth = streamClass == null ? cl.getDeclaredMethod(methodName)
+                    : cl.getDeclaredMethod(methodName, streamClass);
             int mods = meth.getModifiers();
             if (meth.getReturnType() != Void.TYPE ||
                     Modifier.isStatic(mods) ||

--- a/src/jdk.unsupported/share/classes/sun/reflect/ReflectionFactory.java
+++ b/src/jdk.unsupported/share/classes/sun/reflect/ReflectionFactory.java
@@ -144,9 +144,9 @@ public class ReflectionFactory {
     /**
      * Returns a direct MethodHandle for the {@code readObjectNoData} method on
      * a Serializable class.
-     * The first argument of {@link MethodHandle#invoke} is the serializable
-     * object and the second argument is the {@code ObjectInputStream} passed to
-     * {@code readObjectNoData}.
+     * The only argument of {@link MethodHandle#invoke} is the serializable
+     * object, which {@code readObjectNoData} is called on. No arguments are
+     * passed to the {@code readObjectNoData} method.
      *
      * @param cl a Serializable class
      * @return  a direct MethodHandle for the {@code readObjectNoData} method

--- a/test/jdk/sun/reflect/ReflectionFactory/ReflectionFactoryTest.java
+++ b/test/jdk/sun/reflect/ReflectionFactory/ReflectionFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.io.ObjectInput;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
 import java.io.OptionalDataException;
 import java.io.Serializable;
 import java.lang.invoke.MethodHandle;
@@ -45,11 +46,11 @@ import org.testng.TestNG;
 
 /*
  * @test
- * @bug 8137058 8164908 8168980
- * @run testng ReflectionFactoryTest
- * @run testng/othervm/policy=security.policy ReflectionFactoryTest
+ * @bug 8137058 8164908 8168980 8275137
  * @summary Basic test for the unsupported ReflectionFactory
  * @modules jdk.unsupported
+ * @run testng ReflectionFactoryTest
+ * @run testng/othervm/policy=security.policy ReflectionFactoryTest
  */
 
 public class ReflectionFactoryTest {
@@ -81,8 +82,7 @@ public class ReflectionFactoryTest {
      */
     @Test(dataProvider="ClassConstructors")
     static void testConstructor(Class<?> type)
-        throws NoSuchMethodException, InstantiationException,
-            IllegalAccessException, InvocationTargetException
+            throws InstantiationException, IllegalAccessException, InvocationTargetException
     {
         @SuppressWarnings("unchecked")
         Constructor<?> c = factory.newConstructorForSerialization(type);
@@ -131,8 +131,8 @@ public class ReflectionFactoryTest {
         }
 
         Assert.assertEquals(((Foo)o).foo(), expectedFoo);
-        if (o instanceof Baz) {
-            Assert.assertEquals(((Baz)o).baz(), expectedBaz);
+        if (o instanceof Baz b) {
+            Assert.assertEquals(b.baz(), expectedBaz);
         }
     }
 
@@ -178,7 +178,7 @@ public class ReflectionFactoryTest {
     }
 
     /**
-     * Test newConstructorForExternalization returns the constructor and it can be called.
+     * Tests that newConstructorForExternalization returns the constructor and it can be called.
      * @throws NoSuchMethodException - error
      * @throws InstantiationException - error
      * @throws IllegalAccessException - error
@@ -186,8 +186,7 @@ public class ReflectionFactoryTest {
      */
     @Test
     static void newConstructorForExternalization()
-            throws NoSuchMethodException, InstantiationException,
-            IllegalAccessException, InvocationTargetException {
+            throws InstantiationException, IllegalAccessException, InvocationTargetException {
         Constructor<?> cons = factory.newConstructorForExternalization(Ext.class);
         Ext ext = (Ext)cons.newInstance();
         Assert.assertEquals(ext.ext, 1, "Constructor not run");
@@ -251,7 +250,7 @@ public class ReflectionFactoryTest {
             Assert.assertFalse(ser2.readObjectNoDataCalled, "readObjectNoData should not be called");
             Assert.assertFalse(ser2.readResolveCalled, "readResolve should not be called");
 
-            readObjectNoDataMethod.invoke(ser2, ois);
+            readObjectNoDataMethod.invoke(ser2);
             Assert.assertTrue(ser2.readObjectCalled, "readObject should have been called");
             Assert.assertTrue(ser2.readObjectNoDataCalled, "readObjectNoData not called");
             Assert.assertFalse(ser2.readResolveCalled, "readResolve should not be called");
@@ -283,12 +282,12 @@ public class ReflectionFactoryTest {
 
         public Ser() {}
 
-        private void readObject(ObjectInputStream ois) throws IOException {
+        private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
             Assert.assertFalse(writeObjectCalled, "readObject called too many times");
             readObjectCalled = ois.readBoolean();
         }
 
-        private void readObjectNoData(ObjectInputStream ois) throws IOException {
+        private void readObjectNoData() throws ObjectStreamException {
             Assert.assertFalse(readObjectNoDataCalled, "readObjectNoData called too many times");
             readObjectNoDataCalled = true;
         }
@@ -299,13 +298,13 @@ public class ReflectionFactoryTest {
             oos.writeBoolean(writeObjectCalled);
         }
 
-        private Object writeReplace() {
+        private Object writeReplace() throws ObjectStreamException {
             Assert.assertFalse(writeReplaceCalled, "writeReplace called too many times");
             writeReplaceCalled = true;
             return this;
         }
 
-        private Object readResolve() {
+        private Object readResolve() throws ObjectStreamException {
             Assert.assertFalse(readResolveCalled, "readResolve called too many times");
             readResolveCalled = true;
             return this;
@@ -313,7 +312,7 @@ public class ReflectionFactoryTest {
     }
 
     /**
-     * Test the constructor of OptionalDataExceptions.
+     * Tests the constructor of OptionalDataExceptions.
      */
     @Test
     static void newOptionalDataException() {
@@ -323,8 +322,6 @@ public class ReflectionFactoryTest {
         Assert.assertFalse(ode.eof, "eof wrong");
 
     }
-
-
 
     // Main can be used to run the tests from the command line with only testng.jar.
     @SuppressWarnings("raw_types")


### PR DESCRIPTION
sun.reflect.ReflectionFactory provides MethodHandles for the various serialization methods, it is a critical internal API in the jdk.unsupported module (see JEP 260 [1]) that may be used by 3rd party serialization libraries. 

One of these serialization methods is readObjectNoData [2]:

```private void readObjectNoData() throws ObjectStreamException;```

The issue: The method that returns the matching handle, sun.reflect.ReflectionFactory.readObjectNoDataForSerialization, uses an erroneous signature `readObjectNoData(ObjectInputStream)` - note the superfluous parameter.

This change updates the specification and fixes the implementation in java.base/jdk.internal.reflect.ReflectionFactory.

Testing: tier 1-3

[1] https://openjdk.java.net/jeps/260
[2] https://docs.oracle.com/en/java/javase/15/docs/specs/serialization/input.html#the-readobjectnodata-method

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275137](https://bugs.openjdk.java.net/browse/JDK-8275137): jdk.unsupported/sun.reflect.ReflectionFactory.readObjectNoDataForSerialization uses wrong signature


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5951/head:pull/5951` \
`$ git checkout pull/5951`

Update a local copy of the PR: \
`$ git checkout pull/5951` \
`$ git pull https://git.openjdk.java.net/jdk pull/5951/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5951`

View PR using the GUI difftool: \
`$ git pr show -t 5951`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5951.diff">https://git.openjdk.java.net/jdk/pull/5951.diff</a>

</details>
