### PR TITLE
8274888: Dump "-DReproduce=true" to the test VM command line output

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
@@ -153,6 +153,8 @@ public class TestVMProcess {
         } catch (Exception e) {
             throw new TestFrameworkException("Error while executing Test VM", e);
         }
+
+        process.command().add(1, "-DReproduce=true"); // Add after "/path/to/bin/java" in order to rerun the test VM directly
         commandLine = "Command Line:" + System.lineSeparator() + String.join(" ", process.command())
                       + System.lineSeparator();
         hotspotPidFileName = String.format("hotspot_pid%d.log", oa.pid());


### PR DESCRIPTION
When trying to rerun a failure of the test VM, one can copy the test VM command line printed to the output and directly use that one. But this requires to additionally set `-DReproduce=true` to mock the driver VM. This patch improves the manual work of adding `-DReproduce=true` and dumps it now automatically as part of the command line printed on failures.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274888](https://bugs.openjdk.java.net/browse/JDK-8274888): Dump "-DReproduce=true" to the test VM command line output


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6039/head:pull/6039` \
`$ git checkout pull/6039`

Update a local copy of the PR: \
`$ git checkout pull/6039` \
`$ git pull https://git.openjdk.java.net/jdk pull/6039/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6039`

View PR using the GUI difftool: \
`$ git pr show -t 6039`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6039.diff">https://git.openjdk.java.net/jdk/pull/6039.diff</a>

</details>
