### PR TITLE
8275416: G1: remove unnecessary make_referent_alive in precleaning phase

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1695,9 +1695,7 @@ void G1ConcurrentMark::preclean() {
 
   SuspendibleThreadSetJoiner joiner;
 
-  G1CMKeepAliveAndDrainClosure keep_alive(this, task(0), true /* is_serial */);
   BarrierEnqueueDiscoveredFieldClosure enqueue;
-  G1CMDrainMarkingStackClosure drain_mark_stack(this, task(0), true /* is_serial */);
 
   set_concurrency_and_phase(1, true);
 
@@ -1707,9 +1705,7 @@ void G1ConcurrentMark::preclean() {
   // Precleaning is single threaded. Temporarily disable MT discovery.
   ReferenceProcessorMTDiscoveryMutator rp_mut_discovery(rp, false);
   rp->preclean_discovered_references(rp->is_alive_non_header(),
-                                     &keep_alive,
                                      &enqueue,
-                                     &drain_mark_stack,
                                      &yield_cl,
                                      _gc_timer_cm);
 }

--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -1062,9 +1062,7 @@ bool ReferenceProcessor::has_discovered_references() {
 }
 
 void ReferenceProcessor::preclean_discovered_references(BoolObjectClosure* is_alive,
-                                                        OopClosure* keep_alive,
                                                         EnqueueDiscoveredFieldClosure* enqueue,
-                                                        VoidClosure* complete_gc,
                                                         YieldClosure* yield,
                                                         GCTimer* gc_timer) {
   // These lists can be handled here in any order and, indeed, concurrently.
@@ -1078,7 +1076,7 @@ void ReferenceProcessor::preclean_discovered_references(BoolObjectClosure* is_al
         return;
       }
       if (preclean_discovered_reflist(_discoveredSoftRefs[i], is_alive,
-                                      keep_alive, enqueue, complete_gc, yield)) {
+                                      enqueue, yield)) {
         log_reflist("SoftRef abort: ", _discoveredSoftRefs, _max_num_queues);
         return;
       }
@@ -1095,7 +1093,7 @@ void ReferenceProcessor::preclean_discovered_references(BoolObjectClosure* is_al
         return;
       }
       if (preclean_discovered_reflist(_discoveredWeakRefs[i], is_alive,
-                                      keep_alive, enqueue, complete_gc, yield)) {
+                                      enqueue, yield)) {
         log_reflist("WeakRef abort: ", _discoveredWeakRefs, _max_num_queues);
         return;
       }
@@ -1112,7 +1110,7 @@ void ReferenceProcessor::preclean_discovered_references(BoolObjectClosure* is_al
         return;
       }
       if (preclean_discovered_reflist(_discoveredFinalRefs[i], is_alive,
-                                      keep_alive, enqueue, complete_gc, yield)) {
+                                      enqueue, yield)) {
         log_reflist("FinalRef abort: ", _discoveredFinalRefs, _max_num_queues);
         return;
       }
@@ -1129,7 +1127,7 @@ void ReferenceProcessor::preclean_discovered_references(BoolObjectClosure* is_al
         return;
       }
       if (preclean_discovered_reflist(_discoveredPhantomRefs[i], is_alive,
-                                      keep_alive, enqueue, complete_gc, yield)) {
+                                      enqueue, yield)) {
         log_reflist("PhantomRef abort: ", _discoveredPhantomRefs, _max_num_queues);
         return;
       }
@@ -1138,22 +1136,11 @@ void ReferenceProcessor::preclean_discovered_references(BoolObjectClosure* is_al
   }
 }
 
