### PR TITLE
8275869: Problem list applications/jcstress/copy.java on Linux-aarch64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -100,7 +100,7 @@ runtime/os/TestTracePageSizes.java#G1 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
 
-applications/jcstress/copy.java 8229852 linux-x64
+applications/jcstress/copy.java 8229852 linux-all
 
 #############################################################################
 


### PR DESCRIPTION
Please review this small change to problem list copy.java on linux-x64 and linux-aarch64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275869](https://bugs.openjdk.java.net/browse/JDK-8275869): Problem list applications/jcstress/copy.java on Linux-aarch64


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6107/head:pull/6107` \
`$ git checkout pull/6107`

Update a local copy of the PR: \
`$ git checkout pull/6107` \
`$ git pull https://git.openjdk.java.net/jdk pull/6107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6107`

View PR using the GUI difftool: \
`$ git pr show -t 6107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6107.diff">https://git.openjdk.java.net/jdk/pull/6107.diff</a>

</details>
