### PR TITLE
Eliminate dead stores.

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/DESKey.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DESKey.java
@@ -113,7 +113,7 @@ final class DESKey implements SecretKey {
         for (int i = 1; i < this.key.length; i++) {
             retval += this.key[i] * i;
         }
-        return(retval ^= "des".hashCode());
+        return(retval ^ "des".hashCode());
     }
 
     public boolean equals(Object obj) {

--- a/src/java.base/share/classes/com/sun/crypto/provider/DESedeKey.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DESedeKey.java
@@ -112,7 +112,7 @@ final class DESedeKey implements SecretKey {
         for (int i = 1; i < this.key.length; i++) {
             retval += this.key[i] * i;
         }
-        return(retval ^= "desede".hashCode());
+        return(retval ^ "desede".hashCode());
     }
 
     public boolean equals(Object obj) {

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBEKey.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBEKey.java
@@ -110,7 +110,7 @@ final class PBEKey implements SecretKey {
         for (int i = 1; i < this.key.length; i++) {
             retval += this.key[i] * i;
         }
-        return(retval ^= getAlgorithm().toLowerCase(Locale.ENGLISH).hashCode());
+        return(retval ^ getAlgorithm().toLowerCase(Locale.ENGLISH).hashCode());
     }
 
     public boolean equals(Object obj) {

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
@@ -255,7 +255,7 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
         for (int i = 1; i < this.key.length; i++) {
             retval += this.key[i] * i;
         }
-        return(retval ^= getAlgorithm().toLowerCase(Locale.ENGLISH).hashCode());
+        return(retval ^ getAlgorithm().toLowerCase(Locale.ENGLISH).hashCode());
     }
 
     public boolean equals(Object obj) {


### PR DESCRIPTION
A few com.sun.crypto.provider classes include dead stores, where return statements are assigning to local variables for no reason.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5981/head:pull/5981` \
`$ git checkout pull/5981`

Update a local copy of the PR: \
`$ git checkout pull/5981` \
`$ git pull https://git.openjdk.java.net/jdk pull/5981/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5981`

View PR using the GUI difftool: \
`$ git pr show -t 5981`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5981.diff">https://git.openjdk.java.net/jdk/pull/5981.diff</a>

</details>
