### PR TITLE
8196017: java/awt/Mouse/GetMousePositionTest/GetMousePositionWithPopup.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -206,7 +206,6 @@ java/awt/event/MouseEvent/MouseButtonsAndKeyMasksTest/MouseButtonsAndKeyMasksTes
 java/awt/dnd/URIListToFileListBetweenJVMsTest/URIListToFileListBetweenJVMsTest.java 8194947 generic-all
 java/awt/Frame/FramesGC/FramesGC.java 8079069 macosx-all
 java/awt/GridLayout/LayoutExtraGaps/LayoutExtraGaps.java 8000171 windows-all
-java/awt/Mouse/GetMousePositionTest/GetMousePositionWithPopup.java 8196017 windows-all
 java/awt/Scrollbar/ScrollbarMouseWheelTest/ScrollbarMouseWheelTest.java 8196018 windows-all,linux-all
 java/awt/TrayIcon/ActionCommand/ActionCommand.java 8150540 windows-all
 java/awt/TrayIcon/ActionEventMask/ActionEventMask.java 8150540 windows-all

--- a/test/jdk/java/awt/Mouse/GetMousePositionTest/GetMousePositionWithPopup.java
+++ b/test/jdk/java/awt/Mouse/GetMousePositionTest/GetMousePositionWithPopup.java
@@ -27,7 +27,6 @@ import javax.swing.SwingUtilities;
 import java.awt.Frame;
 import java.awt.Point;
 import java.awt.Robot;
-import java.awt.event.InputEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseMotionAdapter;
 
@@ -85,6 +84,9 @@ public class GetMousePositionWithPopup {
         frame1.addMouseMotionListener(new MouseMotionAdapter() {
             @Override
             public void mouseMoved(MouseEvent e) {
+                if (frame2 != null) {
+                    return;
+                }
                 frame2 = new Frame();
                 frame2.setBounds(120, 120, 120, 120);
                 frame2.setVisible(true);

--- a/test/jdk/java/awt/Mouse/GetMousePositionTest/GetMousePositionWithPopup.java
+++ b/test/jdk/java/awt/Mouse/GetMousePositionTest/GetMousePositionWithPopup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,11 @@
 
 import test.java.awt.regtesthelpers.Util;
 
-import javax.swing.*;
-import java.awt.*;
+import javax.swing.SwingUtilities;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseMotionAdapter;
 
@@ -33,11 +36,10 @@ import java.awt.event.MouseMotionAdapter;
  * @key headful
  * @bug 8012026 8027154
  * @summary Component.getMousePosition() does not work in an applet on MacOS
- * @author Petr Pchelko
  * @library ../../regtesthelpers
  * @build Util
  * @compile GetMousePositionWithPopup.java
- * @run main/othervm GetMousePositionWithPopup
+ * @run main GetMousePositionWithPopup
  */
 
 public class GetMousePositionWithPopup {
@@ -48,6 +50,7 @@ public class GetMousePositionWithPopup {
     public static void main(String[] args) throws Exception {
         try {
         Robot r = Util.createRobot();
+        r.setAutoDelay(100);
         r.mouseMove(0, 0);
         Util.waitForIdle(null);
 
@@ -61,7 +64,7 @@ public class GetMousePositionWithPopup {
         Util.waitForIdle(null);
         r.mouseMove(149, 149);
         Util.waitForIdle(null);
-        r.mouseMove(150, 150);
+        r.mouseMove(170, 170);
         Util.waitForIdle(null);
 
         } finally {
@@ -78,20 +81,22 @@ public class GetMousePositionWithPopup {
     private static void constructTestUI() {
         frame1 = new Frame();
         frame1.setBounds(100, 100, 100, 100);
+        frame1.setVisible(true);
         frame1.addMouseMotionListener(new MouseMotionAdapter() {
-
             @Override
             public void mouseMoved(MouseEvent e) {
                 frame2 = new Frame();
                 frame2.setBounds(120, 120, 120, 120);
-
+                frame2.setVisible(true);
                 frame2.addMouseMotionListener(new MouseMotionAdapter() {
                     @Override
                     public void mouseMoved(MouseEvent e)
                     {
                         Point positionInFrame2 = frame2.getMousePosition();
-                        if (positionInFrame2.x != 30 || positionInFrame2.y != 30) {
-                            throw new RuntimeException("Wrong position reported. Should be [30, 30] but was [" +
+                        int deltaX = Math.abs(50 - positionInFrame2.x);
+                        int deltaY = Math.abs(50 - positionInFrame2.y);
+                        if (deltaX > 2 || deltaY > 2) {
+                            throw new RuntimeException("Wrong position reported. Should be [50, 50] but was [" +
                                     positionInFrame2.x + ", " + positionInFrame2.y + "]");
                         }
 
@@ -101,10 +106,7 @@ public class GetMousePositionWithPopup {
                         }
                     }
                 });
-
-                frame2.setVisible(true);
             }
         });
-        frame1.setVisible(true);
     }
 }


### PR DESCRIPTION
The problem here is that due to the approximation of the coordinates when converting
to and from screen cordinate system on screen with 125% magnification 
two things can happen:
1. New mouse position calculated can be 149/149 which is the same as the starting position
and system can refuse to generate new mouse event which causes false positive of the test
since second mouse motion listener was never called;
2. Even if event is generated the resulting reported coordinates can differ by 1 pixel
in any of the directions;

To solve it i moved away the target point to make sure that move event always generated and
comparing expected and actual coordinates with approximation of +/- 1 pixel.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8196017](https://bugs.openjdk.java.net/browse/JDK-8196017): java/awt/Mouse/GetMousePositionTest/GetMousePositionWithPopup.java fails


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6128/head:pull/6128` \
`$ git checkout pull/6128`

Update a local copy of the PR: \
`$ git checkout pull/6128` \
`$ git pull https://git.openjdk.java.net/jdk pull/6128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6128`

View PR using the GUI difftool: \
`$ git pr show -t 6128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6128.diff">https://git.openjdk.java.net/jdk/pull/6128.diff</a>

</details>
