### PR TITLE
JDK-8275865: Print deoptimization statistics in product builds

### DIFF
--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -351,7 +351,7 @@ void print_statistics() {
     CompileBroker::print_times();
   }
 
-#if defined(COMPILER2) || defined(INCLUDE_JVMCI)
+#ifdef COMPILER2_OR_JVMCI
   if ((LogVMOutput || LogCompilation) && UseCompiler) {
     // Only print the statistics to the log file
     FlagSetting fs(DisplayVMOutput, false);

--- a/test/hotspot/jtreg/runtime/logging/DeoptStats.java
+++ b/test/hotspot/jtreg/runtime/logging/DeoptStats.java
@@ -43,34 +43,33 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 public class DeoptStats {
 
-  static class Value {
-    int i;
-  }
-
-  static int f(Value v) {
-    return v.i;
-  }
-
-  public static void verify(String[] logFiles) throws Exception {
-    for (String logFile : logFiles) {
-      OutputAnalyzer oa = new OutputAnalyzer(Paths.get(logFile));
-      oa.shouldMatchByLine("<statistics type='deoptimization'>", // Start from this line
-                           "</statistics>",                      // Match until this line
-                           "(Deoptimization traps recorded:)|( .+)");
+    static class Value {
+        int i;
     }
-  }
 
-  public static void main(String[] args) throws Exception {
-    if (args.length > 0) {
-      verify(args);
+    static int f(Value v) {
+        return v.i;
     }
-    else {
-      for (int i = 0; i < 20_000; i++) {
-        try {
-          f(null);
+
+    public static void verify(String[] logFiles) throws Exception {
+        for (String logFile : logFiles) {
+            OutputAnalyzer oa = new OutputAnalyzer(Paths.get(logFile));
+            oa.shouldMatchByLine("<statistics type='deoptimization'>", // Start from this line
+                                 "</statistics>",                      // Match until this line
+                                 "(Deoptimization traps recorded:)|( .+)");
         }
-        catch (NullPointerException npe) { }
-      }
     }
-  }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length > 0) {
+            verify(args);
+        } else {
+            for (int i = 0; i < 20_000; i++) {
+                try {
+                    f(null);
+                }
+                catch (NullPointerException npe) { }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Deoptimization statistics are already gathered in product builds but for some (probably historical) reasons aren't printed to the VM/Compiler log. These statics can be useful when analyzing the reasons for deoptimization and frequent recompilations.

Because the statistics are already collected anyway, printing them at VM-exit if either `-XX:+LogCompilation` or `-XX:+LogVMOutput` are set won't introduce any runtime overhead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275865](https://bugs.openjdk.java.net/browse/JDK-8275865): Print deoptimization statistics in product builds


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * kvn - **Reviewer** ⚠️ Added manually

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6103/head:pull/6103` \
`$ git checkout pull/6103`

Update a local copy of the PR: \
`$ git checkout pull/6103` \
`$ git pull https://git.openjdk.java.net/jdk pull/6103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6103`

View PR using the GUI difftool: \
`$ git pr show -t 6103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6103.diff">https://git.openjdk.java.net/jdk/pull/6103.diff</a>

</details>
