### PR TITLE
8233724: Remove -Wc++14-compat warning suppression in operator_new.cpp

### DIFF
--- a/src/hotspot/share/memory/operator_new.cpp
+++ b/src/hotspot/share/memory/operator_new.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,12 +89,6 @@ void operator delete [](void* p) throw() {
   fatal("Should not call global delete []");
 }
 
-#ifdef __GNUG__
-// Warning disabled for gcc 5.4
-PRAGMA_DIAG_PUSH
-PRAGMA_DISABLE_GCC_WARNING("-Wc++14-compat")
-#endif // __GNUG__
-
 void operator delete(void* p, size_t size) throw() {
   fatal("Should not call global sized delete");
 }
@@ -102,9 +96,5 @@ void operator delete(void* p, size_t size) throw() {
 void operator delete [](void* p, size_t size) throw() {
   fatal("Should not call global sized delete []");
 }
-
-#ifdef __GNUG__
-PRAGMA_DIAG_POP
-#endif // __GNUG__
 
 #endif // Non-product


### PR DESCRIPTION
Please review this small change to remove the unneeded 'PRAGMA_DISABLE_GCC_WARNING("-Wc++14-compat")' from operator_new.cpp.  The change was tested by running Mach5 tiers 1-2 on Linux, Mac OS, and Windows.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8233724](https://bugs.openjdk.java.net/browse/JDK-8233724): Remove -Wc++14-compat warning suppression in operator_new.cpp


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6005/head:pull/6005` \
`$ git checkout pull/6005`

Update a local copy of the PR: \
`$ git checkout pull/6005` \
`$ git pull https://git.openjdk.java.net/jdk pull/6005/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6005`

View PR using the GUI difftool: \
`$ git pr show -t 6005`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6005.diff">https://git.openjdk.java.net/jdk/pull/6005.diff</a>

</details>
