### PR TITLE
JDK-8276086: Increase size of metaspace mappings

### DIFF
--- a/src/hotspot/share/memory/metaspace/metaspaceSettings.hpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceSettings.hpp
@@ -42,13 +42,12 @@ class Settings : public AllStatic {
 
   // The default size of a VirtualSpaceNode, unless created with an explicitly specified size.
   //  Must be a multiple of the root chunk size.
-  // Increasing this value decreases the number of mappings used for metadata,
-  //  at the cost of increased virtual size used for Metaspace (or, at least,
-  //  coarser growth steps). Matters mostly for 32bit platforms due to limited
-  //  address space.
-  // The default of two root chunks has been chosen on a whim but seems to work out okay
-  //  (coming to a mapping size of 8m per node).
-  static const size_t _virtual_space_node_default_word_size = chunklevel::MAX_CHUNK_WORD_SIZE * 2;
+  // This value only affects the process virtual size, and there only the granularity with which it
+  //  increases. Matters mostly for 32bit platforms due to limited address space.
+  // Note that this only affects the non-class metaspace. Class space ignores this size (it is one
+  //  single large mapping).
+  static const size_t _virtual_space_node_default_word_size =
+      chunklevel::MAX_CHUNK_WORD_SIZE * NOT_LP64(2) LP64_ONLY(16); // 8MB (32-bit) / 64MB (64-bit)
 
   // Alignment of the base address of a virtual space node
   static const size_t _virtual_space_node_reserve_alignment_words = chunklevel::MAX_CHUNK_WORD_SIZE;

--- a/test/hotspot/gtest/metaspace/test_metaspace_misc.cpp
+++ b/test/hotspot/gtest/metaspace/test_metaspace_misc.cpp
@@ -47,7 +47,7 @@ TEST_VM(metaspace, misc_sizes)   {
   ASSERT_TRUE(is_aligned(Settings::virtual_space_node_default_word_size(),
               metaspace::chunklevel::MAX_CHUNK_WORD_SIZE));
   ASSERT_EQ(Settings::virtual_space_node_default_word_size(),
-            metaspace::chunklevel::MAX_CHUNK_WORD_SIZE * 2);
+            metaspace::chunklevel::MAX_CHUNK_WORD_SIZE * NOT_LP64(2) LP64_ONLY(16));
   ASSERT_EQ(Settings::virtual_space_node_reserve_alignment_words(),
             Metaspace::reserve_alignment_words());
 


### PR DESCRIPTION
Disregarding class space, metaspace consists of a list of individual mappings. Traditionally, individual mappings had been rather small (2 root chunks => 8 MB). That is because the mechanism to release metaspace memory to the OS had been to unmap unused mappings, and the larger the mappings were the smaller the chance of them being completely unused, due to fragmentation.

We recently did away with this old release mechanism in favor of a new one with finer granularity (see https://bugs.openjdk.java.net/browse/JDK-8275582). So there is no motivation anymore to keep mappings particularly small.

There are however good reasons to enlarge them:
- less fragmentation on the OS mapping level (e.g. on Linux, number of VMAs would go down, has a number of advantages)
- Larger mappings -> fewer of them -> list gets smaller, which is good for functions iterating this list (e.g. `Metaspace::contains()`, see https://bugs.openjdk.java.net/browse/JDK-8275704).

The effect of larger mappings is an increase in the step size with process *virtual size* will grow. So, before vsize grew in 8MB steps, now those steps are larger and rarer. In total we should not use much more vsize than before. Larger mappings would have no effect on committed memory size.

And note that vsize is pretty much irrelevant with modern OSes. For our hotspot on 64-bit, it is astronomical anyway, so this change would have no impact in real life.

The only exception are 32-bit platforms, where address space itself is limited, so this change is limited to 64-bit.

----

How it looks after loading 3000 classes:

64-bit:

```
Virtual space:                                                                       
  Non-class space:      384,00 MB reserved,     338,94 MB ( 88%) committed,  6 nodes.
      Class space:        1,00 GB reserved,      13,00 MB (  1%) committed,  1 nodes.
             Both:        1,38 GB reserved,     351,94 MB ( 25%) committed.          
```

32-bit  (note: no class space, smaller data):

```
Virtual space:                                                    
    248,00 MB reserved,     242,00 MB ( 98%) committed,  31 nodes.
```

----

Tests:
- manual gtests + metaspace jtreg tests (32bit and 64bit)
- GHAs 
- SAP nightlies

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276086](https://bugs.openjdk.java.net/browse/JDK-8276086): Increase size of metaspace mappings


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**)
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6148/head:pull/6148` \
`$ git checkout pull/6148`

Update a local copy of the PR: \
`$ git checkout pull/6148` \
`$ git pull https://git.openjdk.java.net/jdk pull/6148/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6148`

View PR using the GUI difftool: \
`$ git pr show -t 6148`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6148.diff">https://git.openjdk.java.net/jdk/pull/6148.diff</a>

</details>
