### PR TITLE
JDK-8275368: Correct statement of kinds of elements Processor.process operates over

### DIFF
--- a/src/java.compiler/share/classes/javax/annotation/processing/Processor.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/Processor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -322,15 +322,16 @@ public interface Processor {
     void init(ProcessingEnvironment processingEnv);
 
     /**
-     * Processes a set of annotation interfaces on {@linkplain RoundEnvironment#getRootElements() root elements}
-     * originating from the prior round and returns whether or not
-     * these annotation interfaces are claimed by this processor.  If {@code
-     * true} is returned, the annotation interfaces are claimed and subsequent
-     * processors will not be asked to process them; if {@code false}
-     * is returned, the annotation interfaces are unclaimed and subsequent
-     * processors may be asked to process them.  A processor may
-     * always return the same boolean value or may vary the result
-     * based on its own chosen criteria.
+     * Processes a set of annotation interfaces on {@linkplain
+     * RoundEnvironment#getRootElements() root elements} originating
+     * from the prior round and returns whether or not these
+     * annotation interfaces are claimed by this processor.  If {@code
+     * true} is returned, the annotation interfaces are claimed and
+     * subsequent processors will not be asked to process them; if
+     * {@code false} is returned, the annotation interfaces are
+     * unclaimed and subsequent processors may be asked to process
+     * them.  A processor may always return the same boolean value or
+     * may vary the result based on its own chosen criteria.
      *
      * <p>The input set will be empty if the processor supports {@code
      * "*"} and the root elements have no annotations.  A {@code

--- a/src/java.compiler/share/classes/javax/annotation/processing/RoundEnvironment.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/RoundEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,8 +57,8 @@ public interface RoundEnvironment {
     boolean errorRaised();
 
     /**
-     * Returns the {@linkplain Processor root elements} for annotation processing {@linkplain Filer generated}
-     * by the prior round.
+     * Returns the {@linkplain Processor root elements} for annotation
+     * processing {@linkplain Filer generated} by the prior round.
      *
      * @apiNote
      * Root elements correspond to the top-level declarations in


### PR DESCRIPTION
Correcting docs of Processor.process to not imply that type elements are the only kind of element processed.

Updated lines left un-reflowed to ease review. I'll reflow paragraphs and update copyright years before pushing.

Please also review the corresponding CSR:

https://bugs.openjdk.java.net/browse/JDK-8275369

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275368](https://bugs.openjdk.java.net/browse/JDK-8275368): Correct statement of kinds of elements Processor.process operates over


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**) ⚠️ Review applies to 6f71cdc8070c89d6da2c78d049bf8f66af07195e


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5982/head:pull/5982` \
`$ git checkout pull/5982`

Update a local copy of the PR: \
`$ git checkout pull/5982` \
`$ git pull https://git.openjdk.java.net/jdk pull/5982/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5982`

View PR using the GUI difftool: \
`$ git pr show -t 5982`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5982.diff">https://git.openjdk.java.net/jdk/pull/5982.diff</a>

</details>
