### PR TITLE
8269853: Prefetch::read should accept pointer to const

### DIFF
--- a/src/hotspot/os_cpu/aix_ppc/prefetch_aix_ppc.inline.hpp
+++ b/src/hotspot/os_cpu/aix_ppc/prefetch_aix_ppc.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2013 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -29,7 +29,7 @@
 #include "runtime/prefetch.hpp"
 
 
-inline void Prefetch::read(void *loc, intx interval) {
+inline void Prefetch::read(const void *loc, intx interval) {
 #if !defined(USE_XLC_BUILTINS)
   __asm__ __volatile__ (
     "   dcbt   0, %0       \n"

--- a/src/hotspot/os_cpu/bsd_aarch64/prefetch_bsd_aarch64.inline.hpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/prefetch_bsd_aarch64.inline.hpp
@@ -30,7 +30,7 @@
 #include "runtime/prefetch.hpp"
 
 
-inline void Prefetch::read (void *loc, intx interval) {
+inline void Prefetch::read (const void *loc, intx interval) {
   if (interval >= 0)
     asm("prfm PLDL1KEEP, [%0, %1]" : : "r"(loc), "r"(interval));
 }

--- a/src/hotspot/os_cpu/bsd_x86/prefetch_bsd_x86.inline.hpp
+++ b/src/hotspot/os_cpu/bsd_x86/prefetch_bsd_x86.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
 #include "runtime/prefetch.hpp"
 
 
-inline void Prefetch::read (void *loc, intx interval) {
+inline void Prefetch::read (const void *loc, intx interval) {
 #ifdef AMD64
   __asm__ ("prefetcht0 (%0,%1,1)" : : "r" (loc), "r" (interval));
 #endif // AMD64

--- a/src/hotspot/os_cpu/bsd_zero/prefetch_bsd_zero.inline.hpp
+++ b/src/hotspot/os_cpu/bsd_zero/prefetch_bsd_zero.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2007, 2008 Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -28,7 +28,7 @@
 
 #include "runtime/prefetch.hpp"
 
-inline void Prefetch::read(void* loc, intx interval) {
+inline void Prefetch::read(const void* loc, intx interval) {
 }
 
 inline void Prefetch::write(void* loc, intx interval) {

--- a/src/hotspot/os_cpu/linux_aarch64/prefetch_linux_aarch64.inline.hpp
+++ b/src/hotspot/os_cpu/linux_aarch64/prefetch_linux_aarch64.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -29,7 +29,7 @@
 #include "runtime/prefetch.hpp"
 
 
-inline void Prefetch::read (void *loc, intx interval) {
+inline void Prefetch::read (const void *loc, intx interval) {
   if (interval >= 0)
     asm("prfm PLDL1KEEP, [%0, %1]" : : "r"(loc), "r"(interval));
 }

--- a/src/hotspot/os_cpu/linux_arm/prefetch_linux_arm.inline.hpp
+++ b/src/hotspot/os_cpu/linux_arm/prefetch_linux_arm.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
 
 #include "runtime/prefetch.hpp"
 
-inline void Prefetch::read (void *loc, intx interval) {
+inline void Prefetch::read (const void *loc, intx interval) {
 #if defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_5TE__)
   __asm__ volatile ("pld [%0]" : : "r" (loc));
 #endif

--- a/src/hotspot/os_cpu/linux_ppc/prefetch_linux_ppc.inline.hpp
+++ b/src/hotspot/os_cpu/linux_ppc/prefetch_linux_ppc.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2013 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -29,7 +29,7 @@
 #include "runtime/prefetch.hpp"
 
 
-inline void Prefetch::read(void *loc, intx interval) {
+inline void Prefetch::read(const void *loc, intx interval) {
   __asm__ __volatile__ (
     "   dcbt   0, %0       \n"
     :

--- a/src/hotspot/os_cpu/linux_s390/prefetch_linux_s390.inline.hpp
+++ b/src/hotspot/os_cpu/linux_s390/prefetch_linux_s390.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2016 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -28,7 +28,7 @@
 
 #include "runtime/prefetch.hpp"
 
-inline void Prefetch::read(void* loc, intx interval) {
+inline void Prefetch::read(const void* loc, intx interval) {
   // No prefetch instructions on z/Architecture -> implement trivially.
 }
 

--- a/src/hotspot/os_cpu/linux_x86/prefetch_linux_x86.inline.hpp
+++ b/src/hotspot/os_cpu/linux_x86/prefetch_linux_x86.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
 #include "runtime/prefetch.hpp"
 
 
-inline void Prefetch::read (void *loc, intx interval) {
+inline void Prefetch::read (const void *loc, intx interval) {
 #ifdef AMD64
   __asm__ ("prefetcht0 (%0,%1,1)" : : "r" (loc), "r" (interval));
 #endif // AMD64

--- a/src/hotspot/os_cpu/linux_zero/prefetch_linux_zero.inline.hpp
+++ b/src/hotspot/os_cpu/linux_zero/prefetch_linux_zero.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2007, 2008 Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -28,7 +28,7 @@
 
 #include "runtime/prefetch.hpp"
 
-inline void Prefetch::read(void* loc, intx interval) {
+inline void Prefetch::read(const void* loc, intx interval) {
 }
 
 inline void Prefetch::write(void* loc, intx interval) {

--- a/src/hotspot/os_cpu/windows_aarch64/prefetch_windows_aarch64.inline.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/prefetch_windows_aarch64.inline.hpp
@@ -28,7 +28,7 @@
 #include "runtime/prefetch.hpp"
 
 
-inline void Prefetch::read (void *loc, intx interval) {
+inline void Prefetch::read (const void *loc, intx interval) {
 }
 
 inline void Prefetch::write(void *loc, intx interval) {

--- a/src/hotspot/os_cpu/windows_x86/prefetch_windows_x86.inline.hpp
+++ b/src/hotspot/os_cpu/windows_x86/prefetch_windows_x86.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
 
 #include "runtime/prefetch.hpp"
 
-inline void Prefetch::read (void *loc, intx interval) {}
+inline void Prefetch::read (const void *loc, intx interval) {}
 inline void Prefetch::write(void *loc, intx interval) {}
 
 #endif // OS_CPU_WINDOWS_X86_PREFETCH_WINDOWS_X86_INLINE_HPP

--- a/src/hotspot/share/runtime/prefetch.hpp
+++ b/src/hotspot/share/runtime/prefetch.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ class Prefetch : AllStatic {
   };
 
   // Prefetch anticipating read; must not fault, semantically a no-op
-  static void read(void* loc, intx interval);
+  static void read(const void* loc, intx interval);
 
   // Prefetch anticipating write; must not fault, semantically a no-op
   static void write(void* loc, intx interval);


### PR DESCRIPTION
Please review this fix for JDK-8269853 to add 'const' to the first argument to Prefetch::read().  The fix was tested by running Mach5 tiers 1-2 on Linux, Mac OS, and Windows, and doing Mach5 builds for linux-s390, linux-x86, linux-zero, and linux-ppc.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269853](https://bugs.openjdk.java.net/browse/JDK-8269853): Prefetch::read should accept pointer to const


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6114/head:pull/6114` \
`$ git checkout pull/6114`

Update a local copy of the PR: \
`$ git checkout pull/6114` \
`$ git pull https://git.openjdk.java.net/jdk pull/6114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6114`

View PR using the GUI difftool: \
`$ git pr show -t 6114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6114.diff">https://git.openjdk.java.net/jdk/pull/6114.diff</a>

</details>
