### PR TITLE
8276550: Use SHA256 hash in build.tools.depend.Depend

### DIFF
--- a/make/jdk/src/classes/build/tools/depend/Depend.java
+++ b/make/jdk/src/classes/build/tools/depend/Depend.java
@@ -102,7 +102,7 @@ public class Depend implements Plugin {
             private final MessageDigest apiHash;
             {
                 try {
-                    apiHash = MessageDigest.getInstance("MD5");
+                    apiHash = MessageDigest.getInstance("SHA-256");
                 } catch (NoSuchAlgorithmException ex) {
                     throw new IllegalStateException(ex);
                 }


### PR DESCRIPTION
[JDK-8182285](https://bugs.openjdk.java.net/browse/JDK-8182285) added the incremental build capabilities for modules, by hashing the APIs of each module.

The original change uses MD5, which is quite weak, and [JDK-8214483](https://bugs.openjdk.java.net/browse/JDK-8214483) allows `MessageDigest` to have no MD5 implementation. This is the cause of some build failures when using a FIPS-compliant boot JDK that has no MD5 implementation. I suggest we switch to the latest available hash instead.

Additional testing:
 - [x] Linux x86_64 fastdebug build completes
 - [x] Linux x86_64 fastdebug build times do not regress

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276550](https://bugs.openjdk.java.net/browse/JDK-8276550): Use SHA256 hash in build.tools.depend.Depend


### Reviewers
 * [Andrew Dinn](https://openjdk.java.net/census#adinn) (@adinn - **Reviewer**)
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.java.net/census#andrew) (@gnu-andrew - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6231/head:pull/6231` \
`$ git checkout pull/6231`

Update a local copy of the PR: \
`$ git checkout pull/6231` \
`$ git pull https://git.openjdk.java.net/jdk pull/6231/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6231`

View PR using the GUI difftool: \
`$ git pr show -t 6231`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6231.diff">https://git.openjdk.java.net/jdk/pull/6231.diff</a>

</details>
