### PR TITLE
8275084: CDS warning when building with LOG=debug

### DIFF
--- a/src/hotspot/share/cds/classListWriter.cpp
+++ b/src/hotspot/share/cds/classListWriter.cpp
@@ -59,6 +59,11 @@ void ClassListWriter::write(const InstanceKlass* k, const ClassFileStream* cfs) 
     return;
   }
 
+  // filter out java/lang/invoke/BoundMethodHandle$Species....
+  if (cfs != NULL && strcmp(cfs->source(), "_ClassSpecializer_generateConcreteSpeciesCode") == 0) {
+    return;
+  }
+
   ClassListWriter w;
   write_to_stream(k, w.stream(), cfs);
 }

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleStatics.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleStatics.java
@@ -139,6 +139,9 @@ class MethodHandleStatics {
         if (TRACE_RESOLVE) {
             System.out.println("[SPECIES_RESOLVE] " + cn + (salvage != null ? " (salvaged)" : " (generated)"));
         }
+        if (CDS.isDumpingClassList()) {
+            CDS.traceSpeciesType("[SPECIES_RESOLVE]", cn);
+        }
     }
     // handy shared exception makers (they simplify the common case code)
     /*non-public*/


### PR DESCRIPTION
Hi, Please review
  The generated SPECIES functions archived during dumping CDS archive. But some time rebuild issue warning 
  [2.325s][warning][cds] java.lang.ClassNotFoundException: java.lang.invoke.BoundMethodHandle$Species_LLLLL
  Since we only care archiving functions generated in the four holder classes:
  java.lang.invoke.Invokers$Holder, java.lang.invoke.LambdaForm$Holder, java.lang.invoke.DirectMethodHandle$Holder and java.lang.invoke.DelegatingMethodHandle$Holder
  This patch removed the logging thus the archiving of SPECIES_RESOLVED functions in shared archive.

Tests: tier1,tier4

Thanks
Yumin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275084](https://bugs.openjdk.java.net/browse/JDK-8275084): CDS warning when building with LOG=debug


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/5998/head:pull/5998` \
`$ git checkout pull/5998`

Update a local copy of the PR: \
`$ git checkout pull/5998` \
`$ git pull https://git.openjdk.java.net/jdk pull/5998/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5998`

View PR using the GUI difftool: \
`$ git pr show -t 5998`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/5998.diff">https://git.openjdk.java.net/jdk/pull/5998.diff</a>

</details>
