### PR TITLE
JDK-8276236: Table headers missing in Formatter api docs

### DIFF
--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -388,6 +388,10 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *
  * <table class="striped">
  * <caption style="display:none">time</caption>
+ * <thead>
+ * <tr><th scope="col" style="vertical-align:bottom"> Conversion
+ *     <th scope="col" style="vertical-align:bottom"> Description
+ * </thead>
  * <tbody>
  * <tr><th scope="row" style="vertical-align:top"> {@code 'H'}
  *     <td> Hour of the day for the 24-hour clock, formatted as two digits with
@@ -459,6 +463,10 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *
  * <table class="striped">
  * <caption style="display:none">date</caption>
+ * <thead>
+ * <tr><th scope="col" style="vertical-align:bottom"> Conversion
+ *     <th scope="col" style="vertical-align:bottom"> Description
+ * </thead>
  * <tbody>
  *
  * <tr><th scope="row" style="vertical-align:top">{@code 'B'}
@@ -519,6 +527,10 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *
  * <table class="striped">
  * <caption style="display:none">composites</caption>
+ * <thead>
+ * <tr><th scope="col" style="vertical-align:bottom"> Conversion
+ *     <th scope="col" style="vertical-align:bottom"> Description
+ * </thead>
  * <tbody>
  *
  * <tr><th scope="row" style="vertical-align:top">{@code 'R'}
@@ -738,6 +750,11 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *
  * <table class="striped">
  * <caption style="display:none">dgConv</caption>
+ * <thead>
+ * <tr><th scope="col" style="vertical-align:bottom"> Conversion
+ *     <th scope="col" style="vertical-align:bottom"> Unicode
+ *     <th scope="col" style="vertical-align:bottom"> Description
+ * </thead>
  * <tbody>
  *
  * <tr><th scope="row" style="vertical-align:top"> {@code 'b'}
@@ -796,6 +813,11 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *
  * <table class="striped">
  * <caption style="display:none">dFlags</caption>
+ * <thead>
+ * <tr><th scope="col" style="vertical-align:bottom"> Flag
+ *     <th scope="col" style="vertical-align:bottom"> Unicode
+ *     <th scope="col" style="vertical-align:bottom"> Description
+ * </thead>
  * <tbody>
  *
  * <tr><th scope="row" style="vertical-align:top"> {@code '-'}
@@ -840,6 +862,11 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *
  * <table class="striped">
  * <caption style="display:none">charConv</caption>
+ * <thead>
+ * <tr><th scope="col" style="vertical-align:bottom"> Conversion
+ *     <th scope="col" style="vertical-align:bottom"> Unicode
+ *     <th scope="col" style="vertical-align:bottom"> Description
+ * </thead>
  * <tbody>
  *
  * <tr><th scope="row" style="vertical-align:top"> {@code 'c'}
@@ -944,6 +971,11 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *
  * <table class="striped">
  * <caption style="display:none">IntConv</caption>
+ * <thead>
+ * <tr><th scope="col" style="vertical-align:bottom"> Conversion
+ *     <th scope="col" style="vertical-align:bottom"> Unicode
+ *     <th scope="col" style="vertical-align:bottom"> Description
+ * </thead>
  * <tbody>
  *
  * <tr><th scope="row" style="vertical-align:top"> {@code 'd'}
@@ -1027,6 +1059,11 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *
  * <table class="striped">
  * <caption style="display:none">intFlags</caption>
+ * <thead>
+ * <tr><th scope="col" style="vertical-align:bottom"> Conversion
+ *     <th scope="col" style="vertical-align:bottom"> Unicode
+ *     <th scope="col" style="vertical-align:bottom"> Description
+ * </thead>
  * <tbody>
  *
  * <tr><th scope="row" style="vertical-align:top"> {@code '+'}
@@ -1108,6 +1145,11 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *
  * <table class="striped">
  * <caption style="display:none">bIntConv</caption>
+ * <thead>
+ * <tr><th scope="col" style="vertical-align:bottom"> Conversion
+ *     <th scope="col" style="vertical-align:bottom"> Unicode
+ *     <th scope="col" style="vertical-align:bottom"> Description
+ * </thead>
  * <tbody>
  *
  * <tr><th scope="row" style="vertical-align:top"> {@code 'd'}
@@ -1205,6 +1247,11 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *
  * <table class="striped">
  * <caption style="display:none">floatConv</caption>
