### PR TITLE
JDK-8275320: NMT should perform buffer overrun checks

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -669,13 +669,14 @@ void* os::malloc(size_t size, MEMFLAGS memflags, const NativeCallStack& stack) {
 
   // NMT support
   NMT_TrackingLevel level = MemTracker::tracking_level();
-  size_t            nmt_header_size = MemTracker::malloc_header_size(level);
+  const size_t nmt_overhead =
+      MemTracker::malloc_header_size(level) + MemTracker::malloc_footer_size(level);
 
 #ifndef ASSERT
-  const size_t alloc_size = size + nmt_header_size;
+  const size_t alloc_size = size + nmt_overhead;
 #else
-  const size_t alloc_size = GuardedMemory::get_total_size(size + nmt_header_size);
-  if (size + nmt_header_size > alloc_size) { // Check for rollover.
+  const size_t alloc_size = GuardedMemory::get_total_size(size + nmt_overhead);
+  if (size + nmt_overhead > alloc_size) { // Check for rollover.
     return NULL;
   }
 #endif
@@ -693,7 +694,7 @@ void* os::malloc(size_t size, MEMFLAGS memflags, const NativeCallStack& stack) {
     return NULL;
   }
   // Wrap memory with guard
-  GuardedMemory guarded(ptr, size + nmt_header_size);
+  GuardedMemory guarded(ptr, size + nmt_overhead);
   ptr = guarded.get_user_ptr();
 
   if ((intptr_t)ptr == (intptr_t)MallocCatchPtr) {
@@ -741,8 +742,9 @@ void* os::realloc(void *memblock, size_t size, MEMFLAGS memflags, const NativeCa
    // NMT support
   NMT_TrackingLevel level = MemTracker::tracking_level();
   void* membase = MemTracker::record_free(memblock, level);
-  size_t  nmt_header_size = MemTracker::malloc_header_size(level);
-  void* ptr = ::realloc(membase, size + nmt_header_size);
+  const size_t nmt_overhead =
+      MemTracker::malloc_header_size(level) + MemTracker::malloc_footer_size(level);
+  void* ptr = ::realloc(membase, size + nmt_overhead);
   return MemTracker::record_malloc(ptr, size, memflags, stack, level);
 #else
   if (memblock == NULL) {

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -763,7 +763,10 @@ void* os::realloc(void *memblock, size_t size, MEMFLAGS memflags, const NativeCa
   if (ptr != NULL ) {
     GuardedMemory guarded(MemTracker::malloc_base(memblock));
     // Guard's user data contains NMT header
-    size_t memblock_size = guarded.get_user_size() - MemTracker::malloc_header_size(memblock);
+    NMT_TrackingLevel level = MemTracker::tracking_level();
+    const size_t nmt_overhead =
+        MemTracker::malloc_header_size(level) + MemTracker::malloc_footer_size(level);
+    size_t memblock_size = guarded.get_user_size() - nmt_overhead;
     memcpy(ptr, memblock, MIN2(size, memblock_size));
     if (paranoid) {
       verify_memory(MemTracker::malloc_base(ptr));

--- a/src/hotspot/share/services/mallocSiteTable.cpp
+++ b/src/hotspot/share/services/mallocSiteTable.cpp
@@ -39,7 +39,6 @@ volatile int MallocSiteTable::_access_count = 0;
 // Tracking hashtable contention
 NOT_PRODUCT(int MallocSiteTable::_peak_count = 0;)
 
-
 /*
  * Initialize malloc site table.
  * Hashtable entry is malloc'd, so it can cause infinite recursion.
@@ -49,7 +48,6 @@ NOT_PRODUCT(int MallocSiteTable::_peak_count = 0;)
  * time, it is in single-threaded mode from JVM perspective.
  */
 bool MallocSiteTable::initialize() {
-  assert((size_t)table_size <= MAX_MALLOCSITE_TABLE_SIZE, "Hashtable overflow");
 
   // Fake the call stack for hashtable entry allocation
   assert(NMT_TrackingStackDepth > 1, "At least one tracking stack");

--- a/src/hotspot/share/services/mallocSiteTable.hpp
+++ b/src/hotspot/share/services/mallocSiteTable.hpp
@@ -114,6 +114,9 @@ class MallocSiteTable : AllStatic {
     table_size = (table_base_size * NMT_TrackingStackDepth - 1)
   };
 
+  // The table must not be wider than the maximum value the bucket_idx field
+  // in the malloc header can hold.
+  STATIC_ASSERT(table_size <= MAX_MALLOCSITE_TABLE_SIZE);
 
   // This is a very special lock, that allows multiple shared accesses (sharedLock), but
   // once exclusive access (exclusiveLock) is requested, all shared accesses are

--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -109,7 +109,7 @@ void MallocMemorySummary::initialize() {
 void MallocHeader::mark_block_as_dead() {
   _canary = _header_canary_dead_mark;
   NOT_LP64(_alt_canary = _header_alt_canary_dead_mark);
-  set_footer_byte(_footer_canary_dead_mark);
+  set_footer(_footer_canary_dead_mark);
 }
 
 void MallocHeader::release() {
@@ -211,7 +211,7 @@ void MallocHeader::check_block_integrity() const {
   }
 
   // Check footer canary
-  if (get_footer_byte() != _footer_canary_life_mark) {
+  if (get_footer() != _footer_canary_life_mark) {
     print_block_on_error(tty, footer_address());
     fatal("Block at " PTR_FORMAT ": footer canary broken at " PTR_FORMAT " (buffer overflow?)",
           p2i(this), p2i(footer_address()));

--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -131,7 +131,7 @@ void MallocHeader::print_block_on_error(outputStream* st, address bad_address) c
   assert(bad_address >= (address)this, "sanity");
 
   // This function prints block information, including hex dump, in case of a detected
-  // corruption. The hex dump should show the both block header and the corruption site
+  // corruption. The hex dump should show both block header and corruption site
   // (which may or may not be close together or identical). Plus some surrounding area.
   //
   // Note that we use os::print_hex_dump(), which is able to cope with unmapped

--- a/src/hotspot/share/services/mallocTracker.hpp
+++ b/src/hotspot/share/services/mallocTracker.hpp
@@ -432,11 +432,6 @@ class MallocTracker : AllStatic {
     return header->flags();
   }
 
-  // Get header size
-  static inline size_t get_header_size(void* memblock) {
-    return (memblock == NULL) ? 0 : sizeof(MallocHeader);
-  }
-
   static inline void record_new_arena(MEMFLAGS flags) {
     MallocMemorySummary::record_new_arena(flags);
   }

--- a/src/hotspot/share/services/mallocTracker.hpp
+++ b/src/hotspot/share/services/mallocTracker.hpp
@@ -239,31 +239,99 @@ class MallocMemorySummary : AllStatic {
 
 /*
  * Malloc tracking header.
- * To satisfy malloc alignment requirement, NMT uses 2 machine words for tracking purpose,
- * which ensures 8-bytes alignment on 32-bit systems and 16-bytes on 64-bit systems (Product build).
+ *
+ * If NMT is active (state >= minimal), we need to track allocations. A simple and cheap way to
+ * do this is by using malloc headers.
+ *
+ * The user allocation is preceded by a header and followed by a single footer canary byte:
+ *
+ * +--------------+-------------  ....  ------------------+-----+
+ * |    header    |               user                    | can |
+ * |              |             allocation                | ary |
+ * +--------------+-------------  ....  ------------------+-----+
+ *     16 bytes              user size                      1 byte
+ *
+ * Alignment:
+ *
+ * The start of the user allocation needs to adhere to malloc alignment. We assume 2 words
+ * (16 bytes/8 bytes on 64-bit/32-bit) to be enough for that (todo: it may not be enough on 32bit).
+ *
+ * That dictates a minimum alignment of the size of a malloc header of 2 words. However, since
+ * 8 bytes are not enough to hold all information we need, we have to enlarge the malloc header on
+ * 32-bit. So the malloc header is 16 bytes long on both 32-bit and 64-bit.
+ *
+ * Layout on 64-bit:
+ *
+ *     0        1        2        3        4        5        6        7
+ * +--------+--------+--------+--------+--------+--------+--------+--------+
+ * |                            64-bit size                                |  ...
+ * +--------+--------+--------+--------+--------+--------+--------+--------+
+ *
+ *           8        9        10       11       12       13       14       15          16 ++
+ *       +--------+--------+--------+--------+--------+--------+--------+--------+  ------------------------
+ *  ...  |   bucket idx    |     pos idx     | flags  | unused |     canary      |  ... User payload ....
+ *       +--------+--------+--------+--------+--------+--------+--------+--------+  ------------------------
+ *
+ * Layout on 32-bit:
+ *
+ *     0        1        2        3        4        5        6        7
+ * +--------+--------+--------+--------+--------+--------+--------+--------+
+ * |            alt. canary            |           32-bit size             |  ...
+ * +--------+--------+--------+--------+--------+--------+--------+--------+
+ *
+ *           8        9        10       11       12       13       14       15          16 ++
+ *       +--------+--------+--------+--------+--------+--------+--------+--------+  ------------------------
+ *  ...  |   bucket idx    |     pos idx     | flags  | unused |     canary      |  ... User payload ....
+ *       +--------+--------+--------+--------+--------+--------+--------+--------+  ------------------------
+ *
+ * Notes:
+ * - We have a canary in the two bytes directly preceding the user payload. That allows us to
+ *   catch negative buffer overflows.
+ * - On 32-bit, due to the smaller size_t, we have some bits to spare. So we also have a second
+ *   canary at the very start of the malloc header (generously sized 32 bits).
+ * - The footer canary is just one byte since this is still enough to catch overflows, and it
+ *   allows us to not care about aligned accesses.
  */
 
 class MallocHeader {
-#ifdef _LP64
-  size_t           _size      : 64;
-  size_t           _flags     : 8;
-  size_t           _pos_idx   : 16;
-  size_t           _bucket_idx: 40;
-#define MAX_MALLOCSITE_TABLE_SIZE right_n_bits(40)
-#define MAX_BUCKET_LENGTH         right_n_bits(16)
-#else
-  size_t           _size      : 32;
-  size_t           _flags     : 8;
-  size_t           _pos_idx   : 8;
-  size_t           _bucket_idx: 16;
-#define MAX_MALLOCSITE_TABLE_SIZE  right_n_bits(16)
-#define MAX_BUCKET_LENGTH          right_n_bits(8)
-#endif  // _LP64
+
+  NOT_LP64(uint32_t _alt_canary);
+  size_t _size;
+  uint16_t _bucket_idx;
+  uint16_t _pos_idx;
+  uint8_t _flags;
+  uint8_t _unused;
+  uint16_t _canary;
+
+#define MAX_MALLOCSITE_TABLE_SIZE (USHRT_MAX - 1)
+#define MAX_BUCKET_LENGTH         (USHRT_MAX - 1)
+
+  static const uint16_t _header_canary_life_mark = 0xFA1F;
+  static const uint16_t _header_canary_dead_mark = 0xFB1F;
+  static const uint8_t  _footer_canary_life_mark = 0xFA;
+  static const uint8_t  _footer_canary_dead_mark = 0xFB;
+  NOT_LP64(static const uint32_t _header_alt_canary_life_mark = 0xFAFA1F1F;)
+  NOT_LP64(static const uint32_t _header_alt_canary_dead_mark = 0xFBFB1F1F;)
+
+  // We discount sizes larger than these
+  static const size_t max_reasonable_malloc_size = LP64_ONLY(256 * G) NOT_LP64(3500 * M);
+
+  // Check block integrity. If block is broken, print out a report
+  // to tty (optionally with hex dump surrounding the broken block),
+  // then trigger a fatal error.
+  void check_block_integrity() const;
+  void print_block_on_error(outputStream* st, address bad_address) const;
+  void mark_block_as_dead();
+
+  uint8_t* footer_address() const { return ((address)this) + sizeof(MallocHeader) + _size; }
+  uint8_t get_footer_byte() const { return *footer_address(); }
+  void set_footer_byte(uint8_t b) { (*footer_address()) = b; }
 
  public:
+
   MallocHeader(size_t size, MEMFLAGS flags, const NativeCallStack& stack, NMT_TrackingLevel level) {
-    assert(sizeof(MallocHeader) == sizeof(void*) * 2,
-      "Wrong header size");
+
+    assert(size < max_reasonable_malloc_size, "Too large allocation size?");
 
     if (level == NMT_minimal) {
       return;
@@ -277,10 +345,17 @@ class MallocHeader {
       if (record_malloc_site(stack, size, &bucket_idx, &pos_idx, flags)) {
         assert(bucket_idx <= MAX_MALLOCSITE_TABLE_SIZE, "Overflow bucket index");
         assert(pos_idx <= MAX_BUCKET_LENGTH, "Overflow bucket position index");
-        _bucket_idx = bucket_idx;
-        _pos_idx = pos_idx;
+        _bucket_idx = (uint16_t)bucket_idx;
+        _pos_idx = (uint16_t)pos_idx;
       }
     }
+
+    _unused = 0;
+    _canary = _header_canary_life_mark;
+    // On 32-bit we have some bits more, use them for a second canary
+    // guarding the start of the header.
+    NOT_LP64(_alt_canary = _header_alt_canary_life_mark;)
+    set_footer_byte(_footer_canary_life_mark); // set after initializing _size
 
     MallocMemorySummary::record_malloc(size, flags);
     MallocMemorySummary::record_new_malloc_header(sizeof(MallocHeader));
@@ -290,8 +365,8 @@ class MallocHeader {
   inline MEMFLAGS flags() const { return (MEMFLAGS)_flags; }
   bool get_stack(NativeCallStack& stack) const;
 
-  // Cleanup tracking information before the memory is released.
-  void release() const;
+  // Cleanup tracking information and mark block as dead before the memory is released.
+  void release();
 
  private:
   inline void set_size(size_t size) {
@@ -300,6 +375,9 @@ class MallocHeader {
   bool record_malloc_site(const NativeCallStack& stack, size_t size,
     size_t* bucket_idx, size_t* pos_idx, MEMFLAGS flags) const;
 };
+
+// This needs to be true on both 64-bit and 32-bit platforms
+STATIC_ASSERT(sizeof(MallocHeader) == (sizeof(uint64_t) * 2));
 
 
 // Main class called from MemTracker to track malloc activities
@@ -313,6 +391,11 @@ class MallocTracker : AllStatic {
   // malloc tracking header size for specific tracking level
   static inline size_t malloc_header_size(NMT_TrackingLevel level) {
     return (level == NMT_off) ? 0 : sizeof(MallocHeader);
+  }
+
+  // malloc tracking footer size for specific tracking level
+  static inline size_t malloc_footer_size(NMT_TrackingLevel level) {
+    return (level == NMT_off) ? 0 : 1;
   }
 
   // Parameter name convention:

--- a/src/hotspot/share/services/memTracker.hpp
+++ b/src/hotspot/share/services/memTracker.hpp
@@ -58,6 +58,7 @@ class MemTracker : AllStatic {
     const NativeCallStack& stack, NMT_TrackingLevel level) { return mem_base; }
   static inline size_t malloc_header_size(NMT_TrackingLevel level) { return 0; }
   static inline size_t malloc_header_size(void* memblock) { return 0; }
+  static inline size_t malloc_footer_size(NMT_TrackingLevel level) { return 0; }
   static inline void* malloc_base(void* memblock) { return memblock; }
   static inline void* record_free(void* memblock, NMT_TrackingLevel level) { return memblock; }
 
@@ -155,6 +156,11 @@ class MemTracker : AllStatic {
 
   static inline size_t malloc_header_size(NMT_TrackingLevel level) {
     return MallocTracker::malloc_header_size(level);
+  }
+
+  // malloc tracking footer size for specific tracking level
+  static inline size_t malloc_footer_size(NMT_TrackingLevel level) {
+    return MallocTracker::malloc_footer_size(level);
   }
 
   static size_t malloc_header_size(void* memblock) {

--- a/src/hotspot/share/services/memTracker.hpp
+++ b/src/hotspot/share/services/memTracker.hpp
@@ -163,13 +163,6 @@ class MemTracker : AllStatic {
     return MallocTracker::malloc_footer_size(level);
   }
 
-  static size_t malloc_header_size(void* memblock) {
-    if (tracking_level() != NMT_off) {
-      return MallocTracker::get_header_size(memblock);
-    }
-    return 0;
-  }
-
   // To malloc base address, which is the starting address
   // of malloc tracking header if tracking is enabled.
   // Otherwise, it returns the same address.

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -237,7 +237,6 @@ void report_vm_error(const char* file, int line, const char* error_msg)
 
 
 static void print_error_for_unit_test(const char* message, const char* detail_fmt, va_list detail_args) {
-#ifdef ASSERT
   if (ExecutingUnitTests) {
     char detail_msg[256];
     if (detail_fmt != NULL) {
@@ -262,7 +261,6 @@ static void print_error_for_unit_test(const char* message, const char* detail_fm
       va_end(detail_args_copy);
     }
   }
-#endif // ASSERT
 }
 
 void report_vm_error(const char* file, int line, const char* error_msg, const char* detail_fmt, ...)

--- a/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "precompiled.hpp"
+#include "memory/allocation.hpp"
+#include "runtime/os.hpp"
+#include "services/memTracker.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/ostream.hpp"
+#include "unittest.hpp"
+
+#if INCLUDE_NMT
+
+#define DEFINE_TEST(test_function, expected_assertion_message)                            \
+  TEST_VM_FATAL_ERROR_MSG(NMT, test_function, ".*" expected_assertion_message ".*") {     \
+    if (MemTracker::tracking_level() > NMT_off) {                                         \
+      tty->print_cr("NMT overwrite death test, please ignore subsequent error dump.");    \
+      test_function ();                                                                   \
+    } else {                                                                              \
+      /* overflow detection requires NMT to be on. If off, fake assert. */                \
+      guarantee(false,                                                                    \
+                "fake message ignore this - " expected_assertion_message);                \
+    }                                                                                     \
+  }
+
+///////
+
+static void test_overwrite_front() {
+  address p = (address) os::malloc(1, mtTest);
+  *(p - 1) = 'a';
+  os::free(p);
+}
+
+DEFINE_TEST(test_overwrite_front, "header canary broken")
+
+///////
+
+static void test_overwrite_back() {
+  address p = (address) os::malloc(1, mtTest);
+  *(p + 1) = 'a';
+  os::free(p);
+}
+
+DEFINE_TEST(test_overwrite_back, "footer canary broken")
+
+///////
+
+// this should generate two hex dumps, one with the front header, one with the overwritten
+// portion.
+static void test_overwrite_back_long() {
+  address p = (address) os::malloc(0x2000, mtTest);
+  *(p + 0x2000) = 'a';
+  os::free(p);
+}
+
+DEFINE_TEST(test_overwrite_back_long, "footer canary broken")
+
+///////
+
+static void test_double_free() {
+  address p = (address) os::malloc(1, mtTest);
+  os::free(p);
+  // Now a double free. Note that this is susceptible to concurrency issues should
+  // a concurrent thread have done a malloc and gotten the same address after the
+  // first free. To decrease chance of this happening, we repeat the double free
+  // several times.
+  for (int i = 0; i < 100; i ++) {
+    os::free(p);
+  }
+}
+
+// What assertion message we will see depends on whether the VM wipes the memory-to-be-freed
+// on the first free(), and whether the libc uses the freed memory to store bookkeeping information.
+// If the death marker in the header is still intact after the first free, we will recognize this as
+// double free; if it got wiped, we should at least see a broken header canary.
+// The message would be either
+// - "header canary broken" or
+// - "header canary dead (double free?)".
+// However, since gtest regex expressions do not support unions (a|b), I search for a reasonable
+// subset here.
+DEFINE_TEST(test_double_free, "header canary")
+
+///////
+
+static void test_invalid_block_address() {
+  // very low, like the result of an overflow or of accessing a NULL this pointer
+  os::free((void*)0x100);
+}
+DEFINE_TEST(test_invalid_block_address, "invalid block address")
+
+///////
+
+static void test_unaliged_block_address() {
+  address p = (address) os::malloc(1, mtTest);
+  os::free(p + 6);
+}
+DEFINE_TEST(test_unaliged_block_address, "block address is unaligned");
+
+#endif // INCLUDE_NMT

--- a/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
@@ -66,8 +66,8 @@ DEFINE_TEST(test_overwrite_back, "footer canary broken")
 
 ///////
 
-// this should generate two hex dumps, one with the front header, one with the overwritten
-// portion.
+// A overwriter farther away from the NMT header; the report should show the hex dump split up
+// in two parts, containing both header and corruption site.
 static void test_overwrite_back_long() {
   address p = (address) os::malloc(0x2000, mtTest);
   *(p + 0x2000) = 'a';

--- a/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
@@ -73,7 +73,7 @@ DEFINE_TEST(test_overwrite_back, "footer canary broken")
 
 ///////
 
-// A overwriter farther away from the NMT header; the report should show the hex dump split up
+// A overwrite farther away from the NMT header; the report should show the hex dump split up
 // in two parts, containing both header and corruption site.
 static void test_overwrite_back_long(size_t distance) {
   address p = (address) os::malloc(distance, mtTest);

--- a/test/hotspot/gtest/testutils.cpp
+++ b/test/hotspot/gtest/testutils.cpp
@@ -57,7 +57,8 @@ bool GtestUtils::check_range(const void* p, size_t s, uint8_t expected) {
   }
 
   if (first_wrong != NULL) {
-    tty->print_cr("wrong pattern around " PTR_FORMAT, p2i(first_wrong));
+    tty->print_cr("check_range [" PTR_FORMAT ".." PTR_FORMAT "), 0x%X, : wrong pattern around " PTR_FORMAT,
+                  p2i(p), p2i(p) + s, expected, p2i(first_wrong));
     // Note: We deliberately print the surroundings too without bounds check. Might be interesting,
     // and os::print_hex_dump uses SafeFetch, so this is fine without bounds checks.
     os::print_hex_dump(tty, (address)(align_down(p2, 0x10) - 0x10),

--- a/test/hotspot/gtest/testutils.hpp
+++ b/test/hotspot/gtest/testutils.hpp
@@ -51,8 +51,8 @@ public:
 #define ASSERT_RANGE_IS_MARKED(p, size)             ASSERT_TRUE(GtestUtils::check_range(p, size))
 
 // Convenience asserts
-#define ASSERT_NOT_NULL(p)  ASSERT_NE(p, (char*)NULL)
-#define ASSERT_NULL(p)      ASSERT_EQ(p, (char*)NULL)
+#define ASSERT_NOT_NULL(p)  ASSERT_NE(p2i(p), 0)
+#define ASSERT_NULL(p)      ASSERT_EQ(p2i(p), 0)
 
 #define ASSERT_ALIGN(p, n) ASSERT_TRUE(is_aligned(p, n))
 

--- a/test/hotspot/gtest/unittest.hpp
+++ b/test/hotspot/gtest/unittest.hpp
@@ -149,4 +149,21 @@
     TEST_VM_ASSERT_MSG is only available in debug builds
 #endif
 
+#define TEST_VM_FATAL_ERROR_MSG(category, name, msg)                \
+  static void test_  ## category ## _ ## name ## _();               \
+                                                                    \
+  static void child_ ## category ## _ ## name ## _() {              \
+    ::testing::GTEST_FLAG(throw_on_failure) = true;                 \
+    test_ ## category ## _ ## name ## _();                          \
+    exit(0);                                                        \
+  }                                                                 \
+                                                                    \
+  TEST(category, CONCAT(name, _vm_assert)) {                        \
+    ASSERT_EXIT(child_ ## category ## _ ## name ## _(),             \
+                ::testing::ExitedWithCode(1),                       \
+                msg);                            \
+  }                                                                 \
+                                                                    \
+  void test_ ## category ## _ ## name ## _()
+
 #endif // UNITTEST_HPP


### PR DESCRIPTION
This is part of a number of RFE I plan to improve and simplify C-heap overflow checking in hotspot.

This proposal adds NMT buffer overflow checking:

- it gives us C-heap overflow checking in release builds
- the costs are neglectable: if NMT is off, we won't pay anything; if NMT is on, the added work is minuscule since we have to do malloc header management anyway.
- NMT needs intact headers anyway. Faced with buffer overwrites today, it would maybe crash or maybe account wrongly, but it's a bit of a lottery really. Better to go the extra step and do a real check.
- it could be a preparation for future code removal, if we wanted to do that (see details in umbrella RFE https://bugs.openjdk.java.net/browse/JDK-8275301). That way, net complexity would come down even with this patch.

For more details, please see the JBS issue.

----

Patch notes:

- The malloc header is changed such that it contains a 16-bit canary directly preceding the user payload of the allocation. The new malloc header does not use bitfields anymore but normal types. For more details, see the comment in mallocTracker.hpp.
  - On 64-bit, we don't enlarge the malloc header. It remains 16 bytes in length. So no additional memory cost (apart from the 1-byte-footer, see below). Space for the canary is instead obtained by reducing the size of the bucket index bit field to 16 bits. That bit field is used to store the bucket slot index of the malloc site table in NMT detail mode. With 40 bits it was over-dimensioned, and even 16-bits arguably still are: malloc site table width is 512.
  - On 32-bit, I had to enlarge the header from 8 bytes to 16 bytes to make room for a canary. But strictly speaking 8 bytes were not enough anyway: the header size has to be large enough to satisfy malloc(3) alignment, and that would be 16 bytes. I believe it never led to an error since we don't store 128bit data in malloc'd memory in the hotspot anywhere.

- I added a footer canary trailing the user allocation to catch tail buffer overruns. To keep matters simple (alignment) I made it a single byte only. That is enough to catch most overrun scenarios.

- I brushed up error reporting. When NMT detects corruption, it will now print out a hex dump of the corrupted area to tty before asserting.

- I added a bunch of gtests to test various heap overwrite scenarios. I also had to extend the gtest macros a bit because I wanted these tests of course to run in release builds too, but we did not have a death test macro for release builds yet (there are possibilities for code simplification here too, but that's for another RFE).

- I renamed `nmt_header_size` to `nmt_overhead` since that size includes header and footer now.

- I made the assert for malloc site table width a compile time STATIC_ASSERT.

--------------

Example output a buffer overrun would provide:

```
Block at 0x00005600f86136b0: footer canary broken at 0x00005600f86136c1 (buffer overflow?)
NMT Block at 0x00005600f86136b0, corruption at: 0x00005600f86136c1: 
0x00005600f86136a8:   21 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00
0x00005600f86136b8:   00 00 00 00 0f 00 1f fa 00 61 00 00 00 00 00 00
0x00005600f86136c8:   41 39 00 00 00 00 00 00 00 00 00 00 00 00 00 00
0x00005600f86136d8:   00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
0x00005600f86136e8:   00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
0x00005600f86136f8:   00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
0x00005600f8613708:   00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
0x00005600f8613718:   00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
0x00005600f8613728:   00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
0x00005600f8613738:   00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
assert failed: fatal error: Block at 0x00005600f86136b0: footer canary broken at 0x00005600f86136c1 (buffer overflow?)#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (mallocTracker.cpp:203), pid=10805, tid=10805
#  fatal error: Block at 0x00005600f86136b0: footer canary broken at 0x00005600f86136c1 (buffer overflow?)
#
```
-------

Tests:
- manual tests with Linux x64, x86, minimal build
- GHAs all clean
- SAP nightlies ran for 4 weeks now without problems

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8275320](https://bugs.openjdk.java.net/browse/JDK-8275320): NMT should perform buffer overrun checks
 * [JDK-8275320](https://bugs.openjdk.java.net/browse/JDK-8275320): NMT should perform buffer overrun checks
 * [JDK-8275301](https://bugs.openjdk.java.net/browse/JDK-8275301): Unify C-heap buffer overrun checks into NMT


### Reviewers
 * [Volker Simonis](https://openjdk.java.net/census#simonis) (@simonis - **Reviewer**) ⚠️ Review applies to ea6fe31c08af1a7073e3d14a37a572beb43a027c
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5952/head:pull/5952` \
`$ git checkout pull/5952`

Update a local copy of the PR: \
`$ git checkout pull/5952` \
`$ git pull https://git.openjdk.java.net/jdk pull/5952/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5952`

View PR using the GUI difftool: \
`$ git pr show -t 5952`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5952.diff">https://git.openjdk.java.net/jdk/pull/5952.diff</a>

</details>
