### PR TITLE
8275847: Scheduling fails with "too many D-U pinch points" on small method

### DIFF
--- a/src/hotspot/cpu/x86/vmreg_x86.hpp
+++ b/src/hotspot/cpu/x86/vmreg_x86.hpp
@@ -90,7 +90,13 @@ inline   bool is_concrete() {
 #ifndef AMD64
   if (is_Register()) return true;
 #endif // AMD64
-  return is_even(value());
+  // Do not use is_XMMRegister() here as it depends on the UseAVX settting.
+  if (value() >= ConcreteRegisterImpl::max_fpr && value() < ConcreteRegisterImpl::max_xmm) {
+    int base = value() - ConcreteRegisterImpl::max_fpr;
+    return base % XMMRegisterImpl::max_slots_per_register == 0;
+  } else {
+    return is_even(value());   // General, float, and K registers are all two slots wide
+  }
 }
 
 #endif // CPU_X86_VMREG_X86_HPP

--- a/src/hotspot/cpu/x86/vmreg_x86.hpp
+++ b/src/hotspot/cpu/x86/vmreg_x86.hpp
@@ -90,7 +90,7 @@ inline   bool is_concrete() {
 #ifndef AMD64
   if (is_Register()) return true;
 #endif // AMD64
-  // Do not use is_XMMRegister() here as it depends on the UseAVX settting.
+  // Do not use is_XMMRegister() here as it depends on the UseAVX setting.
   if (value() >= ConcreteRegisterImpl::max_fpr && value() < ConcreteRegisterImpl::max_xmm) {
     int base = value() - ConcreteRegisterImpl::max_fpr;
     return base % XMMRegisterImpl::max_slots_per_register == 0;

--- a/src/hotspot/share/opto/buildOopMap.cpp
+++ b/src/hotspot/share/opto/buildOopMap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -231,10 +231,6 @@ OopMap *OopFlow::build_oop_map( Node *n, int max_reg, PhaseRegAlloc *regalloc, i
 
     VMReg r = OptoReg::as_VMReg(OptoReg::Name(reg), framesize, max_inarg_slot);
 
-    if (false && r->is_reg() && !r->is_concrete()) {
-      continue;
-    }
-
     // See if dead (no reaching def).
     Node *def = _defs[reg];     // Get reaching def
     assert( def, "since live better have reaching def" );
@@ -312,14 +308,10 @@ OopMap *OopFlow::build_oop_map( Node *n, int max_reg, PhaseRegAlloc *regalloc, i
           set_live_bit(live,breg);
           // Already missed our turn?
           if( breg < reg ) {
-            if (b->is_stack() || b->is_concrete() || true ) {
-              omap->set_oop( b);
-            }
+            omap->set_oop(b);
           }
         }
-        if (b->is_stack() || b->is_concrete() || true ) {
-          omap->set_derived_oop( r, b);
-        }
+        omap->set_derived_oop(r, b);
       }
 
     } else if( t->isa_narrowoop() ) {
@@ -347,9 +339,7 @@ OopMap *OopFlow::build_oop_map( Node *n, int max_reg, PhaseRegAlloc *regalloc, i
       assert( dup_check[_callees[reg]]==0, "trying to callee save same reg twice" );
       debug_only( dup_check[_callees[reg]]=1; )
       VMReg callee = OptoReg::as_VMReg(OptoReg::Name(_callees[reg]));
-      if ( callee->is_concrete() || true ) {
-        omap->set_callee_saved( r, callee);
-      }
+      omap->set_callee_saved(r, callee);
 
     } else {
       // Other - some reaching non-oop value

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -2915,6 +2915,16 @@ void Scheduling::anti_do_def( Block *b, Node *def, OptoReg::Name def_reg, int is
   if( !OptoReg::is_valid(def_reg) ) // Ignore stores & control flow
     return;
 
+  if (OptoReg::is_reg(def_reg)) {
+    VMReg vmreg = OptoReg::as_VMReg(def_reg);
+    if (vmreg->is_reg() && !vmreg->is_concrete() && !vmreg->prev()->is_concrete()) {
+      // This is one of the high slots of a vector register.
+      // ScheduleAndBundle already checked there are no live wide
+      // vectors in this method so it can be safely ignored.
+      return;
+    }
+  }
+
   Node *pinch = _reg_node[def_reg]; // Get pinch point
   if ((pinch == NULL) || _cfg->get_block_for_node(pinch) != b || // No pinch-point yet?
       is_def ) {    // Check for a true def (not a kill)

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestScheduleSmallMethod.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestScheduleSmallMethod.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests;
+
+import jdk.test.lib.Asserts;
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8275847
+ * @requires vm.compiler2.enabled
+ * @summary Test that small method with runtime calls can be scheduled.
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.TestScheduleSmallMethod
+ */
+public class TestScheduleSmallMethod {
+
+    public static void main(String[] args) {
+        TestFramework framework = new TestFramework();
+        Scenario schedulerOn = new Scenario(0, "-XX:+OptoScheduling");
+        Scenario schedulerOff = new Scenario(1, "-XX:-OptoScheduling");
+        framework.addScenarios(schedulerOn, schedulerOff).start();
+    }
+
+    @Test
+    public double testSmallMethodTwoRuntimeCalls(double value) {
+        // The two intrinsified Math calls below caused the scheduler to
+        // bail out with "too many D-U pinch points". See bug 8275847.
+        return Math.log(Math.sin(value));
+    }
+
+    @Run(test = "testSmallMethodTwoRuntimeCalls")
+    public void checkTestSmallMethodTwoRuntimeCalls() throws Throwable {
+        Asserts.assertLessThan(testSmallMethodTwoRuntimeCalls(Math.PI/2), 0.00001);
+    }
+}


### PR DESCRIPTION
Since around JDK 16 the following method cannot be compiled by C2 on AArch64:

```java
  public double mergeSync() { return Math.log(Math.sin(value)); }
```

(Reduced from a slightly larger benchmark.)

```
  811 416 ! 3 Test::mergeSync (61 bytes)
  813 417 ! 4 Test::mergeSync (61 bytes)
  816 417 ! 4 Test::mergeSync (61 bytes) COMPILE SKIPPED: too many D-U pinch points (retry at different tier)
  816 418 ! 1 Test::mergeSync (61 bytes)
```

Scheduling::anti_do_def() will create temporary Nodes for each OptoReg killed by the MachProjs from the two runtime leaf calls.  After SVE support was added these runtime calls kill more registers, and the number of new Nodes added by anti_do_def exceeds an internal limit (which is based on the LRG map size and roughly proportional to the method size).

X86 has the same problem if OptoScheduling is enabled because of the wide AVX registers.

The fix here is to ignore OptoRegs which correspond to the high slots of wide vectors (i.e. slots above 64 bits).  The scheduler doesn't run on methods where C->max_vector_size() > 8, so we know these kills can't affect the scheduling result.

The added test fails on the current JDK with:

```
  compiler.lib.ir_framework.shared.TestRunException: Could not compile public double
  compiler.c2.irTests.TestScheduleSmallMethod.testSmallMethodTwoRuntimeCalls(double) at level C2
  after 10s. Last compilation level: 3
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275847](https://bugs.openjdk.java.net/browse/JDK-8275847): Scheduling fails with "too many D-U pinch points" on small method


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6131/head:pull/6131` \
`$ git checkout pull/6131`

Update a local copy of the PR: \
`$ git checkout pull/6131` \
`$ git pull https://git.openjdk.java.net/jdk pull/6131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6131`

View PR using the GUI difftool: \
`$ git pr show -t 6131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6131.diff">https://git.openjdk.java.net/jdk/pull/6131.diff</a>

</details>
