### PR TITLE
8275319 java.net.NetworkInterface throws java.lang.Error instead of SocketException

### DIFF
--- a/src/java.base/windows/native/libnet/NetworkInterface.c
+++ b/src/java.base/windows/native/libnet/NetworkInterface.c
@@ -202,12 +202,15 @@ int enumInterfaces(JNIEnv *env, netif **netifPP)
         free(tableP);
         switch (ret) {
             case ERROR_INVALID_PARAMETER:
-                JNU_ThrowInternalError(env, "IP Helper Library GetIfTable function failed: invalid parameter");
+                JNU_ThrowInternalError(env,
+                    "IP Helper Library GetIfTable function failed: "
+                    "invalid parameter");
                 break;
             default:
                 SetLastError(ret);
-                JNU_ThrowByNameWithMessageAndLastError(env, JNU_JAVANETPKG "SocketException",
-                        "IP Helper Library GetIfTable function failed");
+                JNU_ThrowByNameWithMessageAndLastError(env,
+                    JNU_JAVANETPKG "SocketException",
+                    "IP Helper Library GetIfTable function failed");
                 break;
         }
         // this different error code is to handle the case when we call
@@ -315,7 +318,8 @@ int enumInterfaces(JNIEnv *env, netif **netifPP)
             // it should not fail, because we have called it once before
             if (MultiByteToWideChar(CP_OEMCP, 0, ifrowP->bDescr,
                    ifrowP->dwDescrLen, curr->displayName, wlen) == 0) {
-                JNU_ThrowInternalError(env, "Cannot get multibyte char for interface display name");
+                JNU_ThrowInternalError(env,
+                    "Cannot get multibyte char for interface display name");
                 free_netif(netifP);
                 free(tableP);
                 free(curr->name);
@@ -397,12 +401,15 @@ int lookupIPAddrTable(JNIEnv *env, MIB_IPADDRTABLE **tablePP)
         }
         switch (ret) {
             case ERROR_INVALID_PARAMETER:
-                JNU_ThrowInternalError(env, "IP Helper Library GetIpAddrTable function failed: invalid parameter");
+                JNU_ThrowInternalError(env,
+                    "IP Helper Library GetIpAddrTable function failed: "
+                    "invalid parameter");
                 break;
             default:
                 SetLastError(ret);
-                JNU_ThrowByNameWithMessageAndLastError(env, JNU_JAVANETPKG "SocketException",
-                        "IP Helper Library GetIpAddrTable function failed");
+                JNU_ThrowByNameWithMessageAndLastError(env,
+                    JNU_JAVANETPKG "SocketException",
+                    "IP Helper Library GetIpAddrTable function failed");
                 break;
         }
         // this different error code is to handle the case when we call

--- a/src/java.base/windows/native/libnet/NetworkInterface_winXP.c
+++ b/src/java.base/windows/native/libnet/NetworkInterface_winXP.c
@@ -112,10 +112,14 @@ int getAdapters (JNIEnv *env, int flags, IP_ADAPTER_ADDRESSES **adapters) {
         free (adapterInfo);
         switch (ret) {
             case ERROR_INVALID_PARAMETER:
-                JNU_ThrowInternalError(env, "IP Helper Library GetAdaptersAddresses function failed: invalid parameter");
+                JNU_ThrowInternalError(env,
+                    "IP Helper Library GetAdaptersAddresses function failed: "
+                    "invalid parameter");
                 break;
             case ERROR_NOT_ENOUGH_MEMORY:
-                JNU_ThrowOutOfMemoryError(env, "IP Helper Library GetAdaptersAddresses function failed: not enough memory");
+                JNU_ThrowOutOfMemoryError(env,
+                    "IP Helper Library GetAdaptersAddresses function failed: "
+                    "not enough memory");
                 break;
             case ERROR_NO_DATA:
                 // not an error
@@ -123,8 +127,9 @@ int getAdapters (JNIEnv *env, int flags, IP_ADAPTER_ADDRESSES **adapters) {
                 return ERROR_SUCCESS;
             default:
                 SetLastError(ret);
-                JNU_ThrowByNameWithMessageAndLastError(env, JNU_JAVANETPKG "SocketException",
-                        "IP Helper Library GetAdaptersAddresses function failed");
+                JNU_ThrowByNameWithMessageAndLastError(env,
+                    JNU_JAVANETPKG "SocketException",
+                    "IP Helper Library GetAdaptersAddresses function failed");
                 break;
         }
 
@@ -178,18 +183,23 @@ IP_ADAPTER_ADDRESSES *getAdapter (JNIEnv *env,  jint index) {
         free (adapterInfo);
         switch (val) {
             case ERROR_INVALID_PARAMETER:
-                JNU_ThrowInternalError(env, "IP Helper Library GetAdaptersAddresses function failed: invalid parameter");
+                JNU_ThrowInternalError(env,
+                    "IP Helper Library GetAdaptersAddresses function failed: "
+                    "invalid parameter");
                 break;
             case ERROR_NOT_ENOUGH_MEMORY:
-                JNU_ThrowOutOfMemoryError(env, "IP Helper Library GetAdaptersAddresses function failed: not enough memory");
+                JNU_ThrowOutOfMemoryError(env,
+                    "IP Helper Library GetAdaptersAddresses function failed: "
+                    "not enough memory");
                 break;
             case ERROR_NO_DATA:
                 // not an error
                 break;
             default:
                 SetLastError(val);
-                JNU_ThrowByNameWithMessageAndLastError(env, JNU_JAVANETPKG "SocketException",
-                        "IP Helper Library GetAdaptersAddresses function failed");
+                JNU_ThrowByNameWithMessageAndLastError(env,
+                    JNU_JAVANETPKG "SocketException",
+                    "IP Helper Library GetAdaptersAddresses function failed");
                 break;
         }
         return NULL;


### PR DESCRIPTION
Per Java documentation, "[Error](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/lang/Error.java#L30) [..] indicates serious problems that a reasonable application should not try to catch". Failure to enumerate network interfaces or addresses is not a serious enough situation; many applications can recover from this pretty easily.

All native methods (except `init()`) in [NetworkInterface](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/net/NetworkInterface.java#L436) are declared with `throws SocketException`, so throwing SocketExceptions instead of Errors will match the declared interface.

Unix version of [NetworkInterface](https://github.com/openjdk/jdk/blob/master/src/java.base/unix/native/libnet/NetworkInterface.c#L1189) already throws `SocketException`s in similar situations, and does not throw `Error` under any circumstances.

I searched the bug database and mail archives, but could not find any discussion on the topic; if there's a reason to keep throwing `Error`s, I couldn't find it.

`tier1` tests pass, `java.net` tests pass. No new regression tests as I couldn't find any list of steps to reproduce the problem.

I don't have write access to JBS. I could use some help with creating a ticket.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275319](https://bugs.openjdk.java.net/browse/JDK-8275319): java.net.NetworkInterface throws java.lang.Error instead of SocketException


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5956/head:pull/5956` \
`$ git checkout pull/5956`

Update a local copy of the PR: \
`$ git checkout pull/5956` \
`$ git pull https://git.openjdk.java.net/jdk pull/5956/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5956`

View PR using the GUI difftool: \
`$ git pr show -t 5956`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5956.diff">https://git.openjdk.java.net/jdk/pull/5956.diff</a>

</details>
