### PR TITLE
8276634: Remove `usePlainDatagramSocketImpl` option from the test DatagramChannel/SendReceiveMaxSize.java

### DIFF
--- a/test/jdk/java/nio/channels/DatagramChannel/ChangingAddress.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/ChangingAddress.java
@@ -25,7 +25,7 @@
  * @bug 6431343
  * @summary Test that DatagramChannel.getLocalAddress returns the right local
  *    address after connect/disconnect.
- * @run main/othervm -Djdk.net.usePlainDatagramSocketImpl=false ChangingAddress
+ * @run main/othervm ChangingAddress
  */
 import java.net.*;
 import java.nio.channels.DatagramChannel;

--- a/test/jdk/java/nio/channels/DatagramChannel/SendReceiveMaxSize.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/SendReceiveMaxSize.java
@@ -31,8 +31,6 @@
  * @build jdk.test.lib.net.IPSupport
  * @run testng/othervm SendReceiveMaxSize
  * @run testng/othervm -Djava.net.preferIPv4Stack=true SendReceiveMaxSize
- * @run testng/othervm -Djdk.net.usePlainDatagramSocketImpl SendReceiveMaxSize
- * @run testng/othervm -Djdk.net.usePlainDatagramSocketImpl -Djava.net.preferIPv4Stack=true SendReceiveMaxSize
  */
 
 import jdk.test.lib.RandomFactory;


### PR DESCRIPTION
Hi,

Could someone please review my changes for removing the `usePlainDatagramSocketImpl` option from the test DatagramChannel/SendReceiveMaxSize.java? 

The option `usePlainDatagramSocketImpl` was not removed during [JDK-8253119 - Remove the legacy PlainSocketImpl and PlainDatagramSocketImpl implementation](https://bugs.openjdk.java.net/browse/JDK-8253119). As these implementations have now been removed from the JDK, tests no longer need to check against it.

The test `test/jdk/java/nio/channels/DatagramChannel/SendReceiveMaxSize.java` as well as `test/jdk/java/nio/channels/DatagramChannel/ChangingAddress.java` still have this option as its removal was overlooked in the original issue. It can now be removed from both tests. 


Kind regards,
Patrick

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276634](https://bugs.openjdk.java.net/browse/JDK-8276634): Remove `usePlainDatagramSocketImpl` option from the test DatagramChannel/SendReceiveMaxSize.java


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Vyom Tewari](https://openjdk.java.net/census#vtewari) (@vyommani - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6252/head:pull/6252` \
`$ git checkout pull/6252`

Update a local copy of the PR: \
`$ git checkout pull/6252` \
`$ git pull https://git.openjdk.java.net/jdk pull/6252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6252`

View PR using the GUI difftool: \
`$ git pr show -t 6252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6252.diff">https://git.openjdk.java.net/jdk/pull/6252.diff</a>

</details>
