### PR TITLE
8276100: Remove G1SegmentedArray constructor name parameter

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSetMemory.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.cpp
@@ -35,7 +35,7 @@ template <class Elem>
 G1CardSetAllocator<Elem>::G1CardSetAllocator(const char* name,
                                              const G1CardSetAllocOptions* buffer_options,
                                              G1CardSetBufferList* free_buffer_list) :
-  _segmented_array(name, buffer_options, free_buffer_list),
+  _segmented_array(buffer_options, free_buffer_list),
   _transfer_lock(false),
   _free_nodes_list(),
   _pending_nodes_list(),

--- a/src/hotspot/share/gc/g1/g1SegmentedArray.hpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArray.hpp
@@ -198,8 +198,7 @@ public:
 
   inline uint elem_size() const;
 
-  G1SegmentedArray(const char* name,
-                   const G1SegmentedArrayAllocOptions* buffer_options,
+  G1SegmentedArray(const G1SegmentedArrayAllocOptions* buffer_options,
                    G1SegmentedArrayBufferList<flag>* free_buffer_list);
   ~G1SegmentedArray() {
     drop_all();

--- a/src/hotspot/share/gc/g1/g1SegmentedArray.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArray.inline.hpp
@@ -154,8 +154,7 @@ uint G1SegmentedArray<Elem, flag>::elem_size() const {
 }
 
 template <class Elem, MEMFLAGS flag>
-G1SegmentedArray<Elem, flag>::G1SegmentedArray(const char* name,
-                                               const G1SegmentedArrayAllocOptions* buffer_options,
+G1SegmentedArray<Elem, flag>::G1SegmentedArray(const G1SegmentedArrayAllocOptions* buffer_options,
                                                G1SegmentedArrayBufferList<flag>* free_buffer_list) :
      _alloc_options(buffer_options),
      _first(nullptr),


### PR DESCRIPTION
Hi all,

  can I have reviews for this trivial(?) change to remove an unused parameter to the G1SegmentedArray constructor?

Testing: local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276100](https://bugs.openjdk.java.net/browse/JDK-8276100): Remove G1SegmentedArray constructor name parameter


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6154/head:pull/6154` \
`$ git checkout pull/6154`

Update a local copy of the PR: \
`$ git checkout pull/6154` \
`$ git pull https://git.openjdk.java.net/jdk pull/6154/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6154`

View PR using the GUI difftool: \
`$ git pr show -t 6154`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6154.diff">https://git.openjdk.java.net/jdk/pull/6154.diff</a>

</details>
