### PR TITLE
8275080: G1CollectedHeap::expand() returns the wrong value

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1310,7 +1310,7 @@ bool G1CollectedHeap::expand(size_t expand_bytes, WorkerThreads* pretouch_worker
       vm_exit_out_of_memory(aligned_expand_bytes, OOM_MMAP_ERROR, "G1 heap expansion");
     }
   }
-  return regions_to_expand > 0;
+  return expanded_by > 0;
 }
 
 bool G1CollectedHeap::expand_single_region(uint node_index) {


### PR DESCRIPTION
Hi all,

Could we get reviews for this minor bug fix? See https://bugs.openjdk.java.net/browse/JDK-8275080 for details.
It is authored by colleague Jonathan Joo, and he tested locally with jtreg tier1 and DaCapo benchmarks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275080](https://bugs.openjdk.java.net/browse/JDK-8275080): G1CollectedHeap::expand() returns the wrong value


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Contributors
 * Jonathan Joo `<jonathanjoo@google.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6178/head:pull/6178` \
`$ git checkout pull/6178`

Update a local copy of the PR: \
`$ git checkout pull/6178` \
`$ git pull https://git.openjdk.java.net/jdk pull/6178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6178`

View PR using the GUI difftool: \
`$ git pr show -t 6178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6178.diff">https://git.openjdk.java.net/jdk/pull/6178.diff</a>

</details>
