### PR TITLE
8276314: [JVMCI] check alignment of call displacement during code installation

### DIFF
--- a/src/hotspot/cpu/x86/jvmciCodeInstaller_x86.cpp
+++ b/src/hotspot/cpu/x86/jvmciCodeInstaller_x86.cpp
@@ -188,11 +188,11 @@ void CodeInstaller::pd_relocate_JavaMethod(CodeBuffer &, JVMCIObject hotspot_met
       break;
     }
     default:
-      JVMCI_ERROR("invalid _next_call_type value");
+      JVMCI_ERROR("invalid _next_call_type value: %d", _next_call_type);
       return;
   }
-  if (os::is_MP() && !call->is_displacement_aligned()) {
-    JVMCI_ERROR("unaligned call displacement for call at offset %d", pc_offset);
+  if (!call->is_displacement_aligned()) {
+    JVMCI_ERROR("unaligned displacement for call at offset %d", pc_offset);
   }
 }
 

--- a/src/hotspot/cpu/x86/nativeInst_x86.cpp
+++ b/src/hotspot/cpu/x86/nativeInst_x86.cpp
@@ -260,6 +260,10 @@ void NativeCall::replace_mt_safe(address instr_addr, address code_buffer) {
 
 }
 
+bool NativeCall::is_displacement_aligned() {
+  return ((uintptr_t)displacement_address() + 0) / cache_line_size ==
+         ((uintptr_t)displacement_address() + 3) / cache_line_size;
+}
 
 // Similar to replace_mt_safe, but just changes the destination.  The
 // important thing is that free-running threads are able to execute this
@@ -282,8 +286,7 @@ void NativeCall::set_destination_mt_safe(address dest) {
          CompiledICLocker::is_safe(instruction_address()), "concurrent code patching");
   // Both C1 and C2 should now be generating code which aligns the patched address
   // to be within a single cache line.
-  bool is_aligned = ((uintptr_t)displacement_address() + 0) / cache_line_size ==
-                    ((uintptr_t)displacement_address() + 3) / cache_line_size;
+  bool is_aligned = is_displacement_aligned();
 
   guarantee(is_aligned, "destination must be aligned");
 

--- a/src/hotspot/cpu/x86/nativeInst_x86.cpp
+++ b/src/hotspot/cpu/x86/nativeInst_x86.cpp
@@ -261,8 +261,7 @@ void NativeCall::replace_mt_safe(address instr_addr, address code_buffer) {
 }
 
 bool NativeCall::is_displacement_aligned() {
-  return ((uintptr_t)displacement_address() + 0) / cache_line_size ==
-         ((uintptr_t)displacement_address() + 3) / cache_line_size;
+  return (uintptr_t) displacement_address() % 4 == 0;
 }
 
 // Similar to replace_mt_safe, but just changes the destination.  The

--- a/src/hotspot/cpu/x86/nativeInst_x86.hpp
+++ b/src/hotspot/cpu/x86/nativeInst_x86.hpp
@@ -175,6 +175,7 @@ class NativeCall: public NativeInstruction {
 #endif // AMD64
     set_int_at(displacement_offset, dest - return_address());
   }
+  bool  is_displacement_aligned();
   void  set_destination_mt_safe(address dest);
 
   void  verify_alignment() { assert((intptr_t)addr_at(displacement_offset) % BytesPerInt == 0, "must be aligned"); }

--- a/src/hotspot/cpu/x86/nativeInst_x86.hpp
+++ b/src/hotspot/cpu/x86/nativeInst_x86.hpp
@@ -160,8 +160,6 @@ class NativeCall: public NativeInstruction {
     return_address_offset       =    5
   };
 
-  enum { cache_line_size = BytesPerWord };  // conservative estimate!
-
   address instruction_address() const       { return addr_at(instruction_offset); }
   address next_instruction_address() const  { return addr_at(return_address_offset); }
   int   displacement() const                { return (jint) int_at(displacement_offset); }
@@ -175,10 +173,11 @@ class NativeCall: public NativeInstruction {
 #endif // AMD64
     set_int_at(displacement_offset, dest - return_address());
   }
+  // Returns whether the 4-byte displacement operand is 4-byte aligned.
   bool  is_displacement_aligned();
   void  set_destination_mt_safe(address dest);
 
-  void  verify_alignment() { assert((intptr_t)addr_at(displacement_offset) % BytesPerInt == 0, "must be aligned"); }
+  void  verify_alignment() { assert(is_displacement_aligned(), "displacement of call is not aligned", p2i()); }
   void  verify();
   void  print();
 

--- a/src/hotspot/cpu/x86/nativeInst_x86.hpp
+++ b/src/hotspot/cpu/x86/nativeInst_x86.hpp
@@ -177,7 +177,7 @@ class NativeCall: public NativeInstruction {
   bool  is_displacement_aligned();
   void  set_destination_mt_safe(address dest);
 
-  void  verify_alignment() { assert(is_displacement_aligned(), "displacement of call is not aligned", p2i()); }
+  void  verify_alignment() { assert(is_displacement_aligned(), "displacement of call is not aligned"); }
   void  verify();
   void  print();
 


### PR DESCRIPTION
This PR add verification of code alignment invariants related to x64 call instructions during code installation.
This in turn allows a JVMCI compilation that generates a misaligned call to fail gracefully (i.e. bailout) instead of the VM crashing when it checks alignment before patching the displacement of a call instruction.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276314](https://bugs.openjdk.java.net/browse/JDK-8276314): [JVMCI] check alignment of call displacement during code installation


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6218/head:pull/6218` \
`$ git checkout pull/6218`

Update a local copy of the PR: \
`$ git checkout pull/6218` \
`$ git pull https://git.openjdk.java.net/jdk pull/6218/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6218`

View PR using the GUI difftool: \
`$ git pr show -t 6218`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6218.diff">https://git.openjdk.java.net/jdk/pull/6218.diff</a>

</details>
