### PR TITLE
8275333: Print count in "Too many recored phases?" assert

### DIFF
--- a/src/hotspot/share/gc/shared/gcTimer.cpp
+++ b/src/hotspot/share/gc/shared/gcTimer.cpp
@@ -130,7 +130,7 @@ void TimePartitions::clear() {
 }
 
 void TimePartitions::report_gc_phase_start(const char* name, const Ticks& time, GCPhase::PhaseType type) {
-  assert(_phases->length() <= 1000, "Too many recored phases? (count: %d)", _phases->length());
+  assert(_phases->length() <= 1000, "Too many recorded phases? (count: %d)", _phases->length());
 
   int level = _active_phases.count();
 


### PR DESCRIPTION
Just a small change to get some more information when this assert fails.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275333](https://bugs.openjdk.java.net/browse/JDK-8275333): Print count in "Too many recored phases?" assert


### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to 751ecf5bf74debe28a0b232a1c775513100bc27c
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 751ecf5bf74debe28a0b232a1c775513100bc27c


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5966/head:pull/5966` \
`$ git checkout pull/5966`

Update a local copy of the PR: \
`$ git checkout pull/5966` \
`$ git pull https://git.openjdk.java.net/jdk pull/5966/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5966`

View PR using the GUI difftool: \
`$ git pr show -t 5966`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5966.diff">https://git.openjdk.java.net/jdk/pull/5966.diff</a>

</details>