+ * <thead>
+ * <tr><th scope="col" style="vertical-align:bottom"> Conversion
+ *     <th scope="col" style="vertical-align:bottom"> Unicode
+ *     <th scope="col" style="vertical-align:bottom"> Description
+ * </thead>
  * <tbody>
  *
  * <tr><th scope="row" style="vertical-align:top"> {@code 'e'}
@@ -1442,6 +1489,11 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *
  * <table class="striped">
  * <caption style="display:none">floatConv</caption>
+ * <thead>
+ * <tr><th scope="col" style="vertical-align:bottom"> Conversion
+ *     <th scope="col" style="vertical-align:bottom"> Unicode
+ *     <th scope="col" style="vertical-align:bottom"> Description
+ * </thead>
  * <tbody>
  *
  * <tr><th scope="row" style="vertical-align:top"> {@code 'e'}
@@ -1569,6 +1621,11 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *
  * <table class="striped">
  * <caption style="display:none">DTConv</caption>
+ * <thead>
+ * <tr><th scope="col" style="vertical-align:bottom"> Conversion
+ *     <th scope="col" style="vertical-align:bottom"> Unicode
+ *     <th scope="col" style="vertical-align:bottom"> Description
+ * </thead>
  * <tbody>
  *
  * <tr><th scope="row" style="vertical-align:top"> {@code 't'}
@@ -1592,6 +1649,11 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *
  * <table class="striped">
  * <caption style="display:none">time</caption>
+ * <thead>
+ * <tr><th scope="col" style="vertical-align:bottom"> Conversion
+ *     <th scope="col" style="vertical-align:bottom"> Unicode
+ *     <th scope="col" style="vertical-align:bottom"> Description
+ * </thead>
  * <tbody>
  *
  * <tr><th scope="row" style="vertical-align:top"> {@code 'H'}
@@ -1687,6 +1749,11 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *
  * <table class="striped">
  * <caption style="display:none">date</caption>
+ * <thead>
+ * <tr><th scope="col" style="vertical-align:bottom"> Conversion
+ *     <th scope="col" style="vertical-align:bottom"> Unicode
+ *     <th scope="col" style="vertical-align:bottom"> Description
+ * </thead>
  * <tbody>
  *
  * <tr><th scope="row" style="vertical-align:top">{@code 'B'}
@@ -1763,6 +1830,11 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *
  * <table class="striped">
  * <caption style="display:none">composites</caption>
+ * <thead>
+ * <tr><th scope="col" style="vertical-align:bottom"> Conversion
+ *     <th scope="col" style="vertical-align:bottom"> Unicode
+ *     <th scope="col" style="vertical-align:bottom"> Description
+ * </thead>
  * <tbody>
  *
  * <tr><th scope="row" style="vertical-align:top">{@code 'R'}
@@ -1817,6 +1889,10 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *
  * <table class="striped">
  * <caption style="display:none">DTConv</caption>
+ * <thead>
+ * <tr><th scope="col" style="vertical-align:bottom"> Conversion
+ *     <th scope="col" style="vertical-align:bottom"> Description
+ * </thead>
  * <tbody>
  *
  * <tr><th scope="row" style="vertical-align:top">{@code '%'}
@@ -1845,6 +1921,10 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  *
  * <table class="striped">
  * <caption style="display:none">DTConv</caption>
+ * <thead>
+ * <tr><th scope="col" style="vertical-align:bottom"> Conversion
+ *     <th scope="col" style="vertical-align:bottom"> Description
+ * </thead>
  * <tbody>
  *
  * <tr><th scope="row" style="vertical-align:top">{@code 'n'}


### PR DESCRIPTION
Adds table headers to all tables in Formatter api docs. I inferred the header "Unicode" for the columns that contained unicode
codepoints.

Formatter api docs: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Formatter.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276236](https://bugs.openjdk.java.net/browse/JDK-8276236): Table headers missing in Formatter api docs


### Reviewers
 * [Sean Coffey](https://openjdk.java.net/census#coffeys) (@coffeys - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6195/head:pull/6195` \
`$ git checkout pull/6195`

Update a local copy of the PR: \
`$ git checkout pull/6195` \
`$ git pull https://git.openjdk.java.net/jdk pull/6195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6195`

View PR using the GUI difftool: \
`$ git pr show -t 6195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6195.diff">https://git.openjdk.java.net/jdk/pull/6195.diff</a>

</details>
