### PR TITLE
8275783: G1: fix incorrect region type documentation in HeapRegionType

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegionType.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionType.hpp
@@ -58,8 +58,8 @@ private:
   // 01000 0 [16] Old Mask
   //
   // 10000 0 [32] Archive Mask
-  // 11100 0 [56] Open Archive
-  // 11100 1 [57] Closed Archive
+  // 10100 0 [40] Open Archive
+  // 10100 1 [41] Closed Archive
   //
   typedef enum {
     FreeTag               = 0,


### PR DESCRIPTION
Trivial change of fixing documentation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275783](https://bugs.openjdk.java.net/browse/JDK-8275783): G1: fix incorrect region type documentation in HeapRegionType


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6079/head:pull/6079` \
`$ git checkout pull/6079`

Update a local copy of the PR: \
`$ git checkout pull/6079` \
`$ git pull https://git.openjdk.java.net/jdk pull/6079/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6079`

View PR using the GUI difftool: \
`$ git pr show -t 6079`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6079.diff">https://git.openjdk.java.net/jdk/pull/6079.diff</a>

</details>
