### PR TITLE
8275162: Replace 'def' macros in mutexLocker.cpp

### DIFF
--- a/src/hotspot/share/runtime/mutex.hpp
+++ b/src/hotspot/share/runtime/mutex.hpp
@@ -116,10 +116,8 @@ class Mutex : public CHeapObj<mtSynchronizer> {
   }
 
  public:
-  Rank   rank() const          { return _rank; }
   const char*  rank_name() const;
   Mutex* next()  const         { return _next; }
-  void   set_next(Mutex *next) { _next = next; }
 #endif // ASSERT
 
  protected:
@@ -192,7 +190,8 @@ class Mutex : public CHeapObj<mtSynchronizer> {
   void set_owner(Thread* owner) { set_owner_implementation(owner); }
   bool owned_by_self() const;
 
-  const char *name() const                  { return _name; }
+  const char *name() const     { return _name; }
+  Rank   rank() const          { DEBUG_ONLY(return _rank) NOT_DEBUG(return safepoint); }
 
   // Print all mutexes/monitors that are currently owned by a thread; called
   // by fatal error handler.


### PR DESCRIPTION
This patch removes the 'def' macros from mutexLocker.cpp so it can use the default values for _allow_vm_block when possible and no more macro.
Tested with tier1-3 with product and debug builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275162](https://bugs.openjdk.java.net/browse/JDK-8275162): Replace 'def' macros in mutexLocker.cpp


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.java.net/census#pchilanomate) (@pchilano - Committer)
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6066/head:pull/6066` \
`$ git checkout pull/6066`

Update a local copy of the PR: \
`$ git checkout pull/6066` \
`$ git pull https://git.openjdk.java.net/jdk pull/6066/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6066`

View PR using the GUI difftool: \
`$ git pr show -t 6066`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6066.diff">https://git.openjdk.java.net/jdk/pull/6066.diff</a>

</details>
