### PR TITLE
8271056: C2: "assert(no_dead_loop) failed: dead loop detected" due to cmoving identity

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -1366,9 +1366,12 @@ Node* PhiNode::Identity(PhaseGVN* phase) {
   }
 
   int true_path = is_diamond_phi();
-  if (true_path != 0) {
+  // Delay CMove'ing identity if Ideal has not had the chance to handle unsafe cases, yet.
+  if (true_path != 0 && !(phase->is_IterGVN() && wait_for_region_igvn(phase))) {
     Node* id = is_cmove_id(phase, true_path);
-    if (id != NULL)  return id;
+    if (id != NULL) {
+      return id;
+    }
   }
 
   // Looking for phis with identical inputs.  If we find one that has

--- a/test/hotspot/jtreg/compiler/c2/TestDeadDataLoopCmoveIdentity.java
+++ b/test/hotspot/jtreg/compiler/c2/TestDeadDataLoopCmoveIdentity.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key stress randomness
+ * @bug 8271056
+ * @summary A dead data loop is created when applying an unsafe case of Cmov'ing identity.
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileCommand=compileonly,compiler.c2.TestDeadDataLoopCmoveIdentity::*
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:StressSeed=359948366 compiler.c2.TestDeadDataLoopCmoveIdentity
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileCommand=compileonly,compiler.c2.TestDeadDataLoopCmoveIdentity::*
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN compiler.c2.TestDeadDataLoopCmoveIdentity
+ */
+
+package compiler.c2;
+
+public class TestDeadDataLoopCmoveIdentity {
+    static boolean bFld;
+
+    public static void main(String[] strArr) {
+        test();
+        test2();
+    }
+
+    static void test() {
+        int i33 = 51925, iArr3[] = new int[10];
+        if (bFld) {
+            ;
+        } else if (bFld) {
+            for (int i = 0; i < 100; i++) { }
+            do {
+                if (i33 != 0) {
+                }
+                int i34 = 1;
+                do {
+                    switch (0) {
+                        case 122: { }
+                    }
+                } while (i34 < 1);
+                i33 += i33 + 3;
+            } while (i33 < 5);
+        }
+    }
+
+    static void test2() {
+        int i33 = 51925, iArr3[] = new int[10];
+        if (bFld) {
+            ;
+        } else if (bFld) {
+            do {
+                if (i33 != 0) {
+                }
+                int i34 = 1;
+                do {
+                    switch (0) {
+                        case 122: {}
+                    }
+                } while (i34 < 1);
+            } while (++i33 < 5);
+        }
+    }
+}


### PR DESCRIPTION
In the testcase, an unsafe cmoving identity is applied in `PhiNode::Identity()` after parsing which replaces a loop phi in a dead loop creating a dead data loop which triggers the assertion. The problem is that `PhiNode::Identity()` assumes that a cmoving identity is always safe because `PhiNode::Ideal()` handles unsafe cases and only leaves safe cases to `PhiNode::Identity()`:
https://github.com/openjdk/jdk/blob/4c3491bfa5f296b80c56a37cb4fffd6497323ac2/src/hotspot/share/opto/cfgnode.cpp#L2051-L2055

However, the fix for [JDK-8268883 ](https://github.com/openjdk/jdk17/commit/6d8fc7249a3a1a2350c462f9c4fe38377856392f)added the following additional condition to wait for the region to be processed:
https://github.com/openjdk/jdk/blob/4c3491bfa5f296b80c56a37cb4fffd6497323ac2/src/hotspot/share/opto/cfgnode.cpp#L2047-L2053

This skips the process of an unsafe case in `PhiNode::Ideal()` in the testcase. Afterwards, the unsafe case is replaced unconditionally in `PhiNode::Identity()` resulting in a dead data loop.

I therefore propose to add the same check added in JDK-8268883 to `PhiNode::Identity()` to prevent that.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271056](https://bugs.openjdk.java.net/browse/JDK-8271056): C2: "assert(no_dead_loop) failed: dead loop detected" due to cmoving identity


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6172/head:pull/6172` \
`$ git checkout pull/6172`

Update a local copy of the PR: \
`$ git checkout pull/6172` \
`$ git pull https://git.openjdk.java.net/jdk pull/6172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6172`

View PR using the GUI difftool: \
`$ git pr show -t 6172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6172.diff">https://git.openjdk.java.net/jdk/pull/6172.diff</a>

</details>
