### PR TITLE
8276121: G1: Remove unused and uninitialized _g1h in g1SATBMarkQueueSet.hpp

### DIFF
--- a/src/hotspot/share/gc/g1/g1SATBMarkQueueSet.hpp
+++ b/src/hotspot/share/gc/g1/g1SATBMarkQueueSet.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,13 +27,10 @@
 
 #include "gc/shared/satbMarkQueue.hpp"
 
-class G1CollectedHeap;
 class Monitor;
 class Thread;
 
 class G1SATBMarkQueueSet : public SATBMarkQueueSet {
-  G1CollectedHeap* _g1h;
-
 public:
   G1SATBMarkQueueSet(BufferNode::Allocator* allocator);
 


### PR DESCRIPTION
Code seems to compile without the field.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276121](https://bugs.openjdk.java.net/browse/JDK-8276121): G1: Remove unused and uninitialized _g1h in g1SATBMarkQueueSet.hpp


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6171/head:pull/6171` \
`$ git checkout pull/6171`

Update a local copy of the PR: \
`$ git checkout pull/6171` \
`$ git pull https://git.openjdk.java.net/jdk pull/6171/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6171`

View PR using the GUI difftool: \
`$ git pr show -t 6171`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6171.diff">https://git.openjdk.java.net/jdk/pull/6171.diff</a>

</details>
