### PR TITLE
8276227: ciReplay: SIGSEGV if classfile for replay compilation is not present after JDK-8275868

### DIFF
--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -113,6 +113,7 @@ class CompileReplay : public StackObj {
   FILE*   _stream;
   Thread* _thread;
   Handle  _protection_domain;
+  bool    _protection_domain_initialized;
   Handle  _loader;
 
   GrowableArray<ciMethodRecord*>     _ci_method_records;
@@ -140,6 +141,7 @@ class CompileReplay : public StackObj {
     _thread = THREAD;
     _loader = Handle(_thread, SystemDictionary::java_system_loader());
     _protection_domain = Handle();
+    _protection_domain_initialized = false;
 
     _stream = fopen(filename, "rt");
     if (_stream == NULL) {
@@ -874,12 +876,18 @@ class CompileReplay : public StackObj {
   void process_instanceKlass(TRAPS) {
     // just load the referenced class
     Klass* k = parse_klass(CHECK);
-    if (_protection_domain() == NULL) {
+    if (!_protection_domain_initialized && k != NULL) {
+      assert(_protection_domain() == NULL, "must be uninitialized");
       // The first entry is the holder class of the method for which a replay compilation is requested.
       // Use the same protection domain to load all subsequent classes in order to resolve all classes
       // in signatures of inlinees. This ensures that inlining can be done as stated in the replay file.
       _protection_domain = Handle(_thread, k->protection_domain());
     }
+
+    // Only initialize the protection domain handle with the protection domain of the very first entry.
+    // This also ensures that older replay files work.
+    _protection_domain_initialized = true;
+
     if (k == NULL) {
       return;
     }

--- a/test/hotspot/jtreg/compiler/ciReplay/TestNoClassFile.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/TestNoClassFile.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8276227
+ * @library / /test/lib
+ * @summary Testing that ciReplay works if we do not find the class files to replay compile.
+ * @requires vm.flightRecorder != true & vm.compMode != "Xint" & vm.compMode != "Xcomp" & vm.debug == true & vm.compiler2.enabled
+ * @modules java.base/jdk.internal.misc
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      compiler.ciReplay.TestNoClassFile
+ */
+
+package compiler.ciReplay;
+
+public class TestNoClassFile extends DumpReplayBase {
+
+    public static void main(String[] args) {
+        new TestNoClassFile().runTest(TIERED_DISABLED_VM_OPTION);
+    }
+
+    @Override
+    public void testAction() {
+        // Override classpath such that we do not find any class files for replay compilation. Should exit gracefully.
+        positiveTest("-cp foo", "-XX:+ReplayIgnoreInitErrors");
+    }
+
+    @Override
+    public String getTestClass() {
+        return NoClassFileMain.class.getName();
+    }
+
+}
+
+class NoClassFileMain {
+    public static void main(String[] args) {
+        for (int i = 0; i < 10000; i++) {
+            test();
+        }
+    }
+    public static void test() {
+        NoClassFileHelper.bar();
+    }
+}
+
+class NoClassFileHelper {
+    public static int bar() {
+        return 3;
+    }
+}


### PR DESCRIPTION
The fix for [JDK-8275868](https://bugs.openjdk.java.net/browse/JDK-8275868) does not handle the case when the classfile for the method to be replay compiled is not present. This will fail to load the klass. Afterwards, we are trying to access the protection domain of the failed to load klass (i.e. a null pointer) which results in a segmentation fault. The fix is straight forward to only set the new protection domain if the klass was loaded successfully. I additionally changed the code such that we are only trying to set the protection domain when reading the first `instanceKlass` entry. This avoids some potential problems with older replay files where we do not have this additional first entry set by JDK-8275868.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276227](https://bugs.openjdk.java.net/browse/JDK-8276227): ciReplay: SIGSEGV if classfile for replay compilation is not present after JDK-8275868


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 4fe95743205abbfbe7a03306ebeb911499f1621a
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to 4fe95743205abbfbe7a03306ebeb911499f1621a


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6189/head:pull/6189` \
`$ git checkout pull/6189`

Update a local copy of the PR: \
`$ git checkout pull/6189` \
`$ git pull https://git.openjdk.java.net/jdk pull/6189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6189`

View PR using the GUI difftool: \
`$ git pr show -t 6189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6189.diff">https://git.openjdk.java.net/jdk/pull/6189.diff</a>

</details>
