### PR TITLE
JDK-8276588: Change "ccc" to "CSR" in HotSpot sources

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -728,7 +728,7 @@ oop InstanceKlass::protection_domain() const {
   return java_lang_Class::protection_domain(java_mirror());
 }
 
-// To remove these from requires an incompatible change and CCC request.
+// To remove these from requires an incompatible change and CSR review.
 objArrayOop InstanceKlass::signers() const {
   // return the signers from the mirror
   return java_lang_Class::signers(java_mirror());

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -86,12 +86,12 @@
 // MANAGEABLE flags are writeable external product flags.
 //    They are dynamically writeable through the JDK management interface
 //    (com.sun.management.HotSpotDiagnosticMXBean API) and also through JConsole.
-//    These flags are external exported interface (see CCC).  The list of
+//    These flags are external exported interface (see CSR).  The list of
 //    manageable flags can be queried programmatically through the management
 //    interface.
 //
 //    A flag can be made as "manageable" only if
-//    - the flag is defined in a CCC as an external exported interface.
+//    - the flag is defined in a CSR request as an external exported interface.
 //    - the VM implementation supports dynamic setting of the flag.
 //      This implies that the VM must *always* query the flag variable
 //      and not reuse state related to the flag state at any given time.


### PR DESCRIPTION
I noticed an out-of-date use of "ccc" in the HotSpot sources and grepped over the sources to find and fix all such instances.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276588](https://bugs.openjdk.java.net/browse/JDK-8276588): Change "ccc" to "CSR" in HotSpot sources


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6240/head:pull/6240` \
`$ git checkout pull/6240`

Update a local copy of the PR: \
`$ git checkout pull/6240` \
`$ git pull https://git.openjdk.java.net/jdk pull/6240/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6240`

View PR using the GUI difftool: \
`$ git pr show -t 6240`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6240.diff">https://git.openjdk.java.net/jdk/pull/6240.diff</a>

</details>
