### PR TITLE
8276108: Wrong instruction generation in aarch64 backend

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -476,16 +476,17 @@ class Address {
           assert(size == 0, "bad size");
           size = 0b100;
         }
+        assert(offset_ok_for_immed(_offset, size),
+               "must be, was: %ld, %d", _offset, size);
         unsigned mask = (1 << size) - 1;
-        if (_offset < 0 || _offset & mask)
-          {
-            i->f(0b00, 25, 24);
-            i->f(0, 21), i->f(0b00, 11, 10);
-            i->sf(_offset, 20, 12);
-          } else {
-            i->f(0b01, 25, 24);
-            i->f(_offset >> size, 21, 10);
-          }
+        if (_offset < 0 || _offset & mask) {
+          i->f(0b00, 25, 24);
+          i->f(0, 21), i->f(0b00, 11, 10);
+          i->sf(_offset, 20, 12);
+        } else {
+          i->f(0b01, 25, 24);
+          i->f(_offset >> size, 21, 10);
+        }
       }
       break;
 

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.inline.hpp
@@ -30,8 +30,14 @@
 #include "asm/codeBuffer.hpp"
 #include "code/codeCache.hpp"
 
-
+// Check if an offset is within the encoding range for LDR/STR instructions
+// with an immediate offset, either using unscaled signed 9-bits or, scaled
+// unsigned 12-bits. We favour the scaled unsigned encoding for all aligned
+// offsets (only using the signed 9-bit encoding for negative and unaligned
+// offsets). As a precondition, 0 <= shift <= 4 is the log2(size), for the
+// supported data widths, {1, 2, 4, 8, 16} bytes.
 inline bool Address::offset_ok_for_immed(int64_t offset, uint shift) {
+  precond(shift < 5);
   uint mask = (1 << shift) - 1;
   if (offset < 0 || (offset & mask) != 0) {
     // Unscaled signed offset, encoded in a signed imm9 field.

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -191,10 +191,10 @@ Address LIR_Assembler::as_Address(LIR_Address* addr, Register tmp) {
     assert(addr->scale() == 0,
            "expected for immediate operand, was: %d", addr->scale());
     ptrdiff_t offset = ptrdiff_t(addr->disp());
-    // FIXME: Assuming worst case, 8 byte datum, since operand size is unknown.
-    //        NOTE: Not expecting 16 byte vector access.
-    const uint log2size = 3;
-    if (Address::offset_ok_for_immed(offset, log2size)) {
+    // NOTE: Does not handle any 16 byte vector access.
+    const uint type_size = type2aelembytes(addr->type(), true);
+    const uint log2_size = log2i_exact(type_size);
+    if (Address::offset_ok_for_immed(offset, log2_size)) {
       return Address(base, offset);
     } else {
       __ mov(tmp, offset);

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -193,13 +193,7 @@ Address LIR_Assembler::as_Address(LIR_Address* addr, Register tmp) {
     ptrdiff_t offset = ptrdiff_t(addr->disp());
     // NOTE: Does not handle any 16 byte vector access.
     const uint type_size = type2aelembytes(addr->type(), true);
-    const uint log2_size = log2i_exact(type_size);
-    if (Address::offset_ok_for_immed(offset, log2_size)) {
-      return Address(base, offset);
-    } else {
-      __ mov(tmp, offset);
-      return Address(base, tmp);
-    }
+    return __ legitimize_address(Address(base, offset), type_size, tmp);
   }
   return Address();
 }


### PR DESCRIPTION
C1 code generation on AArch64 may produce bad LDR/STR immediate offset instructions when the actual operand (datum) size is unknown. This change will alter the code generated for the problematic immediate offset to use the register offset version (requiring additional instructions).

Contributed by Nick Gasson.

Added assert in Address::encode() to emphasise the use of a valid immediate (in base_plus_offset).

Added clarifying comment to Address::offset_ok_for_immed() emphasising favouring of the scaled unsigned 12-bit encoding for aligned offsets.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276108](https://bugs.openjdk.java.net/browse/JDK-8276108): Wrong instruction generation in aarch64 backend


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Contributors
 * Nick Gasson `<ngasson@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6212/head:pull/6212` \
`$ git checkout pull/6212`

Update a local copy of the PR: \
`$ git checkout pull/6212` \
`$ git pull https://git.openjdk.java.net/jdk pull/6212/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6212`

View PR using the GUI difftool: \
`$ git pr show -t 6212`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6212.diff">https://git.openjdk.java.net/jdk/pull/6212.diff</a>

</details>
