### PR TITLE
8276306: jdk/jshell/CustomInputToolBuilder.java fails intermittently on storage acquisition

### DIFF
--- a/test/langtools/jdk/jshell/CustomInputToolBuilder.java
+++ b/test/langtools/jdk/jshell/CustomInputToolBuilder.java
@@ -35,6 +35,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import jdk.jshell.tool.JavaShellToolBuilder;
 import org.testng.annotations.Test;
@@ -88,6 +89,7 @@ public class CustomInputToolBuilder extends KullaTesting {
                     .out(printOut, printOut, printOut)
                     .interactiveTerminal(interactiveTerminal)
                     .promptCapture(true)
+                    .persistence(new HashMap<>())
                     .start("--no-startup");
 
             String actual = new String(out.toByteArray());


### PR DESCRIPTION
This test intermittently fails in `tier1` runs on our highly parallel machines. I believe there is the interaction between the tests that use the preferences storage. See bug for the stack trace. I think we can fortify this test by overriding the default persistence storage.

Additional testing:
 - [x] 10x `langtools:tier1`, no failures now

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276306](https://bugs.openjdk.java.net/browse/JDK-8276306): jdk/jshell/CustomInputToolBuilder.java fails intermittently on storage acquisition


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6208/head:pull/6208` \
`$ git checkout pull/6208`

Update a local copy of the PR: \
`$ git checkout pull/6208` \
`$ git pull https://git.openjdk.java.net/jdk pull/6208/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6208`

View PR using the GUI difftool: \
`$ git pr show -t 6208`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6208.diff">https://git.openjdk.java.net/jdk/pull/6208.diff</a>

</details>
