### PR TITLE
8276067: ZGC: Remove unused function alloc_high_address_at_most()

### DIFF
--- a/src/hotspot/share/gc/z/zMemory.cpp
+++ b/src/hotspot/share/gc/z/zMemory.cpp
@@ -172,31 +172,6 @@ uintptr_t ZMemoryManager::alloc_high_address(size_t size) {
   return UINTPTR_MAX;
 }
 
-uintptr_t ZMemoryManager::alloc_high_address_at_most(size_t size, size_t* allocated) {
-  ZLocker<ZLock> locker(&_lock);
-
-  ZMemory* area = _freelist.last();
-  if (area != NULL) {
-    if (area->size() <= size) {
-      // Smaller than or equal to requested, remove area
-      const uintptr_t start = area->start();
-      *allocated = area->size();
-      _freelist.remove(area);
-      destroy(area);
-      return start;
-    } else {
-      // Larger than requested, shrink area
-      shrink_from_back(area, size);
-      *allocated = size;
-      return area->end();
-    }
-  }
-
-  // Out of memory
-  *allocated = 0;
-  return UINTPTR_MAX;
-}
-
 void ZMemoryManager::free(uintptr_t start, size_t size) {
   assert(start != UINTPTR_MAX, "Invalid address");
   const uintptr_t end = start + size;

--- a/src/hotspot/share/gc/z/zMemory.hpp
+++ b/src/hotspot/share/gc/z/zMemory.hpp
@@ -86,7 +86,6 @@ public:
   uintptr_t alloc_low_address(size_t size);
   uintptr_t alloc_low_address_at_most(size_t size, size_t* allocated);
   uintptr_t alloc_high_address(size_t size);
-  uintptr_t alloc_high_address_at_most(size_t size, size_t* allocated);
 
   void free(uintptr_t start, size_t size);
 };


### PR DESCRIPTION
The function ZMemoryManager::alloc_high_address_at_most() is unused and can be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276067](https://bugs.openjdk.java.net/browse/JDK-8276067): ZGC: Remove unused function alloc_high_address_at_most()


### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6146/head:pull/6146` \
`$ git checkout pull/6146`

Update a local copy of the PR: \
`$ git checkout pull/6146` \
`$ git pull https://git.openjdk.java.net/jdk pull/6146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6146`

View PR using the GUI difftool: \
`$ git pr show -t 6146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6146.diff">https://git.openjdk.java.net/jdk/pull/6146.diff</a>

</details>
