### PR TITLE
8277120: Use Optional.isEmpty instead of !Optional.isPresent in java.net.http

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/AuthenticationFilter.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/AuthenticationFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -305,7 +305,7 @@ class AuthenticationFilter implements HeaderFilter {
         AuthInfo au = proxy ? exchange.proxyauth : exchange.serverauth;
         if (au == null) {
             // if no authenticator, let the user deal with 407/401
-            if (!exchange.client().authenticator().isPresent()) return null;
+            if (exchange.client().authenticator().isEmpty()) return null;
 
             PasswordAuthentication pw = getCredentials(authval, proxy, req);
             if (pw == null) {
@@ -331,7 +331,7 @@ class AuthenticationFilter implements HeaderFilter {
             }
 
             // if no authenticator, let the user deal with 407/401
-            if (!exchange.client().authenticator().isPresent()) return null;
+            if (exchange.client().authenticator().isEmpty()) return null;
 
             // try again
             PasswordAuthentication pw = getCredentials(authval, proxy, req);

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpRequestImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpRequestImpl.java
@@ -44,7 +44,6 @@ import java.net.http.HttpRequest;
 
 import jdk.internal.net.http.common.HttpHeadersBuilder;
 import jdk.internal.net.http.common.Utils;
-import jdk.internal.net.http.websocket.OpeningHandshake;
 import jdk.internal.net.http.websocket.WebSocketRequest;
 
 import static jdk.internal.net.http.common.Utils.ALLOWED_HEADERS;
@@ -125,7 +124,7 @@ public class HttpRequestImpl extends HttpRequest implements WebSocketRequest {
             checkTimeout(timeout);
             this.systemHeadersBuilder = new HttpHeadersBuilder();
         }
-        if (!userHeaders.firstValue("User-Agent").isPresent()) {
+        if (userHeaders.firstValue("User-Agent").isEmpty()) {
             this.systemHeadersBuilder.setHeader("User-Agent", USER_AGENT);
         }
         this.uri = requestURI;
@@ -183,7 +182,7 @@ public class HttpRequestImpl extends HttpRequest implements WebSocketRequest {
         this.userHeaders = other.userHeaders;
         this.isWebSocket = other.isWebSocket;
         this.systemHeadersBuilder = new HttpHeadersBuilder();
-        if (!userHeaders.firstValue("User-Agent").isPresent()) {
+        if (userHeaders.firstValue("User-Agent").isEmpty()) {
             this.systemHeadersBuilder.setHeader("User-Agent", USER_AGENT);
         }
         this.uri = uri;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/Utils.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/Utils.java
@@ -175,7 +175,7 @@ public final class Utils {
     // used by caller.
 
     public static final BiPredicate<String, String> CONTEXT_RESTRICTED(HttpClient client) {
-        return (k, v) -> !client.authenticator().isPresent() ||
+        return (k, v) -> client.authenticator().isEmpty() ||
                 (!k.equalsIgnoreCase("Authorization")
                         && !k.equalsIgnoreCase("Proxy-Authorization"));
     }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/websocket/BuilderImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/websocket/BuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,7 @@ public final class BuilderImpl implements Builder {
         this.proxySelector = proxySelector;
         // If a proxy selector was supplied by the user, it should be present
         // on the client and should be the same that what we got as an argument
-        assert !client.proxy().isPresent()
+        assert client.proxy().isEmpty()
                 || client.proxy().equals(proxySelector);
         this.headers = headers;
         this.subprotocols = subprotocols;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/websocket/OpeningHandshake.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/websocket/OpeningHandshake.java
@@ -28,7 +28,6 @@ package jdk.internal.net.http.websocket;
 import java.net.http.HttpClient;
 import java.net.http.HttpClient.Version;
 import java.net.http.HttpHeaders;
-import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.net.http.WebSocketHandshakeException;
@@ -62,7 +61,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
@@ -281,7 +279,7 @@ public class OpeningHandshake {
             throws CheckFailedException
     {
         Optional<String> opt = responseHeaders.firstValue(HEADER_PROTOCOL);
-        if (!opt.isPresent()) {
+        if (opt.isEmpty()) {
             // If there is no such header in the response, then the server
             // doesn't want to use any subprotocol
             return "";
@@ -363,7 +361,7 @@ public class OpeningHandshake {
      * or {@code null} if none is required or applicable.
      */
     private static Proxy proxyFor(Optional<ProxySelector> selector, URI uri) {
-        if (!selector.isPresent()) {
+        if (selector.isEmpty()) {
             return null;
         }
         URI requestURI = createRequestURI(uri); // Based on the HTTP scheme


### PR DESCRIPTION
I propose to replace usages of !Optional.isPresent() with Optional.isEmpty method.
It's makes code a bit easier to read.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277120](https://bugs.openjdk.java.net/browse/JDK-8277120): Use Optional.isEmpty instead of !Optional.isPresent in java.net.http


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5985/head:pull/5985` \
`$ git checkout pull/5985`

Update a local copy of the PR: \
`$ git checkout pull/5985` \
`$ git pull https://git.openjdk.java.net/jdk pull/5985/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5985`

View PR using the GUI difftool: \
`$ git pr show -t 5985`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5985.diff">https://git.openjdk.java.net/jdk/pull/5985.diff</a>

</details>
