### PR TITLE
8276199: java/nio/channels/FileChannel/LargeGatheringWrite.java fails to terminate correctly

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -608,8 +608,6 @@ java/nio/channels/DatagramChannel/Unref.java                    8233519 generic-
 
 java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc64
 
-java/nio/channels/FileChannel/LargeGatheringWrite.java          8276199 windows-x64
-
 ############################################################################
 
 # jdk_rmi

--- a/test/jdk/java/nio/channels/FileChannel/LargeGatheringWrite.java
+++ b/test/jdk/java/nio/channels/FileChannel/LargeGatheringWrite.java
@@ -29,7 +29,7 @@
  * @library ..
  * @library /test/lib
  * @build jdk.test.lib.RandomFactory
- * @run main/othervm -Xmx4G LargeGatheringWrite
+ * @run main/othervm/timeout=240 -Xmx4G LargeGatheringWrite
  * @key randomness
  */
 import java.io.IOException;


### PR DESCRIPTION
Double the test timeout and remove the test from the ProblemList.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276199](https://bugs.openjdk.java.net/browse/JDK-8276199): java/nio/channels/FileChannel/LargeGatheringWrite.java fails to terminate correctly


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6238/head:pull/6238` \
`$ git checkout pull/6238`

Update a local copy of the PR: \
`$ git checkout pull/6238` \
`$ git pull https://git.openjdk.java.net/jdk pull/6238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6238`

View PR using the GUI difftool: \
`$ git pr show -t 6238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6238.diff">https://git.openjdk.java.net/jdk/pull/6238.diff</a>

</details>
