### PR TITLE
8276066: Reset LoopPercentProfileLimit for x86 due to suboptimal performance

### DIFF
--- a/src/hotspot/cpu/x86/c2_globals_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_globals_x86.hpp
@@ -44,7 +44,7 @@ define_pd_global(intx, OnStackReplacePercentage,     140);
 define_pd_global(intx, ConditionalMoveLimit,         3);
 define_pd_global(intx, FreqInlineSize,               325);
 define_pd_global(intx, MinJumpTableSize,             10);
-define_pd_global(intx, LoopPercentProfileLimit,      30);
+define_pd_global(intx, LoopPercentProfileLimit,      10);
 #ifdef AMD64
 define_pd_global(intx,  InteriorEntryAlignment,      16);
 define_pd_global(size_t, NewSizeThreadIncrease,     ScaleForWordSize(4*K));

--- a/test/micro/org/openjdk/bench/vm/compiler/LoopUnroll.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/LoopUnroll.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.*;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Fork(value=1)
+public class LoopUnroll {
+  @Param({"16", "32", "64", "128", "256", "512", "1024"})
+  private int VECLEN;
+
+  private byte[][] a;
+  private byte[][] b;
+  private byte[][] c;
+
+  @Setup
+  public void init() {
+    a = new byte[VECLEN][VECLEN];
+    b = new byte[VECLEN][VECLEN];
+    c = new byte[VECLEN][VECLEN];
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  private int run_workload1(int count, byte[][] a , byte[][] b, byte[][] c) {
+    for(int i = 0; i < a.length; i++) {
+      for (int j = 0; j < a[0].length; j++) {
+        a[i][j] = (byte)(b[i][j] + c[i][j]);
+      }
+    }
+    return a[count][count];
+  }
+
+  @Benchmark
+  public void workload1_caller(Blackhole bh) {
+    int r = 0;
+    for(int i = 0 ; i < 100; i++) {
+      r += run_workload1(i % a.length, a, b, c);
+    }
+    bh.consume(r);
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  private int run_workload2(int count, byte[][] a , byte[][] b) {
+    for(int i = 0; i < b.length; i++) {
+      for (int j = 0; j < b[0].length; j++) {
+        a[i][j] = b[i][j];
+      }
+    }
+    return a[count][count];
+  }
+
+  @Benchmark
+  public void workload2_caller(Blackhole bh) {
+    int r = 0;
+    for(int i = 0 ; i < 100; i++) {
+      r += run_workload2(i % a.length, a, b);
+    }
+    bh.consume(r);
+  }
+}

--- a/test/micro/org/openjdk/bench/vm/compiler/LoopUnroll.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/LoopUnroll.java
@@ -34,55 +34,55 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Thread)
 @Fork(value=1)
 public class LoopUnroll {
-  @Param({"16", "32", "64", "128", "256", "512", "1024"})
-  private int VECLEN;
+    @Param({"16", "32", "64", "128", "256", "512", "1024"})
+    private int VECLEN;
 
-  private byte[][] a;
-  private byte[][] b;
-  private byte[][] c;
+    private byte[][] a;
+    private byte[][] b;
+    private byte[][] c;
 
-  @Setup
-  public void init() {
-    a = new byte[VECLEN][VECLEN];
-    b = new byte[VECLEN][VECLEN];
-    c = new byte[VECLEN][VECLEN];
-  }
-
-  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-  private int run_workload1(int count, byte[][] a , byte[][] b, byte[][] c) {
-    for(int i = 0; i < a.length; i++) {
-      for (int j = 0; j < a[0].length; j++) {
-        a[i][j] = (byte)(b[i][j] + c[i][j]);
-      }
+    @Setup
+    public void init() {
+        a = new byte[VECLEN][VECLEN];
+        b = new byte[VECLEN][VECLEN];
+        c = new byte[VECLEN][VECLEN];
     }
-    return a[count][count];
-  }
 
-  @Benchmark
-  public void workload1_caller(Blackhole bh) {
-    int r = 0;
-    for(int i = 0 ; i < 100; i++) {
-      r += run_workload1(i % a.length, a, b, c);
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    private int run_workload1(int count, byte[][] a , byte[][] b, byte[][] c) {
+        for(int i = 0; i < a.length; i++) {
+            for (int j = 0; j < a[0].length; j++) {
+                a[i][j] = (byte)(b[i][j] + c[i][j]);
+            }
+        }
+        return a[count][count];
     }
-    bh.consume(r);
-  }
 
-  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-  private int run_workload2(int count, byte[][] a , byte[][] b) {
-    for(int i = 0; i < b.length; i++) {
-      for (int j = 0; j < b[0].length; j++) {
-        a[i][j] = b[i][j];
-      }
+    @Benchmark
+    public void workload1_caller(Blackhole bh) {
+        int r = 0;
+        for(int i = 0 ; i < 100; i++) {
+            r += run_workload1(i % a.length, a, b, c);
+        }
+        bh.consume(r);
     }
-    return a[count][count];
-  }
 
-  @Benchmark
-  public void workload2_caller(Blackhole bh) {
-    int r = 0;
-    for(int i = 0 ; i < 100; i++) {
-      r += run_workload2(i % a.length, a, b);
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    private int run_workload2(int count, byte[][] a , byte[][] b) {
+        for(int i = 0; i < b.length; i++) {
+            for (int j = 0; j < b[0].length; j++) {
+                a[i][j] = b[i][j];
+            }
+        }
+        return a[count][count];
     }
-    bh.consume(r);
-  }
+
+    @Benchmark
+    public void workload2_caller(Blackhole bh) {
+        int r = 0;
+        for(int i = 0 ; i < 100; i++) {
+            r += run_workload2(i % a.length, a, b);
+        }
+        bh.consume(r);
+    }
 }


### PR DESCRIPTION
Hi all,

I'd like to reset the value of `LoopPercentProfileLimit` (from 30 to the original 10) for x86 to fix performance degradation.

We had observed that for the same Java App, the performance of x86 is slower than that of aarch64.
But the x86's performance should not be so worse than the aarch64 according to some SPEC benchmark results.

After some investigation, it seems that the slowness of x86 is caused by the different default settings of `LoopPercentProfileLimit` (30 for x86, but 10 for other platforms).
If we change `LoopPercentProfileLimit` from 30 to 10, x86 would run faster.

In JDK-8149421, `LoopPercentProfileLimit` [1] was first added and set to be 30 for x86 and 10 for other platforms.
Logically, the default value of `LoopPercentProfileLimit` is 10 for all platforms even before JDK-8149421.
This is because when `LoopPercentProfileLimit=10`, `10.0` [2] equals `100.0 / LoopPercentProfileLimit` [3].
So if we set `LoopPercentProfileLimit=10`, this unrolling rule [3] would be the same as the original design before JDK-8149421.

One most important fact is that from the very beginning of OpenJDK source code, the default value of `LoopPercentProfileLimit` (logically) is 10 for all platforms.   
So I suggest resetting `LoopPercentProfileLimit` to the original value (10) for x86, just as other platforms.

I've noted that the review thread mentioned that JDK-8149421 would be beneficial for some SPECjvm2008 benchmarks [4].
Then I run SPECjvm2008 with `LoopPercentProfileLimit=10` finding that there is no performance drop on x86.
So it won't revert JDK-8149421's opts for SPECjvm2008.

To show the potential improvement of this change, I've made a jmh test in the patch.
Performance can be improved by 1.25x ~ 2.0x according to this micro benchmark.

Any comments?

Thanks.
Best regards,
Jie

  
[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/loopTransform.cpp#L908
[2] https://github.com/openjdk/jdk8u/blob/master/hotspot/src/share/vm/opto/loopTransform.cpp#L673
[3] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/loopTransform.cpp#L903
[4] https://mail.openjdk.java.net/pipermail/hotspot-compiler-dev/2016-February/021205.html

<img width="420" alt="ratio" src="https://user-images.githubusercontent.com/19923746/139084273-aa2e2eae-4a74-4fcb-8430-d2e2e49d5d5c.png">

<img width="615" alt="before" src="https://user-images.githubusercontent.com/19923746/139084508-793f1109-1ce3-4427-a2e3-660c91758a7c.png">

<img width="617" alt="after" src="https://user-images.githubusercontent.com/19923746/139084542-c8a8a705-d7ed-499f-9ceb-7175671c0e3b.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276066](https://bugs.openjdk.java.net/browse/JDK-8276066): Reset LoopPercentProfileLimit for x86 due to suboptimal performance


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6142/head:pull/6142` \
`$ git checkout pull/6142`

Update a local copy of the PR: \
`$ git checkout pull/6142` \
`$ git pull https://git.openjdk.java.net/jdk pull/6142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6142`

View PR using the GUI difftool: \
`$ git pr show -t 6142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6142.diff">https://git.openjdk.java.net/jdk/pull/6142.diff</a>

</details>
