### PR TITLE
8276164: RandomAccessFile#write method could throw IndexOutOfBoundsException that is not described in javadoc

### DIFF
--- a/src/java.base/share/classes/java/io/DataOutput.java
+++ b/src/java.base/share/classes/java/io/DataOutput.java
@@ -92,6 +92,9 @@ public interface DataOutput {
      * @param      off   the start offset in the data.
      * @param      len   the number of bytes to write.
      * @throws     IOException  if an I/O error occurs.
+     * @throws     IndexOutOfBoundsException If {@code off} is negative,
+     *             {@code len} is negative, or {@code len} is greater than
+     *             {@code b.length - off}
      */
     void write(byte[] b, int off, int len) throws IOException;
 

--- a/src/java.base/share/classes/java/io/DataOutput.java
+++ b/src/java.base/share/classes/java/io/DataOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/io/RandomAccessFile.java
+++ b/src/java.base/share/classes/java/io/RandomAccessFile.java
@@ -553,6 +553,9 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * @param      off   the start offset in the data.
      * @param      len   the number of bytes to write.
      * @throws     IOException  if an I/O error occurs.
+     * @throws     IndexOutOfBoundsException If {@code off} is negative,
+     *             {@code len} is negative, or {@code len} is greater than
+     *             {@code b.length - off}
      */
     public void write(byte[] b, int off, int len) throws IOException {
         writeBytes(b, off, len);

--- a/src/java.base/share/classes/java/io/RandomAccessFile.java
+++ b/src/java.base/share/classes/java/io/RandomAccessFile.java
@@ -553,9 +553,7 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * @param      off   the start offset in the data.
      * @param      len   the number of bytes to write.
      * @throws     IOException  if an I/O error occurs.
-     * @throws     IndexOutOfBoundsException If {@code off} is negative,
-     *             {@code len} is negative, or {@code len} is greater than
-     *             {@code b.length - off}
+     * @throws     IndexOutOfBoundsException {@inheritDoc}
      */
     public void write(byte[] b, int off, int len) throws IOException {
         writeBytes(b, off, len);


### PR DESCRIPTION
Could you please review the 8276164 bug fixes?

I suggest adding the missing javadoc of `@throws IndexOutOfBoundsException`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276164](https://bugs.openjdk.java.net/browse/JDK-8276164): RandomAccessFile#write method could throw IndexOutOfBoundsException that is not described in javadoc


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6168/head:pull/6168` \
`$ git checkout pull/6168`

Update a local copy of the PR: \
`$ git checkout pull/6168` \
`$ git pull https://git.openjdk.java.net/jdk pull/6168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6168`

View PR using the GUI difftool: \
`$ git pr show -t 6168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6168.diff">https://git.openjdk.java.net/jdk/pull/6168.diff</a>

</details>
