### PR TITLE
8262442: (windows) Use all proxy configuration sources when java.net.useSystemProxies=true

### DIFF
--- a/src/java.base/windows/native/libnet/DefaultProxySelector.c
+++ b/src/java.base/windows/native/libnet/DefaultProxySelector.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/windows/native/libnet/DefaultProxySelector.c
+++ b/src/java.base/windows/native/libnet/DefaultProxySelector.c
@@ -230,16 +230,12 @@ Java_sun_net_spi_DefaultProxySelector_getSystemProxies(JNIEnv *env,
         auto_proxy_options.dwFlags = WINHTTP_AUTOPROXY_AUTO_DETECT;
         auto_proxy_options.fAutoLogonIfChallenged = TRUE;
         use_auto_proxy = TRUE;
-    } else if (ie_proxy_config.lpszAutoConfigUrl != NULL) {
+    }
+    if (ie_proxy_config.lpszAutoConfigUrl != NULL) {
         /* Windows uses PAC file */
         auto_proxy_options.lpszAutoConfigUrl = ie_proxy_config.lpszAutoConfigUrl;
-        auto_proxy_options.dwFlags = WINHTTP_AUTOPROXY_CONFIG_URL;
+        auto_proxy_options.dwFlags |= WINHTTP_AUTOPROXY_CONFIG_URL;
         use_auto_proxy = TRUE;
-    } else if (ie_proxy_config.lpszProxy != NULL) {
-        /* Windows uses manually entered proxy. */
-        use_auto_proxy = FALSE;
-        win_bypass_proxy = ie_proxy_config.lpszProxyBypass;
-        win_proxy = ie_proxy_config.lpszProxy;
     }
 
     if (use_auto_proxy) {
@@ -252,6 +248,12 @@ Java_sun_net_spi_DefaultProxySelector_getSystemProxies(JNIEnv *env,
             win_proxy = proxy_info.lpszProxy;
             win_bypass_proxy = proxy_info.lpszProxyBypass;
         }
+    }
+
+    if (!use_auto_proxy && ie_proxy_config.lpszProxy != NULL) {
+        /* Windows uses manually entered proxy. */
+        win_bypass_proxy = ie_proxy_config.lpszProxyBypass;
+        win_proxy = ie_proxy_config.lpszProxy;
     }
 
     /* Check the bypass entry. */


### PR DESCRIPTION
With this patch DefaultProxySelector first attempts to use proxy config autodetection (http://wpad/wpad.dat) when that is configured and available.
If proxy config autodetection is unavailable, selector tries to use configured proxy script (again, if configured and available)
If both the above options fail, selector uses the configured proxy.

Verified on Windows 10 that:
- when `fAutoDetect` is true, http://wpad/wpad.dat refers to an existing file, the file has correct syntax and returns a proxy, that proxy is used
- when `fAutoDetect` is true, but the autoconfig file is not available / unusable for any reason, selector fails over to the next configured method
- when `lpszAutoConfigUrl` is set and usable, the proxy returned is used
- when `lpszAutoConfigUrl` is not set or unusable, selector fails over to next method
- when `lpszProxy` is configured, that proxy is used
- otherwise selector uses direct connection

The proxy configuration scripts are cached on system level, so testing (alternating between good and broken autoconfig script) may require waiting for the caches to invalidate.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262442](https://bugs.openjdk.java.net/browse/JDK-8262442): (windows) Use all proxy configuration sources when java.net.useSystemProxies=true


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5995/head:pull/5995` \
`$ git checkout pull/5995`

Update a local copy of the PR: \
`$ git checkout pull/5995` \
`$ git pull https://git.openjdk.java.net/jdk pull/5995/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5995`

View PR using the GUI difftool: \
`$ git pr show -t 5995`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5995.diff">https://git.openjdk.java.net/jdk/pull/5995.diff</a>

</details>
