### PR TITLE
JDK-8276572: Fake libsyslookup.so library causes tooling issues

### DIFF
--- a/src/jdk.incubator.foreign/share/native/libsyslookup/syslookup.c
+++ b/src/jdk.incubator.foreign/share/native/libsyslookup/syslookup.c
@@ -26,3 +26,8 @@
 // Note: the include below is not strictly required, as dependencies will be pulled using linker flags.
 // Adding at least one #include removes unwanted warnings on some platforms.
 #include <stdlib.h>
+
+// Simple dummy function so this library appears as a normal library to tooling.
+char* syslookup() {
+  return "syslookup";
+}


### PR DESCRIPTION
The lack of anything to compile in `syslookup.c` is leading to a number of issues in our tooling, on some architectures more than others (s390x seems to be the most problematic).  They expect to be able to retrieve debuginfo and compiler flags from generated .so files and fail with libsyslookup.so

This simple patch adds a dummy function to `syslookup.c` so it appears more like a regular file to be compiled. I can't see this causing a problem with the symbol lookup, but we could filter it out on the Java side if need be.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276572](https://bugs.openjdk.java.net/browse/JDK-8276572): Fake libsyslookup.so library causes tooling issues


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6245/head:pull/6245` \
`$ git checkout pull/6245`

Update a local copy of the PR: \
`$ git checkout pull/6245` \
`$ git pull https://git.openjdk.java.net/jdk pull/6245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6245`

View PR using the GUI difftool: \
`$ git pr show -t 6245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6245.diff">https://git.openjdk.java.net/jdk/pull/6245.diff</a>

</details>
