### PR TITLE
8276149: jshell throws EOF error when throwing exception inside switch expression

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/CompletenessAnalyzer.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/CompletenessAnalyzer.java
@@ -557,9 +557,11 @@ class CompletenessAnalyzer {
                         break;
                 }
                 // Detect an error if we are at starting position and the last
-                // token wasn't a terminating one.  Special case: within braces,
-                // comma can proceed semicolon, e.g. the values list in enum
-                if (ct.kind.isStart() && !prevTK.isOkToTerminate() && prevTK != COMMA) {
+                // token wasn't a terminating one.  Special cases:
+                // -within braces, comma can procede semicolon, e.g. the values list in enum
+                // -arrow can be followed by a throw, e.g. in a switch/switch expression
+                if (ct.kind.isStart() && !prevTK.isOkToTerminate() && prevTK != COMMA &&
+                    !(prevTK == ARROW && ct.kind == THROW)) {
                     return new CT(ERROR, current, "No '" + prevTK + "' before '" + ct.kind + "'");
                 }
                 if (stack.isEmpty() || ct.kind.isError()) {

--- a/test/langtools/jdk/jshell/CompletenessTest.java
+++ b/test/langtools/jdk/jshell/CompletenessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8149524 8131024 8165211 8080071 8130454 8167343 8129559 8114842 8182268 8223782 8235474 8246774
+ * @bug 8149524 8131024 8165211 8080071 8130454 8167343 8129559 8114842 8182268 8223782 8235474 8246774 8276149
  * @summary Test SourceCodeAnalysis
  * @build KullaTesting TestingInputStream
  * @run testng CompletenessTest
@@ -223,6 +223,12 @@ public class CompletenessTest extends KullaTesting {
         "static record D(String i, String j)",
         "static record D(String i) {",
         "static record D(String i, String j) {",
+        //JDK-8276149:
+        "void t(int i) { int v = switch (i) { case 0 -> ",
+        "void t(int i) { int v = switch (i) { case 0 -> {",
+        "void t(int i) { int v = switch (i) { case 0 -> a = b;",
+        "void t(int i) { int v = switch (i) { case 0 -> System.err.println(1);",
+        "void t(int i) { int v = switch (i) { case 0 -> throw new IllegalStateException();",
     };
 
     static final String[] unknown = new String[] {


### PR DESCRIPTION
The completeness analysis does not correctly handle `case ... -> throw`, as it does not expect that `->` can be followed by `throw`, and as an ultimate consequence, it will consider this to be a complete snippet:
```
void t(int i) {
     int v = switch (i) {
          case 0 -> throw new IllegalStateException();
```

While it apparently isn't a complete snippet.

The proposed solution is to add a special-case handling for this specific combination, which will ensure JShell will wait for more input for this snippet.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276149](https://bugs.openjdk.java.net/browse/JDK-8276149): jshell throws EOF error when throwing exception inside switch expression


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6207/head:pull/6207` \
`$ git checkout pull/6207`

Update a local copy of the PR: \
`$ git checkout pull/6207` \
`$ git pull https://git.openjdk.java.net/jdk pull/6207/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6207`

View PR using the GUI difftool: \
`$ git pr show -t 6207`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6207.diff">https://git.openjdk.java.net/jdk/pull/6207.diff</a>

</details>
