### PR TITLE
8275666: serviceability/jvmti/GetObjectSizeClass.java shouldn't have vm.flagless

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/GetObjectSizeClass.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetObjectSizeClass.java
@@ -31,7 +31,6 @@ import jdk.test.lib.process.ProcessTools;
  * @bug 8075030
  * @summary JvmtiEnv::GetObjectSize reports incorrect java.lang.Class instance size
  * @requires vm.jvmti
- * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.compiler


### PR DESCRIPTION
Hi all,

could you please review this tiny patch?

from JBS:
> serviceability/jvmti/GetObjectSizeClass.java doesn't ignore external flags (where it matters) and hence should not have been marked w/ vm.flagless

Thanks,
-- Igor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275666](https://bugs.openjdk.java.net/browse/JDK-8275666): serviceability/jvmti/GetObjectSizeClass.java shouldn't have vm.flagless


### Reviewers
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6050/head:pull/6050` \
`$ git checkout pull/6050`

Update a local copy of the PR: \
`$ git checkout pull/6050` \
`$ git pull https://git.openjdk.java.net/jdk pull/6050/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6050`

View PR using the GUI difftool: \
`$ git pr show -t 6050`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6050.diff">https://git.openjdk.java.net/jdk/pull/6050.diff</a>

</details>
