### PR TITLE
8276063: ProblemList gtest dll_address_to_function_and_library_name on macosx-generic

### DIFF
--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -709,7 +709,7 @@ TEST_VM(os, pagesizes_test_print) {
   ASSERT_EQ(strcmp(expected, buffer), 0);
 }
 
-#if defined(__APPLE__) && !defined(AARCH64)  // See JDK-8273967.
+#if defined(__APPLE__)  // See JDK-8273967.
   TEST_VM(os, DISABLED_dll_address_to_function_and_library_name) {
 #else
   TEST_VM(os, dll_address_to_function_and_library_name) {


### PR DESCRIPTION
A trivial fix to ProblemList gtest dll_address_to_function_and_library_name on macosx-generic.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276063](https://bugs.openjdk.java.net/browse/JDK-8276063): ProblemList gtest dll_address_to_function_and_library_name on macosx-generic


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6141/head:pull/6141` \
`$ git checkout pull/6141`

Update a local copy of the PR: \
`$ git checkout pull/6141` \
`$ git pull https://git.openjdk.java.net/jdk pull/6141/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6141`

View PR using the GUI difftool: \
`$ git pr show -t 6141`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6141.diff">https://git.openjdk.java.net/jdk/pull/6141.diff</a>

</details>
