### PR TITLE
8275729: Qualified method names in CodeHeap Analytics

### DIFF
--- a/src/hotspot/share/code/codeHeapState.cpp
+++ b/src/hotspot/share/code/codeHeapState.cpp
@@ -26,6 +26,7 @@
 #include "precompiled.hpp"
 #include "code/codeHeapState.hpp"
 #include "compiler/compileBroker.hpp"
+#include "oops/klass.inline.hpp"
 #include "runtime/safepoint.hpp"
 #include "runtime/sweeper.hpp"
 #include "utilities/powerOfTwo.hpp"
@@ -2334,6 +2335,11 @@ void CodeHeapState::print_names(outputStream* out, CodeHeap* heap) {
             Symbol* methSig   = method->signature();
             const char*   methSigS  = (methSig  == NULL) ? NULL : methSig->as_C_string();
             methSigS  = (methSigS  == NULL) ? "<method signature unavailable>" : methSigS;
+
+            Klass* klass = method->method_holder();
+            assert(klass->is_loader_alive(), "must be alive");
+
+            ast->print("%s.", klass->external_name());
             ast->print("%s", methNameS);
             ast->print("%s", methSigS);
           } else {

--- a/test/hotspot/jtreg/serviceability/dcmd/compiler/CodeHeapAnalyticsMethodNames.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/compiler/CodeHeapAnalyticsMethodNames.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021, Amazon.com Inc. or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.Iterator;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.dcmd.PidJcmdExecutor;
+
+/*
+ * @test CodeHeapAnalyticsMethodNames
+ * @summary Test Compiler.CodeHeap_Analytics output has qualified method names
+ * in the 'METHOD NAMES' section.
+ * @bug 8275729
+ * @requires vm.flagless
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver CodeHeapAnalyticsMethodNames
+ */
+
+public class CodeHeapAnalyticsMethodNames {
+
+    public static void main(String args[]) throws Exception {
+        PidJcmdExecutor executor = new PidJcmdExecutor();
+        OutputAnalyzer out = executor.execute("Compiler.CodeHeap_Analytics");
+        out.shouldHaveExitValue(0);
+        Iterator<String> iter = out.asLines().listIterator();
+        boolean methodNamesSectionFound = false;
+        while (iter.hasNext()) {
+            String line = iter.next();
+            if (line.contains("M E T H O D   N A M E S")) {
+                methodNamesSectionFound = true;
+                break;
+            }
+        }
+        boolean nMethodFound = false;
+        while (iter.hasNext()) {
+            String line = iter.next();
+            if (line.startsWith("0x") && line.contains("nMethod")) {
+                nMethodFound = true;
+                if (line.contains("java.lang.invoke.MethodHandle")) {
+                    return;
+                }
+            }
+        }
+        if (methodNamesSectionFound && nMethodFound) {
+            throw new RuntimeException("No java.lang.invoke.MethodHandle found.");
+        }
+    }
+}


### PR DESCRIPTION
This PR changes nmethods names in `METHOD NAMES for CodeHeap` section to be  qualified.
Testing:
- `make test TEST="gtest"`:  Passed
- `make run-test TEST="tier1"`: Passed
- `make run-test TEST="tier2"`: Passed
- `make run-test TEST=serviceability/dcmd/compiler/CodeHeapAnalyticsMethodNames.java`: Passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275729](https://bugs.openjdk.java.net/browse/JDK-8275729): Qualified method names in CodeHeap Analytics


### Reviewers
 * [Yi Yang](https://openjdk.java.net/census#yyang) (@kelthuzadx - Committer)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6200/head:pull/6200` \
`$ git checkout pull/6200`

Update a local copy of the PR: \
`$ git checkout pull/6200` \
`$ git pull https://git.openjdk.java.net/jdk pull/6200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6200`

View PR using the GUI difftool: \
`$ git pr show -t 6200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6200.diff">https://git.openjdk.java.net/jdk/pull/6200.diff</a>

</details>
