### PR TITLE
8276208: vmTestbase/nsk/jdb/repeat/repeat001/repeat001.java fails with "AssertionError: Unexpected output"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/repeat/repeat001/repeat001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/repeat/repeat001/repeat001.java
@@ -137,11 +137,11 @@ public class repeat001 extends JdbTest {
 
         // Verify that repeated commands are repeatable
         // (`up' just prints `End of stack.' since we're stopped in `main')
-        reply = jdb.receiveReplyFor("2 2 " + JdbCommand.up);
+        reply = jdb.receiveReplyFor("2 2 " + JdbCommand.up, true, 4);
         if (reply.length != 5 || !isPrompt(reply[4])) {
             failure("Unexpected output");
         }
-        if (!Arrays.equals(reply, jdb.receiveReplyFor(""))) {
+        if (!Arrays.equals(reply, jdb.receiveReplyFor("", true, 4))) {
             failure("Repeated command didn't repeat correctly");
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/repeat/repeat001/repeat001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/repeat/repeat001/repeat001.java
@@ -94,55 +94,55 @@ public class repeat001 extends JdbTest {
         // Verify that repeat is off initially
         String[] reply = jdb.receiveReplyFor(JdbCommand.repeat);
         if (reply.length != 2 || !isPrompt(reply[1])) {
-            throw new AssertionError("Unexpected output");
+            failure("Unexpected output");
         }
         if (!reply[0].equals("Repeat is off")) {
-            throw new AssertionError("Incorrect initial repeat setting");
+            failure("Incorrect initial repeat setting");
         }
 
         // Verify that list auto-advance is disabled
         String[] firstList = jdb.receiveReplyFor(JdbCommand.list);
         String[] secondList = jdb.receiveReplyFor(JdbCommand.list);
         if (!Arrays.equals(firstList, secondList)) {
-            throw new AssertionError("Listing inconsistent with repeat off");
+            failure("Listing inconsistent with repeat off");
         }
 
         // Verify that command repetition doesn't happen when disabled
         reply = jdb.receiveReplyFor("");
         if (reply.length != 1 || !isPrompt(reply[0])) {
-            throw new AssertionError("Unexpected output");
+            failure("Unexpected output");
         }
 
         reply = jdb.receiveReplyFor(JdbCommand.repeat + "on");
         if (reply.length != 1 || !isPrompt(reply[0])) {
-            throw new AssertionError("Unexpected output");
+            failure("Unexpected output");
         }
 
         // Verify that repeat is reported on
         reply = jdb.receiveReplyFor(JdbCommand.repeat);
         if (reply.length != 2 || !isPrompt(reply[1])) {
-            throw new AssertionError("Unexpected output");
+            failure("Unexpected output");
         }
         if (!reply[0].equals("Repeat is on")) {
-            throw new AssertionError("Incorrect repeat status reported");
+            failure("Incorrect repeat status reported");
         }
 
         // Verify that non-repeatable commands still don't repeat
         if (jdb.receiveReplyFor(JdbCommand.print + "0").length != 2) {
-            throw new AssertionError("Unexpected output");
+            failure("Unexpected output");
         }
         if (jdb.receiveReplyFor("").length != 1) {
-            throw new AssertionError("Unexpected output");
+            failure("Unexpected output");
         }
 
         // Verify that repeated commands are repeatable
         // (`up' just prints `End of stack.' since we're stopped in `main')
         reply = jdb.receiveReplyFor("2 2 " + JdbCommand.up);
         if (reply.length != 5 || !isPrompt(reply[4])) {
-            throw new AssertionError("Unexpected output");
+            failure("Unexpected output");
         }
         if (!Arrays.equals(reply, jdb.receiveReplyFor(""))) {
-            throw new AssertionError("Repeated command didn't repeat correctly");
+            failure("Repeated command didn't repeat correctly");
         }
     }
 }


### PR DESCRIPTION
This will fix a few issues with the tests added in #5290:

- [x] intermittent failures
- [x] tests should use `failure` method to report problems rather than throwing `AssertionError`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276208](https://bugs.openjdk.java.net/browse/JDK-8276208): vmTestbase/nsk/jdb/repeat/repeat001/repeat001.java fails with "AssertionError: Unexpected output"


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6182/head:pull/6182` \
`$ git checkout pull/6182`

Update a local copy of the PR: \
`$ git checkout pull/6182` \
`$ git pull https://git.openjdk.java.net/jdk pull/6182/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6182`

View PR using the GUI difftool: \
`$ git pr show -t 6182`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6182.diff">https://git.openjdk.java.net/jdk/pull/6182.diff</a>

</details>
