### PR TITLE
8268779: ZGC: runtime/InternalApi/ThreadCpuTimesDeadlock.java#id1 failed with "OutOfMemoryError: Java heap space"

### DIFF
--- a/src/hotspot/share/gc/z/zDriver.cpp
+++ b/src/hotspot/share/gc/z/zDriver.cpp
@@ -438,11 +438,11 @@ public:
   do {                                \
     concurrent_##f();                 \
     if (should_terminate()) {         \
-      return false;                   \
+      return;                         \
     }                                 \
   } while (false)
 
-bool ZDriver::gc(const ZDriverRequest& request) {
+void ZDriver::gc(const ZDriverRequest& request) {
   ZDriverGCScope scope(request);
 
   // Phase 1: Pause Mark Start
@@ -477,8 +477,6 @@ bool ZDriver::gc(const ZDriverRequest& request) {
 
   // Phase 10: Concurrent Relocate
   concurrent(relocate);
-
-  return true;
 }
 
 void ZDriver::run_service() {
@@ -493,7 +491,10 @@ void ZDriver::run_service() {
     ZBreakpoint::at_before_gc();
 
     // Run GC
-    if (!gc(request)) {
+    gc(request);
+
+    if (should_terminate()) {
+      // Abort
       break;
     }
 

--- a/src/hotspot/share/gc/z/zDriver.hpp
+++ b/src/hotspot/share/gc/z/zDriver.hpp
@@ -67,7 +67,7 @@ private:
 
   void check_out_of_memory();
 
-  void gc(const ZDriverRequest& request);
+  bool gc(const ZDriverRequest& request);
 
 protected:
   virtual void run_service();

--- a/src/hotspot/share/gc/z/zDriver.hpp
+++ b/src/hotspot/share/gc/z/zDriver.hpp
@@ -67,7 +67,7 @@ private:
 
   void check_out_of_memory();
 
-  bool gc(const ZDriverRequest& request);
+  void gc(const ZDriverRequest& request);
 
 protected:
   virtual void run_service();


### PR DESCRIPTION
Please review this fix for a ZGC shutdown/abort issue, introduced by JDK-8261759.

If a GC cycle has aborted, we should not notify that it completed and we should not check for out of memory condition. Doing so can cause pre-mature `OutOfMemoryError`.

Testing:
 - Tier 1-7 with ZGC on Linux/x86_64.
 - Wrote a small reproducer that provokes the problem fairly quickly. With this patch, I can no longer reproduced the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268779](https://bugs.openjdk.java.net/browse/JDK-8268779): ZGC: runtime/InternalApi/ThreadCpuTimesDeadlock.java#id1 failed with "OutOfMemoryError: Java heap space"


### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6236/head:pull/6236` \
`$ git checkout pull/6236`

Update a local copy of the PR: \
`$ git checkout pull/6236` \
`$ git pull https://git.openjdk.java.net/jdk pull/6236/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6236`

View PR using the GUI difftool: \
`$ git pr show -t 6236`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6236.diff">https://git.openjdk.java.net/jdk/pull/6236.diff</a>

</details>
