### PR TITLE
JDK-8275688: Suppress warnings on non-serializable non-transient instance fields in DualPivotQuicksort

### DIFF
--- a/src/java.base/share/classes/java/util/DualPivotQuicksort.java
+++ b/src/java.base/share/classes/java/util/DualPivotQuicksort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This should be the last core libraries cleanup of  non-serializable non-transient instance fields ahead of the upcoming javac lint warnings: https://mail.openjdk.java.net/pipermail/jdk-dev/2021-October/006166.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275688](https://bugs.openjdk.java.net/browse/JDK-8275688): Suppress warnings on non-serializable non-transient instance fields in DualPivotQuicksort


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to 126782c3bc8e43fed215b36a2463552d7202863d


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6058/head:pull/6058` \
`$ git checkout pull/6058`

Update a local copy of the PR: \
`$ git checkout pull/6058` \
`$ git pull https://git.openjdk.java.net/jdk pull/6058/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6058`

View PR using the GUI difftool: \
`$ git pr show -t 6058`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6058.diff">https://git.openjdk.java.net/jdk/pull/6058.diff</a>

</details>