-// Walk the given discovered ref list, and remove all reference objects whose
-// referents are still alive or NULL. NOTE: When we are precleaning the
-// ref lists, we do not disable refs discovery to honor the correct semantics of
-// java.lang.Reference. Therefore, as we iterate over the discovered list (DL)
-// and drop elements from it, newly discovered refs can be discovered and added
-// to the DL. Because precleaning is implemented single-threaded today, for
-// each per-thread DL, the insertion of refs (calling `complete_gc`) happens
-// after the iteration. The clear separation means no special synchronization
-// is needed.
 bool ReferenceProcessor::preclean_discovered_reflist(DiscoveredList&    refs_list,
                                                      BoolObjectClosure* is_alive,
-                                                     OopClosure*        keep_alive,
                                                      EnqueueDiscoveredFieldClosure* enqueue,
-                                                     VoidClosure*       complete_gc,
                                                      YieldClosure*      yield) {
-  DiscoveredListIterator iter(refs_list, keep_alive, is_alive, enqueue);
+  DiscoveredListIterator iter(refs_list, nullptr /* keep_alive */, is_alive, enqueue);
   while (iter.has_next()) {
     if (yield->should_return_fine_grain()) {
       return true;
@@ -1165,17 +1152,12 @@ bool ReferenceProcessor::preclean_discovered_reflist(DiscoveredList&    refs_lis
       iter.move_to_next();
     } else if (iter.is_referent_alive()) {
       log_preclean_ref(iter, "reachable");
-      // Remove Reference object from list
       iter.remove();
-      // Keep alive its cohort.
-      iter.make_referent_alive();
       iter.move_to_next();
     } else {
       iter.next();
     }
   }
-  // Close the reachable set
-  complete_gc->do_void();
 
   if (iter.processed() > 0) {
     log_develop_trace(gc, ref)(" Dropped " SIZE_FORMAT " Refs out of " SIZE_FORMAT " Refs in discovered list " INTPTR_FORMAT,

--- a/src/hotspot/share/gc/shared/referenceProcessor.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.hpp
@@ -304,19 +304,19 @@ public:
     setup_policy(always_clear);
   }
 
-  // "Preclean" all the discovered reference lists by removing references that
-  // are active (e.g. due to the mutator calling enqueue()) or with NULL or
-  // strongly reachable referents.
-  // The first argument is a predicate on an oop that indicates
-  // its (strong) reachability and the fourth is a closure that
-  // may be used to incrementalize or abort the precleaning process.
-  // The caller is responsible for taking care of potential
-  // interference with concurrent operations on these lists
-  // (or predicates involved) by other threads.
+  // "Preclean" all the discovered reference lists by removing references whose
+  // referents are NULL or strongly reachable (`is_alive` returns true).
+  // Note: when a referent is strongly reachable, we assume it's already marked
+  // through, so this method doesn't perform (and doesn't need to) any marking
+  // work at all. Currently, this assumption holds because G1 uses SATB and the
+  // marking status of an object is *not* updated when `Reference.get()` is
+  // called.
+  // `yield` is a closure that may be used to incrementalize or abort the
+  // precleaning process. The caller is responsible for taking care of
+  // potential interference with concurrent operations on these lists (or
+  // predicates involved) by other threads.
   void preclean_discovered_references(BoolObjectClosure* is_alive,
-                                      OopClosure*        keep_alive,
                                       EnqueueDiscoveredFieldClosure* enqueue,
-                                      VoidClosure*       complete_gc,
                                       YieldClosure*      yield,
                                       GCTimer*           gc_timer);
 
@@ -331,9 +331,7 @@ private:
   // Returns whether the operation should be aborted.
   bool preclean_discovered_reflist(DiscoveredList&    refs_list,
                                    BoolObjectClosure* is_alive,
-                                   OopClosure*        keep_alive,
                                    EnqueueDiscoveredFieldClosure* enqueue,
-                                   VoidClosure*       complete_gc,
                                    YieldClosure*      yield);
 
   // round-robin mod _num_queues (not: _not_ mod _max_num_queues)


### PR DESCRIPTION
Simple change of removing marking work in G1 precleaning. Evaluation using a contrived example shows ~20% reduction in precleaning. 

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275416](https://bugs.openjdk.java.net/browse/JDK-8275416): G1: remove unnecessary make_referent_alive in precleaning phase


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6003/head:pull/6003` \
`$ git checkout pull/6003`

Update a local copy of the PR: \
`$ git checkout pull/6003` \
`$ git pull https://git.openjdk.java.net/jdk pull/6003/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6003`

View PR using the GUI difftool: \
`$ git pr show -t 6003`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6003.diff">https://git.openjdk.java.net/jdk/pull/6003.diff</a>

</details>
