### PR TITLE
8275342: Change nested classes in java.prefs to static nested classes

### DIFF
--- a/src/java.prefs/macosx/classes/java/util/prefs/MacOSXPreferencesFile.java
+++ b/src/java.prefs/macosx/classes/java/util/prefs/MacOSXPreferencesFile.java
@@ -93,15 +93,9 @@ class MacOSXPreferencesFile {
             });
     }
 
-    private class FlushTask extends TimerTask {
+    private static class FlushTask extends TimerTask {
         public void run() {
             MacOSXPreferencesFile.flushWorld();
-        }
-    }
-
-    private class SyncTask extends TimerTask {
-        public void run() {
-            MacOSXPreferencesFile.syncWorld();
         }
     }
 

--- a/src/java.prefs/share/classes/java/util/prefs/AbstractPreferences.java
+++ b/src/java.prefs/share/classes/java/util/prefs/AbstractPreferences.java
@@ -29,11 +29,6 @@ import java.util.*;
 import java.io.*;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-// These imports needed only as a workaround for a JavaDoc bug
-import java.lang.Integer;
-import java.lang.Long;
-import java.lang.Float;
-import java.lang.Double;
 
 /**
  * This class provides a skeletal implementation of the {@link Preferences}
@@ -1498,13 +1493,13 @@ public abstract class AbstractPreferences extends Preferences {
      * eventQueue so the event dispatch thread knows whether to call
      * childAdded or childRemoved.
      */
-    private class NodeAddedEvent extends NodeChangeEvent {
+    private static class NodeAddedEvent extends NodeChangeEvent {
         private static final long serialVersionUID = -6743557530157328528L;
         NodeAddedEvent(Preferences parent, Preferences child) {
             super(parent, child);
         }
     }
-    private class NodeRemovedEvent extends NodeChangeEvent {
+    private static class NodeRemovedEvent extends NodeChangeEvent {
         private static final long serialVersionUID = 8735497392918824837L;
         NodeRemovedEvent(Preferences parent, Preferences child) {
             super(parent, child);

--- a/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
+++ b/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
@@ -24,6 +24,7 @@
  */
 
 package java.util.prefs;
+
 import java.util.*;
 import java.io.*;
 import java.security.AccessController;
@@ -298,8 +299,8 @@ class FileSystemPreferences extends AbstractPreferences {
      * A temporary file used for saving changes to preferences.  As part of
      * the sync operation, changes are first saved into this file, and then
      * atomically renamed to prefsFile.  This results in an atomic state
-     * change from one valid set of preferences to another.  The
-     * the file-lock is held for the duration of this transformation.
+     * change from one valid set of preferences to another.
+     * The file-lock is held for the duration of this transformation.
      */
     private final File tmpFile;
 
@@ -385,12 +386,12 @@ class FileSystemPreferences extends AbstractPreferences {
     /**
      * Represents a change to a preference.
      */
-    private abstract class Change {
+    private abstract static class Change {
         /**
          * Reapplies the change to prefsCache.
          */
         abstract void replay();
-    };
+    }
 
     /**
      * Represents a preference put.
@@ -426,7 +427,7 @@ class FileSystemPreferences extends AbstractPreferences {
     /**
      * Represents the creation of this node.
      */
-    private class NodeCreate extends Change {
+    private static class NodeCreate extends Change {
         /**
          * Performs no action, but the presence of this object in changeLog
          * will force the node and its ancestors to be made permanent at the


### PR DESCRIPTION
Non-static classes hold a link to their parent classes, which can be avoided.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275342](https://bugs.openjdk.java.net/browse/JDK-8275342): Change nested classes in java.prefs to static nested classes


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5971/head:pull/5971` \
`$ git checkout pull/5971`

Update a local copy of the PR: \
`$ git checkout pull/5971` \
`$ git pull https://git.openjdk.java.net/jdk pull/5971/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5971`

View PR using the GUI difftool: \
`$ git pr show -t 5971`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5971.diff">https://git.openjdk.java.net/jdk/pull/5971.diff</a>

</details>
