### PR TITLE
JDK-8230130: javadoc search result dialog shows cut off headers for long results

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/stylesheet.css
@@ -586,10 +586,10 @@ ul.ui-autocomplete {
     position:fixed;
     z-index:999999;
 }
-ul.ui-autocomplete  li {
+ul.ui-autocomplete li {
     float:left;
     clear:both;
-    width:100%;
+    min-width:100%;
 }
 .result-highlight {
     font-weight:bold;


### PR DESCRIPTION
Please review a simple fix for a rendering bug in the javadoc search result list. For very long items in that list that do not fit into the menu and require horizontal scrolling the colored selection bar used to be cut off. With this change, the selection bar covers at least the length of the item itself, or the width of the menu, whichever is bigger. 

Example output: http://cr.openjdk.java.net/~hannesw/8230130/api.00/

(Search for "XMLEventFactory.createStartElement" as suggested in the bug report and then scroll horizontally.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8230130](https://bugs.openjdk.java.net/browse/JDK-8230130): javadoc search result dialog shows cut off headers for long results


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6016/head:pull/6016` \
`$ git checkout pull/6016`

Update a local copy of the PR: \
`$ git checkout pull/6016` \
`$ git pull https://git.openjdk.java.net/jdk pull/6016/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6016`

View PR using the GUI difftool: \
`$ git pr show -t 6016`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6016.diff">https://git.openjdk.java.net/jdk/pull/6016.diff</a>

</details>
