### PR TITLE
8276429: CodeHeapState::print_names() fails with "assert(klass->is_loader_alive()) failed: must be alive"

### DIFF
--- a/src/hotspot/share/code/codeHeapState.cpp
+++ b/src/hotspot/share/code/codeHeapState.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2019 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -2335,11 +2335,11 @@ void CodeHeapState::print_names(outputStream* out, CodeHeap* heap) {
             Symbol* methSig   = method->signature();
             const char*   methSigS  = (methSig  == NULL) ? NULL : methSig->as_C_string();
             methSigS  = (methSigS  == NULL) ? "<method signature unavailable>" : methSigS;
-
             Klass* klass = method->method_holder();
-            assert(klass->is_loader_alive(), "must be alive");
+            assert(klass != nullptr, "No method holder");
+            const char* classNameS = (klass->name() == nullptr) ? "<class name unavailable>" : klass->external_name();
 
-            ast->print("%s.", klass->external_name());
+            ast->print("%s.", classNameS);
             ast->print("%s", methNameS);
             ast->print("%s", methSigS);
           } else {


### PR DESCRIPTION
This PR fixes `applications/kitchensink/Kitchensink.java` regression introduced by JDK-8275729.
The requirement for a method holder to be alive is relaxed to the holder not to be NULL.
If holder's name is not available the format of the string used for the name is the same as for unavailable method's name and signature, instead of the default string: `<unknown>`.
Testing:
- `make run-test TEST=tier1_serviceability`: Passed
- `make run-test TEST=hotspot_tier2_serviceability`: Passed
- `make run-test TEST=serviceability/dcmd/compiler/CodeHeapAnalyticsMethodNames.java`: Passed