### PR TITLE
8276128: (bf) Remove unused constant ARRAY_BASE_OFFSET from Direct-X-Buffer

### DIFF
--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -48,9 +48,6 @@ class Direct$Type$Buffer$RW$$BO$
 
 #if[rw]
 
-    // Cached array base offset
-    private static final long ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset($type$[].class);
-
     // Cached unaligned-access capability
     protected static final boolean UNALIGNED = Bits.unaligned();
 


### PR DESCRIPTION
Please consider this minor change which would dispense with a vestigial constant.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276128](https://bugs.openjdk.java.net/browse/JDK-8276128): (bf) Remove unused constant ARRAY_BASE_OFFSET from Direct-X-Buffer


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6163/head:pull/6163` \
`$ git checkout pull/6163`

Update a local copy of the PR: \
`$ git checkout pull/6163` \
`$ git pull https://git.openjdk.java.net/jdk pull/6163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6163`

View PR using the GUI difftool: \
`$ git pr show -t 6163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6163.diff">https://git.openjdk.java.net/jdk/pull/6163.diff</a>

</details>
