### PR TITLE
8276385: Re-run blessed-modifier-order script on java.desktop and jdk.accessibility

### DIFF
--- a/src/java.desktop/share/classes/javax/imageio/plugins/tiff/BaselineTIFFTagSet.java
+++ b/src/java.desktop/share/classes/javax/imageio/plugins/tiff/BaselineTIFFTagSet.java
@@ -2173,7 +2173,7 @@ public final class BaselineTIFFTagSet extends TIFFTagSet {
      *
      * @return a {@code BaselineTIFFTagSet} instance.
      */
-    public synchronized static BaselineTIFFTagSet getInstance() {
+    public static synchronized BaselineTIFFTagSet getInstance() {
         if (theInstance == null) {
             initTags();
             theInstance = new BaselineTIFFTagSet();

--- a/src/java.desktop/share/classes/javax/imageio/plugins/tiff/ExifGPSTagSet.java
+++ b/src/java.desktop/share/classes/javax/imageio/plugins/tiff/ExifGPSTagSet.java
@@ -713,7 +713,7 @@ public final class ExifGPSTagSet extends TIFFTagSet {
      *
      * @return an {@code ExifGPSTagSet} instance.
      */
-    public synchronized static ExifGPSTagSet getInstance() {
+    public static synchronized ExifGPSTagSet getInstance() {
         if (theInstance == null) {
             theInstance = new ExifGPSTagSet();
         }

--- a/src/java.desktop/share/classes/javax/imageio/plugins/tiff/ExifInteroperabilityTagSet.java
+++ b/src/java.desktop/share/classes/javax/imageio/plugins/tiff/ExifInteroperabilityTagSet.java
@@ -92,7 +92,7 @@ public final class ExifInteroperabilityTagSet extends TIFFTagSet {
      *
      * @return the {@code ExifInteroperabilityTagSet} instance.
      */
-    public synchronized static ExifInteroperabilityTagSet getInstance() {
+    public static synchronized ExifInteroperabilityTagSet getInstance() {
         if (theInstance == null) {
             initTags();
             theInstance = new ExifInteroperabilityTagSet();

--- a/src/java.desktop/share/classes/javax/imageio/plugins/tiff/ExifParentTIFFTagSet.java
+++ b/src/java.desktop/share/classes/javax/imageio/plugins/tiff/ExifParentTIFFTagSet.java
@@ -84,7 +84,7 @@ public final class ExifParentTIFFTagSet extends TIFFTagSet {
      *
      * @return an {@code ExifParentTIFFTagSet} instance.
      */
-    public synchronized static ExifParentTIFFTagSet getInstance() {
+    public static synchronized ExifParentTIFFTagSet getInstance() {
         if (theInstance == null) {
             initTags();
             theInstance = new ExifParentTIFFTagSet();

--- a/src/java.desktop/share/classes/javax/imageio/plugins/tiff/ExifTIFFTagSet.java
+++ b/src/java.desktop/share/classes/javax/imageio/plugins/tiff/ExifTIFFTagSet.java
@@ -1992,7 +1992,7 @@ public final class ExifTIFFTagSet extends TIFFTagSet {
      *
      * @return an {@code ExifTIFFTagSet} instance.
      */
-    public synchronized static ExifTIFFTagSet getInstance() {
+    public static synchronized ExifTIFFTagSet getInstance() {
         if (theInstance == null) {
             initTags();
             theInstance = new ExifTIFFTagSet();

--- a/src/java.desktop/share/classes/javax/imageio/plugins/tiff/FaxTIFFTagSet.java
+++ b/src/java.desktop/share/classes/javax/imageio/plugins/tiff/FaxTIFFTagSet.java
@@ -135,7 +135,7 @@ public final class FaxTIFFTagSet extends TIFFTagSet {
      *
      * @return a {@code FaxTIFFTagSet} instance.
      */
-    public synchronized static FaxTIFFTagSet getInstance() {
+    public static synchronized FaxTIFFTagSet getInstance() {
         if (theInstance == null) {
             initTags();
             theInstance = new FaxTIFFTagSet();

--- a/src/java.desktop/share/classes/javax/imageio/plugins/tiff/GeoTIFFTagSet.java
+++ b/src/java.desktop/share/classes/javax/imageio/plugins/tiff/GeoTIFFTagSet.java
@@ -138,7 +138,7 @@ public final class GeoTIFFTagSet extends TIFFTagSet {
      *
      * @return a {@code GeoTIFFTagSet} instance.
      */
-    public synchronized static GeoTIFFTagSet getInstance() {
+    public static synchronized GeoTIFFTagSet getInstance() {
         if (theInstance == null) {
             initTags();
             theInstance = new GeoTIFFTagSet();

--- a/src/java.desktop/share/classes/sun/java2d/cmm/lcms/LCMSTransform.java
+++ b/src/java.desktop/share/classes/sun/java2d/cmm/lcms/LCMSTransform.java
@@ -52,7 +52,7 @@ import static sun.java2d.cmm.lcms.LCMSImageLayout.ImageLayoutException;
 
 final class LCMSTransform implements ColorTransform {
 
-    private final static class NativeTransform {
+    private static final class NativeTransform {
         private long ID;
         private int inFormatter;
         private boolean isInIntPacked;

--- a/src/java.desktop/share/classes/sun/java2d/loops/DrawGlyphListColor.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/DrawGlyphListColor.java
@@ -37,10 +37,10 @@ import java.awt.*;
  */
 public class DrawGlyphListColor extends GraphicsPrimitive {
 
-    public final static String methodSignature =
+    public static final String methodSignature =
             "DrawGlyphListColor(...)".toString();
 
-    public final static int primTypeID = makePrimTypeID();
+    public static final int primTypeID = makePrimTypeID();
 
     public static DrawGlyphListColor locate(SurfaceType srctype,
                                             CompositeType comptype,

--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
@@ -85,7 +85,7 @@ final class Win32ShellFolder2 extends ShellFolder {
     static final int LARGE_ICON_SIZE = 32;
     static final int MIN_QUALITY_ICON = 16;
     static final int MAX_QUALITY_ICON = 256;
-    private final static int[] ICON_RESOLUTIONS
+    private static final int[] ICON_RESOLUTIONS
             = {16, 24, 32, 48, 64, 72, 96, 128, 256};
 
     static final int FILE_ICON_ID = 1;

--- a/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/AWTEventMonitor.java
+++ b/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/AWTEventMonitor.java
@@ -50,22 +50,22 @@ public class AWTEventMonitor {
      */
     public AWTEventMonitor() {}
 
-    static private Component componentWithFocus = null;
+    private static Component componentWithFocus = null;
 
     // Low-level listeners
-    static private ComponentListener componentListener = null;
-    static private ContainerListener containerListener = null;
-    static private FocusListener focusListener = null;
-    static private KeyListener keyListener = null;
-    static private MouseListener mouseListener = null;
-    static private MouseMotionListener mouseMotionListener = null;
-    static private WindowListener windowListener = null;
+    private static ComponentListener componentListener = null;
+    private static ContainerListener containerListener = null;
+    private static FocusListener focusListener = null;
+    private static KeyListener keyListener = null;
+    private static MouseListener mouseListener = null;
+    private static MouseMotionListener mouseMotionListener = null;
+    private static WindowListener windowListener = null;
 
     // Semantic listeners
-    static private ActionListener actionListener = null;
-    static private AdjustmentListener adjustmentListener = null;
-    static private ItemListener itemListener = null;
-    static private TextListener textListener = null;
+    private static ActionListener actionListener = null;
+    private static AdjustmentListener adjustmentListener = null;
+    private static ItemListener itemListener = null;
+    private static TextListener textListener = null;
 
     /**
      * The actual listener that is installed on the component instances.
@@ -73,7 +73,7 @@ public class AWTEventMonitor {
      * occurs.  By doing things this way, the actual number of listeners
      * installed on a component instance is drastically reduced.
      */
-    static private final AWTEventsListener awtListener = new AWTEventsListener();
+    private static final AWTEventsListener awtListener = new AWTEventsListener();
 
     /**
      * Returns the component that currently has keyboard focus.  The return
@@ -81,14 +81,14 @@ public class AWTEventMonitor {
      *
      * @return the component that has keyboard focus
      */
-    static public Component getComponentWithFocus() {
+    public static Component getComponentWithFocus() {
         return componentWithFocus;
     }
 
     /*
      * Check permissions
      */
-    static private void checkInstallPermission() {
+    private static void checkInstallPermission() {
         @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
@@ -106,7 +106,7 @@ public class AWTEventMonitor {
      * @param l the listener to add
      * @see #removeComponentListener
      */
-    static public void addComponentListener(ComponentListener l) {
+    public static void addComponentListener(ComponentListener l) {
         if (componentListener == null) {
             checkInstallPermission();
             awtListener.installListeners(EventID.COMPONENT);
@@ -121,7 +121,7 @@ public class AWTEventMonitor {
      * @param l the listener to remove
      * @see #addComponentListener
      */
-    static public void removeComponentListener(ComponentListener l) {
+    public static void removeComponentListener(ComponentListener l) {
         componentListener = AWTEventMulticaster.remove(componentListener, l);
         if (componentListener == null) {
             awtListener.removeListeners(EventID.COMPONENT);
@@ -138,7 +138,7 @@ public class AWTEventMonitor {
      * @param l the listener to add
      * @see #removeContainerListener
      */
-    static public void addContainerListener(ContainerListener l) {
+    public static void addContainerListener(ContainerListener l) {
         containerListener = AWTEventMulticaster.add(containerListener, l);
     }
 
@@ -149,7 +149,7 @@ public class AWTEventMonitor {
      * @param l the listener to remove
      * @see #addContainerListener
      */
-    static public void removeContainerListener(ContainerListener l) {
+    public static void removeContainerListener(ContainerListener l) {
         containerListener = AWTEventMulticaster.remove(containerListener, l);
     }
 
@@ -163,7 +163,7 @@ public class AWTEventMonitor {
      * @param l the listener to add
      * @see #removeFocusListener
      */
-    static public void addFocusListener(FocusListener l) {
+    public static void addFocusListener(FocusListener l) {
         focusListener = AWTEventMulticaster.add(focusListener, l);
     }
 
@@ -174,7 +174,7 @@ public class AWTEventMonitor {
      * @param l the listener to remove
      * @see #addFocusListener
      */
-    static public void removeFocusListener(FocusListener l) {
+    public static void removeFocusListener(FocusListener l) {
         focusListener = AWTEventMulticaster.remove(focusListener, l);
     }
 
@@ -188,7 +188,7 @@ public class AWTEventMonitor {
      * @param l the listener to add
      * @see #removeKeyListener
      */
-    static public void addKeyListener(KeyListener l) {
+    public static void addKeyListener(KeyListener l) {
         if (keyListener == null) {
             checkInstallPermission();
             awtListener.installListeners(EventID.KEY);
@@ -203,7 +203,7 @@ public class AWTEventMonitor {
      * @param l the listener to remove
      * @see #addKeyListener
      */
-    static public void removeKeyListener(KeyListener l) {
+    public static void removeKeyListener(KeyListener l) {
         keyListener = AWTEventMulticaster.remove(keyListener, l);
         if (keyListener == null)  {
             awtListener.removeListeners(EventID.KEY);
@@ -220,7 +220,7 @@ public class AWTEventMonitor {
      * @param l the listener to add
      * @see #removeMouseListener
      */
-    static public void addMouseListener(MouseListener l) {
+    public static void addMouseListener(MouseListener l) {
         if (mouseListener == null) {
             checkInstallPermission();
             awtListener.installListeners(EventID.MOUSE);
@@ -235,7 +235,7 @@ public class AWTEventMonitor {
      * @param l the listener to remove
      * @see #addMouseListener
      */
-    static public void removeMouseListener(MouseListener l) {
+    public static void removeMouseListener(MouseListener l) {
         mouseListener = AWTEventMulticaster.remove(mouseListener, l);
         if (mouseListener == null) {
             awtListener.removeListeners(EventID.MOUSE);
@@ -252,7 +252,7 @@ public class AWTEventMonitor {
      * @param l the listener to add
      * @see #removeMouseMotionListener
      */
-    static public void addMouseMotionListener(MouseMotionListener l) {
+    public static void addMouseMotionListener(MouseMotionListener l) {
         if (mouseMotionListener == null) {
             checkInstallPermission();
             awtListener.installListeners(EventID.MOTION);
@@ -267,7 +267,7 @@ public class AWTEventMonitor {
      * @param l the listener to remove
      * @see #addMouseMotionListener
      */
-    static public void removeMouseMotionListener(MouseMotionListener l) {
+    public static void removeMouseMotionListener(MouseMotionListener l) {
         mouseMotionListener = AWTEventMulticaster.remove(mouseMotionListener, l);
         if (mouseMotionListener == null) {
             awtListener.removeListeners(EventID.MOTION);
@@ -284,7 +284,7 @@ public class AWTEventMonitor {
      * @param l the listener to add
      * @see #removeWindowListener
      */
-    static public void addWindowListener(WindowListener l) {
+    public static void addWindowListener(WindowListener l) {
         if (windowListener == null) {
             checkInstallPermission();
             awtListener.installListeners(EventID.WINDOW);
@@ -299,7 +299,7 @@ public class AWTEventMonitor {
      * @param l the listener to remove
      * @see #addWindowListener
      */
-    static public void removeWindowListener(WindowListener l) {
+    public static void removeWindowListener(WindowListener l) {
         windowListener = AWTEventMulticaster.remove(windowListener, l);
         if (windowListener == null) {
             awtListener.removeListeners(EventID.WINDOW);
@@ -316,7 +316,7 @@ public class AWTEventMonitor {
      * @param l the listener to add
      * @see #removeActionListener
      */
-    static public void addActionListener(ActionListener l) {
+    public static void addActionListener(ActionListener l) {
         if (actionListener == null) {
             checkInstallPermission();
             awtListener.installListeners(EventID.ACTION);
@@ -331,7 +331,7 @@ public class AWTEventMonitor {
      * @param l the listener to remove
      * @see #addActionListener
      */
-    static public void removeActionListener(ActionListener l) {
+    public static void removeActionListener(ActionListener l) {
         actionListener = AWTEventMulticaster.remove(actionListener, l);
         if (actionListener == null) {
             awtListener.removeListeners(EventID.ACTION);
@@ -349,7 +349,7 @@ public class AWTEventMonitor {
      * @param l the listener to add
      * @see #removeAdjustmentListener
      */
-    static public void addAdjustmentListener(AdjustmentListener l) {
+    public static void addAdjustmentListener(AdjustmentListener l) {
         if (adjustmentListener == null) {
             checkInstallPermission();
             awtListener.installListeners(EventID.ADJUSTMENT);
@@ -364,7 +364,7 @@ public class AWTEventMonitor {
      * @param l the listener to remove
      * @see #addAdjustmentListener
      */
-    static public void removeAdjustmentListener(AdjustmentListener l) {
+    public static void removeAdjustmentListener(AdjustmentListener l) {
         adjustmentListener = AWTEventMulticaster.remove(adjustmentListener, l);
         if (adjustmentListener == null) {
             awtListener.removeListeners(EventID.ADJUSTMENT);
@@ -381,7 +381,7 @@ public class AWTEventMonitor {
      * @param l the listener to add
      * @see #removeItemListener
      */
-    static public void addItemListener(ItemListener l) {
+    public static void addItemListener(ItemListener l) {
         if (itemListener == null) {
             checkInstallPermission();
             awtListener.installListeners(EventID.ITEM);
@@ -396,7 +396,7 @@ public class AWTEventMonitor {
      * @param l the listener to remove
      * @see #addItemListener
      */
-    static public void removeItemListener(ItemListener l) {
+    public static void removeItemListener(ItemListener l) {
         itemListener = AWTEventMulticaster.remove(itemListener, l);
         if (itemListener == null) {
             awtListener.removeListeners(EventID.ITEM);
@@ -413,7 +413,7 @@ public class AWTEventMonitor {
      * @param l the listener to add
      * @see #removeTextListener
      */
-    static public void addTextListener(TextListener l) {
+    public static void addTextListener(TextListener l) {
         if (textListener == null) {
             checkInstallPermission();
             awtListener.installListeners(EventID.TEXT);
@@ -428,7 +428,7 @@ public class AWTEventMonitor {
      * @param l the listener to remove
      * @see #addTextListener
      */
-    static public void removeTextListener(TextListener l) {
+    public static void removeTextListener(TextListener l) {
         textListener = AWTEventMulticaster.remove(textListener, l);
         if (textListener == null) {
             awtListener.removeListeners(EventID.TEXT);

--- a/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/AccessibilityEventMonitor.java
+++ b/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/AccessibilityEventMonitor.java
@@ -56,7 +56,7 @@ public class AccessibilityEventMonitor {
      * @see #addPropertyChangeListener
      * @see #removePropertyChangeListener
      */
-    static protected final AccessibilityListenerList listenerList =
+    protected static final AccessibilityListenerList listenerList =
         new AccessibilityListenerList();
 
 
@@ -66,7 +66,7 @@ public class AccessibilityEventMonitor {
      * occurs.  By doing things this way, the actual number of listeners
      * installed on a component instance is drastically reduced.
      */
-    static private final AccessibilityEventListener accessibilityListener =
+    private static final AccessibilityEventListener accessibilityListener =
         new AccessibilityEventListener();
 
     /**
@@ -80,7 +80,7 @@ public class AccessibilityEventMonitor {
      *
      * @see #removePropertyChangeListener
      */
-    static public void addPropertyChangeListener(PropertyChangeListener l) {
+    public static void addPropertyChangeListener(PropertyChangeListener l) {
         if (listenerList.getListenerCount(PropertyChangeListener.class) == 0) {
             accessibilityListener.installListeners();
         }
@@ -93,7 +93,7 @@ public class AccessibilityEventMonitor {
      * @see #addPropertyChangeListener
      * @param l the listener to remove
      */
-    static public void removePropertyChangeListener(PropertyChangeListener l) {
+    public static void removePropertyChangeListener(PropertyChangeListener l) {
         listenerList.remove(PropertyChangeListener.class, l);
         if (listenerList.getListenerCount(PropertyChangeListener.class) == 0) {
             accessibilityListener.removeListeners();

--- a/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/AccessibilityListenerList.java
+++ b/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/AccessibilityListenerList.java
@@ -39,7 +39,7 @@ import javax.accessibility.*;
 
 public class AccessibilityListenerList {
     /* A null array to be shared by all empty listener lists */
-    private final static Object[] NULL_ARRAY = new Object[0];
+    private static final Object[] NULL_ARRAY = new Object[0];
 
     /**
      * The list of listener type, listener pairs

--- a/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/EventID.java
+++ b/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/EventID.java
@@ -45,166 +45,166 @@ public class EventID {
     /**
      * Maps to AWT Action support (i.e., ActionListener and ActionEvent)
      */
-    static public final int ACTION              = 0;
+    public static final int ACTION              = 0;
 
     /**
      * Maps to AWT Adjustment support (i.e., AdjustmentListener
      * and AdjustmentEvent)
      */
-    static public final int ADJUSTMENT          = 1;
+    public static final int ADJUSTMENT          = 1;
 
     /**
      * Maps to AWT Component support (i.e., ComponentListener
      * and ComponentEvent)
      */
-    static public final int COMPONENT           = 2;
+    public static final int COMPONENT           = 2;
 
     /**
      * Maps to AWT Container support (i.e., ContainerListener
      * and ContainerEvent)
      */
-    static public final int CONTAINER           = 3;
+    public static final int CONTAINER           = 3;
 
     /**
      * Maps to AWT Focus support (i.e., FocusListener and FocusEvent)
      */
-    static public final int FOCUS               = 4;
+    public static final int FOCUS               = 4;
 
     /**
      * Maps to AWT Item support (i.e., ItemListener and ItemEvent)
      */
-    static public final int ITEM                = 5;
+    public static final int ITEM                = 5;
 
     /**
      * Maps to AWT Key support (i.e., KeyListener and KeyEvent)
      */
-    static public final int KEY                 = 6;
+    public static final int KEY                 = 6;
 
     /**
      * Maps to AWT Mouse support (i.e., MouseListener and MouseEvent)
      */
-    static public final int MOUSE               = 7;
+    public static final int MOUSE               = 7;
 
     /**
      * Maps to AWT MouseMotion support (i.e., MouseMotionListener
      * and MouseMotionEvent)
      */
-    static public final int MOTION              = 8;
+    public static final int MOTION              = 8;
 
     /**
      * Maps to AWT Text support (i.e., TextListener and TextEvent)
      */
-    static public final int TEXT                = 10;
+    public static final int TEXT                = 10;
 
     /**
      * Maps to AWT Window support (i.e., WindowListener and WindowEvent)
      */
-    static public final int WINDOW              = 11;
+    public static final int WINDOW              = 11;
 
     /**
      * Maps to Swing Ancestor support (i.e., AncestorListener and
      * AncestorEvent)
      */
-    static public final int ANCESTOR           = 12;
+    public static final int ANCESTOR           = 12;
 
     /**
      * Maps to Swing Text Caret support (i.e., CaretListener and
      * CaretEvent)
      */
-    static public final int CARET              = 13;
+    public static final int CARET              = 13;
 
     /**
      * Maps to Swing CellEditor support (i.e., CellEditorListener and
      * CellEditorEvent)
      */
-    static public final int CELLEDITOR         = 14;
+    public static final int CELLEDITOR         = 14;
 
     /**
      * Maps to Swing Change support (i.e., ChangeListener and
      * ChangeEvent)
      */
-    static public final int CHANGE             = 15;
+    public static final int CHANGE             = 15;
 
     /**
      * Maps to Swing TableColumnModel support (i.e.,
      * TableColumnModelListener and TableColumnModelEvent)
      */
-    static public final int COLUMNMODEL        = 16;
+    public static final int COLUMNMODEL        = 16;
 
     /**
      * Maps to Swing Document support (i.e., DocumentListener and
      * DocumentEvent)
      */
-    static public final int DOCUMENT           = 17;
+    public static final int DOCUMENT           = 17;
 
     /**
      * Maps to Swing ListData support (i.e., ListDataListener and
      * ListDataEvent)
      */
-    static public final int LISTDATA           = 18;
+    public static final int LISTDATA           = 18;
 
     /**
      * Maps to Swing ListSelection support (i.e., ListSelectionListener and
      * ListSelectionEvent)
      */
-    static public final int LISTSELECTION      = 19;
+    public static final int LISTSELECTION      = 19;
 
     /**
      * Maps to Swing Menu support (i.e., MenuListener and
      * MenuEvent)
      */
-    static public final int MENU               = 20;
+    public static final int MENU               = 20;
 
     /**
      * Maps to Swing PopupMenu support (i.e., PopupMenuListener and
      * PopupMenuEvent)
      */
-    static public final int POPUPMENU          = 21;
+    public static final int POPUPMENU          = 21;
 
     /**
      * Maps to Swing TableModel support (i.e., TableModelListener and
      * TableModelEvent)
      */
-    static public final int TABLEMODEL         = 22;
+    public static final int TABLEMODEL         = 22;
 
     /**
      * Maps to Swing TreeExpansion support (i.e., TreeExpansionListener and
      * TreeExpansionEvent)
      */
-    static public final int TREEEXPANSION      = 23;
+    public static final int TREEEXPANSION      = 23;
 
     /**
      * Maps to Swing TreeModel support (i.e., TreeModelListener and
      * TreeModelEvent)
      */
-    static public final int TREEMODEL          = 24;
+    public static final int TREEMODEL          = 24;
 
     /**
      * Maps to Swing TreeSelection support (i.e., TreeSelectionListener and
      * TreeSelectionEvent)
      */
-    static public final int TREESELECTION      = 25;
+    public static final int TREESELECTION      = 25;
 
     /**
      * Maps to Swing UndoableEdit support (i.e., UndoableEditListener and
      * UndoableEditEvent)
      */
-    static public final int UNDOABLEEDIT       = 26;
+    public static final int UNDOABLEEDIT       = 26;
 
     /**
      * Maps to Beans PropertyChange support (i.e., PropertyChangeListener
      * and PropertyChangeEvent)
      */
-    static public final int PROPERTYCHANGE     = 27;
+    public static final int PROPERTYCHANGE     = 27;
 
     /**
      * Maps to Beans VetoableChange support (i.e., VetoableChangeListener
      * and VetoableChangeEvent)
      */
-    static public final int VETOABLECHANGE     = 28;
+    public static final int VETOABLECHANGE     = 28;
 
     /**
      * Maps to Swing InternalFrame support (i.e., InternalFrameListener)
      */
-    static public final int INTERNALFRAME      = 29;
+    public static final int INTERNALFRAME      = 29;
 }

--- a/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/EventQueueMonitor.java
+++ b/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/EventQueueMonitor.java
@@ -86,7 +86,7 @@ public class EventQueueMonitor
     /**
      * Class that tells us what the component event dispatch thread is.
      */
-    static private ComponentEvtDispatchThread cedt = null;
+    private static ComponentEvtDispatchThread cedt = null;
 
     /**
      * Handle the synchronization between the thing that populates the
@@ -397,7 +397,7 @@ public class EventQueueMonitor
      * @param p the point to be accessed
      * @return the {@code Accessible} at the specified point
      */
-    static public Accessible getAccessibleAt(Point p) {
+    public static Accessible getAccessibleAt(Point p) {
         Window w = getTopLevelWindowWithFocus();
         Window[] wins = getTopLevelWindows();
         Component c = null;
@@ -464,7 +464,7 @@ public class EventQueueMonitor
      * @return true if the GUI subsystem has been initialized
      * @see #addGUIInitializedListener
      */
-    static public boolean isGUIInitialized() {
+    public static boolean isGUIInitialized() {
         maybeInitialize();
         return guiInitialized;
     }
@@ -478,7 +478,7 @@ public class EventQueueMonitor
      * @see #isGUIInitialized
      * @see #removeTopLevelWindowListener
      */
-    static public void addGUIInitializedListener(GUIInitializedListener l) {
+    public static void addGUIInitializedListener(GUIInitializedListener l) {
         maybeInitialize();
         guiInitializedListener =
             GUIInitializedMulticaster.add(guiInitializedListener,l);
@@ -491,7 +491,7 @@ public class EventQueueMonitor
      * @param l the listener to remove
      * @see #addGUIInitializedListener
      */
-    static public void removeGUIInitializedListener(GUIInitializedListener l) {
+    public static void removeGUIInitializedListener(GUIInitializedListener l) {
         guiInitializedListener =
             GUIInitializedMulticaster.remove(guiInitializedListener,l);
     }
@@ -503,7 +503,7 @@ public class EventQueueMonitor
      * @param l the listener to add
      * @see #removeTopLevelWindowListener
      */
-    static public void addTopLevelWindowListener(TopLevelWindowListener l) {
+    public static void addTopLevelWindowListener(TopLevelWindowListener l) {
         topLevelWindowListener =
             TopLevelWindowMulticaster.add(topLevelWindowListener,l);
     }
@@ -515,7 +515,7 @@ public class EventQueueMonitor
      * @param l the listener to remove
      * @see #addTopLevelWindowListener
      */
-    static public void removeTopLevelWindowListener(TopLevelWindowListener l) {
+    public static void removeTopLevelWindowListener(TopLevelWindowListener l) {
         topLevelWindowListener =
             TopLevelWindowMulticaster.remove(topLevelWindowListener,l);
     }
@@ -525,7 +525,7 @@ public class EventQueueMonitor
      *
      * @return the last recorded position of the mouse in screen coordinates
      */
-    static public Point getCurrentMousePosition() {
+    public static Point getCurrentMousePosition() {
         return currentMousePosition;
     }
 
@@ -534,7 +534,7 @@ public class EventQueueMonitor
      *
      * @return an array of top level {@code Window}s in use in the Java Virtual Machine
      */
-    static public Window[] getTopLevelWindows() {
+    public static Window[] getTopLevelWindows() {
 
         // Because this method is static, do not make it synchronized because
         // it can lock the whole class.  Instead, just lock what needs to be
@@ -559,7 +559,7 @@ public class EventQueueMonitor
      *
      * @return the top level {@code Window} that currently has keyboard focus
      */
-    static public Window getTopLevelWindowWithFocus() {
+    public static Window getTopLevelWindowWithFocus() {
         return topLevelWindowWithFocus;
     }
 }

--- a/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/SwingEventMonitor.java
+++ b/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/SwingEventMonitor.java
@@ -63,7 +63,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * This can only be publicly modified by calling the add or
      * remove listener methods in this class.
      */
-    static protected final EventListenerList listenerList = new EventListenerList();
+    protected static final EventListenerList listenerList = new EventListenerList();
 
     /**
      * The actual listener that is installed on the component instances.
@@ -71,7 +71,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * occurs.  By doing things this way, the actual number of listeners
      * installed on a component instance is drastically reduced.
      */
-    static private final SwingEventListener swingListener = new SwingEventListener();
+    private static final SwingEventListener swingListener = new SwingEventListener();
 
     /**
      * Constructs a {@code SwingEventMonitor}.
@@ -88,7 +88,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to add
      * @see #removeAncestorListener
      */
-    static public void addAncestorListener(AncestorListener l) {
+    public static void addAncestorListener(AncestorListener l) {
         if (listenerList.getListenerCount(AncestorListener.class) == 0) {
             swingListener.installListeners(EventID.ANCESTOR);
         }
@@ -102,7 +102,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to remove
      * @see #addAncestorListener
      */
-    static public void removeAncestorListener(AncestorListener l) {
+    public static void removeAncestorListener(AncestorListener l) {
         listenerList.remove(AncestorListener.class, l);
         if (listenerList.getListenerCount(AncestorListener.class) == 0) {
             swingListener.removeListeners(EventID.ANCESTOR);
@@ -119,7 +119,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to add
      * @see #removeCaretListener
      */
-    static public void addCaretListener(CaretListener l) {
+    public static void addCaretListener(CaretListener l) {
         if (listenerList.getListenerCount(CaretListener.class) == 0) {
             swingListener.installListeners(EventID.CARET);
         }
@@ -133,7 +133,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to remove
      * @see #addCaretListener
      */
-    static public void removeCaretListener(CaretListener l) {
+    public static void removeCaretListener(CaretListener l) {
         listenerList.remove(CaretListener.class, l);
         if (listenerList.getListenerCount(CaretListener.class) == 0) {
             swingListener.removeListeners(EventID.CARET);
@@ -151,7 +151,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to add
      * @see #removeCellEditorListener
      */
-    static public void addCellEditorListener(CellEditorListener l) {
+    public static void addCellEditorListener(CellEditorListener l) {
         if (listenerList.getListenerCount(CellEditorListener.class) == 0) {
             swingListener.installListeners(EventID.CELLEDITOR);
         }
@@ -165,7 +165,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to remove
      * @see #addCellEditorListener
      */
-    static public void removeCellEditorListener(CellEditorListener l) {
+    public static void removeCellEditorListener(CellEditorListener l) {
         listenerList.remove(CellEditorListener.class, l);
         if (listenerList.getListenerCount(CellEditorListener.class) == 0) {
             swingListener.removeListeners(EventID.CELLEDITOR);
@@ -182,7 +182,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to add
      * @see #removeChangeListener
      */
-    static public void addChangeListener(ChangeListener l) {
+    public static void addChangeListener(ChangeListener l) {
         if (listenerList.getListenerCount(ChangeListener.class) == 0) {
             swingListener.installListeners(EventID.CHANGE);
         }
@@ -196,7 +196,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to remove
      * @see #addChangeListener
      */
-    static public void removeChangeListener(ChangeListener l) {
+    public static void removeChangeListener(ChangeListener l) {
         listenerList.remove(ChangeListener.class, l);
         if (listenerList.getListenerCount(ChangeListener.class) == 0) {
             swingListener.removeListeners(EventID.CHANGE);
@@ -213,7 +213,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to add
      * @see #removeColumnModelListener
      */
-    static public void addColumnModelListener(TableColumnModelListener l) {
+    public static void addColumnModelListener(TableColumnModelListener l) {
         if (listenerList.getListenerCount(TableColumnModelListener.class) == 0) {
             swingListener.installListeners(EventID.COLUMNMODEL);
         }
@@ -227,7 +227,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to remove
      * @see #addColumnModelListener
      */
-    static public void removeColumnModelListener(TableColumnModelListener l) {
+    public static void removeColumnModelListener(TableColumnModelListener l) {
         listenerList.remove(TableColumnModelListener.class, l);
         if (listenerList.getListenerCount(TableColumnModelListener.class) == 0) {
             swingListener.removeListeners(EventID.COLUMNMODEL);
@@ -244,7 +244,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to add
      * @see #removeDocumentListener
      */
-    static public void addDocumentListener(DocumentListener l) {
+    public static void addDocumentListener(DocumentListener l) {
         if (listenerList.getListenerCount(DocumentListener.class) == 0) {
             swingListener.installListeners(EventID.DOCUMENT);
         }
@@ -258,7 +258,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to remove
      * @see #addDocumentListener
      */
-    static public void removeDocumentListener(DocumentListener l) {
+    public static void removeDocumentListener(DocumentListener l) {
         listenerList.remove(DocumentListener.class, l);
         if (listenerList.getListenerCount(DocumentListener.class) == 0) {
             swingListener.removeListeners(EventID.DOCUMENT);
@@ -275,7 +275,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to add
      * @see #removeListDataListener
      */
-    static public void addListDataListener(ListDataListener l) {
+    public static void addListDataListener(ListDataListener l) {
         if (listenerList.getListenerCount(ListDataListener.class) == 0) {
             swingListener.installListeners(EventID.LISTDATA);
         }
@@ -289,7 +289,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to remove
      * @see #addListDataListener
      */
-    static public void removeListDataListener(ListDataListener l) {
+    public static void removeListDataListener(ListDataListener l) {
         listenerList.remove(ListDataListener.class, l);
         if (listenerList.getListenerCount(ListDataListener.class) == 0) {
             swingListener.removeListeners(EventID.LISTDATA);
@@ -306,7 +306,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to add
      * @see #removeListSelectionListener
      */
-    static public void addListSelectionListener(ListSelectionListener l) {
+    public static void addListSelectionListener(ListSelectionListener l) {
         if (listenerList.getListenerCount(ListSelectionListener.class) == 0) {
             swingListener.installListeners(EventID.LISTSELECTION);
         }
@@ -320,7 +320,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to remove
      * @see #addListSelectionListener
      */
-    static public void removeListSelectionListener(ListSelectionListener l) {
+    public static void removeListSelectionListener(ListSelectionListener l) {
         listenerList.remove(ListSelectionListener.class, l);
         if (listenerList.getListenerCount(ListSelectionListener.class) == 0) {
             swingListener.removeListeners(EventID.LISTSELECTION);
@@ -337,7 +337,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to add
      * @see #removeMenuListener
      */
-    static public void addMenuListener(MenuListener l) {
+    public static void addMenuListener(MenuListener l) {
         if (listenerList.getListenerCount(MenuListener.class) == 0) {
             swingListener.installListeners(EventID.MENU);
         }
@@ -351,7 +351,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to remove
      * @see #addMenuListener
      */
-    static public void removeMenuListener(MenuListener l) {
+    public static void removeMenuListener(MenuListener l) {
         listenerList.remove(MenuListener.class, l);
         if (listenerList.getListenerCount(MenuListener.class) == 0) {
             swingListener.removeListeners(EventID.MENU);
@@ -368,7 +368,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to add
      * @see #removePopupMenuListener
      */
-    static public void addPopupMenuListener(PopupMenuListener l) {
+    public static void addPopupMenuListener(PopupMenuListener l) {
         if (listenerList.getListenerCount(PopupMenuListener.class) == 0) {
             swingListener.installListeners(EventID.POPUPMENU);
         }
@@ -382,7 +382,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to remove
      * @see #addPopupMenuListener
      */
-    static public void removePopupMenuListener(PopupMenuListener l) {
+    public static void removePopupMenuListener(PopupMenuListener l) {
         listenerList.remove(PopupMenuListener.class, l);
         if (listenerList.getListenerCount(PopupMenuListener.class) == 0) {
             swingListener.removeListeners(EventID.POPUPMENU);
@@ -399,7 +399,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to add
      * @see #removeTableModelListener
      */
-    static public void addTableModelListener(TableModelListener l) {
+    public static void addTableModelListener(TableModelListener l) {
         if (listenerList.getListenerCount(TableModelListener.class) == 0) {
             swingListener.installListeners(EventID.TABLEMODEL);
         }
@@ -413,7 +413,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to remove
      * @see #addTableModelListener
      */
-    static public void removeTableModelListener(TableModelListener l) {
+    public static void removeTableModelListener(TableModelListener l) {
         listenerList.remove(TableModelListener.class, l);
         if (listenerList.getListenerCount(TableModelListener.class) == 0) {
             swingListener.removeListeners(EventID.TABLEMODEL);
@@ -430,7 +430,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to add
      * @see #removeTreeExpansionListener
      */
-    static public void addTreeExpansionListener(TreeExpansionListener l) {
+    public static void addTreeExpansionListener(TreeExpansionListener l) {
         if (listenerList.getListenerCount(TreeExpansionListener.class) == 0) {
             swingListener.installListeners(EventID.TREEEXPANSION);
         }
@@ -444,7 +444,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to remove
      * @see #addTreeExpansionListener
      */
-    static public void removeTreeExpansionListener(TreeExpansionListener l) {
+    public static void removeTreeExpansionListener(TreeExpansionListener l) {
         listenerList.remove(TreeExpansionListener.class, l);
         if (listenerList.getListenerCount(TreeExpansionListener.class) == 0) {
             swingListener.removeListeners(EventID.TREEEXPANSION);
@@ -461,7 +461,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to add
      * @see #removeTreeModelListener
      */
-    static public void addTreeModelListener(TreeModelListener l) {
+    public static void addTreeModelListener(TreeModelListener l) {
         if (listenerList.getListenerCount(TreeModelListener.class) == 0) {
             swingListener.installListeners(EventID.TREEMODEL);
         }
@@ -475,7 +475,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to remove
      * @see #addTreeModelListener
      */
-    static public void removeTreeModelListener(TreeModelListener l) {
+    public static void removeTreeModelListener(TreeModelListener l) {
         listenerList.remove(TreeModelListener.class, l);
         if (listenerList.getListenerCount(TreeModelListener.class) == 0) {
             swingListener.removeListeners(EventID.TREEMODEL);
@@ -492,7 +492,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to add
      * @see #removeTreeSelectionListener
      */
-    static public void addTreeSelectionListener(TreeSelectionListener l) {
+    public static void addTreeSelectionListener(TreeSelectionListener l) {
         if (listenerList.getListenerCount(TreeSelectionListener.class) == 0) {
             swingListener.installListeners(EventID.TREESELECTION);
         }
@@ -505,7 +505,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @see #addTreeSelectionListener
      * @param l the listener to remove
      */
-    static public void removeTreeSelectionListener(TreeSelectionListener l) {
+    public static void removeTreeSelectionListener(TreeSelectionListener l) {
         listenerList.remove(TreeSelectionListener.class, l);
         if (listenerList.getListenerCount(TreeSelectionListener.class) == 0) {
             swingListener.removeListeners(EventID.TREESELECTION);
@@ -522,7 +522,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to add
      * @see #removeUndoableEditListener
      */
-    static public void addUndoableEditListener(UndoableEditListener l) {
+    public static void addUndoableEditListener(UndoableEditListener l) {
         if (listenerList.getListenerCount(UndoableEditListener.class) == 0) {
             swingListener.installListeners(EventID.UNDOABLEEDIT);
         }
@@ -536,7 +536,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to remove
      * @see #addUndoableEditListener
      */
-    static public void removeUndoableEditListener(UndoableEditListener l) {
+    public static void removeUndoableEditListener(UndoableEditListener l) {
         listenerList.remove(UndoableEditListener.class, l);
         if (listenerList.getListenerCount(UndoableEditListener.class) == 0) {
             swingListener.removeListeners(EventID.UNDOABLEEDIT);
@@ -553,7 +553,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to add
      * @see #removeInternalFrameListener
      */
-    static public void addInternalFrameListener(InternalFrameListener l) {
+    public static void addInternalFrameListener(InternalFrameListener l) {
         if (listenerList.getListenerCount(InternalFrameListener.class) == 0) {
             swingListener.installListeners(EventID.INTERNALFRAME);
         }
@@ -567,7 +567,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to remove
      * @see #addInternalFrameListener
      */
-    static public void removeInternalFrameListener(InternalFrameListener l) {
+    public static void removeInternalFrameListener(InternalFrameListener l) {
         listenerList.remove(InternalFrameListener.class, l);
         if (listenerList.getListenerCount(InternalFrameListener.class) == 0) {
             swingListener.removeListeners(EventID.INTERNALFRAME);
@@ -584,7 +584,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to add
      * @see #removePropertyChangeListener
      */
-    static public void addPropertyChangeListener(PropertyChangeListener l) {
+    public static void addPropertyChangeListener(PropertyChangeListener l) {
         if (listenerList.getListenerCount(PropertyChangeListener.class) == 0) {
             swingListener.installListeners(EventID.PROPERTYCHANGE);
         }
@@ -597,7 +597,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @see #addPropertyChangeListener
      * @param l the listener to remove
      */
-    static public void removePropertyChangeListener(PropertyChangeListener l) {
+    public static void removePropertyChangeListener(PropertyChangeListener l) {
         listenerList.remove(PropertyChangeListener.class, l);
         if (listenerList.getListenerCount(PropertyChangeListener.class) == 0) {
             swingListener.removeListeners(EventID.PROPERTYCHANGE);
@@ -614,7 +614,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to add
      * @see #removeVetoableChangeListener
      */
-    static public void addVetoableChangeListener(VetoableChangeListener l) {
+    public static void addVetoableChangeListener(VetoableChangeListener l) {
         if (listenerList.getListenerCount(VetoableChangeListener.class) == 0) {
             swingListener.installListeners(EventID.VETOABLECHANGE);
         }
@@ -628,7 +628,7 @@ public class SwingEventMonitor extends AWTEventMonitor {
      * @param l the listener to remove
      * @see #addVetoableChangeListener
      */
-    static public void removeVetoableChangeListener(VetoableChangeListener l) {
+    public static void removeVetoableChangeListener(VetoableChangeListener l) {
         listenerList.remove(VetoableChangeListener.class, l);
         if (listenerList.getListenerCount(VetoableChangeListener.class) == 0) {
             swingListener.removeListeners(EventID.VETOABLECHANGE);

--- a/src/jdk.accessibility/windows/classes/com/sun/java/accessibility/internal/AccessBridge.java
+++ b/src/jdk.accessibility/windows/classes/com/sun/java/accessibility/internal/AccessBridge.java
@@ -53,7 +53,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * Note: This class has to be public.  It's loaded from the VM like this:
  *       Class.forName(atName).newInstance();
  */
-final public class AccessBridge {
+public final class AccessBridge {
 
     private static AccessBridge theAccessBridge;
     private ObjectReferences references;
@@ -314,15 +314,15 @@ final public class AccessBridge {
     }
 
     // hash table of native window handle to AccessibleContext mappings
-    static private ConcurrentHashMap<Integer,AccessibleContext> windowHandleToContextMap = new ConcurrentHashMap<>();
+    private static ConcurrentHashMap<Integer,AccessibleContext> windowHandleToContextMap = new ConcurrentHashMap<>();
 
     // hash table of AccessibleContext to native window handle mappings
-    static private ConcurrentHashMap<AccessibleContext,Integer> contextToWindowHandleMap = new ConcurrentHashMap<>();
+    private static ConcurrentHashMap<AccessibleContext,Integer> contextToWindowHandleMap = new ConcurrentHashMap<>();
 
     /*
      * adds a virtual window handler to our hash tables
      */
-    static private void registerVirtualFrame(final Accessible a,
+    private static void registerVirtualFrame(final Accessible a,
                                              Integer nativeWindowHandle ) {
         if (a != null) {
             AccessibleContext ac = InvocationUtils.invokeAndWait(new Callable<AccessibleContext>() {
@@ -339,7 +339,7 @@ final public class AccessBridge {
     /*
      * removes a virtual window handler to our hash tables
      */
-    static private void revokeVirtualFrame(final Accessible a,
+    private static void revokeVirtualFrame(final Accessible a,
                                            Integer nativeWindowHandle ) {
         AccessibleContext ac = InvocationUtils.invokeAndWait(new Callable<AccessibleContext>() {
             @Override


### PR DESCRIPTION
Fix the non-blessed modifier order cases that have crept in since back when this was first fixed in JDK 9
http://mail.openjdk.java.net/pipermail/core-libs-dev/2015-September/035217.html
Similar clean up is happening in java.base https://git.openjdk.java.net/jdk/pull/6213

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276385](https://bugs.openjdk.java.net/browse/JDK-8276385): Re-run blessed-modifier-order script on java.desktop and jdk.accessibility


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6217/head:pull/6217` \
`$ git checkout pull/6217`

Update a local copy of the PR: \
`$ git checkout pull/6217` \
`$ git pull https://git.openjdk.java.net/jdk pull/6217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6217`

View PR using the GUI difftool: \
`$ git pr show -t 6217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6217.diff">https://git.openjdk.java.net/jdk/pull/6217.diff</a>

</details>
