### PR TITLE
8276110: Problemlist javax/swing/JMenu/4515762/bug4515762.java for macos12

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -750,7 +750,8 @@ javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.ja
 java/awt/Window/8159168/SetShapeTest.java 8274106 macosx-aarch64
 java/awt/image/multiresolution/MultiResolutionJOptionPaneIconTest.java 8274106 macosx-aarch64
 javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8274106 macosx-aarch64
-javax/swing/JMenu/4515762/bug4515762.java 8276074 macosx-aarch64
+# macos12 failure
+javax/swing/JMenu/4515762/bug4515762.java 8276074 macosx-all
 
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8225012 windows-all,macosx-all
 sanity/client/SwingSet/src/ScrollPaneDemoTest.java 8225013 linux-all


### PR DESCRIPTION
javax/swing/JMenu/4515762/bug4515762.java is failing in macos12 due to same root cause as in JDK-8273520 and JDK-8273506 so problemlist it till it is fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276110](https://bugs.openjdk.java.net/browse/JDK-8276110): Problemlist javax/swing/JMenu/4515762/bug4515762.java for macos12


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6155/head:pull/6155` \
`$ git checkout pull/6155`

Update a local copy of the PR: \
`$ git checkout pull/6155` \
`$ git pull https://git.openjdk.java.net/jdk pull/6155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6155`

View PR using the GUI difftool: \
`$ git pr show -t 6155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6155.diff">https://git.openjdk.java.net/jdk/pull/6155.diff</a>

</details>
