### PR TITLE
8276102: JDK-8245095 integration reverted JDK-8247980

### DIFF
--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -27,7 +27,7 @@ exclusiveAccess.dirs=java/math/BigInteger/largeMemory \
 java/rmi/Naming java/util/prefs sun/management/jmxremote \
 sun/tools/jstatd sun/tools/jcmd \
 sun/tools/jinfo sun/tools/jmap sun/tools/jps sun/tools/jstack sun/tools/jstat \
-com/sun/tools/attach sun/security/mscapi java/util/stream java/util/Arrays/largeMemory \
+com/sun/tools/attach sun/security/mscapi java/util/Arrays/largeMemory \
 java/util/BitSet/stream javax/rmi java/net/httpclient/websocket \
 com/sun/net/httpserver/simpleserver
 


### PR DESCRIPTION
See the [integration commit](https://github.com/openjdk/jdk/commit/9d191fce55fa70d6a2affc724fad57b0e20e4bde#diff-5b9b15832385ab8e02ffca3ddef6d65a9dea73f45abbe5e4f0be561be02073ffR30
) for JDK-8245095. It reintroduced `java/util/stream` in `exclusiveAccess.dirs`, which effectively reverts JDK-8247980. I noticed this because jdk:tier1 became slow again. 

@FrauBoes, that was not intentional, right? 

The solution is to drop `java/util/stream` again.

Additional testing:
 - [x] Linux x86_64 fastdebug `jdk:tier1` tests are fast again

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276102](https://bugs.openjdk.java.net/browse/JDK-8276102): JDK-8245095 integration reverted JDK-8247980


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6153/head:pull/6153` \
`$ git checkout pull/6153`

Update a local copy of the PR: \
`$ git checkout pull/6153` \
`$ git pull https://git.openjdk.java.net/jdk pull/6153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6153`

View PR using the GUI difftool: \
`$ git pr show -t 6153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6153.diff">https://git.openjdk.java.net/jdk/pull/6153.diff</a>

</details>
