### PR TITLE
8225777: java/awt/Mixing/MixingOnDialog.java fails on Ubuntu

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -181,7 +181,6 @@ java/awt/Mixing/AWT_Mixing/JTextFieldInGlassPaneOverlapping.java 8158801 windows
 java/awt/Mixing/AWT_Mixing/JTextFieldOverlapping.java 8158801 windows-all
 java/awt/Mixing/AWT_Mixing/JToggleButtonInGlassPaneOverlapping.java 8158801 windows-all
 java/awt/Mixing/AWT_Mixing/JToggleButtonOverlapping.java 8158801 windows-all
-java/awt/Mixing/MixingOnDialog.java 8225777 linux-all
 java/awt/Mixing/NonOpaqueInternalFrame.java 7124549 macosx-all
 java/awt/Mouse/GetMousePositionTest/GetMousePositionWithOverlay.java 8168388 linux-all
 java/awt/Focus/ActualFocusedWindowTest/ActualFocusedWindowRetaining.java 6829264 generic-all

--- a/test/jdk/java/awt/Mixing/MixingOnDialog.java
+++ b/test/jdk/java/awt/Mixing/MixingOnDialog.java
@@ -79,7 +79,7 @@ public class MixingOnDialog
 
 
         Robot robot = Util.createRobot();
-        robot.setAutoDelay(20);
+        robot.setAutoDelay(100);
 
         Util.waitForIdle(robot);
 

--- a/test/jdk/java/awt/Mixing/MixingOnDialog.java
+++ b/test/jdk/java/awt/Mixing/MixingOnDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,24 +24,28 @@
 /*
   @test
   @key headful
-  @bug 4811096
+  @bug 4811096 8225777
   @summary Tests whether mixing works on Dialogs
-  @author anthony.petrov@...: area=awt.mixing
   @library ../regtesthelpers
   @build Util
   @run main MixingOnDialog
 */
 
 
-/**
+/*
  * MixingOnDialog.java
  *
  * summary:  Tests whether awt.Button and swing.JButton mix correctly
  */
 
-import java.awt.*;
-import java.awt.event.*;
-import javax.swing.*;
+import java.awt.Button;
+import java.awt.Dialog;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import javax.swing.JButton;
+
 import test.java.awt.regtesthelpers.Util;
 
 
@@ -59,25 +63,12 @@ public class MixingOnDialog
         final JButton light = new JButton("  LW Button  ");
 
         // Actions for the buttons add appropriate number to the test sequence
-        heavy.addActionListener(new java.awt.event.ActionListener()
-                {
-                    public void actionPerformed(java.awt.event.ActionEvent e) {
-                        heavyClicked = true;
-                    }
-                }
-                );
-
-        light.addActionListener(new java.awt.event.ActionListener()
-                {
-                    public void actionPerformed(java.awt.event.ActionEvent e) {
-                        lightClicked = true;
-                    }
-                }
-                );
+        heavy.addActionListener(e -> heavyClicked = true);
+        light.addActionListener(e -> lightClicked = true);
 
         // Overlap the buttons
-        heavy.setBounds(30, 30, 200, 200);
-        light.setBounds(10, 10, 50, 50);
+        heavy.setBounds(130, 130, 200, 200);
+        light.setBounds(110, 110, 50, 50);
 
         // Put the components into the frame
         d.setLayout(null);
@@ -98,8 +89,8 @@ public class MixingOnDialog
         robot.mouseMove(heavyLoc.x + 5, heavyLoc.y + 5);
 
         // Now perform the click at this point
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         Util.waitForIdle(robot);
 
         // If the buttons are correctly mixed, the test sequence

--- a/test/jdk/java/awt/Mixing/MixingOnDialog.java
+++ b/test/jdk/java/awt/Mixing/MixingOnDialog.java
@@ -75,6 +75,7 @@ public class MixingOnDialog
         d.add(light);
         d.add(heavy);
         d.setBounds(50, 50, 400, 400);
+        d.setLocationRelativeTo(null);
         d.setVisible(true);
 
 


### PR DESCRIPTION
Looks like the test started failing after increasing of window's title height in Ubuntu theme:

![image](https://user-images.githubusercontent.com/77687766/138088503-f380bcb2-1ffc-4d58-b6b2-2efc56b7975c.png)
So the click happens on windows title instead of the button.

For example, macOS has smaller window title height, which allows test to pass.
<img src="https://user-images.githubusercontent.com/77687766/138088659-bd636518-c23c-4c5e-bf97-61035753c71a.png" width="50%" height="50%">

Fix moves buttons away from window title.
![image](https://user-images.githubusercontent.com/77687766/138088880-a9d1ec38-cde2-437e-80b9-5b7bdf73fd6b.png)

Testing is green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8225777](https://bugs.openjdk.java.net/browse/JDK-8225777): java/awt/Mixing/MixingOnDialog.java fails on Ubuntu


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6040/head:pull/6040` \
`$ git checkout pull/6040`

Update a local copy of the PR: \
`$ git checkout pull/6040` \
`$ git pull https://git.openjdk.java.net/jdk pull/6040/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6040`

View PR using the GUI difftool: \
`$ git pr show -t 6040`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6040.diff">https://git.openjdk.java.net/jdk/pull/6040.diff</a>

</details>
