### PR TITLE
8276096: Simplify Unsafe.{load|store}Fence fallbacks by delegating to fullFence

### DIFF
--- a/src/hotspot/share/classfile/vmIntrinsics.hpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.hpp
@@ -517,13 +517,13 @@ class methodHandle;
   do_intrinsic(_copyMemory,               jdk_internal_misc_Unsafe,     copyMemory_name, copyMemory_signature,         F_RN)     \
    do_name(     copyMemory_name,                                        "copyMemory0")                                           \
    do_signature(copyMemory_signature,                                   "(Ljava/lang/Object;JLjava/lang/Object;JJ)V")            \
-  do_intrinsic(_loadFence,                jdk_internal_misc_Unsafe,     loadFence_name, loadFence_signature,           F_RN)     \
+  do_intrinsic(_loadFence,                jdk_internal_misc_Unsafe,     loadFence_name, loadFence_signature,           F_R)      \
    do_name(     loadFence_name,                                         "loadFence")                                             \
    do_alias(    loadFence_signature,                                    void_method_signature)                                   \
-  do_intrinsic(_storeFence,               jdk_internal_misc_Unsafe,     storeFence_name, storeFence_signature,         F_RN)     \
+  do_intrinsic(_storeFence,               jdk_internal_misc_Unsafe,     storeFence_name, storeFence_signature,         F_R)      \
    do_name(     storeFence_name,                                        "storeFence")                                            \
    do_alias(    storeFence_signature,                                   void_method_signature)                                   \
-  do_intrinsic(_fullFence,                jdk_internal_misc_Unsafe,     fullFence_name, fullFence_signature,           F_RN)     \
+  do_intrinsic(_fullFence,                jdk_internal_misc_Unsafe,     fullFence_name, fullFence_signature,           F_R)      \
    do_name(     fullFence_name,                                         "fullFence")                                             \
    do_alias(    fullFence_signature,                                    void_method_signature)                                   \
                                                                                                                         \

--- a/src/hotspot/share/classfile/vmIntrinsics.hpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.hpp
@@ -523,7 +523,7 @@ class methodHandle;
   do_intrinsic(_storeFence,               jdk_internal_misc_Unsafe,     storeFence_name, storeFence_signature,         F_R)      \
    do_name(     storeFence_name,                                        "storeFence")                                            \
    do_alias(    storeFence_signature,                                   void_method_signature)                                   \
-  do_intrinsic(_fullFence,                jdk_internal_misc_Unsafe,     fullFence_name, fullFence_signature,           F_R)      \
+  do_intrinsic(_fullFence,                jdk_internal_misc_Unsafe,     fullFence_name, fullFence_signature,           F_RN)     \
    do_name(     fullFence_name,                                         "fullFence")                                             \
    do_alias(    fullFence_signature,                                    void_method_signature)                                   \
                                                                                                                         \

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -322,14 +322,6 @@ DEFINE_GETSETOOP_VOLATILE(jdouble, Double);
 
 #undef DEFINE_GETSETOOP_VOLATILE
 
-UNSAFE_LEAF(void, Unsafe_LoadFence(JNIEnv *env, jobject unsafe)) {
-  OrderAccess::acquire();
-} UNSAFE_END
-
-UNSAFE_LEAF(void, Unsafe_StoreFence(JNIEnv *env, jobject unsafe)) {
-  OrderAccess::release();
-} UNSAFE_END
-
 UNSAFE_LEAF(void, Unsafe_FullFence(JNIEnv *env, jobject unsafe)) {
   OrderAccess::fence();
 } UNSAFE_END
