### PR TITLE
8275715: D3D pipeline processes multiple PaintEvent at initial drawing

### DIFF
--- a/src/java.desktop/windows/classes/sun/java2d/d3d/D3DScreenUpdateManager.java
+++ b/src/java.desktop/windows/classes/sun/java2d/d3d/D3DScreenUpdateManager.java
@@ -258,7 +258,7 @@ public class D3DScreenUpdateManager extends ScreenUpdateManager
     {
         if (!done && sd instanceof D3DWindowSurfaceData) {
             D3DWindowSurfaceData d3dw = (D3DWindowSurfaceData)sd;
-            if (!d3dw.isSurfaceLost() || validate(d3dw)) {
+            if (!d3dw.isSurfaceLost() || validate(d3dw, false)) {
                 trackScreenSurface(d3dw);
                 return new SunGraphics2D(sd, fgColor, bgColor, font);
             }
@@ -452,7 +452,7 @@ public class D3DScreenUpdateManager extends ScreenUpdateManager
                         } finally {
                             rq.unlock();
                         }
-                    } else if (!validate(sd)) {
+                    } else if (!validate(sd, true)) {
                         // it is possible that the validation may never
                         // succeed, we need to detect this and replace
                         // the d3dw surface with gdi; the replacement of
@@ -474,7 +474,7 @@ public class D3DScreenUpdateManager extends ScreenUpdateManager
      * @return true if surface wasn't lost or if restoration was successful,
      * false otherwise
      */
-    private boolean validate(D3DWindowSurfaceData sd) {
+    private boolean validate(D3DWindowSurfaceData sd, boolean postEvent) {
         if (sd.isSurfaceLost()) {
             try {
                 sd.restoreSurface();
@@ -491,7 +491,9 @@ public class D3DScreenUpdateManager extends ScreenUpdateManager
                 sd.markClean();
                 // since the surface was successfully restored we need to
                 // repaint whole window to repopulate the back-buffer
-                repaintPeerTarget(sd.getPeer());
+                if (postEvent) {
+                    repaintPeerTarget(sd.getPeer());
+                }
             } catch (InvalidPipeException ipe) {
                 return false;
             }

--- a/test/jdk/sun/java2d/DirectX/MultiPaintEventTest/MultiPaintEventTest.java
+++ b/test/jdk/sun/java2d/DirectX/MultiPaintEventTest/MultiPaintEventTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key headful
+ * @bug 8275715
+ * @summary Tests that paint method is not called twice
+ * @run main/othervm MultiPaintEventTest
+ */
+
+import java.awt.*;
+
+public class MultiPaintEventTest extends Canvas {
+
+    private int count = 0;
+
+    public void paint(Graphics g) {
+        count++;
+
+        int w = getWidth();
+        int h = getHeight();
+
+        Graphics2D g2d = (Graphics2D)g;
+        if (count % 2 == 1) {
+            g2d.setColor(Color.green);
+        } else {
+            g2d.setColor(Color.red);
+        }
+        g2d.fillRect(0, 0, w, h);
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public Dimension getPreferredSize() {
+        return new Dimension(400, 400);
+    }
+
+    public static void main(String[] args) {
+        MultiPaintEventTest test = new MultiPaintEventTest();
+        Frame frame = new Frame();
+        frame.setUndecorated(true);
+        frame.add(test);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+
+        try {
+            Thread.sleep(2000);
+            if (test.getCount() > 1) {
+                throw new RuntimeException("Processed unnecessary paint().");
+            }
+        } catch (InterruptedException ex) {
+        } finally {
+            frame.dispose();
+        }
+    }
+}

--- a/test/jdk/sun/java2d/DirectX/MultiPaintEventTest/MultiPaintEventTest.java
+++ b/test/jdk/sun/java2d/DirectX/MultiPaintEventTest/MultiPaintEventTest.java
@@ -34,9 +34,12 @@ import java.awt.*;
 public class MultiPaintEventTest extends Canvas {
 
     private int count = 0;
+    private final Object lock = new Object();
 
     public void paint(Graphics g) {
-        count++;
+        synchronized(lock) {
+            count++;
+        }
 
         int w = getWidth();
         int h = getHeight();
@@ -51,7 +54,9 @@ public class MultiPaintEventTest extends Canvas {
     }
 
     public int getCount() {
-        return count;
+        synchronized(lock) {
+            return count;
+        }
     }
 
     public Dimension getPreferredSize() {
@@ -73,6 +78,7 @@ public class MultiPaintEventTest extends Canvas {
                 throw new RuntimeException("Processed unnecessary paint().");
             }
         } catch (InterruptedException ex) {
+            throw new RuntimeException("Failed: Interrupted");
         } finally {
             frame.dispose();
         }


### PR DESCRIPTION
Could you please review the 8275715 bug fixes?

I think D3DScreenUpdateManager posts unnecessary PaintEvent during processing PaintEvent. When the validate method is called from createGraphics, repaintPeerTarget should not be called.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275715](https://bugs.openjdk.java.net/browse/JDK-8275715): D3D pipeline processes multiple PaintEvent at initial drawing


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6064/head:pull/6064` \
`$ git checkout pull/6064`

Update a local copy of the PR: \
`$ git checkout pull/6064` \
`$ git pull https://git.openjdk.java.net/jdk pull/6064/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6064`

View PR using the GUI difftool: \
`$ git pr show -t 6064`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6064.diff">https://git.openjdk.java.net/jdk/pull/6064.diff</a>

</details>
