### PR TITLE
8275293: A change done with JDK-8268764 mismatches the java.rmi.server.ObjID.hashCode spec

### DIFF
--- a/src/java.rmi/share/classes/java/rmi/server/ObjID.java
+++ b/src/java.rmi/share/classes/java/rmi/server/ObjID.java
@@ -201,7 +201,7 @@ public final class ObjID implements Serializable {
      */
     @Override
     public int hashCode() {
-        return Long.hashCode(objNum);
+        return (int) objNum;
     }
 
     /**


### PR DESCRIPTION
It looks like we cannot use `Long.hashCode(long)` for `java.rmi.server.ObjID.hashCode()` due to specification: https://docs.oracle.com/en/java/javase/17/docs/api/java.rmi/java/rmi/server/ObjID.html#hashCode().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275293](https://bugs.openjdk.java.net/browse/JDK-8275293): A change done with JDK-8268764 mismatches the java.rmi.server.ObjID.hashCode spec


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Stuart Marks](https://openjdk.java.net/census#smarks) (@stuart-marks - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5963/head:pull/5963` \
`$ git checkout pull/5963`

Update a local copy of the PR: \
`$ git checkout pull/5963` \
`$ git pull https://git.openjdk.java.net/jdk pull/5963/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5963`

View PR using the GUI difftool: \
`$ git pr show -t 5963`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5963.diff">https://git.openjdk.java.net/jdk/pull/5963.diff</a>

</details>
