### PR TITLE
8275375: jfr/api/consumer/security/TestStreamingRemote.java fails with AccessControlException

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Options.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Options.java
@@ -120,17 +120,21 @@ public final class Options {
     }
 
     public static synchronized void setDumpPath(SafePath path) {
-        if (path.toFile().canWrite()) {
-            try {
+        try {
+            if (path.toFile().canWrite()) {
                 jvm.setDumpPath(path.toPath().toRealPath(NOFOLLOW_LINKS).toString());
-            } catch (IOException e) {
+            } else {
                 if (Logger.shouldLog(LogTag.JFR_SYSTEM_SETTING, LogLevel.WARN)) {
-                    Logger.log(LogTag.JFR_SYSTEM_SETTING, LogLevel.WARN, "Error occurred in path resolution: " + e.toString());
+                    Logger.log(LogTag.JFR_SYSTEM_SETTING, LogLevel.WARN, "Cannot write JFR emergency dump to " + path.toString());
                 }
             }
-        } else {
+        } catch (IOException e) {
             if (Logger.shouldLog(LogTag.JFR_SYSTEM_SETTING, LogLevel.WARN)) {
-                Logger.log(LogTag.JFR_SYSTEM_SETTING, LogLevel.WARN, "Cannot write JFR emergency dump to " + path.toString());
+                Logger.log(LogTag.JFR_SYSTEM_SETTING, LogLevel.WARN, "Error occurred in path resolution: " + e.toString());
+            }
+        } catch (SecurityException e) {
+            if (Logger.shouldLog(LogTag.JFR_SYSTEM_SETTING, LogLevel.WARN)) {
+                Logger.log(LogTag.JFR_SYSTEM_SETTING, LogLevel.WARN, "Cannot check emergency dump path: " + e.toString());
             }
         }
     }


### PR DESCRIPTION
We can see AccessControlException in some JFR tests since [JDK-8271949](https://bugs.openjdk.java.net/browse/JDK-8271949). It is caused that SecurityException happens in both `File::canWrite` and `Path::toRealPath`. We should fall-through with empty path because the path will be evaluated when emergency dump happens.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8275375](https://bugs.openjdk.java.net/browse/JDK-8275375)

### Issue
 * [JDK-8275375](https://bugs.openjdk.java.net/browse/JDK-8275375): [REDO] JDK-8271949 dumppath in -XX:FlightRecorderOptions does not affect ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5984/head:pull/5984` \
`$ git checkout pull/5984`

Update a local copy of the PR: \
`$ git checkout pull/5984` \
`$ git pull https://git.openjdk.java.net/jdk pull/5984/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5984`

View PR using the GUI difftool: \
`$ git pr show -t 5984`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5984.diff">https://git.openjdk.java.net/jdk/pull/5984.diff</a>

</details>
