### PR TITLE
8275767: JDK source code contains redundant boolean operations in jdk.charsets

### DIFF
--- a/src/jdk.charsets/share/classes/sun/nio/cs/ext/IBM964.java.template
+++ b/src/jdk.charsets/share/classes/sun/nio/cs/ext/IBM964.java.template
@@ -203,7 +203,7 @@ public class IBM964
         }
 
         protected CoderResult decodeLoop(ByteBuffer src, CharBuffer dst) {
-            if (true && src.hasArray() && dst.hasArray())
+            if (src.hasArray() && dst.hasArray())
                 return decodeArrayLoop(src, dst);
             else
                 return decodeBufferLoop(src, dst);

--- a/src/jdk.charsets/share/classes/sun/nio/cs/ext/SimpleEUCEncoder.java.template
+++ b/src/jdk.charsets/share/classes/sun/nio/cs/ext/SimpleEUCEncoder.java.template
@@ -260,7 +260,7 @@ public abstract class SimpleEUCEncoder
     }
 
     protected CoderResult encodeLoop(CharBuffer src, ByteBuffer dst) {
-        if (true && src.hasArray() && dst.hasArray())
+        if (src.hasArray() && dst.hasArray())
             return encodeArrayLoop(src, dst);
         else
             return encodeBufferLoop(src, dst);


### PR DESCRIPTION
Trivial clean-up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275767](https://bugs.openjdk.java.net/browse/JDK-8275767): JDK source code contains redundant boolean operations in jdk.charsets


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6110/head:pull/6110` \
`$ git checkout pull/6110`

Update a local copy of the PR: \
`$ git checkout pull/6110` \
`$ git pull https://git.openjdk.java.net/jdk pull/6110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6110`

View PR using the GUI difftool: \
`$ git pr show -t 6110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6110.diff">https://git.openjdk.java.net/jdk/pull/6110.diff</a>

</details>
