### PR TITLE
8274987 G1: reuse the newly allocated G1SegmentedArrayBuffer even if current thread failed the race

### DIFF
--- a/src/hotspot/share/gc/g1/g1SegmentedArray.hpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArray.hpp
@@ -97,7 +97,7 @@ public:
   ~G1SegmentedArrayBufferList() { free_all(); }
 
   void bulk_add(G1SegmentedArrayBuffer<flag>& first, G1SegmentedArrayBuffer<flag>& last, size_t num, size_t mem_size);
-  void add(G1SegmentedArrayBuffer<flag>& elem) { _list.prepend(elem); }
+  void add(G1SegmentedArrayBuffer<flag>& elem);
 
   G1SegmentedArrayBuffer<flag>* get();
   G1SegmentedArrayBuffer<flag>* get_all(size_t& num_buffers, size_t& mem_size);

--- a/src/hotspot/share/gc/g1/g1SegmentedArray.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArray.inline.hpp
@@ -90,8 +90,6 @@ G1SegmentedArrayBuffer<flag>* G1SegmentedArrayBufferList<flag>::get() {
   if (result != nullptr) {
     size_t num_buffers = Atomic::sub(&_num_buffers, (size_t)1,memory_order_relaxed);
     size_t mem_size = Atomic::sub(&_mem_size, result->mem_size(), memory_order_relaxed);
-    assert(num_buffers >= 0, "Must be");
-    assert(mem_size >= 0, "Must be");
   }
   return result;
 }
@@ -108,8 +106,6 @@ G1SegmentedArrayBuffer<flag>* G1SegmentedArrayBufferList<flag>::get_all(size_t& 
   if (result != nullptr) {
     size_t buffers = Atomic::sub(&_num_buffers, num_buffers, memory_order_relaxed);
     size_t mem = Atomic::sub(&_mem_size, mem_size, memory_order_relaxed);
-    assert(buffers >= 0, "Must be");
-    assert(mem >= 0, "Must be");
   }
   return result;
 }


### PR DESCRIPTION
This is a follow-up of JDK-8273626.

Current (original) implementation just drops the newly allocated G1SegmentedArrayBuffer if current thread fails race, but seems reuse (e.g adding to freelist) will bring some benefit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8274987](https://bugs.openjdk.java.net/browse/JDK-8274987): G1: reuse the newly allocated G1SegmentedArrayBuffer even if current thread failed the race


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6034/head:pull/6034` \
`$ git checkout pull/6034`

Update a local copy of the PR: \
`$ git checkout pull/6034` \
`$ git pull https://git.openjdk.java.net/jdk pull/6034/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6034`

View PR using the GUI difftool: \
`$ git pr show -t 6034`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6034.diff">https://git.openjdk.java.net/jdk/pull/6034.diff</a>

</details>
