### PR TITLE
8276058: Some swing test fails on specific CI macos system

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -192,7 +192,7 @@ java/awt/Toolkit/RealSync/Test.java 6849383 linux-all
 java/awt/LightweightComponent/LightweightEventTest/LightweightEventTest.java 8159252 windows-all
 java/awt/EventDispatchThread/HandleExceptionOnEDT/HandleExceptionOnEDT.java 8203047 macosx-all
 java/awt/EventDispatchThread/LoopRobustness/LoopRobustness.java 8073636 macosx-all
-java/awt/FullScreen/FullScreenInsets/FullScreenInsets.java 7019055,8266245 windows-all,linux-all,macosx-aarch64
+java/awt/FullScreen/FullScreenInsets/FullScreenInsets.java 7019055,8266245 windows-all,linux-all,macosx-all
 java/awt/Focus/8013611/JDK8013611.java 8175366 windows-all,macosx-all
 java/awt/Focus/6981400/Test1.java 8029675 windows-all,macosx-all
 java/awt/Focus/6981400/Test3.java 8173264 generic-all

--- a/test/jdk/java/awt/Dialog/MakeWindowAlwaysOnTop/MakeWindowAlwaysOnTop.java
+++ b/test/jdk/java/awt/Dialog/MakeWindowAlwaysOnTop/MakeWindowAlwaysOnTop.java
@@ -46,6 +46,10 @@ public class MakeWindowAlwaysOnTop
     private static Frame f;
     private static Dialog d;
 
