### PR TITLE
8275717: Reimplement STATIC_ASSERT to use static_assert

### DIFF
--- a/src/hotspot/share/utilities/debug.hpp
+++ b/src/hotspot/share/utilities/debug.hpp
@@ -174,22 +174,7 @@ void report_untested(const char* file, int line, const char* message);
 
 void warning(const char* format, ...) ATTRIBUTE_PRINTF(1, 2);
 
-// Compile-time asserts.  Cond must be a compile-time constant expression that
-// is convertible to bool.  STATIC_ASSERT() can be used anywhere a declaration
-// may appear.
-//
-// Implementation Note: STATIC_ASSERT_FAILURE<true> provides a value member
-// rather than type member that could be used directly in the typedef, because
-// a type member would require conditional use of "typename", depending on
-// whether Cond is dependent or not.  The use of a value member leads to the
-// use of an array type.
-
-template<bool x> struct STATIC_ASSERT_FAILURE;
-template<> struct STATIC_ASSERT_FAILURE<true> { enum { value = 1 }; };
-
-#define STATIC_ASSERT(Cond) \
-  typedef char PASTE_TOKENS(STATIC_ASSERT_DUMMY_TYPE_, __LINE__)[ \
-    STATIC_ASSERT_FAILURE< (Cond) >::value ]
+#define STATIC_ASSERT(Cond) static_assert((Cond), #Cond)
 
 // out of memory reporting
 void report_java_out_of_memory(const char* message);


### PR DESCRIPTION
We currently have a bespoke implementation of STATIC_ASSERT, which was added before we transitioned over to C++14. I recently saw some compiler warnings (macos-aarch64) about that implementation. I propose that we reimplement STATIC_ASSERT to use static_assert. FWIW, some HotSpot code already uses static_assert instead of STATIC_ASSERT.

An alternative would be to completely remove STATIC_ASSERT and always use static_assert. That would require us to add a message string to all of the > 400 usages. Maybe we should wait with that until we can use C++17, which removes the requirement to provide a message?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275717](https://bugs.openjdk.java.net/browse/JDK-8275717): Reimplement STATIC_ASSERT to use static_assert


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6077/head:pull/6077` \
`$ git checkout pull/6077`

Update a local copy of the PR: \
`$ git checkout pull/6077` \
`$ git pull https://git.openjdk.java.net/jdk pull/6077/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6077`

View PR using the GUI difftool: \
`$ git pr show -t 6077`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6077.diff">https://git.openjdk.java.net/jdk/pull/6077.diff</a>

</details>
