### PR TITLE
8275811 Incorrect instance to dispose

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/DTLSOutputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/DTLSOutputRecord.java
@@ -174,6 +174,11 @@ final class DTLSOutputRecord extends OutputRecord implements DTLSRecord {
     }
 
     @Override
+    void disposeWriteCipher() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     Ciphertext encode(
         ByteBuffer[] srcs, int srcsOffset, int srcsLength,
         ByteBuffer[] dsts, int dstsOffset, int dstsLength) throws IOException {

--- a/src/java.base/share/classes/sun/security/ssl/DTLSOutputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/DTLSOutputRecord.java
@@ -174,11 +174,6 @@ final class DTLSOutputRecord extends OutputRecord implements DTLSRecord {
     }
 
     @Override
-    void disposeWriteCipher() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     Ciphertext encode(
         ByteBuffer[] srcs, int srcsOffset, int srcsLength,
         ByteBuffer[] dsts, int dstsOffset, int dstsLength) throws IOException {

--- a/src/java.base/share/classes/sun/security/ssl/InputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/InputRecord.java
@@ -122,7 +122,7 @@ abstract class InputRecord implements Record, Closeable {
          * Since MAC's doFinal() is called for every SSL/TLS packet, it's
          * not necessary to do the same with MAC's.
          */
-        readCipher.dispose();
+        this.readCipher.dispose();
 
         this.readCipher = readCipher;
     }

--- a/src/java.base/share/classes/sun/security/ssl/OutputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/OutputRecord.java
@@ -190,7 +190,7 @@ abstract class OutputRecord
              * Since MAC's doFinal() is called for every SSL/TLS packet, it's
              * not necessary to do the same with MAC's.
              */
-            writeCipher.dispose();
+            this.writeCipher.dispose();
 
             this.writeCipher = writeCipher;
             this.isFirstAppOutputRecord = true;

--- a/src/java.base/share/classes/sun/security/ssl/OutputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/OutputRecord.java
@@ -219,7 +219,7 @@ abstract class OutputRecord
             flush();
 
             // Dispose of any intermediate state in the underlying cipher.
-            writeCipher.dispose();
+            this.writeCipher.dispose();
 
             this.writeCipher = writeCipher;
             this.isFirstAppOutputRecord = true;

--- a/src/java.base/share/classes/sun/security/ssl/OutputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/OutputRecord.java
@@ -182,16 +182,6 @@ abstract class OutputRecord
                 encodeChangeCipherSpec();
             }
 
-            /*
-             * Dispose of any intermediate state in the underlying cipher.
-             * For PKCS11 ciphers, this will release any attached sessions,
-             * and thus make finalization faster.
-             *
-             * Since MAC's doFinal() is called for every SSL/TLS packet, it's
-             * not necessary to do the same with MAC's.
-             */
-            this.writeCipher.dispose();
-
             this.writeCipher = writeCipher;
             this.isFirstAppOutputRecord = true;
         } finally {
@@ -217,9 +207,6 @@ abstract class OutputRecord
             hm[hm.length - 1] = keyUpdateRequest;
             encodeHandshake(hm, 0, hm.length);
             flush();
-
-            // Dispose of any intermediate state in the underlying cipher.
-            this.writeCipher.dispose();
 
             this.writeCipher = writeCipher;
             this.isFirstAppOutputRecord = true;

--- a/src/java.base/share/classes/sun/security/ssl/OutputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/OutputRecord.java
@@ -142,7 +142,9 @@ abstract class OutputRecord
     abstract void encodeChangeCipherSpec() throws IOException;
 
     // SSLEngine and SSLSocket
-    abstract void disposeWriteCipher();
+    void disposeWriteCipher() {
+        throw new UnsupportedOperationException();
+    }
 
     // apply to SSLEngine only
     Ciphertext encode(

--- a/src/java.base/share/classes/sun/security/ssl/SSLEngineOutputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLEngineOutputRecord.java
@@ -433,7 +433,7 @@ final class SSLEngineOutputRecord extends OutputRecord implements SSLRecord {
         }
 
         void queueUpCipherDispose() {
-            RecordMemo lastMemo = handshakeMemos.getLast();
+            RecordMemo lastMemo = handshakeMemos.peekLast();
             if (lastMemo != null) {
                 lastMemo.disposeCipher = true;
             } else {

--- a/src/java.base/share/classes/sun/security/ssl/SSLEngineOutputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLEngineOutputRecord.java
@@ -152,6 +152,15 @@ final class SSLEngineOutputRecord extends OutputRecord implements SSLRecord {
     }
 
     @Override
+    void disposeWriteCipher() {
+        if (fragmenter == null) {
+            writeCipher.dispose();
+        } else {
+            fragmenter.queueUpCipherDispose();
+        }
+    }
+
+    @Override
     void encodeV2NoCipher() throws IOException {
         isTalkingToV2 = true;
     }
@@ -361,6 +370,7 @@ final class SSLEngineOutputRecord extends OutputRecord implements SSLRecord {
         byte            majorVersion;
         byte            minorVersion;
         SSLWriteCipher  encodeCipher;
+        boolean         disposeCipher;
 
         byte[]          fragment;
     }
@@ -420,6 +430,15 @@ final class SSLEngineOutputRecord extends OutputRecord implements SSLRecord {
             memo.fragment[1] = description;
 
             handshakeMemos.add(memo);
+        }
+
+        void queueUpCipherDispose() {
+            RecordMemo lastMemo = handshakeMemos.getLast();
+            if (lastMemo != null) {
+                lastMemo.disposeCipher = true;
+            } else {
+                writeCipher.dispose();
+            }
         }
 
         Ciphertext acquireCiphertext(ByteBuffer dstBuf) throws IOException {
@@ -521,6 +540,9 @@ final class SSLEngineOutputRecord extends OutputRecord implements SSLRecord {
                     dstPos, dstLim, headerSize,
                     ProtocolVersion.valueOf(memo.majorVersion,
                             memo.minorVersion));
+            if (memo.disposeCipher) {
+                memo.encodeCipher.dispose();
+            }
 
             if (SSLLogger.isOn && SSLLogger.isOn("packet")) {
                 ByteBuffer temporary = dstBuf.duplicate();

--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketOutputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketOutputRecord.java
@@ -244,6 +244,11 @@ final class SSLSocketOutputRecord extends OutputRecord implements SSLRecord {
     }
 
     @Override
+    void disposeWriteCipher() {
+        writeCipher.dispose();
+    }
+
+    @Override
     public void flush() throws IOException {
         recordLock.lock();
         try {


### PR DESCRIPTION
The current code that changes cipher suites disposes the new suite instead of the old one, which usually silently fails. This patch fixes the code to dispose the old instance instead.

DTLS appears to be unaffected: DTLSOutputRecord keeps 2 ciphers and correctly [disposes the old one](https://github.com/openjdk/jdk/blob/739769c8fc4b496f08a92225a12d07414537b6c0/src/java.base/share/classes/sun/security/ssl/DTLSOutputRecord.java#L106), and DTLSInputRecord [doesn't dispose anything](https://github.com/openjdk/jdk/blob/4b9303b77b43d890ebacbec38b4ac5db7e171886/src/java.base/share/classes/sun/security/ssl/DTLSInputRecord.java#L57)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275811](https://bugs.openjdk.java.net/browse/JDK-8275811): Incorrect instance to dispose


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**) ⚠️ Review applies to 60c95ee301a41d69a8d3e9576bef3dd62604ee4e


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6084/head:pull/6084` \
`$ git checkout pull/6084`

Update a local copy of the PR: \
`$ git checkout pull/6084` \
`$ git pull https://git.openjdk.java.net/jdk pull/6084/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6084`

View PR using the GUI difftool: \
`$ git pr show -t 6084`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6084.diff">https://git.openjdk.java.net/jdk/pull/6084.diff</a>

</details>
