### PR TITLE
8275840: Add test to java/nio/channels/Channels/TransferTo.java to test transfer sizes > 2GB

### DIFF
--- a/test/jdk/java/nio/channels/Channels/TransferTo.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo.java
@@ -143,9 +143,11 @@ public class TransferTo {
             Files.write(sourceFile, createRandomBytes(1024 * 1024, 0), StandardOpenOption.APPEND);
 
         // performing actual transfer, effectively by multiple invocations of Filechannel.transferTo(FileChannel)
-        InputStream inputStream = Channels.newInputStream(FileChannel.open(sourceFile));
-        OutputStream outputStream = Channels.newOutputStream(FileChannel.open(targetFile, StandardOpenOption.WRITE));
-        long count = inputStream.transferTo(outputStream);
+        long count;
+        try (InputStream inputStream = Channels.newInputStream(FileChannel.open(sourceFile));
+        OutputStream outputStream = Channels.newOutputStream(FileChannel.open(targetFile, StandardOpenOption.WRITE))) {
+            count = inputStream.transferTo(outputStream);
+        }
 
         // comparing reported transferred bytes, must be 3 GB
         assertEquals(count, 3L * 1024 * 1024 * 1024);

--- a/test/jdk/java/nio/channels/Channels/TransferTo.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo.java
@@ -149,7 +149,8 @@ public class TransferTo {
         // performing actual transfer, effectively by multiple invocations of Filechannel.transferTo(FileChannel)
         long count;
         try (InputStream inputStream = Channels.newInputStream(FileChannel.open(sourceFile));
-        OutputStream outputStream = Channels.newOutputStream(FileChannel.open(targetFile, StandardOpenOption.WRITE))) {
+                OutputStream outputStream = Channels
+                        .newOutputStream(FileChannel.open(targetFile, StandardOpenOption.WRITE))) {
             count = inputStream.transferTo(outputStream);
         }
 

--- a/test/jdk/java/nio/channels/Channels/TransferTo.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo.java
@@ -64,6 +64,10 @@ public class TransferTo {
 
     private static final int ITERATIONS = 10;
 
+    private static final int NUM_WRITES = 3 * 1024;
+    private static final int BYTES_PER_WRITE = 1024 * 1024;
+    private static final long BYTES_WRITTEN = (long) NUM_WRITES * BYTES_PER_WRITE;
+
     private static final Random RND = RandomFactory.getRandom();
 
     /*
@@ -139,8 +143,6 @@ public class TransferTo {
         Path targetFile = Files.createTempFile(null, null);
 
         // writing 3 GB of random bytes into source file
-        int NUM_WRITES = 3 * 1024;
-        int BYTES_PER_WRITE = 1024 * 1024;
         for (int i = 0; i < NUM_WRITES; i++)
             Files.write(sourceFile, createRandomBytes(BYTES_PER_WRITE, 0), StandardOpenOption.APPEND);
 
@@ -152,7 +154,7 @@ public class TransferTo {
         }
 
         // comparing reported transferred bytes, must be 3 GB
-        assertEquals(count, (long) NUM_WRITES * BYTES_PER_WRITE);
+        assertEquals(count, BYTES_WRITTEN);
 
         // comparing content of both files, failing in case of any difference
         assertEquals(Files.mismatch(sourceFile, targetFile), -1);

--- a/test/jdk/java/nio/channels/Channels/TransferTo.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo.java
@@ -139,8 +139,10 @@ public class TransferTo {
         Path targetFile = Files.createTempFile(null, null);
 
         // writing 3 GB of random bytes into source file
-        for (int i = 0; i < 3 * 1024; i++)
-            Files.write(sourceFile, createRandomBytes(1024 * 1024, 0), StandardOpenOption.APPEND);
+        int NUM_WRITES = 3 * 1024;
+        int BYTES_PER_WRITE = 1024 * 1024;
+        for (int i = 0; i < NUM_WRITES; i++)
+            Files.write(sourceFile, createRandomBytes(BYTES_PER_WRITE, 0), StandardOpenOption.APPEND);
 
         // performing actual transfer, effectively by multiple invocations of Filechannel.transferTo(FileChannel)
         long count;
@@ -150,7 +152,7 @@ public class TransferTo {
         }
 
         // comparing reported transferred bytes, must be 3 GB
-        assertEquals(count, 3L * 1024 * 1024 * 1024);
+        assertEquals(count, (long) NUM_WRITES * BYTES_PER_WRITE);
 
         // comparing content of both files, failing in case of any difference
         assertEquals(Files.mismatch(sourceFile, targetFile), -1);


### PR DESCRIPTION
Testing `FileChannel.transferTo(FileChannel)` with more than 2 GB of data is covering the case that *multiple* iterations of `FileChannel.transferTo(FileChannel)` are actually performed by the test.

This change was requested Alan Bateman @AlanBateman.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275840](https://bugs.openjdk.java.net/browse/JDK-8275840): Add test to java/nio/channels/Channels/TransferTo.java to test transfer sizes > 2GB


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6093/head:pull/6093` \
`$ git checkout pull/6093`

Update a local copy of the PR: \
`$ git checkout pull/6093` \
`$ git pull https://git.openjdk.java.net/jdk pull/6093/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6093`

View PR using the GUI difftool: \
`$ git pr show -t 6093`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6093.diff">https://git.openjdk.java.net/jdk/pull/6093.diff</a>

</details>
