### PR TITLE
8275426: PretouchTask num_chunks calculation can overflow

### DIFF
--- a/src/hotspot/share/gc/shared/pretouchTask.cpp
+++ b/src/hotspot/share/gc/shared/pretouchTask.cpp
@@ -81,7 +81,7 @@ void PretouchTask::pretouch(const char* task_name, char* start_address, char* en
   }
 
   if (pretouch_workers != NULL) {
-    size_t num_chunks = (total_bytes + chunk_size - 1) / chunk_size;
+    size_t num_chunks = ((total_bytes - 1) / chunk_size) + 1;
 
     uint num_workers = (uint)MIN2(num_chunks, (size_t)pretouch_workers->max_workers());
     log_debug(gc, heap)("Running %s with %u workers for " SIZE_FORMAT " work units pre-touching " SIZE_FORMAT "B.",


### PR DESCRIPTION
Please review this change to part of the calculation of the number of
threads to apply to a PretouchTask when using a gang of worker threads.

The previous calculation of the number of chunks in the range to be touched
can overflow in the numerator.  (This may only be a realistic problem on
32bit platforms.  On 64bit platforms the value constraint on the chunk size
and plausible or architectural limits on the size of the range probably
prevent such overflow from occurring.)

Testing:
mach5 tier1
Locally (linux-x64) ran with logging of the pretouch parameters enabled,
with various chunk sizes configured, and hand-checked the logged values.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275426](https://bugs.openjdk.java.net/browse/JDK-8275426): PretouchTask num_chunks calculation can overflow


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5993/head:pull/5993` \
`$ git checkout pull/5993`

Update a local copy of the PR: \
`$ git checkout pull/5993` \
`$ git pull https://git.openjdk.java.net/jdk pull/5993/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5993`

View PR using the GUI difftool: \
`$ git pr show -t 5993`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5993.diff">https://git.openjdk.java.net/jdk/pull/5993.diff</a>

</details>
