### PR TITLE
8276218: JFR: Clean up jdk.jfr.dcmd

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
@@ -75,7 +75,6 @@ abstract class AbstractDCmd {
         try {
             boolean log = Logger.shouldLog(LogTag.JFR_DCMD, LogLevel.DEBUG);
             if (log) {
-                System.out.println(arg);
                 Logger.log(LogTag.JFR_DCMD, LogLevel.DEBUG, "Executing " + this.getClass().getSimpleName() + ": " + arg);
             }
             ArgumentParser parser = new ArgumentParser(getArgumentInfos(), arg, delimiter);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -58,8 +58,6 @@ import jdk.jfr.internal.jfc.model.XmlInput;
 //Instantiated by native
 final class DCmdStart extends AbstractDCmd {
 
-    private Object source;
-
     @Override
     public void execute(ArgumentParser parser) throws DCmdException {
         String name = parser.getOption("name");


### PR DESCRIPTION
Hi,

Could I have a review of a fix that removes an unessary field and a System.out.println statement that shouldn't be there.

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276218](https://bugs.openjdk.java.net/browse/JDK-8276218): JFR: Clean up jdk.jfr.dcmd


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6183/head:pull/6183` \
`$ git checkout pull/6183`

Update a local copy of the PR: \
`$ git checkout pull/6183` \
`$ git pull https://git.openjdk.java.net/jdk pull/6183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6183`

View PR using the GUI difftool: \
`$ git pr show -t 6183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6183.diff">https://git.openjdk.java.net/jdk/pull/6183.diff</a>

</details>
