### PR TITLE
8273585: String.charAt performance degrades due to JDK-8268698

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -3177,20 +3177,12 @@ void PhaseIdealLoop::replace_parallel_iv(IdealLoopTree *loop) {
     // Look for induction variables of the form:  X += constant
     if (phi2->region() != loop->_head ||
         incr2->req() != 3 ||
+        incr2->in(1)->uncast() != phi2 ||
         incr2 == incr ||
         incr2->Opcode() != Op_AddI ||
         !incr2->in(2)->is_Con())
       continue;
-    if (incr2->in(1) != phi2) {
-      // incr2 maybe a CastII node whose input is phi2, this could also
-      // be recognized as parallel induction variable.
-      // ---->CountedLoop---->Phi<------------\
-      //                       \               \
-      //                        ---->CastII---->Add
-      if (!incr2->in(1)->is_CastII() || incr2->in(1)->as_CastII()->in(1) != phi2) {
-        continue;
-      }
-    }
+
     // Check for parallel induction variable (parallel to trip counter)
     // via an affine function.  In particular, count-down loops with
     // count-up array indices are common. We only RCE references off


### PR DESCRIPTION
String.charAt shows significant performance regression due to [JDK-8268698](https://bugs.openjdk.java.net/browse/JDK-8268698), which replaces index bound checking with Preconditions.checkIndex intrinsic method.

The result of "time linux-x86_64-server-release/images/jdk/bin/java Test":

```
Before JDK-8268698
    real 0m8.369s
    user 0m8.386s
    sys 0m0.019s

After JDK-8268698,
    real 0m19.722s
    user 0m19.748s
    sys 0m0.013s
```

The reason is Preconditions.checkIndex generates a CastII for index node as index is now known to be >= 0 and < length.:

https://github.com/openjdk/jdk/blob/5dab76b939e381312ce5c89b9aebca628238a387/src/hotspot/share/opto/library_call.cpp#L1077-L1083

CastII can not be recognized as a parallel induction variable because AddNode's input must be the PhiNode:

https://github.com/openjdk/jdk/blob/5dab76b939e381312ce5c89b9aebca628238a387/src/hotspot/share/opto/loopnode.cpp#L3177-L3184

It seems this prevents further loop unrolling. I think we can relax this constraint, i.e CastII can be the input of AddNode if its input is PhiNode. After applying this patch, performance regression disappears:

```
$time ./test.sh 

real    0m9.514s
user    0m10.310s
sys     0m0.155s
```
This is likely the reason for [JDK-8272493](https://bugs.openjdk.java.net/browse/JDK-8272493). Please help review it. Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273585](https://bugs.openjdk.java.net/browse/JDK-8273585): String.charAt performance degrades due to JDK-8268698


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6096/head:pull/6096` \
`$ git checkout pull/6096`

Update a local copy of the PR: \
`$ git checkout pull/6096` \
`$ git pull https://git.openjdk.java.net/jdk pull/6096/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6096`

View PR using the GUI difftool: \
`$ git pr show -t 6096`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6096.diff">https://git.openjdk.java.net/jdk/pull/6096.diff</a>

</details>
