### PR TITLE
JDK-8276046: codestrings.validate_vm gtest fails on ppc64, s390

### DIFF
--- a/test/hotspot/gtest/code/test_codestrings.cpp
+++ b/test/hotspot/gtest/code/test_codestrings.cpp
@@ -26,8 +26,7 @@
 #ifndef PRODUCT
 #ifndef ZERO
 // Neither ppc nor s390 compilers use code strings.
-#ifndef PPC
-#ifndef S390
+#if !defined(PPC) && !defined(S390)
 
 #include "asm/macroAssembler.inline.hpp"
 #include "compiler/disassembler.hpp"
@@ -265,7 +264,6 @@ TEST_VM(codestrings, validate)
     buffer_blob_test();
 }
 
-#endif // not S390
-#endif // not PPC
+#endif // not S390 not PPC
 #endif // not ZERO
 #endif // not PRODUCT


### PR DESCRIPTION
Trivial patch to switch off the associated gtest on these platforms. PPC64 and s390 compilers don't use code strings.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276046](https://bugs.openjdk.java.net/browse/JDK-8276046): codestrings.validate_vm gtest fails on ppc64, s390


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to 0f3e2cf3a280ba024b622ee4b1ab8d2643344332
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to f651b6ae24506ff6ca9bae03bfc4fb9196963754


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6133/head:pull/6133` \
`$ git checkout pull/6133`

Update a local copy of the PR: \
`$ git checkout pull/6133` \
`$ git pull https://git.openjdk.java.net/jdk pull/6133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6133`

View PR using the GUI difftool: \
`$ git pr show -t 6133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6133.diff">https://git.openjdk.java.net/jdk/pull/6133.diff</a>

</details>
