### PR TITLE
8274942: AssertionError at jdk.compiler/com.sun.tools.javac.util.Assert.error(Assert.java:155)

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
@@ -673,8 +673,7 @@ public class Annotate {
             return new Attribute.Error(expectedElementType);
         }
 
-        // Scan the annotation element value and then attribute
-        // the internal annotations to prevent the compiler from crashing
+        // Scan the annotation element value and then attribute nested annotations if present
         if (tree.type != null && tree.type.tsym != null) {
             queueScanTreeAndTypeAnnotate(tree, env, tree.type.tsym, tree.pos());
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
@@ -672,6 +672,13 @@ public class Annotate {
             log.error(tree.pos(), Errors.AttributeValueMustBeConstant);
             return new Attribute.Error(expectedElementType);
         }
+
+        // Scan the annotation element value and then attribute
+        // the internal annotations to prevent the compiler from crashing
+        if (tree.type != null && tree.type.tsym != null) {
+            queueScanTreeAndTypeAnnotate(tree, env, tree.type.tsym, tree.pos());
+        }
+
         result = cfolder.coerce(result, expectedElementType);
         return new Attribute.Constant(expectedElementType, result.constValue());
     }

--- a/test/langtools/tools/javac/annotations/typeAnnotations/NestTypeAnnotation.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/NestTypeAnnotation.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8274942
+ * @summary javac should attribute the internal annotations of the annotation element value
+ * @compile NestTypeAnnotation.java
+ */
+
+import java.lang.annotation.*;
+
+public class NestTypeAnnotation {
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+    public @interface OuterAnnotation {
+        int intVal();
+        float floatVal();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+    public @interface InnerAnnotation { }
+
+    public static void main(String[] args) {
+        int intVal1 = (@OuterAnnotation(intVal = (@InnerAnnotation() int) 2.5, floatVal = (@InnerAnnotation() float) 2.5) int) 2.4;
+        int[] arr = new int []{1, 2}; // use `2.4 * arr[0] + arr[1]` to prevent optimization.
+        int intVal2 = (@OuterAnnotation(intVal = (@InnerAnnotation() int) 2.5, floatVal = (@InnerAnnotation() float) 2.5) int) (2.4 * arr[0] + arr[1]);
+
+        int[] singleArr1 = new @OuterAnnotation(intVal = (@InnerAnnotation() int) 2.5, floatVal = (@InnerAnnotation() float) 2.5) int [2];
+        @OuterAnnotation(intVal = (@InnerAnnotation() int) 2.5, floatVal = (@InnerAnnotation() float) 2.5) int[] singleArr2 = new int [2];
+        int[] singleArr3 = new  int @OuterAnnotation(intVal = (@InnerAnnotation() int) 2.5, floatVal = (@InnerAnnotation() float) 2.5) [2];
+
+        int[][] multiArr1 = new int @OuterAnnotation(intVal = (@InnerAnnotation() int) 2.5, floatVal = (@InnerAnnotation() float) 2.5) [2][3];
+        int[][] multiArr2 = new int [2] @OuterAnnotation(intVal = (@InnerAnnotation() int) 2.5, floatVal = (@InnerAnnotation() float) 2.5) [3];
+    }
+}


### PR DESCRIPTION
Hi all,

Currently, the compiler doesn't `annotate` the internal type annotations of the annotation element value so that the field `JCAnnotation.attribute` is `null` and the compiler crashes. This patch adds the missed scaning step and the corresponding test case.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274942](https://bugs.openjdk.java.net/browse/JDK-8274942): AssertionError at jdk.compiler/com.sun.tools.javac.util.Assert.error(Assert.java:155)


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**) ⚠️ Review applies to 05d2f715ff3143af46a94d62c61bb6d96dc95fc9


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6210/head:pull/6210` \
`$ git checkout pull/6210`

Update a local copy of the PR: \
`$ git checkout pull/6210` \
`$ git pull https://git.openjdk.java.net/jdk pull/6210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6210`

View PR using the GUI difftool: \
`$ git pr show -t 6210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6210.diff">https://git.openjdk.java.net/jdk/pull/6210.diff</a>

</details>
