### PR TITLE
8275386: Change nested classes in jdk.jlink to static nested classes

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImagePluginStack.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImagePluginStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -282,7 +282,7 @@ public final class ImagePluginStack {
      * This pool wrap the original pool and automatically uncompress ResourcePoolEntry
      * if needed.
      */
-    private class LastPoolManager extends ResourcePoolManager {
+    private static class LastPoolManager extends ResourcePoolManager {
         private class LastModule implements ResourcePoolModule {
 
             final ResourcePoolModule module;

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ResourcePoolManager.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ResourcePoolManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,7 +74,7 @@ public class ResourcePoolManager {
                 Resources.canEncapsulate(path);
     }
 
-    class ResourcePoolModuleImpl implements ResourcePoolModule {
+    static class ResourcePoolModuleImpl implements ResourcePoolModule {
 
         final Map<String, ResourcePoolEntry> moduleContent = new LinkedHashMap<>();
         // lazily initialized

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/SystemModulesPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/SystemModulesPlugin.java
@@ -477,7 +477,7 @@ public final class SystemModulesPlugin extends AbstractPlugin {
             return bais;
         }
 
-        class ModuleInfoRewriter extends ByteArrayOutputStream {
+        static class ModuleInfoRewriter extends ByteArrayOutputStream {
             final ModuleInfoExtender extender;
             ModuleInfoRewriter(InputStream in) {
                 this.extender = ModuleInfoExtender.newExtender(in);
@@ -625,7 +625,7 @@ public final class SystemModulesPlugin extends AbstractPlugin {
         }
 
         /**
-         * Generate byteccode for no-arg constructor
+         * Generate bytecode for no-arg constructor
          */
         private void genConstructor(ClassWriter cw) {
             MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);


### PR DESCRIPTION
Non-static classes hold a link to their parent classes, which can be avoided.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275386](https://bugs.openjdk.java.net/browse/JDK-8275386): Change nested classes in jdk.jlink to static nested classes


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5983/head:pull/5983` \
`$ git checkout pull/5983`

Update a local copy of the PR: \
`$ git checkout pull/5983` \
`$ git pull https://git.openjdk.java.net/jdk pull/5983/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5983`

View PR using the GUI difftool: \
`$ git pr show -t 5983`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5983.diff">https://git.openjdk.java.net/jdk/pull/5983.diff</a>

</details>
