### PR TITLE
8276162: Optimise unsigned comparison pattern

### DIFF
--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -1531,36 +1531,34 @@ Node *BoolNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     }
   }
 
-  // Change x + Integer.MIN_VALUE <=> y + Integer.MIN_VALUE into x u<=> y
-  // and x + Integer.MIN_VALUE <=> c into x u<=> c + Integer.MIN_VALUE
+  // Change "CmpI (AddI X min_jint) (AddI Y min_jint)" into "CmpU X Y"
+  // and    "CmpI (AddI X min_jint) C" into "CmpU X (C + min_jint)"
   if (cop == Op_CmpI &&
-      (_test.is_less() || _test.is_greater()) &&
       cmp1_op == Op_AddI &&
       phase->type(cmp1->in(2)) == TypeInt::MIN) {
     if (cmp2_op == Op_ConI) {
-      Node *ncmp2 = phase->intcon(java_add(cmp2->get_int(), min_jint));
-      Node *ncmp = phase->transform(new CmpUNode(cmp1->in(1), ncmp2));
+      Node* ncmp2 = phase->intcon(java_add(cmp2->get_int(), min_jint));
+      Node* ncmp = phase->transform(new CmpUNode(cmp1->in(1), ncmp2));
       return new BoolNode(ncmp, _test._test);
     } else if (cmp2_op == Op_AddI &&
                phase->type(cmp2->in(2)) == TypeInt::MIN) {
-      Node *ncmp = phase->transform(new CmpUNode(cmp1->in(1), cmp2->in(1)));
+      Node* ncmp = phase->transform(new CmpUNode(cmp1->in(1), cmp2->in(1)));
       return new BoolNode(ncmp, _test._test);
     }
   }
 
-  // Change x + Long.MIN_VALUE <=> y + Long.MIN_VALUE into x u<=> y
-  // and x + Long.MIN_VALUE <=> c into x u<=> c + Long.MIN_VALUE
+  // Change "CmpL (AddL X min_jlong) (AddL Y min_jlong)" into "CmpUL X Y"
+  // and    "CmpL (AddL X min_jlong) C" into "CmpUL X (C + min_jlong)"
   if (cop == Op_CmpL &&
-      (_test.is_less() || _test.is_greater()) &&
       cmp1_op == Op_AddL &&
       phase->type(cmp1->in(2)) == TypeLong::MIN) {
     if (cmp2_op == Op_ConL) {
-      Node *ncmp2 = phase->longcon(java_add(cmp2->get_long(), min_jlong));
-      Node *ncmp = phase->transform(new CmpULNode(cmp1->in(1), ncmp2));
+      Node* ncmp2 = phase->longcon(java_add(cmp2->get_long(), min_jlong));
+      Node* ncmp = phase->transform(new CmpULNode(cmp1->in(1), ncmp2));
       return new BoolNode(ncmp, _test._test);
     } else if (cmp2_op == Op_AddL &&
                phase->type(cmp2->in(2)) == TypeLong::MIN) {
-      Node *ncmp = phase->transform(new CmpULNode(cmp1->in(1), cmp2->in(1)));
+      Node* ncmp = phase->transform(new CmpULNode(cmp1->in(1), cmp2->in(1)));
       return new BoolNode(ncmp, _test._test);
     }
   }

--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -1529,11 +1529,46 @@ Node *BoolNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     }
   }
 
+  const int cmp1_op = cmp1->Opcode();
+  const int cmp2_op = cmp2->Opcode();
+
+  // Change x +- Integer.MIN_VALUE <=> y +- Integer.MIN_VALUE into x u<=> y
+  if ((_test._test == BoolTest::lt || _test._test == BoolTest::le ||
+        _test._test == BoolTest::gt || _test._test == BoolTest::ge) &&
+      cop == Op_CmpI &&
+      (cmp1_op == Op_AddI || cmp1_op == Op_SubI) &&
+      phase->type(cmp1->in(2)) == TypeInt::MIN) {
+    if (cmp2_op == Op_ConI) {
+      Node *ncmp2 = phase->intcon(java_add(cmp2->get_int(), min_jint));
+      Node *ncmp = phase->transform(new CmpUNode(cmp1->in(1), ncmp2));
+      return new BoolNode(ncmp, _test._test);
+    } else if ((cmp2_op == Op_AddI || cmp2_op == Op_SubI) &&
+        phase->type(cmp2->in(2)) == TypeInt::MIN) {
+      Node *ncmp = phase->transform(new CmpUNode(cmp1->in(1), cmp2->in(1)));
+      return new BoolNode(ncmp, _test._test);
+    }
+  }
+
+  // Change x +- Long.MIN_VALUE <=> y +- Long.MIN_VALUE into x u<=> y
+  if ((_test._test == BoolTest::lt || _test._test == BoolTest::le ||
+        _test._test == BoolTest::gt || _test._test == BoolTest::ge) &&
+      cop == Op_CmpL &&
+      (cmp1_op == Op_AddL || cmp1_op == Op_SubL) &&
+      phase->type(cmp1->in(2)) == TypeLong::MIN) {
+    if (cmp2_op == Op_ConL) {
+      Node *ncmp2 = phase->longcon(java_add(cmp2->get_long(), min_jlong));
+      Node *ncmp = phase->transform(new CmpULNode(cmp1->in(1), ncmp2));
+      return new BoolNode(ncmp, _test._test);
+    } else if ((cmp2_op == Op_AddL || cmp2_op == Op_SubL) &&
+        phase->type(cmp2->in(2)) == TypeLong::MIN) {
+      Node *ncmp = phase->transform(new CmpULNode(cmp1->in(1), cmp2->in(1)));
+      return new BoolNode(ncmp, _test._test);
+    }
+  }
+
   // Change "bool eq/ne (cmp (xor X 1) 0)" into "bool ne/eq (cmp X 0)".
   // The XOR-1 is an idiom used to flip the sense of a bool.  We flip the
   // test instead.
-  int cmp1_op = cmp1->Opcode();
-  int cmp2_op = cmp2->Opcode();
   const TypeInt* cmp2_type = phase->type(cmp2)->isa_int();
   if (cmp2_type == NULL)  return NULL;
   Node* j_xor = cmp1;
