### PR TITLE
8274160: java/awt/Window/ShapedAndTranslucentWindows/Common.java delay is too high

### DIFF
--- a/test/jdk/java/awt/Window/ShapedAndTranslucentWindows/Common.java
+++ b/test/jdk/java/awt/Window/ShapedAndTranslucentWindows/Common.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ public abstract class Common {
     static final int STATIC_BLOCKS = 30;
     static final Color BG_COLOR = Color.BLUE;
     static final Color FG_COLOR = Color.RED;
-    static final int delay = 55000;
+    static final int delay = 1000;
     static final SecureRandom random = new SecureRandom();
     static final int dl = 100;
     static final Class[] WINDOWS_TO_TEST = { Window.class, Frame.class, Dialog.class };


### PR DESCRIPTION
Along with [JDK-8210776](https://bugs.openjdk.java.net/browse/JDK-8210776) fix, a typo was [introduced](http://hg.openjdk.java.net/jdk/jdk/rev/8c7638601045#l11.8).

This fix reverts it back.

Multiple test runs showed no failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274160](https://bugs.openjdk.java.net/browse/JDK-8274160): java/awt/Window/ShapedAndTranslucentWindows/Common.java delay is too high


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6014/head:pull/6014` \
`$ git checkout pull/6014`

Update a local copy of the PR: \
`$ git checkout pull/6014` \
`$ git pull https://git.openjdk.java.net/jdk pull/6014/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6014`

View PR using the GUI difftool: \
`$ git pr show -t 6014`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6014.diff">https://git.openjdk.java.net/jdk/pull/6014.diff</a>

</details>
