### PR TITLE
JDK-8275440: Remove VirtualSpaceList::is_full()

### DIFF
--- a/src/hotspot/share/memory/metaspace/virtualSpaceList.cpp
+++ b/src/hotspot/share/memory/metaspace/virtualSpaceList.cpp
@@ -200,15 +200,6 @@ bool VirtualSpaceList::contains(const MetaWord* p) const {
   return false;
 }
 
-// Returns true if the vslist is not expandable and no more root chunks
-// can be allocated.
-bool VirtualSpaceList::is_full() const {
-  if (!_can_expand && _first_node != NULL && _first_node->free_words() == 0) {
-    return true;
-  }
-  return false;
-}
-
 // Convenience methods to return the global class-space chunkmanager
 //  and non-class chunkmanager, respectively.
 VirtualSpaceList* VirtualSpaceList::vslist_class() {

--- a/src/hotspot/share/memory/metaspace/virtualSpaceList.hpp
+++ b/src/hotspot/share/memory/metaspace/virtualSpaceList.hpp
@@ -128,10 +128,6 @@ public:
   // Returns true if this pointer is contained in one of our nodes.
   bool contains(const MetaWord* p) const;
 
-  // Returns true if the list is not expandable and no more root chunks
-  // can be allocated.
-  bool is_full() const;
-
   // Convenience methods to return the global class-space vslist
   //  and non-class vslist, respectively.
   static VirtualSpaceList* vslist_class();

--- a/test/hotspot/gtest/metaspace/test_chunkManager_stress.cpp
+++ b/test/hotspot/gtest/metaspace/test_chunkManager_stress.cpp
@@ -61,9 +61,9 @@ class ChunkManagerRandomChunkAllocTest {
     return max_chunks;
   }
 
-  // Return true if, after an allocation error happened, a reserve error seems likely.
+  // Return true if, after an allocation error happened, a reserve error seems possible.
   bool could_be_reserve_error() {
-    return _context.vslist().is_full();
+    return _context.reserve_limit() < max_uintx;
   }
 
   // Return true if, after an allocation error happened, a commit error seems likely.


### PR DESCRIPTION
This function is only used from a single gtest. Ioi remarked that it is not threadsafe. The context in which it is used is not multithreaded, but nevertheless I opted to remove the function and modified the test to make the condition somewhat more generic.

This trades a slight decrease in complexity with a very minor decrease in test precision, but that is fine.

Test: 
- manual gtests
- GHAs
- ran the metaspace jtreg gtests, which execute gtests with various metaspace modes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275440](https://bugs.openjdk.java.net/browse/JDK-8275440): Remove VirtualSpaceList::is_full()


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6147/head:pull/6147` \
`$ git checkout pull/6147`

Update a local copy of the PR: \
`$ git checkout pull/6147` \
`$ git pull https://git.openjdk.java.net/jdk pull/6147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6147`

View PR using the GUI difftool: \
`$ git pr show -t 6147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6147.diff">https://git.openjdk.java.net/jdk/pull/6147.diff</a>

</details>
