### PR TITLE
8275886: G1: remove obsolete comment in HeapRegion::setup_heap_region_size

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -84,8 +84,6 @@ void HeapRegion::setup_heap_region_size(size_t max_heap_size) {
   LogOfHRGrainBytes = region_size_log;
 
   guarantee(GrainBytes == 0, "we should only set it once");
-  // The cast to int is safe, given that we've bounded region_size by
-  // MIN_REGION_SIZE and MAX_REGION_SIZE.
   GrainBytes = region_size;
 
   guarantee(GrainWords == 0, "we should only set it once");


### PR DESCRIPTION
Trivial change of removing obsolete comment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275886](https://bugs.openjdk.java.net/browse/JDK-8275886): G1: remove obsolete comment in HeapRegion::setup_heap_region_size


### Reviewers
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6113/head:pull/6113` \
`$ git checkout pull/6113`

Update a local copy of the PR: \
`$ git checkout pull/6113` \
`$ git pull https://git.openjdk.java.net/jdk pull/6113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6113`

View PR using the GUI difftool: \
`$ git pr show -t 6113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6113.diff">https://git.openjdk.java.net/jdk/pull/6113.diff</a>

</details>
