### PR TITLE
8275439: Remove PrintVtableStats

### DIFF
--- a/src/hotspot/share/oops/arrayKlass.cpp
+++ b/src/hotspot/share/oops/arrayKlass.cpp
@@ -135,24 +135,6 @@ objArrayOop ArrayKlass::allocate_arrayArray(int n, int length, TRAPS) {
   return o;
 }
 
-void ArrayKlass::array_klasses_do(void f(Klass* k, TRAPS), TRAPS) {
-  Klass* k = this;
-  // Iterate over this array klass and all higher dimensions
-  while (k != NULL) {
-    f(k, CHECK);
-    k = ArrayKlass::cast(k)->higher_dimension();
-  }
-}
-
-void ArrayKlass::array_klasses_do(void f(Klass* k)) {
-  Klass* k = this;
-  // Iterate over this array klass and all higher dimensions
-  while (k != NULL) {
-    f(k);
-    k = ArrayKlass::cast(k)->higher_dimension();
-  }
-}
-
 jint ArrayKlass::compute_modifier_flags() const {
   return JVM_ACC_ABSTRACT | JVM_ACC_FINAL | JVM_ACC_PUBLIC;
 }

--- a/src/hotspot/share/oops/arrayKlass.hpp
+++ b/src/hotspot/share/oops/arrayKlass.hpp
@@ -104,10 +104,6 @@ class ArrayKlass: public Klass {
 
   virtual void metaspace_pointers_do(MetaspaceClosure* iter);
 
-  // Iterators
-  void array_klasses_do(void f(Klass* k));
-  void array_klasses_do(void f(Klass* k, TRAPS), TRAPS);
-
   // Return a handle.
   static void     complete_create_array_klass(ArrayKlass* k, Klass* super_klass, ModuleEntry* module, TRAPS);
 

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -1720,16 +1720,6 @@ void InstanceKlass::print_nonstatic_fields(FieldClosure* cl) {
   }
 }
 
-void InstanceKlass::array_klasses_do(void f(Klass* k, TRAPS), TRAPS) {
-  if (array_klasses() != NULL)
-    array_klasses()->array_klasses_do(f, THREAD);
-}
-
-void InstanceKlass::array_klasses_do(void f(Klass* k)) {
-  if (array_klasses() != NULL)
-    array_klasses()->array_klasses_do(f);
-}
-
 #ifdef ASSERT
 static int linear_search(const Array<Method*>* methods,
                          const Symbol* name,

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -1006,8 +1006,6 @@ public:
   void print_nonstatic_fields(FieldClosure* cl); // including inherited and injected fields
 
   void methods_do(void f(Method* method));
-  void array_klasses_do(void f(Klass* k));
-  void array_klasses_do(void f(Klass* k, TRAPS), TRAPS);
 
   static InstanceKlass* cast(Klass* k) {
     return const_cast<InstanceKlass*>(cast(const_cast<const Klass*>(k)));

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -653,8 +653,6 @@ protected:
     clean_weak_klass_links(/*unloading_occurred*/ true , /* clean_alive_klasses */ false);
   }
 
-  virtual void array_klasses_do(void f(Klass* k)) {}
-
   // Return self, except for abstract classes with exactly 1
   // implementor.  Then return the 1 concrete implementation.
   Klass *up_cast_abstract();

--- a/src/hotspot/share/oops/klassVtable.cpp
+++ b/src/hotspot/share/oops/klassVtable.cpp
@@ -1511,9 +1511,6 @@ int klassItable::compute_itable_size(Array<InstanceKlass*>* transitive_interface
   // There's alway an extra itable entry so we can null-terminate it.
   int itable_size = calc_itable_size(cic.nof_interfaces() + 1, cic.nof_methods());
 
-  // Statistics
-  update_stats(itable_size * wordSize);
-
   return itable_size;
 }
 
@@ -1628,75 +1625,4 @@ void vtableEntry::print() {
     tty->print("m " PTR_FORMAT " ", p2i(method()));
   }
 }