@@ -1699,23 +1734,6 @@ Node *BoolNode::Ideal(PhaseGVN *phase, bool can_reshape) {
       phase->type( cmp1->in(2) )->higher_equal(TypeInt::SYMINT) ) {
     Node *ncmp = phase->transform( new CmpINode(cmp1->in(2),cmp2));
     return new BoolNode( ncmp, _test.commute() );
-  }
-
-  // Change x +- Integer.MIN_VALUE <=> y +- Integer.MIN_VALUE into x u<=> y
-  if ((_test._test == BoolTest::lt || _test._test == BoolTest::le ||
-        _test._test == BoolTest::gt || _test._test == BoolTest::ge) &&
-      cop == Op_CmpI &&
-      (cmp1_op == Op_AddI || cmp1_op == Op_SubI) &&
-      phase->type(cmp1->in(2)) == TypeInt::MIN) {
-    if (cmp2->is_Con()) {
-      Node *ncmp2 = phase->intcon(java_add(cmp2->get_int(), min_jint));
-      Node *ncmp = phase->transform(new CmpUNode(cmp1->in(1), ncmp2));
-      return new BoolNode(ncmp, _test._test);
-    } else if ((cmp2_op == Op_AddI || cmp2_op == Op_SubI) &&
-        phase->type(cmp2->in(2)) == TypeInt::MIN) {
-      Node *ncmp = phase->transform(new CmpUNode(cmp1->in(1), cmp2->in(1)));
-      return new BoolNode(ncmp, _test._test);
-    }
   }
 
   // Try to optimize signed integer comparison

--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -1708,7 +1708,7 @@ Node *BoolNode::Ideal(PhaseGVN *phase, bool can_reshape) {
       (cmp1_op == Op_AddI || cmp1_op == Op_SubI) &&
       phase->type(cmp1->in(2)) == TypeInt::MIN) {
     if (cmp2->is_Con()) {
-      Node *ncmp2 = phase->intcon(java_add(cmp2->get_int(), TypeInt::MIN->get_con()));
+      Node *ncmp2 = phase->intcon(java_add(cmp2->get_int(), min_jint));
       Node *ncmp = phase->transform(new CmpUNode(cmp1->in(1), ncmp2));
       return new BoolNode(ncmp, _test._test);
     } else if ((cmp2_op == Op_AddI || cmp2_op == Op_SubI) &&

--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -1718,23 +1718,6 @@ Node *BoolNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     }
   }
 
-  // Change x +- Long.MIN_VALUE <=> y +- Long.MIN_VALUE into x u<=> y
-  if ((_test._test == BoolTest::lt || _test._test == BoolTest::le ||
-        _test._test == BoolTest::gt || _test._test == BoolTest::ge) &&
-      cop == Op_CmpL &&
-      (cmp1_op == Op_AddL || cmp1_op == Op_SubL) &&
-      phase->type(cmp1->in(2)) == TypeLong::MIN) {
-    if (cmp2->is_Con()) {
-      Node *ncmp2 = phase->longcon(java_add(cmp2->get_long(), TypeLong::MIN->get_con()));
-      Node *ncmp = phase->transform(new CmpULNode(cmp1->in(1), ncmp2));
-      return new BoolNode(ncmp, _test._test);
-    } else if ((cmp2_op == Op_AddL || cmp2_op == Op_SubL) &&
-        phase->type(cmp2->in(2)) == TypeLong::MIN) {
-      Node *ncmp = phase->transform(new CmpULNode(cmp1->in(1), cmp2->in(1)));
-      return new BoolNode(ncmp, _test._test);
-    }
-  }
-
   // Try to optimize signed integer comparison
   return fold_cmpI(phase, cmp->as_Sub(), cmp1, cop, cmp1_op, cmp2_type);
 

--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -1506,7 +1506,7 @@ Node *BoolNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   // Change "bool eq/ne (cmp (and X 16) 16)" into "bool ne/eq (cmp (and X 16) 0)".
   if (cop == Op_CmpI &&
       (_test._test == BoolTest::eq || _test._test == BoolTest::ne) &&
-      cmp1->Opcode() == Op_AndI && cmp2->Opcode() == Op_ConI &&
+      cmp1_op == Op_AndI && cmp2_op == Op_ConI &&
       cmp1->in(2)->Opcode() == Op_ConI) {
     const TypeInt *t12 = phase->type(cmp2)->isa_int();
     const TypeInt *t112 = phase->type(cmp1->in(2))->isa_int();
@@ -1520,7 +1520,7 @@ Node *BoolNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   // Same for long type: change "bool eq/ne (cmp (and X 16) 16)" into "bool ne/eq (cmp (and X 16) 0)".
   if (cop == Op_CmpL &&
       (_test._test == BoolTest::eq || _test._test == BoolTest::ne) &&
-      cmp1->Opcode() == Op_AndL && cmp2->Opcode() == Op_ConL &&
+      cmp1_op == Op_AndL && cmp2_op == Op_ConL &&
       cmp1->in(2)->Opcode() == Op_ConL) {
     const TypeLong *t12 = phase->type(cmp2)->isa_long();
     const TypeLong *t112 = phase->type(cmp1->in(2))->isa_long();

--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -1531,8 +1531,8 @@ Node *BoolNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     }
   }
 
-  // Change "CmpI (AddI X min_jint) (AddI Y min_jint)" into "CmpU X Y"
-  // and    "CmpI (AddI X min_jint) C" into "CmpU X (C + min_jint)"
+  // Change "cmp (add X min_jint) (add Y min_jint)" into "cmpu X Y"
+  // and    "cmp (add X min_jint) c" into "cmpu X (c + min_jint)"
   if (cop == Op_CmpI &&
       cmp1_op == Op_AddI &&
       phase->type(cmp1->in(2)) == TypeInt::MIN) {
@@ -1547,8 +1547,8 @@ Node *BoolNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     }
   }
 
