### PR TITLE
8275413: Remove unused InstanceKlass::set_array_klasses() method

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -393,7 +393,6 @@ class InstanceKlass: public Klass {
   // array klasses
   ObjArrayKlass* array_klasses() const     { return _array_klasses; }
   inline ObjArrayKlass* array_klasses_acquire() const; // load with acquire semantics
-  void set_array_klasses(ObjArrayKlass* k) { _array_klasses = k; }
   inline void release_set_array_klasses(ObjArrayKlass* k); // store with release semantics
 
   // methods


### PR DESCRIPTION
Please review this trivial patch that removes unused nstanceKlass::set_array_klasses() method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275413](https://bugs.openjdk.java.net/browse/JDK-8275413): Remove unused InstanceKlass::set_array_klasses() method


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5991/head:pull/5991` \
`$ git checkout pull/5991`

Update a local copy of the PR: \
`$ git checkout pull/5991` \
`$ git pull https://git.openjdk.java.net/jdk pull/5991/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5991`

View PR using the GUI difftool: \
`$ git pr show -t 5991`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5991.diff">https://git.openjdk.java.net/jdk/pull/5991.diff</a>

</details>
