### PR TITLE
8275506: Rename allocated_on_stack to allocated_on_stack_or_embedded

### DIFF
--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -140,7 +140,7 @@ CodeBuffer::~CodeBuffer() {
 
   NOT_PRODUCT(clear_strings());
 
-  assert(_default_oop_recorder.allocated_on_stack(), "should be embedded object");
+  assert(_default_oop_recorder.allocated_on_stack_or_embedded(), "should be embedded object");
 }
 
 void CodeBuffer::initialize_oop_recorder(OopRecorder* r) {

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -161,7 +161,7 @@ void ClassFileParser::parse_constant_pool_entries(const ClassFileStream* const s
   const ClassFileStream cfs1 = *stream;
   const ClassFileStream* const cfs = &cfs1;
 
-  assert(cfs->allocated_on_stack(), "should be local");
+  assert(cfs->allocated_on_stack_or_embedded(), "should be local");
   debug_only(const u1* const old_current = stream->current();)
 
   // Used for batching symbol allocations.

--- a/src/hotspot/share/memory/allocation.cpp
+++ b/src/hotspot/share/memory/allocation.cpp
@@ -191,7 +191,7 @@ void ResourceObj::initialize_allocation_info() {
     // Operator new() is not called for allocations
     // on stack and for embedded objects.
     set_allocation_type((address)this, STACK_OR_EMBEDDED);
-  } else if (allocated_on_stack()) { // STACK_OR_EMBEDDED
+  } else if (allocated_on_stack_or_embedded()) { // STACK_OR_EMBEDDED
     // For some reason we got a value which resembles
     // an embedded or stack object (operator new() does not
     // set such type). Keep it since it is valid value
@@ -199,7 +199,7 @@ void ResourceObj::initialize_allocation_info() {
     // Ignore garbage in other fields.
   } else if (is_type_set()) {
     // Operator new() was called and type was set.
-    assert(!allocated_on_stack(),
+    assert(!allocated_on_stack_or_embedded(),
            "not embedded or stack, this(" PTR_FORMAT ") type %d a[0]=(" PTR_FORMAT ") a[1]=(" PTR_FORMAT ")",
            p2i(this), get_allocation_type(), _allocation_t[0], _allocation_t[1]);
   } else {
@@ -220,7 +220,7 @@ ResourceObj::ResourceObj(const ResourceObj&) {
 }
 
 ResourceObj& ResourceObj::operator=(const ResourceObj& r) {
-  assert(allocated_on_stack(),
+  assert(allocated_on_stack_or_embedded(),
          "copy only into local, this(" PTR_FORMAT ") type %d a[0]=(" PTR_FORMAT ") a[1]=(" PTR_FORMAT ")",
          p2i(this), get_allocation_type(), _allocation_t[0], _allocation_t[1]);
   // Keep current _allocation_t value;

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -408,7 +408,7 @@ class ResourceObj ALLOCATION_SUPER_CLASS_SPEC {
   void initialize_allocation_info();
  public:
   allocation_type get_allocation_type() const;
-  bool allocated_on_stack()    const { return get_allocation_type() == STACK_OR_EMBEDDED; }
+  bool allocated_on_stack_or_embedded() const { return get_allocation_type() == STACK_OR_EMBEDDED; }
   bool allocated_on_res_area() const { return get_allocation_type() == RESOURCE_AREA; }
   bool allocated_on_C_heap()   const { return get_allocation_type() == C_HEAP; }
   bool allocated_on_arena()    const { return get_allocation_type() == ARENA; }

--- a/src/hotspot/share/utilities/growableArray.cpp
+++ b/src/hotspot/share/utilities/growableArray.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,7 @@ void GrowableArrayNestingCheck::on_stack_alloc() const {
 
 void GrowableArrayMetadata::init_checks(const GrowableArrayBase* array) const {
   // Stack allocated arrays support all three element allocation locations
-  if (array->allocated_on_stack()) {
+  if (array->allocated_on_stack_or_embedded()) {
     return;
   }
 

--- a/test/hotspot/gtest/utilities/test_growableArray.cpp
+++ b/test/hotspot/gtest/utilities/test_growableArray.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -452,14 +452,14 @@ TEST_VM_F(GrowableArrayTest, where) {
   {
     ResourceMark rm;
     GrowableArray<int> a(0);
-    ASSERT_TRUE(a.allocated_on_stack());
+    ASSERT_TRUE(a.allocated_on_stack_or_embedded());
     ASSERT_TRUE(elements_on_stack(&a));
   }
 
   // Stack/CHeap allocated
   {
     GrowableArray<int> a(0, mtTest);
-    ASSERT_TRUE(a.allocated_on_stack());
+    ASSERT_TRUE(a.allocated_on_stack_or_embedded());
     ASSERT_TRUE(elements_on_C_heap(&a));
   }
 
@@ -467,7 +467,7 @@ TEST_VM_F(GrowableArrayTest, where) {
   {
     Arena arena(mtTest);
     GrowableArray<int> a(&arena, 0, 0, 0);
-    ASSERT_TRUE(a.allocated_on_stack());
+    ASSERT_TRUE(a.allocated_on_stack_or_embedded());
     ASSERT_TRUE(elements_on_arena(&a));
   }
 
@@ -475,14 +475,14 @@ TEST_VM_F(GrowableArrayTest, where) {
   {
     ResourceMark rm;
     WithEmbeddedArray w(0);
-    ASSERT_TRUE(w._a.allocated_on_stack());
+    ASSERT_TRUE(w._a.allocated_on_stack_or_embedded());
     ASSERT_TRUE(elements_on_stack(&w._a));
   }
 
   // Embedded/CHeap allocated
   {
     WithEmbeddedArray w(0, mtTest);
-    ASSERT_TRUE(w._a.allocated_on_stack());
+    ASSERT_TRUE(w._a.allocated_on_stack_or_embedded());
     ASSERT_TRUE(elements_on_C_heap(&w._a));
   }
 
@@ -490,7 +490,7 @@ TEST_VM_F(GrowableArrayTest, where) {
   {
     Arena arena(mtTest);
     WithEmbeddedArray w(&arena, 0);
-    ASSERT_TRUE(w._a.allocated_on_stack());
+    ASSERT_TRUE(w._a.allocated_on_stack_or_embedded());
     ASSERT_TRUE(elements_on_arena(&w._a));
   }
 }
@@ -518,7 +518,7 @@ TEST(GrowableArrayCHeap, sanity) {
   {
     GrowableArrayCHeap<int, mtTest> a(0);
 #ifdef ASSERT
-    ASSERT_TRUE(a.allocated_on_stack());
+    ASSERT_TRUE(a.allocated_on_stack_or_embedded());
 #endif
     ASSERT_TRUE(a.is_empty());
 


### PR DESCRIPTION
In allocation.hpp, the name allocated_on_stack can be misleading, better rename the function to allocated_on_stack_or_embedded and it will match the name of the enum as a bonus.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275506](https://bugs.openjdk.java.net/browse/JDK-8275506): Rename allocated_on_stack to allocated_on_stack_or_embedded


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6004/head:pull/6004` \
`$ git checkout pull/6004`

Update a local copy of the PR: \
`$ git checkout pull/6004` \
`$ git pull https://git.openjdk.java.net/jdk pull/6004/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6004`

View PR using the GUI difftool: \
`$ git pr show -t 6004`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6004.diff">https://git.openjdk.java.net/jdk/pull/6004.diff</a>

</details>
