### PR TITLE
8276618: Pad cacheline for Thread::_rcu_counter

### DIFF
--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -230,7 +230,7 @@ Thread::Thread() {
   _threads_hazard_ptr = NULL;
   _threads_list_ptr = NULL;
   _nested_threads_hazard_ptr_cnt = 0;
-  _rcu_counter = 0;
+  _rcu_counter._counter = 0;
 
   // the handle mark links itself to last_handle_mark
   new HandleMark(this);

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -49,6 +49,7 @@
 #include "utilities/align.hpp"
 #include "utilities/exceptions.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "utilities/globalCounter.hpp"
 #include "utilities/macros.hpp"
 #if INCLUDE_JFR
 #include "jfr/support/jfrThreadExtension.hpp"
@@ -250,10 +251,10 @@ class Thread: public ThreadShadow {
 
   // Support for GlobalCounter
  private:
-  volatile uintx _rcu_counter;
+  GlobalCounter::PaddedCounter _rcu_counter;
  public:
   volatile uintx* get_rcu_counter() {
-    return &_rcu_counter;
+    return &_rcu_counter._counter;
   }
 
  public:

--- a/src/hotspot/share/utilities/globalCounter.hpp
+++ b/src/hotspot/share/utilities/globalCounter.hpp
@@ -35,22 +35,23 @@ class Thread;
 // critical_section_begin before reading the volatile data and
 // critical_section_end afterwards. Such read-side critical sections may
 // be properly nested. The write side must call write_synchronize
-// before reclaming the memory. The read-path only does an uncontended store
+// before reclaiming the memory. The read-path only does an uncontended store
 // to a thread-local-storage and fence to stop any loads from floating up, thus
 // light weight and wait-free. The write-side is more heavy since it must check
 // all readers and wait until they have left the generation. (a system memory
 // barrier can be used on write-side to remove fence in read-side,
 // not implemented).
 class GlobalCounter : public AllStatic {
- private:
+ public:
   // Since do not know what we will end up next to in BSS, we make sure the
-  // counter is on a seperate cacheline.
+  // counter is on a separate cacheline.
   struct PaddedCounter {
     DEFINE_PAD_MINUS_SIZE(0, DEFAULT_CACHE_LINE_SIZE, 0);
     volatile uintx _counter;
     DEFINE_PAD_MINUS_SIZE(1, DEFAULT_CACHE_LINE_SIZE, sizeof(volatile uintx));
   };
 
+ private:
   // The global counter
   static PaddedCounter _global_counter;
 


### PR DESCRIPTION
Currently, Thread::_rcu_counter is not padded by cacheline, it should be beneficail to do so.

The initial spebjbb test shows about 10.5% improvement of critical, and 0.7% improvement of max in specjbb2015, specjbb arguments:
  GROUP_COUNT=4
  TI_JVM_COUNT=1
  JAVA_OPTS_BE="-server -XX:+UseG1GC -Xms32g -Xmx32g"
  MODE_ARGS="-ikv"