### PR TITLE
8275535: Retrying a failed authentication on multiple LDAP servers can lead to users blocked

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapCtxFactory.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapCtxFactory.java
@@ -189,6 +189,10 @@ public final class LdapCtxFactory implements ObjectFactory, InitialContextFactor
                     ctx = getLdapCtxFromUrl(
                             r.getDomainName(), url, new LdapURL(u), env);
                     return ctx;
+                } catch (AuthenticationException e) {
+                    // do not retry on a different endpoint to avoid blocking
+                    // the user if authentication credentials are wrong.
+                    throw e;
                 } catch (NamingException e) {
                     // try the next element
                     lastException = e;
@@ -241,6 +245,10 @@ public final class LdapCtxFactory implements ObjectFactory, InitialContextFactor
         for (String u : urls) {
             try {
                 return getUsingURL(u, env);
+            } catch (AuthenticationException e) {
+                // do not retry on a different URL to avoid blocking
+                // the user if authentication credentials are wrong.
+                throw e;
             } catch (NamingException e) {
                 ex = e;
             }


### PR DESCRIPTION
I'd like to propose a fix for JDK-8275535. This fix reverts the behavior to the state previous to JDK-8160768, where an authentication failure stops from trying other LDAP servers with the same credentials [1]. After JDK-8160768 we have 2 possible loops to stop: the one that iterates over different URLs and the one that iterates over different endpoints (after a DNS query that returns multiple values).

No test regressions observed in jdk/com/sun/jndi/ldap.

--
[1] - https://hg.openjdk.java.net/jdk/jdk/rev/a609d549992a#l2.137

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issues
 * [JDK-8275535](https://bugs.openjdk.java.net/browse/JDK-8275535): Retrying a failed authentication on multiple LDAP servers can lead to users blocked
 * [JDK-8276959](https://bugs.openjdk.java.net/browse/JDK-8276959): Retrying a failed authentication on multiple LDAP servers can lead to users blocked (**CSR**)


### Reviewers
 * [Aleksei Efimov](https://openjdk.java.net/census#aefimov) (@AlekseiEfimov - Committer)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6043/head:pull/6043` \
`$ git checkout pull/6043`

Update a local copy of the PR: \
`$ git checkout pull/6043` \
`$ git pull https://git.openjdk.java.net/jdk pull/6043/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6043`

View PR using the GUI difftool: \
`$ git pr show -t 6043`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6043.diff">https://git.openjdk.java.net/jdk/pull/6043.diff</a>

</details>
