### PR TITLE
8275302: unexpected compiler error: cast, intersection types and sealed

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1664,7 +1664,7 @@ public class Types {
                 && s.hasTag(CLASS) && s.tsym.kind.matches(Kinds.KindSelector.TYP)
                 && (t.tsym.isSealed() || s.tsym.isSealed())) {
             return (t.isCompound() || s.isCompound()) ?
-                    false :
+                    true :
                     !areDisjoint((ClassSymbol)t.tsym, (ClassSymbol)s.tsym);
         }
         return result;

--- a/test/langtools/tools/javac/sealed/SealedCompilationTests.java
+++ b/test/langtools/tools/javac/sealed/SealedCompilationTests.java
@@ -1250,5 +1250,18 @@ public class SealedCompilationTests extends CompilationTestCase {
                 class Foo<X extends A & I> {}
                 """
         );
+        assertOK(
+                """
+                class Outer {
+                    abstract class Base {}
+                    interface Marker {}
+                    sealed class B extends Base {}
+                    final class C extends B implements Marker {}
+                    private <T extends Base & Marker> void test(T obj) {
+                        B b = (B) obj;
+                    }
+                }
+                """
+        );
     }
 }


### PR DESCRIPTION
Please review this fix which is syncing the compiler with the sealed classes spec. Basically the compiler is failing to accept as valid a cast when the type to be cast is an intersection type, even when all the checks mandated by the spec has been done.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275302](https://bugs.openjdk.java.net/browse/JDK-8275302): unexpected compiler error: cast, intersection types and sealed


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6009/head:pull/6009` \
`$ git checkout pull/6009`

Update a local copy of the PR: \
`$ git checkout pull/6009` \
`$ git pull https://git.openjdk.java.net/jdk pull/6009/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6009`

View PR using the GUI difftool: \
`$ git pr show -t 6009`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6009.diff">https://git.openjdk.java.net/jdk/pull/6009.diff</a>

</details>
