### PR TITLE
8276615: Update CR number of some tests in ProblemList-zgc.txt

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -29,9 +29,9 @@
 
 vmTestbase/jit/escape/AdaptiveBlocking/AdaptiveBlocking001/AdaptiveBlocking001.java 8260303 windows-x64
 
-resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java 8220624   generic-all
-serviceability/sa/CDSJMapClstats.java                         8220624   generic-all
-serviceability/sa/ClhsdbJhisto.java                           8220624   generic-all
+resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java 8276539   generic-all
+serviceability/sa/CDSJMapClstats.java                         8276539   generic-all
+serviceability/sa/ClhsdbJhisto.java                           8276539   generic-all
 
 serviceability/sa/ClhsdbCDSCore.java                          8268722   macosx-x64
 serviceability/sa/ClhsdbFindPC.java#xcomp-core                8268722   macosx-x64


### PR DESCRIPTION
Following tests are referred to [JDK-8220624](https://bugs.openjdk.java.net/browse/JDK-8220624), however it has been closed due to all subtasks were resolved.

* resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java
* serviceability/sa/CDSJMapClstats.java
* serviceability/sa/ClhsdbJhisto.java

We will work these problems in [JDK-8276539](https://bugs.openjdk.java.net/browse/JDK-8276539), so we need to update CR number of them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276615](https://bugs.openjdk.java.net/browse/JDK-8276615): Update CR number of some tests in ProblemList-zgc.txt


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6244/head:pull/6244` \
`$ git checkout pull/6244`

Update a local copy of the PR: \
`$ git checkout pull/6244` \
`$ git pull https://git.openjdk.java.net/jdk pull/6244/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6244`

View PR using the GUI difftool: \
`$ git pr show -t 6244`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6244.diff">https://git.openjdk.java.net/jdk/pull/6244.diff</a>

</details>
