### PR TITLE
8275718: Relax memory constraint on exception counter updates

### DIFF
--- a/src/hotspot/share/utilities/exceptions.cpp
+++ b/src/hotspot/share/utilities/exceptions.cpp
@@ -166,7 +166,7 @@ void Exceptions::_throw(JavaThread* thread, const char* file, int line, Handle h
   }
 
   if (h_exception->is_a(vmClasses::LinkageError_klass())) {
-    Atomic::inc(&_linkage_errors);
+    Atomic::inc(&_linkage_errors, memory_order_relaxed);
   }
 
   assert(h_exception->is_a(vmClasses::Throwable_klass()), "exception is not a subclass of java/lang/Throwable");
@@ -242,7 +242,7 @@ void Exceptions::throw_stack_overflow_exception(JavaThread* THREAD, const char* 
       java_lang_Throwable::fill_in_stack_trace(exception, method);
     }
     // Increment counter for hs_err file reporting
-    Atomic::inc(&Exceptions::_stack_overflow_errors);
+    Atomic::inc(&Exceptions::_stack_overflow_errors, memory_order_relaxed);
   } else {
     // if prior exception, throw that one instead
     exception = Handle(THREAD, THREAD->pending_exception());
@@ -462,12 +462,12 @@ volatile int Exceptions::_out_of_memory_error_class_metaspace_errors = 0;
 
 void Exceptions::count_out_of_memory_exceptions(Handle exception) {
   if (exception() == Universe::out_of_memory_error_metaspace()) {
-     Atomic::inc(&_out_of_memory_error_metaspace_errors);
+     Atomic::inc(&_out_of_memory_error_metaspace_errors, memory_order_relaxed);
   } else if (exception() == Universe::out_of_memory_error_class_metaspace()) {
-     Atomic::inc(&_out_of_memory_error_class_metaspace_errors);
+     Atomic::inc(&_out_of_memory_error_class_metaspace_errors, memory_order_relaxed);
   } else {
      // everything else reported as java heap OOM
-     Atomic::inc(&_out_of_memory_error_java_heap_errors);
+     Atomic::inc(&_out_of_memory_error_java_heap_errors, memory_order_relaxed);
   }
 }
 


### PR DESCRIPTION
This is another instance of counter updates that only need atomic guarantee.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275718](https://bugs.openjdk.java.net/browse/JDK-8275718): Relax memory constraint on exception counter updates


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6065/head:pull/6065` \
`$ git checkout pull/6065`

Update a local copy of the PR: \
`$ git checkout pull/6065` \
`$ git pull https://git.openjdk.java.net/jdk pull/6065/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6065`

View PR using the GUI difftool: \
`$ git pr show -t 6065`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6065.diff">https://git.openjdk.java.net/jdk/pull/6065.diff</a>

</details>