@@ -909,8 +901,6 @@ static JNINativeMethod jdk_internal_misc_Unsafe_methods[] = {
 
     {CC "shouldBeInitialized0", CC "(" CLS ")Z",         FN_PTR(Unsafe_ShouldBeInitialized0)},
 
-    {CC "loadFence",          CC "()V",                  FN_PTR(Unsafe_LoadFence)},
-    {CC "storeFence",         CC "()V",                  FN_PTR(Unsafe_StoreFence)},
     {CC "fullFence",          CC "()V",                  FN_PTR(Unsafe_FullFence)},
 };
 

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -3395,7 +3395,10 @@ public final class Unsafe {
      * @since 1.8
      */
     @IntrinsicCandidate
-    public native void loadFence();
+    public final void loadFence() {
+        // If loadFence intrinsic is not available, fall back to full fence.
+        fullFence();
+    }
 
     /**
      * Ensures that loads and stores before the fence will not be reordered with
@@ -3406,11 +3409,13 @@ public final class Unsafe {
      *
      * Provides a StoreStore barrier followed by a LoadStore barrier.
      *
-     *
      * @since 1.8
      */
     @IntrinsicCandidate
-    public native void storeFence();
+    public final void storeFence() {
+        // If storeFence intrinsic is not available, fall back to full fence.
+        fullFence();
+    }
 
     /**
      * Ensures that loads and stores before the fence will not be reordered


### PR DESCRIPTION
`Unsafe.{load|store}Fence` falls back to `unsafe.cpp` for `OrderAccess::{acquire|release}Fence()`. It seems too heavy-handed (useless?) to call to runtime for a single memory barrier. We can simplify the native `Unsafe` interface by falling back to `fullFence` when `{load|store}Fence` intrinsics are not available. This would be similar to what `Unsafe.{loadLoad|storeStore}Fences` do. 

This is the behavior of these intrinsics now, on x86_64, using benchmarks from JDK-8276054:

```
Benchmark          Mode  Cnt  Score   Error  Units

# Default
Single.acquire     avgt    3   0.407 ± 0.060  ns/op
Single.full        avgt    3   4.693 ± 0.005  ns/op
Single.loadLoad    avgt    3   0.415 ± 0.095  ns/op
Single.plain       avgt    3   0.406 ± 0.002  ns/op
Single.release     avgt    3   0.408 ± 0.047  ns/op
Single.storeStore  avgt    3   0.408 ± 0.043  ns/op

# -XX:DisableIntrinsic=_storeFence
Single.acquire     avgt    3   0.408 ± 0.016  ns/op
Single.full        avgt    3   4.694 ± 0.002  ns/op
Single.loadLoad    avgt    3   0.406 ± 0.002  ns/op
Single.plain       avgt    3   0.406 ± 0.001  ns/op
Single.release     avgt    3   4.694 ± 0.003  ns/op <--- upgraded to full
Single.storeStore  avgt    3   4.690 ± 0.005  ns/op <--- upgraded to full

# -XX:DisableIntrinsic=_loadFence
Single.acquire     avgt    3   4.691 ± 0.001  ns/op <--- upgraded to full
Single.full        avgt    3   4.693 ± 0.009  ns/op
Single.loadLoad    avgt    3   4.693 ± 0.013  ns/op <--- upgraded to full
Single.plain       avgt    3   0.408 ± 0.072  ns/op
Single.release     avgt    3   0.415 ± 0.016  ns/op
Single.storeStore  avgt    3   0.416 ± 0.041  ns/op

# -XX:DisableIntrinsic=_fullFence
Single.acquire     avgt    3   0.406 ± 0.014  ns/op
Single.full        avgt    3  15.836 ± 0.151  ns/op <--- calls runtime
Single.loadLoad    avgt    3   0.406 ± 0.001  ns/op
Single.plain       avgt    3   0.426 ± 0.361  ns/op
Single.release     avgt    3   0.407 ± 0.021  ns/op
Single.storeStore  avgt    3   0.410 ± 0.061  ns/op

# -XX:DisableIntrinsic=_fullFence,_loadFence
Single.acquire     avgt    3  15.822 ± 0.282  ns/op <--- upgraded, calls runtime
Single.full        avgt    3  15.851 ± 0.127  ns/op <--- calls runtime
Single.loadLoad    avgt    3  15.829 ± 0.045  ns/op <--- upgraded, calls runtime
Single.plain       avgt    3   0.406 ± 0.001  ns/op
Single.release     avgt    3   0.414 ± 0.156  ns/op
Single.storeStore  avgt    3   0.422 ± 0.452  ns/op

# -XX:DisableIntrinsic=_fullFence,_storeFence
Single.acquire     avgt    3   0.407 ± 0.016  ns/op
Single.full        avgt    3  15.347 ± 6.783  ns/op <--- calls runtime
Single.loadLoad    avgt    3   0.406 ± 0.001  ns/op
Single.plain       avgt    3   0.406 ± 0.002  ns/op 
Single.release     avgt    3  15.828 ± 0.019  ns/op <--- upgraded, calls runtime
Single.storeStore  avgt    3  15.834 ± 0.045  ns/op <--- upgraded, calls runtime

# -XX:DisableIntrinsic=_fullFence,_loadFence,_storeFence
Single.acquire     avgt    3  15.838 ± 0.030  ns/op <--- upgraded, calls runtime
Single.full        avgt    3  15.854 ± 0.277  ns/op <--- calls runtime
Single.loadLoad    avgt    3  15.826 ± 0.160  ns/op <--- upgraded, calls runtime
Single.plain       avgt    3   0.406 ± 0.003  ns/op
Single.release     avgt    3  15.838 ± 0.019  ns/op <--- upgraded, calls runtime
Single.storeStore  avgt    3  15.844 ± 0.104  ns/op <--- upgraded, calls runtime
```

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276096](https://bugs.openjdk.java.net/browse/JDK-8276096): Simplify Unsafe.{load|store}Fence fallbacks by delegating to fullFence


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to e2c623bef59b40a6115fba1bdae312bc59c2cacd
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**) ⚠️ Review applies to e2c623bef59b40a6115fba1bdae312bc59c2cacd
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6149/head:pull/6149` \
`$ git checkout pull/6149`

Update a local copy of the PR: \
`$ git checkout pull/6149` \
`$ git pull https://git.openjdk.java.net/jdk pull/6149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6149`

View PR using the GUI difftool: \
`$ git pr show -t 6149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6149.diff">https://git.openjdk.java.net/jdk/pull/6149.diff</a>

</details>
