### PR TITLE
8275670: ciReplay: java.lang.NoClassDefFoundError when trying to load java/lang/invoke/LambdaForm$MH

### DIFF
--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -508,8 +508,8 @@ public:
   void record_lambdaform(Thread* thread, oop obj);
   void record_member(Thread* thread, oop obj);
   void record_mh(Thread* thread, oop obj);
-  void record_call_site_obj(Thread* thread, const constantPoolHandle& pool, const Handle appendix);
-  void record_call_site_method(Thread* thread, const constantPoolHandle& pool, Method* adapter);
+  void record_call_site_obj(Thread* thread, oop obj);
+  void record_call_site_method(Thread* thread, Method* adapter);
   void process_invokedynamic(const constantPoolHandle &cp, int index, JavaThread* thread);
   void process_invokehandle(const constantPoolHandle &cp, int index, JavaThread* thread);
   void find_dynamic_call_sites();

--- a/test/hotspot/jtreg/compiler/ciReplay/TestLambdas.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/TestLambdas.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8275670
+ * @library / /test/lib
+ * @summary testing of ciReplay with inlining
+ * @requires vm.flightRecorder != true & vm.compMode != "Xint" & vm.debug == true & vm.compiler2.enabled
+ * @modules java.base/jdk.internal.misc
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      compiler.ciReplay.TestLambdas
+ */
+
+package compiler.ciReplay;
+
+public class TestLambdas extends CiReplayBase {
+    public static void main(String args[]) {
+        new TestLambdas().runTest(false, TIERED_DISABLED_VM_OPTION);
+    }
+
+    @Override
+    public void testAction() {
+        positiveTest(TIERED_DISABLED_VM_OPTION);
+    }
+
+    @Override
+    public String getTestClass() {
+        return Test.class.getName();
+    }
+}
+
+class Test {
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            test(i);
+        }
+    }
+
+    static void test(int i) {
+        concat_lambdas();
+    }
+
+
+    // Create nested BoundMethodHandle using StringConcatHelper
+    static boolean concat_lambdas() {
+        String source = "0123456789abcdefgABCDEFG";
+        String result = "";
+
+        int max = 0x100;
+        max = 10;
+        for (int cp = 0; cp < max; ++cp) {
+            String regex = new String(Character.toChars(cp));
+            result =  source.substring(0, 3) + regex
+                 + source.substring(3, 9) + regex
+                 + source.substring(9, 15) + regex
+                 + source.substring(15);
+        }
+        return result.equals("xyzzy");
+    }
+}

--- a/test/hotspot/jtreg/compiler/ciReplay/TestLambdas.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/TestLambdas.java
@@ -69,8 +69,7 @@ class Test {
         String source = "0123456789abcdefgABCDEFG";
         String result = "";
 
-        int max = 0x100;
-        max = 10;
+        int max = 10;
         for (int cp = 0; cp < max; ++cp) {
             String regex = new String(Character.toChars(cp));
             result =  source.substring(0, 3) + regex


### PR DESCRIPTION
The invokedynamic support added by 8271911 was incomplete.  In particular, it failed to search through argL fields.  This change fixes that, adds a test, and also cleans up the code a bit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275670](https://bugs.openjdk.java.net/browse/JDK-8275670): ciReplay: java.lang.NoClassDefFoundError when trying to load java/lang/invoke/LambdaForm$MH


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6243/head:pull/6243` \
`$ git checkout pull/6243`

Update a local copy of the PR: \
`$ git checkout pull/6243` \
`$ git pull https://git.openjdk.java.net/jdk pull/6243/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6243`

View PR using the GUI difftool: \
`$ git pr show -t 6243`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6243.diff">https://git.openjdk.java.net/jdk/pull/6243.diff</a>

</details>
