### PR TITLE
8276573: Use blessed modifier order in jdk.javadoc

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DeprecatedListWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DeprecatedListWriter.java
@@ -51,7 +51,7 @@ import jdk.javadoc.internal.doclets.toolkit.util.DocPaths;
  */
 public class DeprecatedListWriter extends SummaryListWriter<DeprecatedAPIListBuilder> {
 
-    private final static String TERMINALLY_DEPRECATED_KEY = "doclet.Terminally_Deprecated_Elements";
+    private static final String TERMINALLY_DEPRECATED_KEY = "doclet.Terminally_Deprecated_Elements";
 
     /**
      * Constructor.

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
@@ -84,8 +84,8 @@ public class PackageWriterImpl extends HtmlDocletWriter
     private final BodyContents bodyContents = new BodyContents();
 
     // Maximum number of subpackages and sibling packages to list in related packages table
-    private final static int MAX_SUBPACKAGES = 20;
-    private final static int MAX_SIBLING_PACKAGES = 5;
+    private static final int MAX_SUBPACKAGES = 20;
+    private static final int MAX_SIBLING_PACKAGES = 5;
 
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/snippet/Attribute.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/snippet/Attribute.java
@@ -83,7 +83,7 @@ public /* sealed */ abstract class Attribute {
      * SinglyQuoted or Unquoted to form a (sealed) hierarchy. In that case,
      * `Valued` should become abstract similarly to `Attribute`.
      */
-    final static class Valued extends Attribute {
+    static final class Valued extends Attribute {
 
         private final String value;
 
@@ -104,7 +104,7 @@ public /* sealed */ abstract class Attribute {
         }
     }
 
-    final static class Valueless extends Attribute {
+    static final class Valueless extends Attribute {
 
         Valueless(String name, int nameStartPosition) {
             super(name, nameStartPosition);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/snippet/MarkupParser.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/snippet/MarkupParser.java
@@ -48,7 +48,7 @@ import jdk.javadoc.internal.doclets.toolkit.Resources;
  */
 public final class MarkupParser {
 
-    private final static int EOI = 0x1A;
+    private static final int EOI = 0x1A;
     private char[] buf;
     private int bp;
     private int buflen;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/DocLint.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/DocLint.java
@@ -378,7 +378,7 @@ public class DocLint extends com.sun.tools.doclint.DocLint {
 
     // <editor-fold defaultstate="collapsed" desc="DeclScanner">
 
-    static abstract class DeclScanner extends TreePathScanner<Void, Void> {
+    abstract static class DeclScanner extends TreePathScanner<Void, Void> {
         final Env env;
 
         public DeclScanner(Env env) {


### PR DESCRIPTION
This PR is to jdk.javadoc as JDK-8276348 (#6213) to java.base. This change was produced by running the below command:

    $ sh ./bin/blessed-modifier-order.sh src/jdk.javadoc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276573](https://bugs.openjdk.java.net/browse/JDK-8276573): Use blessed modifier order in jdk.javadoc


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6239/head:pull/6239` \
`$ git checkout pull/6239`

Update a local copy of the PR: \
`$ git checkout pull/6239` \
`$ git pull https://git.openjdk.java.net/jdk pull/6239/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6239`

View PR using the GUI difftool: \
`$ git pr show -t 6239`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6239.diff">https://git.openjdk.java.net/jdk/pull/6239.diff</a>

</details>
