### PR TITLE
8274734: the method jdk.jshell.SourceCodeAnalysis documentation not working

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
@@ -1381,8 +1381,7 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
             FileSystem zipFO = null;
 
             try {
-                URI uri = URI.create("jar:" + srcZip.toUri());
-                zipFO = FileSystems.newFileSystem(uri, Collections.emptyMap());
+                zipFO = FileSystems.newFileSystem(srcZip, Collections.emptyMap());
                 Path root = zipFO.getRootDirectories().iterator().next();
 
                 if (Files.exists(root.resolve("java/lang/Object.java".replace("/", zipFO.getSeparator())))) {

--- a/test/langtools/jdk/jshell/MultipleDocumentationTest.java
+++ b/test/langtools/jdk/jshell/MultipleDocumentationTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.List;
+import java.util.stream.Collectors;
+import jdk.jshell.JShell;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+
+/*
+ * @test
+ * @bug 8274734
+ * @summary Verify multiple SourceCodeAnalysis instances can concurrently provide documentation.
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.jdeps/com.sun.tools.javap
+ *          jdk.jshell/jdk.internal.jshell.tool
+ * @build Compiler toolbox.ToolBox
+ * @run testng MultipleDocumentationTest
+ */
+@Test
+public class MultipleDocumentationTest {
+
+    public void testMultipleDocumentation() {
+        String input = "java.lang.String";
+
+        try (var state1 = JShell.builder()
+                                .out(new PrintStream(new ByteArrayOutputStream()))
+                                .err(new PrintStream(new ByteArrayOutputStream()))
+                                .build()) {
+            var sca1 = state1.sourceCodeAnalysis();
+            List<String> javadocs1 =
+                    sca1.documentation(input, input.length(), true)
+                        .stream()
+                        .map(d -> d.javadoc())
+                        .collect(Collectors.toList());
+
+            try (var state2 = JShell.builder()
+                                    .out(new PrintStream(new ByteArrayOutputStream()))
+                                    .err(new PrintStream(new ByteArrayOutputStream()))
+                                    .build()) {
+                var sca2 = state2.sourceCodeAnalysis();
+                List<String> javadocs2 = sca2.documentation(input, input.length(), true)
+                                             .stream()
+                                             .map(d -> d.javadoc())
+                                             .collect(Collectors.toList());
+
+                assertEquals(javadocs2, javadocs1);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
The `SourceCodeAnalysisImpl` needs to open `src.zip` to read the sources to get javadoc. Unfortunately, it uses the variant of the `newFileSystem` method that can only be used one, and hence only one `SourceCodeAnalysisImpl` can provide documentation. The proposed solution is to use the variant of the `newFileSystem` method that can open the FileSystem multiple times, so that multiple independent SourceCodeAnalysisImpl instances can provide documentation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274734](https://bugs.openjdk.java.net/browse/JDK-8274734): the method jdk.jshell.SourceCodeAnalysis documentation not working


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6080/head:pull/6080` \
`$ git checkout pull/6080`

Update a local copy of the PR: \
`$ git checkout pull/6080` \
`$ git pull https://git.openjdk.java.net/jdk pull/6080/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6080`

View PR using the GUI difftool: \
`$ git pr show -t 6080`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6080.diff">https://git.openjdk.java.net/jdk/pull/6080.diff</a>

</details>
