### PR TITLE
8274860: gcc 10.2.1 produces an uninitialized warning in sharedRuntimeTrig.cpp

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntimeTrig.cpp
+++ b/src/hotspot/share/runtime/sharedRuntimeTrig.cpp
@@ -175,7 +175,7 @@ twon24  = 5.96046447753906250000e-08; /* 0x3E700000, 0x00000000 */
 
 static int __kernel_rem_pio2(double *x, double *y, int e0, int nx, int prec, const int *ipio2) {
   int jz,jx,jv,jp,jk,carry,n,iq[20],i,j,k,m,q0,ih;
-  double z,fw,f[20],fq[20],q[20];
+  double z,fw,f[20],fq[20] = {0.0},q[20];
 
   /* initialize jk*/
   jk = init_jk[prec];


### PR DESCRIPTION
Initialize `fq` to an array to zeroes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8274860](https://bugs.openjdk.java.net/browse/JDK-8274860): gcc 10.2.1 produces an uninitialized warning in sharedRuntimeTrig.cpp


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6220/head:pull/6220` \
`$ git checkout pull/6220`

Update a local copy of the PR: \
`$ git checkout pull/6220` \
`$ git pull https://git.openjdk.java.net/jdk pull/6220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6220`

View PR using the GUI difftool: \
`$ git pr show -t 6220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6220.diff">https://git.openjdk.java.net/jdk/pull/6220.diff</a>

</details>
