### PR TITLE
8158689: java.security.KeyPair should implement Destroyable

### DIFF
--- a/src/java.base/share/classes/java/security/KeyPair.java
+++ b/src/java.base/share/classes/java/security/KeyPair.java
@@ -25,7 +25,9 @@
 
 package java.security;
 
-import java.util.*;
+import javax.security.auth.DestroyFailedException;
+import javax.security.auth.Destroyable;
+import java.io.Serializable;
 
 /**
  * This class is a simple holder for a key pair (a public key and a
@@ -39,16 +41,16 @@ import java.util.*;
  * @since 1.1
  */
 
-public final class KeyPair implements java.io.Serializable {
+public final class KeyPair implements Serializable, Destroyable {
 
     @java.io.Serial
     private static final long serialVersionUID = -7565189502268009837L;
 
     /** The private key. */
-    private PrivateKey privateKey;
+    private final PrivateKey privateKey;
 
     /** The public key. */
-    private PublicKey publicKey;
+    private final PublicKey publicKey;
 
     /**
      * Constructs a key pair from the given public key and private key.
@@ -82,5 +84,34 @@ public final class KeyPair implements java.io.Serializable {
      */
     public PrivateKey getPrivate() {
         return privateKey;
+    }
+
+    /**
+     * Check if the private key has been destroyed.
+     *
+     * @return true is if the private key has been destroyed.
+     *
+     * @since 18
+     */
+    @Override
+    public boolean isDestroyed() {
+        return (privateKey == null || privateKey.isDestroyed());
+    }
+
+    /**
+     * Call to destroy the private key in this key pair. DestroyFailedException
+     * will be thrown if the private key object does not implement a destroy
+     * method.
+     *
+     * @throws DestroyFailedException if the destroy operation fails or there is
+     * no underlying destroy method.
+     *
+     * @since 18
+     */
+    @Override
+    public void destroy() throws DestroyFailedException {
+        if (privateKey != null) {
+            privateKey.destroy();
+        }
     }
 }


### PR DESCRIPTION
Hi,

I need a review of this change.  It makes KeyPair implement Destroyable and implements the methods to call the underlying privateKey.  It also sets the public and private key to 'final'.

The bug includes a CSR and Release Notes
CSR: https://bugs.openjdk.java.net/browse/JDK-8275823
RN: https://bugs.openjdk.java.net/browse/JDK-8275826

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8158689](https://bugs.openjdk.java.net/browse/JDK-8158689): java.security.KeyPair should implement Destroyable


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6089/head:pull/6089` \
`$ git checkout pull/6089`

Update a local copy of the PR: \
`$ git checkout pull/6089` \
`$ git pull https://git.openjdk.java.net/jdk pull/6089/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6089`

View PR using the GUI difftool: \
`$ git pr show -t 6089`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6089.diff">https://git.openjdk.java.net/jdk/pull/6089.diff</a>

</details>
