### PR TITLE
8275872: Sync J2DBench run and analyze Makefile targets with build.xml

### DIFF
--- a/src/demo/share/java2d/J2DBench/Makefile
+++ b/src/demo/share/java2d/J2DBench/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -80,10 +80,10 @@ SCM_DIRs = .hg .svn CVS RCS SCCS Codemgr_wsdata deleted_files
 all: mkdirs J2DBench.jar J2DAnalyzer.jar
 
 run: mkdirs J2DBench.jar
-	java -jar J2DBench.jar
+	java -jar $(DIST)/J2DBench.jar
 
 analyze: mkdirs J2DAnalyzer.jar
-	java -jar J2DAnalyzer.jar
+	java -jar $(DIST)/J2DAnalyzer.jar
 
 J2DBench.jar: \
 	$(J2DBENCH_CLASSES) $(J2DBENCH_RESOURCES) \


### PR DESCRIPTION
The run targets of makefile to run J2DBench.jar/J2DAnalyzer.jar were
lacking the dist directory. This patch is fixing it. Note, that
build.xml have correct paths

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275872](https://bugs.openjdk.java.net/browse/JDK-8275872): Sync J2DBench run and analyze Makefile targets with build.xml


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.java.net/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6068/head:pull/6068` \
`$ git checkout pull/6068`

Update a local copy of the PR: \
`$ git checkout pull/6068` \
`$ git pull https://git.openjdk.java.net/jdk pull/6068/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6068`

View PR using the GUI difftool: \
`$ git pr show -t 6068`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6068.diff">https://git.openjdk.java.net/jdk/pull/6068.diff</a>

</details>
