### PR TITLE
8273967: gtest os.dll_address_to_function_and_library_name_vm fails on macOS12

### DIFF
--- a/src/hotspot/os/bsd/decoder_machO.cpp
+++ b/src/hotspot/os/bsd/decoder_machO.cpp
@@ -52,6 +52,12 @@ bool MachODecoder::demangle(const char* symbol, char *buf, int buflen) {
 
 bool MachODecoder::decode(address addr, char *buf,
       int buflen, int *offset, const void *mach_base) {
+  if (addr == (address)(intptr_t)-1) {
+    // dladdr() in macOS12/Monterey returns success for -1, but that addr value
+    // won't work in this function. Should have been handled by the caller.
+    ShouldNotReachHere();
+    return false;
+  }
   struct symtab_command * symt = (struct symtab_command *)
     mach_find_command((struct mach_header_64 *)mach_base, LC_SYMTAB);
   if (symt == NULL) {

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -907,7 +907,7 @@ bool os::print_function_and_library_name(outputStream* st,
       addr = addr2;
     }
   }
-#endif // HANDLE_FUNCTION_DESCRIPTORS
+#endif // HAVE_FUNCTION_DESCRIPTORS
 
   if (have_function_name) {
     // Print function name, optionally demangled

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -709,11 +709,7 @@ TEST_VM(os, pagesizes_test_print) {
   ASSERT_EQ(strcmp(expected, buffer), 0);
 }
 
-#if defined(__APPLE__)  // See JDK-8273967.
-  TEST_VM(os, DISABLED_dll_address_to_function_and_library_name) {
-#else
-  TEST_VM(os, dll_address_to_function_and_library_name) {
-#endif
+TEST_VM(os, dll_address_to_function_and_library_name) {
   char tmp[1024];
   char output[1024];
   stringStream st(output, sizeof(output));
@@ -726,8 +722,10 @@ TEST_VM(os, pagesizes_test_print) {
 #define LOG(...)
 
   // Invalid addresses
+  LOG("os::print_function_and_library_name(st, -1) expects FALSE.");
   address addr = (address)(intptr_t)-1;
   EXPECT_FALSE(os::print_function_and_library_name(&st, addr));
+  LOG("os::print_function_and_library_name(st, NULL) expects FALSE.");
   addr = NULL;
   EXPECT_FALSE(os::print_function_and_library_name(&st, addr));
 


### PR DESCRIPTION
macOS12 has changed the dladdr() function to accept "-1" as a valid address and
we have functions that use dladdr() to convert DLL addresses into function or
library names. We also have a gtest that verifies that "-1" is not a valid value to use
as a symbol address.

As you might imagine, existing code that uses `os::dll_address_to_function_name()`
or `os::dll_address_to_library_name()` can get quite confused (and sometimes crash)
if an `addr` parameter of `-1` was allowed to be used.

I've also made two cleanup changes as part of this fix:

1) In `src/hotspot/os/bsd/os_bsd.cpp` there is some macOS specific code that should
   be properly `#ifdef`'ed. There is also some code that makes sense for ELF format
   files, but not for Mach-O format files so that code needs to be excluded on macOS.

2) In `src/hotspot/share/runtime/os.cpp` I noticed a simple typo in a comment on an
    `#endif` that I fixed. That typo does not appear anywhere else in the HotSpot code
    base so I'd like to fix it with this bug ID since I'm in related areas.

This fix has been tested with Mach5 Tier[1-6].

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273967](https://bugs.openjdk.java.net/browse/JDK-8273967): gtest os.dll_address_to_function_and_library_name_vm fails on macOS12


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Gerard Ziemski](https://openjdk.java.net/census#gziemski) (@gerard-ziemski - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6193/head:pull/6193` \
`$ git checkout pull/6193`

Update a local copy of the PR: \
`$ git checkout pull/6193` \
`$ git pull https://git.openjdk.java.net/jdk pull/6193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6193`

View PR using the GUI difftool: \
`$ git pr show -t 6193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6193.diff">https://git.openjdk.java.net/jdk/pull/6193.diff</a>

</details>
