### PR TITLE
8274388: ProblemList gtest dll_address_to_function_and_library_name on macosx-x64

### DIFF
--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -709,7 +709,11 @@ TEST_VM(os, pagesizes_test_print) {
   ASSERT_EQ(strcmp(expected, buffer), 0);
 }
 
-TEST_VM(os, dll_address_to_function_and_library_name) {
+#if defined(__APPLE__) && !defined(AARCH64)  // See JDK-8273967.
+  TEST_VM(os, DISABLED_dll_address_to_function_and_library_name) {
+#else
+  TEST_VM(os, dll_address_to_function_and_library_name) {
+#endif
   char tmp[1024];
   char output[1024];
   stringStream st(output, sizeof(output));


### PR DESCRIPTION
A trivial fix to ProblemList ProblemList gtest dll_address_to_function_and_library_name on macosx-x64.

Tested locally on my MBP13. Here's the baseline results for running the
dll_address_to_function_and_library_name sub-test:

$ grep -c dll_address_to_function_and_library_name *.baseline.jtr
GTestWrapper.fastdebug.baseline.jtr:2
GTestWrapper.release.baseline.jtr:2
GTestWrapper.slowdebug.baseline.jtr:2
NMTGtests_nmt-detail.fastdebug.baseline.jtr:2
NMTGtests_nmt-detail.slowdebug.baseline.jtr:2
NMTGtests_nmt-summary.fastdebug.baseline.jtr:0
NMTGtests_nmt-summary.slowdebug.baseline.jtr:0

Here's the results for running the dll_address_to_function_and_library_name sub-test
with the fix in place:

$ grep -c dll_address_to_function_and_library_name *.8274388.jtr
GTestWrapper.fastdebug.8274388.jtr:0
GTestWrapper.release.8274388.jtr:0
GTestWrapper.slowdebug.8274388.jtr:0
NMTGtests_nmt-detail.fastdebug.8274388.jtr:0
NMTGtests_nmt-detail.slowdebug.8274388.jtr:0
NMTGtests_nmt-summary.fastdebug.8274388.jtr:0
NMTGtests_nmt-summary.slowdebug.8274388.jtr:0

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274388](https://bugs.openjdk.java.net/browse/JDK-8274388): ProblemList gtest dll_address_to_function_and_library_name on macosx-x64


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6124/head:pull/6124` \
`$ git checkout pull/6124`

Update a local copy of the PR: \
`$ git checkout pull/6124` \
`$ git pull https://git.openjdk.java.net/jdk pull/6124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6124`

View PR using the GUI difftool: \
`$ git pr show -t 6124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6124.diff">https://git.openjdk.java.net/jdk/pull/6124.diff</a>

</details>
