### PR TITLE
8275277: assert(dest_attr.is_in_cset() == (obj->forwardee() == obj)) failed: Only evac-failed objects must be in the collection set here but <addr> is not

### DIFF
--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.inline.hpp
@@ -111,7 +111,7 @@ template <class T> void G1ParScanThreadState::write_ref_field_post(T* p, oop obj
   // References to the current collection set are references to objects that failed
   // evacuation. Currently these regions are always relabelled as old without
   // remembered sets, so skip them.
-  assert(dest_attr.is_in_cset() == (obj->forwardee() == obj),
+  assert(dest_attr.is_in_cset() == (obj->is_forwarded() && obj->forwardee() == obj),
          "Only evac-failed objects must be in the collection set here but " PTR_FORMAT " is not", p2i(obj));
   if (dest_attr.is_in_cset()) {
     return;


### PR DESCRIPTION
Hi all,

  can I have reviews for this fix of an incomplete assert?

When checking whether the forwardee equals the object, we first need to check whether the object is already forwarded, otherwise we might get false positives. See CR for more details (example).

Testing: gha, failing tests do not fail after 2k repetitions

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275277](https://bugs.openjdk.java.net/browse/JDK-8275277): assert(dest_attr.is_in_cset() == (obj->forwardee() == obj)) failed: Only evac-failed objects must be in the collection set here but <addr> is not


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5965/head:pull/5965` \
`$ git checkout pull/5965`

Update a local copy of the PR: \
`$ git checkout pull/5965` \
`$ git pull https://git.openjdk.java.net/jdk pull/5965/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5965`

View PR using the GUI difftool: \
`$ git pr show -t 5965`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5965.diff">https://git.openjdk.java.net/jdk/pull/5965.diff</a>

</details>
