### PR TITLE
JDK-8275856: Remove MetaspaceHandleDeallocations debug switch

### DIFF
--- a/src/hotspot/share/memory/metaspace/metaspaceSettings.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceSettings.cpp
@@ -43,7 +43,6 @@ bool Settings::_new_chunks_are_fully_committed = false;
 bool Settings::_uncommit_free_chunks = false;
 
 DEBUG_ONLY(bool Settings::_use_allocation_guard = false;)
-DEBUG_ONLY(bool Settings::_handle_deallocations = true;)
 
 void Settings::ergo_initialize() {
   if (strcmp(MetaspaceReclaimPolicy, "none") == 0) {
@@ -76,15 +75,9 @@ void Settings::ergo_initialize() {
   assert(commit_granule_words() <= chunklevel::MAX_CHUNK_WORD_SIZE, "Too large granule size");
   assert(is_power_of_2(commit_granule_words()), "granule size must be a power of 2");
 
-#ifdef ASSERT
-  // Off for release builds, and by default for debug builds, but can be switched on manually to aid
-  // error analysis.
-  _use_allocation_guard = MetaspaceGuardAllocations;
+  // Off for release builds, off by default - but switchable - for debug builds.
+  DEBUG_ONLY(_use_allocation_guard = MetaspaceGuardAllocations;)
 
-  // Deallocations can be manually switched off to aid error analysis, since this removes one layer of complexity
-  //  from allocation.
-  _handle_deallocations = MetaspaceHandleDeallocations;
-#endif
   LogStream ls(Log(metaspace)::info());
   Settings::print_on(&ls);
 }
@@ -97,7 +90,6 @@ void Settings::print_on(outputStream* st) {
   st->print_cr(" - new_chunks_are_fully_committed: %d.", (int)new_chunks_are_fully_committed());
   st->print_cr(" - uncommit_free_chunks: %d.", (int)uncommit_free_chunks());
   st->print_cr(" - use_allocation_guard: %d.", (int)use_allocation_guard());
-  st->print_cr(" - handle_deallocations: %d.", (int)handle_deallocations());
 }
 
 } // namespace metaspace

--- a/src/hotspot/share/memory/metaspace/metaspaceSettings.hpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceSettings.hpp
@@ -69,14 +69,6 @@ class Settings : public AllStatic {
   // If true, metablock allocations are guarded and periodically checked.
   DEBUG_ONLY(static bool _use_allocation_guard;)
 
-  // This enables or disables premature deallocation of metaspace allocated blocks. Using
-  //  Metaspace::deallocate(), blocks can be returned prematurely (before the associated
-  //  Arena dies, e.g. after class unloading) and can be reused by the arena.
-  //  If disabled, those blocks will not be reused until the Arena dies.
-  // Note that premature deallocation is rare under normal circumstances.
-  // By default deallocation handling is enabled.
-  DEBUG_ONLY(static bool _handle_deallocations;)
-
 public:
 
   static size_t commit_granule_bytes()                        { return _commit_granule_bytes; }
@@ -87,7 +79,6 @@ public:
   static bool enlarge_chunks_in_place()                       { return _enlarge_chunks_in_place; }
   static bool uncommit_free_chunks()                          { return _uncommit_free_chunks; }
   static bool use_allocation_guard()                          { return DEBUG_ONLY(_use_allocation_guard) NOT_DEBUG(false); }
-  static bool handle_deallocations()                          { return DEBUG_ONLY(_handle_deallocations) NOT_DEBUG(true); }
 
   static void ergo_initialize();
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1439,9 +1439,6 @@ const intx ObjectAlignmentInBytes = 8;
   develop(bool, MetaspaceGuardAllocations, false,                           \
           "Metapace allocations are guarded.")                              \
                                                                             \
-  develop(bool, MetaspaceHandleDeallocations, true,                         \
-          "Switch off Metapace deallocation handling.")                     \
-                                                                            \
   product(uintx, MinHeapFreeRatio, 40, MANAGEABLE,                          \
           "The minimum percentage of heap free after GC to avoid expansion."\
           " For most GCs this applies to the old generation. In G1 and"     \

--- a/test/hotspot/gtest/metaspace/test_metaspacearena.cpp
+++ b/test/hotspot/gtest/metaspace/test_metaspacearena.cpp
@@ -744,38 +744,36 @@ TEST_VM(metaspace, MetaspaceArena_growth_boot_nc_not_inplace) {
 //  do not increase metaspace usage after the initial allocation (the deallocated
 //  block should be reused by the next allocation).
 static void test_repeatedly_allocate_and_deallocate(bool is_topmost) {
-  if (Settings::handle_deallocations()) {
-    // Test various sizes, including (important) the max. possible block size = 1 root chunk
-    for (size_t blocksize = Metaspace::max_allocation_word_size(); blocksize >= 1; blocksize /= 2) {
-      size_t used1 = 0, used2 = 0, committed1 = 0, committed2 = 0;
-      MetaWord* p = NULL, *p2 = NULL;
+  // Test various sizes, including (important) the max. possible block size = 1 root chunk
+  for (size_t blocksize = Metaspace::max_allocation_word_size(); blocksize >= 1; blocksize /= 2) {
+    size_t used1 = 0, used2 = 0, committed1 = 0, committed2 = 0;
+    MetaWord* p = NULL, *p2 = NULL;
 
-      MetaspaceGtestContext context;
-      MetaspaceArenaTestHelper helper(context, Metaspace::StandardMetaspaceType, false);
+    MetaspaceGtestContext context;
+    MetaspaceArenaTestHelper helper(context, Metaspace::StandardMetaspaceType, false);
 
-      // First allocation
-      helper.allocate_from_arena_with_tests_expect_success(&p, blocksize);
-      if (!is_topmost) {
-        // another one on top, size does not matter.
-        helper.allocate_from_arena_with_tests_expect_success(0x10);
-      }
-
-      // Measure
-      helper.usage_numbers_with_test(&used1, &committed1, NULL);
-
-      // Dealloc, alloc several times with the same size.
-      for (int i = 0; i < 5; i ++) {
-        helper.deallocate_with_tests(p, blocksize);
-        helper.allocate_from_arena_with_tests_expect_success(&p2, blocksize);
-        // We should get the same pointer back.
-        EXPECT_EQ(p2, p);
-      }
-
-      // Measure again
-      helper.usage_numbers_with_test(&used2, &committed2, NULL);
-      EXPECT_EQ(used2, used1);
-      EXPECT_EQ(committed1, committed2);
+    // First allocation
+    helper.allocate_from_arena_with_tests_expect_success(&p, blocksize);
+    if (!is_topmost) {
+      // another one on top, size does not matter.
+      helper.allocate_from_arena_with_tests_expect_success(0x10);
     }
+
+    // Measure
+    helper.usage_numbers_with_test(&used1, &committed1, NULL);
+
+    // Dealloc, alloc several times with the same size.
+    for (int i = 0; i < 5; i ++) {
+      helper.deallocate_with_tests(p, blocksize);
+      helper.allocate_from_arena_with_tests_expect_success(&p2, blocksize);
+      // We should get the same pointer back.
+      EXPECT_EQ(p2, p);
+    }
+
+    // Measure again
+    helper.usage_numbers_with_test(&used2, &committed2, NULL);
+    EXPECT_EQ(used2, used1);
+    EXPECT_EQ(committed1, committed2);
   }
 }
 


### PR DESCRIPTION
`MetaspaceHandleDeallocations` can be used to switch off deallocation handling (which takes care of reusing prematurely deallocated metaspace blocks in case of e.g. class redefinitions or class loading errors). Technically this is a leak then, the intent was to switch off the deallocation handling for error analysis. 

It had been very rarely used, only in the first stages of JEP 387, and it is not covered by tests. I propose to remove it to reduce code complexity.

Tests: GHAs, manual tests (note that we have regression tests in place for deallocation handling), SAP nightlies

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275856](https://bugs.openjdk.java.net/browse/JDK-8275856): Remove MetaspaceHandleDeallocations debug switch


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6098/head:pull/6098` \
`$ git checkout pull/6098`

Update a local copy of the PR: \
`$ git checkout pull/6098` \
`$ git pull https://git.openjdk.java.net/jdk pull/6098/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6098`

View PR using the GUI difftool: \
`$ git pr show -t 6098`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6098.diff">https://git.openjdk.java.net/jdk/pull/6098.diff</a>

</details>
