### PR TITLE
8196440: Regression automated Test 'java/awt/TrayIcon/PopupMenuLeakTest/PopupMenuLeakTest.java' fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -221,7 +221,6 @@ java/awt/TrayIcon/TrayIconEvents/TrayIconEventsTest.java 8150540 windows-all
 java/awt/TrayIcon/TrayIconMouseTest/TrayIconMouseTest.java 8150540 windows-all
 java/awt/TrayIcon/TrayIconPopup/TrayIconPopupClickTest.java 8150540 windows-all,macosx-all
 java/awt/TrayIcon/TrayIconPopup/TrayIconPopupTest.java 8150540 windows-all
-java/awt/TrayIcon/PopupMenuLeakTest/PopupMenuLeakTest.java 8196440 linux-all
 
 java/awt/Window/ShapedAndTranslucentWindows/SetShapeAndClick.java 8197936 macosx-all
 java/awt/Window/ShapedAndTranslucentWindows/SetShapeDynamicallyAndClick.java 8013450 macosx-all

--- a/test/jdk/java/awt/TrayIcon/PopupMenuLeakTest/PopupMenuLeakTest.java
+++ b/test/jdk/java/awt/TrayIcon/PopupMenuLeakTest/PopupMenuLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,6 +54,10 @@ public class PopupMenuLeakTest {
     static final AtomicReference<WeakReference<PopupMenu>> popupWeakReference = new AtomicReference<>();
     static ExtendedRobot robot;
     public static void main(String[] args) throws Exception {
+        if (!SystemTray.isSupported()) {
+            System.out.println("SystemTray not supported. Skipping the test.");
+            return;
+        }
         robot = new ExtendedRobot();
         SwingUtilities.invokeAndWait(PopupMenuLeakTest::createSystemTrayIcon);
         sleep();


### PR DESCRIPTION
The test doesn't take into account that SystemTray may not be supported.
In case of Ubuntu this happens when `_NET_SYSTEM_TRAY` is not present.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8196440](https://bugs.openjdk.java.net/browse/JDK-8196440): Regression automated Test 'java/awt/TrayIcon/PopupMenuLeakTest/PopupMenuLeakTest.java' fails


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6088/head:pull/6088` \
`$ git checkout pull/6088`

Update a local copy of the PR: \
`$ git checkout pull/6088` \
`$ git pull https://git.openjdk.java.net/jdk pull/6088/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6088`

View PR using the GUI difftool: \
`$ git pr show -t 6088`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6088.diff">https://git.openjdk.java.net/jdk/pull/6088.diff</a>

</details>
