### PR TITLE
7124287: [macosx] JTableHeader doesn't get focus after pressing F8 key

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaKeyBindings.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaKeyBindings.java
@@ -379,7 +379,8 @@ public class AquaKeyBindings {
             "ENTER", "selectNextRowCell",
             "shift ENTER", "selectPreviousRowCell",
             "alt TAB", "focusHeader",
-            "alt shift TAB", "focusHeader"
+            "alt shift TAB", "focusHeader",
+            "F8", "focusHeader"
         }));
     }
 

--- a/test/jdk/javax/swing/plaf/basic/BasicTableHeaderUI/6394566/bug6394566.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicTableHeaderUI/6394566/bug6394566.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 6394566
+ * @key headful
+ * @summary Tests that ESC moves the focus from the header to the table
+ * @library ../../../../regtesthelpers
+ * @build SwingTestHelper JRobot
+ * @run main bug6394566
+ */
+
+import java.awt.Component;
+import java.awt.event.KeyEvent;
+import java.awt.event.FocusEvent;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.table.JTableHeader;
+import javax.swing.table.DefaultTableModel;
+
+public class bug6394566 extends SwingTestHelper {
+    private JTable table;
+    private JTableHeader header;
+
+    public static void main(String[] args) throws Throwable {
+        new bug6394566().run(args);
+    }
+
+    protected Component createContentPane() {
+        table = new JTable(new DefaultTableModel(2, 2));
+        header = table.getTableHeader();
+        return new JScrollPane(table);
+    }
+
+    public void onEDT10() {
+        // Give the table the focus.
+        requestAndWaitForFocus(table);
+    }
+
+    //First, give the header focus using F8 on the JTable.
+    //This will fail prior to mustang b72.
+    public void onEDT20() {
+        waitForEvent(header, FocusEvent.FOCUS_GAINED); //set up focus listener
+        robot.hitKey(KeyEvent.VK_F8);
+    }
+
+    //Next, give the table back the focus using ESC.
+    //This will fail prior to the build with this bugfix.
+    public void onEDT30() {
+        waitForEvent(table, FocusEvent.FOCUS_GAINED); //set up focus listener
+        robot.hitKey(KeyEvent.VK_ESCAPE);
+    }
+}


### PR DESCRIPTION
JTableHeader doesn't get focus after pressing F8 key in macos causing test to fail. Added F8 keybindings to macos similar to 
MetalLookAndFeel
https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java#L1232
and BasicLookAndFeel
https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicLookAndFeel.java#L1497

Test is moved from closed to open and now passing in macos.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-7124287](https://bugs.openjdk.java.net/browse/JDK-7124287): [macosx] JTableHeader doesn't get focus after pressing F8 key


### Reviewers
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6019/head:pull/6019` \
`$ git checkout pull/6019`

Update a local copy of the PR: \
`$ git checkout pull/6019` \
`$ git pull https://git.openjdk.java.net/jdk pull/6019/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6019`

View PR using the GUI difftool: \
`$ git pr show -t 6019`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6019.diff">https://git.openjdk.java.net/jdk/pull/6019.diff</a>

</details>
