### PR TITLE
8275145: file.encoding system property has an incorrect value on Windows

### DIFF
--- a/src/java.base/share/native/libjava/System.c
+++ b/src/java.base/share/native/libjava/System.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -146,7 +146,15 @@ Java_jdk_internal_util_SystemProps_00024Raw_platformProperties(JNIEnv *env, jcla
     PUTPROP(propArray, _path_separator_NDX, sprops->path_separator);
     PUTPROP(propArray, _line_separator_NDX, sprops->line_separator);
 
+#ifdef MACOSX
+    /*
+     * Since sun_jnu_encoding is now hard-coded to UTF-8 on Mac, we don't
+     * want to use it to overwrite file.encoding
+     */
     PUTPROP(propArray, _file_encoding_NDX, sprops->encoding);
+#else
+    PUTPROP(propArray, _file_encoding_NDX, sprops->sun_jnu_encoding);
+#endif
     PUTPROP(propArray, _sun_jnu_encoding_NDX, sprops->sun_jnu_encoding);
 
     /*


### PR DESCRIPTION
Fixing a regression in which `file.encoding` was initialized by `sprops->encoding` instead of `sprops->sun_jnu_encoding` on non macOS platforms. tier1-3 tests passed on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275145](https://bugs.openjdk.java.net/browse/JDK-8275145): file.encoding system property has an incorrect value on Windows


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5953/head:pull/5953` \
`$ git checkout pull/5953`

Update a local copy of the PR: \
`$ git checkout pull/5953` \
`$ git pull https://git.openjdk.java.net/jdk pull/5953/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5953`

View PR using the GUI difftool: \
`$ git pr show -t 5953`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5953.diff">https://git.openjdk.java.net/jdk/pull/5953.diff</a>

</details>
