### PR TITLE
8272392: Lanai: SwingSet2. Black background on expanding tree node

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
@@ -184,7 +184,8 @@ replaceTextureRegion(MTLContext *mtlc, id<MTLTexture> dest, const SurfaceDataRas
     @autoreleasepool {
         J2dTraceLn4(J2D_TRACE_VERBOSE, "replaceTextureRegion src (dw, dh) : [%d, %d] dest (dx1, dy1) =[%d, %d]",
                     dw, dh, dx1, dy1);
-        id<MTLBuffer> buff = [[mtlc.device newBufferWithLength:(sw * sh * srcInfo->pixelStride) options:MTLResourceStorageModeManaged] autorelease];
+        id<MTLBuffer> buff = [[[mtlc.device newBufferWithLength:(sw * sh * srcInfo->pixelStride)
+                                options:MTLResourceStorageModeManaged] autorelease] retain];
 
         // copy src pixels inside src bounds to buff
         for (int row = 0; row < sh; row++) {
@@ -194,7 +195,8 @@ replaceTextureRegion(MTLContext *mtlc, id<MTLTexture> dest, const SurfaceDataRas
         [buff didModifyRange:NSMakeRange(0, buff.length)];
 
         if (rfi->swizzleMap != nil) {
-            id <MTLBuffer> swizzled = [[mtlc.device newBufferWithLength:(sw * sh * srcInfo->pixelStride) options:MTLResourceStorageModeManaged] autorelease];
+            id <MTLBuffer> swizzled = [[[mtlc.device newBufferWithLength:(sw * sh * srcInfo->pixelStride)
+                                         options:MTLResourceStorageModeManaged] autorelease] retain];
 
             // this should be cheap, since data is already on GPU
             id<MTLCommandBuffer> cb = [mtlc createCommandBuffer];
@@ -241,6 +243,7 @@ replaceTextureRegion(MTLContext *mtlc, id<MTLTexture> dest, const SurfaceDataRas
         id<MTLCommandBuffer> commandbuf = [cbwrapper getCommandBuffer];
         [commandbuf addCompletedHandler:^(id <MTLCommandBuffer> commandbuf) {
             [cbwrapper release];
+            [buff release];
         }];
         [commandbuf commit];
     }
@@ -595,7 +598,7 @@ MTLBlitLoops_Blit(JNIEnv *env,
             }
 
 #ifdef TRACE_BLIT
-            J2dTraceImpl(J2D_TRACE_VERBOSE, JNI_FALSE,
+            J2dTraceImpl(J2D_TRACE_VERBOSE, JNI_TRUE,
                     "MTLBlitLoops_Blit [tx=%d, xf=%d, AC=%s]: bdst=%s, src=%p (%dx%d) O=%d premul=%d | (%d, %d, %d, %d)->(%1.2f, %1.2f, %1.2f, %1.2f)",
                     texture, xform, [mtlc getCompositeDescription].cString,
                     getSurfaceDescription(dstOps).cString, srcOps,


### PR DESCRIPTION
Corrected memory allocation problem in replaceTextureRegion()

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8272392](https://bugs.openjdk.java.net/browse/JDK-8272392): Lanai: SwingSet2. Black background on expanding tree node


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6241/head:pull/6241` \
`$ git checkout pull/6241`

Update a local copy of the PR: \
`$ git checkout pull/6241` \
`$ git pull https://git.openjdk.java.net/jdk pull/6241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6241`

View PR using the GUI difftool: \
`$ git pr show -t 6241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6241.diff">https://git.openjdk.java.net/jdk/pull/6241.diff</a>

</details>
