### PR TITLE
8255898: Test java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java fails on Mac OS

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -481,7 +481,7 @@ java/awt/Robot/RobotWheelTest/RobotWheelTest.java 8129827 generic-all
 java/awt/Focus/WindowUpdateFocusabilityTest/WindowUpdateFocusabilityTest.java 8202926 linux-all
 java/awt/datatransfer/ConstructFlavoredObjectTest/ConstructFlavoredObjectTest.java 8202860 linux-all
 java/awt/dnd/DisposeFrameOnDragCrash/DisposeFrameOnDragTest.java 8202790 macosx-all,linux-all
-java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java 8202882,8255898 linux-all,macosx-all
+java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java 8202882 linux-all
 java/awt/dnd/MissingDragExitEventTest/MissingDragExitEventTest.java 8030121 macosx-all,linux-all
 java/awt/Choice/ChoicePopupLocation/ChoicePopupLocation.java 8202931 macosx-all,linux-all
 java/awt/Focus/NonFocusableBlockedOwnerTest/NonFocusableBlockedOwnerTest.java 7124275 macosx-all

--- a/test/jdk/java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java
+++ b/test/jdk/java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java
@@ -28,7 +28,7 @@
   @summary namefilter is not called for file dialog on windows
   @library ../../regtesthelpers
   @build Util
-  @run main FilenameFilterTest
+  @run main/othervm FilenameFilterTest
 */
 
 import java.awt.*;


### PR DESCRIPTION
Root cause for this test failure in our CI systems was macOS regression in specific version of Catalina.
This issue is fixed in macOS 10.12 Catalina Beta7 (19A546d) and it is no longer failing after multiple individual test runs as well as multiple FileDialog jtreg test bunch run in our CI systems.

I have added details of similar issue faced in this Catalina version by other applications in the JBS. Some of these observations talk about permission issues when running the application, so to be on safer side i have updated test case to run on othervm mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255898](https://bugs.openjdk.java.net/browse/JDK-8255898): Test java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java fails on Mac OS


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5986/head:pull/5986` \
`$ git checkout pull/5986`

Update a local copy of the PR: \
`$ git checkout pull/5986` \
`$ git pull https://git.openjdk.java.net/jdk pull/5986/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5986`

View PR using the GUI difftool: \
`$ git pr show -t 5986`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5986.diff">https://git.openjdk.java.net/jdk/pull/5986.diff</a>

</details>
