### PR TITLE
8248584: Enable CHECK_UNHANDLED_OOPS for Windows fastdebug builds

### DIFF
--- a/make/hotspot/lib/JvmFlags.gmk
+++ b/make/hotspot/lib/JvmFlags.gmk
@@ -74,8 +74,8 @@ ifeq ($(DEBUG_LEVEL), release)
   endif
 else ifeq ($(DEBUG_LEVEL), fastdebug)
   JVM_CFLAGS_DEBUGLEVEL := -DASSERT
-  ifeq ($(call isTargetOs, windows aix), false)
-    # NOTE: Old build did not define CHECK_UNHANDLED_OOPS on Windows and AIX.
+  ifeq ($(call isTargetOs, aix), false)
+    # NOTE: Old build did not define CHECK_UNHANDLED_OOPS on AIX.
     JVM_CFLAGS_DEBUGLEVEL += -DCHECK_UNHANDLED_OOPS
   endif
 else ifeq ($(DEBUG_LEVEL), slowdebug)


### PR DESCRIPTION
Please review this small change to enable CHECK_UNHANDLED_OOPs for Windows fastdebug builds.  The change was tested by running Mach5 tiers 1-6 on Windows-x64-debug.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248584](https://bugs.openjdk.java.net/browse/JDK-8248584): Enable CHECK_UNHANDLED_OOPS for Windows fastdebug builds


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6023/head:pull/6023` \
`$ git checkout pull/6023`

Update a local copy of the PR: \
`$ git checkout pull/6023` \
`$ git pull https://git.openjdk.java.net/jdk pull/6023/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6023`

View PR using the GUI difftool: \
`$ git pr show -t 6023`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6023.diff">https://git.openjdk.java.net/jdk/pull/6023.diff</a>

</details>
