### PR TITLE
8169474: KeyCharTest: Wrong number of key events: 0

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -196,7 +196,6 @@ java/awt/Focus/8013611/JDK8013611.java 8175366 windows-all,macosx-all
 java/awt/Focus/6981400/Test1.java 8029675 windows-all,macosx-all
 java/awt/Focus/6981400/Test3.java 8173264 generic-all
 java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java 8169476 windows-all,macosx-all
-java/awt/event/KeyEvent/KeyChar/KeyCharTest.java 8169474,8224055 macosx-all,windows-all
 java/awt/event/MouseEvent/SpuriousExitEnter/SpuriousExitEnter_3.java 6854300 generic-all
 java/awt/event/KeyEvent/ExtendedModifiersTest/ExtendedModifiersTest.java 8129778 generic-all
 java/awt/event/KeyEvent/KeyMaskTest/KeyMaskTest.java 8129778 generic-all


### PR DESCRIPTION
When i reproduced the test failures locally on Ubuntu 18 it seems like AWT Frame
that appeared on the screen had not received focus and keyboard events went to the
Window Manager which ignored them for having no meaning in the current context.
Added explicit toFront and requestFocus calls so window gets focused.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8169474](https://bugs.openjdk.java.net/browse/JDK-8169474): KeyCharTest: Wrong number of key events: 0


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6161/head:pull/6161` \
`$ git checkout pull/6161`

Update a local copy of the PR: \
`$ git checkout pull/6161` \
`$ git pull https://git.openjdk.java.net/jdk pull/6161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6161`

View PR using the GUI difftool: \
`$ git pr show -t 6161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6161.diff">https://git.openjdk.java.net/jdk/pull/6161.diff</a>

</details>
