### PR TITLE
8275569: Add linux-aarch64 to test-make profiles

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -559,7 +559,7 @@ var getJibProfilesProfiles = function (input, common, data) {
             "ANT_HOME": input.get("ant", "home_path")
         }
     };
-    [ "linux-x64", "macosx-x64", "windows-x64"]
+    [ "linux-x64", "macosx-x64", "windows-x64", "linux-aarch64"]
         .forEach(function (name) {
             var maketestName = name + "-testmake";
             profiles[maketestName] = concatObjects(profiles[name], testmakeBase);


### PR DESCRIPTION
Please review this trivial change that adds "linux-aarch64" to test make profile.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275569](https://bugs.openjdk.java.net/browse/JDK-8275569): Add linux-aarch64 to test-make profiles


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6051/head:pull/6051` \
`$ git checkout pull/6051`

Update a local copy of the PR: \
`$ git checkout pull/6051` \
`$ git pull https://git.openjdk.java.net/jdk pull/6051/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6051`

View PR using the GUI difftool: \
`$ git pr show -t 6051`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6051.diff">https://git.openjdk.java.net/jdk/pull/6051.diff</a>

</details>
