### PR TITLE
8255286: Implement ParametersTypeData::print_data_on fully

### DIFF
--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -637,8 +637,10 @@ bool ParametersTypeData::profiling_enabled() {
 }
 
 void ParametersTypeData::print_data_on(outputStream* st, const char* extra) const {
-  st->print("parameter types"); // FIXME extra ignored?
+  print_shared(st, "ParametersTypeData", extra);
+  tab(st);
   _parameters.print_data_on(st);
+  st->cr();
 }
 
 void SpeculativeTrapData::print_data_on(outputStream* st, const char* extra) const {


### PR DESCRIPTION
There is a little FIXME leftover since JDK 9 build warning fixes. This basically implements `ParametersTypeData::print_data_on` like `SpeculativeTrapData::print_data_on` is currently implemented.

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255286](https://bugs.openjdk.java.net/browse/JDK-8255286): Implement ParametersTypeData::print_data_on fully


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6143/head:pull/6143` \
`$ git checkout pull/6143`

Update a local copy of the PR: \
`$ git checkout pull/6143` \
`$ git pull https://git.openjdk.java.net/jdk pull/6143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6143`

View PR using the GUI difftool: \
`$ git pr show -t 6143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6143.diff">https://git.openjdk.java.net/jdk/pull/6143.diff</a>

</details>
