### PR TITLE
8274301: Locking with _no_safepoint_check_flag does not check NJT

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1940,7 +1940,7 @@ void G1CollectedHeap::increment_old_marking_cycles_started() {
 
 void G1CollectedHeap::increment_old_marking_cycles_completed(bool concurrent,
                                                              bool whole_heap_examined) {
-  MonitorLocker ml(G1OldGCCount_lock, Mutex::_no_safepoint_check_flag);
+  MonitorLocker ml(G1OldGCCount_lock);
 
   // We assume that if concurrent == true, then the caller is a
   // concurrent thread that was joined the Suspendible Thread

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1379,7 +1379,7 @@ public:
                                    cl.archive_regions_removed(),
                                    cl.humongous_regions_removed());
     {
-      MutexLocker x(ParGCRareEvent_lock, Mutex::_no_safepoint_check_flag);
+      MutexLocker x(ParGCRareEvent_lock);
       _g1h->decrement_summary_bytes(cl.freed_bytes());
 
       _cleanup_list->add_ordered(&local_cleanup_list);

--- a/src/hotspot/share/gc/g1/g1FullGCOopClosures.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCOopClosures.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,7 @@ template <class T> void G1VerifyOopClosure::do_oop_work(T* p) {
     oop obj = CompressedOops::decode_not_null(heap_oop);
     bool failed = false;
     if (!_g1h->is_in(obj) || _g1h->is_obj_dead_cond(obj, _verify_option)) {
-      MutexLocker x(ParGCRareEvent_lock, Mutex::_no_safepoint_check_flag);
+      MutexLocker x(ParGCRareEvent_lock);
       LogStreamHandle(Error, gc, verify) yy;
       if (!_failures) {
         yy.cr();

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -470,7 +470,7 @@ public:
     G1PrepareRegionsClosure cl(_g1h, this);
     _g1h->heap_region_par_iterate_from_worker_offset(&cl, &_claimer, worker_id);
 
-    MutexLocker x(ParGCRareEvent_lock, Mutex::_no_safepoint_check_flag);
+    MutexLocker x(ParGCRareEvent_lock);
     _all_card_set_stats.add(cl.card_set_stats());
   }
 

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -533,8 +533,7 @@ public:
       oop obj = CompressedOops::decode_not_null(heap_oop);
       bool failed = false;
       if (!_g1h->is_in(obj) || _g1h->is_obj_dead_cond(obj, _vo)) {
-        MutexLocker x(ParGCRareEvent_lock,
-          Mutex::_no_safepoint_check_flag);
+        MutexLocker x(ParGCRareEvent_lock);
 
         if (!_failures) {
           log.error("----------");
@@ -605,8 +604,7 @@ public:
                 cv_field == dirty :
                 cv_obj == dirty || cv_field == dirty));
         if (is_bad) {
-          MutexLocker x(ParGCRareEvent_lock,
-            Mutex::_no_safepoint_check_flag);
+          MutexLocker x(ParGCRareEvent_lock);
 
           if (!_failures) {
             log.error("----------");

--- a/src/hotspot/share/gc/shared/concurrentGCBreakpoints.cpp
+++ b/src/hotspot/share/gc/shared/concurrentGCBreakpoints.cpp
@@ -133,7 +133,7 @@ bool ConcurrentGCBreakpoints::run_to(const char* breakpoint) {
 void ConcurrentGCBreakpoints::at(const char* breakpoint) {
   assert(Thread::current()->is_ConcurrentGC_thread(), "precondition");
   assert(breakpoint != NULL, "precondition");
-  MonitorLocker ml(monitor(), Mutex::_no_safepoint_check_flag);
+  MonitorLocker ml(monitor());
 
   // Ignore non-matching request state.
   if ((_run_to == NULL) || (strcmp(_run_to, breakpoint) != 0)) {
@@ -154,7 +154,7 @@ void ConcurrentGCBreakpoints::at(const char* breakpoint) {
 }
 
 void ConcurrentGCBreakpoints::notify_active_to_idle() {
-  MonitorLocker ml(monitor(), Mutex::_no_safepoint_check_flag);
+  MonitorLocker ml(monitor());
   assert(!_is_stopped, "invariant");
   // Notify pending run_to request of miss by replacing the run_to() request
   // with a run_to_idle() request.

--- a/src/hotspot/share/gc/z/zBreakpoint.cpp
+++ b/src/hotspot/share/gc/z/zBreakpoint.cpp
@@ -38,7 +38,7 @@ void ZBreakpoint::start_gc() {
 }
 
 void ZBreakpoint::at_before_gc() {
-  MonitorLocker ml(ConcurrentGCBreakpoints::monitor(), Mutex::_no_safepoint_check_flag);
+  MonitorLocker ml(ConcurrentGCBreakpoints::monitor());
   while (ConcurrentGCBreakpoints::is_controlled() && !_start_gc) {
     ml.wait();
   }

--- a/src/hotspot/share/runtime/nonJavaThread.cpp
+++ b/src/hotspot/share/runtime/nonJavaThread.cpp
@@ -177,7 +177,7 @@ WatcherThread::WatcherThread() : NonJavaThread() {
 int WatcherThread::sleep() const {
   // The WatcherThread does not participate in the safepoint protocol
   // for the PeriodicTask_lock because it is not a JavaThread.
-  MonitorLocker ml(PeriodicTask_lock, Mutex::_no_safepoint_check_flag);
+  MonitorLocker ml(PeriodicTask_lock);
 
   if (_should_terminate) {
     // check for termination before we do any housekeeping or wait
@@ -285,7 +285,7 @@ void WatcherThread::run() {
 
   // Signal that it is terminated
   {
-    MutexLocker mu(Terminator_lock, Mutex::_no_safepoint_check_flag);
+    MutexLocker mu(Terminator_lock);
     _watcher_thread = NULL;
     Terminator_lock->notify_all();
   }

--- a/src/hotspot/share/runtime/task.cpp
+++ b/src/hotspot/share/runtime/task.cpp
@@ -38,7 +38,7 @@ void PeriodicTask::real_time_tick(int delay_time) {
 
   // The WatcherThread does not participate in the safepoint protocol
   // for the PeriodicTask_lock because it is not a JavaThread.
-  MutexLocker ml(PeriodicTask_lock, Mutex::_no_safepoint_check_flag);
+  MutexLocker ml(PeriodicTask_lock);
   int orig_num_tasks = _num_tasks;
 
   for(int index = 0; index < _num_tasks; index++) {

--- a/src/hotspot/share/runtime/vmThread.cpp
+++ b/src/hotspot/share/runtime/vmThread.cpp
@@ -352,10 +352,7 @@ bool VMThread::set_next_operation(VM_Operation *op) {
 }
 
 void VMThread::wait_until_executed(VM_Operation* op) {
-  MonitorLocker ml(VMOperation_lock,
-                   Thread::current()->is_Java_thread() ?
-                     Mutex::_safepoint_check_flag :
-                     Mutex::_no_safepoint_check_flag);
+  MonitorLocker ml(VMOperation_lock);
   {
     TraceTime timer("Installing VM operation", TRACETIME_LOG(Trace, vmthread));
     while (true) {
@@ -440,7 +437,7 @@ void VMThread::inner_execute(VM_Operation* op) {
 
 void VMThread::wait_for_operation() {
   assert(Thread::current()->is_VM_thread(), "Must be the VM thread");
-  MonitorLocker ml_op_lock(VMOperation_lock, Mutex::_no_safepoint_check_flag);
+  MonitorLocker ml_op_lock(VMOperation_lock);
 
   // Clear previous operation.
   // On first call this clears a dummy place-holder.


### PR DESCRIPTION
There are Mutexes that have a safepoint checking rank, that are locked via:
MutexLocker ml(safepoint_lock, Mutex::_no_safepoint_check_flag);

These don't assert for the inconsistency because the thread that calls this is a NonJavaThread.

But if you lock
MutexLocker ml(nosafepoint_lock);  // default safepoint check

These *will* assert for the safepoint checking inconsistency even for NonJavaThreads.

NonJavaThreads don't participate in the safepoint checking protocol.  And some of these safepoint checking locks are shared between java and nonjava threads. So in the existing code, there's a mix of locking with _no_safepoint_check_flag and not.

This has a wrinkle because if you have a safepoint checking lock, and call wait on it, we now have to handle the case that the caller is a NonJavaThread and should not safepoint check (just like the Mutex::lock call).

Maybe this shouldn't be fixed, and we should just document the discrepancy.

Tested with tier1-3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8274301](https://bugs.openjdk.java.net/browse/JDK-8274301): Locking with _no_safepoint_check_flag does not check NJT


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5959/head:pull/5959` \
`$ git checkout pull/5959`

Update a local copy of the PR: \
`$ git checkout pull/5959` \
`$ git pull https://git.openjdk.java.net/jdk pull/5959/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5959`

View PR using the GUI difftool: \
`$ git pr show -t 5959`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5959.diff">https://git.openjdk.java.net/jdk/pull/5959.diff</a>

</details>
