### PR TITLE
Improve documentation accessibility

### DIFF
--- a/src/java.base/share/classes/java/net/Inet6Address.java
+++ b/src/java.base/share/classes/java/net/Inet6Address.java
@@ -119,10 +119,10 @@ import java.util.Arrays;
  * <h3> Special IPv6 address </h3>
  *
  * <blockquote>
- * <table class="borderless">
- * <caption style="display:none">Description of IPv4-mapped address</caption>
- * <tr><th style="vertical-align:top; padding-right:2px"><i>IPv4-mapped address</i></th>
- *         <td>Of the form ::ffff:w.x.y.z, this IPv6 address is used to
+ * <dl>
+ * 	<dt style="vertical-align:top; padding-right:2px"><b><i>IPv4-mapped address</i></b></dt>
+ *
+ *         <dd>Of the form ::ffff:w.x.y.z, this IPv6 address is used to
  *         represent an IPv4 address. It allows the native program to
  *         use the same address data structure and also the same
  *         socket when communicating with both IPv4 and IPv6 nodes.
@@ -131,13 +131,13 @@ import java.util.Arrays;
  *         representation; it has no functional role. Java will never
  *         return an IPv4-mapped address.  These classes can take an
  *         IPv4-mapped address as input, both in byte array and text
- *         representation. However, it will be converted into an IPv4
- *         address.</td></tr>
- * </table></blockquote>
+ *         representation. However, it will be converted into an IPv4 
+ *         address.</dd>
+ * </dl></blockquote>
  *
  * <h3><a id="scoped">Textual representation of IPv6 scoped addresses</a></h3>
  *
- * <p> The textual representation of IPv6 addresses as described above can be
+ * <p>The textual representation of IPv6 addresses as described above can be
  * extended to specify IPv6 scoped addresses. This extension to the basic
  * addressing architecture is described in [draft-ietf-ipngwg-scoping-arch-04.txt].
  *


### PR DESCRIPTION
Single-row table was being used as a hack here, a description list
seems more appropriate

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6007/head:pull/6007` \
`$ git checkout pull/6007`

Update a local copy of the PR: \
`$ git checkout pull/6007` \
`$ git pull https://git.openjdk.java.net/jdk pull/6007/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6007`

View PR using the GUI difftool: \
`$ git pr show -t 6007`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6007.diff">https://git.openjdk.java.net/jdk/pull/6007.diff</a>

</details>
