### PR TITLE
8231490: Fix a data race in java.util.zip.Inflater

### DIFF
--- a/src/java.base/share/classes/java/util/zip/Inflater.java
+++ b/src/java.base/share/classes/java/util/zip/Inflater.java
@@ -419,7 +419,9 @@ public class Inflater {
                 needDict = true;
             }
             if (input != null) {
-                input.position(inputPos + read);
+                if (read > 0) {
+                    input.position(inputPos + read);
+                }
             } else {
                 this.inputPos = inputPos + read;
             }


### PR DESCRIPTION
This change applies the minimal fix suggested in
https://bugs.openjdk.java.net/browse/JDK-8231490.
The bug text suggests possibilities for reworking, but notes that
this change is enough to fix the data race.
Adding a regression test is probaby not feasible but we do observe
that Java TSAN no longer reports a race after the change.