-  // Change "CmpL (AddL X min_jlong) (AddL Y min_jlong)" into "CmpUL X Y"
-  // and    "CmpL (AddL X min_jlong) C" into "CmpUL X (C + min_jlong)"
+  // Change "cmp (add X min_jlong) (add Y min_jlong)" into "cmpu X Y"
+  // and    "cmp (add X min_jlong) c" into "cmpu X (c + min_jlong)"
   if (cop == Op_CmpL &&
       cmp1_op == Op_AddL &&
       phase->type(cmp1->in(2)) == TypeLong::MIN) {

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestUnsignedComparison.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestUnsignedComparison.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests;
+
+import jdk.test.lib.Asserts;
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8276162
+ * @summary Test that unsigned comparison transformation works as intended.
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.TestUnsignedComparison
+ */
+public class TestUnsignedComparison {
+    private static final String CMP_REGEX = "(\\d+(\\s){2}(" + "Cmp(I|L)" + ".*)+(\\s){2}===.*)";
+    private static final String CMPU_REGEX = "(\\d+(\\s){2}(" + "Cmp(U|UL)" + ".*)+(\\s){2}===.*)";
+    private static final String ADD_REGEX = "(\\d+(\\s){2}(" + "Add(I|L)" + ".*)+(\\s){2}===.*)";
+
+    private static final int[] INT_DATA = {
+        0,
+        1,
+        2,
+        3,
+        0x8000_0000,
+        0x8000_0001,
+        0x8000_0002,
+        0x8000_0003,
+        0xFFFF_FFFE,
+        0xFFFF_FFFF,
+    };
+
+    private static final long[] LONG_DATA = {
+        0L,
+        1L,
+        2L,
+        3L,
+        0x00000000_80000000L,
+        0x00000000_FFFFFFFFL,
+        0x00000001_00000000L,
+        0x80000000_00000000L,
+        0x80000000_00000001L,
+        0x80000000_00000002L,
+        0x80000000_00000003L,
+        0x80000000_80000000L,
+        0xFFFFFFFF_FFFFFFFEL,
+        0xFFFFFFFF_FFFFFFFFL,
+    };
+
+    public static void main(String[] args) {
+        TestFramework framework = new TestFramework();
+        framework.start();
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testIntEQ(int x, int y) {
+        return x + Integer.MIN_VALUE == y + Integer.MIN_VALUE;
+    }
+
+    @Run(test = "testIntEQ")
+    public void checkTestIntEQ() {
+        for (int i = 0; i < INT_DATA.length; i++) {
+            for (int j = 0; j < INT_DATA.length; j++) {
+                Asserts.assertEquals(testIntEQ(INT_DATA[i], INT_DATA[j]),
+                                     i == j);
+            }
+        }
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testIntNE(int x, int y) {
+        return x + Integer.MIN_VALUE != y + Integer.MIN_VALUE;
+    }
+
+    @Run(test = "testIntNE")
+    public void checkTestIntNE() {
+        for (int i = 0; i < INT_DATA.length; i++) {
+            for (int j = 0; j < INT_DATA.length; j++) {
+                Asserts.assertEquals(testIntNE(INT_DATA[i], INT_DATA[j]),
+                                     i != j);
+            }
+        }
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testIntLT(int x, int y) {
+        return x + Integer.MIN_VALUE < y + Integer.MIN_VALUE;
+    }
+
+    @Run(test = "testIntLT")
+    public void checkTestIntLT() {
+        for (int i = 0; i < INT_DATA.length; i++) {
+            for (int j = 0; j < INT_DATA.length; j++) {
+                Asserts.assertEquals(testIntLT(INT_DATA[i], INT_DATA[j]),
+                                     i < j);
+            }
+        }
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testIntLE(int x, int y) {
+        return x + Integer.MIN_VALUE <= y + Integer.MIN_VALUE;
+    }
+
+    @Run(test = "testIntLE")
+    public void checkTestIntLE() {
+        for (int i = 0; i < INT_DATA.length; i++) {
+            for (int j = 0; j < INT_DATA.length; j++) {
+                Asserts.assertEquals(testIntLE(INT_DATA[i], INT_DATA[j]),
+                                     i <= j);
+            }
+        }
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testIntGT(int x, int y) {
+        return x + Integer.MIN_VALUE > y + Integer.MIN_VALUE;
+    }
+
+    @Run(test = "testIntGT")
+    public void checkTestIntGT() {
+        for (int i = 0; i < INT_DATA.length; i++) {
+            for (int j = 0; j < INT_DATA.length; j++) {
+                Asserts.assertEquals(testIntGT(INT_DATA[i], INT_DATA[j]),
+                                     i > j);
+            }
+        }
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testIntGE(int x, int y) {
+        return x + Integer.MIN_VALUE >= y + Integer.MIN_VALUE;
+    }
+
+    @Run(test = "testIntGE")
+    public void checkTestIntGE() {
+        for (int i = 0; i < INT_DATA.length; i++) {
+            for (int j = 0; j < INT_DATA.length; j++) {
+                Asserts.assertEquals(testIntGE(INT_DATA[i], INT_DATA[j]),
+                                     i >= j);
+            }
+        }
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testLongEQ(long x, long y) {
+        return x + Long.MIN_VALUE == y + Long.MIN_VALUE;
+    }
+
+    @Run(test = "testLongEQ")
+    public void checkTestLongEQ() {
+        for (int i = 0; i < LONG_DATA.length; i++) {
+            for (int j = 0; j < LONG_DATA.length; j++) {
+                Asserts.assertEquals(testLongEQ(LONG_DATA[i], LONG_DATA[j]),
+                                     i == j);
+            }
+        }
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testLongNE(long x, long y) {
+        return x + Long.MIN_VALUE != y + Long.MIN_VALUE;
+    }
+
+    @Run(test = "testLongNE")
+    public void checkTestLongNE() {
+        for (int i = 0; i < LONG_DATA.length; i++) {
+            for (int j = 0; j < LONG_DATA.length; j++) {
+                Asserts.assertEquals(testLongNE(LONG_DATA[i], LONG_DATA[j]),
+                                     i != j);
+            }
+        }
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testLongLT(long x, long y) {
+        return x + Long.MIN_VALUE < y + Long.MIN_VALUE;
+    }
+
+    @Run(test = "testLongLT")
+    public void checkTestLongLT() {
+        for (int i = 0; i < LONG_DATA.length; i++) {
+            for (int j = 0; j < LONG_DATA.length; j++) {
+                Asserts.assertEquals(testLongLT(LONG_DATA[i], LONG_DATA[j]),
+                                     i < j);
+            }
+        }
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testLongLE(long x, long y) {
+        return x + Long.MIN_VALUE <= y + Long.MIN_VALUE;
+    }
+
+    @Run(test = "testLongLE")
+    public void checkTestLongLE() {
+        for (int i = 0; i < LONG_DATA.length; i++) {
+            for (int j = 0; j < LONG_DATA.length; j++) {
+                Asserts.assertEquals(testLongLE(LONG_DATA[i], LONG_DATA[j]),
+                                     i <= j);
+            }
+        }
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testLongGT(long x, long y) {
+        return x + Long.MIN_VALUE > y + Long.MIN_VALUE;
+    }
+
+    @Run(test = "testLongGT")
+    public void checkTestLongGT() {
+        for (int i = 0; i < LONG_DATA.length; i++) {
+            for (int j = 0; j < LONG_DATA.length; j++) {
+                Asserts.assertEquals(testLongGT(LONG_DATA[i], LONG_DATA[j]),
+                                     i > j);
+            }
+        }
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testLongGE(long x, long y) {
+        return x + Long.MIN_VALUE >= y + Long.MIN_VALUE;
+    }
+
+    @Run(test = "testLongGE")
+    public void checkTestLongGE() {
+        for (int i = 0; i < LONG_DATA.length; i++) {
+            for (int j = 0; j < LONG_DATA.length; j++) {
+                Asserts.assertEquals(testLongGE(LONG_DATA[i], LONG_DATA[j]),
+                                     i >= j);
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestUnsignedComparison.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestUnsignedComparison.java
@@ -38,6 +38,10 @@ public class TestUnsignedComparison {
     private static final String CMPU_REGEX = "(\\d+(\\s){2}(" + "Cmp(U|UL)" + ".*)+(\\s){2}===.*)";
     private static final String ADD_REGEX = "(\\d+(\\s){2}(" + "Add(I|L)" + ".*)+(\\s){2}===.*)";
 
+    private static final int INT_MIN = Integer.MIN_VALUE;
+    private static final long LONG_MIN = Long.MIN_VALUE;
+
+    // Integers are sorted in unsignedly increasing order
     private static final int[] INT_DATA = {
         0,
         1,
@@ -51,6 +55,7 @@ public class TestUnsignedComparison {
         0xFFFF_FFFF,
     };
 
+    // Longs are sorted in unsignedly increasing order
     private static final long[] LONG_DATA = {
         0L,
         1L,
@@ -68,6 +73,11 @@ public class TestUnsignedComparison {
         0xFFFFFFFF_FFFFFFFFL,
     };
 
+    // Constants to compare against, add MIN_VALUE beforehand for convenience
+    private static final int CONST_INDEX = 6;
+    private static final int INT_CONST = INT_DATA[CONST_INDEX] + INT_MIN;
+    private static final long LONG_CONST = LONG_DATA[CONST_INDEX] + LONG_MIN;
+
     public static void main(String[] args) {
         TestFramework framework = new TestFramework();
         framework.start();
@@ -76,100 +86,64 @@ public class TestUnsignedComparison {
     @Test
     @IR(failOn = {CMP_REGEX, ADD_REGEX})
     @IR(counts = {CMPU_REGEX, "1"})
-    public boolean testIntEQ(int x, int y) {
-        return x + Integer.MIN_VALUE == y + Integer.MIN_VALUE;
+    public boolean testIntVarEQ(int x, int y) {
+        return x + INT_MIN == y + INT_MIN;
     }
 
-    @Run(test = "testIntEQ")
-    public void checkTestIntEQ() {
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testIntVarNE(int x, int y) {
+        return x + INT_MIN != y + INT_MIN;
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testIntVarLT(int x, int y) {
+        return x + INT_MIN < y + INT_MIN;
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testIntVarLE(int x, int y) {
+        return x + INT_MIN <= y + INT_MIN;
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testIntVarGT(int x, int y) {
+        return x + INT_MIN > y + INT_MIN;
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testIntVarGE(int x, int y) {
+        return x + INT_MIN >= y + INT_MIN;
+    }
+
+    @Run(test = {"testIntVarEQ", "testIntVarNE",
+                 "testIntVarLT", "testIntVarLE",
+                 "testIntVarGT", "testIntVarGE"})
+    public void checkTestIntVar() {
+        // Verify the transformation "cmp (add X min_jint) (add Y min_jint)"
+        // to "cmpu X Y"
         for (int i = 0; i < INT_DATA.length; i++) {
             for (int j = 0; j < INT_DATA.length; j++) {
-                Asserts.assertEquals(testIntEQ(INT_DATA[i], INT_DATA[j]),
+                Asserts.assertEquals(testIntVarEQ(INT_DATA[i], INT_DATA[j]),
                                      i == j);
-            }
-        }
-    }
-
-    @Test
-    @IR(failOn = {CMP_REGEX, ADD_REGEX})
-    @IR(counts = {CMPU_REGEX, "1"})
-    public boolean testIntNE(int x, int y) {
-        return x + Integer.MIN_VALUE != y + Integer.MIN_VALUE;
-    }
-
-    @Run(test = "testIntNE")
-    public void checkTestIntNE() {
-        for (int i = 0; i < INT_DATA.length; i++) {
-            for (int j = 0; j < INT_DATA.length; j++) {
-                Asserts.assertEquals(testIntNE(INT_DATA[i], INT_DATA[j]),
+                Asserts.assertEquals(testIntVarNE(INT_DATA[i], INT_DATA[j]),
                                      i != j);
-            }
-        }
-    }
-
-    @Test
-    @IR(failOn = {CMP_REGEX, ADD_REGEX})
-    @IR(counts = {CMPU_REGEX, "1"})
-    public boolean testIntLT(int x, int y) {
-        return x + Integer.MIN_VALUE < y + Integer.MIN_VALUE;
-    }
-
-    @Run(test = "testIntLT")
-    public void checkTestIntLT() {
-        for (int i = 0; i < INT_DATA.length; i++) {
-            for (int j = 0; j < INT_DATA.length; j++) {
-                Asserts.assertEquals(testIntLT(INT_DATA[i], INT_DATA[j]),
-                                     i < j);
-            }
-        }
-    }
-
-    @Test
-    @IR(failOn = {CMP_REGEX, ADD_REGEX})
-    @IR(counts = {CMPU_REGEX, "1"})
-    public boolean testIntLE(int x, int y) {
-        return x + Integer.MIN_VALUE <= y + Integer.MIN_VALUE;
-    }
-
-    @Run(test = "testIntLE")
-    public void checkTestIntLE() {
-        for (int i = 0; i < INT_DATA.length; i++) {
-            for (int j = 0; j < INT_DATA.length; j++) {
-                Asserts.assertEquals(testIntLE(INT_DATA[i], INT_DATA[j]),
+                Asserts.assertEquals(testIntVarLT(INT_DATA[i], INT_DATA[j]),
+                                     i <  j);
+                Asserts.assertEquals(testIntVarLE(INT_DATA[i], INT_DATA[j]),
                                      i <= j);
-            }
-        }
-    }
-
-    @Test
-    @IR(failOn = {CMP_REGEX, ADD_REGEX})
-    @IR(counts = {CMPU_REGEX, "1"})
-    public boolean testIntGT(int x, int y) {
-        return x + Integer.MIN_VALUE > y + Integer.MIN_VALUE;
-    }
-
-    @Run(test = "testIntGT")
-    public void checkTestIntGT() {
-        for (int i = 0; i < INT_DATA.length; i++) {
-            for (int j = 0; j < INT_DATA.length; j++) {
-                Asserts.assertEquals(testIntGT(INT_DATA[i], INT_DATA[j]),
-                                     i > j);
-            }
-        }
-    }
-
-    @Test
-    @IR(failOn = {CMP_REGEX, ADD_REGEX})
-    @IR(counts = {CMPU_REGEX, "1"})
-    public boolean testIntGE(int x, int y) {
-        return x + Integer.MIN_VALUE >= y + Integer.MIN_VALUE;
-    }
-
-    @Run(test = "testIntGE")
-    public void checkTestIntGE() {
-        for (int i = 0; i < INT_DATA.length; i++) {
-            for (int j = 0; j < INT_DATA.length; j++) {
-                Asserts.assertEquals(testIntGE(INT_DATA[i], INT_DATA[j]),
+                Asserts.assertEquals(testIntVarGT(INT_DATA[i], INT_DATA[j]),
+                                     i >  j);
+                Asserts.assertEquals(testIntVarGE(INT_DATA[i], INT_DATA[j]),
                                      i >= j);
             }
         }
@@ -178,102 +152,194 @@ public class TestUnsignedComparison {
     @Test
     @IR(failOn = {CMP_REGEX, ADD_REGEX})
     @IR(counts = {CMPU_REGEX, "1"})
-    public boolean testLongEQ(long x, long y) {
-        return x + Long.MIN_VALUE == y + Long.MIN_VALUE;
+    public boolean testIntConEQ(int x) {
+        return x + INT_MIN == INT_CONST;
     }
 
-    @Run(test = "testLongEQ")
-    public void checkTestLongEQ() {
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testIntConNE(int x) {
+        return x + INT_MIN != INT_CONST;
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testIntConLT(int x) {
+        return x + INT_MIN < INT_CONST;
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testIntConLE(int x) {
+        return x + INT_MIN <= INT_CONST;
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testIntConGT(int x) {
+        return x + INT_MIN > INT_CONST;
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testIntConGE(int x) {
+        return x + INT_MIN >= INT_CONST;
+    }
+
+    @Run(test = {"testIntConEQ", "testIntConNE",
+                 "testIntConLT", "testIntConLE",
+                 "testIntConGT", "testIntConGE"})
+    public void checkTestIntCon() {
+        // Verify the transformation "cmp (add X min_jint) c"
+        // to "cmpu X (c + min_jint)"
+        for (int i = 0; i < INT_DATA.length; i++) {
+            Asserts.assertEquals(testIntConEQ(INT_DATA[i]),
+                                 i == CONST_INDEX);
+            Asserts.assertEquals(testIntConNE(INT_DATA[i]),
+                                 i != CONST_INDEX);
+            Asserts.assertEquals(testIntConLT(INT_DATA[i]),
+                                 i <  CONST_INDEX);
+            Asserts.assertEquals(testIntConLE(INT_DATA[i]),
+                                 i <= CONST_INDEX);
+            Asserts.assertEquals(testIntConGT(INT_DATA[i]),
+                                 i >  CONST_INDEX);
+            Asserts.assertEquals(testIntConGE(INT_DATA[i]),
+                                 i >= CONST_INDEX);
+        }
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testLongVarEQ(long x, long y) {
+        return x + LONG_MIN == y + LONG_MIN;
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testLongVarNE(long x, long y) {
+        return x + LONG_MIN != y + LONG_MIN;
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testLongVarLT(long x, long y) {
+        return x + LONG_MIN < y + LONG_MIN;
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testLongVarLE(long x, long y) {
+        return x + LONG_MIN <= y + LONG_MIN;
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testLongVarGT(long x, long y) {
+        return x + LONG_MIN > y + LONG_MIN;
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testLongVarGE(long x, long y) {
+        return x + LONG_MIN >= y + LONG_MIN;
+    }
+
+    @Run(test = {"testLongVarEQ", "testLongVarNE",
+                 "testLongVarLT", "testLongVarLE",
+                 "testLongVarGT", "testLongVarGE"})
+    public void checkTestLongVar() {
+        // Verify the transformation "cmp (add X min_jlong) (add Y min_jlong)"
+        // to "cmpu X Y"
         for (int i = 0; i < LONG_DATA.length; i++) {
             for (int j = 0; j < LONG_DATA.length; j++) {
-                Asserts.assertEquals(testLongEQ(LONG_DATA[i], LONG_DATA[j]),
+                Asserts.assertEquals(testLongVarEQ(LONG_DATA[i], LONG_DATA[j]),
                                      i == j);
-            }
-        }
-    }
-
-    @Test
-    @IR(failOn = {CMP_REGEX, ADD_REGEX})
-    @IR(counts = {CMPU_REGEX, "1"})
-    public boolean testLongNE(long x, long y) {
-        return x + Long.MIN_VALUE != y + Long.MIN_VALUE;
-    }
-
-    @Run(test = "testLongNE")
-    public void checkTestLongNE() {
-        for (int i = 0; i < LONG_DATA.length; i++) {
-            for (int j = 0; j < LONG_DATA.length; j++) {
-                Asserts.assertEquals(testLongNE(LONG_DATA[i], LONG_DATA[j]),
+                Asserts.assertEquals(testLongVarNE(LONG_DATA[i], LONG_DATA[j]),
                                      i != j);
-            }
-        }
-    }
-
-    @Test
-    @IR(failOn = {CMP_REGEX, ADD_REGEX})
-    @IR(counts = {CMPU_REGEX, "1"})
-    public boolean testLongLT(long x, long y) {
-        return x + Long.MIN_VALUE < y + Long.MIN_VALUE;
-    }
-
-    @Run(test = "testLongLT")
-    public void checkTestLongLT() {
-        for (int i = 0; i < LONG_DATA.length; i++) {
-            for (int j = 0; j < LONG_DATA.length; j++) {
-                Asserts.assertEquals(testLongLT(LONG_DATA[i], LONG_DATA[j]),
-                                     i < j);
-            }
-        }
-    }
-
-    @Test
-    @IR(failOn = {CMP_REGEX, ADD_REGEX})
-    @IR(counts = {CMPU_REGEX, "1"})
-    public boolean testLongLE(long x, long y) {
-        return x + Long.MIN_VALUE <= y + Long.MIN_VALUE;
-    }
-
-    @Run(test = "testLongLE")
-    public void checkTestLongLE() {
-        for (int i = 0; i < LONG_DATA.length; i++) {
-            for (int j = 0; j < LONG_DATA.length; j++) {
-                Asserts.assertEquals(testLongLE(LONG_DATA[i], LONG_DATA[j]),
+                Asserts.assertEquals(testLongVarLT(LONG_DATA[i], LONG_DATA[j]),
+                                     i <  j);
+                Asserts.assertEquals(testLongVarLE(LONG_DATA[i], LONG_DATA[j]),
                                      i <= j);
-            }
-        }
-    }
-
-    @Test
-    @IR(failOn = {CMP_REGEX, ADD_REGEX})
-    @IR(counts = {CMPU_REGEX, "1"})
-    public boolean testLongGT(long x, long y) {
-        return x + Long.MIN_VALUE > y + Long.MIN_VALUE;
-    }
-
-    @Run(test = "testLongGT")
-    public void checkTestLongGT() {
-        for (int i = 0; i < LONG_DATA.length; i++) {
-            for (int j = 0; j < LONG_DATA.length; j++) {
-                Asserts.assertEquals(testLongGT(LONG_DATA[i], LONG_DATA[j]),
-                                     i > j);
-            }
-        }
-    }
-
-    @Test
-    @IR(failOn = {CMP_REGEX, ADD_REGEX})
-    @IR(counts = {CMPU_REGEX, "1"})
-    public boolean testLongGE(long x, long y) {
-        return x + Long.MIN_VALUE >= y + Long.MIN_VALUE;
-    }
-
-    @Run(test = "testLongGE")
-    public void checkTestLongGE() {
-        for (int i = 0; i < LONG_DATA.length; i++) {
-            for (int j = 0; j < LONG_DATA.length; j++) {
-                Asserts.assertEquals(testLongGE(LONG_DATA[i], LONG_DATA[j]),
+                Asserts.assertEquals(testLongVarGT(LONG_DATA[i], LONG_DATA[j]),
+                                     i >  j);
+                Asserts.assertEquals(testLongVarGE(LONG_DATA[i], LONG_DATA[j]),
                                      i >= j);
             }
+        }
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testLongConEQ(long x) {
+        return x + LONG_MIN == LONG_CONST;
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testLongConNE(long x) {
+        return x + LONG_MIN != LONG_CONST;
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testLongConLT(long x) {
+        return x + LONG_MIN < LONG_CONST;
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testLongConLE(long x) {
+        return x + LONG_MIN <= LONG_CONST;
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testLongConGT(long x) {
+        return x + LONG_MIN > LONG_CONST;
+    }
+
+    @Test
+    @IR(failOn = {CMP_REGEX, ADD_REGEX})
+    @IR(counts = {CMPU_REGEX, "1"})
+    public boolean testLongConGE(long x) {
+        return x + LONG_MIN >= LONG_CONST;
+    }
+
+    @Run(test = {"testLongConEQ", "testLongConNE",
+                 "testLongConLT", "testLongConLE",
+                 "testLongConGT", "testLongConGE"})
+    public void checkTestLongConGE() {
+        // Verify the transformation "cmp (add X min_jlong) c"
+        // to "cmpu X (c + min_jlong)"
+        for (int i = 0; i < LONG_DATA.length; i++) {
+            Asserts.assertEquals(testLongConEQ(LONG_DATA[i]),
+                                 i == CONST_INDEX);
+            Asserts.assertEquals(testLongConNE(LONG_DATA[i]),
+                                 i != CONST_INDEX);
+            Asserts.assertEquals(testLongConLT(LONG_DATA[i]),
+                                 i <  CONST_INDEX);
+            Asserts.assertEquals(testLongConLE(LONG_DATA[i]),
+                                 i <= CONST_INDEX);
+            Asserts.assertEquals(testLongConGT(LONG_DATA[i]),
+                                 i >  CONST_INDEX);
+            Asserts.assertEquals(testLongConGE(LONG_DATA[i]),
+                                 i >= CONST_INDEX);
         }
     }
 }

--- a/test/micro/org/openjdk/bench/vm/compiler/UnsignedComparison.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/UnsignedComparison.java
@@ -33,24 +33,178 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class UnsignedComparison {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public long compareInt(int arg0, int arg1) {
-        return arg0 + Integer.MIN_VALUE < arg1 + Integer.MIN_VALUE ? 1 : 0;
+    public static boolean intEQ(int arg0, int arg1) {
+        return arg0 + Integer.MIN_VALUE == arg1 + Integer.MIN_VALUE;
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public long compareLong(long arg0, long arg1) {
-        return arg0 + Long.MIN_VALUE < arg1 + Long.MIN_VALUE ? 1 : 0;
+    public static boolean intNE(int arg0, int arg1) {
+        return arg0 + Integer.MIN_VALUE != arg1 + Integer.MIN_VALUE;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static boolean intLT(int arg0, int arg1) {
+        return arg0 + Integer.MIN_VALUE < arg1 + Integer.MIN_VALUE;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static boolean intLE(int arg0, int arg1) {
+        return arg0 + Integer.MIN_VALUE <= arg1 + Integer.MIN_VALUE;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static boolean intGT(int arg0, int arg1) {
+        return arg0 + Integer.MIN_VALUE > arg1 + Integer.MIN_VALUE;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static boolean intGE(int arg0, int arg1) {
+        return arg0 + Integer.MIN_VALUE >= arg1 + Integer.MIN_VALUE;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static boolean intLibLT(int arg0, int arg1) {
+        return Integer.compareUnsigned(arg0, arg1) < 0;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static boolean intLibGT(int arg0, int arg1) {
+        return Integer.compareUnsigned(arg0, arg1) > 0;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static boolean longEQ(long arg0, long arg1) {
+        return arg0 + Long.MIN_VALUE == arg1 + Long.MIN_VALUE;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static boolean longNE(long arg0, long arg1) {
+        return arg0 + Long.MIN_VALUE != arg1 + Long.MIN_VALUE;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static boolean longLT(long arg0, long arg1) {
+        return arg0 + Long.MIN_VALUE < arg1 + Long.MIN_VALUE;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static boolean longLE(long arg0, long arg1) {
+        return arg0 + Long.MIN_VALUE <= arg1 + Long.MIN_VALUE;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static boolean longGT(long arg0, long arg1) {
+        return arg0 + Long.MIN_VALUE > arg1 + Long.MIN_VALUE;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static boolean longGE(long arg0, long arg1) {
+        return arg0 + Long.MIN_VALUE >= arg1 + Long.MIN_VALUE;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static boolean longLibLT(long arg0, long arg1) {
+        return Long.compareUnsigned(arg0, arg1) < 0;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static boolean longLibGT(long arg0, long arg1) {
+        return Long.compareUnsigned(arg0, arg1) > 0;
     }
 
     @Benchmark
-    public void runInt() {
-        compareInt(0, -1);
-        compareInt(-1, 0);
+    public void runIntEQ() {
+        intEQ(0, 0);
+        intEQ(-1, 0);
     }
 
     @Benchmark
-    public void runLong() {
-        compareLong(0L, -1L);
-        compareLong(-1L, 0L);
+    public void runIntNE() {
+        intNE(0, 0);
+        intNE(-1, 0);
+    }
+
+    @Benchmark
+    public void runIntLT() {
+        intLT(0, -1);
+        intLT(-1, 0);
+    }
+
+    @Benchmark
+    public void runIntLE() {
+        intLE(0, -1);
+        intLE(-1, 0);
+    }
+
+    @Benchmark
+    public void runIntGT() {
+        intGT(0, -1);
+        intGT(-1, 0);
+    }
+
+    @Benchmark
+    public void runIntGE() {
+        intGE(0, -1);
+        intGE(-1, 0);
+    }
+
+    @Benchmark
+    public void runIntLibLT() {
+        intLibLT(0, -1);
+        intLibLT(-1, 0);
+    }
+
+    @Benchmark
+    public void runIntLibGT() {
+        intLibGT(0, -1);
+        intLibGT(-1, 0);
+    }
+
+    @Benchmark
+    public void runLongEQ() {
+        longEQ(0, 0);
+        longEQ(-1, 0);
+    }
+
+    @Benchmark
+    public void runLongNE() {
+        longNE(0, 0);
+        longNE(-1, 0);
+    }
+
+    @Benchmark
+    public void runLongLT() {
+        longLT(0, -1);
+        longLT(-1, 0);
+    }
+
+    @Benchmark
+    public void runLongLE() {
+        longLE(0, -1);
+        longLE(-1, 0);
+    }
+
+    @Benchmark
+    public void runLongGT() {
+        longGT(0, -1);
+        longGT(-1, 0);
+    }
+
+    @Benchmark
+    public void runLongGE() {
+        longGE(0, -1);
+        longGE(-1, 0);
+    }
+
+    @Benchmark
+    public void runLongLibLT() {
+        longLibLT(0, -1);
+        longLibLT(-1, 0);
+    }
+
+    @Benchmark
+    public void runLongLibGT() {
+        longLibGT(0, -1);
+        longLibGT(-1, 0);
     }
 }

--- a/test/micro/org/openjdk/bench/vm/compiler/UnsignedComparison.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/UnsignedComparison.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Mai Dang Quan Anh. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/vm/compiler/UnsignedComparison.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/UnsignedComparison.java
@@ -24,187 +24,115 @@ package org.openjdk.bench.vm.compiler;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@State(Scope.Thread)
 public class UnsignedComparison {
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static boolean intEQ(int arg0, int arg1) {
-        return arg0 + Integer.MIN_VALUE == arg1 + Integer.MIN_VALUE;
-    }
+    private static final int ITERATIONS = 1000;
 
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static boolean intNE(int arg0, int arg1) {
-        return arg0 + Integer.MIN_VALUE != arg1 + Integer.MIN_VALUE;
-    }
+    private static final int CONST_OPERAND = 4;
+    private static final int INT_MIN = Integer.MIN_VALUE;
+    private static final long LONG_MIN = Long.MIN_VALUE;
 
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static boolean intLT(int arg0, int arg1) {
-        return arg0 + Integer.MIN_VALUE < arg1 + Integer.MIN_VALUE;
-    }
+    int arg0 = 0, arg1 = 4;
 
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static boolean intLE(int arg0, int arg1) {
-        return arg0 + Integer.MIN_VALUE <= arg1 + Integer.MIN_VALUE;
-    }
-
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static boolean intGT(int arg0, int arg1) {
-        return arg0 + Integer.MIN_VALUE > arg1 + Integer.MIN_VALUE;
-    }
-
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static boolean intGE(int arg0, int arg1) {
-        return arg0 + Integer.MIN_VALUE >= arg1 + Integer.MIN_VALUE;
-    }
-
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static boolean intLibLT(int arg0, int arg1) {
-        return Integer.compareUnsigned(arg0, arg1) < 0;
-    }
-
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static boolean intLibGT(int arg0, int arg1) {
-        return Integer.compareUnsigned(arg0, arg1) > 0;
-    }
-
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static boolean longEQ(long arg0, long arg1) {
-        return arg0 + Long.MIN_VALUE == arg1 + Long.MIN_VALUE;
-    }
-
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static boolean longNE(long arg0, long arg1) {
-        return arg0 + Long.MIN_VALUE != arg1 + Long.MIN_VALUE;
-    }
-
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static boolean longLT(long arg0, long arg1) {
-        return arg0 + Long.MIN_VALUE < arg1 + Long.MIN_VALUE;
-    }
-
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static boolean longLE(long arg0, long arg1) {
-        return arg0 + Long.MIN_VALUE <= arg1 + Long.MIN_VALUE;
-    }
-
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static boolean longGT(long arg0, long arg1) {
-        return arg0 + Long.MIN_VALUE > arg1 + Long.MIN_VALUE;
-    }
-
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static boolean longGE(long arg0, long arg1) {
-        return arg0 + Long.MIN_VALUE >= arg1 + Long.MIN_VALUE;
-    }
-
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static boolean longLibLT(long arg0, long arg1) {
-        return Long.compareUnsigned(arg0, arg1) < 0;
-    }
-
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static boolean longLibGT(long arg0, long arg1) {
-        return Long.compareUnsigned(arg0, arg1) > 0;
+    @Setup(Level.Invocation)
+    public void toggle() {
+        arg0 = (arg0 + 1) & 7;
     }
 
     @Benchmark
-    public void runIntEQ() {
-        intEQ(0, 0);
-        intEQ(-1, 0);
+    public void intVarDirect(Blackhole bh) {
+        for (int i = 0; i < ITERATIONS; i++) {
+            bh.consume(arg0 + INT_MIN < arg1 + INT_MIN);
+        }
     }
 
     @Benchmark
-    public void runIntNE() {
-        intNE(0, 0);
-        intNE(-1, 0);
+    public void intVarLibLT(Blackhole bh) {
+        for (int i = 0; i < ITERATIONS; i++) {
+            bh.consume(Integer.compareUnsigned(arg0, arg1) < 0);
+        }
     }
 
     @Benchmark
-    public void runIntLT() {
-        intLT(0, -1);
-        intLT(-1, 0);
+    public void intVarLibGT(Blackhole bh) {
+        for (int i = 0; i < ITERATIONS; i++) {
+            bh.consume(Integer.compareUnsigned(arg0, arg1) > 0);
+        }
     }
 
     @Benchmark
-    public void runIntLE() {
-        intLE(0, -1);
-        intLE(-1, 0);
+    public void intConDirect(Blackhole bh) {
+        for (int i = 0; i < ITERATIONS; i++) {
+            bh.consume(arg0 + INT_MIN < CONST_OPERAND + INT_MIN);
+        }
     }
 
     @Benchmark
-    public void runIntGT() {
-        intGT(0, -1);
-        intGT(-1, 0);
+    public void intConLibLT(Blackhole bh) {
+        for (int i = 0; i < ITERATIONS; i++) {
+            bh.consume(Integer.compareUnsigned(arg0, CONST_OPERAND) < 0);
+        }
     }
 
     @Benchmark
-    public void runIntGE() {
-        intGE(0, -1);
-        intGE(-1, 0);
+    public void intConLibGT(Blackhole bh) {
+        for (int i = 0; i < ITERATIONS; i++) {
+            bh.consume(Integer.compareUnsigned(arg0, CONST_OPERAND) > 0);
+        }
     }
 
     @Benchmark
-    public void runIntLibLT() {
-        intLibLT(0, -1);
-        intLibLT(-1, 0);
+    public void longVarDirect(Blackhole bh) {
+        for (int i = 0; i < ITERATIONS; i++) {
+            bh.consume(arg0 + LONG_MIN < arg1 + LONG_MIN);
+        }
     }
 
     @Benchmark
-    public void runIntLibGT() {
-        intLibGT(0, -1);
-        intLibGT(-1, 0);
+    public void longVarLibLT(Blackhole bh) {
+        for (int i = 0; i < ITERATIONS; i++) {
+            bh.consume(Long.compareUnsigned(arg0, arg1) < 0);
+        }
     }
 
     @Benchmark
-    public void runLongEQ() {
-        longEQ(0, 0);
-        longEQ(-1, 0);
+    public void longVarLibGT(Blackhole bh) {
+        for (int i = 0; i < ITERATIONS; i++) {
+            bh.consume(Long.compareUnsigned(arg0, arg1) > 0);
+        }
     }
 
     @Benchmark
-    public void runLongNE() {
-        longNE(0, 0);
-        longNE(-1, 0);
+    public void longConDirect(Blackhole bh) {
+        for (int i = 0; i < ITERATIONS; i++) {
+            bh.consume(arg0 + LONG_MIN < CONST_OPERAND + LONG_MIN);
+        }
     }
 
     @Benchmark
-    public void runLongLT() {
-        longLT(0, -1);
-        longLT(-1, 0);
+    public void longConLibLT(Blackhole bh) {
+        for (int i = 0; i < ITERATIONS; i++) {
+            bh.consume(Long.compareUnsigned(arg0, CONST_OPERAND) < 0);
+        }
     }
 
     @Benchmark
-    public void runLongLE() {
-        longLE(0, -1);
-        longLE(-1, 0);
-    }
-
-    @Benchmark
-    public void runLongGT() {
-        longGT(0, -1);
-        longGT(-1, 0);
-    }
-
-    @Benchmark
-    public void runLongGE() {
-        longGE(0, -1);
-        longGE(-1, 0);
-    }
-
-    @Benchmark
-    public void runLongLibLT() {
-        longLibLT(0, -1);
-        longLibLT(-1, 0);
-    }
-
-    @Benchmark
-    public void runLongLibGT() {
-        longLibGT(0, -1);
-        longLibGT(-1, 0);
+    public void longConLibGT(Blackhole bh) {
+        for (int i = 0; i < ITERATIONS; i++) {
+            bh.consume(Long.compareUnsigned(arg0, CONST_OPERAND) > 0);
+        }
     }
 }

--- a/test/micro/org/openjdk/bench/vm/compiler/UnsignedComparison.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/UnsignedComparison.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021, Mai Dang Quan Anh. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class UnsignedComparison {
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public long compareInt(int arg0, int arg1) {
+        return arg0 + Integer.MIN_VALUE < arg1 + Integer.MIN_VALUE ? 1 : 0;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public long compareLong(long arg0, long arg1) {
+        return arg0 + Long.MIN_VALUE < arg1 + Long.MIN_VALUE ? 1 : 0;
+    }
+
+    @Benchmark
+    public void runInt() {
+        compareInt(0, -1);
+        compareInt(-1, 0);
+    }
+
+    @Benchmark
+    public void runLong() {
+        compareLong(0L, -1L);
+        compareLong(-1L, 0L);
+    }
+}


### PR DESCRIPTION
This patch changes operations in the form `x +- Integer.MIN_VALUE <=> y +- Integer.MIN_VALUE`, which is a pattern used to do unsigned comparisons, into `x u<=> y`.

In addition to being basic operations, they may be utilised to implement range checks such as the methods in `jdk.internal.util.Preconditions`, or in places where the compiler cannot deduce the non-negativeness of the bound as in `java.util.ArrayList`.

Thank you very much.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276162](https://bugs.openjdk.java.net/browse/JDK-8276162): Optimise unsigned comparison pattern


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 4dada5fcf7db00952c60ae25202255c2ce9c4635


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6101/head:pull/6101` \
`$ git checkout pull/6101`

Update a local copy of the PR: \
`$ git checkout pull/6101` \
`$ git pull https://git.openjdk.java.net/jdk pull/6101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6101`

View PR using the GUI difftool: \
`$ git pr show -t 6101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6101.diff">https://git.openjdk.java.net/jdk/pull/6101.diff</a>

</details>
