### PR TITLE
8276252: java/nio/channels/Channels/TransferTo.java  failed with OOM java heap space error

### DIFF
--- a/test/jdk/java/nio/channels/Channels/TransferTo.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo.java
@@ -52,7 +52,7 @@ import static org.testng.Assert.assertTrue;
  * @test
  * @library /test/lib
  * @build jdk.test.lib.RandomFactory
- * @run testng TransferTo
+ * @run testng/othervm TransferTo
  * @bug 8265891
  * @summary tests whether sun.nio.ChannelInputStream.transferTo conforms to the
  *          InputStream.transferTo contract defined in the javadoc


### PR DESCRIPTION
This request proposes to change the test to run in `othervm` mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276252](https://bugs.openjdk.java.net/browse/JDK-8276252): java/nio/channels/Channels/TransferTo.java  failed with OOM java heap space error


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6219/head:pull/6219` \
`$ git checkout pull/6219`

Update a local copy of the PR: \
`$ git checkout pull/6219` \
`$ git pull https://git.openjdk.java.net/jdk pull/6219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6219`

View PR using the GUI difftool: \
`$ git pr show -t 6219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6219.diff">https://git.openjdk.java.net/jdk/pull/6219.diff</a>

</details>
