### PR TITLE
8276401: Use blessed modifier order in java.net.http

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Exchange.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Exchange.java
@@ -117,7 +117,7 @@ class Http1Exchange<T> extends ExchangeImpl<T> {
      * concrete implementations: {@link Http1Request.StreamSubscriber}, and
      * {@link Http1Request.FixedContentSubscriber}, for receiving chunked and
      * fixed length bodies, respectively. */
-    static abstract class Http1BodySubscriber implements Flow.Subscriber<ByteBuffer> {
+    abstract static class Http1BodySubscriber implements Flow.Subscriber<ByteBuffer> {
         final MinimalFuture<Flow.Subscription> whenSubscribed = new MinimalFuture<>();
         private volatile Flow.Subscription subscription;
         volatile boolean complete;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Response.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Response.java
@@ -71,14 +71,14 @@ class Http1Response<T> {
     private volatile EOFException eof;
     private volatile BodyParser bodyParser;
     // max number of bytes of (fixed length) body to ignore on redirect
-    private final static int MAX_IGNORE = 1024;
+    private static final int MAX_IGNORE = 1024;
 
     // Revisit: can we get rid of this?
     static enum State {INITIAL, READING_HEADERS, READING_BODY, DONE}
     private volatile State readProgress = State.INITIAL;
 
     final Logger debug = Utils.getDebugLogger(this::dbgString, Utils.DEBUG);
-    final static AtomicLong responseCount = new AtomicLong();
+    static final AtomicLong responseCount = new AtomicLong();
     final long id = responseCount.incrementAndGet();
     private Http1HeaderParser hd;
 
@@ -294,7 +294,7 @@ class Http1Response<T> {
      * subscribed.
      * @param <U> The type of response.
      */
-    final static class Http1BodySubscriber<U> implements TrustedSubscriber<U> {
+    static final class Http1BodySubscriber<U> implements TrustedSubscriber<U> {
         final HttpResponse.BodySubscriber<U> userSubscriber;
         final AtomicBoolean completed = new AtomicBoolean();
         volatile Throwable withError;
@@ -585,7 +585,7 @@ class Http1Response<T> {
 
     }
 
-    static abstract class Receiver<T>
+    abstract static class Receiver<T>
             implements Http1AsyncReceiver.Http1AsyncDelegate {
         abstract void start(T parser);
         abstract CompletableFuture<State> completion();

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2ClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2ClientImpl.java
@@ -54,7 +54,7 @@ import static jdk.internal.net.http.frame.SettingsFrame.MAX_FRAME_SIZE;
  */
 class Http2ClientImpl {
 
-    final static Logger debug =
+    static final Logger debug =
             Utils.getDebugLogger("Http2ClientImpl"::toString, Utils.DEBUG);
 
     private final HttpClientImpl client;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -113,14 +113,14 @@ import static jdk.internal.net.http.frame.SettingsFrame.*;
 class Http2Connection  {
 
     final Logger debug = Utils.getDebugLogger(this::dbgString, Utils.DEBUG);
-    final static Logger DEBUG_LOGGER =
+    static final Logger DEBUG_LOGGER =
             Utils.getDebugLogger("Http2Connection"::toString, Utils.DEBUG);
     private final Logger debugHpack =
             Utils.getHpackLogger(this::dbgString, Utils.DEBUG_HPACK);
     static final ByteBuffer EMPTY_TRIGGER = ByteBuffer.allocate(0);
 
-    static private final int MAX_CLIENT_STREAM_ID = Integer.MAX_VALUE; // 2147483647
-    static private final int MAX_SERVER_STREAM_ID = Integer.MAX_VALUE - 1; // 2147483646
+    private static final int MAX_CLIENT_STREAM_ID = Integer.MAX_VALUE; // 2147483647
+    private static final int MAX_SERVER_STREAM_ID = Integer.MAX_VALUE - 1; // 2147483646
 
     /**
      * Flag set when no more streams to be opened on this connection.

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
@@ -135,7 +135,7 @@ final class HttpClientImpl extends HttpClient implements Trackable {
      * is the SelectorManager thread. If the current thread is not
      * the selector manager thread the given task is executed inline.
      */
-    final static class DelegatingExecutor implements Executor {
+    static final class DelegatingExecutor implements Executor {
         private final BooleanSupplier isInSelectorThread;
         private final Executor delegate;
         DelegatingExecutor(BooleanSupplier isInSelectorThread, Executor delegate) {
@@ -436,7 +436,7 @@ final class HttpClientImpl extends HttpClient implements Trackable {
         return pendingOperationCount.get();
     }
 
-    final static class HttpClientTracker implements Tracker {
+    static final class HttpClientTracker implements Tracker {
         final AtomicLong httpCount;
         final AtomicLong http2Count;
         final AtomicLong websocketCount;
@@ -670,7 +670,7 @@ final class HttpClientImpl extends HttpClient implements Trackable {
     }
 
     // Main loop for this client's selector
-    private final static class SelectorManager extends Thread {
+    private static final class SelectorManager extends Thread {
 
         // For testing purposes we have an internal System property that
         // can control the frequency at which the selector manager will wake
@@ -1007,7 +1007,7 @@ final class HttpClientImpl extends HttpClient implements Trackable {
         private final SelectableChannel chan;
         private final Selector selector;
         private final Set<AsyncEvent> pending;
-        private final static Logger debug =
+        private static final Logger debug =
                 Utils.getDebugLogger("SelectorAttachment"::toString, Utils.DEBUG);
         private int interestOps;
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpConnection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpConnection.java
@@ -67,7 +67,7 @@ import static jdk.internal.net.http.common.Utils.ProxyHeaders;
 abstract class HttpConnection implements Closeable {
 
     final Logger debug = Utils.getDebugLogger(this::dbgString, Utils.DEBUG);
-    final static Logger DEBUG_LOGGER = Utils.getDebugLogger(
+    static final Logger DEBUG_LOGGER = Utils.getDebugLogger(
             () -> "HttpConnection(SocketTube(?))", Utils.DEBUG);
 
     /** The address this connection is connected to. Could be a server or a proxy. */

--- a/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
@@ -362,7 +362,7 @@ public class ResponseSubscribers {
             result.completeExceptionally(throwable);
         }
 
-        static private byte[] join(List<ByteBuffer> bytes) {
+        private static byte[] join(List<ByteBuffer> bytes) {
             int size = Utils.remaining(bytes, Integer.MAX_VALUE);
             byte[] res = new byte[size];
             int from = 0;
@@ -396,7 +396,7 @@ public class ResponseSubscribers {
     public static class HttpResponseInputStream extends InputStream
         implements TrustedSubscriber<InputStream>
     {
-        final static int MAX_BUFFERS_IN_QUEUE = 1;  // lock-step with the producer
+        static final int MAX_BUFFERS_IN_QUEUE = 1;  // lock-step with the producer
 
         // An immutable ByteBuffer sentinel to mark that the last byte was received.
         private static final ByteBuffer LAST_BUFFER = ByteBuffer.wrap(new byte[0]);
@@ -882,7 +882,7 @@ public class ResponseSubscribers {
         // A subscription that wraps an upstream subscription and
         // holds a reference to a subscriber. The subscriber reference
         // is cleared when the subscription is cancelled
-        final static class SubscriptionRef implements Flow.Subscription {
+        static final class SubscriptionRef implements Flow.Subscription {
             final Flow.Subscription subscription;
             final SubscriberRef subscriberRef;
             SubscriptionRef(Flow.Subscription subscription,

--- a/src/java.net.http/share/classes/jdk/internal/net/http/SocketTube.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/SocketTube.java
@@ -226,7 +226,7 @@ final class SocketTube implements FlowTube {
      * signaled. It is the responsibility of the code triggered by
      * {@code signalEvent} to resume the event if required.
      */
-    private static abstract class SocketFlowEvent extends AsyncEvent {
+    private abstract static class SocketFlowEvent extends AsyncEvent {
         final SocketChannel channel;
         final int defaultInterest;
         volatile int interestOps;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/DebugLogger.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/DebugLogger.java
@@ -46,19 +46,19 @@ import java.util.function.Supplier;
  */
 final class DebugLogger implements Logger {
     // deliberately not in the same subtree than standard loggers.
-    final static String HTTP_NAME  = "jdk.internal.httpclient.debug";
-    final static String WS_NAME  = "jdk.internal.httpclient.websocket.debug";
-    final static String HPACK_NAME = "jdk.internal.httpclient.hpack.debug";
-    final static System.Logger HTTP = System.getLogger(HTTP_NAME);
-    final static System.Logger WS = System.getLogger(WS_NAME);
-    final static System.Logger HPACK = System.getLogger(HPACK_NAME);
+    static final String HTTP_NAME  = "jdk.internal.httpclient.debug";
+    static final String WS_NAME  = "jdk.internal.httpclient.websocket.debug";
+    static final String HPACK_NAME = "jdk.internal.httpclient.hpack.debug";
+    static final System.Logger HTTP = System.getLogger(HTTP_NAME);
+    static final System.Logger WS = System.getLogger(WS_NAME);
+    static final System.Logger HPACK = System.getLogger(HPACK_NAME);
     private static final DebugLogger NO_HTTP_LOGGER =
             new DebugLogger(HTTP, "HTTP"::toString, Level.OFF, Level.OFF);
     private static final DebugLogger NO_WS_LOGGER =
             new DebugLogger(HTTP, "WS"::toString, Level.OFF, Level.OFF);
     private static final DebugLogger NO_HPACK_LOGGER =
             new DebugLogger(HTTP, "HPACK"::toString, Level.OFF, Level.OFF);
-    final static long START_NANOS = System.nanoTime();
+    static final long START_NANOS = System.nanoTime();
 
     private final Supplier<String> dbgTag;
     private final Level errLevel;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/FlowTube.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/FlowTube.java
@@ -138,7 +138,7 @@ public interface FlowTube extends
      * It is not required that a {@code TubePublisher} implementation extends
      * this class.
      */
-    static abstract class AbstractTubePublisher implements TubePublisher {
+    abstract static class AbstractTubePublisher implements TubePublisher {
         static final class TubePublisherWrapper extends AbstractTubePublisher {
             final Flow.Publisher<List<ByteBuffer>> delegate;
             public TubePublisherWrapper(Flow.Publisher<List<ByteBuffer>> delegate) {
@@ -156,7 +156,7 @@ public interface FlowTube extends
      * It is not required that a {@code TubeSubscriber} implementation extends
      * this class.
      */
-    static abstract class AbstractTubeSubscriber implements TubeSubscriber {
+    abstract static class AbstractTubeSubscriber implements TubeSubscriber {
         static final class TubeSubscriberWrapper extends  AbstractTubeSubscriber {
             final Flow.Subscriber<? super List<ByteBuffer>> delegate;
             TubeSubscriberWrapper(Flow.Subscriber<? super List<ByteBuffer>> delegate) {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/MinimalFuture.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/MinimalFuture.java
@@ -42,7 +42,7 @@ public final class MinimalFuture<T> extends CompletableFuture<T> {
         U get() throws Throwable;
     }
 
-    private final static AtomicLong TOKENS = new AtomicLong();
+    private static final AtomicLong TOKENS = new AtomicLong();
     private final long id;
     private final Cancelable cancelable;
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLTube.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLTube.java
@@ -184,7 +184,7 @@ public class SSLTube implements FlowTube {
     // The DelegateWrapper wraps a subscribed {@code Flow.Subscriber} and
     // tracks the subscriber's state. In particular it makes sure that
     // onComplete/onError are not called before onSubscribed.
-    final static class DelegateWrapper implements FlowTube.TubeSubscriber {
+    static final class DelegateWrapper implements FlowTube.TubeSubscriber {
         private final FlowTube.TubeSubscriber delegate;
         private final Logger debug;
         volatile boolean subscribedCalled;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/SequentialScheduler.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/SequentialScheduler.java
@@ -111,7 +111,7 @@ public final class SequentialScheduler {
      * later time, and maybe in different thread. This type exists for
      * readability purposes at use-sites only.
      */
-    public static abstract class DeferredCompleter {
+    public abstract static class DeferredCompleter {
 
         /** Extensible from this (outer) class ONLY. */
         private DeferredCompleter() { }
@@ -140,7 +140,7 @@ public final class SequentialScheduler {
      * A simple and self-contained task that completes once its {@code run}
      * method returns.
      */
-    public static abstract class CompleteRestartableTask
+    public abstract static class CompleteRestartableTask
         implements RestartableTask
     {
         @Override


### PR DESCRIPTION
Hi, 

Please find here a trivial cleanup change that updates classes in the `java.net.http` module to use the "blessed modifier order".

The changeset was obtained by running `sh ./bin/blessed-modifier-order.sh src/java.net.http`.

best regards,

-- daniel

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276401](https://bugs.openjdk.java.net/browse/JDK-8276401): Use blessed modifier order in java.net.http


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6228/head:pull/6228` \
`$ git checkout pull/6228`

Update a local copy of the PR: \
`$ git checkout pull/6228` \
`$ git pull https://git.openjdk.java.net/jdk pull/6228/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6228`

View PR using the GUI difftool: \
`$ git pr show -t 6228`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6228.diff">https://git.openjdk.java.net/jdk/pull/6228.diff</a>

</details>
