### PR TITLE
8275334: Move class loading Events to a separate section in hs_err files

### DIFF
--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -1138,7 +1138,7 @@ InstanceKlass* ClassLoader::load_class(Symbol* name, bool search_append_only, TR
 
   const char* const class_name = name->as_C_string();
 
-  EventMark m("loading class %s", class_name);
+  EventMarkClassLoading m("Loading class %s", class_name);
 
   const char* const file_name = file_name_for_class_name(class_name,
                                                          name->utf8_length());

--- a/src/hotspot/share/utilities/events.cpp
+++ b/src/hotspot/share/utilities/events.cpp
@@ -39,6 +39,7 @@ StringEventLog* Events::_vm_operations = NULL;
 ExceptionsEventLog* Events::_exceptions = NULL;
 StringEventLog* Events::_redefinitions = NULL;
 UnloadingEventLog* Events::_class_unloading = NULL;
+StringEventLog* Events::_class_loading = NULL;
 StringEventLog* Events::_deopt_messages = NULL;
 
 EventLog::EventLog() {
@@ -96,6 +97,7 @@ void Events::init() {
     _exceptions = new ExceptionsEventLog("Internal exceptions", "exc");
     _redefinitions = new StringEventLog("Classes redefined", "redef");
     _class_unloading = new UnloadingEventLog("Classes unloaded", "unload");
+    _class_loading = new StringEventLog("Classes loaded", "load");
     _deopt_messages = new StringEventLog("Deoptimization events", "deopt");
   }
 }

--- a/src/hotspot/share/utilities/events.hpp
+++ b/src/hotspot/share/utilities/events.hpp
@@ -235,6 +235,9 @@ class Events : AllStatic {
 
   // Class unloading events
   static UnloadingEventLog* _class_unloading;
+
+  // Class loading events
+  static StringEventLog* _class_loading;
  public:
 
   // Print all event logs; limit number of events per event log to be printed with max
@@ -259,6 +262,8 @@ class Events : AllStatic {
   static void log_redefinition(Thread* thread, const char* format, ...) ATTRIBUTE_PRINTF(2, 3);
 
   static void log_class_unloading(Thread* thread, InstanceKlass* ik);
+
+  static void log_class_loading(Thread* thread, const char* format, ...) ATTRIBUTE_PRINTF(2, 3);
 
   static void log_deopt_message(Thread* thread, const char* format, ...) ATTRIBUTE_PRINTF(2, 3);
 
@@ -311,6 +316,15 @@ inline void Events::log_redefinition(Thread* thread, const char* format, ...) {
 inline void Events::log_class_unloading(Thread* thread, InstanceKlass* ik) {
   if (LogEvents && _class_unloading != NULL) {
     _class_unloading->log(thread, ik);
+  }
+}
+
+inline void Events::log_class_loading(Thread* thread, const char* format, ...) {
+  if (LogEvents && _class_loading != NULL) {
+    va_list ap;
+    va_start(ap, format);
+    _class_loading->logv(thread, format, ap);
+    va_end(ap);
   }
 }
 
@@ -472,5 +486,8 @@ typedef EventMarkWithLogFunction<Events::log> EventMark;
 
 // These end up in the vm_operation log.
 typedef EventMarkWithLogFunction<Events::log_vm_operation> EventMarkVMOperation;
+
+// These end up in the class loading log.
+typedef EventMarkWithLogFunction<Events::log_class_loading> EventMarkClassLoading;
 
 #endif // SHARE_UTILITIES_EVENTS_HPP


### PR DESCRIPTION
The generic "Events" section in hs_err files tend to fill up with class loading events. I propose that we move class loading events to its own section.

We already have a section for class unloading, so adding a class loading section is also good for symmetry reasons. 

This is what this will look like after the patch:
```
Classes loaded (20 events):
Event: 4,426 Loading class com/sun/org/apache/xerces/internal/xinclude/MultipleScopeNamespaceSupport done
Event: 4,426 Loading class com/sun/org/apache/xerces/internal/xinclude/XIncludeNamespaceSupport done
Event: 4,428 Loading class com/sun/org/apache/xerces/internal/parsers/AbstractSAXParser$LocatorProxy
Event: 4,428 Loading class org/xml/sax/ext/Locator2
Event: 4,428 Loading class org/xml/sax/ext/Locator2 done
Event: 4,428 Loading class com/sun/org/apache/xerces/internal/parsers/AbstractSAXParser$LocatorProxy done
Event: 4,430 Loading class com/sun/org/apache/xerces/internal/impl/XMLScanner$NameType
Event: 4,430 Loading class com/sun/org/apache/xerces/internal/impl/XMLScanner$NameType done
Event: 4,435 Loading class org/xml/sax/helpers/LocatorImpl
Event: 4,435 Loading class org/xml/sax/helpers/LocatorImpl done
Event: 4,498 Loading class java/util/Vector$ListItr
Event: 4,498 Loading class java/util/Vector$ListItr done
Event: 4,499 Loading class java/lang/StrictMath
Event: 4,499 Loading class java/lang/StrictMath done
Event: 4,623 Loading class java/util/BitSet
Event: 4,623 Loading class java/util/BitSet done
Event: 4,656 Loading class java/util/ArrayList$ListItr
Event: 4,657 Loading class java/util/ArrayList$ListItr done
Event: 4,693 Loading class java/util/ArrayList$SubList
Event: 4,694 Loading class java/util/ArrayList$SubList done

Classes unloaded (20 events):
Event: 3,445 Thread 0x00007f061c2578d0 Unloading class 0x0000000100088000 'avrora/Main'
Event: 4,864 Thread 0x00007f061c2578d0 Unloading class 0x00000001000a3c00 'java/lang/invoke/LambdaForm$MH+0x00000001000a3c00'
Event: 4,864 Thread 0x00007f061c2578d0 Unloading class 0x00000001000a3400 'java/lang/invoke/LambdaForm$MH+0x00000001000a3400'
Event: 4,864 Thread 0x00007f061c2578d0 Unloading class 0x00000001000a1c00 'java/lang/invoke/LambdaForm$MH+0x00000001000a1c00'
Event: 4,864 Thread 0x00007f061c2578d0 Unloading class 0x00000001000a1400 'java/lang/invoke/LambdaForm$MH+0x00000001000a1400'
Event: 4,864 Thread 0x00007f061c2578d0 Unloading class 0x00000001000a1000 'java/lang/invoke/LambdaForm$MH+0x00000001000a1000'
Event: 4,864 Thread 0x00007f061c2578d0 Unloading class 0x00000001000a0c00 'java/lang/invoke/LambdaForm$MH+0x00000001000a0c00'
Event: 4,864 Thread 0x00007f061c2578d0 Unloading class 0x00000001000a0800 'java/lang/invoke/LambdaForm$MH+0x00000001000a0800'
Event: 4,864 Thread 0x00007f061c2578d0 Unloading class 0x00000001000a0400 'java/lang/invoke/LambdaForm$MH+0x00000001000a0400'
Event: 4,864 Thread 0x00007f061c2578d0 Unloading class 0x00000001000a0000 'java/lang/invoke/LambdaForm$MH+0x00000001000a0000'
Event: 4,864 Thread 0x00007f061c2578d0 Unloading class 0x000000010012c000 'jdk/internal/reflect/GeneratedMethodAccessor1'
Event: 4,864 Thread 0x00007f061c2578d0 Unloading class 0x0000000100123000 'java/lang/invoke/LambdaForm$MH+0x0000000100123000'
Event: 4,864 Thread 0x00007f061c2578d0 Unloading class 0x0000000100121800 'java/lang/invoke/LambdaForm$MH+0x0000000100121800'
Event: 4,864 Thread 0x00007f061c2578d0 Unloading class 0x0000000100121000 'java/lang/invoke/LambdaForm$MH+0x0000000100121000'
Event: 4,864 Thread 0x00007f061c2578d0 Unloading class 0x000000010009fc00 'java/lang/invoke/LambdaForm$MH+0x000000010009fc00'
Event: 4,864 Thread 0x00007f061c2578d0 Unloading class 0x000000010009ec00 'java/lang/invoke/LambdaForm$MH+0x000000010009ec00'
Event: 4,864 Thread 0x00007f061c2578d0 Unloading class 0x000000010009e800 'java/lang/invoke/LambdaForm$MH+0x000000010009e800'
Event: 4,864 Thread 0x00007f061c2578d0 Unloading class 0x000000010009e400 'java/lang/invoke/LambdaForm$MH+0x000000010009e400'
Event: 4,864 Thread 0x00007f061c2578d0 Unloading class 0x000000010009cc00 'java/lang/invoke/LambdaForm$MH+0x000000010009cc00'
Event: 5,914 Thread 0x00007f061c2578d0 Unloading class 0x0000000100123000 'jdk/internal/reflect/GeneratedMethodAccessor2'
...
Events (20 events):
Event: 5,565 Thread 0x00007f061c2f97e0 flushing nmethod 0x00007f060dada610
Event: 5,565 Thread 0x00007f061c2f97e0 flushing nmethod 0x00007f060dadd990
Event: 5,565 Thread 0x00007f061c2f97e0 flushing nmethod 0x00007f060dadfd90
Event: 5,565 Thread 0x00007f061c2f97e0 flushing nmethod 0x00007f060dae9e90
Event: 5,565 Thread 0x00007f061c2f97e0 flushing nmethod 0x00007f060daea490
Event: 5,565 Thread 0x00007f061c2f97e0 flushing nmethod 0x00007f060daeee90
Event: 5,565 Thread 0x00007f061c2f97e0 flushing nmethod 0x00007f060daf0710
Event: 5,565 Thread 0x00007f061c2f97e0 flushing nmethod 0x00007f060daf2410
Event: 5,565 Thread 0x00007f061c2f97e0 flushing nmethod 0x00007f060dafe810
Event: 5,565 Thread 0x00007f061c2f97e0 flushing nmethod 0x00007f060db01d10
Event: 5,565 Thread 0x00007f061c2f97e0 flushing nmethod 0x00007f060db63c90
Event: 5,681 Thread 0x00007f05901b3bd0 Thread exited: 0x00007f05901b3bd0
Event: 5,681 Thread 0x00007f058c2319d0 Thread exited: 0x00007f058c2319d0
Event: 5,687 Thread 0x00007f05cc533030 Thread exited: 0x00007f05cc533030
Event: 5,687 Thread 0x00007f058c229ff0 Thread exited: 0x00007f058c229ff0
Event: 5,715 Thread 0x00007f058401fb00 Thread exited: 0x00007f058401fb00
Event: 5,715 Thread 0x00007f05cc449b80 Thread exited: 0x00007f05cc449b80
Event: 5,715 Thread 0x00007f05cc45b6f0 Thread exited: 0x00007f05cc45b6f0
Event: 5,872 Thread 0x00007f0584179750 Thread added: 0x00007f0584179750
Event: 5,872 Protecting memory [0x00007f05f85f8000,0x00007f05f85fc000] with protection modes 0
```

Before the patch:
```
Classes unloaded (20 events):
Event: 4,911 Thread 0x00007fe1282560f0 Unloading class 0x00000001000a3c00 'java/lang/invoke/LambdaForm$MH+0x00000001000a3c00'
Event: 4,911 Thread 0x00007fe1282560f0 Unloading class 0x00000001000a3400 'java/lang/invoke/LambdaForm$MH+0x00000001000a3400'
Event: 4,911 Thread 0x00007fe1282560f0 Unloading class 0x00000001000a1c00 'java/lang/invoke/LambdaForm$MH+0x00000001000a1c00'
Event: 4,911 Thread 0x00007fe1282560f0 Unloading class 0x00000001000a1400 'java/lang/invoke/LambdaForm$MH+0x00000001000a1400'
Event: 4,911 Thread 0x00007fe1282560f0 Unloading class 0x00000001000a1000 'java/lang/invoke/LambdaForm$MH+0x00000001000a1000'
Event: 4,911 Thread 0x00007fe1282560f0 Unloading class 0x00000001000a0c00 'java/lang/invoke/LambdaForm$MH+0x00000001000a0c00'
Event: 4,911 Thread 0x00007fe1282560f0 Unloading class 0x00000001000a0800 'java/lang/invoke/LambdaForm$MH+0x00000001000a0800'
Event: 4,911 Thread 0x00007fe1282560f0 Unloading class 0x00000001000a0400 'java/lang/invoke/LambdaForm$MH+0x00000001000a0400'
Event: 4,911 Thread 0x00007fe1282560f0 Unloading class 0x00000001000a0000 'java/lang/invoke/LambdaForm$MH+0x00000001000a0000'
Event: 4,911 Thread 0x00007fe1282560f0 Unloading class 0x000000010012c000 'jdk/internal/reflect/GeneratedMethodAccessor1'
Event: 4,911 Thread 0x00007fe1282560f0 Unloading class 0x0000000100123000 'java/lang/invoke/LambdaForm$MH+0x0000000100123000'
Event: 4,911 Thread 0x00007fe1282560f0 Unloading class 0x0000000100121800 'java/lang/invoke/LambdaForm$MH+0x0000000100121800'
Event: 4,911 Thread 0x00007fe1282560f0 Unloading class 0x0000000100121000 'java/lang/invoke/LambdaForm$MH+0x0000000100121000'
Event: 4,911 Thread 0x00007fe1282560f0 Unloading class 0x000000010009fc00 'java/lang/invoke/LambdaForm$MH+0x000000010009fc00'
Event: 4,911 Thread 0x00007fe1282560f0 Unloading class 0x000000010009ec00 'java/lang/invoke/LambdaForm$MH+0x000000010009ec00'
Event: 4,911 Thread 0x00007fe1282560f0 Unloading class 0x000000010009e800 'java/lang/invoke/LambdaForm$MH+0x000000010009e800'
Event: 4,911 Thread 0x00007fe1282560f0 Unloading class 0x000000010009e400 'java/lang/invoke/LambdaForm$MH+0x000000010009e400'
Event: 4,911 Thread 0x00007fe1282560f0 Unloading class 0x000000010009cc00 'java/lang/invoke/LambdaForm$MH+0x000000010009cc00'
Event: 5,964 Thread 0x00007fe1282560f0 Unloading class 0x00000001000a3400 'jdk/internal/reflect/GeneratedMethodAccessor2'
Event: 6,059 Thread 0x00007fe1282560f0 Unloading class 0x00000001000a3400 'jdk/internal/reflect/GeneratedMethodAccessor3'
...
Events (20 events):
Event: 4,662 loading class java/util/BitSet
Event: 4,663 loading class java/util/BitSet done
Event: 4,697 loading class java/util/ArrayList$ListItr
Event: 4,697 loading class java/util/ArrayList$ListItr done
Event: 4,738 loading class java/util/ArrayList$SubList
Event: 4,739 loading class java/util/ArrayList$SubList done
Event: 4,745 Thread 0x00007fe0940ebe70 Thread added: 0x00007fe0940ebe70
Event: 4,745 Protecting memory [0x00007fe109bb9000,0x00007fe109bbd000] with protection modes 0
Event: 4,803 Thread 0x00007fe0c03f1850 Thread added: 0x00007fe0c03f1850
Event: 4,803 Protecting memory [0x00007fe109ab8000,0x00007fe109abc000] with protection modes 0
Event: 4,809 Thread 0x00007fe0c412be00 Thread added: 0x00007fe0c412be00
Event: 4,809 Protecting memory [0x00007fe1097b5000,0x00007fe1097b9000] with protection modes 0
Event: 5,839 Thread 0x00007fe0c412be00 Thread exited: 0x00007fe0c412be00
Event: 5,846 Thread 0x00007fe0c03f1850 Thread exited: 0x00007fe0c03f1850
Event: 5,874 Thread 0x00007fe0940ebe70 Thread exited: 0x00007fe0940ebe70
Event: 5,874 Thread 0x00007fe0c03044d0 Thread exited: 0x00007fe0c03044d0
Event: 5,874 Thread 0x00007fe0dc465540 Thread exited: 0x00007fe0dc465540
Event: 5,894 Thread 0x00007fe0c02e7420 Thread exited: 0x00007fe0c02e7420
Event: 6,024 Thread 0x00007fe09c184030 Thread added: 0x00007fe09c184030
Event: 6,024 Protecting memory [0x00007fe1095b2000,0x00007fe1095b6000] with protection modes 0
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275334](https://bugs.openjdk.java.net/browse/JDK-8275334): Move class loading Events to a separate section in hs_err files


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5968/head:pull/5968` \
`$ git checkout pull/5968`

Update a local copy of the PR: \
`$ git checkout pull/5968` \
`$ git pull https://git.openjdk.java.net/jdk pull/5968/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5968`

View PR using the GUI difftool: \
`$ git pr show -t 5968`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5968.diff">https://git.openjdk.java.net/jdk/pull/5968.diff</a>

</details>
