### PR TITLE
8275730: Relax memory constraint on MultiThreadedRefCounter

### DIFF
--- a/src/hotspot/share/jfr/utilities/jfrRefCountPointer.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrRefCountPointer.hpp
@@ -112,15 +112,15 @@ class MultiThreadedRefCounter {
   MultiThreadedRefCounter() : _refs(0) {}
 
   void inc() const {
-    Atomic::add(&_refs, 1);
+    Atomic::inc(&_refs, memory_order_relaxed);
   }
 
   bool dec() const {
-    return 0 == Atomic::add(&_refs, (-1));
+    return 0 == Atomic::sub(&_refs, 1, memory_order_relaxed);
   }
 
   intptr_t current() const {
-   return _refs;
+    return Atomic::load(&_refs);
   }
 };
 


### PR DESCRIPTION
It is just an atomic counter, only needs atomic guarantee.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275730](https://bugs.openjdk.java.net/browse/JDK-8275730): Relax memory constraint on MultiThreadedRefCounter


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6069/head:pull/6069` \
`$ git checkout pull/6069`

Update a local copy of the PR: \
`$ git checkout pull/6069` \
`$ git pull https://git.openjdk.java.net/jdk pull/6069/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6069`

View PR using the GUI difftool: \
`$ git pr show -t 6069`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6069.diff">https://git.openjdk.java.net/jdk/pull/6069.diff</a>

</details>
