### PR TITLE
JDK-8275518: accessibility issue in Inet6Address docs

### DIFF
--- a/src/java.base/share/classes/java/net/Inet6Address.java
+++ b/src/java.base/share/classes/java/net/Inet6Address.java
@@ -120,8 +120,7 @@ import java.util.Arrays;
  *
  * <blockquote>
  * <dl>
- *   <dt style="vertical-align:top; padding-right:2px"><b><i>IPv4-mapped address</i></b></dt>
- *
+ *   <dt>IPv4-mapped address</dt>
  *         <dd>Of the form ::ffff:w.x.y.z, this IPv6 address is used to
  *         represent an IPv4 address. It allows the native program to
  *         use the same address data structure and also the same
@@ -133,7 +132,8 @@ import java.util.Arrays;
  *         IPv4-mapped address as input, both in byte array and text
  *         representation. However, it will be converted into an IPv4
  *         address.</dd>
- * </dl></blockquote>
+ * </dl>
+ * </blockquote>
  *
  * <h3><a id="scoped">Textual representation of IPv6 scoped addresses</a></h3>
  *


### PR DESCRIPTION
Single-row table was being used for visual effect, but a description list seems more appropriate.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275518](https://bugs.openjdk.java.net/browse/JDK-8275518): accessibility issue in Inet6Address docs


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to dc2ff1a7c8cbefe43587d3e993559955f6fa9cd2
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6010/head:pull/6010` \
`$ git checkout pull/6010`

Update a local copy of the PR: \
`$ git checkout pull/6010` \
`$ git pull https://git.openjdk.java.net/jdk pull/6010/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6010`

View PR using the GUI difftool: \
`$ git pr show -t 6010`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6010.diff">https://git.openjdk.java.net/jdk/pull/6010.diff</a>

</details>
