### PR TITLE
8276047: G1: refactor G1CardSetArrayLocker

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
@@ -196,19 +196,19 @@ private:
   static const EntryCountType EntryMask = LockBitMask - 1;
 
   class G1CardSetArrayLocker : public StackObj {
-    EntryCountType volatile* _value;
-    EntryCountType volatile _original_value;
-    bool _success;
+    EntryCountType volatile* _num_entries_addr;
+    EntryCountType _local_num_entries;
   public:
     G1CardSetArrayLocker(EntryCountType volatile* value);
 
-    EntryCountType num_entries() const { return _original_value; }
-    void inc_num_entries() { _success = true; }
+    EntryCountType num_entries() const { return _local_num_entries; }
+    void inc_num_entries() {
+      assert(((_local_num_entries + 1) & EntryMask) == (EntryCountType)(_local_num_entries + 1), "no overflow" );
+      _local_num_entries++;
+    }
 
     ~G1CardSetArrayLocker() {
-      assert(((_original_value + _success) & EntryMask) == (EntryCountType)(_original_value + _success), "precondition!" );
-
-      Atomic::release_store(_value, (EntryCountType)(_original_value + _success));
+      Atomic::release_store(_num_entries_addr, _local_num_entries);
     }
   };
 


### PR DESCRIPTION
Simple refactoring in `G1CardSetArrayLocker`:

1. rename fields to sth more explicit
2. drop `volatile` for thread-local variables
3. increment directly without treating `bool` as an integer

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276047](https://bugs.openjdk.java.net/browse/JDK-8276047): G1: refactor G1CardSetArrayLocker


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6134/head:pull/6134` \
`$ git checkout pull/6134`

Update a local copy of the PR: \
`$ git checkout pull/6134` \
`$ git pull https://git.openjdk.java.net/jdk pull/6134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6134`

View PR using the GUI difftool: \
`$ git pr show -t 6134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6134.diff">https://git.openjdk.java.net/jdk/pull/6134.diff</a>

</details>
