### PR TITLE
JDK-8275923: Override the LPR path using a system property

### DIFF
--- a/src/java.desktop/share/classes/sun/print/PSPrinterJob.java
+++ b/src/java.desktop/share/classes/sun/print/PSPrinterJob.java
@@ -1630,7 +1630,7 @@ public class PSPrinterJob extends RasterPrinterJob {
         String osname = System.getProperty("os.name");
         if (osname.equals("Linux") || osname.contains("OS X")) {
             execCmd = new String[ncomps];
-            execCmd[n++] = "/usr/bin/lpr";
+            execCmd[n++] = System.getProperty("sun.print.lprPath", "/usr/bin/lpr");
             if ((pFlags & PRINTER) != 0) {
                 execCmd[n++] = "-P" + printer;
             }
@@ -1652,7 +1652,7 @@ public class PSPrinterJob extends RasterPrinterJob {
         } else {
             ncomps+=1; //add 1 arg for lp
             execCmd = new String[ncomps];
-            execCmd[n++] = "/usr/bin/lp";
+            execCmd[n++] = System.getProperty("sun.print.lpPath", "/usr/bin/lp");
             execCmd[n++] = "-c";           // make a copy of the spool file
             if ((pFlags & PRINTER) != 0) {
                 execCmd[n++] = "-d" + printer;


### PR DESCRIPTION
On some select systems, the LPR binary may be placed elsewhere (for example at `/app/bin/lpr`). For that reason, we need to be able to override this value. This proposal also allows overriding the LP's path, as it could experience similar difficulties.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed
- [ ] Change requires a CSR request to be approved

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8275923](https://bugs.openjdk.java.net/browse/JDK-8275923)

### Issue
 * [JDK-8275923](https://bugs.openjdk.java.net/browse/JDK-8275923): Allow overriding the path to the lpr binary ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6052/head:pull/6052` \
`$ git checkout pull/6052`

Update a local copy of the PR: \
`$ git checkout pull/6052` \
`$ git pull https://git.openjdk.java.net/jdk pull/6052/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6052`

View PR using the GUI difftool: \
`$ git pr show -t 6052`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6052.diff">https://git.openjdk.java.net/jdk/pull/6052.diff</a>

</details>
