### PR TITLE
8275975: Remove dead code in ciInstanceKlass

### DIFF
--- a/src/hotspot/share/ci/ciArrayKlass.hpp
+++ b/src/hotspot/share/ci/ciArrayKlass.hpp
@@ -54,7 +54,6 @@ public:
 
   // What kind of vmObject is this?
   bool is_array_klass() const { return true; }
-  bool is_java_klass() const  { return true; }
 
   static ciArrayKlass* make(ciType* element_type);
 };

--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -63,7 +63,6 @@ ciInstanceKlass::ciInstanceKlass(Klass* k) :
   _has_finalizer = access_flags.has_finalizer();
   _has_subklass = flags().is_final() ? subklass_false : subklass_unknown;
   _init_state = ik->init_state();
-  _nonstatic_field_size = ik->nonstatic_field_size();
   _has_nonstatic_fields = ik->has_nonstatic_fields();
   _has_nonstatic_concrete_methods = ik->has_nonstatic_concrete_methods();
   _is_hidden = ik->is_hidden();
@@ -123,7 +122,6 @@ ciInstanceKlass::ciInstanceKlass(ciSymbol* name,
 {
   assert(name->char_at(0) != JVM_SIGNATURE_ARRAY, "not an instance klass");
   _init_state = (InstanceKlass::ClassState)0;
-  _nonstatic_field_size = -1;
   _has_nonstatic_fields = false;
   _nonstatic_fields = NULL;
   _has_injected_fields = -1;
@@ -495,9 +493,6 @@ int ciInstanceKlass::compute_nonstatic_fields() {
     return 0;
   }
   assert(!is_java_lang_Object(), "bootstrap OK");
-
-  // Size in bytes of my fields, including inherited fields.
-  int fsize = nonstatic_field_size() * heapOopSize;
 
   ciInstanceKlass* super = this->super();
   GrowableArray<ciField*>* super_fields = NULL;

--- a/src/hotspot/share/ci/ciInstanceKlass.hpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.hpp
@@ -61,8 +61,6 @@ private:
   bool                   _is_record;
 
   ciFlags                _flags;
-  jint                   _nonstatic_field_size;
-  jint                   _nonstatic_oop_map_size;
 
   // Lazy fields get filled in only upon request.
   ciInstanceKlass*       _super;
@@ -173,15 +171,9 @@ public:
     return (Klass::layout_helper_size_in_bytes(layout_helper())
             >> LogHeapWordSize);
   }
-  jint                   nonstatic_field_size()  {
-    assert(is_loaded(), "must be loaded");
-    return _nonstatic_field_size; }
   jint                   has_nonstatic_fields()  {
     assert(is_loaded(), "must be loaded");
     return _has_nonstatic_fields; }
-  jint                   nonstatic_oop_map_size()  {
-    assert(is_loaded(), "must be loaded");
-    return _nonstatic_oop_map_size; }
   ciInstanceKlass*       super();
   jint                   nof_implementors() {
     ciInstanceKlass* impl;
@@ -283,7 +275,6 @@ public:
 
   // What kind of ciObject is this?
   bool is_instance_klass() const { return true; }
-  bool is_java_klass() const     { return true; }
 
   virtual ciKlass* exact_klass() {
     if (is_loaded() && is_final() && !is_interface()) {


### PR DESCRIPTION
I've noticed some dead code in `ciInstanceKlass` (and also in `ciArrayKlass`). Mostly leftovers from [JDK-8237767](https://bugs.openjdk.java.net/browse/JDK-8237767).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275975](https://bugs.openjdk.java.net/browse/JDK-8275975): Remove dead code in ciInstanceKlass


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6118/head:pull/6118` \
`$ git checkout pull/6118`

Update a local copy of the PR: \
`$ git checkout pull/6118` \
`$ git pull https://git.openjdk.java.net/jdk pull/6118/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6118`

View PR using the GUI difftool: \
`$ git pr show -t 6118`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6118.diff">https://git.openjdk.java.net/jdk/pull/6118.diff</a>

</details>
