### PR TITLE
8275287: Relax memory ordering constraints on updating instance class and array class counters

### DIFF
--- a/src/hotspot/share/classfile/classLoaderDataGraph.inline.hpp
+++ b/src/hotspot/share/classfile/classLoaderDataGraph.inline.hpp
@@ -56,12 +56,8 @@ void ClassLoaderDataGraph::inc_instance_classes(size_t count) {
 }
 
 void ClassLoaderDataGraph::dec_instance_classes(size_t count) {
-#ifdef ASSERT
-  // To avoid false positive, following assertion should read up-to-date counter.
-  OrderAccess::storeload();
-  assert(count <= num_instance_classes(), "Sanity");
-#endif
-  Atomic::sub(&_num_instance_classes, count, memory_order_relaxed);
+  size_t old_count = Atomic::fetch_and_add(&_num_instance_classes, -count, memory_order_relaxed);
+  assert(old_count >= count, "Sanity");
 }
 
 void ClassLoaderDataGraph::inc_array_classes(size_t count) {
@@ -69,12 +65,8 @@ void ClassLoaderDataGraph::inc_array_classes(size_t count) {
 }
 
 void ClassLoaderDataGraph::dec_array_classes(size_t count) {
-#ifdef ASSERT
-  // To avoid false positive, following assertion should read up-to-date counter.
-  OrderAccess::storeload();
-  assert(count <= num_array_classes(), "Sanity");
-#endif
-  Atomic::sub(&_num_array_classes, count, memory_order_relaxed);
+  size_t old_count = Atomic::fetch_and_add(&_num_array_classes, -count, memory_order_relaxed);
+  assert(old_count >= count, "Sanity");
 }
 
 bool ClassLoaderDataGraph::should_clean_metaspaces_and_reset() {


### PR DESCRIPTION
The same as JDK-8261600, the counters only need atomic guarantee,  so that, their memory constraints can be relaxed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275287](https://bugs.openjdk.java.net/browse/JDK-8275287): Relax memory ordering constraints on updating instance class and array class counters


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5970/head:pull/5970` \
`$ git checkout pull/5970`

Update a local copy of the PR: \
`$ git checkout pull/5970` \
`$ git pull https://git.openjdk.java.net/jdk pull/5970/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5970`

View PR using the GUI difftool: \
`$ git pr show -t 5970`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5970.diff">https://git.openjdk.java.net/jdk/pull/5970.diff</a>

</details>
