### PR TITLE
8276629: Use blessed modifier order in core-libs code

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
@@ -689,7 +689,7 @@ public final class Connection implements Runnable {
     // "synchronize" might lead to deadlock so don't synchronize method
     // Use streamLock instead for synchronizing update to stream
 
-    synchronized public void replaceStreams(InputStream newIn, OutputStream newOut) {
+    public synchronized void replaceStreams(InputStream newIn, OutputStream newOut) {
         if (debug) {
             System.err.println("Replacing " + inStream + " with: " + newIn);
             System.err.println("Replacing " + outStream + " with: " + newOut);
@@ -712,7 +712,7 @@ public final class Connection implements Runnable {
     /*
      * Replace streams and set isUpdradedToStartTls flag to the provided value
      */
-    synchronized public void replaceStreams(InputStream newIn, OutputStream newOut, boolean isStartTls) {
+    public synchronized void replaceStreams(InputStream newIn, OutputStream newOut, boolean isStartTls) {
         synchronized (startTlsLock) {
             replaceStreams(newIn, newOut);
             isUpgradedToStartTls = isStartTls;
@@ -731,7 +731,7 @@ public final class Connection implements Runnable {
      * This ensures that there is no contention between the main thread
      * and the Connection thread when the main thread updates inStream.
      */
-    synchronized private InputStream getInputStream() {
+    private synchronized InputStream getInputStream() {
         return inStream;
     }
 
@@ -1043,7 +1043,7 @@ public final class Connection implements Runnable {
      */
     private volatile HandshakeListener tlsHandshakeListener;
 
-    synchronized public void setHandshakeCompletedListener(SSLSocket sslSocket) {
+    public synchronized void setHandshakeCompletedListener(SSLSocket sslSocket) {
         if (tlsHandshakeListener != null)
             tlsHandshakeListener.tlsHandshakeCompleted.cancel(false);
 

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapClient.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapClient.java
@@ -312,7 +312,7 @@ public final class LdapClient implements PooledConnection {
      * @param auth The authentication mechanism
      *
      */
-    synchronized public LdapResult ldapBind(String dn, byte[]toServer,
+    public synchronized LdapResult ldapBind(String dn, byte[]toServer,
         Control[] bindCtls, String auth, boolean pauseAfterReceipt)
         throws java.io.IOException, NamingException {
 
@@ -486,7 +486,7 @@ public final class LdapClient implements PooledConnection {
     /*
      * Used by connection pooling to close physical connection.
      */
-    synchronized public void closeConnection() {
+    public synchronized void closeConnection() {
         forceClose(false); // this is a pool callback so no need to clean pool
     }
 

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapCtx.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapCtx.java
@@ -2648,7 +2648,7 @@ public final class LdapCtx extends ComponentDirContext
         }
     }
 
-    synchronized public void close() throws NamingException {
+    public synchronized void close() throws NamingException {
         if (debug) {
             System.err.println("LdapCtx: close() called " + this);
             (new Throwable()).printStackTrace();

--- a/src/java.rmi/share/classes/java/rmi/server/LoaderHandler.java
+++ b/src/java.rmi/share/classes/java/rmi/server/LoaderHandler.java
@@ -42,7 +42,7 @@ import java.net.URL;
 public interface LoaderHandler {
 
     /** package of system <code>LoaderHandler</code> implementation. */
-    final static String packagePrefix = "sun.rmi.server";
+    static final String packagePrefix = "sun.rmi.server";
 
     /**
      * Loads a class from the location specified by the

--- a/src/java.rmi/share/classes/java/rmi/server/RMISocketFactory.java
+++ b/src/java.rmi/share/classes/java/rmi/server/RMISocketFactory.java
@@ -131,7 +131,7 @@ public abstract class RMISocketFactory
      * @see java.lang.SecurityManager#checkSetFactory()
      * @since 1.1
      */
-    public synchronized static void setSocketFactory(RMISocketFactory fac)
+    public static synchronized void setSocketFactory(RMISocketFactory fac)
         throws IOException
     {
         if (factory != null) {
@@ -153,7 +153,7 @@ public abstract class RMISocketFactory
      * @see #setSocketFactory(RMISocketFactory)
      * @since 1.1
      */
-    public synchronized static RMISocketFactory getSocketFactory()
+    public static synchronized RMISocketFactory getSocketFactory()
     {
         return factory;
     }
@@ -166,7 +166,7 @@ public abstract class RMISocketFactory
      * @return the default RMI socket factory
      * @since 1.1
      */
-    public synchronized static RMISocketFactory getDefaultSocketFactory() {
+    public static synchronized RMISocketFactory getDefaultSocketFactory() {
         if (defaultSocketFactory == null) {
             defaultSocketFactory =
                 new sun.rmi.transport.tcp.TCPDirectSocketFactory();
@@ -193,7 +193,7 @@ public abstract class RMISocketFactory
      * @see java.rmi.server.RMIFailureHandler#failure(Exception)
      * @since 1.1
      */
-    public synchronized static void setFailureHandler(RMIFailureHandler fh)
+    public static synchronized void setFailureHandler(RMIFailureHandler fh)
     {
         @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
@@ -210,7 +210,7 @@ public abstract class RMISocketFactory
      * @see #setFailureHandler(RMIFailureHandler)
      * @since 1.1
      */
-    public synchronized static RMIFailureHandler getFailureHandler()
+    public static synchronized RMIFailureHandler getFailureHandler()
     {
         return handler;
     }

--- a/src/java.rmi/share/classes/java/rmi/server/RemoteObject.java
+++ b/src/java.rmi/share/classes/java/rmi/server/RemoteObject.java
@@ -45,7 +45,7 @@ import sun.rmi.server.Util;
 public abstract class RemoteObject implements Remote, java.io.Serializable {
 
     /** The object's remote reference. */
-    transient protected RemoteRef ref;
+    protected transient RemoteRef ref;
 
     /** indicate compatibility with JDK 1.1.x version of class */
     @java.io.Serial

--- a/src/java.rmi/share/classes/java/rmi/server/RemoteRef.java
+++ b/src/java.rmi/share/classes/java/rmi/server/RemoteRef.java
@@ -53,7 +53,7 @@ public interface RemoteRef extends java.io.Externalizable {
      * UnicastServerRef) are located in the package defined by the
      * prefix.
      */
-    final static String packagePrefix = "sun.rmi.server";
+    static final String packagePrefix = "sun.rmi.server";
 
     /**
      * Invoke a method. This form of delegating method invocation

--- a/src/java.rmi/share/classes/java/rmi/server/RemoteStub.java
+++ b/src/java.rmi/share/classes/java/rmi/server/RemoteStub.java
@@ -40,7 +40,7 @@ package java.rmi.server;
  * for information about dynamic stub generation.
  */
 @Deprecated
-abstract public class RemoteStub extends RemoteObject {
+public abstract class RemoteStub extends RemoteObject {
 
     /** indicate compatibility with JDK 1.1.x version of class */
     private static final long serialVersionUID = -1585587260594494182L;

--- a/src/java.rmi/share/classes/sun/rmi/log/ReliableLog.java
+++ b/src/java.rmi/share/classes/sun/rmi/log/ReliableLog.java
@@ -78,8 +78,8 @@ import java.security.PrivilegedAction;
  */
 public class ReliableLog {
 
-    public final static int PreferredMajorVersion = 0;
-    public final static int PreferredMinorVersion = 2;
+    public static final int PreferredMajorVersion = 0;
+    public static final int PreferredMinorVersion = 2;
 
     // sun.rmi.log.debug=false
     private boolean Debug = false;

--- a/src/java.rmi/share/classes/sun/rmi/transport/ObjectTable.java
+++ b/src/java.rmi/share/classes/sun/rmi/transport/ObjectTable.java
@@ -49,7 +49,7 @@ public final class ObjectTable {
 
     /** maximum interval between complete garbage collections of local heap */
     @SuppressWarnings("removal")
-    private final static long gcInterval =              // default 1 hour
+    private static final long gcInterval =              // default 1 hour
         AccessController.doPrivileged((PrivilegedAction<Long>) () ->
             Long.getLong("sun.rmi.dgc.server.gcInterval", 3600000));
 

--- a/src/java.rmi/share/classes/sun/rmi/transport/Target.java
+++ b/src/java.rmi/share/classes/sun/rmi/transport/Target.java
@@ -308,7 +308,7 @@ public final class Target {
      * Remove endpoint from the reference set.
      */
     @SuppressWarnings("removal")
-    synchronized private void refSetRemove(VMID vmid) {
+    private synchronized void refSetRemove(VMID vmid) {
         // remove notification request
         DGCImpl.getDGCImpl().unregisterTarget(vmid, this);
 
@@ -434,7 +434,7 @@ public final class Target {
      * vmid dies.  In that case, the vmid should be removed
      * from the reference set.
      */
-    synchronized public void vmidDead(VMID vmid) {
+    public synchronized void vmidDead(VMID vmid) {
         if (DGCImpl.dgcLog.isLoggable(Log.BRIEF)) {
             DGCImpl.dgcLog.log(Log.BRIEF, "removing endpoint " +
                             vmid + " from reference set");

--- a/src/java.sql.rowset/share/classes/javax/sql/rowset/RowSetProvider.java
+++ b/src/java.sql.rowset/share/classes/javax/sql/rowset/RowSetProvider.java
@@ -226,7 +226,7 @@ public class RowSetProvider {
      *
      */
     @SuppressWarnings("removal")
-    static private ClassLoader getContextClassLoader() throws SecurityException {
+    private static ClassLoader getContextClassLoader() throws SecurityException {
         return AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
 
             public ClassLoader run() {
@@ -252,7 +252,7 @@ public class RowSetProvider {
      * context class loader followed by the current class loader.
      *  @return The class which was loaded
      */
-    static private Class<?> getFactoryClass(String factoryClassName, ClassLoader cl,
+    private static Class<?> getFactoryClass(String factoryClassName, ClassLoader cl,
             boolean doFallback) throws ClassNotFoundException {
         Class<?> factoryClass = null;
 
@@ -284,7 +284,7 @@ public class RowSetProvider {
      * Use the ServiceLoader mechanism to load  the default RowSetFactory
      * @return default RowSetFactory Implementation
      */
-    static private RowSetFactory loadViaServiceLoader() throws SQLException {
+    private static RowSetFactory loadViaServiceLoader() throws SQLException {
         RowSetFactory theFactory = null;
         try {
             trace("***in loadViaServiceLoader():");
@@ -310,7 +310,7 @@ public class RowSetProvider {
      * or a {@code SecurityException} occurs.
      */
     @SuppressWarnings("removal")
-    static private String getSystemProperty(final String propName) {
+    private static String getSystemProperty(final String propName) {
         String property = null;
         try {
             property = AccessController.doPrivileged(new PrivilegedAction<String>() {

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/BiClassValue.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/BiClassValue.java
@@ -87,7 +87,7 @@ final class BiClassValue<T> {
      * creates the association from a type Class object to its BiClassValues'.
      * @param <T> the type of the values
      */
-    private final static class BiClassValues<T> {
+    private static final class BiClassValues<T> {
         // These will be used for compareAndExchange on forward and reverse fields.
         private static final VarHandle FORWARD;
         private static final VarHandle REVERSE;

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Annotation.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Annotation.java
@@ -73,7 +73,7 @@ public class Annotation {
     /**
      * See JVMS, section 4.8.16.1.
      */
-    public static abstract class element_value {
+    public abstract static class element_value {
         public static element_value read(ClassReader cr)
                 throws IOException, InvalidAnnotation {
             int tag = cr.readUnsignedByte();

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/ConstantPool.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/ConstantPool.java
@@ -370,7 +370,7 @@ public class ConstantPool {
         R visitUtf8(CONSTANT_Utf8_info info, P p);
     }
 
-    public static abstract class CPInfo {
+    public abstract static class CPInfo {
         CPInfo() {
             this.cp = null;
         }
@@ -394,7 +394,7 @@ public class ConstantPool {
         protected final ConstantPool cp;
     }
 
-    public static abstract class CPRefInfo extends CPInfo {
+    public abstract static class CPRefInfo extends CPInfo {
         protected CPRefInfo(ConstantPool cp, ClassReader cr, int tag) throws IOException {
             super(cp);
             this.tag = tag;

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Dependencies.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Dependencies.java
@@ -557,7 +557,7 @@ public class Dependencies {
         private int showAccess;
     }
 
-    static abstract class BasicDependencyFinder implements Finder {
+    abstract static class BasicDependencyFinder implements Finder {
         private Map<String,Location> locations = new ConcurrentHashMap<>();
 
         Location getLocation(String className) {

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/StackMapTable_attribute.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/StackMapTable_attribute.java
@@ -77,7 +77,7 @@ public class StackMapTable_attribute extends Attribute {
     public final int number_of_entries;
     public final stack_map_frame entries[];
 
-    public static abstract class stack_map_frame {
+    public abstract static class stack_map_frame {
         static stack_map_frame read(ClassReader cr)
                 throws IOException, InvalidStackMap {
             int frame_type = cr.readUnsignedByte();

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/JavapTask.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/JavapTask.java
@@ -98,7 +98,7 @@ public class JavapTask implements DisassemblerTool.DisassemblerTask, Messages {
         boolean showUsage;
     }
 
-    static abstract class Option {
+    abstract static class Option {
         Option(boolean hasArg, String... aliases) {
             this.hasArg = hasArg;
             this.aliases = aliases;

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
@@ -106,7 +106,7 @@ class JdepsTask {
         }
     }
 
-    static abstract class Option {
+    abstract static class Option {
         Option(boolean hasArg, String... aliases) {
             this.hasArg = hasArg;
             this.aliases = aliases;
@@ -139,7 +139,7 @@ class JdepsTask {
         final String[] aliases;
     }
 
-    static abstract class HiddenOption extends Option {
+    abstract static class HiddenOption extends Option {
         HiddenOption(boolean hasArg, String... aliases) {
             super(hasArg, aliases);
         }

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/Module.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/Module.java
@@ -183,7 +183,7 @@ class Module extends Archive {
         return name();
     }
 
-    public final static class Builder {
+    public static final class Builder {
         final String name;
         final ModuleDescriptor descriptor;
         final boolean isSystem;

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/Profile.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/Profile.java
@@ -111,7 +111,7 @@ enum Profile {
         return null;
     }
 
-    private final static Set<Module> JDK = new HashSet<>();
+    private static final Set<Module> JDK = new HashSet<>();
     static synchronized void init(Map<String, Module> systemModules) {
         Arrays.stream(Profile.values()).forEach(p ->
             // this includes platform-dependent module that may not exist

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImagePluginStack.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImagePluginStack.java
@@ -87,7 +87,7 @@ public final class ImagePluginStack {
         }
     }
 
-    private final static class CheckOrderResourcePoolManager extends ResourcePoolManager {
+    private static final class CheckOrderResourcePoolManager extends ResourcePoolManager {
 
         private final List<ResourcePoolEntry> orderedList;
         private int currentIndex;

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImageResourcesTree.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ImageResourcesTree.java
@@ -107,7 +107,7 @@ public final class ImageResourcesTree {
          * A reference to a package. Empty packages can be located inside one or
          * more modules. A package with classes exist in only one module.
          */
-        final static class PackageReference {
+        static final class PackageReference {
 
             private final String name;
             private final boolean isEmpty;

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/PluginRepository.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/PluginRepository.java
@@ -90,7 +90,7 @@ public final class PluginRepository {
      * Explicit registration of a plugin in the repository. Used by unit tests
      * @param plugin The plugin to register.
      */
-    public synchronized static void registerPlugin(Plugin plugin) {
+    public static synchronized void registerPlugin(Plugin plugin) {
         Objects.requireNonNull(plugin);
         registeredPlugins.put(plugin.getName(), plugin);
     }
@@ -101,7 +101,7 @@ public final class PluginRepository {
      *
      * @param name Plugin name
      */
-    public synchronized static void unregisterPlugin(String name) {
+    public static synchronized void unregisterPlugin(String name) {
         Objects.requireNonNull(name);
         registeredPlugins.remove(name);
     }

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ResourceFilter.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ResourceFilter.java
@@ -42,7 +42,7 @@ import jdk.tools.jlink.internal.Utils;
  * Filter resource resources using path matcher.
  */
 public class ResourceFilter implements Predicate<String> {
-    private final static List<String> EMPTY_LIST = Collections.emptyList();
+    private static final List<String> EMPTY_LIST = Collections.emptyList();
 
     private final List<PathMatcher> matchers;
     private final boolean include;

--- a/src/jdk.jlink/share/classes/jdk/tools/jmod/JmodTask.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jmod/JmodTask.java
@@ -1041,7 +1041,7 @@ public class JmodTask {
      * Specific subclasses should do whatever validation is required on the
      * individual path elements, if any.
      */
-    static abstract class AbstractPathConverter implements ValueConverter<List<Path>> {
+    abstract static class AbstractPathConverter implements ValueConverter<List<Path>> {
         @Override
         public List<Path> convert(String value) {
             List<Path> paths = new ArrayList<>();

--- a/src/jdk.naming.dns/share/classes/com/sun/jndi/dns/DnsContext.java
+++ b/src/jdk.naming.dns/share/classes/com/sun/jndi/dns/DnsContext.java
@@ -989,7 +989,7 @@ abstract class BaseNameClassPairEnumeration<T> implements NamingEnumeration<T> {
         return hasMore();
     }
 
-    abstract public T next() throws NamingException;
+    public abstract T next() throws NamingException;
 
     public final T nextElement() {
         try {

--- a/src/jdk.naming.rmi/share/classes/com/sun/jndi/rmi/registry/RegistryContextFactory.java
+++ b/src/jdk.naming.rmi/share/classes/com/sun/jndi/rmi/registry/RegistryContextFactory.java
@@ -59,7 +59,7 @@ public class RegistryContextFactory
     /**
      * The type of each address in an RMI registry reference.
      */
-    public final static String ADDRESS_TYPE = "URL";
+    public static final String ADDRESS_TYPE = "URL";
 
     public Context getInitialContext(Hashtable<?,?> env) throws NamingException {
 


### PR DESCRIPTION
I ran bin/blessed-modifier-order.sh on source owned by core-libs. This scripts verifies that modifiers are in the "blessed" order, and fixes it otherwise. I have manually checked the changes made by the script to make sure they are sound.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276629](https://bugs.openjdk.java.net/browse/JDK-8276629): Use blessed modifier order in core-libs code


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Aleksei Efimov](https://openjdk.java.net/census#aefimov) (@AlekseiEfimov - Committer)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6250/head:pull/6250` \
`$ git checkout pull/6250`

Update a local copy of the PR: \
`$ git checkout pull/6250` \
`$ git pull https://git.openjdk.java.net/jdk pull/6250/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6250`

View PR using the GUI difftool: \
`$ git pr show -t 6250`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6250.diff">https://git.openjdk.java.net/jdk/pull/6250.diff</a>

</details>
