### PR TITLE
8268595: java/io/Serializable/serialFilter/GlobalFilterTest.java#id1 failed in timeout

### DIFF
--- a/test/jdk/java/io/Serializable/serialFilter/GlobalFilterTest.java
+++ b/test/jdk/java/io/Serializable/serialFilter/GlobalFilterTest.java
@@ -53,18 +53,6 @@ import org.testng.annotations.DataProvider;
  *
  * @summary Test Global Filters
  */
-
-/* @test
- * @bug 8261160
- * @summary Add a deserialization JFR event
- * @build GlobalFilterTest SerialFilterTest
- * @requires vm.hasJFR
- * @run testng/othervm/policy=security.policy
- *        -XX:StartFlightRecording:name=DeserializationEvent,dumponexit=true
- *        -Djava.security.properties=${test.src}/java.security-extra1
- *        -Djava.security.debug=properties GlobalFilterTest
- */
-
 @Test
 public class GlobalFilterTest {
     private static final String serialPropName = "jdk.serialFilter";


### PR DESCRIPTION
The `GlobalFilterTest` has to 2 `@test` tags. One of them has failed with a timeout as noted in https://bugs.openjdk.java.net/browse/JDK-8268595. The timeout seems to have happened even after the tests had already completed successfully. Like I note in the JBS comments of that issue, I suspect it might have to do with the "-XX:StartFlightRecording:name=DeserializationEvent,dumponexit=true" usage in this test action.

The commit in this PR removes that second `@test` altogether because (correct me if I'm wrong) from what I understand, this test never enables the DeserializationEvent which means there is no JFR events being captured for deserialization in this test, nor does the test do any JFR events related testing. So, I think this second `@test` is virtually a no-op when it comes to the JFR testing. There's a separate `TestDeserializationEvent` which has a comprehensive testing of the DeserializationEvent.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268595](https://bugs.openjdk.java.net/browse/JDK-8268595): java/io/Serializable/serialFilter/GlobalFilterTest.java#id1 failed in timeout


### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6008/head:pull/6008` \
`$ git checkout pull/6008`

Update a local copy of the PR: \
`$ git checkout pull/6008` \
`$ git pull https://git.openjdk.java.net/jdk pull/6008/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6008`

View PR using the GUI difftool: \
`$ git pr show -t 6008`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6008.diff">https://git.openjdk.java.net/jdk/pull/6008.diff</a>

</details>
