### PR TITLE
8276205: Shenandoah: CodeCache_lock should always be held for initializing code cache iteration

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahCodeRoots.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCodeRoots.cpp
@@ -355,12 +355,15 @@ ShenandoahCodeRootsIterator::ShenandoahCodeRootsIterator() :
         _par_iterator(CodeCache::heaps()),
         _table_snapshot(NULL) {
   assert(SafepointSynchronize::is_at_safepoint(), "Must be at safepoint");
+  MutexLocker locker(CodeCache_lock, Mutex::_no_safepoint_check_flag);
   _table_snapshot = ShenandoahCodeRoots::table()->snapshot_for_iteration();
 }
 
 ShenandoahCodeRootsIterator::~ShenandoahCodeRootsIterator() {
+  MonitorLocker locker(CodeCache_lock, Mutex::_no_safepoint_check_flag);
   ShenandoahCodeRoots::table()->finish_iteration(_table_snapshot);
   _table_snapshot = NULL;
+  locker.notify_all();
 }
 
 void ShenandoahCodeRootsIterator::possibly_parallel_blobs_do(CodeBlobClosure *f) {


### PR DESCRIPTION
There are few bugs in current implementation:
1) No CodeCache_lock is held when initialize code cache iterator at safepoints. This is a problem for concurrent GC, since it can initialize a concurrent code cache iterator while holding CodeCache_lock without safepoint check.

2) Does not notify waiters upon completion of iteration at safepoints

3) Unnecessary held CodeCache_lock during concurrent code cache iteration.

Test:
- [x] hotspot_gc_shenandoah on Linux x86_64
- [x] hotspot_gc_shenandoah on Linux aarch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276205](https://bugs.openjdk.java.net/browse/JDK-8276205): Shenandoah: CodeCache_lock should always be held for initializing code cache iteration


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6192/head:pull/6192` \
`$ git checkout pull/6192`

Update a local copy of the PR: \
`$ git checkout pull/6192` \
`$ git pull https://git.openjdk.java.net/jdk pull/6192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6192`

View PR using the GUI difftool: \
`$ git pr show -t 6192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6192.diff">https://git.openjdk.java.net/jdk/pull/6192.diff</a>

</details>