+    // move away from cursor
+    private final static int OFFSET_X = -20;
+    private final static int OFFSET_Y = -20;
+
     public static void main(String[] args) throws Exception
     {
         Robot r = Util.createRobot();
@@ -101,7 +105,7 @@ public class MakeWindowAlwaysOnTop
         Util.waitForIdle(r);
 
 
-        Color c = r.getPixelColor(p.x + f.getWidth() / 2, p.y + f.getHeight() / 2);
+        Color c = r.getPixelColor(p.x + f.getWidth() / 2 - OFFSET_X, p.y + f.getHeight() / 2 - OFFSET_Y);
         System.out.println("Color = " + c);
 
         String exceptionMessage = null;

--- a/test/jdk/java/awt/Dialog/MakeWindowAlwaysOnTop/MakeWindowAlwaysOnTop.java
+++ b/test/jdk/java/awt/Dialog/MakeWindowAlwaysOnTop/MakeWindowAlwaysOnTop.java
@@ -101,7 +101,7 @@ public class MakeWindowAlwaysOnTop
         Util.waitForIdle(r);
 
 
-        Color c = r.getPixelColor(p.x + f.getWidth() / 2, p.y + f.getHeight() / 2);
+        Color c = r.getPixelColor(p.x + f.getWidth() / 2-10, p.y + f.getHeight() / 2-10);
         System.out.println("Color = " + c);
 
         String exceptionMessage = null;

--- a/test/jdk/java/awt/Dialog/MakeWindowAlwaysOnTop/MakeWindowAlwaysOnTop.java
+++ b/test/jdk/java/awt/Dialog/MakeWindowAlwaysOnTop/MakeWindowAlwaysOnTop.java
@@ -101,7 +101,7 @@ public class MakeWindowAlwaysOnTop
         Util.waitForIdle(r);
 
 
-        Color c = r.getPixelColor(p.x + f.getWidth() / 2-10, p.y + f.getHeight() / 2-10);
+        Color c = r.getPixelColor(p.x + f.getWidth() / 2, p.y + f.getHeight() / 2);
         System.out.println("Color = " + c);
 
         String exceptionMessage = null;

--- a/test/jdk/java/awt/FullScreen/FullScreenInsets/FullScreenInsets.java
+++ b/test/jdk/java/awt/FullScreen/FullScreenInsets/FullScreenInsets.java
@@ -122,6 +122,7 @@ public final class FullScreenInsets {
 
     private static void testColor(final Window w, final Color color) {
         final Robot r;
+        int tolerance = 5;
         try {
             r = new Robot(w.getGraphicsConfiguration().getDevice());
         } catch (AWTException e) {
@@ -132,7 +133,12 @@ public final class FullScreenInsets {
         final BufferedImage bi = r.createScreenCapture(w.getBounds());
         for (int y = 0; y < bi.getHeight(); y++) {
             for (int x = 0; x < bi.getWidth(); x++) {
-                if (bi.getRGB(x, y) != color.getRGB()) {
+                Color col = new Color(bi.getRGB(x,y));
+
+		if ((Math.abs(col.getAlpha()-color.getAlpha()) > tolerance) ||
+		    (Math.abs(col.getRed()-color.getRed()) > tolerance) ||
+		    (Math.abs(col.getBlue()-color.getBlue()) > tolerance) ||
+		    (Math.abs(col.getGreen()-color.getGreen()) > tolerance)) {
                     System.err.println(
                             "Incorrect pixel at " + x + "x" + y + " : " +
                             Integer.toHexString(bi.getRGB(x, y)) +

--- a/test/jdk/java/awt/FullScreen/FullScreenInsets/FullScreenInsets.java
+++ b/test/jdk/java/awt/FullScreen/FullScreenInsets/FullScreenInsets.java
@@ -135,10 +135,10 @@ public final class FullScreenInsets {
             for (int x = 0; x < bi.getWidth(); x++) {
                 Color col = new Color(bi.getRGB(x,y));
 
-		if ((Math.abs(col.getAlpha()-color.getAlpha()) > tolerance) ||
-		    (Math.abs(col.getRed()-color.getRed()) > tolerance) ||
-		    (Math.abs(col.getBlue()-color.getBlue()) > tolerance) ||
-		    (Math.abs(col.getGreen()-color.getGreen()) > tolerance)) {
+                if ((Math.abs(col.getAlpha()-color.getAlpha()) > tolerance) ||
+                    (Math.abs(col.getRed()-color.getRed()) > tolerance) ||
+                    (Math.abs(col.getBlue()-color.getBlue()) > tolerance) ||
+                    (Math.abs(col.getGreen()-color.getGreen()) > tolerance)) {
                     System.err.println(
                             "Incorrect pixel at " + x + "x" + y + " : " +
                             Integer.toHexString(bi.getRGB(x, y)) +

--- a/test/jdk/java/awt/FullScreen/FullScreenInsets/FullScreenInsets.java
+++ b/test/jdk/java/awt/FullScreen/FullScreenInsets/FullScreenInsets.java
@@ -122,7 +122,6 @@ public final class FullScreenInsets {
 
     private static void testColor(final Window w, final Color color) {
         final Robot r;
-        int tolerance = 5;
         try {
             r = new Robot(w.getGraphicsConfiguration().getDevice());
         } catch (AWTException e) {
@@ -133,12 +132,7 @@ public final class FullScreenInsets {
         final BufferedImage bi = r.createScreenCapture(w.getBounds());
         for (int y = 0; y < bi.getHeight(); y++) {
             for (int x = 0; x < bi.getWidth(); x++) {
-                Color col = new Color(bi.getRGB(x,y));
-
-                if ((Math.abs(col.getAlpha()-color.getAlpha()) > tolerance) ||
-                    (Math.abs(col.getRed()-color.getRed()) > tolerance) ||
-                    (Math.abs(col.getBlue()-color.getBlue()) > tolerance) ||
-                    (Math.abs(col.getGreen()-color.getGreen()) > tolerance)) {
+                if (bi.getRGB(x, y) != color.getRGB()) {
                     System.err.println(
                             "Incorrect pixel at " + x + "x" + y + " : " +
                             Integer.toHexString(bi.getRGB(x, y)) +

--- a/test/jdk/javax/swing/JButton/8151303/PressedIconTest.java
+++ b/test/jdk/javax/swing/JButton/8151303/PressedIconTest.java
@@ -59,6 +59,9 @@ public class PressedIconTest {
     private static volatile int centerX;
     private static volatile int centerY;
     private static volatile Point location;
+    // move away from cursor
+    private final static int OFFSET_X = -20;
+    private final static int OFFSET_Y = -20;
 
     public static void main(String[] args) throws Exception {
         Robot robot = new Robot();
@@ -84,7 +87,7 @@ public class PressedIconTest {
         robot.waitForIdle();
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.waitForIdle();
-        Color color = robot.getPixelColor(centerX, centerY);
+        Color color = robot.getPixelColor(centerX - OFFSET_X, centerY - OFFSET_Y);
 
         Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
         Rectangle screen = new Rectangle(0, 0, (int) screenSize.getWidth(), (int) screenSize.getHeight());
@@ -97,11 +100,11 @@ public class PressedIconTest {
         SwingUtilities.invokeAndWait(() -> frame.dispose());
 
         if (scale == 1 && !similar(color, COLOR_1X)) {
-            System.out.println("color " + color + " COLOR_1X" + COLOR_1X);
+            System.out.println("color " + color + " COLOR_1X " + COLOR_1X);
             throw new RuntimeException("Colors is different for scale=1!");
         }
         if (scale == 2 && !similar(color, COLOR_2X)) {
-            System.out.println("color " + color + " COLOR_2X" + COLOR_2X);
+            System.out.println("color " + color + " COLOR_2X " + COLOR_2X);
             throw new RuntimeException("Colors is different for scale=2!");
         }
         System.out.println("Test Passed");

--- a/test/jdk/javax/swing/JButton/8151303/PressedIconTest.java
+++ b/test/jdk/javax/swing/JButton/8151303/PressedIconTest.java
@@ -84,7 +84,7 @@ public class PressedIconTest {
         robot.waitForIdle();
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.waitForIdle();
-        Color color = robot.getPixelColor(centerX-10, centerY-10);
+        Color color = robot.getPixelColor(centerX, centerY);
 
         Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
         Rectangle screen = new Rectangle(0, 0, (int) screenSize.getWidth(), (int) screenSize.getHeight());

--- a/test/jdk/javax/swing/JButton/8151303/PressedIconTest.java
+++ b/test/jdk/javax/swing/JButton/8151303/PressedIconTest.java
@@ -26,7 +26,9 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.Robot;
+import java.awt.Toolkit;
 import java.awt.event.InputEvent;
 import java.awt.image.BaseMultiResolutionImage;
 import java.awt.image.BufferedImage;
@@ -56,37 +58,53 @@ public class PressedIconTest {
     private static volatile double scale = -1;
     private static volatile int centerX;
     private static volatile int centerY;
+    private static volatile Point location;
 
     public static void main(String[] args) throws Exception {
         Robot robot = new Robot();
-        robot.setAutoDelay(50);
+        robot.setAutoDelay(100);
 
         SwingUtilities.invokeAndWait(() -> createAndShowGUI());
         robot.waitForIdle();
+        robot.delay(1000);
 
         SwingUtilities.invokeAndWait(() -> {
             scale = frame.getGraphicsConfiguration().getDefaultTransform()
                     .getScaleX();
-            Point location = frame.getLocation();
+            location = frame.getLocation();
             Dimension size = frame.getSize();
             centerX = location.x + size.width / 2;
             centerY = location.y + size.height / 2;
         });
         robot.waitForIdle();
 
+        System.out.println("scale " + scale);
+
         robot.mouseMove(centerX, centerY);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
         robot.waitForIdle();
-        Thread.sleep(100);
-        Color color = robot.getPixelColor(centerX, centerY);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.waitForIdle();
+        Color color = robot.getPixelColor(centerX-10, centerY-10);
+
+        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+        Rectangle screen = new Rectangle(0, 0, (int) screenSize.getWidth(), (int) screenSize.getHeight());
+        BufferedImage img = robot.createScreenCapture(screen);
+        javax.imageio.ImageIO.write(img, "png", new java.io.File("image.png"));
+
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
 
         SwingUtilities.invokeAndWait(() -> frame.dispose());
 
-        if ((scale == 1 && !similar(color, COLOR_1X))
-                || (scale == 2 && !similar(color, COLOR_2X))) {
-            throw new RuntimeException("Colors are different!");
+        if (scale == 1 && !similar(color, COLOR_1X)) {
+            System.out.println("color " + color + " COLOR_1X" + COLOR_1X);
+            throw new RuntimeException("Colors is different for scale=1!");
         }
+        if (scale == 2 && !similar(color, COLOR_2X)) {
+            System.out.println("color " + color + " COLOR_2X" + COLOR_2X);
+            throw new RuntimeException("Colors is different for scale=2!");
+        }
+        System.out.println("Test Passed");
     }
 
     private static void createAndShowGUI() {
@@ -108,6 +126,8 @@ public class PressedIconTest {
         panel.add(button, BorderLayout.CENTER);
 
         frame.getContentPane().add(panel);
+	frame.setUndecorated(true);
+	frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
 

--- a/test/jdk/javax/swing/JButton/8151303/PressedIconTest.java
+++ b/test/jdk/javax/swing/JButton/8151303/PressedIconTest.java
@@ -126,8 +126,8 @@ public class PressedIconTest {
         panel.add(button, BorderLayout.CENTER);
 
         frame.getContentPane().add(panel);
-	frame.setUndecorated(true);
-	frame.setLocationRelativeTo(null);
+        frame.setUndecorated(true);
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
 

--- a/test/jdk/javax/swing/JInternalFrame/8069348/bug8069348.java
+++ b/test/jdk/javax/swing/JInternalFrame/8069348/bug8069348.java
@@ -92,10 +92,10 @@ public class bug8069348 {
 
             robot.mouseMove(cx, cy);
             robot.waitForIdle();
-	    Color color = robot.getPixelColor(cx-10, cy-10);
+            Color color = robot.getPixelColor(cx-10, cy-10);
             if (!FRAME_COLOR.equals(color)) {
 
-		System.out.println("cx " + cx + " cy " + cy);
+                System.out.println("cx " + cx + " cy " + cy);
                 System.err.println("FRAME_COLOR Red: " + FRAME_COLOR.getRed() + "; Green: " + FRAME_COLOR.getGreen() + "; Blue: " + FRAME_COLOR.getBlue());
                 System.err.println("Pixel color Red: " + color.getRed() + "; Green: " + color.getGreen() + "; Blue: " + color.getBlue());
                 Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
@@ -112,7 +112,7 @@ public class bug8069348 {
                 }
             });
         }
-	System.out.println("Test Passed");
+        System.out.println("Test Passed");
     }
 
     private static boolean isSupported() {

--- a/test/jdk/javax/swing/JInternalFrame/8069348/bug8069348.java
+++ b/test/jdk/javax/swing/JInternalFrame/8069348/bug8069348.java
@@ -23,9 +23,12 @@
 
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Rectangle;
 import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.image.BufferedImage;
 import java.awt.event.InputEvent;
 import javax.swing.JDesktopPane;
 import javax.swing.JFrame;
@@ -66,7 +69,7 @@ public class bug8069348 {
             SwingUtilities.invokeAndWait(bug8069348::createAndShowGUI);
 
             Robot robot = new Robot();
-            robot.setAutoDelay(50);
+            robot.setAutoDelay(100);
             robot.waitForIdle();
 
             Rectangle screenBounds = getInternalFrameScreenBounds();
@@ -79,27 +82,42 @@ public class bug8069348 {
             robot.mouseMove(x, y);
             robot.waitForIdle();
 
-            robot.mousePress(InputEvent.BUTTON1_MASK);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.mouseMove(x + dx, y + dy);
-            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
 
             int cx = screenBounds.x + screenBounds.width + dx / 2;
             int cy = screenBounds.y + screenBounds.height + dy / 2;
 
             robot.mouseMove(cx, cy);
-            if (!FRAME_COLOR.equals(robot.getPixelColor(cx, cy))) {
+            robot.waitForIdle();
+	    Color color = robot.getPixelColor(cx-10, cy-10);
+            if (!FRAME_COLOR.equals(color)) {
+
+		System.out.println("cx " + cx + " cy " + cy);
+                System.err.println("FRAME_COLOR Red: " + FRAME_COLOR.getRed() + "; Green: " + FRAME_COLOR.getGreen() + "; Blue: " + FRAME_COLOR.getBlue());
+                System.err.println("Pixel color Red: " + color.getRed() + "; Green: " + color.getGreen() + "; Blue: " + color.getBlue());
+                Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+                Rectangle screen = new Rectangle(0, 0, (int) screenSize.getWidth(), (int) screenSize.getHeight());
+                BufferedImage img = robot.createScreenCapture(screen);
+                javax.imageio.ImageIO.write(img, "png", new java.io.File("image.png"));
+
                 throw new RuntimeException("Internal frame is not correctly dragged!");
             }
         } finally {
-            if (frame != null) {
-                frame.dispose();
-            }
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
         }
+	System.out.println("Test Passed");
     }
 
     private static boolean isSupported() {
         String d3d = System.getProperty("sun.java2d.d3d");
+        System.out.println("d3d " + d3d);
         return !Boolean.getBoolean(d3d) || getOSType() == OSType.WINDOWS;
     }
 
@@ -138,6 +156,7 @@ public class bug8069348 {
         panel.add(desktopPane, BorderLayout.CENTER);
         frame.add(panel);
         frame.setSize(WIN_WIDTH, WIN_HEIGHT);
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
         frame.requestFocus();
     }

--- a/test/jdk/javax/swing/JInternalFrame/8069348/bug8069348.java
+++ b/test/jdk/javax/swing/JInternalFrame/8069348/bug8069348.java
@@ -55,6 +55,10 @@ public class bug8069348 {
     private static final Color DESKTOPPANE_COLOR = Color.YELLOW;
     private static final Color FRAME_COLOR = Color.ORANGE;
 
+     // move away from cursor
+    private final static int OFFSET_X = -20;
+    private final static int OFFSET_Y = -20;
+
     private static JFrame frame;
     private static JInternalFrame internalFrame;
 
@@ -92,11 +96,12 @@ public class bug8069348 {
 
             robot.mouseMove(cx, cy);
             robot.waitForIdle();
-            Color color = robot.getPixelColor(cx, cy);
+            Color color = robot.getPixelColor(cx - OFFSET_X, cy - OFFSET_Y);
+
+            if (!FRAME_COLOR.equals(color)) {
                 System.out.println("cx " + cx + " cy " + cy);
                 System.err.println("FRAME_COLOR Red: " + FRAME_COLOR.getRed() + "; Green: " + FRAME_COLOR.getGreen() + "; Blue: " + FRAME_COLOR.getBlue());
                 System.err.println("Pixel color Red: " + color.getRed() + "; Green: " + color.getGreen() + "; Blue: " + color.getBlue());
-            if (!FRAME_COLOR.equals(color)) {
 
                 Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
                 Rectangle screen = new Rectangle(0, 0, (int) screenSize.getWidth(), (int) screenSize.getHeight());

--- a/test/jdk/javax/swing/JInternalFrame/8069348/bug8069348.java
+++ b/test/jdk/javax/swing/JInternalFrame/8069348/bug8069348.java
@@ -92,12 +92,12 @@ public class bug8069348 {
 
             robot.mouseMove(cx, cy);
             robot.waitForIdle();
-            Color color = robot.getPixelColor(cx-10, cy-10);
-            if (!FRAME_COLOR.equals(color)) {
-
+            Color color = robot.getPixelColor(cx, cy);
                 System.out.println("cx " + cx + " cy " + cy);
                 System.err.println("FRAME_COLOR Red: " + FRAME_COLOR.getRed() + "; Green: " + FRAME_COLOR.getGreen() + "; Blue: " + FRAME_COLOR.getBlue());
                 System.err.println("Pixel color Red: " + color.getRed() + "; Green: " + color.getGreen() + "; Blue: " + color.getBlue());
+            if (!FRAME_COLOR.equals(color)) {
+
                 Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
                 Rectangle screen = new Rectangle(0, 0, (int) screenSize.getWidth(), (int) screenSize.getHeight());
                 BufferedImage img = robot.createScreenCapture(screen);

--- a/test/jdk/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
+++ b/test/jdk/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
@@ -43,6 +43,10 @@ public class bug6276188 {
     private static Point p;
     private static JFrame testFrame;
 
+     // move away from cursor
+    private final static int OFFSET_X = -20;
+    private final static int OFFSET_Y = -20;
+
     public static void main(String[] args) throws Throwable {
         try {
             Robot robot = new Robot();
@@ -76,12 +80,12 @@ public class bug6276188 {
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
 
-            Color color = robot.getPixelColor(p.x, p.y);
+            Color color = robot.getPixelColor(p.x - OFFSET_X, p.y - OFFSET_y);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
             boolean red = color.getRed() > 0 && color.getGreen() == 0 && color.getBlue() == 0;
-                System.err.println("Red: " + color.getRed() + "; Green: " + color.getGreen() + "; Blue: " + color.getBlue());
             if (!red) {
+                System.err.println("Red: " + color.getRed() + "; Green: " + color.getGreen() + "; Blue: " + color.getBlue());
                 Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
                 Rectangle screen = new Rectangle(0, 0, (int) screenSize.getWidth(), (int) screenSize.getHeight());
                 BufferedImage img = robot.createScreenCapture(screen);

--- a/test/jdk/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
+++ b/test/jdk/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
@@ -69,7 +69,7 @@ public class bug6276188 {
             robot.delay(1000);
 
             p = Util.getCenterPoint(button);
-	    System.out.println("Button center point: " + p);
+            System.out.println("Button center point: " + p);
 
             robot.mouseMove(p.x , p.y);
             robot.waitForIdle();
@@ -84,7 +84,7 @@ public class bug6276188 {
                 System.err.println("Red: " + color.getRed() + "; Green: " + color.getGreen() + "; Blue: " + color.getBlue());
                 throw new RuntimeException("Synth ButtonUI does not handle PRESSED & MOUSE_OVER state");
             }
-	} finally {
+        } finally {
             SwingUtilities.invokeAndWait(() -> {
                 if (testFrame != null) {
                     testFrame.dispose();

--- a/test/jdk/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
+++ b/test/jdk/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
@@ -76,12 +76,16 @@ public class bug6276188 {
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
 
-            Color color = robot.getPixelColor(p.x-10, p.y-10);
+            Color color = robot.getPixelColor(p.x, p.y);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
             boolean red = color.getRed() > 0 && color.getGreen() == 0 && color.getBlue() == 0;
-            if (!red) {
                 System.err.println("Red: " + color.getRed() + "; Green: " + color.getGreen() + "; Blue: " + color.getBlue());
+            if (!red) {
+                Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+                Rectangle screen = new Rectangle(0, 0, (int) screenSize.getWidth(), (int) screenSize.getHeight());
+                BufferedImage img = robot.createScreenCapture(screen);
+                javax.imageio.ImageIO.write(img, "png", new java.io.File("image.png"));
                 throw new RuntimeException("Synth ButtonUI does not handle PRESSED & MOUSE_OVER state");
             }
         } finally {

--- a/test/jdk/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
+++ b/test/jdk/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
@@ -37,46 +37,59 @@ import java.awt.event.*;
 import javax.swing.*;
 import javax.swing.plaf.synth.*;
 
-public class bug6276188 extends JFrame {
+public class bug6276188 {
 
     private static JButton button;
     private static Point p;
+    private static JFrame testFrame;
 
     public static void main(String[] args) throws Throwable {
-        SynthLookAndFeel lookAndFeel = new SynthLookAndFeel();
-        lookAndFeel.load(bug6276188.class.getResourceAsStream("bug6276188.xml"), bug6276188.class);
+        try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
 
-        UIManager.setLookAndFeel(lookAndFeel);
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                JFrame testFrame = new JFrame();
-                testFrame.setLayout(new BorderLayout());
-                testFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-                testFrame.add(BorderLayout.CENTER, button = new JButton());
+            SynthLookAndFeel lookAndFeel = new SynthLookAndFeel();
+            lookAndFeel.load(bug6276188.class.getResourceAsStream("bug6276188.xml"), bug6276188.class);
+            UIManager.setLookAndFeel(lookAndFeel);
 
-                testFrame.setSize(new Dimension(320, 200));
-                testFrame.setVisible(true);
+            SwingUtilities.invokeAndWait(new Runnable() {
+                public void run() {
+                    testFrame = new JFrame();
+                    testFrame.setLayout(new BorderLayout());
+                    testFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+                    testFrame.add(BorderLayout.CENTER, button = new JButton());
+
+                    testFrame.setSize(new Dimension(320, 200));
+                    testFrame.setLocationRelativeTo(null);
+                    testFrame.setVisible(true);
+                }
+            });
+
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            p = Util.getCenterPoint(button);
+	    System.out.println("Button center point: " + p);
+
+            robot.mouseMove(p.x , p.y);
+            robot.waitForIdle();
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+
+            Color color = robot.getPixelColor(p.x-10, p.y-10);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+            boolean red = color.getRed() > 0 && color.getGreen() == 0 && color.getBlue() == 0;
+            if (!red) {
+                System.err.println("Red: " + color.getRed() + "; Green: " + color.getGreen() + "; Blue: " + color.getBlue());
+                throw new RuntimeException("Synth ButtonUI does not handle PRESSED & MOUSE_OVER state");
             }
-        });
-
-        Robot robot = new Robot();
-        robot.setAutoDelay(50);
-        robot.waitForIdle();
-        robot.delay(200);
-
-        p = Util.getCenterPoint(button);
-
-        robot.mouseMove(p.x , p.y);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.waitForIdle();
-        robot.delay(1000);
-
-        Color color = robot.getPixelColor(p.x, p.y);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
-        boolean red = color.getRed() > 0 && color.getGreen() == 0 && color.getBlue() == 0;
-        if (!red) {
-            System.err.println("Red: " + color.getRed() + "; Green: " + color.getGreen() + "; Blue: " + color.getBlue());
-            throw new RuntimeException("Synth ButtonUI does not handle PRESSED & MOUSE_OVER state");
+	} finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (testFrame != null) {
+                    testFrame.dispose();
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
As per JDK-8252813, some tests fails recurringly in CI macos system. This is an attempt to fix the swing tests.
It was seen from the logs that we have color mismatch in these tests.

For example, in PressedIcon test, we had following log

----------System.out:(1/75)----------
color java.awt.Color[r=55,g=55,b=55] COLOR_1Xjava.awt.Color[r=255,g=0,b=0]
----------System.err:(13/842)----------
java.lang.RuntimeException: Colors is different for scale=1!
	at PressedIconTest.main(PressedIconTest.java:97)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:76)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:51)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
	at java.base/java.lang.Thread.run(Thread.java:833)

and JInternalFrame test, we had 
----------System.err:(15/939)----------
FRAME_COLOR Red: 255; Green: 200; Blue: 0
Pixel color Red: 55; Green: 55; Blue: 55
java.lang.RuntimeException: Internal frame is not correctly dragged!
	at bug8069348.main(bug8069348.java:96)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:76)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:51)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
	at java.base/java.lang.Thread.run(Thread.java:833)

where color is obtained as 55,55,55 instead of required color. The png image generated at failure also did not reveal anything abnormal apart from presence of mouse cursor around the same area where the getPixelColor location is pointing to. And since mouse cursor is also grayish black, it seems robot was wrongly picking up cursor pixels instead of background color.
Modified tests to use location.x-10, location.y-10 to obtain the pixel color. It does not hamper the test as the whole area around the location is coloured with same color in the test so getting pixel color from a bit wide of the centre will not affect the test.
Modified swing tests are passing in the affected system and also in other macos systems and platforms. Link in JBS.

The awt tests that are failing seems to have different root cause and will be handled separately.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276058](https://bugs.openjdk.java.net/browse/JDK-8276058): Some swing test fails on specific CI macos system


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6140/head:pull/6140` \
`$ git checkout pull/6140`

Update a local copy of the PR: \
`$ git checkout pull/6140` \
`$ git pull https://git.openjdk.java.net/jdk pull/6140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6140`

View PR using the GUI difftool: \
`$ git pr show -t 6140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6140.diff">https://git.openjdk.java.net/jdk/pull/6140.diff</a>

</details>
