### PR TITLE
JDK-8275436 [BACKOUT] JDK-8271949 dumppath in -XX:FlightRecorderOptions does not affect

### DIFF
--- a/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,6 @@
 #include "jfr/recorder/repository/jfrRepository.hpp"
 #include "jfr/recorder/repository/jfrChunkRotation.hpp"
 #include "jfr/recorder/repository/jfrChunkWriter.hpp"
-#include "jfr/recorder/repository/jfrEmergencyDump.hpp"
 #include "jfr/recorder/service/jfrEventThrottler.hpp"
 #include "jfr/recorder/service/jfrOptionSet.hpp"
 #include "jfr/recorder/stacktrace/jfrStackTraceRepository.hpp"
@@ -315,16 +314,6 @@ JVM_END
 JVM_ENTRY_NO_ENV(void, jfr_set_repository_location(JNIEnv* env, jobject repo, jstring location))
   return JfrRepository::set_path(location, thread);
 JVM_END
-
-NO_TRANSITION(void, jfr_set_dump_path(JNIEnv* env, jobject jvm, jstring dumppath))
-  const char* dump_path = env->GetStringUTFChars(dumppath, NULL);
-  JfrEmergencyDump::set_dump_path(dump_path);
-  env->ReleaseStringUTFChars(dumppath, dump_path);
-NO_TRANSITION_END
-
-NO_TRANSITION(jstring, jfr_get_dump_path(JNIEnv* env, jobject jvm))
-  return env->NewStringUTF(JfrEmergencyDump::get_dump_path());
-NO_TRANSITION_END
 
 JVM_ENTRY_NO_ENV(void, jfr_uncaught_exception(JNIEnv* env, jobject jvm, jobject t, jthrowable throwable))
   JfrJavaSupport::uncaught_exception(throwable, thread);

--- a/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,10 +112,6 @@ jdouble JNICALL jfr_time_conv_factor(JNIEnv* env, jobject jvm);
 jlong JNICALL jfr_type_id(JNIEnv* env, jobject jvm, jclass jc);
 
 void JNICALL jfr_set_repository_location(JNIEnv* env, jobject repo, jstring location);
-
-void JNICALL jfr_set_dump_path(JNIEnv* env, jobject jvm, jstring dumppath);
-
-jstring JNICALL jfr_get_dump_path(JNIEnv* env, jobject jvm);
 
 jobject JNICALL jfr_get_event_writer(JNIEnv* env, jclass cls);
 

