### PR TITLE
8275950: Use only _thread_in_vm in ~ThreadBlockInVMPreprocess()

### DIFF
--- a/src/hotspot/share/runtime/interfaceSupport.inline.hpp
+++ b/src/hotspot/share/runtime/interfaceSupport.inline.hpp
@@ -228,7 +228,7 @@ class ThreadBlockInVMPreprocess : public ThreadStateTransition {
   }
   ~ThreadBlockInVMPreprocess() {
     assert(_thread->thread_state() == _thread_blocked, "coming from wrong thread state");
-    // Change to transition state and ensure it is seen by the VM thread.
+    // Change back to _thread_in_vm and ensure it is seen by the VM thread.
     _thread->set_thread_state_fence(_thread_in_vm);
 
     if (SafepointMechanism::should_process(_thread, _allow_suspend)) {

--- a/src/hotspot/share/runtime/interfaceSupport.inline.hpp
+++ b/src/hotspot/share/runtime/interfaceSupport.inline.hpp
@@ -229,14 +229,12 @@ class ThreadBlockInVMPreprocess : public ThreadStateTransition {
   ~ThreadBlockInVMPreprocess() {
     assert(_thread->thread_state() == _thread_blocked, "coming from wrong thread state");
     // Change to transition state and ensure it is seen by the VM thread.
-    _thread->set_thread_state_fence(_thread_blocked_trans);
+    _thread->set_thread_state_fence(_thread_in_vm);
 
     if (SafepointMechanism::should_process(_thread, _allow_suspend)) {
       _pr(_thread);
       SafepointMechanism::process_if_requested(_thread, _allow_suspend);
     }
-
-    _thread->set_thread_state(_thread_in_vm);
   }
 
   static void emptyOp(JavaThread* current) {}

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -706,7 +706,6 @@ void SafepointSynchronize::block(JavaThread *thread) {
   }
 
   JavaThreadState state = thread->thread_state();
-  assert(is_a_block_safe_state(state), "Illegal threadstate encountered: %d", state);
   thread->frame_anchor()->make_walkable(thread);
 
   uint64_t safepoint_id = SafepointSynchronize::safepoint_counter();

--- a/src/hotspot/share/runtime/safepoint.hpp
+++ b/src/hotspot/share/runtime/safepoint.hpp
@@ -128,14 +128,7 @@ class SafepointSynchronize : AllStatic {
 
   static bool is_a_block_safe_state(JavaThreadState state) {
     // Check that we have a valid thread_state before blocking for safepoints
-    switch(state) {
-      case _thread_in_vm:
-      case _thread_in_Java:        // From compiled code
-      case _thread_blocked_trans:
-        return true;
-      default:
-        return false;
-    }
+    return state == _thread_in_vm || state == _thread_in_Java;
   }
   // Called when a thread voluntarily blocks
   static void block(JavaThread *thread);


### PR DESCRIPTION
Please review this small change. Since _thread_in_vm is already an unsafe state there is no need to use the intermediate _thread_blocked_trans state when transitioning back in ~ThreadBlockInVMPreprocess(). Tested tiers1-3 in mach5.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275950](https://bugs.openjdk.java.net/browse/JDK-8275950): Use only _thread_in_vm in ~ThreadBlockInVMPreprocess()


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 11da08be9a62ad9bc3b45aa604afb6f27db2a1c2
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6120/head:pull/6120` \
`$ git checkout pull/6120`

Update a local copy of the PR: \
`$ git checkout pull/6120` \
`$ git pull https://git.openjdk.java.net/jdk pull/6120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6120`

View PR using the GUI difftool: \
`$ git pr show -t 6120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6120.diff">https://git.openjdk.java.net/jdk/pull/6120.diff</a>

</details>
