### PR TITLE
8275517: Off-by-one error in allocation

### DIFF
--- a/src/hotspot/share/services/finalizerService.cpp
+++ b/src/hotspot/share/services/finalizerService.cpp
@@ -46,7 +46,7 @@ static const char* allocate(oop string) {
   const typeArrayOop value = java_lang_String::value(string);
   if (value != nullptr) {
     const int length = java_lang_String::utf8_length(string, value);
-    str = NEW_C_HEAP_ARRAY(char, length, mtServiceability);
+    str = NEW_C_HEAP_ARRAY(char, length + 1, mtServiceability);
     java_lang_String::as_utf8_string(string, value, str, length + 1);
   }
   return str;
@@ -94,9 +94,7 @@ FinalizerEntry::FinalizerEntry(const InstanceKlass* ik) :
     _total_finalizers_run(0) {}
 
 FinalizerEntry::~FinalizerEntry() {
-  if (_codesource != nullptr) {
-    FREE_C_HEAP_ARRAY(char, _codesource);
-  }
+  FREE_C_HEAP_ARRAY(char, _codesource);
 }
 
 const InstanceKlass* FinalizerEntry::klass() const {


### PR DESCRIPTION
Greetings (again),

The quick fix for [JDK-8275445](https://bugs.openjdk.java.net/browse/JDK-8275445) includes an off-by-one error as part of the allocation. :-(

Sorry for this inconvenience.

Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275517](https://bugs.openjdk.java.net/browse/JDK-8275517): Off-by-one error in allocation


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6018/head:pull/6018` \
`$ git checkout pull/6018`

Update a local copy of the PR: \
`$ git checkout pull/6018` \
`$ git pull https://git.openjdk.java.net/jdk pull/6018/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6018`

View PR using the GUI difftool: \
`$ git pr show -t 6018`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6018.diff">https://git.openjdk.java.net/jdk/pull/6018.diff</a>

</details>
