### PR TITLE
8275534: com.sun.net.httpserver.BasicAuthenticator should check whether "realm" is a quoted string

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/Utils.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/Utils.java
@@ -391,7 +391,6 @@ public final class Utils {
         return new URLPermission(urlString, actionStringBuilder.toString());
     }
 
-
     // ABNF primitives defined in RFC 7230
     private static final boolean[] tchar      = new boolean[256];
     private static final boolean[] fieldvchar = new boolean[256];
@@ -411,7 +410,7 @@ public final class Utils {
     }
 
     /*
-     * Validates a RFC 7230 field-name.
+     * Validates an RFC 7230 field-name.
      */
     public static boolean isValidName(String token) {
         for (int i = 0; i < token.length(); i++) {
@@ -472,7 +471,7 @@ public final class Utils {
     }
 
     /*
-     * Validates a RFC 7230 field-value.
+     * Validates an RFC 7230 field-value.
      *
      * "Obsolete line folding" rule
      *
@@ -494,7 +493,6 @@ public final class Utils {
         }
         return true;
     }
-
 
     @SuppressWarnings("removal")
     public static int getIntegerNetProperty(String name, int defaultValue) {

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/BasicAuthenticator.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/BasicAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.nio.charset.Charset;
 import java.util.Base64;
 import java.util.Objects;
 
+import static sun.net.httpserver.Utils.isQuotedString;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -49,11 +50,17 @@ public abstract class BasicAuthenticator extends Authenticator {
      * The Basic authentication credentials (username and password) are decoded
      * using the platform's {@link Charset#defaultCharset() default character set}.
      *
+     * @apiNote Where a backslash ("\") is used as quoting mechanism within the
+     * realm string, it must be escaped by two preceding backslashes, for example
+     * {@code "foo\\\"bar\\\""} will be embedded as {@code "foo\"bar\""}.
+     *
      * @param realm the HTTP Basic authentication realm
      * @throws NullPointerException if realm is {@code null}
-     * @throws IllegalArgumentException if realm is an empty string
+     * @throws IllegalArgumentException if realm is an empty string or is not
+     *         valid, see <a href="https://tools.ietf.org/html/rfc7230#section-3.2">
+     *         RFC 7230 section-3.2</a>.
      */
-    public BasicAuthenticator (String realm) {
+    public BasicAuthenticator(String realm) {
         this(realm, Charset.defaultCharset());
     }
 
@@ -65,16 +72,23 @@ public abstract class BasicAuthenticator extends Authenticator {
      * @apiNote {@code UTF-8} is the recommended charset because its usage is
      * communicated to the client, and therefore more likely to be used also
      * by the client.
+     * <p>Where a backslash ("\") is used as quoting mechanism within the realm
+     * string, it must be escaped by two preceding backslashes, for example
+     * {@code "foo\\\"bar\\\""} will be embedded as {@code "foo\"bar\""}.
      *
      * @param realm the HTTP Basic authentication realm
      * @param charset the {@code Charset} to decode incoming credentials from the client
      * @throws NullPointerException if realm or charset are {@code null}
-     * @throws IllegalArgumentException if realm is an empty string
+     * @throws IllegalArgumentException if realm is an empty string or is not
+     *         valid, see <a href="https://tools.ietf.org/html/rfc7230#section-3.2">
+     *         RFC 7230 section-3.2</a>.
      */
-    public BasicAuthenticator (String realm, Charset charset) {
+    public BasicAuthenticator(String realm, Charset charset) {
         Objects.requireNonNull(charset);
         if (realm.isEmpty()) // implicit NPE check
             throw new IllegalArgumentException("realm must not be empty");
+        if (!isQuotedString(realm))
+            throw new IllegalArgumentException("realm invalid: " + realm);
         this.realm = realm;
         this.charset = charset;
         this.isUTF8 = charset.equals(UTF_8);

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/BasicAuthenticator.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/BasicAuthenticator.java
@@ -29,7 +29,7 @@ import java.nio.charset.Charset;
 import java.util.Base64;
 import java.util.Objects;
 
-import static sun.net.httpserver.Utils.isQuotedString;
+import static sun.net.httpserver.Utils.isQuotedStringContent;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -50,15 +50,16 @@ public abstract class BasicAuthenticator extends Authenticator {
      * The Basic authentication credentials (username and password) are decoded
      * using the platform's {@link Charset#defaultCharset() default character set}.
      *
-     * @apiNote Where a backslash ("\") is used as quoting mechanism within the
-     * realm string, it must be escaped by two preceding backslashes, for example
-     * {@code "foo\\\"bar\\\""} will be embedded as {@code "foo\"bar\""}.
+     * @apiNote The value of the {@code realm} parameter will be embedded in a
+     * quoted string.
      *
      * @param realm the HTTP Basic authentication realm
      * @throws NullPointerException if realm is {@code null}
      * @throws IllegalArgumentException if realm is an empty string or is not
-     *         valid, see <a href="https://tools.ietf.org/html/rfc7230#section-3.2">
-     *         RFC 7230 section-3.2</a>.
+     *         correctly quoted, as specified in <a href="https://tools.ietf.org/html/rfc7230#section-3.2">
+     *         RFC 7230 section-3.2</a>. Note, any {@code \} character used for
+     *         quoting must itself be quoted in source code.
+
      */
     public BasicAuthenticator(String realm) {
         this(realm, Charset.defaultCharset());
@@ -72,22 +73,22 @@ public abstract class BasicAuthenticator extends Authenticator {
      * @apiNote {@code UTF-8} is the recommended charset because its usage is
      * communicated to the client, and therefore more likely to be used also
      * by the client.
-     * <p>Where a backslash ("\") is used as quoting mechanism within the realm
-     * string, it must be escaped by two preceding backslashes, for example
-     * {@code "foo\\\"bar\\\""} will be embedded as {@code "foo\"bar\""}.
+     * <p>The value of the {@code realm} parameter will be embedded in a quoted
+     * string.
      *
      * @param realm the HTTP Basic authentication realm
      * @param charset the {@code Charset} to decode incoming credentials from the client
      * @throws NullPointerException if realm or charset are {@code null}
      * @throws IllegalArgumentException if realm is an empty string or is not
-     *         valid, see <a href="https://tools.ietf.org/html/rfc7230#section-3.2">
-     *         RFC 7230 section-3.2</a>.
+     *         correctly quoted, as specified in <a href="https://tools.ietf.org/html/rfc7230#section-3.2">
+     *         RFC 7230 section-3.2</a>. Note, any {@code \} character used for
+     *         quoting must itself be quoted in source code.
      */
     public BasicAuthenticator(String realm, Charset charset) {
         Objects.requireNonNull(charset);
         if (realm.isEmpty()) // implicit NPE check
             throw new IllegalArgumentException("realm must not be empty");
-        if (!isQuotedString(realm))
+        if (!isQuotedStringContent(realm))
             throw new IllegalArgumentException("realm invalid: " + realm);
         this.realm = realm;
         this.charset = charset;

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
@@ -39,6 +39,7 @@ import java.security.PrivilegedAction;
 import sun.net.httpserver.HttpConnection.State;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static sun.net.httpserver.Utils.*;
 
 /**
  * Provides implementation for both HTTP and HTTPS
@@ -586,7 +587,7 @@ class ServerImpl implements TimeSource {
                 Headers headers = req.headers();
                 /* check key for illegal characters */
                 for (var k : headers.keySet()) {
-                    if (!isValidHeaderKey(k)) {
+                    if (!isValidName(k)) {
                         reject(Code.HTTP_BAD_REQUEST, requestLine,
                                 "Header key contains illegal characters");
                         return;
@@ -933,25 +934,5 @@ class ServerImpl implements TimeSource {
         } else {
             return secs * 1000;
         }
-    }
-
-    /*
-     * Validates a RFC 7230 header-key.
-     */
-    static boolean isValidHeaderKey(String token) {
-        if (token == null) return false;
-
-        boolean isValidChar;
-        char[] chars = token.toCharArray();
-        String validSpecialChars = "!#$%&'*+-.^_`|~";
-        for (char c : chars) {
-            isValidChar = ((c >= 'a') && (c <= 'z')) ||
-                          ((c >= 'A') && (c <= 'Z')) ||
-                          ((c >= '0') && (c <= '9'));
-            if (!isValidChar && validSpecialChars.indexOf(c) == -1) {
-                return false;
-            }
-        }
-        return !token.isEmpty();
     }
 }

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/Utils.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/Utils.java
@@ -73,7 +73,7 @@ public class Utils {
     /*
      * Validates an RFC 7230 quoted-string.
      */
-    public static boolean isQuotedString(String token) {
+    public static boolean isQuotedStringContent(String token) {
         for (int i = 0; i < token.length(); i++) {
             char c = token.charAt(i);
             if (c > 255) {

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/Utils.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/Utils.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.net.httpserver;
+
+/**
+ * Provides utility methods for checking header field names and quoted strings.
+ */
+public class Utils {
+
+    // ABNF primitives defined in RFC 7230
+    private static final boolean[] TCHAR = new boolean[256];
+    private static final boolean[] QDTEXT = new boolean[256];
+    private static final boolean[] QUOTED_PAIR = new boolean[256];
+
+    static {
+        char[] allowedTokenChars =
+                ("!#$%&'*+-.^_`|~0123456789" +
+                        "abcdefghijklmnopqrstuvwxyz" +
+                        "ABCDEFGHIJKLMNOPQRSTUVWXYZ").toCharArray();
+        for (char c : allowedTokenChars) {
+            TCHAR[c] = true;
+        }
+        for (char c = 0x20; c <= 0xFF; c++) {
+            QDTEXT[c] = true;
+        }
+        QDTEXT[0x22] = false;  // (")   illegal
+        QDTEXT[0x5c] = false;  // (\)   illegal
+        QDTEXT[0x7F] = false;  // (DEL) illegal
+
+        for (char c = 0x20; c <= 0xFF; c++) {
+            QUOTED_PAIR[c] = true;
+        }
+        QUOTED_PAIR[0x09] = true;  // (\t)    legal
+        QUOTED_PAIR[0x7F] = false; // (DEL) illegal
+    }
+
+    /*
+     * Validates an RFC 7230 field-name.
+     */
+    public static boolean isValidName(String token) {
+        for (int i = 0; i < token.length(); i++) {
+            char c = token.charAt(i);
+            if (c > 255 || !TCHAR[c]) {
+                return false;
+            }
+        }
+        return !token.isEmpty();
+    }
+
+    /*
+     * Validates an RFC 7230 quoted-string.
+     */
+    public static boolean isQuotedString(String token) {
+        for (int i = 0; i < token.length(); i++) {
+            char c = token.charAt(i);
+            if (c > 255) {
+                return false;
+            } else if (c == 0x5c) {  // check if valid quoted-pair
+                if (i == token.length() - 1 || !QUOTED_PAIR[token.charAt(i++)]) {
+                    return false;
+                }
+            } else if (!QDTEXT[c]) {
+                return false; // illegal char
+            }
+        }
+        return true;
+    }
+}

--- a/test/jdk/com/sun/net/httpserver/BasicAuthenticatorRealm.java
+++ b/test/jdk/com/sun/net/httpserver/BasicAuthenticatorRealm.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8275534
+ * @summary  Check that ISO-8859-1 encoded realm strings are transported correctly
+ *           with HttpURLConnection and HttpClient
+ * @modules jdk.httpserver
+ * @library /test/lib
+ * @run testng/othervm BasicAuthenticatorRealm
+ */
+
+import com.sun.net.httpserver.BasicAuthenticator;
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpHandlers;
+import com.sun.net.httpserver.HttpServer;
+import java.net.Authenticator;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.PasswordAuthentication;
+import java.net.Proxy;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandlers;
+
+import jdk.test.lib.net.URIBuilder;
+import org.testng.annotations.Test;
+
+import static java.net.http.HttpClient.Builder.NO_PROXY;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertEquals;
+
+public class BasicAuthenticatorRealm {
+
+    static final String REALM = "U\u00ffU@realm";  // non-ASCII char
+    static final String EXPECTED_AUTH_HEADER_VALUE = "Basic realm=\"U\u00ffU@realm\", charset=\"UTF-8\"";
+
+    static final InetAddress LOOPBACK_ADDR = InetAddress.getLoopbackAddress();
+
+    @Test
+    public static void testURLConnection() throws Exception {
+        var server = HttpServer.create(new InetSocketAddress(LOOPBACK_ADDR, 0), 0);
+        var handler = HttpHandlers.of(200, Headers.of(), "");
+        var context = server.createContext("/test", handler);
+        var auth = new ServerAuthenticator(REALM);
+
+        context.setAuthenticator(auth);
+
+        try {
+            server.start();
+            var url = uri(server).toURL();
+            var connection = (HttpURLConnection)url.openConnection(Proxy.NO_PROXY);
+            assertEquals(connection.getResponseCode(), 401);
+            assertEquals(connection.getHeaderField("WWW-Authenticate"), EXPECTED_AUTH_HEADER_VALUE);
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public static void testURLConnectionAuthenticated() throws Exception {
+        var server = HttpServer.create(new InetSocketAddress(LOOPBACK_ADDR, 0), 0);
+        var handler = HttpHandlers.of(200, Headers.of(), "foo");
+        var context = server.createContext("/test", handler);
+        var auth = new ServerAuthenticator(REALM);
+
+        context.setAuthenticator(auth);
+        Authenticator.setDefault(new ClientAuthenticator());
+
+        try {
+            server.start();
+            var url = uri(server).toURL();
+            var connection = (HttpURLConnection)url.openConnection(Proxy.NO_PROXY);
+            assertEquals(connection.getResponseCode(), 200);
+            assertEquals(connection.getInputStream().readAllBytes(), "foo".getBytes(UTF_8));
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public static void testHttpClient() throws Exception {
+        var server = HttpServer.create(new InetSocketAddress(LOOPBACK_ADDR, 0), 0);
+        var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
+        var request = HttpRequest.newBuilder(uri(server)).build();
+        var handler = HttpHandlers.of(200, Headers.of(), "foo");
+        var context = server.createContext("/test", handler);
+        var authenticator = new ServerAuthenticator(REALM);
+
+        context.setAuthenticator(authenticator);
+
+        try {
+            server.start();
+            var response = client.send(request, BodyHandlers.ofString(UTF_8));
+            assertEquals(response.statusCode(), 401);
+            assertEquals(response.headers().firstValue("WWW-Authenticate").orElseThrow(), EXPECTED_AUTH_HEADER_VALUE);
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public static void testHttpClientAuthenticated() throws Exception {
+        var server = HttpServer.create(new InetSocketAddress(LOOPBACK_ADDR, 0), 0);
+        var request = HttpRequest.newBuilder(uri(server)).build();
+        var handler = HttpHandlers.of(200, Headers.of(), "foo");
+        var context = server.createContext("/test", handler);
+        var auth = new ServerAuthenticator(REALM);
+        var client = HttpClient.newBuilder()
+                .proxy(NO_PROXY)
+                .authenticator(new ClientAuthenticator())
+                .build();
+
+        context.setAuthenticator(auth);
+
+        try {
+            server.start();
+            var response = client.send(request, BodyHandlers.ofString(UTF_8));
+            assertEquals(response.statusCode(), 200);
+            assertEquals(response.body(), "foo");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    static class ServerAuthenticator extends BasicAuthenticator {
+        ServerAuthenticator(String realm) {
+            super(realm);
+        }
+
+        @Override
+        public boolean checkCredentials(String username, String password) {
+            if (!getRealm().equals(realm)) {
+                return false;
+            }
+            return true;
+        }
+    }
+
+    static class ClientAuthenticator extends java.net.Authenticator {
+        @Override
+        public PasswordAuthentication getPasswordAuthentication() {
+            if (!getRequestingPrompt().equals(REALM)) {
+                throw new RuntimeException("realm does not match");
+            }
+            return new PasswordAuthentication("username", "password".toCharArray());
+        }
+    }
+
+    public static URI uri(HttpServer server) {
+        return URIBuilder.newBuilder()
+                .scheme("http")
+                .host(server.getAddress().getAddress())
+                .port(server.getAddress().getPort())
+                .path("/test/")
+                .buildUnchecked();
+    }
+}

--- a/test/jdk/com/sun/net/httpserver/bugs/BasicAuthenticatorExceptionCheck.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/BasicAuthenticatorExceptionCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,12 +21,12 @@
  * questions.
  */
 
-/**
+/*
  * @test
- * @bug 8230159
+ * @bug 8230159 8275534
  * @library /test/lib
  * @summary Ensure that correct exceptions are being thrown in
- * BasicAuthenticator constructor
+ *          BasicAuthenticator constructor
  * @run testng BasicAuthenticatorExceptionCheck
  */
 
@@ -36,6 +36,7 @@ import com.sun.net.httpserver.BasicAuthenticator;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.expectThrows;
+import static org.testng.Assert.assertEquals;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 
@@ -73,6 +74,7 @@ public class BasicAuthenticatorExceptionCheck {
 
         ex = expectThrows(IAE, () ->
                 createBasicAuthenticator("", UTF_8));
+        assertEquals(ex.getMessage(), "realm must not be empty");
         System.out.println("Empty string for realm and valid charset provided - " +
                 "IllegalArgumentException thrown as expected: " + ex);
 
@@ -83,7 +85,22 @@ public class BasicAuthenticatorExceptionCheck {
 
         ex = expectThrows(IAE, () ->
                 createBasicAuthenticator(""));
+        assertEquals(ex.getMessage(), "realm must not be empty");
         System.out.println("Empty string for realm provided - " +
                 "IllegalArgumentException thrown as expected: " + ex);
+
+        ex = expectThrows(IAE, () ->
+                createBasicAuthenticator("\"/test\""));
+        assertEquals(ex.getMessage(), "realm invalid: \"/test\"");
+        System.out.println("Invalid string for realm provided - " +
+                "IllegalArgumentException thrown as expected: " + ex);
+
+        ex = expectThrows(IAE, () ->
+                createBasicAuthenticator("\""));
+        assertEquals(ex.getMessage(), "realm invalid: \"");
+        System.out.println("Invalid string for realm provided - " +
+                "IllegalArgumentException thrown as expected: " + ex);
+
+        createBasicAuthenticator("\\\"/test\\\"");
     }
 }


### PR DESCRIPTION
This change ensures that the realm string passed to the BasicAuthenticator constructor is a quoted-string, as per RFC7230 [1]. A Utils class is added to jdk.httpserver/sun.net.httpserver that holds the new isQuotedString() method and the pre-existing isValidName() method (previously in ServerImpl.) 
Two tests are included:
- BasicAuthenticatorRealm.java to check that Latin-1 chars in the realm string are transported correctly,
- BasicAuthenticatorExceptionCheck.java to check realm strings with escaped quotes.

Testing: tier 1-3.

[1] https://datatracker.ietf.org/doc/html/rfc7230

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275534](https://bugs.openjdk.java.net/browse/JDK-8275534): com.sun.net.httpserver.BasicAuthenticator should check whether "realm" is a quoted string


### Reviewers
 * [Michael McMahon](https://openjdk.java.net/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6117/head:pull/6117` \
`$ git checkout pull/6117`

Update a local copy of the PR: \
`$ git checkout pull/6117` \
`$ git pull https://git.openjdk.java.net/jdk pull/6117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6117`

View PR using the GUI difftool: \
`$ git pr show -t 6117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6117.diff">https://git.openjdk.java.net/jdk/pull/6117.diff</a>

</details>