-
-class VtableStats : AllStatic {
- public:
-  static int no_klasses;                // # classes with vtables
-  static int no_array_klasses;          // # array classes
-  static int no_instance_klasses;       // # instanceKlasses
-  static int sum_of_vtable_len;         // total # of vtable entries
-  static int sum_of_array_vtable_len;   // total # of vtable entries in array klasses only
-  static int fixed;                     // total fixed overhead in bytes
-  static int filler;                    // overhead caused by filler bytes
-  static int entries;                   // total bytes consumed by vtable entries
-  static int array_entries;             // total bytes consumed by array vtable entries
-
-  static void do_class(Klass* k) {
-    Klass* kl = k;
-    klassVtable vt = kl->vtable();
-    no_klasses++;
-    if (kl->is_instance_klass()) {
-      no_instance_klasses++;
-      kl->array_klasses_do(do_class);
-    }
-    if (kl->is_array_klass()) {
-      no_array_klasses++;
-      sum_of_array_vtable_len += vt.length();
-    }
-    sum_of_vtable_len += vt.length();
-  }
-
-  static void compute() {
-    LockedClassesDo locked_do_class(&do_class);
-    ClassLoaderDataGraph::classes_do(&locked_do_class);
-    fixed  = no_klasses * oopSize;      // vtable length
-    // filler size is a conservative approximation
-    filler = oopSize * (no_klasses - no_instance_klasses) * (sizeof(InstanceKlass) - sizeof(ArrayKlass) - 1);
-    entries = sizeof(vtableEntry) * sum_of_vtable_len;
-    array_entries = sizeof(vtableEntry) * sum_of_array_vtable_len;
-  }
-};
-
-int VtableStats::no_klasses = 0;
-int VtableStats::no_array_klasses = 0;
-int VtableStats::no_instance_klasses = 0;
-int VtableStats::sum_of_vtable_len = 0;
-int VtableStats::sum_of_array_vtable_len = 0;
-int VtableStats::fixed = 0;
-int VtableStats::filler = 0;
-int VtableStats::entries = 0;
-int VtableStats::array_entries = 0;
-
-void klassVtable::print_statistics() {
-  ResourceMark rm;
-  VtableStats::compute();
-  tty->print_cr("vtable statistics:");
-  tty->print_cr("%6d classes (%d instance, %d array)", VtableStats::no_klasses, VtableStats::no_instance_klasses, VtableStats::no_array_klasses);
-  int total = VtableStats::fixed + VtableStats::filler + VtableStats::entries;
-  tty->print_cr("%6d bytes fixed overhead (refs + vtable object header)", VtableStats::fixed);
-  tty->print_cr("%6d bytes filler overhead", VtableStats::filler);
-  tty->print_cr("%6d bytes for vtable entries (%d for arrays)", VtableStats::entries, VtableStats::array_entries);
-  tty->print_cr("%6d bytes total", total);
-}
-
-int    klassItable::_total_classes;   // Total no. of classes with itables
-size_t klassItable::_total_size;      // Total no. of bytes used for itables
-
-void klassItable::print_statistics() {
- tty->print_cr("itable statistics:");
- tty->print_cr("%6d classes with itables", _total_classes);
- tty->print_cr(SIZE_FORMAT_W(6) " K uses for itables (average by class: " SIZE_FORMAT " bytes)",
-               _total_size / K, _total_size / _total_classes);
-}
-
 #endif // PRODUCT

--- a/src/hotspot/share/oops/klassVtable.hpp
+++ b/src/hotspot/share/oops/klassVtable.hpp
@@ -97,7 +97,6 @@ class klassVtable {
   // Debugging code
   void print()                                              PRODUCT_RETURN;
   void verify(outputStream* st, bool force = false);
-  static void print_statistics()                            PRODUCT_RETURN;
 
  protected:
   friend class vtableEntry;
@@ -319,8 +318,6 @@ class klassItable {
   static int compute_itable_size(Array<InstanceKlass*>* transitive_interfaces);
   static void setup_itable_offset_table(InstanceKlass* klass);
 
-  // Debugging/Statistics
-  static void print_statistics() PRODUCT_RETURN;
  private:
   intptr_t* vtable_start() const { return ((intptr_t*)_klass) + _table_offset; }
   intptr_t* method_start() const { return vtable_start() + _size_offset_table * itableOffsetEntry::size(); }
@@ -328,11 +325,6 @@ class klassItable {
   // Helper methods
   static int  calc_itable_size(int num_interfaces, int num_methods) { return (num_interfaces * itableOffsetEntry::size()) + (num_methods * itableMethodEntry::size()); }
 
-  // Statistics
-  NOT_PRODUCT(static int  _total_classes;)   // Total no. of classes with itables
-  NOT_PRODUCT(static size_t _total_size;)    // Total no. of bytes used for itables
-
-  static void update_stats(int size) PRODUCT_RETURN NOT_PRODUCT({ _total_classes++; _total_size += size; })
 };
 
 #endif // SHARE_OOPS_KLASSVTABLE_HPP

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1091,9 +1091,6 @@ const intx ObjectAlignmentInBytes = 8;
   develop(bool, DebugVtables, false,                                        \
           "add debugging code to vtable dispatch")                          \
                                                                             \
-  notproduct(bool, PrintVtableStats, false,                                 \
-          "print vtables stats at end of run")                              \
-                                                                            \
   develop(bool, TraceCreateZombies, false,                                  \
           "trace creation of zombie nmethods")                              \
                                                                             \

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -306,10 +306,6 @@ void print_statistics() {
     CodeCache::print_internals();
   }
 
-  if (PrintVtableStats) {
-    klassVtable::print_statistics();
-    klassItable::print_statistics();
-  }
   if (VerifyOops && Verbose) {
     tty->print_cr("+VerifyOops count: %d", StubRoutines::verify_oop_count());
   }


### PR DESCRIPTION
PrintVtableStats has not been very useful and reported information may not be accurate neither. Please see the CR and comments in JDK-8275413 for details.

- PrintVtableStats is none product flag, so does not require a CSR to remove it.
- The patch also removes Klass::array_klasses_do() and families, as PrintVtableStats is the last use.
- InstanceKlass/ArrayKlass::array_klasses_do(void f(Klass* k, TRAPS), TRAPS) have no use, remove them as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275439](https://bugs.openjdk.java.net/browse/JDK-8275439): Remove PrintVtableStats


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6017/head:pull/6017` \
`$ git checkout pull/6017`

Update a local copy of the PR: \
`$ git checkout pull/6017` \
`$ git pull https://git.openjdk.java.net/jdk pull/6017/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6017`

View PR using the GUI difftool: \
`$ git pr show -t 6017`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6017.diff">https://git.openjdk.java.net/jdk/pull/6017.diff</a>

</details>
