### PR TITLE
8273704: DrawStringWithInfiniteXform.java failed : drawString with InfiniteXform transform takes long time

### DIFF
--- a/test/jdk/java/awt/FontClass/DrawStringWithInfiniteXform.java
+++ b/test/jdk/java/awt/FontClass/DrawStringWithInfiniteXform.java
@@ -35,11 +35,12 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 public class DrawStringWithInfiniteXform {
-    Timer timer;
-    boolean done;
+
+    volatile Timer timer;
+    volatile boolean done;
+
     class ScheduleTask extends TimerTask {
         public void run() {
-            timer.cancel();
             if (!done) {
                 throw new
                 RuntimeException("drawString with InfiniteXform transform takes long time");
@@ -48,7 +49,7 @@ public class DrawStringWithInfiniteXform {
     }
     public DrawStringWithInfiniteXform() {
         timer = new Timer();
-        timer.schedule(new ScheduleTask(), 10000);
+        timer.schedule(new ScheduleTask(), 20000);
     }
 
     public static void main(String [] args) {
@@ -73,6 +74,7 @@ public class DrawStringWithInfiniteXform {
             g2d.drawString("abc", 20, 20);
         }
         done = true;
+        timer.cancel();
         System.out.println("Test passed");
     }
 }


### PR DESCRIPTION
This test has only failed once - for reasons that are not clear.
I wanted to just increase the timeout but the test was written such that it always waited as long
as the timeout since it had an un-canceled scheduled task.

So I've also made the test cancel the task once it is complete and made the variables volatile
so that they should be read properly by the other thread.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273704](https://bugs.openjdk.java.net/browse/JDK-8273704): DrawStringWithInfiniteXform.java failed : drawString with InfiniteXform transform takes long time


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6087/head:pull/6087` \
`$ git checkout pull/6087`

Update a local copy of the PR: \
`$ git checkout pull/6087` \
`$ git pull https://git.openjdk.java.net/jdk pull/6087/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6087`

View PR using the GUI difftool: \
`$ git pr show -t 6087`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6087.diff">https://git.openjdk.java.net/jdk/pull/6087.diff</a>

</details>
