### PR TITLE
8276107: Preventive collections trigger before maxing out heap

### DIFF
--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1445,7 +1445,7 @@ bool G1Policy::preventive_collection_required(uint alloc_region_count) {
   uint required_regions = (uint)(get_num_regions_adjust_for_plab_waste(total_young_predicted_surviving_bytes) +
                                 get_num_regions_adjust_for_plab_waste(_predicted_surviving_bytes_from_old));
 
-  if (required_regions > _g1h->num_free_regions() - alloc_region_count) {
+  if (required_regions > _g1h->num_free_or_available_regions() - alloc_region_count) {
     log_debug(gc, ergo, cset)("Preventive GC, insufficient free regions. Predicted need %u. Curr Eden %u (Pred %u). Curr Survivor %u (Pred %u). Curr Old %u (Pred %u) Free %u Alloc %u",
             required_regions,
             eden_count,

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1446,16 +1446,18 @@ bool G1Policy::preventive_collection_required(uint alloc_region_count) {
                                 get_num_regions_adjust_for_plab_waste(_predicted_surviving_bytes_from_old));
 
   if (required_regions > _g1h->num_free_or_available_regions() - alloc_region_count) {
-    log_debug(gc, ergo, cset)("Preventive GC, insufficient free regions. Predicted need %u. Curr Eden %u (Pred %u). Curr Survivor %u (Pred %u). Curr Old %u (Pred %u) Free %u Alloc %u",
-            required_regions,
-            eden_count,
-            (uint)get_num_regions_adjust_for_plab_waste(eden_surv_bytes_pred),
-            _g1h->survivor_regions_count(),
-            (uint)get_num_regions_adjust_for_plab_waste(_predicted_surviving_bytes_from_survivor),
-            _g1h->old_regions_count(),
-            (uint)get_num_regions_adjust_for_plab_waste(_predicted_surviving_bytes_from_old),
-            _g1h->num_free_regions(),
-            alloc_region_count);
+    log_debug(gc, ergo, cset)("Preventive GC, insufficient free or available regions. "
+                              "Predicted need %u. Curr Eden %u (Pred %u). Curr Survivor %u (Pred %u). Curr Old %u (Pred %u) Free or Avail %u (Free %u) Alloc %u",
+                              required_regions,
+                              eden_count,
+                              (uint)get_num_regions_adjust_for_plab_waste(eden_surv_bytes_pred),
+                              _g1h->survivor_regions_count(),
+                              (uint)get_num_regions_adjust_for_plab_waste(_predicted_surviving_bytes_from_survivor),
+                              _g1h->old_regions_count(),
+                              (uint)get_num_regions_adjust_for_plab_waste(_predicted_surviving_bytes_from_old),
+                              _g1h->num_free_or_available_regions(),
+                              _g1h->num_free_regions(),
+                              alloc_region_count);
 
     return true;
   }


### PR DESCRIPTION
Hi all,

  can I have reviews for this small fix for an issue where preventive gcs that are supposed to prevent evacuation failure were also started if there were only not enough free committed regions available but more than enough uncommitted regions to expand the heap (to avoid the evacuation failure).

Testing: gha, tier1-3

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276107](https://bugs.openjdk.java.net/browse/JDK-8276107): Preventive collections trigger before maxing out heap


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to a9e53bc28dd470a3d18c317f8c0d5a42402d5016
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6160/head:pull/6160` \
`$ git checkout pull/6160`

Update a local copy of the PR: \
`$ git checkout pull/6160` \
`$ git pull https://git.openjdk.java.net/jdk pull/6160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6160`

View PR using the GUI difftool: \
`$ git pr show -t 6160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6160.diff">https://git.openjdk.java.net/jdk/pull/6160.diff</a>

</details>
