### PR TITLE
JDK-8276939: Fix AbstractLdapNamingEnumeration next to throw NoSuchElementException instead of NullPointerException

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/AbstractLdapNamingEnumeration.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/AbstractLdapNamingEnumeration.java
@@ -199,6 +199,9 @@ abstract class AbstractLdapNamingEnumeration<T extends NameClassPair>
         if (!hasMoreCalled) {
             hasMore();
         }
+        if (!more) {
+            throw new NoSuchElementException();
+        }
         hasMoreCalled = false;
         return nextImpl();
     }


### PR DESCRIPTION
`AbstractLdapNamingEnumeration` `next` throws `NullPointerException` instead of `NoSuchElementException`, however the javadoc for `NamingEnumeration` says that next should throw `NoSuchElementException` when no elements are available (https://docs.oracle.com/en/java/javase/17/docs/api/java.naming/javax/naming/NamingEnumeration.html#next())

The bug is basically that `next()` calls `hasMore()` -> `hasMoreImpl()` which calls `cleanup()` when there are no more elements.  `cleanup()` sets `homeCtx = null;` which causes NullPointerException to be thrown on this line in `getNextBatch()`: `res = homeCtx.getSearchReply(enumClnt, res);`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8276939](https://bugs.openjdk.java.net/browse/JDK-8276939): Fix AbstractLdapNamingEnumeration next to throw NoSuchElementException instead of NullPointerException


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6095/head:pull/6095` \
`$ git checkout pull/6095`

Update a local copy of the PR: \
`$ git checkout pull/6095` \
`$ git pull https://git.openjdk.java.net/jdk pull/6095/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6095`

View PR using the GUI difftool: \
`$ git pr show -t 6095`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6095.diff">https://git.openjdk.java.net/jdk/pull/6095.diff</a>

</details>
