### PR TITLE
8276201: Shenandoah: Race results degenerated GC to enter wrong entry point

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -113,8 +113,10 @@ void ShenandoahDegenGC::op_degenerated() {
       op_mark();
 
     case _degenerated_mark:
-      // No fallthrough. Continue mark, handed over from concurrent mark
-      if (_degen_point == ShenandoahDegenPoint::_degenerated_mark) {
+      // No fallthrough. Continue mark, handed over from concurrent mark if
+      // concurrent mark has yet completed
+      if (_degen_point == ShenandoahDegenPoint::_degenerated_mark &&
+          heap->is_concurrent_mark_in_progress()) {
         op_finish_mark();
       }
       assert(!heap->cancelled_gc(), "STW mark can not OOM");


### PR DESCRIPTION
There is subtle race when concurrent GC comes out of final mark safepoint: an allocation failure occurred before control thread checks OOM conditional, that triggers degenerated GC enters "mark" degenerated point.

Degenerated GC re-executes final mark, then switching off SATB, but it is already off, because concurrent GC already completed final mark, that triggers the assertion.

The solution is to consult concurrent_mark_in_progress flag when selects degen-point.

Test:
- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276201](https://bugs.openjdk.java.net/browse/JDK-8276201): Shenandoah: Race results degenerated GC to enter wrong entry point


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6179/head:pull/6179` \
`$ git checkout pull/6179`

Update a local copy of the PR: \
`$ git checkout pull/6179` \
`$ git pull https://git.openjdk.java.net/jdk pull/6179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6179`

View PR using the GUI difftool: \
`$ git pr show -t 6179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6179.diff">https://git.openjdk.java.net/jdk/pull/6179.diff</a>

</details>
