### PR TITLE
8274750: java/io/File/GetXSpace.java failed: '/dev': 191488 != 190976

### DIFF
--- a/test/jdk/java/io/File/GetXSpace.java
+++ b/test/jdk/java/io/File/GetXSpace.java
@@ -51,6 +51,7 @@ import jdk.test.lib.Platform;
 import static java.lang.System.err;
 import static java.lang.System.out;
 
+@SuppressWarnings("removal")
 public class GetXSpace {
 
     private static SecurityManager [] sma = { null, new Allow(), new DenyFSA(),


### PR DESCRIPTION
Please consider this proposed change to ignore comparing the total size of `/dev` as returned by `DF(1)` and `STAT(2)` on macOS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274750](https://bugs.openjdk.java.net/browse/JDK-8274750): java/io/File/GetXSpace.java failed: '/dev': 191488 != 190976


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to c48f313201e43f7f99b925e7330b9016a25ac7d6


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6122/head:pull/6122` \
`$ git checkout pull/6122`

Update a local copy of the PR: \
`$ git checkout pull/6122` \
`$ git pull https://git.openjdk.java.net/jdk pull/6122/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6122`

View PR using the GUI difftool: \
`$ git pr show -t 6122`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6122.diff">https://git.openjdk.java.net/jdk/pull/6122.diff</a>

</details>
