### PR TITLE
8275385: Change nested classes in jdk.jdi to static nested classes

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/Commands.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/Commands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ import java.io.*;
 
 class Commands {
 
-    abstract class AsyncExecution {
+    abstract static class AsyncExecution {
         abstract void action();
 
         AsyncExecution() {

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/ConnectorImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/ConnectorImpl.java
@@ -146,7 +146,7 @@ abstract class ConnectorImpl implements Connector {
     }
 
     @SuppressWarnings("serial") // JDK implementation class
-    abstract class ArgumentImpl implements Connector.Argument, Cloneable {
+    abstract static class ArgumentImpl implements Connector.Argument, Cloneable {
         private String name;
         private String label;
         private String description;
@@ -276,7 +276,7 @@ abstract class ConnectorImpl implements Connector {
         }
     }
 
-    class IntegerArgumentImpl extends ConnectorImpl.ArgumentImpl
+    static class IntegerArgumentImpl extends ConnectorImpl.ArgumentImpl
                               implements Connector.IntegerArgument {
         private static final long serialVersionUID = 763286081923797770L;
         private final int min;
@@ -377,7 +377,7 @@ abstract class ConnectorImpl implements Connector {
         }
     }
 
-    class StringArgumentImpl extends ConnectorImpl.ArgumentImpl
+    static class StringArgumentImpl extends ConnectorImpl.ArgumentImpl
                              implements Connector.StringArgument {
         private static final long serialVersionUID = 7500484902692107464L;
         StringArgumentImpl(String name, String label, String description,
@@ -394,7 +394,7 @@ abstract class ConnectorImpl implements Connector {
         }
     }
 
-    class SelectedArgumentImpl extends ConnectorImpl.ArgumentImpl
+    static class SelectedArgumentImpl extends ConnectorImpl.ArgumentImpl
                               implements Connector.SelectedArgument {
         private static final long serialVersionUID = -5689584530908382517L;
         @SuppressWarnings("serial") // Type of field is not Serializable

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/SDE.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/SDE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ class SDE {
     /* for C capatibility */
     static final String NullString = null;
 
-    private class FileTableRecord {
+    private static class FileTableRecord {
         int fileId;
         String sourceName;
         String sourcePath; // do not read - use accessor
@@ -72,7 +72,7 @@ class SDE {
         }
     }
 
-    private class LineTableRecord {
+    private static class LineTableRecord {
         int jplsStart;
         int jplsEnd;
         int jplsLineInc;
@@ -82,7 +82,7 @@ class SDE {
         int fileId;
     }
 
-    private class StratumTableRecord {
+    private static class StratumTableRecord {
         String id;
         int fileIndex;
         int lineIndex;


### PR DESCRIPTION
Non-static classes hold a link to their parent classes, which can be avoided.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275385](https://bugs.openjdk.java.net/browse/JDK-8275385): Change nested classes in jdk.jdi to static nested classes


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5978/head:pull/5978` \
`$ git checkout pull/5978`

Update a local copy of the PR: \
`$ git checkout pull/5978` \
`$ git pull https://git.openjdk.java.net/jdk pull/5978/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5978`

View PR using the GUI difftool: \
`$ git pr show -t 5978`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5978.diff">https://git.openjdk.java.net/jdk/pull/5978.diff</a>

</details>
