### PR TITLE
8276540: Howl Full CardSet container iteration marks too many cards

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSetContainers.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.inline.hpp
@@ -330,7 +330,7 @@ inline void G1CardSetHowl::iterate_cardset(CardSetPtr const card_set, uint index
       if (found.start_iterate(G1GCPhaseTimes::MergeRSHowlFull)) {
         assert(card_set == G1CardSet::FullCardSet, "Must be");
         uint offset = index << config->log2_num_cards_in_howl_bitmap();
-        for (uint i = 0; i < config->max_cards_in_region(); i++) {
+        for (uint i = 0; i < config->num_cards_in_howl_bitmap(); i++) {
           found((offset | (uint)i));
         }
       }


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that fixes how many cards are being iterated over during Howl Full CardSet container iteration? There is no need to iterate over `max_cards_in_region()` cards, it is sufficient to iterate just over the area that this Howl partition represents, i.e. `num_cards_in_howl_bitmap()`.

I will change the way to iterate over this card set container within the howl container in JDK-8276548 to keep this change small.

Testing: tier1-5 (with JDK-8276548).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276540](https://bugs.openjdk.java.net/browse/JDK-8276540): Howl Full CardSet container iteration marks too many cards


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6229/head:pull/6229` \
`$ git checkout pull/6229`

Update a local copy of the PR: \
`$ git checkout pull/6229` \
`$ git pull https://git.openjdk.java.net/jdk pull/6229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6229`

View PR using the GUI difftool: \
`$ git pr show -t 6229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6229.diff">https://git.openjdk.java.net/jdk/pull/6229.diff</a>

</details>
