### PR TITLE
8276207: Properties.loadFromXML/storeToXML works incorrectly for supplementary characters

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/xml/impl/Parser.java
+++ b/src/java.base/share/classes/jdk/internal/util/xml/impl/Parser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1993,19 +1993,17 @@ public abstract class Parser {
                             try {
                                 int i = Integer.parseInt(
                                         new String(mBuff, idx + 1, mBuffIdx - idx), 10);
-                                if (i >= 0xffff) {
-                                    panic(FAULT);
+                                //          Restore the buffer offset
+                                mBuffIdx = idx - 1;
+                                for(char character : Character.toChars(i)) {
+                                    if (character == ' ' || mInp.next != null) {
+                                        bappend(character, flag);
+                                    } else {
+                                        bappend(character);
+                                    }
                                 }
-                                ch = (char) i;
                             } catch (NumberFormatException nfe) {
                                 panic(FAULT);
-                            }
-                            //          Restore the buffer offset
-                            mBuffIdx = idx - 1;
-                            if (ch == ' ' || mInp.next != null) {
-                                bappend(ch, flag);
-                            } else {
-                                bappend(ch);
                             }
                             st = -1;
                             break;
@@ -2034,19 +2032,17 @@ public abstract class Parser {
                             try {
                                 int i = Integer.parseInt(
                                         new String(mBuff, idx + 1, mBuffIdx - idx), 16);
-                                if (i >= 0xffff) {
-                                    panic(FAULT);
+                                //          Restore the buffer offset
+                                mBuffIdx = idx - 1;
+                                for(char character : Character.toChars(i)) {
+                                    if (character == ' ' || mInp.next != null) {
+                                        bappend(character, flag);
+                                    } else {
+                                        bappend(character);
+                                    }
                                 }
-                                ch = (char) i;
                             } catch (NumberFormatException nfe) {
                                 panic(FAULT);
-                            }
-                            //          Restore the buffer offset
-                            mBuffIdx = idx - 1;
-                            if (ch == ' ' || mInp.next != null) {
-                                bappend(ch, flag);
-                            } else {
-                                bappend(ch);
                             }
                             st = -1;
                             break;

--- a/src/java.base/share/classes/jdk/internal/util/xml/impl/XMLStreamWriterImpl.java
+++ b/src/java.base/share/classes/jdk/internal/util/xml/impl/XMLStreamWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -361,6 +361,15 @@ public class XMLStreamWriterImpl implements XMLStreamWriter {
     }
 
     /**
+     * Writes character reference in hex format.
+     */
+    private void writeCharRef(int codePoint) throws XMLStreamException {
+        _writer.write(ENCODING_PREFIX);
+        _writer.write(Integer.toHexString(codePoint));
+        _writer.write(SEMICOLON);
+    }
+
+    /**
      * Writes XML content to underlying writer. Escapes characters unless
      * escaping character feature is turned off.
      */
@@ -383,10 +392,15 @@ public class XMLStreamWriterImpl implements XMLStreamWriter {
             if (!_writer.canEncode(ch)) {
                 _writer.write(content, startWritePos, index - startWritePos);
 
-                // Escape this char as underlying encoder cannot handle it
-                _writer.write(ENCODING_PREFIX);
-                _writer.write(Integer.toHexString(ch));
-                _writer.write(SEMICOLON);
+                // Check if current and next characters forms a surrogate pair
+                // and escape it to avoid generation of invalid xml content
+                if ( index != end - 1 && Character.isSurrogatePair(ch, content[index+1])) {
+                    writeCharRef(Character.toCodePoint(ch, content[index+1]));
+                    index++;
+                } else {
+                    writeCharRef(ch);
+                }
+
                 startWritePos = index + 1;
                 continue;
             }
@@ -455,10 +469,15 @@ public class XMLStreamWriterImpl implements XMLStreamWriter {
             if (!_writer.canEncode(ch)) {
                 _writer.write(content, startWritePos, index - startWritePos);
 
-                // Escape this char as underlying encoder cannot handle it
-                _writer.write(ENCODING_PREFIX);
-                _writer.write(Integer.toHexString(ch));
-                _writer.write(SEMICOLON);
+                // Check if current and next characters forms a surrogate pair
+                // and escape it to avoid generation of invalid xml content
+                if ( index != end - 1 && Character.isSurrogatePair(ch, content.charAt(index+1))) {
+                    writeCharRef(Character.toCodePoint(ch, content.charAt(index+1)));
+                    index++;
+                } else {
+                    writeCharRef(ch);
+                }
+
                 startWritePos = index + 1;
                 continue;
             }


### PR DESCRIPTION
This fixes Properties.loadFromXML/storeToXML so that it works correctly for supplementary characters.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276207](https://bugs.openjdk.java.net/browse/JDK-8276207): Properties.loadFromXML/storeToXML works incorrectly for supplementary characters


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6216/head:pull/6216` \
`$ git checkout pull/6216`

Update a local copy of the PR: \
`$ git checkout pull/6216` \
`$ git pull https://git.openjdk.java.net/jdk pull/6216/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6216`

View PR using the GUI difftool: \
`$ git pr show -t 6216`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6216.diff">https://git.openjdk.java.net/jdk/pull/6216.diff</a>

</details>
