### PR TITLE
8257534: misc tests failed with "NoClassDefFoundError: Could not initialize class java.util.concurrent.ThreadLocalRandom"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/gp/GarbageUtils.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/gp/GarbageUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -203,12 +203,7 @@ public final class GarbageUtils {
           *
           * It is Important that the impl is not inlined.
           */
-
-         public static int eatMemory(ExecutionController stresser, GarbageProducer gp, long initialFactor, long minMemoryChunk, long factor, OOM_TYPE type) {
-            try {
-               // Using a methodhandle invoke of eatMemoryImpl to prevent inlining of it
-               MethodHandles.Lookup lookup = MethodHandles.lookup();
-               MethodType mt = MethodType.methodType(
+          private static MethodType mt = MethodType.methodType(
                      int.class,
                      ExecutionController.class,
                      GarbageProducer.class,
@@ -216,6 +211,11 @@ public final class GarbageUtils {
                      long.class,
                      long.class,
                      OOM_TYPE.class);
+
+         public static int eatMemory(ExecutionController stresser, GarbageProducer gp, long initialFactor, long minMemoryChunk, long factor, OOM_TYPE type) {
+            try {
+               // Using a methodhandle invoke of eatMemoryImpl to prevent inlining of it
+               MethodHandles.Lookup lookup = MethodHandles.lookup();
                MethodHandle eat = lookup.findStatic(GarbageUtils.class, "eatMemoryImpl", mt);
                return (int) eat.invoke(stresser, gp, initialFactor, minMemoryChunk, factor, type);
             } catch (OutOfMemoryError e) {


### PR DESCRIPTION
Move the initialization and potential class loading of the MethodType out of eatMemory so that we don't get this OOME while loading this class.
Tested with tier5 and 7.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257534](https://bugs.openjdk.java.net/browse/JDK-8257534): misc tests failed with "NoClassDefFoundError: Could not initialize class java.util.concurrent.ThreadLocalRandom"


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5969/head:pull/5969` \
`$ git checkout pull/5969`

Update a local copy of the PR: \
`$ git checkout pull/5969` \
`$ git pull https://git.openjdk.java.net/jdk pull/5969/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5969`

View PR using the GUI difftool: \
`$ git pr show -t 5969`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5969.diff">https://git.openjdk.java.net/jdk/pull/5969.diff</a>

</details>