--- a/src/hotspot/share/jfr/jni/jfrJniMethodRegistration.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethodRegistration.cpp
@@ -75,8 +75,6 @@ JfrJniMethodRegistration::JfrJniMethodRegistration(JNIEnv* env) {
       (char*)"flush", (char*)"(Ljdk/jfr/internal/EventWriter;II)Z", (void*)jfr_event_writer_flush,
       (char*)"flush", (char*)"()V", (void*)jfr_flush,
       (char*)"setRepositoryLocation", (char*)"(Ljava/lang/String;)V", (void*)jfr_set_repository_location,
-      (char*)"setDumpPath", (char*)"(Ljava/lang/String;)V", (void*)jfr_set_dump_path,
-      (char*)"getDumpPath", (char*)"()Ljava/lang/String;", (void*)jfr_get_dump_path,
       (char*)"abort", (char*)"(Ljava/lang/String;)V", (void*)jfr_abort,
       (char*)"addStringConstant", (char*)"(JLjava/lang/String;)Z", (void*)jfr_add_string_constant,
       (char*)"uncaughtException", (char*)"(Ljava/lang/Thread;Ljava/lang/Throwable;)V", (void*)jfr_uncaught_exception,

--- a/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp
@@ -41,8 +41,6 @@
 #include "utilities/growableArray.hpp"
 #include "utilities/ostream.hpp"
 
-char JfrEmergencyDump::_dump_path[JVM_MAXPATHLEN] = { 0 };
-
 static const char vm_error_filename_fmt[] = "hs_err_pid%p.jfr";
 static const char vm_oom_filename_fmt[] = "hs_oom_pid%p.jfr";
 static const char vm_soe_filename_fmt[] = "hs_soe_pid%p.jfr";
@@ -68,17 +66,12 @@ static bool is_path_empty() {
 }
 
 // returns with an appended file separator (if successful)
-static size_t get_dump_directory() {
-  const char* dump_path = JfrEmergencyDump::get_dump_path();
-  if (*dump_path == '\0') {
-    if (os::get_current_directory(_path_buffer, sizeof(_path_buffer)) == NULL) {
-      return 0;
-    }
-  } else {
-    strcpy(_path_buffer, dump_path);
+static size_t get_current_directory() {
+  if (os::get_current_directory(_path_buffer, sizeof(_path_buffer)) == NULL) {
+    return 0;
   }
-  const size_t path_len = strlen(_path_buffer);
-  const int result = jio_snprintf(_path_buffer + path_len,
+  const size_t cwd_len = strlen(_path_buffer);
+  const int result = jio_snprintf(_path_buffer + cwd_len,
                                   sizeof(_path_buffer),
                                   "%s",
                                   os::file_separator());
@@ -112,7 +105,7 @@ static void close_emergency_dump_file() {
 static const char* create_emergency_dump_path() {
   assert(is_path_empty(), "invariant");
 
-  const size_t path_len = get_dump_directory();
+  const size_t path_len = get_current_directory();
   if (path_len == 0) {
     return NULL;
   }
@@ -132,21 +125,12 @@ static const char* create_emergency_dump_path() {
   return result ? _path_buffer : NULL;
 }
 
-bool JfrEmergencyDump::open_emergency_dump_file() {
+static bool open_emergency_dump_file() {
   if (is_emergency_dump_file_open()) {
     // opened already
     return true;
   }
-
-  bool result = open_emergency_dump_fd(create_emergency_dump_path());
-  if (!result && *_dump_path != '\0') {
-    log_warning(jfr)("Unable to create an emergency dump file at the location set by dumppath=%s", _dump_path);
-    // Fallback. Try to create it in the current directory.
-    *_dump_path = '\0';
-    *_path_buffer = '\0';
-    result = open_emergency_dump_fd(create_emergency_dump_path());
-  }
-  return result;
+  return open_emergency_dump_fd(create_emergency_dump_path());
 }
 
 static void report(outputStream* st, bool emergency_file_opened, const char* repository_path) {
@@ -164,19 +148,6 @@ static void report(outputStream* st, bool emergency_file_opened, const char* rep
     st->print_raw_cr(_path_buffer);
     st->print_raw_cr("#");
   }
-}
-
-void JfrEmergencyDump::set_dump_path(const char* dump_path) {
-  if (dump_path != NULL) {
-    if (strlen(dump_path) < JVM_MAXPATHLEN) {
-      strncpy(_dump_path, dump_path, JVM_MAXPATHLEN);
-      _dump_path[JVM_MAXPATHLEN - 1] = '\0';
-    }
-  }
-}
-
-const char* JfrEmergencyDump::get_dump_path() {
-  return _dump_path;
 }
 
 void JfrEmergencyDump::on_vm_error_report(outputStream* st, const char* repository_path) {

--- a/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.hpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,14 +32,7 @@
 // Responsible for creating an hs_err<pid>.jfr file in exceptional shutdown situations (crash, OOM)
 //
 class JfrEmergencyDump : AllStatic {
- private:
-  static char _dump_path[JVM_MAXPATHLEN];
-
-  static bool open_emergency_dump_file();
-
  public:
-  static void set_dump_path(const char* dump_path);
-  static const char* get_dump_path();
   static const char* chunk_path(const char* repository_path);
   static void on_vm_error(const char* repository_path);
   static void on_vm_error_report(outputStream* st, const char* repository_path);

--- a/src/hotspot/share/jfr/recorder/service/jfrOptionSet.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrOptionSet.cpp
@@ -163,7 +163,6 @@ bool JfrOptionSet::allow_event_retransforms() {
 
 // default options for the dcmd parser
 const char* const default_repository = NULL;
-const char* const default_dumppath = NULL;
 const char* const default_global_buffer_size = "512k";
 const char* const default_num_global_buffers = "20";
 const char* const default_memory_size = "10m";
@@ -182,13 +181,6 @@ static DCmdArgument<char*> _dcmd_repository(
   "STRING",
   false,
   default_repository);
-
-static DCmdArgument<char*> _dcmd_dumppath(
-  "dumppath",
-  "Path to emergency dump",
-  "STRING",
-  false,
-  default_dumppath);
 
 static DCmdArgument<MemorySizeArgument> _dcmd_threadbuffersize(
   "threadbuffersize",
@@ -266,7 +258,6 @@ static DCmdParser _parser;
 
 static void register_parser_options() {
   _parser.add_dcmd_option(&_dcmd_repository);
-  _parser.add_dcmd_option(&_dcmd_dumppath);
   _parser.add_dcmd_option(&_dcmd_threadbuffersize);
   _parser.add_dcmd_option(&_dcmd_memorysize);
   _parser.add_dcmd_option(&_dcmd_globalbuffersize);
@@ -353,18 +344,6 @@ bool JfrOptionSet::configure(TRAPS) {
     }
     strncpy(repo_copy, repo, len + 1);
     configure._repository_path.set_value(repo_copy);
-  }
-
-  configure._dump_path.set_is_set(_dcmd_dumppath.is_set());
-  char* dumppath = _dcmd_dumppath.value();
-  if (dumppath != NULL) {
-    const size_t len = strlen(dumppath);
-    char* dumppath_copy = JfrCHeapObj::new_array<char>(len + 1);
-    if (NULL == dumppath_copy) {
-      return false;
-    }
-    strncpy(dumppath_copy, dumppath, len + 1);
-    configure._dump_path.set_value(dumppath_copy);
   }
 
   configure._stack_depth.set_is_set(_dcmd_stackdepth.is_set());

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
@@ -473,25 +473,12 @@ public final class JVM {
     public native void flush();
 
     /**
-     * Sets the location of the disk repository.
+     * Sets the location of the disk repository, to be used at an emergency
+     * dump.
      *
      * @param dirText
      */
     public native void setRepositoryLocation(String dirText);
-
-    /**
-     * Sets the path to emergency dump.
-     *
-     * @param dumpPathText
-     */
-    public native void setDumpPath(String dumpPathText);
-
-    /**
-     * Gets the path to emergency dump.
-     *
-     * @return The path to emergency dump.
-     */
-    public native String getDumpPath();
 
    /**
     * Access to VM termination support.

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/SecuritySupport.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/SecuritySupport.java
@@ -77,6 +77,7 @@ public final class SecuritySupport {
     private static final Module JFR_MODULE = Event.class.getModule();
     public  static final SafePath JFC_DIRECTORY = getPathInProperty("java.home", "lib/jfr");
     public static final FileAccess PRIVILEGED = new Privileged();
+    static final SafePath USER_HOME = getPathInProperty("user.home", null);
     static final SafePath JAVA_IO_TMPDIR = getPathInProperty("java.io.tmpdir", null);
 
     static {


### PR DESCRIPTION
This reverts commit 31500692d1503cb73249e0425e6930aaaa49258a.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275436](https://bugs.openjdk.java.net/browse/JDK-8275436): [BACKOUT] JDK-8271949 dumppath in -XX:FlightRecorderOptions does not affect


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5994/head:pull/5994` \
`$ git checkout pull/5994`

Update a local copy of the PR: \
`$ git checkout pull/5994` \
`$ git pull https://git.openjdk.java.net/jdk pull/5994/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5994`

View PR using the GUI difftool: \
`$ git pr show -t 5994`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5994.diff">https://git.openjdk.java.net/jdk/pull/5994.diff</a>

</details>
