### PR TITLE
8275347  ciReplay: staticfield lines not properly terminated

### DIFF
--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -707,7 +707,7 @@ class StaticFinalFieldPrinter : public FieldClosure {
             assert(fd->field_type() == T_OBJECT, "");
             if (value->is_a(vmClasses::String_klass())) {
               const char* ascii_value = java_lang_String::as_quoted_ascii(value);
-              _out->print("\"%s\"", (ascii_value != NULL) ? ascii_value : "");
+              _out->print_cr("\"%s\"", (ascii_value != NULL) ? ascii_value : "");
             } else {
               const char* klass_name  = value->klass()->name()->as_quoted_ascii();
               _out->print_cr("%s", klass_name);

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -128,7 +128,6 @@ class CompileReplay : public StackObj {
   char* _bufptr;
   char* _buffer;
   int   _buffer_length;
-  int   _buffer_pos;
 
   // "compile" data
   ciKlass* _iklass;
@@ -153,7 +152,6 @@ class CompileReplay : public StackObj {
     _buffer_length = 32;
     _buffer = NEW_RESOURCE_ARRAY(char, _buffer_length);
     _bufptr = _buffer;
-    _buffer_pos = 0;
 
     _imethod = NULL;
     _iklass  = NULL;
@@ -189,10 +187,6 @@ class CompileReplay : public StackObj {
 
   void report_error(const char* msg) {
     _error_message = msg;
-    // Restore the _buffer contents for error reporting
-    for (int i = 0; i < _buffer_pos; i++) {
-      if (_buffer[i] == '\0') _buffer[i] = ' ';
-    }
   }
 
   int parse_int(const char* label) {
@@ -232,6 +226,10 @@ class CompileReplay : public StackObj {
     }
   }
 
+  // Ignore the rest of the line
+  void skip_remaining() {
+    _bufptr = &_bufptr[strlen(_bufptr)]; // skip ahead to terminator
+  }
 
   char* scan_and_terminate(char delim) {
     char* str = _bufptr;
@@ -581,8 +579,9 @@ class CompileReplay : public StackObj {
   }
 
   int get_line(int c) {
+    int buffer_pos = 0;
     while(c != EOF) {
-      if (_buffer_pos + 1 >= _buffer_length) {
+      if (buffer_pos + 1 >= _buffer_length) {
         int new_length = _buffer_length * 2;
         // Next call will throw error in case of OOM.
         _buffer = REALLOC_RESOURCE_ARRAY(char, _buffer, _buffer_length, new_length);
@@ -594,13 +593,12 @@ class CompileReplay : public StackObj {
       } else if (c == '\r') {
         // skip LF
       } else {
-        _buffer[_buffer_pos++] = c;
+        _buffer[buffer_pos++] = c;
       }
       c = getc(_stream);
     }
     // null terminate it, reset the pointer
-    _buffer[_buffer_pos] = '\0'; // NL or EOF
-    _buffer_pos = 0;
+    _buffer[buffer_pos] = '\0'; // NL or EOF
     _bufptr = _buffer;
     return c;
   }
@@ -614,7 +612,8 @@ class CompileReplay : public StackObj {
       c = get_line(c);
       process_command(THREAD);
       if (had_error()) {
-        tty->print_cr("Error while parsing line %d: %s\n", line_no, _error_message);
+        int pos = _bufptr - _buffer + 1;
+        tty->print_cr("Error while parsing line %d at position %d: %s\n", line_no, pos, _error_message);
         if (ReplayIgnoreInitErrors) {
           CLEAR_PENDING_EXCEPTION;
           _error_message = NULL;
@@ -632,7 +631,11 @@ class CompileReplay : public StackObj {
       return;
     }
     if (strcmp("#", cmd) == 0) {
-      // ignore
+      // comment line, print or ignore
+      if (Verbose) {
+        tty->print_cr("# %s", _bufptr);
+      }
+      skip_remaining();
     } else if (strcmp("compile", cmd) == 0) {
       process_compile(CHECK);
     } else if (strcmp("ciMethod", cmd) == 0) {
@@ -651,6 +654,9 @@ class CompileReplay : public StackObj {
 #endif // INCLUDE_JVMTI
     } else {
       report_error("unknown command");
+    }
+    if (!had_error() && *_bufptr != '\0') {
+      report_error("line not properly terminated");
     }
   }
 
@@ -877,9 +883,13 @@ class CompileReplay : public StackObj {
       report_error("hidden class with comment expected");
       return;
     }
-    if (is_comment && Verbose) {
-      const char* hidden = parse_string();
-      tty->print_cr("Found %s for %s", k->name()->as_quoted_ascii(), hidden);
+    // comment, print or ignore
+    if (is_comment) {
+      if (Verbose) {
+        const char* hidden = parse_string();
+        tty->print_cr("Found %s for %s", k->name()->as_quoted_ascii(), hidden);
+      }
+      skip_remaining();
     }
   }
 
@@ -990,6 +1000,7 @@ class CompileReplay : public StackObj {
 
     if (k == NULL || ReplaySuppressInitializers == 0 ||
         (ReplaySuppressInitializers == 2 && k->class_loader() == NULL)) {
+      skip_remaining();
       return;
     }
 

--- a/test/hotspot/jtreg/compiler/ciReplay/CiReplayBase.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/CiReplayBase.java
@@ -81,6 +81,12 @@ public abstract class CiReplayBase {
     }
 
     public static class TestMain {
+        private static final String emptyString;
+
+        static {
+          emptyString = "";
+        }
+
         public static void main(String[] args) {
             // explicitly trigger native compilation
             Lambda start = () -> 0;


### PR DESCRIPTION
Summary of changes:
- fix staticfield line termination for empty String constants
- tighten up checks during parse time to detect any un-parsed input at the end of a line
- updated test to trigger the problem, so that it fails without the fix
- cleanup: removed _buffer_pos field and related logic that isn't needed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275347](https://bugs.openjdk.java.net/browse/JDK-8275347): ciReplay: staticfield lines not properly terminated


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6057/head:pull/6057` \
`$ git checkout pull/6057`

Update a local copy of the PR: \
`$ git checkout pull/6057` \
`$ git pull https://git.openjdk.java.net/jdk pull/6057/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6057`

View PR using the GUI difftool: \
`$ git pr show -t 6057`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6057.diff">https://git.openjdk.java.net/jdk/pull/6057.diff</a>

</details>
