### PR TITLE
8275381 G1: refactor 2 constructors of G1CardSetConfiguration

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.hpp
@@ -51,23 +51,23 @@ class G1CardSetConfiguration {
   uint _inline_ptr_bits_per_card;
 
   uint _num_cards_in_array;
-  uint _num_cards_in_howl_bitmap;
   uint _num_buckets_in_howl;
   uint _max_cards_in_card_set;
   uint _cards_in_howl_threshold;
+  uint _num_cards_in_howl_bitmap;
   uint _cards_in_howl_bitmap_threshold;
   uint _log2_num_cards_in_howl_bitmap;
   size_t _bitmap_hash_mask;
 
   G1CardSetAllocOptions* _card_set_alloc_options;
 
+  G1CardSetConfiguration(uint inline_ptr_bits_per_card,
+                         uint num_cards_in_array,
+                         double cards_in_bitmap_threshold_percent,
+                         uint num_buckets_in_howl,
+                         double cards_in_howl_threshold_percent,
+                         uint max_cards_in_card_set);
   void init_card_set_alloc_options();
-  void init(uint inline_ptr_bits_per_card,
-            uint num_cards_in_array,
-            double cards_in_bitmap_threshold_percent,
-            uint max_buckets_in_howl,
-            double cards_in_howl_threshold_percent,
-            uint max_cards_in_cardset);
 
   void log_configuration();
 public:
@@ -75,12 +75,12 @@ public:
   // Initialize card set configuration from globals.
   G1CardSetConfiguration();
   // Initialize card set configuration from parameters.
-  G1CardSetConfiguration(uint inline_ptr_bits_per_card,
-                         uint num_cards_in_array,
+  // Only for test
+  G1CardSetConfiguration(uint num_cards_in_array,
                          double cards_in_bitmap_threshold_percent,
                          uint max_buckets_in_howl,
                          double cards_in_howl_threshold_percent,
-                         uint max_cards_in_cardset);
+                         uint max_cards_in_card_set);
 
   ~G1CardSetConfiguration();
 

--- a/test/hotspot/gtest/gc/g1/test_g1CardSet.cpp
+++ b/test/hotspot/gtest/gc/g1/test_g1CardSet.cpp
@@ -206,7 +206,11 @@ void G1CardSetTest::cardset_basic_test() {
   const double FullCardSetThreshold = 0.8;
   const double BitmapCoarsenThreshold = 0.9;
 
-  G1CardSetConfiguration config(log2i_exact(CardsPerRegion), 28, BitmapCoarsenThreshold, 8, FullCardSetThreshold, CardsPerRegion);
+  G1CardSetConfiguration config(28,
+                                BitmapCoarsenThreshold,
+                                8,
+                                FullCardSetThreshold,
+                                CardsPerRegion);
   G1CardSetFreePool free_pool(config.num_mem_object_types());
   G1CardSetMemoryManager mm(&config, &free_pool);
 
@@ -420,7 +424,11 @@ void G1CardSetTest::cardset_mt_test() {
   const double FullCardSetThreshold = 1.0;
   const uint BitmapCoarsenThreshold = 1.0;
 
-  G1CardSetConfiguration config(log2i_exact(CardsPerRegion), 120, BitmapCoarsenThreshold, 8, FullCardSetThreshold, CardsPerRegion);
+  G1CardSetConfiguration config(120,
+                                BitmapCoarsenThreshold,
+                                8,
+                                FullCardSetThreshold,
+                                CardsPerRegion);
   G1CardSetFreePool free_pool(config.num_mem_object_types());
   G1CardSetMemoryManager mm(&config, &free_pool);
 


### PR DESCRIPTION
2 constructors of G1CardSetConfiguration share some code, it's better to refacoring them to simplify the code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275381](https://bugs.openjdk.java.net/browse/JDK-8275381): G1: refactor 2 constructors of G1CardSetConfiguration


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6033/head:pull/6033` \
`$ git checkout pull/6033`

Update a local copy of the PR: \
`$ git checkout pull/6033` \
`$ git pull https://git.openjdk.java.net/jdk pull/6033/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6033`

View PR using the GUI difftool: \
`$ git pr show -t 6033`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6033.diff">https://git.openjdk.java.net/jdk/pull/6033.diff</a>

</details>
