### PR TITLE
8275405: Linking error for classes with lambda template parameters and virtual functions

### DIFF
--- a/make/hotspot/lib/JvmMapfile.gmk
+++ b/make/hotspot/lib/JvmMapfile.gmk
@@ -106,7 +106,7 @@ else ifeq ($(call isTargetOs, windows), true)
   # number of exported symbols below that limit.
   #
   # Some usages of C++ lambdas require the vftable symbol of classes that use
-  # the lambda type as a template parameter. The usage of those classes wont
+  # the lambda type as a template parameter. The usage of those classes won't
   # link if their vftable symbols are removed. That's why there's an exception
   # for vftable symbols containing the string 'lambda'.
   #


### PR DESCRIPTION
We encountered the following linking error when trying to build Generational ZGC on Windows:
```
jvm.exp : error LNK2001: unresolved external symbol "const ZBasicOopIterateClosure<class <lambda_9767402e468f9fc654281195f9700e48> >::`vftable'" (??_7?$ZBasicOopIterateClosure@V<lambda_9767402e468f9fc654281195f9700e48>@@@@6B@)
```

I narrowed this down to a simple reproducer, which doesn't link when built through the HotSpot build system:
```
#include <functional>
std::function<void()> = [](){};
```

I found that we have a line in our make files that filters out symbols that contain the string vftable (though it checks the mangled name, so a bit hard to find):
```
else ifeq ($(call isTargetOs, windows), true)
  DUMP_SYMBOLS_CMD := $(DUMPBIN) -symbols *.obj
  FILTER_SYMBOLS_AWK_SCRIPT := \
      '{ \
        if ($$7 ~ /??_7.*@@6B@/ && $$7 !~ /type_info/) print $$7; \
      }'
```

The following line prints the vftable symbol if it doesn't contain the string 'type_info':
 if ($$7 ~ /??_7.*@@6B@/ && $$7 !~ /type_info/) print $$7;

The printed values are added to a list of symbols that get filtered out of the mapfile, which is then passed to the linker.

I can get the code to link if I add a second exception for vftable symbols containing the string 'lambda':
 if ($$7 ~ /??_7.*@@6B@/ && $$7 !~ /type_info/ && $$7 !~ /lambda/) print $$7;

I did an additional experiment where I completely removed this filtering of vftable symbols. When I did that the linker complained that we used more than 64K symbols.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275405](https://bugs.openjdk.java.net/browse/JDK-8275405): Linking error for classes with lambda template parameters and virtual functions


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to 54a353f3cc57411d0b33508bbaaae49ddef797e1
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6030/head:pull/6030` \
`$ git checkout pull/6030`

Update a local copy of the PR: \
`$ git checkout pull/6030` \
`$ git pull https://git.openjdk.java.net/jdk pull/6030/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6030`

View PR using the GUI difftool: \
`$ git pr show -t 6030`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6030.diff">https://git.openjdk.java.net/jdk/pull/6030.diff</a>

</details>
