### PR TITLE
8275607 G1: G1CardSetAllocator::drop_all needs to call G1SegmentedArray::drop_all

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSetMemory.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.cpp
@@ -114,6 +114,7 @@ void G1CardSetAllocator<Elem>::drop_all() {
   _pending_nodes_list.pop_all();
   _num_pending_nodes = 0;
   _num_free_nodes = 0;
+  _segmented_array.drop_all();
 }
 
 template <class Elem>


### PR DESCRIPTION
This is a follow-up of JDK-8273626.

G1CardSetAllocator::drop_all should call call G1SegmentedArray::drop_all to put all buffers into buffer free list, which is the original behavior of G1CardSetAllocator.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275607](https://bugs.openjdk.java.net/browse/JDK-8275607): G1: G1CardSetAllocator::drop_all needs to call G1SegmentedArray::drop_all


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6035/head:pull/6035` \
`$ git checkout pull/6035`

Update a local copy of the PR: \
`$ git checkout pull/6035` \
`$ git pull https://git.openjdk.java.net/jdk pull/6035/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6035`

View PR using the GUI difftool: \
`$ git pr show -t 6035`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6035.diff">https://git.openjdk.java.net/jdk/pull/6035.diff</a>

</details>
