### PR TITLE
8276632: Use blessed modifier order in security-libs code

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/jgss/ProviderList.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/ProviderList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.security.jgss/share/classes/sun/security/jgss/ProviderList.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/ProviderList.java
@@ -160,7 +160,7 @@ public final class ProviderList {
     }
 
     // So the existing code do not have to be changed
-    synchronized public MechanismFactory getMechFactory(Oid mechOid)
+    public synchronized MechanismFactory getMechFactory(Oid mechOid)
         throws GSSException {
         if (mechOid == null) mechOid = ProviderList.DEFAULT_MECH_OID;
         return getMechFactory(mechOid, null);
@@ -177,7 +177,7 @@ public final class ProviderList {
      * support the desired mechanism, or when no provider supports
      * the desired mechanism.
      */
-    synchronized public MechanismFactory getMechFactory(Oid mechOid,
+    public synchronized MechanismFactory getMechFactory(Oid mechOid,
                                                         Provider p)
         throws GSSException {
 
@@ -335,7 +335,7 @@ public final class ProviderList {
         return mechs.toArray(new Oid[] {});
     }
 
-    synchronized public void addProviderAtFront(Provider p, Oid mechOid)
+    public synchronized void addProviderAtFront(Provider p, Oid mechOid)
         throws GSSException {
 
         PreferencesEntry newEntry = new PreferencesEntry(p, mechOid);
@@ -367,7 +367,7 @@ public final class ProviderList {
         }
     }
 
-    synchronized public void addProviderAtEnd(Provider p, Oid mechOid)
+    public synchronized void addProviderAtEnd(Provider p, Oid mechOid)
         throws GSSException {
 
         PreferencesEntry newEntry = new PreferencesEntry(p, mechOid);

--- a/src/java.security.jgss/share/classes/sun/security/jgss/TokenTracker.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/TokenTracker.java
@@ -147,7 +147,7 @@ public class TokenTracker {
      * (This analysis leaves out the possibility that expectedNumber passes
      * initNumber after wrapping around. That may be added later.)
      */
-    synchronized public final void getProps(int number, MessageProp prop) {
+    public final synchronized void getProps(int number, MessageProp prop) {
 
         boolean gap = false;
         boolean old = false;

--- a/src/java.security.jgss/share/classes/sun/security/jgss/TokenTracker.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/TokenTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/ktab/KeyTab.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/ktab/KeyTab.java
@@ -123,7 +123,7 @@ public class KeyTab implements KeyTabConstants {
      * @param s file name of keytab, must not be null
      * @return the keytab object, can be invalid, but never null.
      */
-    private synchronized static KeyTab getInstance0(String s) {
+    private static synchronized KeyTab getInstance0(String s) {
         long lm = new File(s).lastModified();
         KeyTab old = map.get(s);
         if (old != null && old.isValid() && old.lastModified == lm) {
@@ -429,7 +429,7 @@ public class KeyTab implements KeyTabConstants {
     /**
      * Creates a new default key table.
      */
-    public synchronized static KeyTab create()
+    public static synchronized KeyTab create()
         throws IOException, RealmException {
         String dname = getDefaultTabName();
         return create(dname);
@@ -438,7 +438,7 @@ public class KeyTab implements KeyTabConstants {
     /**
      * Creates a new default key table.
      */
-    public synchronized static KeyTab create(String name)
+    public static synchronized KeyTab create(String name)
         throws IOException, RealmException {
 
         try (KeyTabOutputStream kos =

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/ktab/KeyTab.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/ktab/KeyTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.smartcardio/share/classes/javax/smartcardio/CardNotPresentException.java
+++ b/src/java.smartcardio/share/classes/javax/smartcardio/CardNotPresentException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.smartcardio/share/classes/javax/smartcardio/CardNotPresentException.java
+++ b/src/java.smartcardio/share/classes/javax/smartcardio/CardNotPresentException.java
@@ -35,7 +35,7 @@ package javax.smartcardio;
  */
 public class CardNotPresentException extends CardException {
 
-    private final static long serialVersionUID = 1346879911706545215L;
+    private static final long serialVersionUID = 1346879911706545215L;
 
     /**
      * Constructs a new CardNotPresentException with the specified detail message.

--- a/src/java.smartcardio/share/classes/javax/smartcardio/CardPermission.java
+++ b/src/java.smartcardio/share/classes/javax/smartcardio/CardPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.smartcardio/share/classes/javax/smartcardio/CardPermission.java
+++ b/src/java.smartcardio/share/classes/javax/smartcardio/CardPermission.java
@@ -74,17 +74,17 @@ public class CardPermission extends Permission {
 
     private static final long serialVersionUID = 7146787880530705613L;
 
-    private final static int A_CONNECT              = 0x01;
-    private final static int A_EXCLUSIVE            = 0x02;
-    private final static int A_GET_BASIC_CHANNEL    = 0x04;
-    private final static int A_OPEN_LOGICAL_CHANNEL = 0x08;
-    private final static int A_RESET                = 0x10;
-    private final static int A_TRANSMIT_CONTROL     = 0x20;
+    private static final int A_CONNECT              = 0x01;
+    private static final int A_EXCLUSIVE            = 0x02;
+    private static final int A_GET_BASIC_CHANNEL    = 0x04;
+    private static final int A_OPEN_LOGICAL_CHANNEL = 0x08;
+    private static final int A_RESET                = 0x10;
+    private static final int A_TRANSMIT_CONTROL     = 0x20;
 
     // sum of all the actions above
-    private final static int A_ALL                  = 0x3f;
+    private static final int A_ALL                  = 0x3f;
 
-    private final static int[] ARRAY_MASKS = {
+    private static final int[] ARRAY_MASKS = {
         A_ALL,
         A_CONNECT,
         A_EXCLUSIVE,
@@ -94,16 +94,16 @@ public class CardPermission extends Permission {
         A_TRANSMIT_CONTROL,
     };
 
-    private final static String S_CONNECT              = "connect";
-    private final static String S_EXCLUSIVE            = "exclusive";
-    private final static String S_GET_BASIC_CHANNEL    = "getBasicChannel";
-    private final static String S_OPEN_LOGICAL_CHANNEL = "openLogicalChannel";
-    private final static String S_RESET                = "reset";
-    private final static String S_TRANSMIT_CONTROL     = "transmitControl";
+    private static final String S_CONNECT              = "connect";
+    private static final String S_EXCLUSIVE            = "exclusive";
+    private static final String S_GET_BASIC_CHANNEL    = "getBasicChannel";
+    private static final String S_OPEN_LOGICAL_CHANNEL = "openLogicalChannel";
+    private static final String S_RESET                = "reset";
+    private static final String S_TRANSMIT_CONTROL     = "transmitControl";
 
-    private final static String S_ALL                  = "*";
+    private static final String S_ALL                  = "*";
 
-    private final static String[] ARRAY_STRINGS = {
+    private static final String[] ARRAY_STRINGS = {
         S_ALL,
         S_CONNECT,
         S_EXCLUSIVE,

--- a/src/java.smartcardio/share/classes/javax/smartcardio/TerminalFactory.java
+++ b/src/java.smartcardio/share/classes/javax/smartcardio/TerminalFactory.java
@@ -88,12 +88,12 @@ import sun.security.jca.GetInstance.*;
  */
 public final class TerminalFactory {
 
-    private final static String PROP_NAME =
+    private static final String PROP_NAME =
                         "javax.smartcardio.TerminalFactory.DefaultType";
 
-    private final static String defaultType;
+    private static final String defaultType;
 
-    private final static TerminalFactory defaultFactory;
+    private static final TerminalFactory defaultFactory;
 
     static {
         // lookup up the user specified type, default to PC/SC
@@ -133,14 +133,14 @@ public final class TerminalFactory {
     private static final class NoneProvider extends Provider {
 
         private static final long serialVersionUID = 2745808869881593918L;
-        final static Provider INSTANCE = new NoneProvider();
+        static final Provider INSTANCE = new NoneProvider();
         private NoneProvider() {
             super("None", "1.0", "none");
         }
     }
 
     private static final class NoneFactorySpi extends TerminalFactorySpi {
-        final static TerminalFactorySpi INSTANCE = new NoneFactorySpi();
+        static final TerminalFactorySpi INSTANCE = new NoneFactorySpi();
         private NoneFactorySpi() {
             // empty
         }
@@ -150,7 +150,7 @@ public final class TerminalFactory {
     }
 
     private static final class NoneCardTerminals extends CardTerminals {
-        final static CardTerminals INSTANCE = new NoneCardTerminals();
+        static final CardTerminals INSTANCE = new NoneCardTerminals();
         private NoneCardTerminals() {
             // empty
         }

--- a/src/java.smartcardio/share/classes/sun/security/smartcardio/ChannelImpl.java
+++ b/src/java.smartcardio/share/classes/sun/security/smartcardio/ChannelImpl.java
@@ -114,13 +114,13 @@ final class ChannelImpl extends CardChannel {
         return responseBytes.length;
     }
 
-    private final static boolean t0GetResponse =
+    private static final boolean t0GetResponse =
         getBooleanProperty("sun.security.smartcardio.t0GetResponse", true);
 
-    private final static boolean t1GetResponse =
+    private static final boolean t1GetResponse =
         getBooleanProperty("sun.security.smartcardio.t1GetResponse", true);
 
-    private final static boolean t1StripLe =
+    private static final boolean t1StripLe =
         getBooleanProperty("sun.security.smartcardio.t1StripLe", false);
 
     private static boolean getBooleanProperty(String name, boolean def) {
@@ -151,8 +151,8 @@ final class ChannelImpl extends CardChannel {
         return res;
     }
 
-    private final static int RESPONSE_ITERATIONS = 256;
-    private final static byte[] B0 = new byte[0];
+    private static final int RESPONSE_ITERATIONS = 256;
+    private static final byte[] B0 = new byte[0];
 
     private byte[] doTransmit(byte[] command) throws CardException {
         // note that we modify the 'command' array in some cases, so it must

--- a/src/java.smartcardio/share/classes/sun/security/smartcardio/PCSC.java
+++ b/src/java.smartcardio/share/classes/sun/security/smartcardio/PCSC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.smartcardio/share/classes/sun/security/smartcardio/PCSC.java
+++ b/src/java.smartcardio/share/classes/sun/security/smartcardio/PCSC.java
@@ -93,83 +93,83 @@ final class PCSC extends PlatformPCSC {
             throws PCSCException;
 
     // PCSC success/error/failure/warning codes
-    final static int SCARD_S_SUCCESS             = 0x00000000;
-    final static int SCARD_E_CANCELLED           = 0x80100002;
-    final static int SCARD_E_CANT_DISPOSE        = 0x8010000E;
-    final static int SCARD_E_INSUFFICIENT_BUFFER = 0x80100008;
-    final static int SCARD_E_INVALID_ATR         = 0x80100015;
-    final static int SCARD_E_INVALID_HANDLE      = 0x80100003;
-    final static int SCARD_E_INVALID_PARAMETER   = 0x80100004;
-    final static int SCARD_E_INVALID_TARGET      = 0x80100005;
-    final static int SCARD_E_INVALID_VALUE       = 0x80100011;
-    final static int SCARD_E_NO_MEMORY           = 0x80100006;
-    final static int SCARD_F_COMM_ERROR          = 0x80100013;
-    final static int SCARD_F_INTERNAL_ERROR      = 0x80100001;
-    final static int SCARD_F_UNKNOWN_ERROR       = 0x80100014;
-    final static int SCARD_F_WAITED_TOO_LONG     = 0x80100007;
-    final static int SCARD_E_UNKNOWN_READER      = 0x80100009;
-    final static int SCARD_E_TIMEOUT             = 0x8010000A;
-    final static int SCARD_E_SHARING_VIOLATION   = 0x8010000B;
-    final static int SCARD_E_NO_SMARTCARD        = 0x8010000C;
-    final static int SCARD_E_UNKNOWN_CARD        = 0x8010000D;
-    final static int SCARD_E_PROTO_MISMATCH      = 0x8010000F;
-    final static int SCARD_E_NOT_READY           = 0x80100010;
-    final static int SCARD_E_SYSTEM_CANCELLED    = 0x80100012;
-    final static int SCARD_E_NOT_TRANSACTED      = 0x80100016;
-    final static int SCARD_E_READER_UNAVAILABLE  = 0x80100017;
+    static final int SCARD_S_SUCCESS             = 0x00000000;
+    static final int SCARD_E_CANCELLED           = 0x80100002;
+    static final int SCARD_E_CANT_DISPOSE        = 0x8010000E;
+    static final int SCARD_E_INSUFFICIENT_BUFFER = 0x80100008;
+    static final int SCARD_E_INVALID_ATR         = 0x80100015;
+    static final int SCARD_E_INVALID_HANDLE      = 0x80100003;
+    static final int SCARD_E_INVALID_PARAMETER   = 0x80100004;
+    static final int SCARD_E_INVALID_TARGET      = 0x80100005;
+    static final int SCARD_E_INVALID_VALUE       = 0x80100011;
+    static final int SCARD_E_NO_MEMORY           = 0x80100006;
+    static final int SCARD_F_COMM_ERROR          = 0x80100013;
+    static final int SCARD_F_INTERNAL_ERROR      = 0x80100001;
+    static final int SCARD_F_UNKNOWN_ERROR       = 0x80100014;
+    static final int SCARD_F_WAITED_TOO_LONG     = 0x80100007;
+    static final int SCARD_E_UNKNOWN_READER      = 0x80100009;
+    static final int SCARD_E_TIMEOUT             = 0x8010000A;
+    static final int SCARD_E_SHARING_VIOLATION   = 0x8010000B;
+    static final int SCARD_E_NO_SMARTCARD        = 0x8010000C;
+    static final int SCARD_E_UNKNOWN_CARD        = 0x8010000D;
+    static final int SCARD_E_PROTO_MISMATCH      = 0x8010000F;
+    static final int SCARD_E_NOT_READY           = 0x80100010;
+    static final int SCARD_E_SYSTEM_CANCELLED    = 0x80100012;
+    static final int SCARD_E_NOT_TRANSACTED      = 0x80100016;
+    static final int SCARD_E_READER_UNAVAILABLE  = 0x80100017;
 
-    final static int SCARD_W_UNSUPPORTED_CARD    = 0x80100065;
-    final static int SCARD_W_UNRESPONSIVE_CARD   = 0x80100066;
-    final static int SCARD_W_UNPOWERED_CARD      = 0x80100067;
-    final static int SCARD_W_RESET_CARD          = 0x80100068;
-    final static int SCARD_W_REMOVED_CARD        = 0x80100069;
-    final static int SCARD_W_INSERTED_CARD       = 0x8010006A;
+    static final int SCARD_W_UNSUPPORTED_CARD    = 0x80100065;
+    static final int SCARD_W_UNRESPONSIVE_CARD   = 0x80100066;
+    static final int SCARD_W_UNPOWERED_CARD      = 0x80100067;
+    static final int SCARD_W_RESET_CARD          = 0x80100068;
+    static final int SCARD_W_REMOVED_CARD        = 0x80100069;
+    static final int SCARD_W_INSERTED_CARD       = 0x8010006A;
 
-    final static int SCARD_E_UNSUPPORTED_FEATURE = 0x8010001F;
-    final static int SCARD_E_PCI_TOO_SMALL       = 0x80100019;
-    final static int SCARD_E_READER_UNSUPPORTED  = 0x8010001A;
-    final static int SCARD_E_DUPLICATE_READER    = 0x8010001B;
-    final static int SCARD_E_CARD_UNSUPPORTED    = 0x8010001C;
-    final static int SCARD_E_NO_SERVICE          = 0x8010001D;
-    final static int SCARD_E_SERVICE_STOPPED     = 0x8010001E;
+    static final int SCARD_E_UNSUPPORTED_FEATURE = 0x8010001F;
+    static final int SCARD_E_PCI_TOO_SMALL       = 0x80100019;
+    static final int SCARD_E_READER_UNSUPPORTED  = 0x8010001A;
+    static final int SCARD_E_DUPLICATE_READER    = 0x8010001B;
+    static final int SCARD_E_CARD_UNSUPPORTED    = 0x8010001C;
+    static final int SCARD_E_NO_SERVICE          = 0x8010001D;
+    static final int SCARD_E_SERVICE_STOPPED     = 0x8010001E;
 
     // MS undocumented
-    final static int SCARD_E_NO_READERS_AVAILABLE = 0x8010002E;
+    static final int SCARD_E_NO_READERS_AVAILABLE = 0x8010002E;
     // std. Windows invalid handle return code, used instead of SCARD code
-    final static int WINDOWS_ERROR_INVALID_HANDLE = 6;
-    final static int WINDOWS_ERROR_INVALID_PARAMETER = 87;
+    static final int WINDOWS_ERROR_INVALID_HANDLE = 6;
+    static final int WINDOWS_ERROR_INVALID_PARAMETER = 87;
 
     //
-    final static int SCARD_SCOPE_USER      =  0x0000;
-    final static int SCARD_SCOPE_TERMINAL  =  0x0001;
-    final static int SCARD_SCOPE_SYSTEM    =  0x0002;
-    final static int SCARD_SCOPE_GLOBAL    =  0x0003;
+    static final int SCARD_SCOPE_USER      =  0x0000;
+    static final int SCARD_SCOPE_TERMINAL  =  0x0001;
+    static final int SCARD_SCOPE_SYSTEM    =  0x0002;
+    static final int SCARD_SCOPE_GLOBAL    =  0x0003;
 
-    final static int SCARD_SHARE_EXCLUSIVE =  0x0001;
-    final static int SCARD_SHARE_SHARED    =  0x0002;
-    final static int SCARD_SHARE_DIRECT    =  0x0003;
+    static final int SCARD_SHARE_EXCLUSIVE =  0x0001;
+    static final int SCARD_SHARE_SHARED    =  0x0002;
+    static final int SCARD_SHARE_DIRECT    =  0x0003;
 
-    final static int SCARD_LEAVE_CARD      =  0x0000;
-    final static int SCARD_RESET_CARD      =  0x0001;
-    final static int SCARD_UNPOWER_CARD    =  0x0002;
-    final static int SCARD_EJECT_CARD      =  0x0003;
+    static final int SCARD_LEAVE_CARD      =  0x0000;
+    static final int SCARD_RESET_CARD      =  0x0001;
+    static final int SCARD_UNPOWER_CARD    =  0x0002;
+    static final int SCARD_EJECT_CARD      =  0x0003;
 
-    final static int SCARD_STATE_UNAWARE     = 0x0000;
-    final static int SCARD_STATE_IGNORE      = 0x0001;
-    final static int SCARD_STATE_CHANGED     = 0x0002;
-    final static int SCARD_STATE_UNKNOWN     = 0x0004;
-    final static int SCARD_STATE_UNAVAILABLE = 0x0008;
-    final static int SCARD_STATE_EMPTY       = 0x0010;
-    final static int SCARD_STATE_PRESENT     = 0x0020;
-    final static int SCARD_STATE_ATRMATCH    = 0x0040;
-    final static int SCARD_STATE_EXCLUSIVE   = 0x0080;
-    final static int SCARD_STATE_INUSE       = 0x0100;
-    final static int SCARD_STATE_MUTE        = 0x0200;
-    final static int SCARD_STATE_UNPOWERED   = 0x0400;
+    static final int SCARD_STATE_UNAWARE     = 0x0000;
+    static final int SCARD_STATE_IGNORE      = 0x0001;
+    static final int SCARD_STATE_CHANGED     = 0x0002;
+    static final int SCARD_STATE_UNKNOWN     = 0x0004;
+    static final int SCARD_STATE_UNAVAILABLE = 0x0008;
+    static final int SCARD_STATE_EMPTY       = 0x0010;
+    static final int SCARD_STATE_PRESENT     = 0x0020;
+    static final int SCARD_STATE_ATRMATCH    = 0x0040;
+    static final int SCARD_STATE_EXCLUSIVE   = 0x0080;
+    static final int SCARD_STATE_INUSE       = 0x0100;
+    static final int SCARD_STATE_MUTE        = 0x0200;
+    static final int SCARD_STATE_UNPOWERED   = 0x0400;
 
-    final static int TIMEOUT_INFINITE = 0xffffffff;
+    static final int TIMEOUT_INFINITE = 0xffffffff;
 
-    private final static char[] hexDigits = "0123456789abcdef".toCharArray();
+    private static final char[] hexDigits = "0123456789abcdef".toCharArray();
 
     public static String toString(byte[] b) {
         StringBuilder sb = new StringBuilder(b.length * 3);

--- a/src/java.smartcardio/unix/classes/sun/security/smartcardio/PlatformPCSC.java
+++ b/src/java.smartcardio/unix/classes/sun/security/smartcardio/PlatformPCSC.java
@@ -44,11 +44,11 @@ class PlatformPCSC {
 
     static final Debug debug = Debug.getInstance("pcsc");
 
-    private final static String PROP_NAME = "sun.security.smartcardio.library";
+    private static final String PROP_NAME = "sun.security.smartcardio.library";
 
-    private final static String LIB1 = "/usr/$LIBISA/libpcsclite.so";
-    private final static String LIB2 = "/usr/local/$LIBISA/libpcsclite.so";
-    private final static String PCSC_FRAMEWORK = "/System/Library/Frameworks/PCSC.framework/Versions/Current/PCSC";
+    private static final String LIB1 = "/usr/$LIBISA/libpcsclite.so";
+    private static final String LIB2 = "/usr/local/$LIBISA/libpcsclite.so";
+    private static final String PCSC_FRAMEWORK = "/System/Library/Frameworks/PCSC.framework/Versions/Current/PCSC";
 
     PlatformPCSC() {
         // empty
@@ -138,16 +138,16 @@ class PlatformPCSC {
 
     // PCSC constants defined differently under Windows and MUSCLE
     // MUSCLE version
-    final static int SCARD_PROTOCOL_T0     =  0x0001;
-    final static int SCARD_PROTOCOL_T1     =  0x0002;
-    final static int SCARD_PROTOCOL_RAW    =  0x0004;
+    static final int SCARD_PROTOCOL_T0     =  0x0001;
+    static final int SCARD_PROTOCOL_T1     =  0x0002;
+    static final int SCARD_PROTOCOL_RAW    =  0x0004;
 
-    final static int SCARD_UNKNOWN         =  0x0001;
-    final static int SCARD_ABSENT          =  0x0002;
-    final static int SCARD_PRESENT         =  0x0004;
-    final static int SCARD_SWALLOWED       =  0x0008;
-    final static int SCARD_POWERED         =  0x0010;
-    final static int SCARD_NEGOTIABLE      =  0x0020;
-    final static int SCARD_SPECIFIC        =  0x0040;
+    static final int SCARD_UNKNOWN         =  0x0001;
+    static final int SCARD_ABSENT          =  0x0002;
+    static final int SCARD_PRESENT         =  0x0004;
+    static final int SCARD_SWALLOWED       =  0x0008;
+    static final int SCARD_POWERED         =  0x0010;
+    static final int SCARD_NEGOTIABLE      =  0x0020;
+    static final int SCARD_SPECIFIC        =  0x0040;
 
 }

--- a/src/java.smartcardio/windows/classes/sun/security/smartcardio/PlatformPCSC.java
+++ b/src/java.smartcardio/windows/classes/sun/security/smartcardio/PlatformPCSC.java
@@ -58,16 +58,16 @@ class PlatformPCSC {
 
     // PCSC constants defined differently under Windows and MUSCLE
     // Windows version
-    final static int SCARD_PROTOCOL_T0     =  0x0001;
-    final static int SCARD_PROTOCOL_T1     =  0x0002;
-    final static int SCARD_PROTOCOL_RAW    =  0x10000;
+    static final int SCARD_PROTOCOL_T0     =  0x0001;
+    static final int SCARD_PROTOCOL_T1     =  0x0002;
+    static final int SCARD_PROTOCOL_RAW    =  0x10000;
 
-    final static int SCARD_UNKNOWN         =  0x0000;
-    final static int SCARD_ABSENT          =  0x0001;
-    final static int SCARD_PRESENT         =  0x0002;
-    final static int SCARD_SWALLOWED       =  0x0003;
-    final static int SCARD_POWERED         =  0x0004;
-    final static int SCARD_NEGOTIABLE      =  0x0005;
-    final static int SCARD_SPECIFIC        =  0x0006;
+    static final int SCARD_UNKNOWN         =  0x0000;
+    static final int SCARD_ABSENT          =  0x0001;
+    static final int SCARD_PRESENT         =  0x0002;
+    static final int SCARD_SWALLOWED       =  0x0003;
+    static final int SCARD_POWERED         =  0x0004;
+    static final int SCARD_NEGOTIABLE      =  0x0005;
+    static final int SCARD_SPECIFIC        =  0x0006;
 
 }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Secmod.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Secmod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Secmod.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Secmod.java
@@ -76,11 +76,11 @@ public final class Secmod {
     // Slot IDs - defined in j2secmod.h on the native side
     // Values obtained from NSS's pkcs11i.h header
 
-    private final static int NETSCAPE_SLOT_ID = 0x1;
+    private static final int NETSCAPE_SLOT_ID = 0x1;
 
-    private final static int PRIVATE_KEY_SLOT_ID = 0x2;
+    private static final int PRIVATE_KEY_SLOT_ID = 0x2;
 
-    private final static int FIPS_SLOT_ID = 0x3;
+    private static final int FIPS_SLOT_ID = 0x3;
 
     // handle to be passed to the native code, 0 means not initialized
     private long nssHandle;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/Constants.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/Constants.java
@@ -50,7 +50,7 @@ package sun.security.pkcs11.wrapper;
 
 
 /**
- * This class holds only final static member variables that are constants
+ * This class holds only static final member variables that are constants
  * in this package.
  *
  * @author Karl Scheibelhofer <Karl.Scheibelhofer@iaik.at>

--- a/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CKey.java
+++ b/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CKey.java
@@ -83,7 +83,7 @@ abstract class CKey implements Key, Length {
     }
 
     // Native method to cleanup the key handle.
-    private native static void cleanUp(long hCryptProv, long hCryptKey);
+    private static native void cleanUp(long hCryptProv, long hCryptKey);
 
     @Override
     public int length() {
@@ -102,9 +102,9 @@ abstract class CKey implements Key, Length {
         return algorithm;
     }
 
-    protected native static String getContainerName(long hCryptProv);
+    protected static native String getContainerName(long hCryptProv);
 
-    protected native static String getKeyType(long hCryptKey);
+    protected static native String getKeyType(long hCryptKey);
 
     // This java method generates EC BLOBs for public key or private key.
     // See https://docs.microsoft.com/en-us/windows/desktop/api/bcrypt/ns-bcrypt-_bcrypt_ecckey_blob

--- a/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CRSACipher.java
+++ b/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CRSACipher.java
@@ -505,8 +505,8 @@ public final class CRSACipher extends CipherSpi {
         }
     }
 
-    private native static byte[] encryptDecrypt(byte[] data, int dataSize,
+    private static native byte[] encryptDecrypt(byte[] data, int dataSize,
             long key, boolean doEncrypt) throws KeyException;
-    private native static byte[] cngEncryptDecrypt(byte[] data, int dataSize,
+    private static native byte[] cngEncryptDecrypt(byte[] data, int dataSize,
             long key, boolean doEncrypt) throws KeyException;
 }

--- a/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CSignature.java
+++ b/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CSignature.java
@@ -743,7 +743,7 @@ abstract class CSignature extends SignatureSpi {
      * Sign hash using CNG API with HCRYPTKEY.
      * @param type 0 no padding, 1, pkcs1, 2, pss
      */
-    native static byte[] signCngHash(
+    static native byte[] signCngHash(
             int type, byte[] hash,
             int hashSize, int saltLength, String hashAlgorithm,
             long hCryptProv, long nCryptKey)
@@ -753,7 +753,7 @@ abstract class CSignature extends SignatureSpi {
      * Verify a signed hash using CNG API with HCRYPTKEY.
      * @param type 0 no padding, 1, pkcs1, 2, pss
      */
-    private native static boolean verifyCngSignedHash(
+    private static native boolean verifyCngSignedHash(
             int type, byte[] hash, int hashSize,
             byte[] signature, int signatureSize,
             int saltLength, String hashAlgorithm,
@@ -845,14 +845,14 @@ abstract class CSignature extends SignatureSpi {
      * Sign hash using Microsoft Crypto API with HCRYPTKEY.
      * The returned data is in little-endian.
      */
-    private native static byte[] signHash(boolean noHashOID, byte[] hash,
+    private static native byte[] signHash(boolean noHashOID, byte[] hash,
         int hashSize, String hashAlgorithm, long hCryptProv, long hCryptKey)
             throws SignatureException;
 
     /**
      * Verify a signed hash using Microsoft Crypto API with HCRYPTKEY.
      */
-    private native static boolean verifySignedHash(byte[] hash, int hashSize,
+    private static native boolean verifySignedHash(byte[] hash, int hashSize,
         String hashAlgorithm, byte[] signature, int signatureSize,
         long hCryptProv, long hCryptKey) throws SignatureException;
 


### PR DESCRIPTION
I ran bin/blessed-modifier-order.sh on source owned by security-libs. This scripts verifies that modifiers are in the "blessed" order, and fixes it otherwise. I have manually checked the changes made by the script to make sure they are sound.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276632](https://bugs.openjdk.java.net/browse/JDK-8276632): Use blessed modifier order in security-libs code


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6251/head:pull/6251` \
`$ git checkout pull/6251`

Update a local copy of the PR: \
`$ git checkout pull/6251` \
`$ git pull https://git.openjdk.java.net/jdk pull/6251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6251`

View PR using the GUI difftool: \
`$ git pr show -t 6251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6251.diff">https://git.openjdk.java.net/jdk/pull/6251.diff</a>

</details>
