### PR TITLE
8159451: [TEST_BUG] java/awt/Mixing/AWT_Mixing/JMenuBarOverlapping.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -148,7 +148,6 @@ java/awt/KeyboardFocusmanager/TypeAhead/SubMenuShowTest/SubMenuShowTest.java 827
 java/awt/KeyboardFocusmanager/TypeAhead/TestDialogTypeAhead.java 8198626 macosx-all
 java/awt/Mixing/AWT_Mixing/HierarchyBoundsListenerMixingTest.java 8049405 macosx-all
 java/awt/Mixing/AWT_Mixing/OpaqueOverlappingChoice.java 8048171 generic-all
-java/awt/Mixing/AWT_Mixing/JMenuBarOverlapping.java 8159451 linux-all,windows-all,macosx-all
 java/awt/Mixing/AWT_Mixing/JSplitPaneOverlapping.java 6986109 generic-all
 java/awt/Mixing/AWT_Mixing/JInternalFrameMoveOverlapping.java 6986109 windows-all
 java/awt/Mixing/AWT_Mixing/MixingPanelsResizing.java 8049405 generic-all

--- a/test/jdk/java/awt/Mixing/AWT_Mixing/JMenuBarOverlapping.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/JMenuBarOverlapping.java
@@ -53,7 +53,7 @@ import test.java.awt.regtesthelpers.Util;
  *          java.desktop/java.awt.peer
  * @build java.desktop/java.awt.Helper
  * @build Util
- * @run main JMenuBarOverlapping
+ * @run main/timeout=180 JMenuBarOverlapping
  */
 public class JMenuBarOverlapping extends OverlappingTestBase {
 
@@ -141,6 +141,8 @@ public class JMenuBarOverlapping extends OverlappingTestBase {
             e.printStackTrace();
             throw new RuntimeException("Where is separator?");
         }
+
+        if(currentAwtControl == null) { System.out.println("t"); }
         sepLoc.translate(20, 1);
         clickAndBlink(robot, sepLoc, false);
 

--- a/test/jdk/java/awt/Mixing/AWT_Mixing/JMenuBarOverlapping.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/JMenuBarOverlapping.java
@@ -142,7 +142,6 @@ public class JMenuBarOverlapping extends OverlappingTestBase {
             throw new RuntimeException("Where is separator?");
         }
 
-        if(currentAwtControl == null) { System.out.println("t"); }
         sepLoc.translate(20, 1);
         clickAndBlink(robot, sepLoc, false);
 

--- a/test/jdk/java/awt/Mixing/AWT_Mixing/OverlappingTestBase.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/OverlappingTestBase.java
@@ -355,8 +355,9 @@ public abstract class OverlappingTestBase {
     protected String failMessage = "The LW component did not received the click.";
 
     private static boolean isValidForPixelCheck(Component component) {
-        if ((component instanceof java.awt.Scrollbar)
-                || (isMac && ((component instanceof java.awt.Button) || (component == null)))) {
+        if ((component instanceof java.awt.Scrollbar) ||
+                (isMac && ((component instanceof java.awt.Button) ||
+                        (component == null)))) {
             return false;
         }
         return true;

--- a/test/jdk/java/awt/Mixing/AWT_Mixing/OverlappingTestBase.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/OverlappingTestBase.java
@@ -355,7 +355,8 @@ public abstract class OverlappingTestBase {
     protected String failMessage = "The LW component did not received the click.";
 
     private static boolean isValidForPixelCheck(Component component) {
-        if ((component instanceof java.awt.Scrollbar) || isMac && (component instanceof java.awt.Button)) {
+        if ((component instanceof java.awt.Scrollbar)
+                || (isMac && ((component instanceof java.awt.Button) || (component == null)))) {
             return false;
         }
         return true;


### PR DESCRIPTION
Added more time to test, removed pixel check during EmbeddedFrame test from OverlappingTestBase.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8159451](https://bugs.openjdk.java.net/browse/JDK-8159451): [TEST_BUG] java/awt/Mixing/AWT_Mixing/JMenuBarOverlapping.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6177/head:pull/6177` \
`$ git checkout pull/6177`

Update a local copy of the PR: \
`$ git checkout pull/6177` \
`$ git pull https://git.openjdk.java.net/jdk pull/6177/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6177`

View PR using the GUI difftool: \
`$ git pr show -t 6177`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6177.diff">https://git.openjdk.java.net/jdk/pull/6177.diff</a>

</details>
