### PR TITLE
8275714: G1: remove unused variable in G1Policy::transfer_survivors_to_cset

### DIFF
--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1501,7 +1501,6 @@ void G1Policy::update_survival_estimates_for_next_collection() {
 void G1Policy::transfer_survivors_to_cset(const G1SurvivorRegions* survivors) {
   start_adding_survivor_regions();
 
-  HeapRegion* last = NULL;
   for (GrowableArrayIterator<HeapRegion*> it = survivors->regions()->begin();
        it != survivors->regions()->end();
        ++it) {
@@ -1512,8 +1511,6 @@ void G1Policy::transfer_survivors_to_cset(const G1SurvivorRegions* survivors) {
     // the incremental collection set for the next evacuation
     // pause.
     _collection_set->add_survivor_regions(curr);
-
-    last = curr;
   }
   stop_adding_survivor_regions();
 


### PR DESCRIPTION
Trivial change of removing unused variables.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275714](https://bugs.openjdk.java.net/browse/JDK-8275714): G1: remove unused variable in G1Policy::transfer_survivors_to_cset


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6062/head:pull/6062` \
`$ git checkout pull/6062`

Update a local copy of the PR: \
`$ git checkout pull/6062` \
`$ git pull https://git.openjdk.java.net/jdk pull/6062/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6062`

View PR using the GUI difftool: \
`$ git pr show -t 6062`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6062.diff">https://git.openjdk.java.net/jdk/pull/6062.diff</a>

</details>
