### PR TITLE
8276260: (se) Remove java/nio/channels/Selector/Wakeup.java from ProblemList (win)

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -609,8 +609,6 @@ java/nio/channels/DatagramChannel/Unref.java                    8233519 generic-
 
 java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc64
 
-java/nio/channels/Selector/Wakeup.java                          6963118 windows-all
-
 ############################################################################
 
 # jdk_rmi


### PR DESCRIPTION
This request would reinstate the JDK test java/nio/channels/Selector/Wakeup.java  in testing on Windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276260](https://bugs.openjdk.java.net/browse/JDK-8276260): (se) Remove java/nio/channels/Selector/Wakeup.java from ProblemList (win)


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6201/head:pull/6201` \
`$ git checkout pull/6201`

Update a local copy of the PR: \
`$ git checkout pull/6201` \
`$ git pull https://git.openjdk.java.net/jdk pull/6201/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6201`

View PR using the GUI difftool: \
`$ git pr show -t 6201`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6201.diff">https://git.openjdk.java.net/jdk/pull/6201.diff</a>

</details>
