### PR TITLE
8275689: [TESTBUG] Use color tolerance only for XRender in BlitRotateClippedArea test

### DIFF
--- a/test/jdk/java/awt/image/DrawImage/BlitRotateClippedArea.java
+++ b/test/jdk/java/awt/image/DrawImage/BlitRotateClippedArea.java
@@ -32,17 +32,12 @@ import java.io.IOException;
 
 import javax.imageio.ImageIO;
 
-import jdk.test.lib.Platform;
-
 import static java.awt.Transparency.TRANSLUCENT;
 
 /**
  * @test
  * @bug 8255722 8255724
  * @key headful
- * @library /test/lib
- * @build jdk.test.lib.Platform
- * @run main BlitRotateClippedArea
  */
 public class BlitRotateClippedArea {
 
@@ -61,6 +56,7 @@ public class BlitRotateClippedArea {
         System.setProperty("sun.java2d.uiScale", "1");
         var ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
         var gc = ge.getDefaultScreenDevice().getDefaultConfiguration();
+        var className = gc.getClass().getSimpleName();
 
         var gold = gc.createCompatibleImage(1000, 1000, TRANSLUCENT);
         var dstVI2BI = gc.createCompatibleImage(1000, 1000, TRANSLUCENT);
@@ -99,14 +95,14 @@ public class BlitRotateClippedArea {
         } while (dstVI2VI.contentsLost() || dstBI2VI.contentsLost()
                 || srcVI.contentsLost());
 
-        validate(gold, snapshotVI2VI);
-        validate(gold, snapshotBI2VI);
-        validate(gold, dstVI2BI);
+        validate(gold, snapshotVI2VI, className);
+        validate(gold, snapshotBI2VI, className);
+        validate(gold, dstVI2BI, className);
     }
 
-    private static void validate(BufferedImage gold, BufferedImage img)
-            throws IOException {
-        if (!Platform.isLinux()) {
+    private static void validate(BufferedImage gold, BufferedImage img,
+                                 String className) throws IOException {
+        if (!(className.equals("XRGraphicsConfig"))) {
             for (int x = 0; x < gold.getWidth(); ++x) {
                 for (int y = 0; y < gold.getHeight(); ++y) {
                     if (gold.getRGB(x, y) != img.getRGB(x, y)) {
@@ -163,4 +159,3 @@ public class BlitRotateClippedArea {
         graphics.dispose();
     }
 }
-


### PR DESCRIPTION
This is follow up change after : https://bugs.openjdk.java.net/browse/JDK-8255724

Now color tolerance is only added for Linux(XRender is default pipeline in Linux and Solaris is not supported anymore). So I am using jdk.test.lib.Platform to determine which OS we are running on. CI run on all platforms is green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275689](https://bugs.openjdk.java.net/browse/JDK-8275689): [TESTBUG] Use color tolerance only for XRender in BlitRotateClippedArea test


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6119/head:pull/6119` \
`$ git checkout pull/6119`

Update a local copy of the PR: \
`$ git checkout pull/6119` \
`$ git pull https://git.openjdk.java.net/jdk pull/6119/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6119`

View PR using the GUI difftool: \
`$ git pr show -t 6119`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6119.diff">https://git.openjdk.java.net/jdk/pull/6119.diff</a>

</details>
