### PR TITLE
8276700: Improve java.lang.ref.Cleaner javadocs

### DIFF
--- a/src/java.base/share/classes/java/lang/ref/Cleaner.java
+++ b/src/java.base/share/classes/java/lang/ref/Cleaner.java
@@ -87,8 +87,10 @@ import java.util.function.Function;
  * <pre>{@code
  * public class CleaningExample implements AutoCloseable {
  *        // A cleaner, preferably one shared within a library
- *        private static final Cleaner cleaner = <cleaner>;
+ *        private static final Cleaner cleaner = Cleaner.create();
  *
+ *        // Static state class, capturing information necessary for
+ *        // cleanup, but no reference to the instance being cleaned
  *        static class State implements Runnable {
  *
  *            State(...) {

--- a/src/java.base/share/classes/java/lang/ref/Cleaner.java
+++ b/src/java.base/share/classes/java/lang/ref/Cleaner.java
@@ -90,7 +90,9 @@ import java.util.function.Function;
  *        private static final Cleaner cleaner = Cleaner.create();
  *
  *        // Static state class, capturing information necessary for
- *        // cleanup, but no reference to the instance being cleaned
+ *        // State class captures information necessary for cleanup.
+ *        // It must hold no reference to the instance being cleaned
+ *        // and therefore it is a static inner class in this CleaningExample.
  *        static class State implements Runnable {
  *
  *            State(...) {

--- a/src/java.base/share/classes/java/lang/ref/Cleaner.java
+++ b/src/java.base/share/classes/java/lang/ref/Cleaner.java
@@ -89,10 +89,9 @@ import java.util.function.Function;
  *        // A cleaner, preferably one shared within a library
  *        private static final Cleaner cleaner = Cleaner.create();
  *
- *        // Static state class, capturing information necessary for
  *        // State class captures information necessary for cleanup.
  *        // It must hold no reference to the instance being cleaned
- *        // and therefore it is a static inner class in this CleaningExample.
+ *        // and therefore it is a static inner class in this example.
  *        static class State implements Runnable {
  *
  *            State(...) {

--- a/src/java.base/share/classes/java/lang/ref/Cleaner.java
+++ b/src/java.base/share/classes/java/lang/ref/Cleaner.java
@@ -86,7 +86,8 @@ import java.util.function.Function;
  * by the Cleaner when the CleaningExample instance has become phantom reachable.
  * <pre>{@code
  * public class CleaningExample implements AutoCloseable {
- *        // A cleaner, preferably one shared within a library
+ *        // A cleaner (preferably one shared within a library,
+          // but for the sake of example, a new one is created here)
  *        private static final Cleaner cleaner = Cleaner.create();
  *
  *        // State class captures information necessary for cleanup.


### PR DESCRIPTION
Trivial improvement.

Explicitly show how to create a `Cleaner` instance using `Cleaner.create()`.
Repeat (again) in the code example that the `State` `Runnable `should be implemented as static class and not reference the instance to be cleaned, to make the point even more clear to those people who never read the javadoc *prose*.

I have signed the OCA a while back as [hschreiber](https://openjdk.java.net/census#hschreiber).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276700](https://bugs.openjdk.java.net/browse/JDK-8276700): Improve java.lang.ref.Cleaner javadocs


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6076/head:pull/6076` \
`$ git checkout pull/6076`

Update a local copy of the PR: \
`$ git checkout pull/6076` \
`$ git pull https://git.openjdk.java.net/jdk pull/6076/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6076`

View PR using the GUI difftool: \
`$ git pr show -t 6076`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6076.diff">https://git.openjdk.java.net/jdk/pull/6076.diff</a>

</details>
