### PR TITLE
8276151: AArch64: Incorrect result for double to int vector conversion

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64_neon.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_neon.ad
@@ -515,7 +515,8 @@ instruct vcvt2Dto2I(vecD dst, vecX src)
   %}
   ins_encode %{
     __ ins(as_FloatRegister($dst$$reg), __ D, as_FloatRegister($src$$reg), 0, 1);
-    // Converting from double to int directly follows Java specification.
+    // We can't use fcvtzs(vector, integer) instruction here because we need
+    // saturation arithmetic. See JDK-8276151.
     __ fcvtzdw(rscratch1, as_FloatRegister($src$$reg));
     __ fcvtzdw(rscratch2, as_FloatRegister($dst$$reg));
     __ fmovs(as_FloatRegister($dst$$reg), rscratch1);

--- a/src/hotspot/cpu/aarch64/aarch64_neon.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_neon.ad
@@ -506,12 +506,20 @@ instruct vcvt2Dto2I(vecD dst, vecX src)
 %{
   predicate(n->as_Vector()->length() == 2 && n->bottom_type()->is_vect()->element_basic_type() == T_INT);
   match(Set dst (VectorCastD2X src));
-  format %{ "fcvtzs  $dst, T2D, $src\n\t"
-            "xtn     $dst, T2S, $dst, T2D\t# convert 2D to 2I vector"
+  effect(TEMP_DEF dst);
+  format %{ "ins      $dst, D, $src, 0, 1\n\t"
+            "fcvtzdw  rscratch1, $src\n\t"
+            "fcvtzdw  rscratch2, $dst\n\t"
+            "fmovs    $dst, rscratch1\n\t"
+            "mov      $dst, T2S, 1, rscratch2\t#convert 2D to 2I vector"
   %}
   ins_encode %{
-    __ fcvtzs(as_FloatRegister($dst$$reg), __ T2D, as_FloatRegister($src$$reg));
-    __ xtn(as_FloatRegister($dst$$reg), __ T2S, as_FloatRegister($dst$$reg), __ T2D);
+    __ ins(as_FloatRegister($dst$$reg), __ D, as_FloatRegister($src$$reg), 0, 1);
+    // Converting from double to int directly follows Java specification.
+    __ fcvtzdw(rscratch1, as_FloatRegister($src$$reg));
+    __ fcvtzdw(rscratch2, as_FloatRegister($dst$$reg));
+    __ fmovs(as_FloatRegister($dst$$reg), rscratch1);
+    __ mov(as_FloatRegister($dst$$reg), __ T2S, 1, rscratch2);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/aarch64/aarch64_neon_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_neon_ad.m4
@@ -272,25 +272,42 @@ dnl             $1 $2 $3 $4 $5
 VECTOR_CAST_F2I(2, F, I, D, 2S)
 VECTOR_CAST_F2I(4, F, I, X, 4S)
 VECTOR_CAST_F2I(2, D, L, X, 2D)
-dnl
-define(`VECTOR_CAST_F2I_L', `
-instruct vcvt$1$2to$1$3`'(vec$4 dst, vec$5 src)
+
+instruct vcvt4Fto4S(vecD dst, vecX src)
 %{
-  predicate(n->as_Vector()->length() == $1 && n->bottom_type()->is_vect()->element_basic_type() == T_`'TYPE2DATATYPE($3));
-  match(Set dst (VectorCast$2`'2X src));
-  format %{ "fcvtzs  $dst, T$6, $src\n\t"
-            "xtn     $dst, T$7, $dst, T$6\t# convert $1$2 to $1$3 vector"
+  predicate(n->as_Vector()->length() == 4 && n->bottom_type()->is_vect()->element_basic_type() == T_SHORT);
+  match(Set dst (VectorCastF2X src));
+  format %{ "fcvtzs  $dst, T4S, $src\n\t"
+            "xtn     $dst, T4H, $dst, T4S\t# convert 4F to 4S vector"
   %}
   ins_encode %{
-    __ fcvtzs(as_FloatRegister($dst$$reg), __ T$6, as_FloatRegister($src$$reg));
-    __ xtn(as_FloatRegister($dst$$reg), __ T$7, as_FloatRegister($dst$$reg), __ T$6);
+    __ fcvtzs(as_FloatRegister($dst$$reg), __ T4S, as_FloatRegister($src$$reg));
+    __ xtn(as_FloatRegister($dst$$reg), __ T4H, as_FloatRegister($dst$$reg), __ T4S);
   %}
   ins_pipe(pipe_slow);
-%}')dnl
-dnl               $1 $2 $3 $4 $5 $6  $7
-VECTOR_CAST_F2I_L(4, F, S, D, X, 4S, 4H)
-VECTOR_CAST_F2I_L(2, D, I, D, X, 2D, 2S)
-dnl
+%}
+
+instruct vcvt2Dto2I(vecD dst, vecX src)
+%{
+  predicate(n->as_Vector()->length() == 2 && n->bottom_type()->is_vect()->element_basic_type() == T_INT);
+  match(Set dst (VectorCastD2X src));
+  effect(TEMP_DEF dst);
+  format %{ "ins      $dst, D, $src, 0, 1\n\t"
+            "fcvtzdw  rscratch1, $src\n\t"
+            "fcvtzdw  rscratch2, $dst\n\t"
+            "fmovs    $dst, rscratch1\n\t"
+            "mov      $dst, T2S, 1, rscratch2\t#convert 2D to 2I vector"
+  %}
+  ins_encode %{
+    __ ins(as_FloatRegister($dst$$reg), __ D, as_FloatRegister($src$$reg), 0, 1);
+    // Converting from double to int directly follows Java specification.
+    __ fcvtzdw(rscratch1, as_FloatRegister($src$$reg));
+    __ fcvtzdw(rscratch2, as_FloatRegister($dst$$reg));
+    __ fmovs(as_FloatRegister($dst$$reg), rscratch1);
+    __ mov(as_FloatRegister($dst$$reg), __ T2S, 1, rscratch2);
+  %}
+  ins_pipe(pipe_slow);
+%}
 
 instruct vcvt4Fto4B(vecD dst, vecX src)
 %{

--- a/src/hotspot/cpu/aarch64/aarch64_neon_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_neon_ad.m4
@@ -300,7 +300,8 @@ instruct vcvt2Dto2I(vecD dst, vecX src)
   %}
   ins_encode %{
     __ ins(as_FloatRegister($dst$$reg), __ D, as_FloatRegister($src$$reg), 0, 1);
-    // Converting from double to int directly follows Java specification.
+    // We can't use fcvtzs(vector, integer) instruction here because we need
+    // saturation arithmetic. See JDK-8276151.
     __ fcvtzdw(rscratch1, as_FloatRegister($src$$reg));
     __ fcvtzdw(rscratch2, as_FloatRegister($dst$$reg));
     __ fmovs(as_FloatRegister($dst$$reg), rscratch1);

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorCastShape64Test.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorCastShape64Test.java
@@ -24,6 +24,7 @@
 package compiler.vectorapi;
 
 import java.util.Random;
+import jdk.test.lib.Utils;
 
 import jdk.incubator.vector.ByteVector;
 import jdk.incubator.vector.DoubleVector;
@@ -39,9 +40,11 @@ import org.testng.annotations.Test;
 /**
  * @test
  * @bug 8268966
+ * @key randomness
  * @summary AArch64: 'bad AD file' in some vector conversion tests
+ * @library /test/lib
  * @modules jdk.incubator.vector
- * @run testng/othervm -XX:-TieredCompilation compiler.vectorapi.VectorCastShape64Test
+ * @run testng/othervm -XX:-TieredCompilation -XX:CompileThreshold=100 compiler.vectorapi.VectorCastShape64Test
  */
 
 
@@ -54,8 +57,8 @@ public class VectorCastShape64Test {
     private static final VectorSpecies<Float> fspec = FloatVector.SPECIES_64;
     private static final VectorSpecies<Double> dspec = DoubleVector.SPECIES_64;
 
-    private static final int NUM_ITER = 50000;
-    private static final int LENGTH = 512;
+    private static final int NUM_ITER = 10000;
+    private static final int LENGTH = 1024;
     private static int[] ia;
     private static int[] ib;
     private static byte[] ba;
@@ -68,6 +71,50 @@ public class VectorCastShape64Test {
     private static double[] db;
     private static float[] fa;
     private static float[] fb;
+
+    public static float [] fspecial = {
+        0.0f,
+        -0.0f,
+        Float.MAX_VALUE,
+        Float.MIN_VALUE,
+        -Float.MAX_VALUE,
+        -Float.MIN_VALUE,
+        Float.NaN,
+        Float.POSITIVE_INFINITY,
+        Float.NEGATIVE_INFINITY,
+        Integer.MAX_VALUE,
+        Integer.MIN_VALUE,
+        Long.MAX_VALUE,
+        Long.MIN_VALUE,
+    };
+
+    public static double [] dspecial = {
+        0.0,
+        -0.0,
+        Double.MAX_VALUE,
+        Double.MIN_VALUE,
+        -Double.MAX_VALUE,
+        -Double.MIN_VALUE,
+        Double.NaN,
+        Double.POSITIVE_INFINITY,
+        Double.NEGATIVE_INFINITY,
+        Integer.MAX_VALUE,
+        Integer.MIN_VALUE,
+        Long.MIN_VALUE,
+        Long.MAX_VALUE,
+    };
+
+    public static int [] ispecial = {
+        0,
+        Integer.MAX_VALUE,
+        Integer.MIN_VALUE,
+    };
+
+    public static long [] lspecial = {
+        0,
+        Long.MAX_VALUE,
+        Long.MIN_VALUE,
+    };
 
     private static void initialize() {
         ia = new int[LENGTH];
@@ -82,14 +129,23 @@ public class VectorCastShape64Test {
         fb = new float[LENGTH];
         da = new double[LENGTH];
         db = new double[LENGTH];
-        Random r = new Random();
+        Random r = Utils.getRandomInstance();
         for (int i = 0; i < LENGTH; i++) {
             ia[i] = r.nextInt();
             la[i] = r.nextLong();
             sa[i] = (short) r.nextInt();
             ba[i] = (byte) r.nextInt();
-            fa[i] = r.nextFloat();
-            da[i] = r.nextDouble();
+            fa[i] = ia[i] + r.nextFloat();
+            da[i] = la[i] + r.nextDouble();
+        }
+
+        // Replicate to make sure the values get tested, as some elements may be
+        // ignored for some vector conversions.
+        for (int i = 0; i < 4; i++) {
+            System.arraycopy(ispecial, 0, ia, ispecial.length * i, ispecial.length);
+            System.arraycopy(lspecial, 0, la, lspecial.length * i, lspecial.length);
+            System.arraycopy(fspecial, 0, fa, fspecial.length * i, fspecial.length);
+            System.arraycopy(dspecial, 0, da, dspecial.length * i, dspecial.length);
         }
     }
 


### PR DESCRIPTION
Current NEON vector double to integer conversion generates code to convert double to long first and then narrow to integer, which does not follow Java language spec [1], and will get incorrect results for double values larger than Integer.MAX_VALUE or less than Integer.MIN_VALUE. For those too large/small values, result should be the largest/smallest representable value of type int, but converting to long and then narrowing to int will get different results.

There's no direct double to int vector conversion NEON instruction, so we simply do it with scalar conversion.

Also update compiler/vectorapi test cases to cover some corner cases.

[1] https://docs.oracle.com/javase/specs/jls/se17/html/jls-5.html#jls-5.1.3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276151](https://bugs.openjdk.java.net/browse/JDK-8276151): AArch64: Incorrect result for double to int vector conversion


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6247/head:pull/6247` \
`$ git checkout pull/6247`

Update a local copy of the PR: \
`$ git checkout pull/6247` \
`$ git pull https://git.openjdk.java.net/jdk pull/6247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6247`

View PR using the GUI difftool: \
`$ git pr show -t 6247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6247.diff">https://git.openjdk.java.net/jdk/pull/6247.diff</a>

</details>
