### PR TITLE
JDK-8276175: codestrings.validate_vm gtest still broken on ppc64 after JDK-8276046

### DIFF
--- a/test/hotspot/gtest/code/test_codestrings.cpp
+++ b/test/hotspot/gtest/code/test_codestrings.cpp
@@ -25,8 +25,6 @@
 
 #ifndef PRODUCT
 #ifndef ZERO
-// Neither ppc nor s390 compilers use code strings.
-#if !defined(PPC) && !defined(S390)
 
 #include "asm/macroAssembler.inline.hpp"
 #include "compiler/disassembler.hpp"
@@ -258,12 +256,16 @@ static void buffer_blob_test()
     BufferBlob::free(blob);
 }
 
+#if defined(PPC) || defined(S390)
+// Neither ppc nor s390 compiler use code strings
+TEST_VM(codestrings, DISABLED_validate)
+#else
 TEST_VM(codestrings, validate)
+#endif
 {
     code_buffer_test();
     buffer_blob_test();
 }
 
-#endif // not S390 not PPC
 #endif // not ZERO
 #endif // not PRODUCT


### PR DESCRIPTION
Frustratingly, JDK-8276046 failed to work because the #ifdef PPC was added to the existing group of #ifdefs at the very start of test_codestrings.cpp.

PPC is not a primary macro however, it gets set via macros.hpp if one of PPC32 or PPC64 is set. Therefore this only works after the inclusion of macro.hpp (Works for ZERO and PRODUCT, since those are primary macros).

This fix revives my original fix using the DISABLED_... moniker on test functions. That seems to be the default way to disable tests anyway.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276175](https://bugs.openjdk.java.net/browse/JDK-8276175): codestrings.validate_vm gtest still broken on ppc64 after JDK-8276046


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6174/head:pull/6174` \
`$ git checkout pull/6174`

Update a local copy of the PR: \
`$ git checkout pull/6174` \
`$ git pull https://git.openjdk.java.net/jdk pull/6174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6174`

View PR using the GUI difftool: \
`$ git pr show -t 6174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6174.diff">https://git.openjdk.java.net/jdk/pull/6174.diff</a>

</details>
