### PR TITLE
8276166: Remove dead code from MimeTable and MimeEntry

### DIFF
--- a/src/java.base/share/classes/sun/net/www/MimeEntry.java
+++ b/src/java.base/share/classes/sun/net/www/MimeEntry.java
@@ -24,7 +24,6 @@
  */
 
 package sun.net.www;
-import java.net.URL;
 import java.io.*;
 import java.util.StringJoiner;
 import java.util.StringTokenizer;
@@ -61,34 +60,6 @@ public class MimeEntry implements Cloneable {
         // Default action is UNKNOWN so clients can decide what the default
         // should be, typically save to file or ask user.
         this(type, UNKNOWN, null, null, null);
-    }
-
-    //
-    // The next two constructors are used only by the deprecated
-    // PlatformMimeTable classes or, in last case, is called by the public
-    // constructor.  They are kept here anticipating putting support for
-    // mailcap formatted config files back in (so BOTH the properties format
-    // and the mailcap formats are supported).
-    //
-    MimeEntry(String type, String imageFileName, String extensionString) {
-        typeName = type.toLowerCase();
-        action = UNKNOWN;
-        command = null;
-        this.imageFileName = imageFileName;
-        setExtensions(extensionString);
-        starred = isStarred(typeName);
-    }
-
-    // For use with MimeTable::parseMailCap
-    MimeEntry(String typeName, int action, String command,
-              String tempFileNameTemplate) {
-        this.typeName = typeName.toLowerCase();
-        this.action = action;
-        this.command = command;
-        this.imageFileName = null;
-        this.fileExtensions = null;
-
-        this.tempFileNameTemplate = tempFileNameTemplate;
     }
 
     // This is the one called by the public constructor.

--- a/src/java.base/share/classes/sun/net/www/MimeTable.java
+++ b/src/java.base/share/classes/sun/net/www/MimeTable.java
@@ -36,11 +36,11 @@ import java.util.StringTokenizer;
 public class MimeTable implements FileNameMap {
     /** Keyed by content type, returns MimeEntries */
     private Hashtable<String, MimeEntry> entries
-        = new Hashtable<String, MimeEntry>();
+        = new Hashtable<>();
 
     /** Keyed by file extension (with the .), returns MimeEntries */
     private Hashtable<String, MimeEntry> extensionMap
-        = new Hashtable<String, MimeEntry>();
+        = new Hashtable<>();
 
     // Will be reset if in the platform-specific data file
     @SuppressWarnings("removal")
@@ -54,7 +54,6 @@ public class MimeTable implements FileNameMap {
                 });
 
     private static final String filePreamble = "sun.net.www MIME content-types table";
-    private static final String fileMagic = "#" + filePreamble;
 
     MimeTable() {
         load();
@@ -66,7 +65,7 @@ public class MimeTable implements FileNameMap {
         @SuppressWarnings("removal")
         static MimeTable getDefaultInstance() {
             return java.security.AccessController.doPrivileged(
-                new java.security.PrivilegedAction<MimeTable>() {
+                new java.security.PrivilegedAction<>() {
                 public MimeTable run() {
                     MimeTable instance = new MimeTable();
                     URLConnection.setFileNameMap(instance);
@@ -89,7 +88,7 @@ public class MimeTable implements FileNameMap {
      */
     public static FileNameMap loadTable() {
         MimeTable mt = getDefaultTable();
-        return (FileNameMap)mt;
+        return mt;
     }
 
     public synchronized int getSize() {
@@ -346,17 +345,6 @@ public class MimeTable implements FileNameMap {
         }
 
         // else illegal name exception
-    }
-
-    String[] getExtensions(String list) {
-        StringTokenizer tokenizer = new StringTokenizer(list, ",");
-        int n = tokenizer.countTokens();
-        String[] extensions = new String[n];
-        for (int i = 0; i < n; i++) {
-            extensions[i] = tokenizer.nextToken();
-        }
-
-        return extensions;
     }
 
     int getActionCode(String action) {


### PR DESCRIPTION
There are unused methods/constructors in mentioned classes that can be safely removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276166](https://bugs.openjdk.java.net/browse/JDK-8276166): Remove dead code from MimeTable and MimeEntry


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6169/head:pull/6169` \
`$ git checkout pull/6169`

Update a local copy of the PR: \
`$ git checkout pull/6169` \
`$ git pull https://git.openjdk.java.net/jdk pull/6169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6169`

View PR using the GUI difftool: \
`$ git pr show -t 6169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6169.diff">https://git.openjdk.java.net/jdk/pull/6169.diff</a>

</details>
