### PR TITLE
8202667: java/awt/Debug/DumpOnKey/DumpOnKey.java times out on Windows

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -473,7 +473,6 @@ java/awt/font/TextLayout/LigatureCaretTest.java 8266312  generic-all
 java/awt/image/VolatileImage/CustomCompositeTest.java 8199002 windows-all,linux-all
 java/awt/image/VolatileImage/GradientPaints.java 8199003 linux-all
 java/awt/JAWT/JAWT.sh 8197798 windows-all,linux-all
-java/awt/Debug/DumpOnKey/DumpOnKey.java 8202667 windows-all
 java/awt/Robot/RobotWheelTest/RobotWheelTest.java 8129827 generic-all
 java/awt/Focus/WindowUpdateFocusabilityTest/WindowUpdateFocusabilityTest.java 8202926 linux-all
 java/awt/datatransfer/ConstructFlavoredObjectTest/ConstructFlavoredObjectTest.java 8202860 linux-all

--- a/test/jdk/java/awt/Debug/DumpOnKey/DumpOnKey.java
+++ b/test/jdk/java/awt/Debug/DumpOnKey/DumpOnKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 
 import java.awt.AWTException;
+import java.awt.EventQueue;
 import java.awt.Frame;
 import java.awt.Robot;
 import java.awt.Window;
@@ -58,9 +59,11 @@ public final class DumpOnKey {
         w.setSize(200, 200);
         w.setLocationRelativeTo(null);
         w.setVisible(true);
+        w.toFront();
+        w.requestFocus();
 
         final Robot robot = new Robot();
-        robot.setAutoDelay(50);
+        robot.setAutoDelay(100);
         robot.setAutoWaitForIdle(true);
         robot.mouseMove(w.getX() + w.getWidth() / 2,
                         w.getY() + w.getHeight() / 2);
@@ -74,7 +77,14 @@ public final class DumpOnKey {
         robot.keyRelease(KeyEvent.VK_SHIFT);
         robot.keyRelease(KeyEvent.VK_CONTROL);
 
-        w.dispose();
+        try {
+            EventQueue.invokeAndWait(() -> {
+                w.dispose();
+            });
+        } catch (Exception e) {}
+
+        robot.delay(2000);
+
         if (dumped != dump) {
             throw new RuntimeException("Exp:" + dump + ", actual:" + dumped);
         }


### PR DESCRIPTION
Looks like the problem occurs when system is slow to actually close windows,
then keyboard events are going to the wrong window. The idea of the fix is to
bring the new window to front before actual testing starts and close window
on EDT and then wait for 2 seconds for actual hardware window to disappear.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8202667](https://bugs.openjdk.java.net/browse/JDK-8202667): java/awt/Debug/DumpOnKey/DumpOnKey.java times out on Windows


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6194/head:pull/6194` \
`$ git checkout pull/6194`

Update a local copy of the PR: \
`$ git checkout pull/6194` \
`$ git pull https://git.openjdk.java.net/jdk pull/6194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6194`

View PR using the GUI difftool: \
`$ git pr show -t 6194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6194.diff">https://git.openjdk.java.net/jdk/pull/6194.diff</a>

</details>
