### PR TITLE
8276048: Error in javadoc regarding Long method public static Long valueOf(String s)

### DIFF
--- a/src/java.base/share/classes/java/lang/Long.java
+++ b/src/java.base/share/classes/java/lang/Long.java
@@ -1138,7 +1138,7 @@ public final class Long extends Number
      * interpreted as representing a signed decimal {@code long},
      * exactly as if the argument were given to the {@link
      * #parseLong(java.lang.String)} method. The result is a
-     * {@code Long} object that represents the integer value
+     * {@code Long} object that represents the {@code Long} value
      * specified by the string.
      *
      * <p>In other words, this method returns a {@code Long} object


### PR DESCRIPTION
8276048: Error in javadoc regarding Long method public static Long valueOf(String s)
Fix: Changing integer to {@code Long}

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8276048](https://bugs.openjdk.java.net/browse/JDK-8276048): Error in javadoc regarding Long method public static Long valueOf(String s)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6135/head:pull/6135` \
`$ git checkout pull/6135`

Update a local copy of the PR: \
`$ git checkout pull/6135` \
`$ git pull https://git.openjdk.java.net/jdk pull/6135/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6135`

View PR using the GUI difftool: \
`$ git pr show -t 6135`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6135.diff">https://git.openjdk.java.net/jdk/pull/6135.diff</a>

</details>
