### PR TITLE
8276556: ProblemList java/nio/channels/FileChannel/LargeGatheringWrite.java on windows-x64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -608,6 +608,8 @@ java/nio/channels/DatagramChannel/Unref.java                    8233519 generic-
 
 java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc64
 
+java/nio/channels/FileChannel/LargeGatheringWrite.java          8276199 windows-x64
+
 ############################################################################
 
 # jdk_rmi


### PR DESCRIPTION
A trivial fix to ProblemList java/nio/channels/FileChannel/LargeGatheringWrite.java on windows-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276556](https://bugs.openjdk.java.net/browse/JDK-8276556): ProblemList java/nio/channels/FileChannel/LargeGatheringWrite.java on windows-x64


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6235/head:pull/6235` \
`$ git checkout pull/6235`

Update a local copy of the PR: \
`$ git checkout pull/6235` \
`$ git pull https://git.openjdk.java.net/jdk pull/6235/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6235`

View PR using the GUI difftool: \
`$ git pr show -t 6235`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6235.diff">https://git.openjdk.java.net/jdk/pull/6235.diff</a>

</details>
