### PR TITLE
JDK-8275686: Suppress warnings on non-serializable non-transient instance fields in java.rmi

### DIFF
--- a/src/java.rmi/share/classes/sun/rmi/server/UnicastRef.java
+++ b/src/java.rmi/share/classes/sun/rmi/server/UnicastRef.java
@@ -71,6 +71,7 @@ public class UnicastRef implements RemoteRef {
                        Boolean.getBoolean("sun.rmi.client.logCalls")));
     private static final long serialVersionUID = 8258372400816541186L;
 
+    @SuppressWarnings("serial") // Type of field is not Serializable
     protected LiveRef ref;
 
     /**


### PR DESCRIPTION
Another serialization warnings cleanup; this time in java.rmi.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275686](https://bugs.openjdk.java.net/browse/JDK-8275686): Suppress warnings on non-serializable non-transient instance fields in java.rmi


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6055/head:pull/6055` \
`$ git checkout pull/6055`

Update a local copy of the PR: \
`$ git checkout pull/6055` \
`$ git pull https://git.openjdk.java.net/jdk pull/6055/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6055`

View PR using the GUI difftool: \
`$ git pr show -t 6055`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6055.diff">https://git.openjdk.java.net/jdk/pull/6055.diff</a>

</details>
