### PR TITLE
8273660: ObjectInputStream.GetField.get returns null instead of handling ClassNotFoundException

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -2660,7 +2660,8 @@ public class ObjectInputStream
                 handles.markDependency(passHandle, objHandle);
                 ClassNotFoundException ex = handles.lookupException(objHandle);
                 if (ex != null) {
-                    // Wrap the exception so it can be handled in GetField.get(String, Object)
+                    // Wrap the exception to be caught in readSerialData when
+                    // invokeReadObject is called.
                     throw new IOException(ex);
                 }
                 return objValues[off];

--- a/test/jdk/java/io/Serializable/GetField/ReadFieldsCNF.java
+++ b/test/jdk/java/io/Serializable/GetField/ReadFieldsCNF.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8273660
+ * @summary Verify that ObjectInputStream ReadFields correctly reports ClassNotFoundException
+ *    while getting the field value. The test uses Vector that calls ReadFields from its readObject.
+ * @run main ReadFieldsCNF
+ */
+
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.HexFormat;
+import java.util.Vector;
+
+public class ReadFieldsCNF {
+
+    public static void main(String[] args) throws IOException, ClassNotFoundException {
+
+        Role role = new Role();
+        Vector<Role> vector = new Vector<>();
+        vector.add(role);
+
+        // Serialize the Vector with the Role
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try {
+            ObjectOutputStream objectOutputStream = new ObjectOutputStream(baos);
+            objectOutputStream.writeObject(vector);
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw e;
+        }
+
+        // Modify the byte stream to change the classname to be deserialized to
+        // XeadFieldsCNF$Role.
+        byte[] bytes = baos.toByteArray();
+        int off = 160;
+        if (bytes[off] != 'R') {
+            // Classname not where it was expected, print debug info
+            String s = new String(bytes);
+            off = s.indexOf(Role.class.getName()) + 1;
+            System.out.println("Role offset: " + off);
+            System.out.println("dump: " + HexFormat.of().formatHex(bytes, off, off + 16));
+            System.out.println("str:  " + new String(bytes, off, 16));
+            throw new RuntimeException("class not found at index: " + off);
+        }
+
+        bytes[off] = (byte) 'X';  // replace R with X -> Class not found
+
+        // Deserialize the Vector expecting a ClassNotFoundException
+        ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes));
+        try {
+            Object obj = in.readObject();
+            System.out.println("Read: " + obj);
+            throw new RuntimeException("Missing exception, should not reach here");
+        } catch (ClassNotFoundException cnfe) {
+            // Expected ClassNotFoundException
+            String expected = "XeadFieldsCNF$Role";
+            if (!(expected.equals(cnfe.getMessage()))) {
+                throw new RuntimeException("Expected: " + expected + ", actual: " + cnfe.getMessage());
+            }
+        }
+        // Other exceptions cause the test to fail
+    }
+
+    static class Role implements Serializable {
+        private static final long serialVersionUID = 0L;
+
+        Role() {}
+    }
+}


### PR DESCRIPTION
The ObjectInputStream.GetField method `get(String name, Object val)` should have been throwing
a ClassNotFoundException if the class was not found.  Instead the implementation was returning null.
A design error does not allow the `get(String name, Object val)`  method to throw CNFE as it should.
However, an exception must be thrown to prevent invalid data from being returned.
Wrapping the CNFE in IOException allows it to be thrown and the exception handled.
The call to `get(String name, Object val)`  is always from within a `readObject` method
so the deserialization logic can catch the IOException and unwrap it to handle the CNFE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ The change requires a CSR request to be approved.

### Issue
 * [JDK-8273660](https://bugs.openjdk.java.net/browse/JDK-8273660): ObjectInputStream.GetField.get returns null instead of handling ClassNotFoundException


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Stuart Marks](https://openjdk.java.net/census#smarks) (@stuart-marks - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6053/head:pull/6053` \
`$ git checkout pull/6053`

Update a local copy of the PR: \
`$ git checkout pull/6053` \
`$ git pull https://git.openjdk.java.net/jdk pull/6053/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6053`

View PR using the GUI difftool: \
`$ git pr show -t 6053`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6053.diff">https://git.openjdk.java.net/jdk/pull/6053.diff</a>

</details>
